### PR TITLE
Add clarifying comment in HashableClauseMutator

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2858,6 +2858,13 @@ HashableClauseMutator(Node *originalNode, Var *partitionColumn)
 
 		Oid leftHashFunction = InvalidOid;
 		Oid rightHashFunction = InvalidOid;
+
+		/*
+		 * If operatorExpression->opno is NOT the registered '=' operator for
+		 * any hash opfamilies, then get_op_hash_functions will return false.
+		 * This means this function both ensures a hash function exists for the
+		 * types in question AND filters out any clauses lacking equality ops.
+		 */
 		bool hasHashFunction = get_op_hash_functions(operatorExpression->opno,
 													 &leftHashFunction,
 													 &rightHashFunction);


### PR DESCRIPTION
While reading this code last week, it appeared as though there was no place we ensured that the partition clause actually used equality ops. As such, I was worried that we might transform a clause such as `id < 5` into a constraint like `hash(id) = hash(5)` when doing shard pruning. The relevant code seemed to just ensure:

  1. The node is an `OpExpr`
  2. With a related hash function
  3. It compares the partition column
  4. Against a constant

A superficial reading implied we didn't actually make sure the original op was equality-related, but it turns out the hash lookup function _does_ ensure that for us. So I added a comment.