### PR TITLE
Add complex count distinct support

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4343,13 +4343,16 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 		{
 			StringInfo mergeTableQueryString =
 				MergeTableQueryString(taskIdIndex, targetEntryList);
+			char *escapedMergeTableQueryString =
+				quote_literal_cstr(mergeTableQueryString->data);
 			StringInfo intermediateTableQueryString =
 				IntermediateTableQueryString(jobId, taskIdIndex, reduceQuery);
-
+			char *escapedIntermediateTableQueryString =
+				quote_literal_cstr(intermediateTableQueryString->data);
 			StringInfo mergeAndRunQueryString = makeStringInfo();
 			appendStringInfo(mergeAndRunQueryString, MERGE_FILES_AND_RUN_QUERY_COMMAND,
-							 jobId, taskIdIndex, mergeTableQueryString->data,
-							 intermediateTableQueryString->data);
+							 jobId, taskIdIndex, escapedMergeTableQueryString,
+							 escapedIntermediateTableQueryString);
 
 			mergeTask = CreateBasicTask(jobId, mergeTaskId, MERGE_TASK,
 										mergeAndRunQueryString->data);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -41,7 +41,7 @@
 #define MERGE_FILES_INTO_TABLE_COMMAND "SELECT worker_merge_files_into_table \
  (" UINT64_FORMAT ", %d, '%s', '%s')"
 #define MERGE_FILES_AND_RUN_QUERY_COMMAND \
-	"SELECT worker_merge_files_and_run_query(" UINT64_FORMAT ", %d, '%s', '%s')"
+	"SELECT worker_merge_files_and_run_query(" UINT64_FORMAT ", %d, %s, %s)"
 
 
 typedef enum CitusRTEKind

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -16,3 +16,4 @@
 /multi_subquery.out
 /multi_subquery_0.out
 /worker_copy.out
+/multi_complex_count_distinct.out

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -920,9 +920,20 @@ SELECT
 		articles_hash
  	GROUP BY
 		author_id;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  aggregate (distinct) on complex expressions is unsupported
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ c 
+---
+ 4
+ 5
+ 5
+ 5
+ 5
+ 5
+ 5
+ 5
+ 5
+ 5
+(10 rows)
+
 -- queries inside transactions can be router plannable
 BEGIN;
 SELECT *

--- a/src/test/regress/expected/multi_single_relation_subquery.out
+++ b/src/test/regress/expected/multi_single_relation_subquery.out
@@ -171,9 +171,9 @@ from
         l_tax) as distributed_table;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Subqueries without aggregates are not supported yet
--- Check that we don't support subqueries with count(distinct).
+-- Check that we support subqueries with count(distinct).
 select
-    different_shipment_days
+    avg(different_shipment_days)
 from
     (select
         count(distinct l_shipdate) as different_shipment_days
@@ -181,8 +181,11 @@ from
         lineitem
     group by
         l_partkey) as distributed_table;
