### PR TITLE
Support RETURNING

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -59,9 +59,9 @@ multi_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		{
 			Task *task = NULL;
 			List *taskList = workerJob->taskList;
+			TupleDesc tupleDescriptor = ExecCleanTypeFromTL(
+				planStatement->planTree->targetlist, false);
 			List *dependendJobList PG_USED_FOR_ASSERTS_ONLY = workerJob->dependedJobList;
-			List *workerTargetList = multiPlan->workerJob->jobQuery->targetList;
-			TupleDesc tupleDescriptor = ExecCleanTypeFromTL(workerTargetList, false);
 
 			/* router executor can only execute distributed plans with a single task */
 			Assert(list_length(taskList) == 1);

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -116,6 +116,14 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 
 	ErrorIfModifyQueryNotSupported(modifyQuery);
 
+	/* reject queries with a returning list */
+	if (list_length(modifyQuery->returningList) > 0)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("master_modify_multiple_shards() does not support RETURNING")));
+	}
+
 	shardIntervalList = LoadShardIntervalList(relationId);
 	restrictClauseList = WhereClauseList(modifyQuery->jointree);
 

--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -25,6 +25,8 @@
 
 #include "executor/executor.h"
 
+#include "nodes/makefuncs.h"
+
 #include "optimizer/planner.h"
 
 #include "utils/memutils.h"
@@ -196,11 +198,17 @@ MultiQueryContainerNode(PlannedStmt *result, MultiPlan *multiPlan)
 	if (!ExecSupportsBackwardScan(result->planTree))
 	{
 		FuncExpr *funcExpr = makeNode(FuncExpr);
+		TargetEntry *targetEntry = NULL;
+		bool resjunkAttribute = true;
+
 		funcExpr->funcretset = true;
+
+		targetEntry = makeTargetEntry((Expr *) funcExpr, InvalidAttrNumber, NULL,
+									  resjunkAttribute);
 
 		fauxFunctionScan->scan.plan.targetlist =
 			lappend(fauxFunctionScan->scan.plan.targetlist,
-					funcExpr);
+					targetEntry);
 	}
 
 	result->planTree = (Plan *) fauxFunctionScan;

--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -185,6 +185,9 @@ MultiQueryContainerNode(PlannedStmt *result, MultiPlan *multiPlan)
 	fauxFunctionScan = makeNode(FunctionScan);
 	fauxFunctionScan->functions = lappend(fauxFunctionScan->functions, fauxFunction);
 
+	/* copy original targetlist, accessed for RETURNING queries  */
+	fauxFunctionScan->scan.plan.targetlist = copyObject(result->planTree->targetlist);
+
 	/*
 	 * Add set returning function to target list if the original (postgres
 	 * created) plan doesn't support backward scans; doing so prevents

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -255,16 +255,6 @@ ErrorIfModifyQueryNotSupported(Query *queryTree)
 								  "supported.")));
 	}
 
-	/* reject queries with a returning list */
-	if (list_length(queryTree->returningList) > 0)
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot perform distributed planning for the given"
-							   " modification"),
-						errdetail("RETURNING clauses are not supported in distributed "
-								  "modifications.")));
-	}
-
 	if (commandType == CMD_INSERT || commandType == CMD_UPDATE ||
 		commandType == CMD_DELETE)
 	{
@@ -297,6 +287,11 @@ ErrorIfModifyQueryNotSupported(Query *queryTree)
 		if (joinTree != NULL && contain_mutable_functions(joinTree->quals))
 		{
 			hasNonConstQualExprs = true;
+		}
+
+		if (contain_mutable_functions((Node *) queryTree->returningList))
+		{
+			hasNonConstTargetEntryExprs = true;
 		}
 	}
 

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -18,8 +18,6 @@ extern bool AllModificationsCommutative;
 extern void RouterExecutorStart(QueryDesc *queryDesc, int eflags, Task *task);
 extern void RouterExecutorRun(QueryDesc *queryDesc, ScanDirection direction, long count,
 							  Task *task);
-extern bool ExecuteTaskAndStoreResults(Task *task, TupleDesc tupleDescriptor,
-									   Tuplestorestate *tupleStore);
 extern void RouterExecutorFinish(QueryDesc *queryDesc);
 extern void RouterExecutorEnd(QueryDesc *queryDesc);
 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -195,11 +195,6 @@ DETAIL:  Multi-row INSERTs to distributed tables are not supported.
 INSERT INTO limit_orders SELECT * FROM limit_orders;
 ERROR:  cannot perform distributed planning for the given modifications
 DETAIL:  Subqueries are not supported in distributed modifications.
