### PR TITLE
Fix use of INT64CONST macro

### DIFF
--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -22,7 +22,7 @@
 
 
 /* total number of hash tokens (2^32) */
-#define HASH_TOKEN_COUNT INT64CONST(4294967296UL)
+#define HASH_TOKEN_COUNT INT64CONST(4294967296)
 
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval


### PR DESCRIPTION
This macro is intended to receive a bare integer literal (no suffix). It adds a suffix as necessary, depending upon available features. On e.g. 32-bit platforms, the existing code failed to compile because a suffix was added to the existing suffix. This fixes that problem.