### PR TITLE
Improve error handling during failed modification PR

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -827,7 +827,7 @@ MasterPartitionMethod(RangeVar *relation)
 	}
 	else
 	{
-		ReportRemoteError(masterConnection, queryResult);
+		ReportRemoteError(masterConnection, queryResult, false);
 		ereport(ERROR, (errmsg("could not get the partition method of the "
 							   "distributed table")));
 	}
@@ -924,7 +924,7 @@ OpenCopyTransactions(CopyStmt *copyStatement, ShardConnections *shardConnections
 		result = PQexec(connection, "BEGIN");
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 			failedPlacementList = lappend(failedPlacementList, placement);
 
 			PQclear(result);
@@ -937,7 +937,7 @@ OpenCopyTransactions(CopyStmt *copyStatement, ShardConnections *shardConnections
 		result = PQexec(connection, copyCommand->data);
 		if (PQresultStatus(result) != PGRES_COPY_IN)
 		{
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 			failedPlacementList = lappend(failedPlacementList, placement);
 
 			PQclear(result);
@@ -1504,7 +1504,7 @@ RemoteCreateEmptyShard(char *relationName)
 	}
 	else
 	{
-		ReportRemoteError(masterConnection, queryResult);
+		ReportRemoteError(masterConnection, queryResult, false);
 		ereport(ERROR, (errmsg("could not create a new empty shard on the remote node")));
 	}
 

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -827,7 +827,7 @@ MasterPartitionMethod(RangeVar *relation)
 	}
 	else
 	{
-		ReportRemoteError(masterConnection, queryResult, false);
+		WarnRemoteError(masterConnection, queryResult);
 		ereport(ERROR, (errmsg("could not get the partition method of the "
 							   "distributed table")));
 	}
@@ -924,7 +924,7 @@ OpenCopyTransactions(CopyStmt *copyStatement, ShardConnections *shardConnections
 		result = PQexec(connection, "BEGIN");
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result, false);
+			WarnRemoteError(connection, result);
 			failedPlacementList = lappend(failedPlacementList, placement);
 
 			PQclear(result);
@@ -937,7 +937,7 @@ OpenCopyTransactions(CopyStmt *copyStatement, ShardConnections *shardConnections
 		result = PQexec(connection, copyCommand->data);
 		if (PQresultStatus(result) != PGRES_COPY_IN)
 		{
-			ReportRemoteError(connection, result, false);
+			WarnRemoteError(connection, result);
 			failedPlacementList = lappend(failedPlacementList, placement);
 
 			PQclear(result);
@@ -1504,7 +1504,7 @@ RemoteCreateEmptyShard(char *relationName)
 	}
 	else
 	{
-		ReportRemoteError(masterConnection, queryResult, false);
+		WarnRemoteError(masterConnection, queryResult);
 		ereport(ERROR, (errmsg("could not create a new empty shard on the remote node")));
 	}
 

--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -141,7 +141,7 @@ MultiClientConnect(const char *nodeName, uint32 nodePort, const char *nodeDataba
 	}
 	else
 	{
-		ReportRemoteError(connection, NULL);
+		ReportRemoteError(connection, NULL, false);
 
 		PQfinish(connection);
 		connectionId = INVALID_CONNECTION_ID;
@@ -194,7 +194,7 @@ MultiClientConnectStart(const char *nodeName, uint32 nodePort, const char *nodeD
 	}
 	else
 	{
-		ReportRemoteError(connection, NULL);
+		ReportRemoteError(connection, NULL, false);
 
 		PQfinish(connection);
 		connectionId = INVALID_CONNECTION_ID;
@@ -249,7 +249,7 @@ MultiClientConnectPoll(int32 connectionId)
 	}
 	else if (pollingStatus == PGRES_POLLING_FAILED)
 	{
-		ReportRemoteError(connection, NULL);
+		ReportRemoteError(connection, NULL, false);
 
 		connectStatus = CLIENT_CONNECTION_BAD;
 	}
@@ -433,7 +433,7 @@ MultiClientQueryResult(int32 connectionId, void **queryResult, int *rowCount,
 	}
 	else
 	{
-		ReportRemoteError(connection, result);
+		ReportRemoteError(connection, result, false);
 		PQclear(result);
 	}
 
@@ -500,7 +500,7 @@ MultiClientBatchResult(int32 connectionId, void **queryResult, int *rowCount,
 	}
 	else
 	{
-		ReportRemoteError(connection, result);
+		ReportRemoteError(connection, result, false);
 		PQclear(result);
 		queryStatus = CLIENT_BATCH_QUERY_FAILED;
 	}
@@ -585,7 +585,7 @@ MultiClientQueryStatus(int32 connectionId)
 			copyResults = true;
 		}
 
-		ReportRemoteError(connection, result);
+		ReportRemoteError(connection, result, false);
 	}
 
 	/* clear the result object */
@@ -675,7 +675,7 @@ MultiClientCopyData(int32 connectionId, int32 fileDescriptor)
 		{
 			copyStatus = CLIENT_COPY_FAILED;
 
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 		}
 
 		PQclear(result);
@@ -685,7 +685,7 @@ MultiClientCopyData(int32 connectionId, int32 fileDescriptor)
 		/* received an error */
 		copyStatus = CLIENT_COPY_FAILED;
 
-		ReportRemoteError(connection, NULL);
+		ReportRemoteError(connection, NULL, false);
 	}
 
 	/* if copy out completed, make sure we drain all results from libpq */

