### PR TITLE
Clarify Error Message Related to shared_preload_libraries

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -83,7 +83,10 @@ _PG_init(void)
 	if (!process_shared_preload_libraries_in_progress)
 	{
 		ereport(ERROR, (errmsg("Citus can only be loaded via shared_preload_libraries"),
-						errhint("Add citus to shared_preload_libraries.")));
+						errhint("Add citus to shared_preload_libraries configuration "
+								"variable in postgresql.conf in master and workers. Note "
+								"that citus should be at the beginning of "
+								"shared_preload_libraries.")));
 	}
 
 	/*


### PR DESCRIPTION
Fixes #363

This change modifies the error message given when Citus is attempted
to be loaded other than shared_preload_libraries. Explanations have been
extended with that shared_preload_parameters parameter is in
postgresql.conf and citus should be at the beginning.