### PR TITLE
Fix wrong storage type for foreign tables

### DIFF
--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -158,7 +158,15 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	/* set shard storage type according to relation type */
 	if (relationKind == RELKIND_FOREIGN_TABLE)
 	{
-		shardStorageType = SHARD_STORAGE_FOREIGN;
+		bool cstoreTable = CStoreTable(distributedTableId);
+		if (cstoreTable)
+		{
+			shardStorageType = SHARD_STORAGE_COLUMNAR;
+		}
+		else
+		{
+			shardStorageType = SHARD_STORAGE_FOREIGN;
+		}
 	}
 	else
 	{

--- a/src/test/regress/expected/multi_fdw_storage_type.out
+++ b/src/test/regress/expected/multi_fdw_storage_type.out
@@ -1,0 +1,63 @@
+--
+-- MULTI_FDW_STORAGE_TYPE
+--
+-- Create two tables one regular and one foreign, then check whether
+-- shardstorage is correct
+-- explicitly set shard id
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 400000;
+-- create regular table
+CREATE TABLE people (
+	id bigint not null,
+	firstname char(10) not null,
+	lastname char(10) not null,
+	age integer not null);
+-- create distributed table
+SELECT master_create_distributed_table('people', 'id', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- create worker shards
+SELECT master_create_empty_shard('people');
+ master_create_empty_shard 
+---------------------------
+                    400000
+(1 row)
+
+-- check shardstorage
+SELECT shardstorage FROM pg_dist_shard WHERE shardid = 400000;
+ shardstorage 
+--------------
+ t
+(1 row)
+
+-- create foreign table
+CREATE FOREIGN TABLE people_foreign (
+	id bigint not null,
+	firstname char(10) not null,
+	lastname char(10) not null,
+	age integer not null)
+SERVER file_server 
+OPTIONS (format 'text', filename '', delimiter '|', null '');
+-- create distributed table
+SELECT master_create_distributed_table('people_foreign', 'id', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- create worker shards
+SELECT master_create_empty_shard('people_foreign');
+ master_create_empty_shard 
+---------------------------
+                    400001
+(1 row)
+
+-- check shardstorage
+SELECT shardstorage FROM pg_dist_shard WHERE shardid = 400001;
+ shardstorage 
+--------------
+ f
+(1 row)
+

--- a/src/test/regress/multi_fdw_schedule
+++ b/src/test/regress/multi_fdw_schedule
@@ -11,6 +11,7 @@
 test: multi_fdw_create_table
 test: multi_fdw_master_protocol
 test: multi_fdw_stage_data
+test: multi_fdw_storage_type
 
 # ----------
 # Parallel TPC-H tests to check our distributed execution behavior

--- a/src/test/regress/sql/multi_fdw_storage_type.sql
+++ b/src/test/regress/sql/multi_fdw_storage_type.sql
@@ -1,0 +1,43 @@
+--
+-- MULTI_FDW_STORAGE_TYPE
+--
+
+-- Create two tables one regular and one foreign, then check whether
+-- shardstorage is correct
+
+-- explicitly set shard id
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 400000;
+
+-- create regular table
+CREATE TABLE people (
+	id bigint not null,
+	firstname char(10) not null,
+	lastname char(10) not null,
+	age integer not null);
+
+-- create distributed table
+SELECT master_create_distributed_table('people', 'id', 'append');
+
+-- create worker shards
+SELECT master_create_empty_shard('people');
+
+-- check shardstorage
+SELECT shardstorage FROM pg_dist_shard WHERE shardid = 400000;
+
+-- create foreign table
+CREATE FOREIGN TABLE people_foreign (
+	id bigint not null,
+	firstname char(10) not null,
+	lastname char(10) not null,
+	age integer not null)
+SERVER file_server 
+OPTIONS (format 'text', filename '', delimiter '|', null '');
+
+-- create distributed table
+SELECT master_create_distributed_table('people_foreign', 'id', 'append');
+
+-- create worker shards
+SELECT master_create_empty_shard('people_foreign');
+
+-- check shardstorage
+SELECT shardstorage FROM pg_dist_shard WHERE shardid = 400001;


### PR DESCRIPTION
Fixes #496

Previously we do not check whether table is foreign or not while creating empty
shards, and set storage type to 't'(Standard table) or 'c'(Columnar table). Now
if the table is foreign table(but not CStore foreign table) we set storage
type to 'f'(Foreign table). If it is CStore foreign table, we set its storage
type to 'c', i.e. columnar table have priority over foreign table.

I also tested the issue in #497 and it is resolved as well with this change.

Please note that 'c' is only used for CStore tables not for other possible
columnar stores at the moment. Possible improvement could be checking for other
columnar stores, though I am not sure if there is a way to check it for all
other columnar stores.