--- commands with a RETURNING clause are unsupported
-INSERT INTO limit_orders VALUES (7285, 'AMZN', 3278, '2016-01-05 02:07:36', 'sell', 0.00)
-						 RETURNING *;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  RETURNING clauses are not supported in distributed modifications.
 -- commands containing a CTE are unsupported
 WITH deleted_orders AS (DELETE FROM limit_orders RETURNING *)
 INSERT INTO limit_orders DEFAULT VALUES;
@@ -244,10 +239,6 @@ DELETE FROM limit_orders USING bidders WHERE limit_orders.id = 246 AND
 											 limit_orders.bidder_id = bidders.id AND
 											 bidders.name = 'Bernie Madoff';
 ERROR:  cannot plan queries that include both regular and partitioned relations
--- commands with a RETURNING clause are unsupported
-DELETE FROM limit_orders WHERE id = 246 RETURNING *;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  RETURNING clauses are not supported in distributed modifications.
 -- commands containing a CTE are unsupported
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 DELETE FROM limit_orders;
@@ -363,10 +354,6 @@ UPDATE limit_orders SET limit_price = 0.00 FROM bidders
 						  limit_orders.bidder_id = bidders.id AND
 						  bidders.name = 'Bernie Madoff';
 ERROR:  cannot plan queries that include both regular and partitioned relations
--- commands with a RETURNING clause are unsupported
-UPDATE limit_orders SET symbol = 'GM' WHERE id = 246 RETURNING *;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  RETURNING clauses are not supported in distributed modifications.
 -- commands containing a CTE are unsupported
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 UPDATE limit_orders SET symbol = 'GM';

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -97,6 +97,13 @@ SELECT COUNT(*) FROM limit_orders WHERE id = 32743;
      1
 (1 row)
 
+-- basic single-row INSERT with RETURNING
+INSERT INTO limit_orders VALUES (32744, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy', 20.69) RETURNING *;
+  id   | symbol | bidder_id |        placed_at         | kind | limit_price 
+-------+--------+-----------+--------------------------+------+-------------
+ 32744 | AAPL   |      9580 | Tue Oct 19 10:23:54 2004 | buy  |       20.69
+(1 row)
+
 -- try a single-row INSERT with no shard to receive it
 INSERT INTO insufficient_shards VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
 										20.69);
@@ -173,6 +180,14 @@ INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy
 ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
 DETAIL:  Key (id)=(32743) already exists.
 CONTEXT:  while executing command on localhost:57638
+-- INSERT violating primary key constraint, with RETURNING specified.
+INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58) RETURNING *;
+ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
+DETAIL:  Key (id)=(32743) already exists.
+CONTEXT:  while executing command on localhost:57638
+-- INSERT, with RETURNING specified, failing with a non-constraint error
+INSERT INTO limit_orders VALUES (34153, 'LEE', 5994, '2001-04-16 03:37:28', 'buy', 0.58) RETURNING id / 0;
+ERROR:  could not modify any active placements
 SET client_min_messages TO DEFAULT;
 -- commands with non-constant partition values are unsupported
 INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:45',
@@ -210,6 +225,19 @@ SELECT COUNT(*) FROM limit_orders WHERE id = 246;
 
 DELETE FROM limit_orders WHERE id = 246;
 SELECT COUNT(*) FROM limit_orders WHERE id = 246;
+ count 
+-------
+     0
+(1 row)
+
+-- test simple DELETE with RETURNING
+DELETE FROM limit_orders WHERE id = 430 RETURNING *;
+ id  | symbol | bidder_id |        placed_at         | kind |   limit_price   
+-----+--------+-----------+--------------------------+------+-----------------
+ 430 | IBM    |       214 | Tue Jan 28 15:31:17 2003 | buy  | 1.4142135623731
+(1 row)
+
+SELECT COUNT(*) FROM limit_orders WHERE id = 430;
  count 
 -------
      0
@@ -256,6 +284,13 @@ SELECT symbol FROM limit_orders WHERE id = 246;
  GM
 (1 row)
 
