### PR TITLE
Fix bug related to poll timeout

### DIFF
--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -800,14 +800,14 @@ MultiClientRegisterWait(WaitInfo *waitInfo, TaskExecutionStatus executionStatus,
 void
 MultiClientWait(WaitInfo *waitInfo)
 {
-	long sleepIntervalPerCycle = RemoteTaskCheckInterval * 1000L;
-
 	/*
 	 * If we had a failure, we always want to sleep for a bit, to prevent
 	 * flooding the other system, probably making the situation worse.
 	 */
 	if (waitInfo->haveFailedWaiter)
 	{
+		long sleepIntervalPerCycle = RemoteTaskCheckInterval * 1000L;
+
 		pg_usleep(sleepIntervalPerCycle);
 		return;
 	}
@@ -828,7 +828,7 @@ MultiClientWait(WaitInfo *waitInfo)
 		 * times as long.
 		 */
 		int rc = poll(waitInfo->pollfds, waitInfo->registeredWaiters,
-					  sleepIntervalPerCycle * 10);
+					  RemoteTaskCheckInterval * 10);
 
 		if (rc < 0)
 		{


### PR DESCRIPTION
Fixed #580 

This commit fixes a bug on setting polling timeout. The code
updated to conform to the comment that is already placed.

Now, when both workers are down, we get the error in ~150 msec compared to 100 seconds.