### PR TITLE
Eliminate compile time warnings in multi_logical_optimizer.c

### DIFF
--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -2871,7 +2871,8 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 				{
 					ereport(WARNING, (errmsg("could not receive response for cleanup "
 											 "query status for job " UINT64_FORMAT " "
-											 "on node \"%s:%u\" with status %d", jobId,
+																				   "on node \"%s:%u\" with status %d",
+											 jobId,
 											 nodeName, nodePort, (int) queryStatus),
 									  errhint("Manually clean job resources on node "
 											  "\"%s:%u\" by running \"%s\" ", nodeName,
@@ -2887,10 +2888,11 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 			{
 				ereport(WARNING, (errmsg("could not receive response for cleanup query "
 										 "result for job " UINT64_FORMAT " on node "
-										 "\"%s:%u\" with status %d", jobId, nodeName,
+																		 "\"%s:%u\" with status %d",
+										 jobId, nodeName,
 										 nodePort, (int) resultStatus),
-						  	  	  errhint("Manually clean job resources on node "
-						  	  			  "\"%s:%u\" by running \"%s\" ", nodeName,
+								  errhint("Manually clean job resources on node "
+										  "\"%s:%u\" by running \"%s\" ", nodeName,
 										  nodePort, jobCleanupTask->queryString)));
 			}
 			else

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -1705,9 +1705,10 @@ WorkerExtendedOpNode(MultiExtendedOp *originalOpNode)
 	AttrNumber targetProjectionNumber = 1;
 	WorkerAggregateWalkerContext *walkerContext =
 		palloc0(sizeof(WorkerAggregateWalkerContext));
+	Index nextSortGroupRefIndex = 0;
+
 	walkerContext->repartitionSubquery = false;
 	walkerContext->expressionList = NIL;
-	Index nextSortGroupRefIndex = 0;
 
 	if (CitusIsA(parentNode, MultiTable) && CitusIsA(childNode, MultiCollect))
 	{
@@ -2501,6 +2502,7 @@ TablePartitioningSupportsDistinct(List *tableNodeList, MultiExtendedOp *opNode,
 		Oid relationId = tableNode->relationId;
 		bool tableDistinctSupported = false;
 		char partitionMethod = 0;
+		List *shardList = NIL;
 
 		if (relationId == SUBQUERY_RELATION_ID)
 		{
@@ -2508,7 +2510,7 @@ TablePartitioningSupportsDistinct(List *tableNodeList, MultiExtendedOp *opNode,
 		}
 
 		/* if table has one shard, task results don't overlap */
-		List *shardList = LoadShardList(relationId);
+		shardList = LoadShardList(relationId);
 		if (list_length(shardList) == 1)
 		{
 			continue;


### PR DESCRIPTION
This change removes some issues about mixed declarations
and code in TablePartitioningSupportsDistinct() and
WorkerExtendedOpNode() functions.