### PR TITLE
Remove unnecessary memory context switch on the planner

### DIFF
--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -52,19 +52,10 @@ multi_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	if (NeedsDistributedPlanning(parse))
 	{
-		MemoryContext oldcontext = NULL;
-		MultiPlan *physicalPlan = NULL;
-
-		/* Switch to top level message context */
-		oldcontext = MemoryContextSwitchTo(MessageContext);
-
-		physicalPlan = CreatePhysicalPlan(parse);
+		MultiPlan *physicalPlan = CreatePhysicalPlan(parse);
 
 		/* store required data into the planned statement */
 		result = MultiQueryContainerNode(result, physicalPlan);
-
-		/* Now switch back to original context */
-		MemoryContextSwitchTo(oldcontext);
 	}
 
 	return result;


### PR DESCRIPTION
This commit removes the unnecessary on the planner which was added for historical reasons. The removed memory context switch leads memory leak with copy_to_distributed_table script. Aside from that, this approach is the correct approach such that the planner does not change its memory context.

Fixes #308