--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -141,7 +141,7 @@ MultiClientConnect(const char *nodeName, uint32 nodePort, const char *nodeDataba
 	}
 	else
 	{
-		ReportRemoteError(connection, NULL, false);
+		WarnRemoteError(connection, NULL);
 
 		PQfinish(connection);
 		connectionId = INVALID_CONNECTION_ID;
@@ -194,7 +194,7 @@ MultiClientConnectStart(const char *nodeName, uint32 nodePort, const char *nodeD
 	}
 	else
 	{
-		ReportRemoteError(connection, NULL, false);
+		WarnRemoteError(connection, NULL);
 
 		PQfinish(connection);
 		connectionId = INVALID_CONNECTION_ID;
@@ -249,7 +249,7 @@ MultiClientConnectPoll(int32 connectionId)
 	}
 	else if (pollingStatus == PGRES_POLLING_FAILED)
 	{
-		ReportRemoteError(connection, NULL, false);
+		WarnRemoteError(connection, NULL);
 
 		connectStatus = CLIENT_CONNECTION_BAD;
 	}
@@ -433,7 +433,7 @@ MultiClientQueryResult(int32 connectionId, void **queryResult, int *rowCount,
 	}
 	else
 	{
-		ReportRemoteError(connection, result, false);
+		WarnRemoteError(connection, result);
 		PQclear(result);
 	}
 
@@ -500,7 +500,7 @@ MultiClientBatchResult(int32 connectionId, void **queryResult, int *rowCount,
 	}
 	else
 	{
-		ReportRemoteError(connection, result, false);
+		WarnRemoteError(connection, result);
 		PQclear(result);
 		queryStatus = CLIENT_BATCH_QUERY_FAILED;
 	}
@@ -585,7 +585,7 @@ MultiClientQueryStatus(int32 connectionId)
 			copyResults = true;
 		}
 
-		ReportRemoteError(connection, result, false);
+		WarnRemoteError(connection, result);
 	}
 
 	/* clear the result object */
@@ -675,7 +675,7 @@ MultiClientCopyData(int32 connectionId, int32 fileDescriptor)
 		{
 			copyStatus = CLIENT_COPY_FAILED;
 
-			ReportRemoteError(connection, result, false);
+			WarnRemoteError(connection, result);
 		}
 
 		PQclear(result);
@@ -685,7 +685,7 @@ MultiClientCopyData(int32 connectionId, int32 fileDescriptor)
 		/* received an error */
 		copyStatus = CLIENT_COPY_FAILED;
 
