### PR TITLE
Enrich .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ win32ver.rc
 *.exe
 lib*dll.def
 lib*.pc
+.cproject
+.project
+gmon.out
+*.unc-backup.md5~
+*.unc-backup~
 
 # Local excludes in root directory
 /config.log


### PR DESCRIPTION
This change provides nicer results for `git status` command. The following
items are added to .gitignore:
- Eclipse CDT project files
- Uncrustify backup files
- Output files of `perf`