+-- simple UPDATE with RETURNING
+UPDATE limit_orders SET symbol = 'GM' WHERE id = 246 RETURNING *;
+ id  | symbol | bidder_id |        placed_at         | kind | limit_price 
+-----+--------+-----------+--------------------------+------+-------------
+ 246 | GM     |       162 | Mon Jul 02 16:32:15 2007 | sell |       20.69
+(1 row)
+
 -- expression UPDATE
 UPDATE limit_orders SET bidder_id = 6 * 3 WHERE id = 246;
 SELECT bidder_id FROM limit_orders WHERE id = 246;
@@ -264,12 +299,26 @@ SELECT bidder_id FROM limit_orders WHERE id = 246;
         18
 (1 row)
 
+-- expression UPDATE with RETURNING
+UPDATE limit_orders SET bidder_id = 6 * 5 WHERE id = 246 RETURNING *;
+ id  | symbol | bidder_id |        placed_at         | kind | limit_price 
+-----+--------+-----------+--------------------------+------+-------------
+ 246 | GM     |        30 | Mon Jul 02 16:32:15 2007 | sell |       20.69
+(1 row)
+
 -- multi-column UPDATE
 UPDATE limit_orders SET (kind, limit_price) = ('buy', DEFAULT) WHERE id = 246;
 SELECT kind, limit_price FROM limit_orders WHERE id = 246;
  kind | limit_price 
 ------+-------------
  buy  |        0.00
+(1 row)
+
+-- multi-column UPDATE with RETURNING
+UPDATE limit_orders SET (kind, limit_price) = ('buy', 999) WHERE id = 246 RETURNING *;
+ id  | symbol | bidder_id |        placed_at         | kind | limit_price 
+-----+--------+-----------+--------------------------+------+-------------
+ 246 | GM     |        30 | Mon Jul 02 16:32:15 2007 | buy  |         999
 (1 row)
 
 -- Test that on unique contraint violations, we fail fast
@@ -362,7 +411,7 @@ DETAIL:  Common table expressions are not supported in distributed modifications
 SELECT symbol, bidder_id FROM limit_orders WHERE id = 246;
  symbol | bidder_id 
 --------+-----------
- GM     |        18
+ GM     |        30
 (1 row)
 
 -- updates referencing just a var are supported
@@ -377,12 +426,51 @@ SELECT symbol, bidder_id FROM limit_orders WHERE id = 246;
  gm     |       247
 (1 row)
 
+-- IMMUTABLE functions are allowed -- even in returning
+UPDATE limit_orders SET symbol = UPPER(symbol) WHERE id = 246 RETURNING id, LOWER(symbol), symbol;
+ id  | lower | symbol 
+-----+-------+--------
+ 246 | gm    | GM
+(1 row)
+
 -- updates referencing non-IMMUTABLE functions are unsupported
 UPDATE limit_orders SET placed_at = now() WHERE id = 246;
+ERROR:  functions used in modification queries on distributed tables must be marked IMMUTABLE
+-- even in RETURNING
+UPDATE limit_orders SET placed_at = placed_at WHERE id = 246 RETURNING NOW();
 ERROR:  functions used in modification queries on distributed tables must be marked IMMUTABLE
 -- cursors are not supported
 UPDATE limit_orders SET symbol = 'GM' WHERE CURRENT OF cursor_name;
 ERROR:  distributed modifications must target exactly one shard
+-- check that multi-row UPDATE/DELETEs with RETURNING work
+INSERT INTO multiple_hash VALUES ('0', '1');
+INSERT INTO multiple_hash VALUES ('0', '2');
+INSERT INTO multiple_hash VALUES ('0', '3');
+INSERT INTO multiple_hash VALUES ('0', '4');
+INSERT INTO multiple_hash VALUES ('0', '5');
+INSERT INTO multiple_hash VALUES ('0', '6');
+UPDATE multiple_hash SET data = data ||'-1' WHERE category = '0' RETURNING *;
+ category | data 
+----------+------
+ 0        | 1-1
+ 0        | 2-1
+ 0        | 3-1
+ 0        | 4-1
+ 0        | 5-1
+ 0        | 6-1
+(6 rows)
+
+DELETE FROM multiple_hash WHERE category = '0' RETURNING *;
+ category | data 
+----------+------
+ 0        | 1-1
+ 0        | 2-1
+ 0        | 3-1
+ 0        | 4-1
+ 0        | 5-1
+ 0        | 6-1
+(6 rows)
+
 -- ensure returned row counters are correct
 \set QUIET off
 INSERT INTO multiple_hash VALUES ('1', '1');
