### PR TITLE
Change duplicated function name - RecieveRegularFile()

### DIFF
--- a/src/backend/distributed/commands/transmit.c
+++ b/src/backend/distributed/commands/transmit.c
@@ -31,12 +31,12 @@ static bool ReceiveCopyData(StringInfo copyData);
 
 
 /*
- * ReceiveRegularFile receives data from stdin using the standard copy
+ * RedirectCopyDataToRegularFile receives data from stdin using the standard copy
  * protocol. The function then creates or truncates a file with the given
  * filename, and appends received data to this file.
  */
 void
-ReceiveRegularFile(const char *filename)
+RedirectCopyDataToRegularFile(const char *filename)
 {
 	StringInfo copyData = makeStringInfo();
 	bool copyDone = false;

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -123,7 +123,7 @@ multi_ProcessUtility(Node *parsetree,
 		/* ->relation->relname is the target file in our overloaded COPY */
 		if (copyStatement->is_from)
 		{
-			ReceiveRegularFile(copyStatement->relation->relname);
+			RedirectCopyDataToRegularFile(copyStatement->relation->relname);
 		}
 		else
 		{

--- a/src/include/distributed/transmit.h
+++ b/src/include/distributed/transmit.h
@@ -15,7 +15,7 @@
 
 
 /* Function declarations for transmitting files between two nodes */
-extern void ReceiveRegularFile(const char *filename);
+extern void RedirectCopyDataToRegularFile(const char *filename);
 extern void SendRegularFile(const char *filename);
 
 /* Function declaration local to commands and worker modules */


### PR DESCRIPTION
Fixes #469 

There were two functions named as ReceiveRegularFile. One of them actually receives a file from remote node, the other one reads the data from stdin and redirects it to a file. This change renames second ReceiveRegularFile function with more descriptive name.

@anarazel Andres since you opened the issue, could you also review the change?