### PR TITLE
Rename citus.copy_transaction_manager

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -25,7 +25,7 @@
  * hash or range-partitioned tables, this can cause a problem when some of the
  * transactions fail to commit while others have succeeded. To ensure no data
  * is lost, COPY can use two-phase commit, by increasing max_prepared_transactions
- * on the worker and setting citus.copy_transaction_manager to '2pc'. The default
+ * on the worker and setting citus.multi_shard_commit_protocol to '2pc'. The default
  * is '1pc'. This is not a problem for append-partitioned tables because new
  * shards are created and in the case of failure, metadata changes are rolled
  * back on the master node.
@@ -124,9 +124,6 @@
 
 #define INITIAL_CONNECTION_CACHE_SIZE 1001
 
-
-/* the transaction manager to use for COPY commands */
-int CopyTransactionManager = TRANSACTION_MANAGER_1PC;
 
 /* constant used in binary protocol */
 static const char BinarySignature[11] = "PGCOPY\n\377\r\n\0";
@@ -449,7 +446,7 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 		/* close the COPY input on all shard placements */
 		EndRemoteCopy(connectionList, true);
 
-		if (CopyTransactionManager == TRANSACTION_MANAGER_2PC)
+		if (MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC)
 		{
 			PrepareRemoteTransactions(connectionList);
 		}

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -68,9 +68,9 @@ static const struct config_enum_entry shard_placement_policy_options[] = {
 	{ NULL, 0, false }
 };
 
-static const struct config_enum_entry transaction_manager_options[] = {
-	{ "1pc", TRANSACTION_MANAGER_1PC, false },
-	{ "2pc", TRANSACTION_MANAGER_2PC, false },
+static const struct config_enum_entry multi_shard_commit_protocol_options[] = {
+	{ "1pc", COMMIT_PROTOCOL_1PC, false },
+	{ "2pc", COMMIT_PROTOCOL_2PC, false },
 	{ NULL, 0, false }
 };
 
@@ -448,16 +448,17 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomEnumVariable(
-		"citus.copy_transaction_manager",
-		gettext_noop("Sets the transaction manager for COPY into distributed tables."),
-		gettext_noop("When a failure occurs during when copying into a distributed "
-					 "table, 2PC is required to ensure data is never lost. Change "
-					 "this setting to '2pc' from its default '1pc' to enable 2PC."
-					 "You must also set max_prepared_transactions on the worker "
-					 "nodes. Recovery from failed 2PCs is currently manual."),
-		&CopyTransactionManager,
-		TRANSACTION_MANAGER_1PC,
-		transaction_manager_options,
+		"citus.multi_shard_commit_protocol",
+		gettext_noop("Sets the commit protocol for commands modifying multiple shards."),
+		gettext_noop("When a failure occurs during commands that modify multiple "
+					 "shards (currently, only COPY on distributed tables modifies more "
+					 "than one shard), two-phase commit is required to ensure data is "
+					 "never lost. Change this setting to '2pc' from its default '1pc' to "
+					 "enable 2 PC. You must also set max_prepared_transactions on the "
+					 "worker nodes. Recovery from failed 2PCs is currently manual."),
+		&MultiShardCommitProtocol,
+		COMMIT_PROTOCOL_1PC,
+		multi_shard_commit_protocol_options,
 		PGC_USERSET,
 		0,
 		NULL, NULL, NULL);

--- a/src/backend/distributed/utils/multi_transaction.c
+++ b/src/backend/distributed/utils/multi_transaction.c
@@ -28,6 +28,10 @@ static uint32 DistributedTransactionId = 0;
 static StringInfo BuildTransactionName(int connectionId);
 
 
+/* the commit protocol to use for COPY commands */
+int MultiShardCommitProtocol = COMMIT_PROTOCOL_1PC;
+
+
 /*
  * InitializeDistributedTransaction prepares the distributed transaction ID
  * used in transaction names.
@@ -41,7 +45,7 @@ InitializeDistributedTransaction(void)
 
 /*
  * PrepareRemoteTransactions prepares all transactions on connections in
- * connectionList for commit if the 2PC transaction manager is enabled.
+ * connectionList for commit if the 2PC commit protocol is enabled.
  * On failure, it reports an error and stops.
  */
 void

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -17,7 +17,7 @@
 
 
 /* config variable managed via guc.c */
-extern int CopyTransactionManager;
+extern int MultiShardCommitProtocol;
 
 
 /*

--- a/src/include/distributed/multi_transaction.h
+++ b/src/include/distributed/multi_transaction.h
@@ -18,12 +18,12 @@
 #include "nodes/pg_list.h"
 
 
-/* Enumeration that defines the different transaction managers available */
+/* Enumeration that defines the different commit protocols available */
 typedef enum
 {
-	TRANSACTION_MANAGER_1PC = 0,
-	TRANSACTION_MANAGER_2PC = 1
-} TransactionManagerType;
+	COMMIT_PROTOCOL_1PC = 0,
+	COMMIT_PROTOCOL_2PC = 1
+} CommitProtocolType;
 
 /* Enumeration that defines different remote transaction states */
 typedef enum
@@ -45,6 +45,10 @@ typedef struct TransactionConnection
 	TransactionState transactionState;
 	PGconn *connection;
 } TransactionConnection;
+
+
+/* config variable managed via guc.c */
+extern int MultiShardCommitProtocol;
 
 
 /* Functions declarations for transaction and connection management */


### PR DESCRIPTION
This change renames the distributed transaction manager parameter from
citus.copy_transaction_manager to citus.multi_shard_commit_protocol.

Distributed transaction manager has been used only by the COPY on hash
partitioned tables but it can be used by upcoming features so, we needed
to rename so that its name do not contain a reference to COPY.

The change also includes renames like transaction_manager_options to
commit_protocol_options and TRANSACTION_MANAGER_1PC to COMMIT_PROTOCOL_1PC.

With this change, declaration of MultiShardCommitProtocol (was
CopyTransactionManager) is moved from multi_copy.c to multi_transaction.c.