@@ -397,6 +485,13 @@ INSERT INTO multiple_hash VALUES ('2', '2');
 INSERT 0 1
 INSERT INTO multiple_hash VALUES ('2', '3');
 INSERT 0 1
+INSERT INTO multiple_hash VALUES ('2', '3') RETURNING *;
+ category | data 
+----------+------
+ 2        | 3
+(1 row)
+
+INSERT 0 1
 -- check that update return the right number of rows
 -- one row
 UPDATE multiple_hash SET data = data ||'-1' WHERE category = '1' AND data = '1';
@@ -404,13 +499,23 @@ UPDATE 1
 -- three rows
 UPDATE multiple_hash SET data = data ||'-2' WHERE category = '1';
 UPDATE 3
+-- three rows, with RETURNING
+UPDATE multiple_hash SET data = data ||'-2' WHERE category = '1' RETURNING category;
+ category 
+----------
+ 1
+ 1
+ 1
+(3 rows)
+
+UPDATE 3
 -- check
 SELECT * FROM multiple_hash WHERE category = '1' ORDER BY category, data;
- category | data  
-----------+-------
- 1        | 1-1-2
- 1        | 2-2
- 1        | 3-2
+ category |  data   
+----------+---------
+ 1        | 1-1-2-2
+ 1        | 2-2-2
+ 1        | 3-2-2
 (3 rows)
 
 -- check that deletes return the right number of rows
@@ -419,8 +524,23 @@ DELETE FROM multiple_hash WHERE category = '2' AND data = '1';
 DELETE 1
 -- two rows
 DELETE FROM multiple_hash WHERE category = '2';
-DELETE 2
+DELETE 3
+-- three rows, with RETURNING
+DELETE FROM multiple_hash WHERE category = '1' RETURNING category;
+ category 
+----------
+ 1
+ 1
+ 1
+(3 rows)
+
+DELETE 3
 -- check
+SELECT * FROM multiple_hash WHERE category = '1' ORDER BY category, data;
+ category | data 
+----------+------
+(0 rows)
+
 SELECT * FROM multiple_hash WHERE category = '2' ORDER BY category, data;
  category | data 
 ----------+------

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -12,10 +12,20 @@ CREATE TABLE limit_orders (
 	kind order_side NOT NULL,
 	limit_price decimal NOT NULL DEFAULT 0.00 CHECK (limit_price >= 0.00)
 );
