### PR TITLE
Add deprecation warning to copy_to_distributed_table

### DIFF
--- a/src/bin/scripts/copy_to_distributed_table
+++ b/src/bin/scripts/copy_to_distributed_table
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+echo "WARNING: copy_to_distributed_table is now deprecated." >&2
+echo "HINT: You can use \\COPY on distributed tables, which is a lot faster." >&2
 
 # make bash behave
 set -euo pipefail


### PR DESCRIPTION
Considered removing it, but as long as it's all over our docs it might be nicer to add a deprecation warning.

Closes #319 