### PR TITLE
Refactor multi_planner to create router plan directly

### DIFF
--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -72,15 +72,8 @@ MultiPlan *
 CreatePhysicalPlan(Query *parse)
 {
 	Query *parseCopy = copyObject(parse);
-	MultiPlan *physicalPlan = NULL;
-	bool routerPlannable = MultiRouterPlannableQuery(parseCopy, TaskExecutorType);
-	if (routerPlannable)
-	{
-		ereport(DEBUG2, (errmsg("Creating router plan")));
-		physicalPlan = MultiRouterPlanCreate(parseCopy);
-		CheckNodeIsDumpable((Node *) physicalPlan);
-	}
-	else
+	MultiPlan *physicalPlan = MultiRouterPlanCreate(parseCopy, TaskExecutorType);
+	if (physicalPlan == NULL)
 	{
 		/* Create and optimize logical plan */
 		MultiTreeRoot *logicalPlan = MultiLogicalPlanCreate(parseCopy);

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -30,8 +30,8 @@
 #define UPSERT_ALIAS "citus_table_alias"
 #endif
 
-extern MultiPlan * MultiRouterPlanCreate(Query *query);
+extern MultiPlan * MultiRouterPlanCreate(Query *query,
+										 MultiExecutorType taskExecutorType);
 extern void ErrorIfModifyQueryNotSupported(Query *queryTree);
-extern bool MultiRouterPlannableQuery(Query *query, MultiExecutorType taskExecutorType);
 
 #endif /* MULTI_ROUTER_PLANNER_H */


### PR DESCRIPTION
If router plan creation fails, it falls back to normal planner

Fixes the first task of  #501 