### PR TITLE
A couple of fixes that allow citus to compile

### DIFF
--- a/src/backend/distributed/test/connection_utils.c
+++ b/src/backend/distributed/test/connection_utils.c
@@ -13,9 +13,9 @@
  *-------------------------------------------------------------------------
  */
 
-#include "internal/c.h"
+#include "../internal/c.h"
 #include "libpq-fe.h"
-#include "internal/libpq-int.h"
+#include "../internal/libpq-int.h"
 
 #include "distributed/test_helper_functions.h"
 


### PR DESCRIPTION
I cannot compile citus on my machine, against Postgres 9.5.2+epsilon, gcc 5.3.1.

At least one of these is from changes you were making in a53fb90ef94ff3d2097539eeee38cc0b5bdf8d55, @jasonmp85. I'm not sure how they're supposed to work given I don't understand where the directory `internal` is coming from.

The Postgres involved is compiled from source. I'm also on Fedora. I wonder if "internal" is a debianism? It doesn't appear as a directory in the postgres nor citus source trees.

Here's a dump of the `pg_config` output.

```
BINDIR = /tmp/pg/bin
DOCDIR = /tmp/pg/share/doc/postgresql
HTMLDIR = /tmp/pg/share/doc/postgresql
INCLUDEDIR = /tmp/pg/include
PKGINCLUDEDIR = /tmp/pg/include/postgresql
INCLUDEDIR-SERVER = /tmp/pg/include/postgresql/server
LIBDIR = /tmp/pg/lib
PKGLIBDIR = /tmp/pg/lib/postgresql
LOCALEDIR = /tmp/pg/share/locale
MANDIR = /tmp/pg/share/man
SHAREDIR = /tmp/pg/share/postgresql
SYSCONFDIR = /tmp/pg/etc/postgresql
PGXS = /tmp/pg/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--prefix=/tmp/pg' '--enable-cassert' '--enable-debug' '--enable-depend' 'CFLAGS=-ggdb -O0'
CC = gcc
CPPFLAGS = -D_GNU_SOURCE
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -ggdb -O0
CFLAGS_SL = -fpic
LDFLAGS = -L../../../src/common -Wl,--as-needed -Wl,-rpath,'/tmp/pg/lib',--enable-new-dtags
LDFLAGS_EX = 
LDFLAGS_SL = 
LIBS = -lpgcommon -lpgport -lz -lreadline -lrt -lcrypt -ldl -lm 
VERSION = PostgreSQL 9.5.2
```