### PR TITLE
Freebsd fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -58,6 +58,9 @@ SAVE_CFLAGS="$CFLAGS"
 AC_PROG_CC([$($PG_CONFIG --cc)])
 CFLAGS="$SAVE_CFLAGS"
 
+# Add the Postgres PKGINCLUDEDIR to the include search path
+CPPFLAGS="$CPPFLAGS -I$($PG_CONFIG --pkgincludedir)"
+
 # check for a number of CFLAGS that make development easier
 
 # CITUSAC_PROG_CC_CFLAGS_OPT

--- a/configure.in
+++ b/configure.in
@@ -58,9 +58,6 @@ SAVE_CFLAGS="$CFLAGS"
 AC_PROG_CC([$($PG_CONFIG --cc)])
 CFLAGS="$SAVE_CFLAGS"
 
-# Add the Postgres PKGINCLUDEDIR to the include search path
-CPPFLAGS="$CPPFLAGS -I$($PG_CONFIG --pkgincludedir)"
-
 # check for a number of CFLAGS that make development easier
 
 # CITUSAC_PROG_CC_CFLAGS_OPT

--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -19,6 +19,7 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "commands/dbcommands.h"

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -20,6 +20,7 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "commands/dbcommands.h"

--- a/src/backend/distributed/test/connection_utils.c
+++ b/src/backend/distributed/test/connection_utils.c
@@ -13,9 +13,9 @@
  *-------------------------------------------------------------------------
  */
 
-#include "internal/c.h"
+#include "c.h"
 #include "libpq-fe.h"
-#include "internal/libpq-int.h"
+#include "libpq-int.h"
 
 #include "distributed/test_helper_functions.h"
 

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -17,6 +17,7 @@
 #include "postgres.h"
 #include "funcapi.h"
 
+#include <netinet/in.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #ifdef HAVE_INTTYPES_H

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -17,7 +17,7 @@
 #include "postgres.h"
 #include "funcapi.h"
 
-#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #ifdef HAVE_INTTYPES_H

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -22,7 +22,7 @@
 
 
 /* total number of hash tokens (2^32) */
-#define HASH_TOKEN_COUNT INT64CONST(4294967296UL)
+#define HASH_TOKEN_COUNT INT64CONST(4294967296)
 
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval


### PR DESCRIPTION
Hi,

Thank you very much for open-sourcing citus.  When I saw the announcement, I just had to port it and add it to the official FreeBSD ports collection.  In doing so, I only found a small number of issues that affected compilation -- mostly to do with needing some additional header files and allowing the compiler to find postgresql's include files which are installed in a different place than for a typical Linux distribution.

There was one issue that would potentially cause compilation problems on a number of 32-bit platforms,
where this construct: INT64CONST(4294967296UL) could expand to 4294967296ULLL, which is a syntax error.

Once I've committed the port, within a few days it will become available as a official package available on all supported FreeBSD releases by:
{{{
  # pkg install pg_citus
}}}