### PR TITLE
Proper indentation for code blocks in lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,75 +18,75 @@ why we ask this as well as instructions for how to proceed, see the
 1. Install Xcode
 2. Install packages with Homebrew
 
-   ```bash
-   brew update
-   brew install git postgresql
-   ```
+  ```bash
+  brew update
+  brew install git postgresql
+  ```
 
 3. Get, build, and test the code
 
-   ```bash
-   git clone https://github.com/citusdata/citus.git
+  ```bash
+  git clone https://github.com/citusdata/citus.git
 
-   cd citus
-   ./configure
-   make
-   make install
-   cd src/test/regress
-   make check
-   ```
+  cd citus
+  ./configure
+  make
+  make install
+  cd src/test/regress
+  make check
+  ```
 
 #### Debian-based Linux (Ubuntu, Debian)
 
 1. Install build dependencies
 
-   ```bash
-   echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
-        sudo tee /etc/apt/sources.list.d/pgdg.list
-   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
-        sudo apt-key add -
-   sudo apt-get update
+  ```bash
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
+       sudo tee /etc/apt/sources.list.d/pgdg.list
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+       sudo apt-key add -
+  sudo apt-get update
 
-   sudo apt-get install -y postgresql-server-dev-9.5 postgresql-9.5 \
-                           libedit-dev libselinux1-dev libxslt-dev  \
-                           libpam0g-dev git flex make
-   ```
+  sudo apt-get install -y postgresql-server-dev-9.5 postgresql-9.5 \
+                          libedit-dev libselinux1-dev libxslt-dev  \
+                          libpam0g-dev git flex make
+  ```
 
 2. Get, build, and test the code
 
-   ```bash
-   git clone https://github.com/citusdata/citus.git
-   cd citus
-   ./configure
-   make
-   sudo make install
-   cd src/test/regress
-   make check
-   ```
+  ```bash
+  git clone https://github.com/citusdata/citus.git
+  cd citus
+  ./configure
+  make
+  sudo make install
+  cd src/test/regress
+  make check
+  ```
 
 #### Red Hat-based Linux (RHEL, CentOS, Fedora)
 
 1. Find the PostgreSQL 9.5 RPM URL for your repo at [yum.postgresql.org](http://yum.postgresql.org/repopackages.php#pg95)
 2. Register its contents with Yum:
 
-   ```bash
-   sudo yum install -y <url>
-   ```
+  ```bash
+  sudo yum install -y <url>
+  ```
 
 3. Install build dependencies
 
-   ```bash
-   sudo yum update -y
-   sudo yum groupinstall -y 'Development Tools'
-   sudo yum install -y postgresql95-devel postgresql95-server    \
-                       libxml2-devel libxslt-devel openssl-devel \
-                       pam-devel readline-devel git
+  ```bash
+  sudo yum update -y
+  sudo yum groupinstall -y 'Development Tools'
+  sudo yum install -y postgresql95-devel postgresql95-server    \
+                      libxml2-devel libxslt-devel openssl-devel \
+                      pam-devel readline-devel git
 
-   git clone https://github.com/citusdata/citus.git
-   cd citus
-   PG_CONFIG=/usr/pgsql-9.5/bin/pg_config ./configure
-   make
-   sudo make install
-   cd src/test/regress
-   make check
-   ```
+  git clone https://github.com/citusdata/citus.git
+  cd citus
+  PG_CONFIG=/usr/pgsql-9.5/bin/pg_config ./configure
+  make
+  sudo make install
+  cd src/test/regress
+  make check
+  ```

--- a/README.md
+++ b/README.md
@@ -38,27 +38,27 @@ To learn more, visit [citusdata.com](https://www.citusdata.com).
 
 * Install docker-compose: [Mac][mac_install] | [Linux][linux_install]
 * (Mac only) connect to Docker VM
-   ```bash
-   eval $(docker-machine env default)
-   ```
+  ```bash
+  eval $(docker-machine env default)
+  ```
 
 * Pull and start the docker images
-   ```bash
-   wget https://raw.githubusercontent.com/citusdata/docker/master/docker-compose.yml
-   docker-compose -p citus up -d
-   ```
+  ```bash
+  wget https://raw.githubusercontent.com/citusdata/docker/master/docker-compose.yml
+  docker-compose -p citus up -d
+  ```
 
 * Connect to the master database
-   ```bash
-   docker exec -it citus_master psql -U postgres -d postgres
-   ```
+  ```bash
+  docker exec -it citus_master psql -U postgres -d postgres
+  ```
 
 * Follow the [first tutorial][tutorial] instructions
 * To shut the cluster down, run
 
-   ```bash
-   docker-compose -p citus down
-   ```
+  ```bash
+  docker-compose -p citus down
+  ```
 
 ### Learn More
 


### PR DESCRIPTION
Corrects a problem I discovered after merging changes to CONTRIBUTING.md and seeing how Github actually renders them. Code blocks in list items require an indentation that is a multiple of two. Otherwise Github eats into some lines deeper than others when it can do so, leading to this #ocdnightmare:

![screen shot 2016-03-30 at 1 42 36 pm](https://cloud.githubusercontent.com/assets/911911/14157411/b9cac99a-f67f-11e5-9e73-11726b38b150.png)

(I saw the problem happen locally when previewing with [grip](https://github.com/joeyespo/grip) but thought it was a glitch. In future I'll trust grip entirely.)