-		ReportRemoteError(connection, NULL, false);
+		WarnRemoteError(connection, NULL);
 	}
 
 	/* if copy out completed, make sure we drain all results from libpq */

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -267,7 +267,19 @@ ExecuteDistributedModify(Task *task)
 		result = PQexec(connection, task->queryString);
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result);
+			char *sqlStateString = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+			int category = 0;
+			bool raiseError = false;
+
+			/*
+			 * If the error code is in constraint violation class, we want to
+			 * fail fast because we must get the same error from all shard
+			 * placements.
+			 */
+			category = ERRCODE_TO_CATEGORY(ERRCODE_INTEGRITY_CONSTRAINT_VIOLATION);
+			raiseError = SqlStateMatchesCategory(sqlStateString, category);
+
+			ReportRemoteError(connection, result, raiseError);
 			PQclear(result);
 
 			failedPlacementList = lappend(failedPlacementList, taskPlacement);
@@ -451,14 +463,14 @@ SendQueryInSingleRowMode(PGconn *connection, char *query)
 	querySent = PQsendQuery(connection, query);
 	if (querySent == 0)
 	{
-		ReportRemoteError(connection, NULL);
+		ReportRemoteError(connection, NULL, false);
 		return false;
 	}
 
 	singleRowMode = PQsetSingleRowMode(connection);
 	if (singleRowMode == 0)
 	{
-		ReportRemoteError(connection, NULL);
+		ReportRemoteError(connection, NULL, false);
 		return false;
 	}
 
@@ -505,7 +517,7 @@ StoreQueryResult(PGconn *connection, TupleDesc tupleDescriptor,
 		resultStatus = PQresultStatus(result);
 		if ((resultStatus != PGRES_SINGLE_TUPLE) && (resultStatus != PGRES_TUPLES_OK))
 		{
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 			PQclear(result);
 
 			return false;

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -371,14 +371,14 @@ SendQueryToPlacements(char *shardQueryString, ShardConnections *shardConnections
 		result = PQexec(connection, "BEGIN");
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result, false);
+			WarnRemoteError(connection, result);
 			ereport(ERROR, (errmsg("could not send query to shard placement")));
 		}
 
 		result = PQexec(connection, shardQueryString);
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result, false);
+			WarnRemoteError(connection, result);
 			ereport(ERROR, (errmsg("could not send query to shard placement")));
 		}
 

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -371,14 +371,14 @@ SendQueryToPlacements(char *shardQueryString, ShardConnections *shardConnections
 		result = PQexec(connection, "BEGIN");
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 			ereport(ERROR, (errmsg("could not send query to shard placement")));
 		}
 
 		result = PQexec(connection, shardQueryString);
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 			ereport(ERROR, (errmsg("could not send query to shard placement")));
 		}
 

--- a/src/backend/distributed/test/connection_cache.c
+++ b/src/backend/distributed/test/connection_cache.c
@@ -59,7 +59,7 @@ initialize_remote_temp_table(PG_FUNCTION_ARGS)
 	result = PQexec(connection, POPULATE_TEMP_TABLE);
 	if (PQresultStatus(result) != PGRES_COMMAND_OK)
 	{
-		ReportRemoteError(connection, result);
+		ReportRemoteError(connection, result, false);
 	}
 
 	PQclear(result);
@@ -90,7 +90,7 @@ count_remote_temp_table_rows(PG_FUNCTION_ARGS)
 	result = PQexec(connection, COUNT_TEMP_TABLE);
 	if (PQresultStatus(result) != PGRES_TUPLES_OK)
 	{
-		ReportRemoteError(connection, result);
+		ReportRemoteError(connection, result, false);
 	}
 	else
 	{

--- a/src/backend/distributed/test/connection_cache.c
+++ b/src/backend/distributed/test/connection_cache.c
@@ -59,7 +59,7 @@ initialize_remote_temp_table(PG_FUNCTION_ARGS)
 	result = PQexec(connection, POPULATE_TEMP_TABLE);
 	if (PQresultStatus(result) != PGRES_COMMAND_OK)
 	{
-		ReportRemoteError(connection, result, false);
+		WarnRemoteError(connection, result);
 	}
 
 	PQclear(result);
@@ -90,7 +90,7 @@ count_remote_temp_table_rows(PG_FUNCTION_ARGS)
 	result = PQexec(connection, COUNT_TEMP_TABLE);
 	if (PQresultStatus(result) != PGRES_TUPLES_OK)
 	{
-		ReportRemoteError(connection, result, false);
+		WarnRemoteError(connection, result);
 	}
 	else
 	{

--- a/src/backend/distributed/utils/connection_cache.c
+++ b/src/backend/distributed/utils/connection_cache.c
@@ -298,7 +298,7 @@ ReportRemoteError(PGconn *connection, PGresult *result, bool raiseError)
 							 messageDetail ? errdetail("%s", messageDetail) : 0,
 							 messageHint ? errhint("%s", messageHint) : 0,
 							 messageContext ? errcontext("%s", messageContext) : 0,
-							 errcontext("Error occurred on remote connection to %s:%s.",
+							 errcontext("while executing command on %s:%s",
 										nodeName, nodePort)));
 	}
 }