+CREATE TABLE multiple_hash (
+	category text NOT NULL,
+	data text NOT NULL
+);
 CREATE TABLE insufficient_shards ( LIKE limit_orders );
 CREATE TABLE range_partitioned ( LIKE limit_orders );
 CREATE TABLE append_partitioned ( LIKE limit_orders );
 SELECT master_create_distributed_table('limit_orders', 'id', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_distributed_table('multiple_hash', 'category', 'hash');
  master_create_distributed_table 
 ---------------------------------
  
@@ -40,6 +50,12 @@ SELECT master_create_distributed_table('append_partitioned', 'id', 'append');
 (1 row)
 
 SELECT master_create_worker_shards('limit_orders', 2, 2);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('multiple_hash', 2, 2);
  master_create_worker_shards 
 -----------------------------
  
@@ -95,7 +111,7 @@ INSERT INTO append_partitioned VALUES (414123, 'AAPL', 9580, '2004-10-19 10:23:5
 SET client_min_messages TO 'DEBUG2';
 SET citus.task_executor_type TO 'real-time';
 SELECT * FROM range_partitioned WHERE id = 32743;
-DEBUG:  predicate pruning for shardId 750004
+DEBUG:  predicate pruning for shardId 750006
 DEBUG:  Plan is router executable
   id   | symbol | bidder_id |        placed_at         | kind | limit_price 
 -------+--------+-----------+--------------------------+------+-------------
@@ -103,7 +119,7 @@ DEBUG:  Plan is router executable
 (1 row)
 
 SELECT * FROM append_partitioned WHERE id = 414123;
-DEBUG:  predicate pruning for shardId 750006
+DEBUG:  predicate pruning for shardId 750008
 DEBUG:  Plan is router executable
    id   | symbol | bidder_id |        placed_at         | kind | limit_price 
 --------+--------+-----------+--------------------------+------+-------------
@@ -380,3 +396,46 @@ ERROR:  functions used in modification queries on distributed tables must be mar
 -- cursors are not supported
 UPDATE limit_orders SET symbol = 'GM' WHERE CURRENT OF cursor_name;
 ERROR:  distributed modifications must target exactly one shard
+-- ensure returned row counters are correct
+\set QUIET off
+INSERT INTO multiple_hash VALUES ('1', '1');
+INSERT 0 1
+INSERT INTO multiple_hash VALUES ('1', '2');
+INSERT 0 1
+INSERT INTO multiple_hash VALUES ('1', '3');
+INSERT 0 1
+INSERT INTO multiple_hash VALUES ('2', '1');
+INSERT 0 1
+INSERT INTO multiple_hash VALUES ('2', '2');
+INSERT 0 1
+INSERT INTO multiple_hash VALUES ('2', '3');
+INSERT 0 1
+-- check that update return the right number of rows
+-- one row
+UPDATE multiple_hash SET data = data ||'-1' WHERE category = '1' AND data = '1';
+UPDATE 1
+-- three rows
+UPDATE multiple_hash SET data = data ||'-2' WHERE category = '1';
+UPDATE 3
+-- check
+SELECT * FROM multiple_hash WHERE category = '1' ORDER BY category, data;
+ category | data  
+----------+-------
+ 1        | 1-1-2
+ 1        | 2-2
+ 1        | 3-2
+(3 rows)
+
+-- check that deletes return the right number of rows
+-- one row
+DELETE FROM multiple_hash WHERE category = '2' AND data = '1';
+DELETE 1
+-- two rows
+DELETE FROM multiple_hash WHERE category = '2';
+DELETE 2
+-- check
+SELECT * FROM multiple_hash WHERE category = '2' ORDER BY category, data;
+ category | data 
+----------+------
+(0 rows)
+

--- a/src/test/regress/expected/multi_shard_modify.out
+++ b/src/test/regress/expected/multi_shard_modify.out
@@ -62,8 +62,7 @@ ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Joins are not supported in distributed modifications.
 -- commands with a RETURNING clause are unsupported
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = 3 RETURNING *');
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  RETURNING clauses are not supported in distributed modifications.
+ERROR:  master_modify_multiple_shards() does not support RETURNING
 -- commands containing a CTE are unsupported
 SELECT master_modify_multiple_shards('WITH deleted_stuff AS (INSERT INTO multi_shard_modify_test DEFAULT VALUES RETURNING *) DELETE FROM multi_shard_modify_test');
 ERROR:  cannot perform distributed planning for the given modification
@@ -205,8 +204,7 @@ ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Joins are not supported in distributed modifications.
 -- commands with a RETURNING clause are unsupported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''FAIL'' WHERE t_key=4 RETURNING *');
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  RETURNING clauses are not supported in distributed modifications.
+ERROR:  master_modify_multiple_shards() does not support RETURNING
 -- commands containing a CTE are unsupported
 SELECT master_modify_multiple_shards('WITH t AS (INSERT INTO multi_shard_modify_test DEFAULT VALUES RETURNING *) UPDATE multi_shard_modify_test SET t_name = ''FAIL'' ');
 ERROR:  cannot perform distributed planning for the given modification

--- a/src/test/regress/expected/multi_upsert.out
+++ b/src/test/regress/expected/multi_upsert.out
@@ -105,6 +105,23 @@ SELECT * FROM upsert_test;
         1 |         5 |       872
 (1 row)
 
+-- Test upsert, with returning:
+INSERT INTO upsert_test (part_key, other_col) VALUES (2, 2)
+	ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+        RETURNING *;
+ part_key | other_col | third_col 
+----------+-----------+-----------
+        2 |         2 |          
+(1 row)
+
+INSERT INTO upsert_test (part_key, other_col) VALUES (2, 2)
+	ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+        RETURNING *;
+ part_key | other_col | third_col 
+----------+-----------+-----------
+        2 |         3 |          
+(1 row)
+
 -- create another table
 CREATE TABLE upsert_test_2
 (

--- a/src/test/regress/expected/multi_upsert_0.out
+++ b/src/test/regress/expected/multi_upsert_0.out
@@ -138,6 +138,19 @@ SELECT * FROM upsert_test;
         1 |         1 |          
 (1 row)
 
+-- Test upsert, with returning:
+INSERT INTO upsert_test (part_key, other_col) VALUES (2, 2)
+	ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+        RETURNING *;
+ERROR:  syntax error at or near "ON"
+LINE 2:  ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+         ^
+INSERT INTO upsert_test (part_key, other_col) VALUES (2, 2)
+	ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+        RETURNING *;
+ERROR:  syntax error at or near "ON"
+LINE 2:  ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+         ^
 -- create another table
 CREATE TABLE upsert_test_2
 (

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -69,6 +69,9 @@ INSERT INTO limit_orders VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'bu
 								 20.69);
 SELECT COUNT(*) FROM limit_orders WHERE id = 32743;
 
+-- basic single-row INSERT with RETURNING
+INSERT INTO limit_orders VALUES (32744, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy', 20.69) RETURNING *;
+
 -- try a single-row INSERT with no shard to receive it
 INSERT INTO insufficient_shards VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
 										20.69);
@@ -118,9 +121,15 @@ INSERT INTO limit_orders VALUES (NULL, 'T', 975234, DEFAULT);
 -- INSERT violating column constraint
 INSERT INTO limit_orders VALUES (18811, 'BUD', 14962, '2014-04-05 08:32:16', 'sell',
 								 -5.00);
-
 -- INSERT violating primary key constraint
 INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58);
+
+-- INSERT violating primary key constraint, with RETURNING specified.
+INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58) RETURNING *;
+
+-- INSERT, with RETURNING specified, failing with a non-constraint error
+INSERT INTO limit_orders VALUES (34153, 'LEE', 5994, '2001-04-16 03:37:28', 'buy', 0.58) RETURNING id / 0;
+
 
 SET client_min_messages TO DEFAULT;
 
@@ -154,6 +163,10 @@ SELECT COUNT(*) FROM limit_orders WHERE id = 246;
 DELETE FROM limit_orders WHERE id = 246;
 SELECT COUNT(*) FROM limit_orders WHERE id = 246;
 
+-- test simple DELETE with RETURNING
+DELETE FROM limit_orders WHERE id = 430 RETURNING *;
+SELECT COUNT(*) FROM limit_orders WHERE id = 430;
+
 -- DELETE with expression in WHERE clause
 INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell', 20.69);
 SELECT COUNT(*) FROM limit_orders WHERE id = 246;
@@ -183,13 +196,22 @@ INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell'
 UPDATE limit_orders SET symbol = 'GM' WHERE id = 246;
 SELECT symbol FROM limit_orders WHERE id = 246;
 
+-- simple UPDATE with RETURNING
+UPDATE limit_orders SET symbol = 'GM' WHERE id = 246 RETURNING *;
+
 -- expression UPDATE
 UPDATE limit_orders SET bidder_id = 6 * 3 WHERE id = 246;
 SELECT bidder_id FROM limit_orders WHERE id = 246;
 
+-- expression UPDATE with RETURNING
+UPDATE limit_orders SET bidder_id = 6 * 5 WHERE id = 246 RETURNING *;
+
 -- multi-column UPDATE
 UPDATE limit_orders SET (kind, limit_price) = ('buy', DEFAULT) WHERE id = 246;
 SELECT kind, limit_price FROM limit_orders WHERE id = 246;
+
+-- multi-column UPDATE with RETURNING
+UPDATE limit_orders SET (kind, limit_price) = ('buy', 999) WHERE id = 246 RETURNING *;
 
 -- Test that on unique contraint violations, we fail fast
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
@@ -285,12 +307,28 @@ UPDATE limit_orders SET symbol = LOWER(symbol) WHERE id = 246;
 
 SELECT symbol, bidder_id FROM limit_orders WHERE id = 246;
 
+-- IMMUTABLE functions are allowed -- even in returning
+UPDATE limit_orders SET symbol = UPPER(symbol) WHERE id = 246 RETURNING id, LOWER(symbol), symbol;
+
 -- updates referencing non-IMMUTABLE functions are unsupported
 UPDATE limit_orders SET placed_at = now() WHERE id = 246;
+
+-- even in RETURNING
+UPDATE limit_orders SET placed_at = placed_at WHERE id = 246 RETURNING NOW();
 
 -- cursors are not supported
 UPDATE limit_orders SET symbol = 'GM' WHERE CURRENT OF cursor_name;
 
+-- check that multi-row UPDATE/DELETEs with RETURNING work
+INSERT INTO multiple_hash VALUES ('0', '1');
+INSERT INTO multiple_hash VALUES ('0', '2');
+INSERT INTO multiple_hash VALUES ('0', '3');
+INSERT INTO multiple_hash VALUES ('0', '4');
+INSERT INTO multiple_hash VALUES ('0', '5');
+INSERT INTO multiple_hash VALUES ('0', '6');
+
+UPDATE multiple_hash SET data = data ||'-1' WHERE category = '0' RETURNING *;
+DELETE FROM multiple_hash WHERE category = '0' RETURNING *;
 
 -- ensure returned row counters are correct
 \set QUIET off
@@ -300,12 +338,15 @@ INSERT INTO multiple_hash VALUES ('1', '3');
 INSERT INTO multiple_hash VALUES ('2', '1');
 INSERT INTO multiple_hash VALUES ('2', '2');
 INSERT INTO multiple_hash VALUES ('2', '3');
+INSERT INTO multiple_hash VALUES ('2', '3') RETURNING *;
 
 -- check that update return the right number of rows
 -- one row
 UPDATE multiple_hash SET data = data ||'-1' WHERE category = '1' AND data = '1';
 -- three rows
 UPDATE multiple_hash SET data = data ||'-2' WHERE category = '1';
+-- three rows, with RETURNING
+UPDATE multiple_hash SET data = data ||'-2' WHERE category = '1' RETURNING category;
 -- check
 SELECT * FROM multiple_hash WHERE category = '1' ORDER BY category, data;
 
@@ -314,5 +355,8 @@ SELECT * FROM multiple_hash WHERE category = '1' ORDER BY category, data;
 DELETE FROM multiple_hash WHERE category = '2' AND data = '1';
 -- two rows
 DELETE FROM multiple_hash WHERE category = '2';
+-- three rows, with RETURNING
+DELETE FROM multiple_hash WHERE category = '1' RETURNING category;
 -- check
+SELECT * FROM multiple_hash WHERE category = '1' ORDER BY category, data;
 SELECT * FROM multiple_hash WHERE category = '2' ORDER BY category, data;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -143,10 +143,6 @@ INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);
 -- INSERT ... SELECT ... FROM commands are unsupported
 INSERT INTO limit_orders SELECT * FROM limit_orders;
 
