### PR TITLE
Add HINT to error when creating shards but there aren't enough workers.

### DIFF
--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -359,7 +359,9 @@ master_get_local_first_candidate_nodes(PG_FUNCTION_ARGS)
 			if (candidateNode == NULL)
 			{
 				ereport(ERROR, (errmsg("could only find %u of %u required nodes",
-									   currentNodeCount, desiredNodeCount)));
+									   currentNodeCount, desiredNodeCount),
+							          errhint("If you're running a development cluster, consider running"
+																" SET citus.shard_replication_factor = %u;", currentNodeCount)));
 			}
 		}
 
@@ -449,7 +451,9 @@ master_get_round_robin_candidate_nodes(PG_FUNCTION_ARGS)
 		if (candidateNode == NULL)
 		{
 			ereport(ERROR, (errmsg("could only find %u of %u required nodes",
-								   currentNodeCount, desiredNodeCount)));
+								   currentNodeCount, desiredNodeCount),
+							        errhint("If you're running a development cluster, consider running"
+														  " SET citus.shard_replication_factor = %u;", currentNodeCount)));
 		}
 
 		candidateDatum = WorkerNodeGetDatum(candidateNode, functionContext->tuple_desc);

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -120,7 +120,9 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 		if (candidateNode == NULL)
 		{
 			ereport(ERROR, (errmsg("could only find %u of %u possible nodes",
-								   candidateNodeCount, attemptableNodeCount)));
+								   candidateNodeCount, attemptableNodeCount),
+  					          errhint("If this is a development cluster, consider running"
+														  " SET citus.shard_replication_factor = %u;", candidateNodeCount)));
 		}
 
 		candidateNodeList = lappend(candidateNodeList, candidateNode);


### PR DESCRIPTION
Previously we returned this:

````
brian=# select master_create_empty_shard('tablz');
ERROR:  could only find 1 of 2 possible nodes
````

Now we return this:

````
brian=# select master_create_empty_shard('tablz');
ERROR:  could only find 1 of 2 possible nodes
HINT:  If this is a development cluster, consider running SET citus.shard_replication_factor = 1;
````

Which I think could be useful for newer users.