### PR TITLE
Linux build howto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,42 +6,87 @@ We're happy you want to contribute! You can help us in different ways:
   suggestions for improvements
 * Fork this repository and submit a pull request
 
-As with the majority of major open source projects, we ask that
-Citus contributors sign a Contributor License Agreement (CLA). We
-know that this creates a bit of red tape, but also believe that it
-is the best way to create total transparency around your rights as
-a contributor and the most effective way of protecting you as well
-as Citus Data as the company behind the open source project.
-
-If you plan on contributing to Citus, please follow these [instructions
-for signing our CLA](https://www.citusdata.com/community/CLA)
+Before accepting any code contributions we ask that Citus contributors
+sign a Contributor License Agreement (CLA). For an explanation of
+why we ask this as well as instructions for how to proceed, see the
+[Citus CLA](https://cla.citusdata.com).
 
 ### Getting and building
 
 #### Mac
 
-1. Install XCode
-2. Install packages with homebrew
+1. Install Xcode
+2. Install packages with Homebrew
 
    ```bash
    brew update
-   brew install git openssl postgresql
-   brew link openssl --force
+   brew install git postgresql
    ```
 
-3. Get the code
+3. Get, build, and test the code
 
    ```bash
    git clone https://github.com/citusdata/citus.git
+
+   cd citus
+   ./configure
+   make
+   make install
+   cd src/test/regress
+   make check
    ```
 
-4. Build and test
+#### Debian-based Linux (Ubuntu, Debian)
+
+1. Install build dependencies
 
    ```bash
+   echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
+        sudo tee /etc/apt/sources.list.d/pgdg.list
+   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+        sudo apt-key add -
+   sudo apt-get update
+
+   sudo apt-get install -y postgresql-server-dev-9.5 postgresql-9.5 \
+                           libedit-dev libselinux1-dev libxslt-dev  \
+                           libpam0g-dev git flex make
+   ```
+
+2. Get, build, and test the code
+
+   ```bash
+   git clone https://github.com/citusdata/citus.git
    cd citus
    ./configure
    make
    sudo make install
    cd src/test/regress
-   make check-multi
+   make check
+   ```
+
+#### Red Hat-based Linux (RHEL, CentOS, Fedora)
+
+1. Find the PostgreSQL 9.5 RPM URL for your repo at [yum.postgresql.org](http://yum.postgresql.org/repopackages.php#pg95)
+2. Register its contents with Yum:
+
+   ```bash
+   sudo yum install -y <url>
+   ```
+
+3. Install build dependencies
+
+   ```bash
+   sudo yum update -y
+   sudo yum groupinstall -y 'Development Tools'
+   sudo yum install -y postgresql95-devel postgresql95-server    \
+                       libxml2-devel libxslt-devel openssl-devel \
+                       pam-devel readline-devel git
+
+   git clone https://github.com/citusdata/citus.git
+   cd citus
+   PG_CONFIG=/usr/pgsql-9.5/bin/pg_config ./configure
+   make
+   sudo make install
+   cd src/test/regress
+   make check
    ```


### PR DESCRIPTION
Adds build instructions for Linux.

These instructions worked for me on fresh Ubuntu 14.04 and CentOS 7.2 boxes on Digital Ocean. Actually they worked up until doing `make check` because that tried to initdb which failed due to my being logged in as root. I assume make check would work at this point for a non-root user.

### Final Fixes

  - [x] Make _Homebrew_ title case
  - [x] Unify formatting of `<yum|apt-get> install <package list>`. Right now the Debian section wraps differently from the Red Hat one (minor)
  - [x] Use new CLA URL