### PR TITLE
Treat nodePort as the 64bit integer it is.

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -337,7 +337,7 @@ TupleToShardPlacement(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	shardPlacement->shardLength = DatumGetInt64(shardLength);
 	shardPlacement->shardState = DatumGetUInt32(shardState);
 	shardPlacement->nodeName = TextDatumGetCString(nodeName);
-	shardPlacement->nodePort = DatumGetUInt32(nodePort);
+	shardPlacement->nodePort = DatumGetInt64(nodePort);
 
 	return shardPlacement;
 }
@@ -420,7 +420,7 @@ InsertShardPlacementRow(uint64 shardId, char shardState, uint64 shardLength,
 	values[Anum_pg_dist_shard_placement_shardstate - 1] = CharGetDatum(shardState);
 	values[Anum_pg_dist_shard_placement_shardlength - 1] = Int64GetDatum(shardLength);
 	values[Anum_pg_dist_shard_placement_nodename - 1] = CStringGetTextDatum(nodeName);
-	values[Anum_pg_dist_shard_placement_nodeport - 1] = UInt32GetDatum(nodePort);
+	values[Anum_pg_dist_shard_placement_nodeport - 1] = Int64GetDatum(nodePort);
 
 	/* open shard placement relation and insert new tuple */
 	pgDistShardPlacement = heap_open(DistShardPlacementRelationId(), RowExclusiveLock);


### PR DESCRIPTION
Node port is defined as a bigint in the schema, but in `master_metadata_utility` (and everywhere else, really), we treat it as a uint32. This commit fixes the regression tests on 32-bit systems.

Closes #422 and closes #408