### PR TITLE
make task cleanup logic less error prone

### DIFF
--- a/src/test/regress/expected/multi_large_table_join_planning.out
+++ b/src/test/regress/expected/multi_large_table_join_planning.out
@@ -104,12 +104,12 @@ DETAIL:  Creating dependency on merge taskId 13
 DEBUG:  assigned task 9 to node localhost:57637
 DEBUG:  assigned task 6 to node localhost:57638
 DEBUG:  assigned task 3 to node localhost:57637
-DEBUG:  completed cleanup query for job 1252 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1252 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1251 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1251 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1250 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1250 on node "localhost:57637"
+DEBUG:  completed cleanup query for job 1252
+DEBUG:  completed cleanup query for job 1252
+DEBUG:  completed cleanup query for job 1251
+DEBUG:  completed cleanup query for job 1251
+DEBUG:  completed cleanup query for job 1250
+DEBUG:  completed cleanup query for job 1250
 DEBUG:  CommitTransactionCommand
  l_partkey | o_orderkey | count 
 -----------+------------+-------
@@ -221,12 +221,12 @@ DEBUG:  assigned task 3 to node localhost:57638
 DEBUG:  assigned task 6 to node localhost:57637
 DEBUG:  assigned task 9 to node localhost:57638
 DEBUG:  assigned task 12 to node localhost:57637
-DEBUG:  completed cleanup query for job 1255 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1255 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1253 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1253 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1254 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1254 on node "localhost:57637"
+DEBUG:  completed cleanup query for job 1255
+DEBUG:  completed cleanup query for job 1255
+DEBUG:  completed cleanup query for job 1253
+DEBUG:  completed cleanup query for job 1253
+DEBUG:  completed cleanup query for job 1254
+DEBUG:  completed cleanup query for job 1254
 DEBUG:  CommitTransactionCommand
  l_partkey | o_orderkey | count 
 -----------+------------+-------

--- a/src/test/regress/expected/multi_large_table_join_planning_0.out
+++ b/src/test/regress/expected/multi_large_table_join_planning_0.out
@@ -104,12 +104,12 @@ DETAIL:  Creating dependency on merge taskId 13
 DEBUG:  assigned task 9 to node localhost:57637
 DEBUG:  assigned task 6 to node localhost:57638
 DEBUG:  assigned task 3 to node localhost:57637
-DEBUG:  completed cleanup query for job 1252 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1252 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1251 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1251 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1250 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1250 on node "localhost:57637"
+DEBUG:  completed cleanup query for job 1252
+DEBUG:  completed cleanup query for job 1252
+DEBUG:  completed cleanup query for job 1251
+DEBUG:  completed cleanup query for job 1251
+DEBUG:  completed cleanup query for job 1250
+DEBUG:  completed cleanup query for job 1250
 DEBUG:  CommitTransactionCommand
  l_partkey | o_orderkey | count 
 -----------+------------+-------
@@ -221,12 +221,12 @@ DEBUG:  assigned task 3 to node localhost:57638
 DEBUG:  assigned task 6 to node localhost:57637
 DEBUG:  assigned task 9 to node localhost:57638
 DEBUG:  assigned task 12 to node localhost:57637
-DEBUG:  completed cleanup query for job 1255 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1255 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1253 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1253 on node "localhost:57637"
-DEBUG:  completed cleanup query for job 1254 on node "localhost:57638"
-DEBUG:  completed cleanup query for job 1254 on node "localhost:57637"
+DEBUG:  completed cleanup query for job 1255
+DEBUG:  completed cleanup query for job 1255
+DEBUG:  completed cleanup query for job 1253
+DEBUG:  completed cleanup query for job 1253
+DEBUG:  completed cleanup query for job 1254
+DEBUG:  completed cleanup query for job 1254
 DEBUG:  CommitTransactionCommand
  l_partkey | o_orderkey | count 
 -----------+------------+-------


### PR DESCRIPTION
Changed task cleanup logic to remove one large sleep and replaced that with multiple small sleeps until a predetermined timeout occurs.

We used to wait for 150 milliseconds or twice the RemoteTaskCheckInterval whichever is larger before checking if task cleanup job is sent to worker. This approach had problems when there is a load on the master. Cleanup jobs were never delivered to worker, and resources for the job were never released. It had 2 consequences, 1 - warning on the master about job not being cleaned. 2- more importantly, worker run out of shared memory since resources were not reclaimed.

Now it is changed to give more chances to master to deliver the cleanup task. We check every 10 milliseconds until we reach a timeout of Max(200 milliseconds or 2xRemoteTaskCheckInterval). 

Increasing minimum timeout will not have adverse affect on query performance since it is the worse case scenario, most cleanup tasks will be sent before that and we will wait way less than before.

fixes #345 

CR : not determined yet