-ERROR:  cannot compute count (distinct)
-DETAIL:  Subqueries with aggregate (distinct) are not supported yet
+          avg           
+------------------------
+ 1.02907126318497555956
+(1 row)
+
 -- Check that if subquery is pulled, we don't error and run query properly.
 SELECT max(l_suppkey) FROM
 (

--- a/src/test/regress/input/multi_complex_count_distinct.source
+++ b/src/test/regress/input/multi_complex_count_distinct.source
@@ -1,0 +1,284 @@
+--
+-- COMPLEX_COUNT_DISTINCT
+--
+
+CREATE TABLE lineitem_hash (
+	l_orderkey bigint not null,
+	l_partkey integer not null,
+	l_suppkey integer not null,
+	l_linenumber integer not null,
+	l_quantity decimal(15, 2) not null,
+	l_extendedprice decimal(15, 2) not null,
+	l_discount decimal(15, 2) not null,
+	l_tax decimal(15, 2) not null,
+	l_returnflag char(1) not null,
+	l_linestatus char(1) not null,
+	l_shipdate date not null,
+	l_commitdate date not null,
+	l_receiptdate date not null,
+	l_shipinstruct char(25) not null,
+	l_shipmode char(10) not null,
+	l_comment varchar(44) not null,
+	PRIMARY KEY(l_orderkey, l_linenumber) );
+	
+SELECT master_create_distributed_table('lineitem_hash', 'l_orderkey', 'hash');
+SELECT master_create_worker_shards('lineitem_hash', 8, 1);
+
+\COPY lineitem_hash FROM '@abs_srcdir@/data/lineitem.1.data' with delimiter '|'
+\COPY lineitem_hash FROM '@abs_srcdir@/data/lineitem.2.data' with delimiter '|'
+
+SET citus.task_executor_type to "task-tracker";
+
+-- count(distinct) is supported on top level query if there
+-- is a grouping on the partition key	
+SELECT
+	l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- it is not supported if there is no grouping or grouping is on non-partition field
+SELECT
+	count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	ORDER BY 1 DESC
+	LIMIT 10;
+
+SELECT
+	l_shipmode, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- count distinct is supported on single table subqueries
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT l_partkey)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+SELECT *
+	FROM (
+		SELECT
+			l_partkey, count(DISTINCT l_orderkey)
+			FROM lineitem_hash
+			GROUP BY l_partkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- case expr in count distinct is supported.
+-- count orders partkeys if l_shipmode is air
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT CASE WHEN l_shipmode = 'AIR' THEN l_partkey ELSE NULL END) as count
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	WHERE count > 0
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- text like operator is also supported
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT CASE WHEN l_shipmode like '%A%' THEN l_partkey ELSE NULL END) as count
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	WHERE count > 0
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- count distinct is rejected if it does not reference any columns
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT 1)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- count distinct is rejected if it does not reference any columns
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT (random() * 5)::int)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- even non-const function calls are supported within count distinct
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT (random() * 5)::int = l_linenumber)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 0;
+
+-- multiple nested subquery
+SELECT
+    total,
+    avg(avg_count) as total_avg_count
+	FROM (
+		SELECT
+	        number_sum,
+	        count(DISTINCT l_suppkey) as total,
+	        avg(total_count) avg_count
+    		FROM (
+    			SELECT
+    				l_suppkey,
+					sum(l_linenumber) as number_sum,
+					count(DISTINCT l_shipmode) as total_count
+					FROM
+						lineitem_hash
+					WHERE
+						l_partkey > 100 and
+						l_quantity > 2 and
+						l_orderkey < 10000
+					GROUP BY
+						l_suppkey) as distributed_table
+			WHERE
+				number_sum >= 10
+			GROUP BY
+				number_sum) as distributed_table_2
+	GROUP BY
+		total
+	ORDER BY
+		total_avg_count DESC;
+
+-- multiple cases query
+SELECT *
+	FROM (
+		SELECT
+			count(DISTINCT
+				CASE
+					WHEN l_shipmode = 'TRUCK' THEN l_partkey
+					WHEN l_shipmode = 'AIR' THEN l_quantity
+					WHEN l_shipmode = 'SHIP' THEN l_discount
+					ELSE l_suppkey
+				END) as count,
+			l_shipdate
+		FROM
+			lineitem_hash
+		GROUP BY
+			l_shipdate) sub
+	WHERE
+		count > 0
+	ORDER BY
+		1 DESC, 2 DESC
+	LIMIT 10;
+
+-- count DISTINCT expression
+SELECT *
+	FROM (
+		SELECT
+			l_quantity, count(DISTINCT ((l_orderkey / 1000)  * 1000 ))  as count
+			FROM
+				lineitem_hash
+			GROUP BY
+				l_quantity) sub
+	WHERE
+		count > 0
+	ORDER BY
+		2 DESC, 1 DESC
+	LIMIT 10;
+
+-- count DISTINCT is part of an expression which inclues another aggregate
+SELECT *
+	FROM (
+		SELECT
+			sum(((l_partkey * l_tax) / 100)) /
+				count(DISTINCT
+					CASE
+						WHEN l_shipmode = 'TRUCK' THEN l_partkey
+						ELSE l_suppkey
+					END) as avg,
+			l_shipmode
+			FROM
+				lineitem_hash
+			GROUP BY
+				l_shipmode) sub
+	ORDER BY
+		1 DESC, 2 DESC
+	LIMIT 10;
+
+--- count DISTINCT CASE WHEN expression
+SELECT *
+	FROM (
+		SELECT
+			count(DISTINCT
+				CASE
+					WHEN l_shipmode = 'TRUCK' THEN l_linenumber
+					WHEN l_shipmode = 'AIR' THEN l_linenumber + 10
+					ELSE 2
+				END) as avg
+			FROM
+				lineitem_hash
+			GROUP BY  l_shipdate) sub
+	ORDER BY 1 DESC
+	LIMIT 10;
+
+-- COUNT DISTINCT (c1, c2)
+SELECT *
+	FROM
+		(SELECT
+			l_shipmode,
+			count(DISTINCT (l_shipdate, l_tax))
+			FROM
+				lineitem_hash
+			GROUP BY
+				l_shipmode) t
+	ORDER BY
+		2 DESC,1 DESC
+	LIMIT 10;
+
+-- other distinct aggregate are not supported
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, sum(DISTINCT l_partkey)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, avg(DISTINCT l_partkey)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- whole row references, oid, and ctid are not supported in count distinct
+-- test table does not have oid or ctid enabled, so tests for them are skipped
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT lineitem_hash)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT lineitem_hash.*)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+DROP TABLE lineitem_hash;
+

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -144,3 +144,8 @@ test: multi_large_shardid
 # multi_drop_extension makes sure we can safely drop and recreate the extension
 # ----------
 test: multi_drop_extension
