### PR TITLE
Copy toplevel queryId to citus' master statement.

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -153,8 +153,14 @@ multi_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 * the later hooks, so we set a flag marking this as a distributed
 			 * statement running on the master. That e.g. allows us to drop the
 			 * temp table later.
+			 *
+			 * We copy the original statement's queryId, to allow
+			 * pg_stat_statements and similar extension to associate the
+			 * statement with the toplevel statement.
 			 */
+			masterSelectPlan->queryId = queryDesc->plannedstmt->queryId;
 			queryDesc->plannedstmt = masterSelectPlan;
+
 			eflags |= EXEC_FLAG_CITUS_MASTER_SELECT;
 		}
 	}


### PR DESCRIPTION
multi_ExecutorStart() replaces the original planned statement with the
master select statement. As that hasn't gone through the parse analysis
hooks, it'll not have a associated queryId.  This prevents extensions
pg_stat_statements to show useful data associated with the query.
