### PR TITLE
DROP EXTENSION without any warnings

### DIFF
--- a/src/test/regress/expected/multi_drop_extension.out
+++ b/src/test/regress/expected/multi_drop_extension.out
@@ -1,0 +1,39 @@
+--
+-- MULTI_DROP_EXTENSION
+--
+-- Tests around dropping and recreating the extension
+CREATE TABLE testtableddl(somecol int, distributecol text NOT NULL);
+SELECT master_create_distributed_table('testtableddl', 'distributecol', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- this emits a NOTICE message for every table we are dropping with our CASCADE. It would
+-- be nice to check that we get those NOTICE messages, but it's nicer to not have to
+-- change this test every time the previous tests change the set of tables they leave
+-- around.
+SET client_min_messages TO 'WARNING';
+DROP EXTENSION citus CASCADE;
+RESET client_min_messages;
+CREATE EXTENSION citus;
+-- verify that a table can be created after the extension has been dropped and recreated
+CREATE TABLE testtableddl(somecol int, distributecol text NOT NULL);
+SELECT master_create_distributed_table('testtableddl', 'distributecol', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT 1 FROM master_create_empty_shard('testtableddl');
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT * FROM testtableddl;
+ somecol | distributecol 
+---------+---------------
+(0 rows)
+
+DROP TABLE testtableddl;

--- a/src/test/regress/expected/multi_table_ddl.out
+++ b/src/test/regress/expected/multi_table_ddl.out
@@ -11,8 +11,6 @@ SELECT master_create_distributed_table('testtableddl', 'distributecol', 'append'
 
 -- verify that the citus extension can't be dropped while distributed tables exist
 DROP EXTENSION citus;
-WARNING:  could not clean the metadata cache on DROP EXTENSION command
-HINT:  Reconnect to the server again.
 ERROR:  cannot drop extension citus because other objects depend on it
 DETAIL:  table testtableddl depends on extension citus
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
@@ -62,11 +60,6 @@ SELECT * FROM pg_dist_shard_placement;
 ---------+------------+-------------+----------+----------
 (0 rows)
 
--- check that the extension now can be dropped (and recreated). We reconnect
--- before creating the extension to expire extension specific variables which
--- are cached for performance.
+-- check that the extension now can be dropped (and recreated)
 DROP EXTENSION citus;
-WARNING:  could not clean the metadata cache on DROP EXTENSION command
-HINT:  Reconnect to the server again.
-\c
 CREATE EXTENSION citus;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -135,3 +135,8 @@ test: multi_router_planner
 # multi_large_shardid stages more shards into lineitem
 # ----------
 test: multi_large_shardid
+
+# ----------
+# multi_drop_extension makes sure we can safely drop and recreate the extension
+# ----------
+test: multi_drop_extension

--- a/src/test/regress/sql/multi_drop_extension.sql
+++ b/src/test/regress/sql/multi_drop_extension.sql
@@ -1,0 +1,25 @@
+--
+-- MULTI_DROP_EXTENSION
+--
+-- Tests around dropping and recreating the extension
+
+
+CREATE TABLE testtableddl(somecol int, distributecol text NOT NULL);
+SELECT master_create_distributed_table('testtableddl', 'distributecol', 'append');
+
+-- this emits a NOTICE message for every table we are dropping with our CASCADE. It would
+-- be nice to check that we get those NOTICE messages, but it's nicer to not have to
+-- change this test every time the previous tests change the set of tables they leave
+-- around.
+SET client_min_messages TO 'WARNING';
+DROP EXTENSION citus CASCADE;
+RESET client_min_messages;
+
+CREATE EXTENSION citus;
+
+-- verify that a table can be created after the extension has been dropped and recreated
+CREATE TABLE testtableddl(somecol int, distributecol text NOT NULL);
+SELECT master_create_distributed_table('testtableddl', 'distributecol', 'append');
+SELECT 1 FROM master_create_empty_shard('testtableddl');
+SELECT * FROM testtableddl;
+DROP TABLE testtableddl;

--- a/src/test/regress/sql/multi_table_ddl.sql
+++ b/src/test/regress/sql/multi_table_ddl.sql
@@ -34,9 +34,6 @@ SELECT * FROM pg_dist_partition;
 SELECT * FROM pg_dist_shard;
 SELECT * FROM pg_dist_shard_placement;
 
--- check that the extension now can be dropped (and recreated). We reconnect
--- before creating the extension to expire extension specific variables which
--- are cached for performance.
+-- check that the extension now can be dropped (and recreated)
 DROP EXTENSION citus;
-\c
 CREATE EXTENSION citus;


### PR DESCRIPTION
fixes #367 
Also fixes #200

Not quite ready for review, there are some big issues with this PR that maybe @anarazel can help me resolve. 

**1**

The approach I used is to make sure the oid of `pg_dist_shard_placement` is cached. Every time it is invalidated I call `get_relname_relid` to see if it still exists, and if it doesn't I wipe all state.

`get_relname_relid` must be called inside a transaction though (or else an assertion in `cache/catcache:SearchCatCache` will fail), which makes the code a little more complicated. Is there another method I can call?

**2**

From my position of ignorance this seems super fragile. 

If you call `CREATE EXTENSION` and immediately follow it with `DROP EXTENSION` the invalidate callback is never called. That's fine because we also never cached anything. But I can't figure out in what situations it is called. `extensionLoaded` is set whenever `IsDistributedTable` is called, and if any of those places don't also cause the invalidate callback to be later called this code will break.

What causes postgres to start sending invalidation callbacks for our tables?

**Misc adtl issues for myself**

- Do we also need to reset `DistPartitionScanKey` and `DistShardScanKey`?