### PR TITLE
Add LIMIT/OFFSET Support

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -382,12 +382,6 @@ ErrorIfQueryNotSupported(Query *queryTree)
 		errorDetail = "Window functions are currently unsupported";
 	}
 
-	if (queryTree->limitOffset)
-	{
-		preconditionsSatisfied = false;
-		errorDetail = "Limit Offset clause is currently unsupported";
-	}
-
 	if (queryTree->setOperations)
 	{
 		preconditionsSatisfied = false;
@@ -560,6 +554,12 @@ ErrorIfSubqueryNotSupported(Query *subqueryTree)
 	{
 		preconditionsSatisfied = false;
 		errorDetail = "Subqueries with limit are not supported yet";
+	}
+
+	if (subqueryTree->limitOffset != NULL)
+	{
+		preconditionsSatisfied = false;
+		errorDetail = "Subqueries with offset are not supported yet";
 	}
 
 	/* finally check and error out if not satisfied */

--- a/src/backend/distributed/planner/multi_master_planner.c
+++ b/src/backend/distributed/planner/multi_master_planner.c
@@ -246,7 +246,7 @@ BuildSelectStatement(Query *masterQuery, char *masterTableName,
 	}
 
 	/* (5) add a limit plan if needed */
-	if (masterQuery->limitCount)
+	if (masterQuery->limitCount || masterQuery->limitOffset)
 	{
 		Node *limitCount = masterQuery->limitCount;
 		Node *limitOffset = masterQuery->limitOffset;

--- a/src/test/regress/expected/multi_basic_queries.out
+++ b/src/test/regress/expected/multi_basic_queries.out
@@ -2,7 +2,6 @@
 -- MULTI_BASIC_QUERIES
 --
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 440000;
-ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 440000;
 -- Execute simple sum, average, and count queries on data recently uploaded to
 -- our partitioned table.
 SELECT count(*) FROM lineitem;

--- a/src/test/regress/expected/multi_complex_expressions.out
+++ b/src/test/regress/expected/multi_complex_expressions.out
@@ -347,3 +347,115 @@ SELECT count(*) FROM lineitem JOIN orders ON l_orderkey = o_orderkey
 SELECT count(*) FROM lineitem, orders WHERE l_orderkey + 1 = o_orderkey;
 ERROR:  cannot perform local joins that involve expressions
 DETAIL:  local joins can be performed between columns only
+-- Check that we can issue limit/offset queries
+-- OFFSET in subqueries are not supported
+-- Error in the planner when subquery pushdown is off
+SELECT * FROM (SELECT o_orderkey FROM orders ORDER BY o_orderkey OFFSET 20) sq;
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries with offset are not supported yet
+SET citus.subquery_pushdown TO true;
+-- Error in the optimizer when subquery pushdown is on
+SELECT * FROM (SELECT o_orderkey FROM orders ORDER BY o_orderkey OFFSET 20) sq;
+ERROR:  cannot push down this subquery
+DETAIL:  Offset clause is currently unsupported
+SET citus.subquery_pushdown TO false;
+-- Simple LIMIT/OFFSET with ORDER BY
+SELECT o_orderkey FROM orders ORDER BY o_orderkey LIMIT 10 OFFSET 20;
+ o_orderkey 
+------------
+         69
+         70
+         71
+         96
+         97
+         98
+         99
+        100
+        101
+        102
+(10 rows)
+
+-- LIMIT/OFFSET with a subquery
+SET client_min_messages TO 'debug1';
+SET citus.task_executor_type TO 'task-tracker';
+SELECT 
+	customer_keys.o_custkey,
+	SUM(order_count) AS total_order_count 
+FROM 
+	(SELECT o_custkey, o_orderstatus, COUNT(*) AS order_count 
+	 FROM orders GROUP BY o_custkey, o_orderstatus ) customer_keys
+GROUP BY 
+	customer_keys.o_custkey
+ORDER BY 
+	customer_keys.o_custkey DESC
+LIMIT 10 OFFSET 20;
+DEBUG:  push down of limit count: 30
+DEBUG:  building index "pg_toast_16953_index" on table "pg_toast_16953"
+ o_custkey | total_order_count 
+-----------+-------------------
+      1466 |                 1
+      1465 |                 2
+      1463 |                 4
+      1462 |                10
+      1460 |                 1
+      1459 |                 6
+      1457 |                 1
+      1456 |                 3
+      1454 |                 2
+      1453 |                 5
+(10 rows)
+
+SET citus.task_executor_type TO 'real-time';
+-- Ensure that we push down LIMIT and OFFSET properly
+-- No Group-By -> Push Down
+CREATE TEMP TABLE temp_limit_test_1 AS
+SELECT o_custkey FROM orders LIMIT 10 OFFSET 15;
+DEBUG:  push down of limit count: 25
+-- GROUP BY without ORDER BY -> No push-down
+CREATE TEMP TABLE temp_limit_test_2 AS
+SELECT o_custkey FROM orders GROUP BY o_custkey LIMIT 10 OFFSET 15;
+-- GROUP BY and ORDER BY non-aggregate -> push-down
+CREATE TEMP TABLE temp_limit_test_3 AS
+SELECT o_custkey FROM orders GROUP BY o_custkey ORDER BY o_custkey LIMIT 10 OFFSET 15;
+DEBUG:  push down of limit count: 25
+-- GROUP BY and ORDER BY aggregate -> No push-down
+CREATE TEMP TABLE temp_limit_test_4 AS
+SELECT o_custkey, COUNT(*) AS ccnt FROM orders GROUP BY o_custkey ORDER BY ccnt DESC LIMIT 10 OFFSET 15;
+-- OFFSET without LIMIT
+SELECT o_custkey FROM orders ORDER BY o_custkey OFFSET 2980;
+ o_custkey 
+-----------
+      1498
+      1499
+      1499
+      1499
+(4 rows)
+
+-- LIMIT/OFFSET with Joins
+SELECT 
+	li.l_partkey,
+	o.o_custkey,
+	li.l_quantity
+FROM 
+	lineitem li JOIN orders o ON li.l_orderkey = o.o_orderkey
+WHERE 
+	li.l_quantity > 25
+ORDER BY
+	li.l_quantity
+LIMIT 10 OFFSET 20;
+DEBUG:  push down of limit count: 30
+ l_partkey | o_custkey | l_quantity 
+-----------+-----------+------------
+    135912 |       509 |      26.00
+     75351 |      1261 |      26.00
+    199475 |      1052 |      26.00
+     91309 |         8 |      26.00
+     53624 |       400 |      26.00
+    182736 |      1048 |      26.00
+     59694 |       163 |      26.00
+     20481 |       173 |      26.00
+     78748 |      1499 |      26.00
+      7614 |      1397 |      26.00
+(10 rows)
+
+RESET client_min_messages;

--- a/src/test/regress/expected/multi_verify_no_subquery.out
+++ b/src/test/regress/expected/multi_verify_no_subquery.out
@@ -4,7 +4,6 @@
 -- This test checks that we simply emit an error message instead of trying to
 -- process a distributed unsupported SQL subquery.
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1030000;
-ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1030000;
 SELECT * FROM lineitem WHERE l_orderkey IN
 	(SELECT l_orderkey FROM lineitem WHERE l_quantity > 0);
 ERROR:  cannot perform distributed planning on this query

--- a/src/test/regress/sql/multi_basic_queries.sql
+++ b/src/test/regress/sql/multi_basic_queries.sql
@@ -4,7 +4,6 @@
 
 
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 440000;
-ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 440000;
 
 
 -- Execute simple sum, average, and count queries on data recently uploaded to

--- a/src/test/regress/sql/multi_verify_no_subquery.sql
+++ b/src/test/regress/sql/multi_verify_no_subquery.sql
@@ -7,7 +7,6 @@
 
 
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1030000;
-ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1030000;
 
 
 SELECT * FROM lineitem WHERE l_orderkey IN


### PR DESCRIPTION
Fixes #394 

This change adds LIMIT/OFFSET support for non router-plannable
distributed queries.

In cases that we can push the LIMIT down, we add the OFFSET value to
that LIMIT in the worker queries. When a query with LIMIT x OFFSET y is issued, 
the query is propagated to the workers as LIMIT (x+y) OFFSET 0, and on the 
master table, the original LIMIT and OFFSET values are used. With this change, 
we can use OFFSET wherever we can use LIMIT.