### PR TITLE
Change equality operator check for operator expressions

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -3364,8 +3364,7 @@ SupportedLateralQuery(Query *parentQuery, Query *lateralQuery)
 	{
 		OpExpr *operatorExpression = NULL;
 		List *argumentList = NIL;
-		char *operatorName = NULL;
-		int equalsOperator = 0;
+		bool equalsOperator = false;
 		Expr *leftArgument = NULL;
 		Expr *rightArgument = NULL;
 		Expr *outerQueryExpression = NULL;
@@ -3396,15 +3395,8 @@ SupportedLateralQuery(Query *parentQuery, Query *lateralQuery)
 			continue;
 		}
 
-		/*
-		 * We accept all column types that can be joined with an equals sign as
-		 * valid. These include columns that have cross-type equals operators
-		 * (such as int48eq) and columns that can be casted at run-time (such as
-		 * from numeric to int4).
-		 */
-		operatorName = get_opname(operatorExpression->opno);
-		equalsOperator = strncmp(operatorName, EQUAL_OPERATOR_STRING, NAMEDATALEN);
-		if (equalsOperator != 0)
+		equalsOperator = OperatorImplementsEquality(operatorExpression->opno);
+		if (!equalsOperator)
 		{
 			continue;
 		}

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2861,9 +2861,8 @@ HashableClauseMutator(Node *originalNode, Var *partitionColumn)
 		ScalarArrayOpExpr *arrayOperatorExpression = (ScalarArrayOpExpr *) originalNode;
 		Node *leftOpExpression = linitial(arrayOperatorExpression->args);
 		Node *strippedLeftOpExpression = strip_implicit_coercions(leftOpExpression);
-		char *operatorName = get_opname(arrayOperatorExpression->opno);
-		int equalsCompare = strncmp(operatorName, EQUAL_OPERATOR_STRING, NAMEDATALEN);
-		bool usingEqualityOperator = (equalsCompare == 0);
+		bool usingEqualityOperator = OperatorImplementsEquality(
+			arrayOperatorExpression->opno);
 
 		/*
 		 * Citus cannot prune hash-distributed shards with ANY/ALL. We show a NOTICE

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1009,8 +1009,6 @@ ColumnMatchExpressionAtTopLevelConjunction(Node *node, Var *column)
 		OpExpr *opExpr = (OpExpr *) node;
 		bool simpleExpression = SimpleOpExpression((Expr *) opExpr);
 		bool columnInExpr = false;
-		char *operatorName = NULL;
-		int operatorNameComparison = 0;
 		bool usingEqualityOperator = false;
 
 		if (!simpleExpression)
@@ -1024,10 +1022,7 @@ ColumnMatchExpressionAtTopLevelConjunction(Node *node, Var *column)
 			return false;
 		}
 
-		operatorName = get_opname(opExpr->opno);
-		operatorNameComparison = strncmp(operatorName, EQUAL_OPERATOR_STRING,
-										 NAMEDATALEN);
-		usingEqualityOperator = (operatorNameComparison == 0);
+		usingEqualityOperator = OperatorImplementsEquality(opExpr->opno);
 
 		return usingEqualityOperator;
 	}

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -22,8 +22,6 @@
 #include "nodes/pg_list.h"
 
 
-/* Defines the operator string used for equi joins */
-#define EQUAL_OPERATOR_STRING "="
 #define SUBQUERY_RANGE_TABLE_ID -1
 #define SUBQUERY_RELATION_ID 10000
 #define HEAP_ANALYTICS_SUBQUERY_RELATION_ID 10001
@@ -201,6 +199,7 @@ extern List * TableEntryList(List *rangeTableList);
 extern bool ExtractRangeTableRelationWalker(Node *node, List **rangeTableList);
 extern bool ExtractRangeTableEntryWalker(Node *node, List **rangeTableList);
 extern List * pull_var_clause_default(Node *node);
+extern bool OperatorImplementsEquality(Oid opno);
 
 
 #endif   /* MULTI_LOGICAL_PLANNER_H */


### PR DESCRIPTION
This work changes how an operator type is checked to see if it is an equality operator. We used to get the operator name and compare it against string '='. 

Now we would be getting operator strategy, and check if this operator implement ```BTEqualStrategyNumber```

Fixes #467 