--- a/src/backend/distributed/utils/multi_transaction.c
+++ b/src/backend/distributed/utils/multi_transaction.c
@@ -75,7 +75,7 @@ PrepareRemoteTransactions(List *connectionList)
 			/* a failure to prepare is an implicit rollback */
 			transactionConnection->transactionState = TRANSACTION_STATE_CLOSED;
 
-			ReportRemoteError(connection, result);
+			ReportRemoteError(connection, result, false);
 			PQclear(result);
 
 			ereport(ERROR, (errcode(ERRCODE_IO_ERROR),

--- a/src/backend/distributed/utils/multi_transaction.c
+++ b/src/backend/distributed/utils/multi_transaction.c
@@ -75,7 +75,7 @@ PrepareRemoteTransactions(List *connectionList)
 			/* a failure to prepare is an implicit rollback */
 			transactionConnection->transactionState = TRANSACTION_STATE_CLOSED;
 
-			ReportRemoteError(connection, result, false);
+			WarnRemoteError(connection, result);
 			PQclear(result);
 
 			ereport(ERROR, (errcode(ERRCODE_IO_ERROR),

--- a/src/include/distributed/connection_cache.h
+++ b/src/include/distributed/connection_cache.h
@@ -56,7 +56,8 @@ typedef struct NodeConnectionEntry
 /* function declarations for obtaining and using a connection */
 extern PGconn * GetOrEstablishConnection(char *nodeName, int32 nodePort);
 extern void PurgeConnection(PGconn *connection);
-extern void ReportRemoteError(PGconn *connection, PGresult *result);
+extern bool SqlStateMatchesCategory(char *sqlStateString, int category);
+extern void ReportRemoteError(PGconn *connection, PGresult *result, bool raiseError);
 extern PGconn * ConnectToNode(char *nodeName, int nodePort, char *nodeUser);
 extern char * ConnectionGetOptionValue(PGconn *connection, char *optionKeyword);
 #endif /* CONNECTION_CACHE_H */

--- a/src/include/distributed/connection_cache.h
+++ b/src/include/distributed/connection_cache.h
@@ -57,7 +57,8 @@ typedef struct NodeConnectionEntry
 extern PGconn * GetOrEstablishConnection(char *nodeName, int32 nodePort);
 extern void PurgeConnection(PGconn *connection);
 extern bool SqlStateMatchesCategory(char *sqlStateString, int category);
-extern void ReportRemoteError(PGconn *connection, PGresult *result, bool raiseError);
+extern void WarnRemoteError(PGconn *connection, PGresult *result);
+extern void ReraiseRemoteError(PGconn *connection, PGresult *result);
 extern PGconn * ConnectToNode(char *nodeName, int nodePort, char *nodeUser);
 extern char * ConnectionGetOptionValue(PGconn *connection, char *optionKeyword);
 #endif /* CONNECTION_CACHE_H */

--- a/src/test/regress/expected/multi_connection_cache.out
+++ b/src/test/regress/expected/multi_connection_cache.out
@@ -28,7 +28,7 @@ CREATE FUNCTION set_connection_status_bad(cstring, integer)
 \set VERBOSITY terse
 -- connect to non-existent host
 SELECT initialize_remote_temp_table('dummy-host-name', 12345);
-WARNING:  Connection failed to dummy-host-name:12345
+WARNING:  connection failed to dummy-host-name:12345
  initialize_remote_temp_table 
 ------------------------------
  f

--- a/src/test/regress/expected/multi_create_insert_proxy.out
+++ b/src/test/regress/expected/multi_create_insert_proxy.out
@@ -68,7 +68,7 @@ INSERT INTO pg_temp.:"proxy_tablename" (id) VALUES (1);
 -- test copy with bad row in middle
 \set VERBOSITY terse
 COPY pg_temp.:"proxy_tablename" FROM stdin;
-ERROR:  could not modify any active placements
+ERROR:  null value in column "data" violates not-null constraint
 \set VERBOSITY default
 -- verify rows were copied to distributed table
 SELECT * FROM insert_target ORDER BY id ASC;

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -139,12 +139,13 @@ ERROR:  creating unique indexes on append-partitioned tables is currently unsupp
 CREATE INDEX lineitem_orderkey_index ON lineitem (l_orderkey);
 ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: data type bigint has no default operator class for access method "gist"
+WARNING:  data type bigint has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX try_index ON lineitem (non_existent_column);
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: column "non_existent_column" does not exist
+WARNING:  column "non_existent_column" does not exist
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX ON lineitem (l_orderkey);
 ERROR:  creating index without a name on a distributed table is currently unsupported

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -141,11 +141,11 @@ ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
 WARNING:  data type bigint has no default operator class for access method "gist"
 HINT:  You must specify an operator class for the index or define a default operator class for the data type.
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX try_index ON lineitem (non_existent_column);
 WARNING:  column "non_existent_column" does not exist
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX ON lineitem (l_orderkey);
 ERROR:  creating index without a name on a distributed table is currently unsupported

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -151,12 +151,12 @@ INSERT INTO limit_orders VALUES (18811, 'BUD', 14962, '2014-04-05 08:32:16', 'se
 								 -5.00);
 ERROR:  new row for relation "limit_orders_750000" violates check constraint "limit_orders_limit_price_check"
 DETAIL:  Failing row contains (18811, BUD, 14962, 2014-04-05 08:32:16, sell, -5.00).
-CONTEXT:  Error occurred on remote connection to localhost:57637.
+CONTEXT:  while executing command on localhost:57637
 -- INSERT violating primary key constraint
 INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58);
 ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
 DETAIL:  Key (id)=(32743) already exists.
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 SET client_min_messages TO DEFAULT;
 -- commands with non-constant partition values are unsupported
 INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:45',
@@ -270,7 +270,7 @@ INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell',
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
 DETAIL:  Key (id)=(275) already exists.
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 -- Test that shards which miss a modification are marked unhealthy
 -- First: Connect to the second worker node
 \c - - - :worker_2_port
@@ -281,7 +281,7 @@ DROP TABLE limit_orders_750000;
 -- Fourth: Perform an INSERT on the remaining node
 INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 WARNING:  relation "limit_orders_750000" does not exist
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 -- Last: Verify the insert worked but the deleted placement is now unhealthy
 SELECT count(*) FROM limit_orders WHERE id = 276;
  count 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -274,8 +274,8 @@ CONTEXT:  while executing command on localhost:57638
 -- Test that shards which miss a modification are marked unhealthy
 -- First: Connect to the second worker node
 \c - - - :worker_2_port
--- Second: Drop limit_orders shard on the second worker node
-DROP TABLE limit_orders_750000;
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
 -- Third: Connect back to master node
 \c - - - :master_port
 -- Fourth: Perform an INSERT on the remaining node
@@ -302,6 +302,39 @@ AND    s.logicalrelid = 'limit_orders'::regclass;
      1
 (1 row)
 
+-- Test that if all shards miss a modification, no state change occurs
+-- First: Connect to the first worker node
+\c - - - :worker_1_port
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
+-- Third: Connect back to master node
+\c - - - :master_port
+-- Fourth: Perform an INSERT on the remaining node
+INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+WARNING:  relation "limit_orders_750000" does not exist
+CONTEXT:  while executing command on localhost:57637
+ERROR:  could not modify any active placements
+-- Last: Verify worker is still healthy
+SELECT count(*)
+FROM   pg_dist_shard_placement AS sp,
+	   pg_dist_shard           AS s
+WHERE  sp.shardid = s.shardid
+AND    sp.nodename = 'localhost'
+AND    sp.nodeport = :worker_1_port
+AND    sp.shardstate = 1
+AND    s.logicalrelid = 'limit_orders'::regclass;
+ count 
+-------
+     2
+(1 row)
+
+-- Undo our change...
+-- First: Connect to the first worker node
+\c - - - :worker_1_port
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE renamed_orders RENAME TO limit_orders_750000;
+-- Third: Connect back to master node
+\c - - - :master_port
 -- commands with no constraints on the partition key are not supported
 UPDATE limit_orders SET limit_price = 0.00;
 ERROR:  distributed modifications must target exactly one shard

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -149,10 +149,14 @@ ERROR:  cannot plan INSERT using row with NULL value in partition column
 -- INSERT violating column constraint
 INSERT INTO limit_orders VALUES (18811, 'BUD', 14962, '2014-04-05 08:32:16', 'sell',
 								 -5.00);
-ERROR:  could not modify any active placements
+ERROR:  new row for relation "limit_orders_750000" violates check constraint "limit_orders_limit_price_check"
+DETAIL:  Failing row contains (18811, BUD, 14962, 2014-04-05 08:32:16, sell, -5.00).
+CONTEXT:  Error occurred on remote connection to localhost:57637.
 -- INSERT violating primary key constraint
 INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58);
-ERROR:  could not modify any active placements
+ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
+DETAIL:  Key (id)=(32743) already exists.
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 SET client_min_messages TO DEFAULT;
 -- commands with non-constant partition values are unsupported
 INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:45',
@@ -261,26 +265,25 @@ SELECT kind, limit_price FROM limit_orders WHERE id = 246;
  buy  |        0.00
 (1 row)
 
--- Test that shards which miss a modification are marked unhealthy
--- First: Mark all placements for a node as inactive
-UPDATE pg_dist_shard_placement
-SET    shardstate = 3
-WHERE  nodename = 'localhost' AND
-	   nodeport = :worker_1_port;
--- Second: Perform an INSERT to the remaining node
+-- Test that on unique contraint violations, we fail fast
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
--- Third: Mark the original placements as healthy again
-UPDATE pg_dist_shard_placement
-SET    shardstate = 1
-WHERE  nodename = 'localhost' AND
-	   nodeport = :worker_1_port;
--- Fourth: Perform the same INSERT (primary key violation)
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
-WARNING:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
+ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
 DETAIL:  Key (id)=(275) already exists.
 CONTEXT:  Error occurred on remote connection to localhost:57638.
--- Last: Verify the insert worked but the placement with the PK violation is now unhealthy
-SELECT count(*) FROM limit_orders WHERE id = 275;
+-- Test that shards which miss a modification are marked unhealthy
+-- First: Connect to the second worker node
+\c - - - :worker_2_port
+-- Second: Drop limit_orders shard on the second worker node
+DROP TABLE limit_orders_750000;
+-- Third: Connect back to master node
+\c - - - :master_port
+-- Fourth: Perform an INSERT on the remaining node
+INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+WARNING:  relation "limit_orders_750000" does not exist
+CONTEXT:  Error occurred on remote connection to localhost:57638.
+-- Last: Verify the insert worked but the deleted placement is now unhealthy
+SELECT count(*) FROM limit_orders WHERE id = 276;
  count 
 -------
      1

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -276,8 +276,9 @@ WHERE  nodename = 'localhost' AND
 	   nodeport = :worker_1_port;
 -- Fourth: Perform the same INSERT (primary key violation)
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: duplicate key value violates unique constraint "limit_orders_pkey_750001"
+WARNING:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
+DETAIL:  Key (id)=(275) already exists.
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 -- Last: Verify the insert worked but the placement with the PK violation is now unhealthy
 SELECT count(*) FROM limit_orders WHERE id = 275;
  count 

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -261,8 +261,8 @@ ALTER TABLE IF EXISTS non_existent_table ADD COLUMN new_column INTEGER;
 NOTICE:  relation "non_existent_table" does not exist, skipping
 ALTER TABLE IF EXISTS lineitem_alter ALTER COLUMN int_column2 SET DATA TYPE INTEGER;
 ALTER TABLE lineitem_alter DROP COLUMN non_existent_column;
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: column "non_existent_column" of relation "lineitem_alter_220000" does not exist
+WARNING:  column "non_existent_column" of relation "lineitem_alter_220000" does not exist
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 NOTICE:  column "non_existent_column" of relation "lineitem_alter" does not exist, skipping
@@ -361,16 +361,16 @@ DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT and TYPE subc
 -- Verify that we error out in case of postgres errors on supported statement
 -- types
 ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: type "non_existent_type" does not exist
+WARNING:  type "non_existent_type" does not exist
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: column "null_column" contains null values
+WARNING:  column "null_column" contains null values
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
-WARNING:  Bad result from localhost:57638
-DETAIL:  Remote message: invalid input syntax for integer: "a"
+WARNING:  invalid input syntax for integer: "a"
+CONTEXT:  Error occurred on remote connection to localhost:57638.
 ERROR:  could not execute DDL command on worker node shards
 -- Verify that we error out on statements involving RENAME
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -262,7 +262,7 @@ NOTICE:  relation "non_existent_table" does not exist, skipping
 ALTER TABLE IF EXISTS lineitem_alter ALTER COLUMN int_column2 SET DATA TYPE INTEGER;
 ALTER TABLE lineitem_alter DROP COLUMN non_existent_column;
 WARNING:  column "non_existent_column" of relation "lineitem_alter_220000" does not exist
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 NOTICE:  column "non_existent_column" of relation "lineitem_alter" does not exist, skipping
@@ -362,15 +362,15 @@ DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT and TYPE subc
 -- types
 ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
 WARNING:  type "non_existent_type" does not exist
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
 WARNING:  column "null_column" contains null values
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 WARNING:  invalid input syntax for integer: "a"
-CONTEXT:  Error occurred on remote connection to localhost:57638.
+CONTEXT:  while executing command on localhost:57638
 ERROR:  could not execute DDL command on worker node shards
 -- Verify that we error out on statements involving RENAME
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -455,8 +455,8 @@ COPY customer_worker_copy_append FROM '@abs_srcdir@/data/customer.1.data' with (
 COPY customer_worker_copy_append FROM '@abs_srcdir@/data/customer.2.data' with (delimiter '|', master_host 'localhost', master_port 57636);
 -- Test if there is no relation to copy data with the worker copy
 COPY lineitem_copy_none FROM '@abs_srcdir@/data/lineitem.1.data' with (delimiter '|', master_host 'localhost', master_port 57636);
-WARNING:  Bad result from localhost:57636
-DETAIL:  Remote message: relation "lineitem_copy_none" does not exist
+WARNING:  relation "lineitem_copy_none" does not exist
+CONTEXT:  Error occurred on remote connection to localhost:57636.
 ERROR:  could not run copy from the worker node
 -- Connect back to the master node
 \c - - - 57636

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -456,7 +456,7 @@ COPY customer_worker_copy_append FROM '@abs_srcdir@/data/customer.2.data' with (
 -- Test if there is no relation to copy data with the worker copy
 COPY lineitem_copy_none FROM '@abs_srcdir@/data/lineitem.1.data' with (delimiter '|', master_host 'localhost', master_port 57636);
 WARNING:  relation "lineitem_copy_none" does not exist
-CONTEXT:  Error occurred on remote connection to localhost:57636.
+CONTEXT:  while executing command on localhost:57636
 ERROR:  could not run copy from the worker node
 -- Connect back to the master node
 \c - - - 57636

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -199,8 +199,8 @@ INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell',
 -- First: Connect to the second worker node
 \c - - - :worker_2_port
 
--- Second: Drop limit_orders shard on the second worker node
-DROP TABLE limit_orders_750000;
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
 
 -- Third: Connect back to master node
 \c - - - :master_port
@@ -210,6 +210,7 @@ INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell',
 
 -- Last: Verify the insert worked but the deleted placement is now unhealthy
 SELECT count(*) FROM limit_orders WHERE id = 276;
+
 SELECT count(*)
 FROM   pg_dist_shard_placement AS sp,
 	   pg_dist_shard           AS s
@@ -218,6 +219,41 @@ AND    sp.nodename = 'localhost'
 AND    sp.nodeport = :worker_2_port
 AND    sp.shardstate = 3
 AND    s.logicalrelid = 'limit_orders'::regclass;
+
+-- Test that if all shards miss a modification, no state change occurs
+
+-- First: Connect to the first worker node
+\c - - - :worker_1_port
+
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
+
+-- Third: Connect back to master node
+\c - - - :master_port
+
+-- Fourth: Perform an INSERT on the remaining node
+INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+
+-- Last: Verify worker is still healthy
+SELECT count(*)
+FROM   pg_dist_shard_placement AS sp,
+	   pg_dist_shard           AS s
+WHERE  sp.shardid = s.shardid
+AND    sp.nodename = 'localhost'
+AND    sp.nodeport = :worker_1_port
+AND    sp.shardstate = 1
+AND    s.logicalrelid = 'limit_orders'::regclass;
+
+-- Undo our change...
+
+-- First: Connect to the first worker node
+\c - - - :worker_1_port
+
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE renamed_orders RENAME TO limit_orders_750000;
+
+-- Third: Connect back to master node
+\c - - - :master_port
 
 -- commands with no constraints on the partition key are not supported
 UPDATE limit_orders SET limit_price = 0.00;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -190,28 +190,26 @@ SELECT bidder_id FROM limit_orders WHERE id = 246;
 UPDATE limit_orders SET (kind, limit_price) = ('buy', DEFAULT) WHERE id = 246;
 SELECT kind, limit_price FROM limit_orders WHERE id = 246;
 
+-- Test that on unique contraint violations, we fail fast
+INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+
 -- Test that shards which miss a modification are marked unhealthy
 
--- First: Mark all placements for a node as inactive
-UPDATE pg_dist_shard_placement
-SET    shardstate = 3
-WHERE  nodename = 'localhost' AND
-	   nodeport = :worker_1_port;
+-- First: Connect to the second worker node
+\c - - - :worker_2_port
 
--- Second: Perform an INSERT to the remaining node
-INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+-- Second: Drop limit_orders shard on the second worker node
+DROP TABLE limit_orders_750000;
 
--- Third: Mark the original placements as healthy again
-UPDATE pg_dist_shard_placement
-SET    shardstate = 1
-WHERE  nodename = 'localhost' AND
-	   nodeport = :worker_1_port;
+-- Third: Connect back to master node
+\c - - - :master_port
 
--- Fourth: Perform the same INSERT (primary key violation)
-INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
+-- Fourth: Perform an INSERT on the remaining node
+INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 
--- Last: Verify the insert worked but the placement with the PK violation is now unhealthy
-SELECT count(*) FROM limit_orders WHERE id = 275;
+-- Last: Verify the insert worked but the deleted placement is now unhealthy
+SELECT count(*) FROM limit_orders WHERE id = 276;
 SELECT count(*)
 FROM   pg_dist_shard_placement AS sp,
 	   pg_dist_shard           AS s


### PR DESCRIPTION
Fixes #221. Now, for constraint violations, we fail fast.

Fixes #401. Now, we fail fast on duplicate values, and we don't mark the shard placements as inactive.

Notes: 

- For #401, a similar problem would arise with intermittent network problems. Though it is less likely to happen, we can fix it with proper locking on shard placement metadata.

- This PR fixes the message improvement part in #480, but still we mark all involved shard placements as inactive. We may want to rename #480 or open another issue after merging this PR.

## Review Tasks ##

- [x] Add `raiseError` field to `ReportRemoteError and assign an `errlevel` based on it

- [x] Make a simple `SqlStateMatchesCategory(char *sqlState, int category)` function to help determine if we need to raise an error (useful here, but will also be useful for DDL stuff later)

- [x] Use `SqlStateMatchesCategory` to detect constraint violations and pass `raiseError = true` to `ReportRemoteError`

- [x] Similar to `dblink_res_error` and `pgfdw_report_error`, extract state, message, detail, hint, and context from the connection, using them _directly_ to report a warning or error

- [x] Add a `errcontext` call like _while executing command on <host>:<port>_ to the `ereport` call to ensure the host/port are reported
