### PR TITLE
Ensure router executor acquires proper shard lock

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -153,7 +153,7 @@ CommutativityRuleToLockMode(CmdType commandType, bool upsertQuery)
 static void
 AcquireExecutorShardLock(Task *task, LOCKMODE lockMode)
 {
-	int64 shardId = task->shardId;
+	int64 shardId = task->anchorShardId;
 
 	LockShardResource(shardId, lockMode);
 }

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -14,9 +14,10 @@
  */
 
 #include "postgres.h"
-
+#include "c.h"
 #include "miscadmin.h"
 
+#include "distributed/relay_utility.h"
 #include "distributed/resource_lock.h"
 #include "storage/lmgr.h"
 
@@ -67,6 +68,8 @@ LockShardResource(uint64 shardId, LOCKMODE lockmode)
 	LOCKTAG	tag;
 	const bool sessionLock = false;
 	const bool dontWait = false;
+
+	AssertArg(shardId != INVALID_SHARD_ID);
 
 	SET_LOCKTAG_SHARD_RESOURCE(tag, MyDatabaseId, shardId);
 


### PR DESCRIPTION
Though Citus' Task struct has a shardId field, it doesn't have the same semantics as the one previously used in pg_shard code. The analogous field in the Citus Task is anchorShardId. I've also added an argument check to the relevant locking function to catch future locking attempts which pass an invalid argument.

Fixes #342
