### PR TITLE
Rename GetConnection to address name conflict

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -250,7 +250,7 @@ ExecuteDistributedModify(Task *task)
 
 		Assert(taskPlacement->shardState == FILE_FINALIZED);
 
-		connection = GetConnection(nodeName, nodePort);
+		connection = GetOrEstablishConnection(nodeName, nodePort);
 		if (connection == NULL)
 		{
 			failedPlacementList = lappend(failedPlacementList, taskPlacement);
@@ -383,7 +383,7 @@ ExecuteTaskAndStoreResults(Task *task, TupleDesc tupleDescriptor,
 		bool queryOK = false;
 		bool storedOK = false;
 
-		PGconn *connection = GetConnection(nodeName, nodePort);
+		PGconn *connection = GetOrEstablishConnection(nodeName, nodePort);
 		if (connection == NULL)
 		{
 			continue;

--- a/src/backend/distributed/test/connection_cache.c
+++ b/src/backend/distributed/test/connection_cache.c
@@ -48,7 +48,7 @@ initialize_remote_temp_table(PG_FUNCTION_ARGS)
 	int32 nodePort = PG_GETARG_INT32(1);
 	PGresult *result = NULL;
 
-	PGconn *connection = GetConnection(nodeName, nodePort);
+	PGconn *connection = GetOrEstablishConnection(nodeName, nodePort);
 	if (connection == NULL)
 	{
 		PG_RETURN_BOOL(false);
@@ -79,7 +79,7 @@ count_remote_temp_table_rows(PG_FUNCTION_ARGS)
 	Datum count = Int32GetDatum(-1);
 	PGresult *result = NULL;
 
-	PGconn *connection = GetConnection(nodeName, nodePort);
+	PGconn *connection = GetOrEstablishConnection(nodeName, nodePort);
 	if (connection == NULL)
 	{
 		PG_RETURN_DATUM(count);
@@ -114,7 +114,7 @@ get_and_purge_connection(PG_FUNCTION_ARGS)
 	char *nodeName = PG_GETARG_CSTRING(0);
 	int32 nodePort = PG_GETARG_INT32(1);
 
-	PGconn *connection = GetConnection(nodeName, nodePort);
+	PGconn *connection = GetOrEstablishConnection(nodeName, nodePort);
 	if (connection == NULL)
 	{
 		PG_RETURN_BOOL(false);
@@ -136,7 +136,7 @@ set_connection_status_bad(PG_FUNCTION_ARGS)
 	char *nodeName = PG_GETARG_CSTRING(0);
 	int32 nodePort = PG_GETARG_INT32(1);
 
-	PGconn *connection = GetConnection(nodeName, nodePort);
+	PGconn *connection = GetOrEstablishConnection(nodeName, nodePort);
 	if (connection == NULL)
 	{
 		PG_RETURN_BOOL(false);

--- a/src/backend/distributed/utils/connection_cache.c
+++ b/src/backend/distributed/utils/connection_cache.c
@@ -32,7 +32,7 @@
 
 /*
  * NodeConnectionHash is the connection hash itself. It begins uninitialized.
- * The first call to GetConnection triggers hash creation.
+ * The first call to GetOrEstablishConnection triggers hash creation.
  */
 static HTAB *NodeConnectionHash = NULL;
 
@@ -44,10 +44,10 @@ static char * ConnectionGetOptionValue(PGconn *connection, char *optionKeyword);
 
 
 /*
- * GetConnection returns a PGconn which can be used to execute queries on a
- * remote PostgreSQL server. If no suitable connection to the specified node on
- * the specified port yet exists, the function establishes a new connection and
- * returns that.
+ * GetOrEstablishConnection returns a PGconn which can be used to execute
+ * queries on a remote PostgreSQL server. If no suitable connection to the
+ * specified node on the specified port yet exists, the function establishes
+ * a new connection and adds it to the connection cache before returning it.
  *
  * Returned connections are guaranteed to be in the CONNECTION_OK state. If the
  * requested connection cannot be established, or if it was previously created
@@ -56,7 +56,7 @@ static char * ConnectionGetOptionValue(PGconn *connection, char *optionKeyword);
  * This function throws an error if a hostname over 255 characters is provided.
  */
 PGconn *
-GetConnection(char *nodeName, int32 nodePort)
+GetOrEstablishConnection(char *nodeName, int32 nodePort)
 {
 	PGconn *connection = NULL;
 	NodeConnectionKey nodeConnectionKey;

--- a/src/include/distributed/connection_cache.h
+++ b/src/include/distributed/connection_cache.h
@@ -51,7 +51,7 @@ typedef struct NodeConnectionEntry
 
 
 /* function declarations for obtaining and using a connection */
-extern PGconn * GetConnection(char *nodeName, int32 nodePort);
+extern PGconn * GetOrEstablishConnection(char *nodeName, int32 nodePort);
 extern void PurgeConnection(PGconn *connection);
 extern void ReportRemoteError(PGconn *connection, PGresult *result);
 


### PR DESCRIPTION
The postgres_fdw extension has an extern function with an identical signature, which can cause problems when both extensions are loaded. A simple rename can fix this for now (this is the only function with) such a conflict.

Fixes #236.
