### PR TITLE
Prototype: Rely less on remote_task_check_interval.

### DIFF
--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -226,7 +226,7 @@ InitTaskExecution(Task *task, TaskExecStatus initialTaskExecStatus)
 	taskExecution->jobId = task->jobId;
 	taskExecution->taskId = task->taskId;
 	taskExecution->nodeCount = nodeCount;
-	taskExecution->connectPollCount = 0;
+	taskExecution->connectStartTime = 0;
 	taskExecution->currentNodeIndex = 0;
 	taskExecution->dataFetchTaskIndex = -1;
 	taskExecution->failureCount = 0;

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -850,7 +850,9 @@ TrackerConnectPoll(TaskTracker *taskTracker)
 			{
 				taskTracker->trackerStatus = TRACKER_CONNECTED;
 			}
-			else if (pollStatus == CLIENT_CONNECTION_BUSY)
+			else if (pollStatus == CLIENT_CONNECTION_BUSY ||
+					 pollStatus == CLIENT_CONNECTION_BUSY_READ ||
+					 pollStatus == CLIENT_CONNECTION_BUSY_WRITE)
 			{
 				taskTracker->trackerStatus = TRACKER_CONNECT_POLL;
 			}
@@ -864,7 +866,8 @@ TrackerConnectPoll(TaskTracker *taskTracker)
 
 			/* now check if we have been trying to connect for too long */
 			taskTracker->connectPollCount++;
-			if (pollStatus == CLIENT_CONNECTION_BUSY)
+			if (pollStatus == CLIENT_CONNECTION_BUSY_READ ||
+				pollStatus == CLIENT_CONNECTION_BUSY_WRITE)
 			{
 				uint32 maxCount = REMOTE_NODE_CONNECT_TIMEOUT / RemoteTaskCheckInterval;
 				uint32 currentCount = taskTracker->connectPollCount;

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -14,6 +14,7 @@
 #ifndef MULTI_PHYSICAL_PLANNER_H
 #define MULTI_PHYSICAL_PLANNER_H
 
+#include "datatype/timestamp.h"
 #include "distributed/citus_nodes.h"
 #include "distributed/master_metadata_utility.h"
 #include "distributed/multi_logical_planner.h"

--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -121,7 +121,7 @@ struct TaskExecution
 	TransmitExecStatus *transmitStatusArray;
 	int32 *connectionIdArray;
 	int32 *fileDescriptorArray;
-	uint32 connectPollCount;
+	TimestampTz connectStartTime;
 	uint32 nodeCount;
 	uint32 currentNodeIndex;
 	uint32 querySourceNodeIndex; /* only applies to map fetch tasks */


### PR DESCRIPTION
When executing queries with `citus.task_executor = 'real-time'`, query execution could, so far, spend a significant amount of time sleeping. That's because we were

  * sleeping after several phases of query execution, even if we're not
waiting for network IO
  *  sleeping for a fixed amount of time when waiting for network IO;
often a lot longer than actually required

Just reducing the amount of time slept isn't a real solution, because that just increases CPU usage.

Instead have the real-time executor's `ManageTaskExecution` return whether a task is currently being processed, waiting for reads or writes, or failed. When all tasks are waiting for IO use `poll()` to wait for IO readiness.

That requires to slightly redefine how connection timeouts are handled: before we counted the number of times `ManageTaskExecution()` was called, and compared that with the timeout divided by the task check interval. That, if processing of tasks took a while, could significantly increase the time till a timeout occurred. Because it was based on the `ManageTaskExecution()` being called on a constant interval, this approach isn't feasible anymore. Instead measure the actual time since connection establishment was started. That could in theory, if task processing takes a very long time, lead to few passes over `PQconnectPoll()`.

The problem of sleeping too much also exists for the `task-tracker` executor, but is generally less problematic there, as processing the individual tasks usually will take longer. That said, for e.g. the regression tests it'd be helpful to use a similar approach.

# Review Tasks

  - [x] Rely on `ResetWaitInfo` to initialize new `WaitInfo`s
  - [x] Rename `RememberWait` to `MultiClientRegisterWait` (and update comment referencing the non-existent `AddWait` function)
  - [x] Remove extraneous `break`
  - [x] Consider `TaskConnStatus` instead of `WaitStatus`
  - [x] Consider `READY`, `ERRORED`, `WAIT_READ`, and `WAIT_WRITE` as enum states
  - [x] Add `INVALID` state, explicitly assign enum integer values
  - [x] Rename `WaitInfo` fields (`registeredWaits`, `maxWaits`, `connectionReady`, `errorOccurred`, `pollFileDescriptors`
  - [x] Rebase