--- commands with a RETURNING clause are unsupported
-INSERT INTO limit_orders VALUES (7285, 'AMZN', 3278, '2016-01-05 02:07:36', 'sell', 0.00)
-						 RETURNING *;
-
 -- commands containing a CTE are unsupported
 WITH deleted_orders AS (DELETE FROM limit_orders RETURNING *)
 INSERT INTO limit_orders DEFAULT VALUES;
@@ -173,9 +169,6 @@ CREATE TABLE bidders ( name text, id bigint );
 DELETE FROM limit_orders USING bidders WHERE limit_orders.id = 246 AND
 											 limit_orders.bidder_id = bidders.id AND
 											 bidders.name = 'Bernie Madoff';
-
--- commands with a RETURNING clause are unsupported
-DELETE FROM limit_orders WHERE id = 246 RETURNING *;
 
 -- commands containing a CTE are unsupported
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
@@ -274,9 +267,6 @@ UPDATE limit_orders SET limit_price = 0.00 FROM bidders
 					WHERE limit_orders.id = 246 AND
 						  limit_orders.bidder_id = bidders.id AND
 						  bidders.name = 'Bernie Madoff';
-
--- commands with a RETURNING clause are unsupported
-UPDATE limit_orders SET symbol = 'GM' WHERE id = 246 RETURNING *;
 
 -- commands containing a CTE are unsupported
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)

--- a/src/test/regress/sql/multi_upsert.sql
+++ b/src/test/regress/sql/multi_upsert.sql
@@ -85,6 +85,15 @@ INSERT INTO upsert_test as ups_test (part_key, other_col) VALUES (1, 1) ON CONFL
 -- see the results
 SELECT * FROM upsert_test;
 
+-- Test upsert, with returning:
+INSERT INTO upsert_test (part_key, other_col) VALUES (2, 2)
+	ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+        RETURNING *;
+
+INSERT INTO upsert_test (part_key, other_col) VALUES (2, 2)
+	ON CONFLICT (part_key) DO UPDATE SET other_col = 3
+        RETURNING *;
+
 -- create another table
 CREATE TABLE upsert_test_2
 (


### PR DESCRIPTION
Most of the code changes aren't really about returning itself, but about making it easy to support RETURNING.  I've tried to break it down to individually review-able commits. There's one bigger commit "Combine router executor paths for select and modify commands." which I previously had split up further; I can do that again.

Fixes #242