### PR TITLE
Error out earlier when creating an index with a name collision.

### DIFF
--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -135,9 +135,7 @@ ERROR:  creating unique indexes on append-partitioned tables is currently unsupp
 -- Verify that we error out in case of postgres errors on supported statement
 -- types.
 CREATE INDEX lineitem_orderkey_index ON lineitem (l_orderkey);
-WARNING:  could not receive query results from localhost:57638
-DETAIL:  Client error: relation "lineitem_orderkey_index_102014" already exists
-ERROR:  could not execute DDL command on worker node shards
+ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
 WARNING:  could not receive query results from localhost:57638
 DETAIL:  Client error: data type bigint has no default operator class for access method "gist"
@@ -146,6 +144,8 @@ CREATE INDEX try_index ON lineitem (non_existent_column);
 WARNING:  could not receive query results from localhost:57638
 DETAIL:  Client error: column "non_existent_column" does not exist
 ERROR:  could not execute DDL command on worker node shards
+CREATE INDEX ON lineitem (l_orderkey);
+ERROR:  creating index without a name on a distributed table is currently unsupported
 -- Verify that none of failed indexes got created on the master node
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
  schemaname |    tablename     |          indexname           | tablespace |                                                     indexdef                                                     

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -73,6 +73,7 @@ CREATE UNIQUE INDEX try_unique_append_index_a_b ON index_test_append(a,b);
 CREATE INDEX lineitem_orderkey_index ON lineitem (l_orderkey);
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
 CREATE INDEX try_index ON lineitem (non_existent_column);
+CREATE INDEX ON lineitem (l_orderkey);
 
 -- Verify that none of failed indexes got created on the master node
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;


### PR DESCRIPTION
Fixes #350 

Also, make the error prettier when user attempts to create an index
without a name. Previously those statements gave cryptic errors:

````
brian=# create index on c (b);
WARNING:  could not receive query results from localhost:9700
DETAIL:  Client error: cannot extend name for null index name
ERROR:  could not execute DDL command on worker node shards
````

They now return

````
brian=# create index on c (b);
ERROR:  you must specify a name when creating an index on a distributed table
````