### PR TITLE
Fix SELECT problem with no target list

### DIFF
--- a/src/backend/distributed/utils/citus_nodefuncs.c
+++ b/src/backend/distributed/utils/citus_nodefuncs.c
@@ -46,7 +46,7 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind,
 	Const *fragmentTableData = NULL;
 	Const *tableIdListData = NULL;
 
-	Assert(rte->eref && rte->eref->colnames != NIL);
+	Assert(rte->eref);
 
 	/* store RTE kind as a plain int4 */
 	rteKindData = makeNode(Const);

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -285,6 +285,19 @@ SELECT COUNT(*) FROM articles;
     50
 (1 row)
 
+-- test with empty target list
+SELECT FROM articles;
+--
+(50 rows)
+
+SELECT FROM articles WHERE author_id = 3737;
+--
+(0 rows)
+
+SELECT FROM articles WHERE word_count = 65500;
+--
+(0 rows)
+
 -- having queries unsupported in Citus
 SELECT author_id, sum(word_count) AS corpus_size FROM articles
 	GROUP BY author_id

--- a/src/test/regress/sql/multi_simple_queries.sql
+++ b/src/test/regress/sql/multi_simple_queries.sql
@@ -166,6 +166,13 @@ $sharded_sql$;
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
 
+-- test with empty target list
+SELECT FROM articles;
+
+SELECT FROM articles WHERE author_id = 3737;
+
+SELECT FROM articles WHERE word_count = 65500;
+
 -- having queries unsupported in Citus
 SELECT author_id, sum(word_count) AS corpus_size FROM articles
 	GROUP BY author_id


### PR DESCRIPTION
Prior to this change, performing a SELECT query without a target
list caused backend to crash.

Sample Query: SELECT FROM github_events; (without any * before FROM)

PostgreSQL:
```
--
(39599 rows)
```
Citus:
```
server closed the connection unexpectedly
    This probably means the server terminated abnormally
    before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
!>
```

The problem was an unnecessary Assert on column list in
SetRangeTblExtraData(citus_nodefuncs.c)

Fixes #374