### PR TITLE
Remove redundant implementations of error funcs.

### DIFF
--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -137,12 +137,12 @@ ERROR:  creating unique indexes on append-partitioned tables is currently unsupp
 CREATE INDEX lineitem_orderkey_index ON lineitem (l_orderkey);
 ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
-WARNING:  could not receive query results from localhost:57637
-DETAIL:  Client error: data type bigint has no default operator class for access method "gist"
+WARNING:  Bad result from localhost:57637
+DETAIL:  Remote message: data type bigint has no default operator class for access method "gist"
 ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX try_index ON lineitem (non_existent_column);
-WARNING:  could not receive query results from localhost:57637
-DETAIL:  Client error: column "non_existent_column" does not exist
+WARNING:  Bad result from localhost:57637
+DETAIL:  Remote message: column "non_existent_column" does not exist
 ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX ON lineitem (l_orderkey);
 ERROR:  creating index without a name on a distributed table is currently unsupported

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -260,8 +260,8 @@ ALTER TABLE IF EXISTS non_existent_table ADD COLUMN new_column INTEGER;
 NOTICE:  relation "non_existent_table" does not exist, skipping
 ALTER TABLE IF EXISTS lineitem_alter ALTER COLUMN int_column2 SET DATA TYPE INTEGER;
 ALTER TABLE lineitem_alter DROP COLUMN non_existent_column;
-WARNING:  could not receive query results from localhost:57638
-DETAIL:  Client error: column "non_existent_column" of relation "lineitem_alter_103000" does not exist
+WARNING:  Bad result from localhost:57638
+DETAIL:  Remote message: column "non_existent_column" of relation "lineitem_alter_103000" does not exist
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 NOTICE:  column "non_existent_column" of relation "lineitem_alter" does not exist, skipping
@@ -360,16 +360,16 @@ DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT and TYPE subc
 -- Verify that we error out in case of postgres errors on supported statement
 -- types
 ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
-WARNING:  could not receive query results from localhost:57638
-DETAIL:  Client error: type "non_existent_type" does not exist
+WARNING:  Bad result from localhost:57638
+DETAIL:  Remote message: type "non_existent_type" does not exist
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
-WARNING:  could not receive query results from localhost:57638
-DETAIL:  Client error: column "null_column" contains null values
+WARNING:  Bad result from localhost:57638
+DETAIL:  Remote message: column "null_column" contains null values
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
-WARNING:  could not receive query results from localhost:57638
-DETAIL:  Client error: invalid input syntax for integer: "a"
+WARNING:  Bad result from localhost:57638
+DETAIL:  Remote message: invalid input syntax for integer: "a"
 ERROR:  could not execute DDL command on worker node shards
 -- Verify that we error out on statements involving RENAME
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -332,8 +332,8 @@ COPY customer_worker_copy_append FROM '@abs_srcdir@/data/customer.1.data' with (
 COPY customer_worker_copy_append FROM '@abs_srcdir@/data/customer.2.data' with (delimiter '|', master_host 'localhost', master_port 57636);
 -- Test if there is no relation to copy data with the worker copy
 COPY lineitem_copy_none FROM '@abs_srcdir@/data/lineitem.1.data' with (delimiter '|', master_host 'localhost', master_port 57636);
-WARNING:  could not receive query results from localhost:57636
-DETAIL:  Client error: relation "lineitem_copy_none" does not exist
+WARNING:  Bad result from localhost:57636
+DETAIL:  Remote message: relation "lineitem_copy_none" does not exist
 ERROR:  could not run copy from the worker node
 -- Connect back to the master node
 \c - - - 57636


### PR DESCRIPTION
This patch does some basic cleaning jobs. It removes duplicated
implementations of ReportRemoteError() and related ones and adjusts
regression tests.