### PR TITLE
FIX Complie Time Warning in multi_logical_optimizer.c

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -2907,7 +2907,8 @@ IsPartitionColumnRecursive(Expr *columnExpression, Query *query)
 	List *rangetableList = query->rtable;
 	Index rangeTableEntryIndex = 0;
 	RangeTblEntry *rangeTableEntry = NULL;
-	Expr *strippedColumnExpression = strip_implicit_coercions(columnExpression);
+	Expr *strippedColumnExpression = (Expr *) strip_implicit_coercions(
+		(Node *) columnExpression);
 
 	if (IsA(strippedColumnExpression, Var))
 	{


### PR DESCRIPTION
With #426, some new warning messages started to arise, because of
cross assignment of Node and Expr pointers. This change fixes the
warnings with type casts.

The warning message:
```
planner/multi_logical_optimizer.c:2911:60: warning: incompatible pointer types passing 'Expr *' (aka 'struct Expr *') to parameter of type 'Node *'
      (aka 'struct Node *') [-Wincompatible-pointer-types]
        Expr *strippedColumnExpression = strip_implicit_coercions(columnExpression);
                                                                  ^~~~~~~~~~~~~~~~
/usr/local/pgsql/include/server/nodes/nodeFuncs.h:33:45: note: passing argument to parameter 'node' here
extern Node *strip_implicit_coercions(Node *node);
                                            ^
planner/multi_logical_optimizer.c:2911:8: warning: incompatible pointer types initializing 'Expr *' (aka 'struct Expr *') with an expression of type
      'Node *' (aka 'struct Node *') [-Wincompatible-pointer-types]
        Expr *strippedColumnExpression = strip_implicit_coercions(columnExpression);
```