### PR TITLE
Faster regression tests

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -37,7 +37,7 @@ output_files := $(patsubst $(citus_abs_srcdir)/output/%.source,expected/%.out, $
 # intermediate, for muscle memory backward compatibility.
 check: check-full
 # check-full triggers all tests that ought to be run routinely
-check-full: check-multi check-multi-task-tracker check-multi-binary check-worker check-multi-fdw
+check-full: check-multi check-multi-task-tracker-extra check-multi-binary check-worker check-multi-fdw
 
 # using pg_regress_multi_check unnecessarily starts up multiple nodes, which isn't needed
 # for check-worker. But that's harmless besides a few cycles.
@@ -57,17 +57,17 @@ check-multi-hll: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --load-extension=hll -- \
 	$(MULTI_REGRESS_OPTS) $(EXTRA_TESTS) multi_create_table multi_master_protocol multi_stage_data multi_agg_approximate_distinct
 
-check-multi-task-tracker: all tempinstall-main
+check-multi-task-tracker-extra: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
 	--server-option=citus.task_executor_type=task-tracker \
-	--server-option=citus.task_tracker_delay=50ms \
 	--server-option=citus.large_table_shard_count=1 \
-	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_task_tracker_extra_schedule $(EXTRA_TESTS)
+
 
 check-multi-binary: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
 	--server-option=citus.binary_worker_copy_format=on \
-	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_binary_schedule $(EXTRA_TESTS)
 
 clean distclean maintainer-clean:
 	rm -f $(output_files) $(input_files)

--- a/src/test/regress/expected/multi_single_relation_subquery.out
+++ b/src/test/regress/expected/multi_single_relation_subquery.out
@@ -198,7 +198,7 @@ SELECT max(l_suppkey) FROM
                 l_suppkey,
                 count(*)
             FROM
-                lineitem_subquery
+                lineitem
             WHERE
                 l_orderkey < 20000
             GROUP BY

--- a/src/test/regress/multi_binary_schedule
+++ b/src/test/regress/multi_binary_schedule
@@ -1,0 +1,33 @@
+# ----------
+# $Id$
+#
+# Regression tests that test binary mode data transfer between workers.
+# No new tests are expected here unless they are specifically testing for changes
+# in binary mode data transfer
+#
+# ----------
+
+# ---
+# Tests around schema changes, these are run first, so there's no preexisting objects.
+# ---
+test: multi_extension
+test: multi_table_ddl
+
+# ----------
+# The following distributed tests depend on creating a partitioned table and
+# uploading data to it.
+# ----------
+test: multi_create_table
+test: multi_stage_data
+
+test: multi_basic_queries multi_complex_expressions multi_verify_no_subquery
+test: multi_single_relation_subquery
+test: multi_binary_master_copy_format
+
+test: multi_simple_queries
+
+# ---------
+# multi_copy creates hash and range-partitioned tables and performs COPY
+# ---------
+test: multi_copy
+

--- a/src/test/regress/multi_task_tracker_extra_schedule
+++ b/src/test/regress/multi_task_tracker_extra_schedule
@@ -1,11 +1,9 @@
 # ----------
 # $Id$
 #
-# Regression tests that exercise distributed planning/execution functionality.
-#
-# All new regression tests are expected to be run by this schedule. Tests that
-# do not set specific task executor type should also be added to 
-# multi_task_tracker_extra_schedule.
+# Regression tests for task tracker executor. This schedule runs tests
+# in task tracker executor. Any test that do not explicitly set the task executor
+# are expected to be placed here in addition to multi_schedule. 
 #
 # Note that we use variant comparison files to test version dependent regression
 # test results. For more information:
@@ -30,9 +28,6 @@ test: multi_stage_data
 # Miscellaneous tests to check our query planning behavior
 # ----------
 test: multi_basic_queries multi_complex_expressions multi_verify_no_subquery
-test: multi_explain
-test: multi_subquery
-test: multi_single_relation_subquery
 test: multi_agg_distinct multi_limit_clause multi_limit_clause_approximate
 test: multi_average_expression multi_working_columns
 test: multi_array_agg
@@ -45,8 +40,6 @@ test: multi_task_assignment_policy
 test: multi_utility_statements
 test: multi_dropped_column_aliases
 test: multi_verify_no_join_with_alias
-test: multi_binary_master_copy_format
-test: multi_prepare_sql multi_prepare_plsql
 
 # ----------
 # Parallel TPC-H tests to check our distributed execution behavior
@@ -64,15 +57,6 @@ test: multi_stage_more_data
 test: multi_join_order_tpch_large
 
 # ----------
-# Tests for large-table join planning and execution.
-# Be careful when staging new data before these tests, as they
-# expect specific shard identifiers in the output.
-# ----------
-test: multi_large_table_join_planning
-test: multi_large_table_pruning
-test: multi_large_table_task_assignment
-
-# ----------
 # Tests to check our large record staging and shard deletion behavior
 # ----------
 test: multi_stage_large_records
@@ -80,28 +64,10 @@ test: multi_master_delete_protocol
 test: multi_shard_modify
 
 # ----------
-# Tests around DDL statements run on distributed tables
-# ----------
-test: multi_index_statements
-test: multi_alter_table_statements
-
-# ----------
 # multi_create_schema tests creation, staging and querying of a table in a new
 # schema (namespace).
 # ----------
 test: multi_create_schema
-
-# ----------
-# Tests to check if we inform the user about potential caveats of creating new
-# databases, schemas, and roles.
-# ----------
-test: multi_utility_warnings
-
-# ---------
-# multi_append_table_to_shard stages shards in a way that forces
-# shard caching.
-# ---------
-test: multi_append_table_to_shard
 
 # ---------
 # multi_outer_join stages shards to create different mappings for outer joins
@@ -112,11 +78,10 @@ test: multi_outer_join
 # Tests covering mostly modification queries and required preliminary
 # functionality related to metadata, shard creation, shard pruning and
 # "hacky" copy script for hash partitioned tables.
-# Note that the order of the following tests are important. multi_complex_count_distinct
-# is independed from the rest of the group, it is added to increase parallelism.
+# Note that the order of the following tests are important.
 # ---
 test: multi_create_fdw
-test: multi_connection_cache multi_complex_count_distinct
+test: multi_connection_cache
 test: multi_distribution_metadata
 test: multi_generate_ddl_commands
 test: multi_create_shards
@@ -128,17 +93,11 @@ test: multi_simple_queries
 test: multi_utilities
 test: multi_create_insert_proxy
 test: multi_data_types
-test: multi_repartitioned_subquery_udf
 
 # ---------
 # multi_copy creates hash and range-partitioned tables and performs COPY
 # ---------
 test: multi_copy
-
-# ---------
-# multi_router_planner creates hash partitioned tables. 
-# ---------
-test: multi_router_planner
 
 # ----------
 # multi_large_shardid stages more shards into lineitem
@@ -149,3 +108,4 @@ test: multi_large_shardid
 # multi_drop_extension makes sure we can safely drop and recreate the extension
 # ----------
 test: multi_drop_extension
+

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -96,6 +96,8 @@ push(@pgOptions, '-c', "max_prepared_transactions=100");
 push(@pgOptions, '-c', "citus.shard_max_size=300kB");
 push(@pgOptions, '-c', "citus.max_running_tasks_per_node=4");
 push(@pgOptions, '-c', "citus.expire_cached_shards=on");
+push(@pgOptions, '-c', "citus.task_tracker_delay=10ms");
+push(@pgOptions, '-c', "citus.remote_task_check_interval=1ms");
 
 # Add externally added options last, so they overwrite the default ones above
 for my $option (@userPgOptions)
@@ -301,8 +303,14 @@ for my $extension (@extensions)
 # Append remaining ARGV arguments to pg_regress arguments
 push(@arguments, @ARGV);
 
+my $startTime = time();
+
 # Finally run the tests
 system("$pgxsdir/src/test/regress/pg_regress", @arguments) == 0
     or die "Could not run regression tests";
+
+my $endTime = time();
+
+print "Finished in ". ($endTime - $startTime)." seconds. \n";
 
 exit 0;

--- a/src/test/regress/sql/multi_single_relation_subquery.sql
+++ b/src/test/regress/sql/multi_single_relation_subquery.sql
@@ -152,7 +152,7 @@ SELECT max(l_suppkey) FROM
                 l_suppkey,
                 count(*)
             FROM
-                lineitem_subquery
+                lineitem
             WHERE
                 l_orderkey < 20000
             GROUP BY


### PR DESCRIPTION
We used to go over multi_schedule 3 times to run  check-multi, check-multi-binary and check-multi-task-tracker runs during check-full.

This was causing extra long running times during development.
I created 2 more schedules multi_binary_schedule and multi_task_tracker_extra_schedule. These schedules are stripped down versions of multi_schedule.  

multi_task_tracker_extra_schedule : contains tests that do not explicitly set task-executor in the beginning of the test. This way the same test is run in both modes only if it does not specify the task-executor.

multi_binary_schedule : contains **some** regression tests that do repartitioning since binary-worker-copy-format is only related to data repartitioning. Unfortunately, I could not make this a part of multi_schedule since this parameter is on the worker side, and only activated after a restart. 

Changes in above tests are related to reducing number of tests run in check-full.

I also added 2 settings when running those schedules.
```
task_tracker_delay = 10ms
remote_task_check_interval = 1 ms
```

These are pretty aggressive numbers. However, they seem to be fine on both my laptop and on travis.

Overall total runtime is reduced to the less than half of original value.

There are few more optimizations possible
1- reduce the number of schedules being run, since setup time costs significant time. For example setup time for ```check-worker``` takes longer than actual tests. Perhaps we could merge check-multi-fdw, check-multi-hll into a single schedule. This would save us from one test setup time (about 15 seconds on my laptop)

2-go over long running tests and reduce the number of cases that do repartitioning. We need to be careful about not reducing the coverage here, same coverage with less tests.

Fixes #346 