+
+# ----------
+# multi_complex_count_distinct creates table lineitem_hash, creates shards and load data
+# ----------
+test: multi_complex_count_distinct

--- a/src/test/regress/output/multi_complex_count_distinct.source
+++ b/src/test/regress/output/multi_complex_count_distinct.source
@@ -1,0 +1,438 @@
+--
+-- COMPLEX_COUNT_DISTINCT
+--
+CREATE TABLE lineitem_hash (
+	l_orderkey bigint not null,
+	l_partkey integer not null,
+	l_suppkey integer not null,
+	l_linenumber integer not null,
+	l_quantity decimal(15, 2) not null,
+	l_extendedprice decimal(15, 2) not null,
+	l_discount decimal(15, 2) not null,
+	l_tax decimal(15, 2) not null,
+	l_returnflag char(1) not null,
+	l_linestatus char(1) not null,
+	l_shipdate date not null,
+	l_commitdate date not null,
+	l_receiptdate date not null,
+	l_shipinstruct char(25) not null,
+	l_shipmode char(10) not null,
+	l_comment varchar(44) not null,
+	PRIMARY KEY(l_orderkey, l_linenumber) );
+	
+SELECT master_create_distributed_table('lineitem_hash', 'l_orderkey', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('lineitem_hash', 8, 1);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+\COPY lineitem_hash FROM '@abs_srcdir@/data/lineitem.1.data' with delimiter '|'
+\COPY lineitem_hash FROM '@abs_srcdir@/data/lineitem.2.data' with delimiter '|'
+SET citus.task_executor_type to "task-tracker";
+-- count(distinct) is supported on top level query if there
+-- is a grouping on the partition key	
+SELECT
+	l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ l_orderkey | count 
+------------+-------
+      14885 |     7
+      14884 |     7
+      14821 |     7
+      14790 |     7
+      14785 |     7
+      14755 |     7
+      14725 |     7
+      14694 |     7
+      14627 |     7
+      14624 |     7
+(10 rows)
+
+-- it is not supported if there is no grouping or grouping is on non-partition field
+SELECT
+	count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	ORDER BY 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  table partitioning is unsuitable for aggregate (distinct)
+HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+SELECT
+	l_shipmode, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  table partitioning is unsuitable for aggregate (distinct)
+HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+-- count distinct is supported on single table subqueries
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT l_partkey)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ l_orderkey | count 
+------------+-------
+      14885 |     7
+      14884 |     7
+      14821 |     7
+      14790 |     7
+      14785 |     7
+      14755 |     7
+      14725 |     7
+      14694 |     7
+      14627 |     7
+      14624 |     7
+(10 rows)
+
+SELECT *
+	FROM (
+		SELECT
+			l_partkey, count(DISTINCT l_orderkey)
+			FROM lineitem_hash
+			GROUP BY l_partkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ l_partkey | count 
+-----------+-------
+    199146 |     3
+    188804 |     3
+    177771 |     3
+    160895 |     3
+    149926 |     3
+    136884 |     3
+     87761 |     3
+     15283 |     3
+      6983 |     3
+      1927 |     3
+(10 rows)
+
+-- case expr in count distinct is supported.
+-- count orders partkeys if l_shipmode is air
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT CASE WHEN l_shipmode = 'AIR' THEN l_partkey ELSE NULL END) as count
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	WHERE count > 0
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ l_orderkey | count 
+------------+-------
+      12005 |     4
+       5409 |     4
+       4964 |     4
+      14848 |     3
+      14496 |     3
+      13473 |     3
+      13122 |     3
+      12929 |     3
+      12645 |     3
+      12417 |     3
+(10 rows)
+
+-- text like operator is also supported
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT CASE WHEN l_shipmode like '%A%' THEN l_partkey ELSE NULL END) as count
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	WHERE count > 0
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ l_orderkey | count 
+------------+-------
+      14275 |     7
+      14181 |     7
+      13605 |     7
+      12707 |     7
+      12384 |     7
+      11746 |     7
+      10727 |     7
+      10467 |     7
+       5636 |     7
+       4614 |     7
+(10 rows)
+
+-- count distinct is rejected if it does not reference any columns
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT 1)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  aggregate (distinct) with no columns is unsupported
+HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+-- count distinct is rejected if it does not reference any columns
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT (random() * 5)::int)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  aggregate (distinct) with no columns is unsupported
+HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+-- even non-const function calls are supported within count distinct
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT (random() * 5)::int = l_linenumber)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 0;
+ l_orderkey | count 
+------------+-------
+(0 rows)
+
+-- multiple nested subquery
+SELECT
+    total,
+    avg(avg_count) as total_avg_count
+	FROM (
+		SELECT
+	        number_sum,
+	        count(DISTINCT l_suppkey) as total,
+	        avg(total_count) avg_count
+    		FROM (
+    			SELECT
+    				l_suppkey,
+					sum(l_linenumber) as number_sum,
+					count(DISTINCT l_shipmode) as total_count
+					FROM
+						lineitem_hash
+					WHERE
+						l_partkey > 100 and
+						l_quantity > 2 and
+						l_orderkey < 10000
+					GROUP BY
+						l_suppkey) as distributed_table
+			WHERE
+				number_sum >= 10
+			GROUP BY
+				number_sum) as distributed_table_2
+	GROUP BY
+		total
+	ORDER BY
+		total_avg_count DESC;
+ total |  total_avg_count   
+-------+--------------------
+     1 | 3.6000000000000000
+     6 | 2.8333333333333333
+    10 | 2.6000000000000000
+    27 | 2.5555555555555556
+    32 | 2.4687500000000000
+    77 | 2.1948051948051948
+    57 | 2.1754385964912281
+(7 rows)
+
+-- multiple cases query
+SELECT *
+	FROM (
+		SELECT
+			count(DISTINCT
+				CASE
+					WHEN l_shipmode = 'TRUCK' THEN l_partkey
+					WHEN l_shipmode = 'AIR' THEN l_quantity
+					WHEN l_shipmode = 'SHIP' THEN l_discount
+					ELSE l_suppkey
+				END) as count,
+			l_shipdate
+		FROM
+			lineitem_hash
+		GROUP BY
+			l_shipdate) sub
+	WHERE
+		count > 0
+	ORDER BY
+		1 DESC, 2 DESC
+	LIMIT 10;
+ count | l_shipdate 
+-------+------------
+    14 | 07-30-1997
+    13 | 05-26-1998
+    13 | 08-08-1997
+    13 | 11-17-1995
+    13 | 01-09-1993
+    12 | 01-15-1998
+    12 | 10-15-1997
+    12 | 09-07-1997
+    12 | 06-02-1997
+    12 | 03-14-1997
+(10 rows)
+
+-- count DISTINCT expression
+SELECT *
+	FROM (
+		SELECT
+			l_quantity, count(DISTINCT ((l_orderkey / 1000)  * 1000 ))  as count
+			FROM
+				lineitem_hash
+			GROUP BY
+				l_quantity) sub
+	WHERE
+		count > 0
+	ORDER BY
+		2 DESC, 1 DESC
+	LIMIT 10;
+ l_quantity | count 
+------------+-------
+      48.00 |    13
+      47.00 |    13
+      37.00 |    13
+      33.00 |    13
+      26.00 |    13
+      25.00 |    13
+      23.00 |    13
+      21.00 |    13
+      15.00 |    13
+      12.00 |    13
+(10 rows)
+
+-- count DISTINCT is part of an expression which inclues another aggregate
+SELECT *
+	FROM (
+		SELECT
+			sum(((l_partkey * l_tax) / 100)) /
+				count(DISTINCT
+					CASE
+						WHEN l_shipmode = 'TRUCK' THEN l_partkey
+						ELSE l_suppkey
+					END) as avg,
+			l_shipmode
+			FROM
+				lineitem_hash
+			GROUP BY
+				l_shipmode) sub
+	ORDER BY
+		1 DESC, 2 DESC
+	LIMIT 10;
+           avg           | l_shipmode 
+-------------------------+------------
+ 44.82904609027336300064 | MAIL      
+ 44.80704536679536679537 | SHIP      
+ 44.68891732736572890026 | AIR       
+ 44.34106724470134874759 | REG AIR   
+ 43.12739987269255251432 | FOB       
+ 43.07299253636938646426 | RAIL      
+ 40.50298377916903813318 | TRUCK     
+(7 rows)
+
+--- count DISTINCT CASE WHEN expression
+SELECT *
+	FROM (
+		SELECT
+			count(DISTINCT
+				CASE
+					WHEN l_shipmode = 'TRUCK' THEN l_linenumber
+					WHEN l_shipmode = 'AIR' THEN l_linenumber + 10
+					ELSE 2
+				END) as avg
+			FROM
+				lineitem_hash
+			GROUP BY  l_shipdate) sub
+	ORDER BY 1 DESC
+	LIMIT 10;
+ avg 
+-----
+   7
+   6
+   6
+   6
+   6
+   6
+   6
+   6
+   5
+   5
+(10 rows)
+
+-- COUNT DISTINCT (c1, c2)
+SELECT *
+	FROM
+		(SELECT
+			l_shipmode,
+			count(DISTINCT (l_shipdate, l_tax))
+			FROM
+				lineitem_hash
+			GROUP BY
+				l_shipmode) t
+	ORDER BY
+		2 DESC,1 DESC
+	LIMIT 10;
+ l_shipmode | count 
+------------+-------
+ TRUCK      |  1689
+ MAIL       |  1683
+ FOB        |  1655
+ AIR        |  1650
+ SHIP       |  1644
+ RAIL       |  1636
+ REG AIR    |  1607
+(7 rows)
+
+-- other distinct aggregate are not supported
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, sum(DISTINCT l_partkey)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  Only count(distinct) aggregate is supported in subqueries
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, avg(DISTINCT l_partkey)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  Only count(distinct) aggregate is supported in subqueries
+-- whole row references, oid, and ctid are not supported in count distinct
+-- test table does not have oid or ctid enabled, so tests for them are skipped
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT lineitem_hash)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute count (distinct)
+DETAIL:  Non-column references are not supported yet
+SELECT *
+	FROM (
+		SELECT
+			l_orderkey, count(DISTINCT lineitem_hash.*)
+			FROM lineitem_hash
+			GROUP BY l_orderkey) sub
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  cannot compute count (distinct)
+DETAIL:  Non-column references are not supported yet
+DROP TABLE lineitem_hash;

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -14,3 +14,4 @@
 /multi_stage_more_data.sql
 /multi_subquery.sql
 /worker_copy.sql
