### PR TITLE
Fix join pruning performance

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -3601,17 +3601,16 @@ FragmentInterval(RangeTableFragment *fragment)
 bool
 ShardIntervalsOverlap(ShardInterval *firstInterval, ShardInterval *secondInterval)
 {
-	Oid typeId = InvalidOid;
-	FmgrInfo *comparisonFunction = NULL;
 	bool nonOverlap = false;
+	DistTableCacheEntry *intervalRelation =
+		DistributedTableCacheEntry(firstInterval->relationId);
+	FmgrInfo *comparisonFunction = intervalRelation->shardIntervalCompareFunction;
 
 	Datum firstMin = 0;
 	Datum firstMax = 0;
 	Datum secondMin = 0;
 	Datum secondMax = 0;
 
-	typeId = firstInterval->valueTypeId;
-	comparisonFunction = GetFunctionInfo(typeId, BTREE_AM_OID, BTORDER_PROC);
 
 	firstMin = firstInterval->minValue;
 	firstMax = firstInterval->maxValue;


### PR DESCRIPTION
@sumedhpathak @ozgune Could either of you review this soon-ish? Or assign somebody to do that? I think both fixes are fairly simple, the first being nearly trivial.

The first commit gets plan time for the query in issue #607 goes from 8764 ms to 2889 ms, the second from 2889 ms to 106 ms.

Fixes #607 