### PR TITLE
Fix check-full failures

### DIFF
--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -2,6 +2,7 @@
 -- MULTI_EXPLAIN
 --
 \a\t
+SET citus.task_executor_type TO 'real-time';
 SET citus.explain_distributed_queries TO on;
 -- Test Text format
 EXPLAIN (COSTS FALSE, FORMAT TEXT)

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -2,6 +2,7 @@
 -- MULTI_EXPLAIN
 --
 \a\t
+SET citus.task_executor_type TO 'real-time';
 SET citus.explain_distributed_queries TO on;
 -- Test Text format
 EXPLAIN (COSTS FALSE, FORMAT TEXT)

--- a/src/test/regress/expected/multi_hash_pruning.out
+++ b/src/test/regress/expected/multi_hash_pruning.out
@@ -31,6 +31,14 @@ SELECT master_create_worker_shards('orders_hash_partitioned', 4, 1);
 SET client_min_messages TO DEBUG2;
 -- Check that we can prune shards for simple cases, boolean expressions and
 -- immutable functions.
+-- Since router plans are not triggered for task-tracker executor type,
+-- we need to run the tests that triggers router planning seperately for
+-- both executors. Otherwise, check-full fails on the task-tracker.
+-- Later, we need to switch back to the actual task executor
+-- to contuinue with correct executor type for check-full.
+SELECT quote_literal(current_setting('citus.task_executor_type')) AS actual_task_executor
+\gset
+SET citus.task_executor_type TO 'real-time';
 SELECT count(*) FROM orders_hash_partitioned;
  count 
 -------
@@ -81,6 +89,92 @@ DEBUG:  Plan is router executable
      0
 (1 row)
 
+SELECT count(*) FROM orders_hash_partitioned
+	WHERE o_orderkey = 1 AND o_clerk = 'aaa';
+DEBUG:  Creating router plan
+DEBUG:  predicate pruning for shardId 102034
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+DEBUG:  Plan is router executable
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = abs(-1);
+DEBUG:  Creating router plan
+DEBUG:  predicate pruning for shardId 102034
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+DEBUG:  Plan is router executable
+ count 
+-------
+     0
+(1 row)
+
+SET citus.task_executor_type TO 'task-tracker';
+SELECT count(*) FROM orders_hash_partitioned;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 1;
+DEBUG:  predicate pruning for shardId 102034
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 2;
+DEBUG:  predicate pruning for shardId 102033
+DEBUG:  predicate pruning for shardId 102034
+DEBUG:  predicate pruning for shardId 102035
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 3;
+DEBUG:  predicate pruning for shardId 102033
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 4;
+DEBUG:  predicate pruning for shardId 102033
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned
+	WHERE o_orderkey = 1 AND o_clerk = 'aaa';
+DEBUG:  predicate pruning for shardId 102034
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = abs(-1);
+DEBUG:  predicate pruning for shardId 102034
+DEBUG:  predicate pruning for shardId 102035
+DEBUG:  predicate pruning for shardId 102036
+ count 
+-------
+     0
+(1 row)
+
+SET citus.task_executor_type TO :actual_task_executor;
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey is NULL;
 DEBUG:  predicate pruning for shardId 102033
 DEBUG:  predicate pruning for shardId 102034
@@ -119,18 +213,6 @@ SELECT count(*) FROM orders_hash_partitioned
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned
-	WHERE o_orderkey = 1 AND o_clerk = 'aaa';
-DEBUG:  Creating router plan
-DEBUG:  predicate pruning for shardId 102034
-DEBUG:  predicate pruning for shardId 102035
-DEBUG:  predicate pruning for shardId 102036
-DEBUG:  Plan is router executable
- count 
--------
-     0
-(1 row)
-
-SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 OR (o_orderkey = 3 AND o_clerk = 'aaa');
 DEBUG:  predicate pruning for shardId 102035
 DEBUG:  predicate pruning for shardId 102036
@@ -153,17 +235,6 @@ SELECT count(*) FROM
 DEBUG:  predicate pruning for shardId 102034
 DEBUG:  predicate pruning for shardId 102035
 DEBUG:  predicate pruning for shardId 102036
- count 
--------
-     0
-(1 row)
-
-SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = abs(-1);
-DEBUG:  Creating router plan
-DEBUG:  predicate pruning for shardId 102034
-DEBUG:  predicate pruning for shardId 102035
-DEBUG:  predicate pruning for shardId 102036
-DEBUG:  Plan is router executable
  count 
 -------
      0

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -4,6 +4,7 @@
 
 \a\t
 
+SET citus.task_executor_type TO 'real-time';
 SET citus.explain_distributed_queries TO on;
 
 -- Test Text format


### PR DESCRIPTION
This commit fixes failures happen during check-full. The change does make
clean separation of executor types in certain places to keep the outputs
stable.

Now check-full passes for both pg_9.4 and pg_9.5.