+/multi_complex_count_distinct.sql

--- a/src/test/regress/sql/multi_single_relation_subquery.sql
+++ b/src/test/regress/sql/multi_single_relation_subquery.sql
@@ -125,10 +125,10 @@ from
     group by
         l_tax) as distributed_table;
 
--- Check that we don't support subqueries with count(distinct).
+-- Check that we support subqueries with count(distinct).
 
 select
-    different_shipment_days
+    avg(different_shipment_days)
 from
     (select
         count(distinct l_shipdate) as different_shipment_days


### PR DESCRIPTION
We can now support complex count distinct in queries in single table subqueries with repartitioning, i.e. queries like

```sql
SELECT *
FROM (
	SELECT 
		l_orderkey, count(DISTINCT CASE WHEN l_shipmode = 'AIR' THEN l_partkey ELSE NULL END) as count 
	FROM 
		lineitem 
	GROUP BY
		l_orderkey) sub
WHERE count > 0
ORDER BY 2 DESC, 1 DESC 
LIMIT 10;
```

Fixes #434 and #365 

Solution involves adding columns in count distinct aggregate to target list, and to the group by list of worker re-partition query. Actual count distinct operation is performed while merging the partitions during reduce.

Note that the fix is specific to single table subqueries, single level repartition queries can not have complex count distinct aggregates yet.
