### PR TITLE
Stamp 5.1

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -29,7 +29,7 @@ $(EXTENSION)--5.0.sql: $(EXTENSION).sql
 	cat $^ > $@
 $(EXTENSION)--5.0-1.sql: $(EXTENSION)--5.0.sql $(EXTENSION)--5.0--5.0-1.sql
 	cat $^ > $@
-$(EXTENSION)--5.0-2.sql: $(EXTENSION)--5.0.sql $(EXTENSION)--5.0--5.0-1.sql $(EXTENSION)--5.0-1--5.0-2.sql
+$(EXTENSION)--5.0-2.sql: $(EXTENSION)--5.0-1.sql $(EXTENSION)--5.0-1--5.0-2.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -5,7 +5,9 @@ citus_top_builddir = ../../..
 
 MODULE_big = citus
 EXTENSION = citus
-EXTVERSIONS = 5.0 5.0-1 5.0-2
+EXTVERSIONS = 5.0 5.0-1 5.0-2  \
+	5.1-1
+
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
 # Generated files for each version
@@ -30,6 +32,8 @@ $(EXTENSION)--5.0.sql: $(EXTENSION).sql
 $(EXTENSION)--5.0-1.sql: $(EXTENSION)--5.0.sql $(EXTENSION)--5.0--5.0-1.sql
 	cat $^ > $@
 $(EXTENSION)--5.0-2.sql: $(EXTENSION)--5.0-1.sql $(EXTENSION)--5.0-1--5.0-2.sql
+	cat $^ > $@
+$(EXTENSION)--5.1-1.sql: $(EXTENSION)--5.0-2.sql $(EXTENSION)--5.0-2--5.1-1.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--5.0-2--5.1-1.sql
+++ b/src/backend/distributed/citus--5.0-2--5.1-1.sql
@@ -1,0 +1,3 @@
+/* citus--5.0-2--5.1-1.sql */
+
+/* empty, but required to update the extension version */

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '5.0-2'
+default_version = '5.1-1'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -12,6 +12,7 @@ DROP EXTENSION citus;
 CREATE EXTENSION citus VERSION '5.0';
 ALTER EXTENSION citus UPDATE TO '5.0-1';
 ALTER EXTENSION citus UPDATE TO '5.0-2';
+ALTER EXTENSION citus UPDATE TO '5.1-1';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -14,6 +14,7 @@ DROP EXTENSION citus;
 CREATE EXTENSION citus VERSION '5.0';
 ALTER EXTENSION citus UPDATE TO '5.0-1';
 ALTER EXTENSION citus UPDATE TO '5.0-2';
+ALTER EXTENSION citus UPDATE TO '5.1-1';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;


### PR DESCRIPTION
I wondered about continuing the "version" number scheme into 5.1 (i.e. making it 5.1-3), but decided against it, because the current scheme would continue to work if we'd discovered that we need to add a schema fixup in a released branch.