### PR TITLE
Do not copy outer join clauses into WHERE

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -3286,12 +3286,22 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *depended
 		foreach(nextJoinClauseCell, nextJoinClauseList)
 		{
 			OpExpr *nextJoinClause = (OpExpr *) lfirst(nextJoinClauseCell);
-			Var *leftColumn = LeftColumn(nextJoinClause);
-			Var *rightColumn = RightColumn(nextJoinClause);
-			Index leftRangeTableId = leftColumn->varno;
-			Index rightRangeTableId = rightColumn->varno;
+			Var *leftColumn = NULL;
+			Var *rightColumn = NULL;
+			Index leftRangeTableId = 0;
+			Index rightRangeTableId = 0;
 			bool leftPartitioned = false;
 			bool rightPartitioned = false;
+
+			if (!IsJoinClause((Node *) nextJoinClause))
+			{
+				continue;
+			}
+
+			leftColumn = LeftColumn(nextJoinClause);
+			rightColumn = RightColumn(nextJoinClause);
+			leftRangeTableId = leftColumn->varno;
+			rightRangeTableId = rightColumn->varno;
 
 			/*
 			 * We have a table from the existing join list joining with the next

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -192,6 +192,7 @@ extern bool BinaryOperator(MultiNode *node);
 extern List * OutputTableIdList(MultiNode *multiNode);
 extern List * FindNodesOfType(MultiNode *node, int type);
 extern List * JoinClauseList(List *whereClauseList);
+extern bool IsJoinClause(Node *clause);
 extern List * SubqueryEntryList(Query *queryTree);
 extern bool ExtractRangeTableIndexWalker(Node *node, List **rangeTableIndexList);
 extern List * WhereClauseList(FromExpr *fromExpr);

--- a/src/test/regress/input/multi_outer_join.source
+++ b/src/test/regress/input/multi_outer_join.source
@@ -113,6 +113,14 @@ WHERE
 	r_custkey = 5;
 
 
+-- Apply a filter before the join
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND r_custkey = 5);
+
+
 -- Right join should be disallowed in this case
 SELECT
 	min(r_custkey), max(r_custkey)
@@ -189,6 +197,14 @@ FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b ON (l_custkey = r_custkey)
 WHERE
 	r_custkey = 21;
+
+
+-- Apply a filter before the join
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND r_custkey = 21);
 
 
 -- Right join should be allowed in this case

--- a/src/test/regress/input/multi_outer_join.source
+++ b/src/test/regress/input/multi_outer_join.source
@@ -120,6 +120,19 @@ FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
 	ON (l_custkey = r_custkey AND r_custkey = 5);
 
+-- Apply a filter before the join (no matches right)
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND r_custkey = -1 /* nonexistant */);
+
+-- Apply a filter before the join (no matches left)
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND l_custkey = -1 /* nonexistant */);
 
 -- Right join should be disallowed in this case
 SELECT

--- a/src/test/regress/output/multi_outer_join.source
+++ b/src/test/regress/output/multi_outer_join.source
@@ -158,6 +158,30 @@ LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_
     20 |     1
 (1 row)
 
+-- Apply a filter before the join (no matches right)
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND r_custkey = -1 /* nonexistant */);
+LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_right" ]
+ count | count 
+-------+-------
+    20 |     0
+(1 row)
+
+-- Apply a filter before the join (no matches left)
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND l_custkey = -1 /* nonexistant */);
+LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_right" ]
+ count | count 
+-------+-------
+    20 |     0
+(1 row)
+
 -- Right join should be disallowed in this case
 SELECT
 	min(r_custkey), max(r_custkey)

--- a/src/test/regress/output/multi_outer_join.source
+++ b/src/test/regress/output/multi_outer_join.source
@@ -146,6 +146,18 @@ LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_
    5 |   5
 (1 row)
 
+-- Apply a filter before the join
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND r_custkey = 5);
+LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_right" ]
+ count | count 
+-------+-------
+    20 |     1
+(1 row)
+
 -- Right join should be disallowed in this case
 SELECT
 	min(r_custkey), max(r_custkey)
@@ -247,6 +259,18 @@ LOG:  join order: [ "multi_outer_join_left" ][ local partition join "multi_outer
  min | max 
 -----+-----
   21 |  21
+(1 row)
+
+-- Apply a filter before the join
+SELECT
+	count(l_custkey), count(r_custkey)
+FROM
+	multi_outer_join_left a LEFT JOIN multi_outer_join_right b
+	ON (l_custkey = r_custkey AND r_custkey = 21);
+LOG:  join order: [ "multi_outer_join_left" ][ local partition join "multi_outer_join_right" ]
+ count | count 
+-------+-------
+    25 |     1
 (1 row)
 
 -- Right join should be allowed in this case


### PR DESCRIPTION
Currently, we extract all non-join clauses from ON (...) sections and put them in the selectClauseList of the multi-plan, but this is wrong for outer joins, since these clauses apply to the underlying table, while the where clause applies to the join result. This change restricts WhereClauseList to ON (...) sections of inner joins.

Closes #599 