### PR TITLE
Detect flex in citus configure script, instead of relying postgres'.

### DIFF
--- a/Makefile.global.in
+++ b/Makefile.global.in
@@ -56,6 +56,14 @@ ifneq (@CC@,)
     override CC=@CC@
 endif
 
+# If detected by our configure script, override the FLEX postgres
+# detected.  That allows to compile citus against a postgres which was
+# built without flex available (possible because generated files are
+# included)
+ifneq (@FLEX@,)
+    override FLEX=@FLEX@
+endif
+
 # Add options passed to configure or computed therein, to CFLAGS/CPPFLAGS/...
 override CFLAGS += @CFLAGS@ @CITUS_CFLAGS@
 override CPPFLAGS := @CPPFLAGS@ -I '${citus_abs_top_srcdir}/src/include' $(CPPFLAGS)

--- a/configure
+++ b/configure
@@ -597,6 +597,7 @@ CC
 vpath_build
 PATH
 PG_CONFIG
+FLEX
 SED
 target_alias
 host_alias
@@ -1808,6 +1809,50 @@ fi
 $as_echo "$ac_cv_path_SED" >&6; }
  SED="$ac_cv_path_SED"
   rm -f conftest.sed
+
+
+# Re-check for flex. That allows to compile citus against a postgres
+# which was built without flex available (possible because generated
+# files are included)
+# Extract the first word of "flex", so it can be a program name with args.
+set dummy flex; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_FLEX+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $FLEX in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_FLEX="$FLEX" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_FLEX="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+FLEX=$ac_cv_path_FLEX
+if test -n "$FLEX"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $FLEX" >&5
+$as_echo "$FLEX" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
 
 
 # Locate pg_config binary

--- a/configure.in
+++ b/configure.in
@@ -10,6 +10,11 @@ AC_COPYRIGHT([Copyright (c) 2012-2016, Citus Data, Inc.])
 
 AC_PROG_SED
 
+# Re-check for flex. That allows to compile citus against a postgres
+# which was built without flex available (possible because generated
+# files are included)
+AC_PATH_PROG([FLEX], [flex])
+
 # Locate pg_config binary
 AC_ARG_VAR([PG_CONFIG], [Location to find pg_config for target PostgreSQL instalation (default PATH)])
 AC_ARG_VAR([PATH], [PATH for target PostgreSQL install pg_config])

--- a/src/bin/csql/Makefile
+++ b/src/bin/csql/Makefile
@@ -36,7 +36,9 @@ override CPPFLAGS := -I$(client_includes) -I$(libpq_srcdir) -I$(citus_abs_top_sr
 # psqlscan is compiled as part of mainloop
 mainloop.o: psqlscan.c
 psqlscan.c: FLEXFLAGS = -Cfe -p -p
-psqlscan.c: FLEX_NO_BACKUP=yes
+
+psqlscan.c: psqlscan.l
+	$(FLEX) $(FLEXFLAGS) -o'$@' $<
 
 clean: csql-clean
 csql-clean:


### PR DESCRIPTION
If postgres was compiled without flex support - possible when building
from a tarball, because those contain the flex generated files - citus
compilation would fail, because FLEX is defined as missing.

Add detection for flex, overwriting postgres' detection if one was
found.

Fixes #439