### PR TITLE
Add schema name to worker apply shard ddl command

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -6,7 +6,7 @@ citus_top_builddir = ../../..
 MODULE_big = citus
 EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
-	5.1-1 5.1-2 5.1-3
+	5.1-1 5.1-2 5.1-3 5.1-4
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -38,6 +38,8 @@ $(EXTENSION)--5.1-1.sql: $(EXTENSION)--5.0-2.sql $(EXTENSION)--5.0-2--5.1-1.sql
 $(EXTENSION)--5.1-2.sql: $(EXTENSION)--5.1-1.sql $(EXTENSION)--5.1-1--5.1-2.sql
 	cat $^ > $@
 $(EXTENSION)--5.1-3.sql: $(EXTENSION)--5.1-2.sql $(EXTENSION)--5.1-2--5.1-3.sql
+	cat $^ > $@
+$(EXTENSION)--5.1-4.sql: $(EXTENSION)--5.1-3.sql $(EXTENSION)--5.1-3--5.1-4.sql
 	cat $^ > $@
 	
 NO_PGXS = 1

--- a/src/backend/distributed/citus--5.1-3--5.1-4.sql
+++ b/src/backend/distributed/citus--5.1-3--5.1-4.sql
@@ -1,0 +1,8 @@
+DROP FUNCTION IF EXISTS pg_catalog.worker_apply_shard_ddl_command(bigint, text);
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_apply_shard_ddl_command(bigint, text, text)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$worker_apply_shard_ddl_command$$;
+COMMENT ON FUNCTION worker_apply_shard_ddl_command(bigint, text, text)
+    IS 'extend ddl command with shardId and apply on database';

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '5.1-3'
+default_version = '5.1-4'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1106,6 +1106,8 @@ ExecuteCommandOnWorkerShards(Oid relationId, const char *commandString)
 	char *tableOwner = TableOwner(relationId);
 	HTAB *shardConnectionHash = NULL;
 	ListCell *shardIntervalCell = NULL;
+	Oid schemaId = get_rel_namespace(relationId);
+	char *schemaName = get_namespace_name(schemaId);
 
 	MemoryContext oldContext = MemoryContextSwitchTo(TopTransactionContext);
 
@@ -1113,7 +1115,6 @@ ExecuteCommandOnWorkerShards(Oid relationId, const char *commandString)
 
 	shardConnectionHash = OpenTransactionsToAllShardPlacements(shardIntervalList,
 															   tableOwner);
-
 	MemoryContextSwitchTo(oldContext);
 
 	foreach(shardIntervalCell, shardIntervalList)
@@ -1122,7 +1123,8 @@ ExecuteCommandOnWorkerShards(Oid relationId, const char *commandString)
 		uint64 shardId = shardInterval->shardId;
 		ShardConnections *shardConnections = NULL;
 		bool shardConnectionsFound = false;
-		char *escapedCommandString = NULL;
+		char *escapedSchemaName = quote_literal_cstr(schemaName);
+		char *escapedCommandString = quote_literal_cstr(commandString);
 		StringInfo applyCommand = makeStringInfo();
 
 		shardConnections = GetShardConnections(shardConnectionHash,
@@ -1131,9 +1133,8 @@ ExecuteCommandOnWorkerShards(Oid relationId, const char *commandString)
 		Assert(shardConnectionsFound);
 
 		/* build the shard ddl command */
-		escapedCommandString = quote_literal_cstr(commandString);
 		appendStringInfo(applyCommand, WORKER_APPLY_SHARD_DDL_COMMAND, shardId,
-						 escapedCommandString);
+						 escapedSchemaName, escapedCommandString);
 
 		ExecuteCommandOnShardPlacements(applyCommand, shardId, shardConnections);
 

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -203,8 +203,8 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 		 */
 		LockShardDistributionMetadata(shardId, ExclusiveLock);
 
-		CreateShardPlacements(shardId, ddlCommandList, relationOwner, workerNodeList,
-							  roundRobinNodeIndex, replicationFactor);
+		CreateShardPlacements(distributedTableId, shardId, ddlCommandList, relationOwner,
+							  workerNodeList, roundRobinNodeIndex, replicationFactor);
 
 		InsertShardRow(distributedTableId, shardId, shardStorageType,
 					   minHashTokenText, maxHashTokenText);

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -40,8 +40,8 @@
 
 
 /* Local functions forward declarations */
-static bool WorkerCreateShard(char *nodeName, uint32 nodePort, uint64 shardId,
-							  char *newShardOwner, List *ddlCommandList);
+static bool WorkerCreateShard(Oid relationId, char *nodeName, uint32 nodePort,
+							  uint64 shardId, char *newShardOwner, List *ddlCommandList);
 static bool WorkerShardStats(char *nodeName, uint32 nodePort, Oid relationId,
 							 char *shardName, uint64 *shardSize,
 							 text **shardMinValue, text **shardMaxValue);
@@ -167,7 +167,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 		candidateNodeIndex++;
 	}
 
-	CreateShardPlacements(shardId, ddlEventList, relationOwner,
+	CreateShardPlacements(relationId, shardId, ddlEventList, relationOwner,
 						  candidateNodeList, 0, ShardReplicationFactor);
 
 	InsertShardRow(relationId, shardId, storageType, nullMinValue, nullMaxValue);
@@ -377,8 +377,9 @@ CheckDistributedTable(Oid relationId)
  * nodes if some DDL commands had been successful).
  */
 void
-CreateShardPlacements(int64 shardId, List *ddlEventList, char *newPlacementOwner,
-					  List *workerNodeList, int workerStartIndex, int replicationFactor)
+CreateShardPlacements(Oid relationId, int64 shardId, List *ddlEventList,
+					  char *newPlacementOwner, List *workerNodeList,
+					  int workerStartIndex, int replicationFactor)
 {
 	int attemptCount = replicationFactor;
 	int workerNodeCount = list_length(workerNodeList);
@@ -398,8 +399,8 @@ CreateShardPlacements(int64 shardId, List *ddlEventList, char *newPlacementOwner
 		char *nodeName = workerNode->workerName;
 		uint32 nodePort = workerNode->workerPort;
 
-		bool created = WorkerCreateShard(nodeName, nodePort, shardId, newPlacementOwner,
-										 ddlEventList);
+		bool created = WorkerCreateShard(relationId, nodeName, nodePort, shardId,
+										 newPlacementOwner, ddlEventList);
 		if (created)
 		{
 			const RelayFileState shardState = FILE_FINALIZED;
@@ -435,9 +436,12 @@ CreateShardPlacements(int64 shardId, List *ddlEventList, char *newPlacementOwner
  * each DDL command, and could leave the shard in an half-initialized state.
  */
 static bool
-WorkerCreateShard(char *nodeName, uint32 nodePort, uint64 shardId,
-				  char *newShardOwner, List *ddlCommandList)
+WorkerCreateShard(Oid relationId, char *nodeName, uint32 nodePort,
+				  uint64 shardId, char *newShardOwner, List *ddlCommandList)
 {
+	Oid schemaId = get_rel_namespace(relationId);
+	char *schemaName = get_namespace_name(schemaId);
+	char *escapedSchemaName = quote_literal_cstr(schemaName);
 	bool shardCreated = true;
 	ListCell *ddlCommandCell = NULL;
 
@@ -446,10 +450,10 @@ WorkerCreateShard(char *nodeName, uint32 nodePort, uint64 shardId,
 		char *ddlCommand = (char *) lfirst(ddlCommandCell);
 		char *escapedDDLCommand = quote_literal_cstr(ddlCommand);
 		List *queryResultList = NIL;
-
 		StringInfo applyDDLCommand = makeStringInfo();
-		appendStringInfo(applyDDLCommand, WORKER_APPLY_SHARD_DDL_COMMAND,
-						 shardId, escapedDDLCommand);
+
+		appendStringInfo(applyDDLCommand, WORKER_APPLY_SHARD_DDL_COMMAND, shardId,
+						 escapedSchemaName, escapedDDLCommand);
 
 		queryResultList = ExecuteRemoteQuery(nodeName, nodePort, newShardOwner,
 											 applyDDLCommand);

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -400,13 +400,15 @@ Datum
 worker_apply_shard_ddl_command(PG_FUNCTION_ARGS)
 {
 	uint64 shardId = PG_GETARG_INT64(0);
-	text *ddlCommandText = PG_GETARG_TEXT_P(1);
+	text *schemaNameText = PG_GETARG_TEXT_P(1);
+	text *ddlCommandText = PG_GETARG_TEXT_P(2);
 
+	char *schemaName = text_to_cstring(schemaNameText);
 	const char *ddlCommand = text_to_cstring(ddlCommandText);
 	Node *ddlCommandNode = ParseTreeNode(ddlCommand);
 
 	/* extend names in ddl command and apply extended command */
-	RelayEventExtendNames(ddlCommandNode, shardId);
+	RelayEventExtendNames(ddlCommandNode, schemaName, shardId);
 	ProcessUtility(ddlCommandNode, ddlCommand, PROCESS_UTILITY_TOPLEVEL,
 				   NULL, None_Receiver, NULL);
 

--- a/src/bin/csql/stage.c
+++ b/src/bin/csql/stage.c
@@ -1387,15 +1387,23 @@ static bool
 ApplyShardDDLCommand(PGconn *workerNode, uint64 shardId, const char *ddlCommand)
 {
 	const char *remoteCommand = APPLY_SHARD_DDL_COMMAND;
-	const char *parameterValue[2];
-	const int parameterCount = 2;
+	const char *parameterValue[3];
+	const int parameterCount = 3;
 	PGresult *ddlResult = NULL;
 
 	char shardIdString[NAMEDATALEN];
 	snprintf(shardIdString, NAMEDATALEN, UINT64_FORMAT, shardId);
 
+	/*
+	 * We changed worker_apply_shard_ddl_command and now it requires schema name. Since
+	 * \STAGE will be deprecated anyway, we use public schema for everything to make it
+	 * work with worker_apply_shard_ddl_command. Please note that if user specifies
+	 * schema name, this will not override it, because we prioritize schema names given
+	 * in the query in worker_apply_shard_ddl_command.
+	 */
 	parameterValue[0] = shardIdString;
-	parameterValue[1] = ddlCommand;
+	parameterValue[1] = "public";
+	parameterValue[2] = ddlCommand;
 
 	ddlResult = ExecuteRemoteCommand(workerNode, remoteCommand,
 									 parameterValue, parameterCount);

--- a/src/bin/csql/stage.h
+++ b/src/bin/csql/stage.h
@@ -65,7 +65,7 @@
 	"SELECT * FROM (SELECT (pg_options_to_table(ftoptions)).* FROM pg_foreign_table " \
 	"WHERE ftrelid = %u) AS Q WHERE option_name = 'filename';"
 #define APPLY_SHARD_DDL_COMMAND \
-	"SELECT * FROM worker_apply_shard_ddl_command ($1::int8, $2::text)"
+	"SELECT * FROM worker_apply_shard_ddl_command ($1::int8, $2::text, $3::text)"
 #define REMOTE_FILE_SIZE_COMMAND "SELECT size FROM pg_stat_file('%s')"
 #define SHARD_COLUMNAR_TABLE_SIZE_COMMAND "SELECT cstore_table_size('%s')"
 

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -50,7 +50,7 @@
 
 /* Remote call definitions to help with data staging and deletion */
 #define WORKER_APPLY_SHARD_DDL_COMMAND \
-	"SELECT worker_apply_shard_ddl_command (" UINT64_FORMAT ", %s)"
+	"SELECT worker_apply_shard_ddl_command (" UINT64_FORMAT ", %s, %s)"
 #define WORKER_APPEND_TABLE_TO_SHARD \
 	"SELECT worker_append_table_to_shard (%s, %s, %s, %u)"
 #define SHARD_MIN_VALUE_QUERY "SELECT min(%s) FROM %s"
@@ -88,10 +88,9 @@ extern bool CStoreTable(Oid relationId);
 extern Oid ResolveRelationId(text *relationName);
 extern List * GetTableDDLEvents(Oid relationId);
 extern void CheckDistributedTable(Oid relationId);
-extern void CreateShardPlacements(int64 shardId, List *ddlEventList,
-								  char *newPlacementOwner,
-								  List *workerNodeList, int workerStartIndex,
-								  int replicationFactor);
+extern void CreateShardPlacements(Oid relationId, int64 shardId, List *ddlEventList,
+								  char *newPlacementOwner, List *workerNodeList,
+								  int workerStartIndex, int replicationFactor);
 extern uint64 UpdateShardStatistics(int64 shardId);
 
 /* Function declarations for generating metadata for shard creation */

--- a/src/include/distributed/relay_utility.h
+++ b/src/include/distributed/relay_utility.h
@@ -40,7 +40,7 @@ typedef enum
 
 
 /* Function declarations to extend names in DDL commands */
-extern void RelayEventExtendNames(Node *parseTree, uint64 shardId);
+extern void RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId);
 extern void AppendShardIdToName(char **name, uint64 shardId);
 extern void AppendShardIdToStringInfo(StringInfo name, uint64 shardId);
 

--- a/src/test/regress/expected/multi_complex_expressions.out
+++ b/src/test/regress/expected/multi_complex_expressions.out
@@ -390,7 +390,7 @@ ORDER BY
 	customer_keys.o_custkey DESC
 LIMIT 10 OFFSET 20;
 DEBUG:  push down of limit count: 30
-DEBUG:  building index "pg_toast_16953_index" on table "pg_toast_16953"
+DEBUG:  building index "pg_toast_16958_index" on table "pg_toast_16958"
  o_custkey | total_order_count 
 -----------+-------------------
       1466 |                 1

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -17,6 +17,7 @@ ALTER EXTENSION citus UPDATE TO '5.0-2';
 ALTER EXTENSION citus UPDATE TO '5.1-1';
 ALTER EXTENSION citus UPDATE TO '5.1-2';
 ALTER EXTENSION citus UPDATE TO '5.1-3';
+ALTER EXTENSION citus UPDATE TO '5.1-4';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -138,7 +138,7 @@ SELECT master_create_distributed_table('test_schema_support.nation_hash', 'n_nat
  
 (1 row)
 
-SELECT master_create_worker_shards('test_schema_support.nation_hash', 4, 1);
+SELECT master_create_worker_shards('test_schema_support.nation_hash', 4, 2);
  master_create_worker_shards 
 -----------------------------
  
@@ -391,7 +391,7 @@ SELECT * FROM test_schema_support.nation_hash;
            1 | ARGENTINA                 |           2 | al foxes promise slyly according to the regular accounts. bold requests alon
            5 | ETHIOPIA                  |           1 | ven packages wake quickly. regu
            7 | GERMANY                   |           4 | 
-           0 | ALGERIA                   |           1 |  haggle. carefully final deposits detect slyly agai
+           0 | ALGERIA                   |           1 | haggle. carefully final deposits detect slyly agai
            3 | CANADA                    |           2 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           5 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
            6 | FRANCE                    |           4 | 
@@ -413,7 +413,7 @@ SELECT * FROM nation_hash;
            1 | ARGENTINA                 |           3 | al foxes promise slyly according to the regular accounts. bold requests alon
            5 | ETHIOPIA                  |           2 | ven packages wake quickly. regu
            7 | GERMANY                   |           5 | 
-           0 | ALGERIA                   |           2 |  haggle. carefully final deposits detect slyly agai
+           0 | ALGERIA                   |           2 | haggle. carefully final deposits detect slyly agai
            3 | CANADA                    |           3 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           6 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
            6 | FRANCE                    |           5 | 
@@ -442,7 +442,7 @@ SELECT master_create_distributed_table('test_schema_support.nation_hash_collatio
  
 (1 row)
 
-SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 4, 1);
+SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 4, 2);
  master_create_worker_shards 
 -----------------------------
  
@@ -454,7 +454,7 @@ SELECT * FROM test_schema_support.nation_hash_collation;
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
            1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
            5 | ETHIOPIA                  |           0 | ven packages wake quickly. regu
-           0 | ALGERIA                   |           0 |  haggle. carefully final deposits detect slyly agai
+           0 | ALGERIA                   |           0 | haggle. carefully final deposits detect slyly agai
            3 | CANADA                    |           1 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           4 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
            2 | BRAZIL                    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
@@ -465,7 +465,7 @@ SELECT n_comment FROM test_schema_support.nation_hash_collation ORDER BY n_comme
 -------------------------------------------------------------------------------------------------------------
  al foxes promise slyly according to the regular accounts. bold requests alon
  eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
-  haggle. carefully final deposits detect slyly agai
+ haggle. carefully final deposits detect slyly agai
  ven packages wake quickly. regu
  y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
  y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
@@ -485,7 +485,7 @@ SELECT master_create_distributed_table('nation_hash_collation_search_path', 'n_n
  
 (1 row)
 
-SELECT master_create_worker_shards('nation_hash_collation_search_path', 4, 1);
+SELECT master_create_worker_shards('nation_hash_collation_search_path', 4, 2);
  master_create_worker_shards 
 -----------------------------
  
@@ -497,7 +497,7 @@ SELECT * FROM nation_hash_collation_search_path;
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
            1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
            5 | ETHIOPIA                  |           0 | ven packages wake quickly. regu
-           0 | ALGERIA                   |           0 |  haggle. carefully final deposits detect slyly agai
+           0 | ALGERIA                   |           0 | haggle. carefully final deposits detect slyly agai
            3 | CANADA                    |           1 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           4 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
            2 | BRAZIL                    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
@@ -508,7 +508,7 @@ SELECT n_comment FROM nation_hash_collation_search_path ORDER BY n_comment COLLA
 -------------------------------------------------------------------------------------------------------------
  al foxes promise slyly according to the regular accounts. bold requests alon
  eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
-  haggle. carefully final deposits detect slyly agai
+ haggle. carefully final deposits detect slyly agai
  ven packages wake quickly. regu
  y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
  y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
@@ -537,7 +537,7 @@ SELECT master_create_distributed_table('test_schema_support.nation_hash_composit
  
 (1 row)
 
-SELECT master_create_worker_shards('test_schema_support.nation_hash_composite_types', 4, 1);
+SELECT master_create_worker_shards('test_schema_support.nation_hash_composite_types', 4, 2);
  master_create_worker_shards 
 -----------------------------
  
@@ -546,16 +546,258 @@ SELECT master_create_worker_shards('test_schema_support.nation_hash_composite_ty
 -- insert some data to verify composite type queries
 \COPY test_schema_support.nation_hash_composite_types FROM STDIN with delimiter '|';
 SELECT * FROM test_schema_support.nation_hash_composite_types WHERE test_col = '(a,a)'::test_schema_support.new_composite_type;
- n_nationkey |          n_name           | n_regionkey |                      n_comment                      | test_col 
--------------+---------------------------+-------------+-----------------------------------------------------+----------
-           0 | ALGERIA                   |           0 |  haggle. carefully final deposits detect slyly agai | (a,a)
+ n_nationkey |          n_name           | n_regionkey |                     n_comment                      | test_col 
+-------------+---------------------------+-------------+----------------------------------------------------+----------
+           0 | ALGERIA                   |           0 | haggle. carefully final deposits detect slyly agai | (a,a)
 (1 row)
 
 --test with search_path is set
 SET search_path TO test_schema_support;
 SELECT * FROM nation_hash_composite_types WHERE test_col = '(a,a)'::new_composite_type;
- n_nationkey |          n_name           | n_regionkey |                      n_comment                      | test_col 
--------------+---------------------------+-------------+-----------------------------------------------------+----------
-           0 | ALGERIA                   |           0 |  haggle. carefully final deposits detect slyly agai | (a,a)
+ n_nationkey |          n_name           | n_regionkey |                     n_comment                      | test_col 
+-------------+---------------------------+-------------+----------------------------------------------------+----------
+           0 | ALGERIA                   |           0 | haggle. carefully final deposits detect slyly agai | (a,a)
 (1 row)
+
+-- test ALTER TABLE ADD/DROP queries with schemas
+SET search_path TO public;
+ALTER TABLE test_schema_support.nation_hash ADD COLUMN new_col INT;
+-- verify column is added
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+ new_col     | integer                | 
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+ new_col     | integer                | 
+
+\c - - - :master_port
+ALTER TABLE test_schema_support.nation_hash DROP COLUMN IF EXISTS non_existent_column;
+NOTICE:  column "non_existent_column" of relation "nation_hash" does not exist, skipping
+ALTER TABLE test_schema_support.nation_hash DROP COLUMN IF EXISTS new_col;
+-- verify column is dropped
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :master_port
+--test with search_path is set
+SET search_path TO test_schema_support;
+ALTER TABLE nation_hash ADD COLUMN new_col INT;
+-- verify column is added
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+ new_col     | integer                | 
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+ new_col     | integer                | 
+
+\c - - - :master_port
+SET search_path TO test_schema_support;
+ALTER TABLE nation_hash DROP COLUMN IF EXISTS non_existent_column;
+NOTICE:  column "non_existent_column" of relation "nation_hash" does not exist, skipping
+ALTER TABLE nation_hash DROP COLUMN IF EXISTS new_col;
+-- verify column is dropped
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :master_port
+-- test CREATE/DROP INDEX with schemas
+SET search_path TO public;
+-- CREATE index
+CREATE INDEX index1 ON test_schema_support.nation_hash(n_name);
+--verify INDEX is created
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+Indexes:
+    "index1" btree (n_name)
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+Indexes:
+    "index1_1190003" btree (n_name)
+
+\c - - - :master_port
+-- DROP index
+DROP INDEX test_schema_support.index1;
+--verify INDEX is dropped
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :master_port
+--test with search_path is set
+SET search_path TO test_schema_support;
+-- CREATE index
+CREATE INDEX index1 ON nation_hash(n_name);
+--verify INDEX is created
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+Indexes:
+    "index1" btree (n_name)
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+Indexes:
+    "index1_1190003" btree (n_name)
+
+\c - - - :master_port
+-- DROP index
+SET search_path TO test_schema_support;
+DROP INDEX index1;
+--verify INDEX is dropped
+\d test_schema_support.nation_hash;
+     Table "test_schema_support.nation_hash"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :worker_1_port
+\d test_schema_support.nation_hash_1190003;
+ Table "test_schema_support.nation_hash_1190003"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ n_nationkey | integer                | not null
+ n_name      | character(25)          | not null
+ n_regionkey | integer                | not null
+ n_comment   | character varying(152) | 
+
+\c - - - :master_port
+-- test master_copy_shard_placement with schemas
+SET search_path TO public;
+-- mark shard as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1190000 and nodeport = :worker_1_port;
+SELECT master_copy_shard_placement(1190000, 'localhost', :worker_2_port, 'localhost', :worker_1_port);
+ master_copy_shard_placement 
+-----------------------------
+ 
+(1 row)
+
+-- verify shardstate
+SELECT * FROM pg_dist_shard_placement WHERE shardid = 1190000;
+ shardid | shardstate | shardlength | nodename  | nodeport 
+---------+------------+-------------+-----------+----------
+ 1190000 |          1 |        8192 | localhost |    57638
+ 1190000 |          1 |           0 | localhost |    57637
+(2 rows)
+
+--test with search_path is set
+SET search_path TO test_schema_support;
+-- mark shard as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1190000 and nodeport = :worker_1_port;
+SELECT master_copy_shard_placement(1190000, 'localhost', :worker_2_port, 'localhost', :worker_1_port);
+ master_copy_shard_placement 
+-----------------------------
+ 
+(1 row)
+
+-- verify shardstate
+SELECT * FROM pg_dist_shard_placement WHERE shardid = 1190000;
+ shardid | shardstate | shardlength | nodename  | nodeport 
+---------+------------+-------------+-----------+----------
+ 1190000 |          1 |        8192 | localhost |    57638
+ 1190000 |          1 |           0 | localhost |    57637
+(2 rows)
 

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -22,6 +22,7 @@ ALTER EXTENSION citus UPDATE TO '5.0-2';
 ALTER EXTENSION citus UPDATE TO '5.1-1';
 ALTER EXTENSION citus UPDATE TO '5.1-2';
 ALTER EXTENSION citus UPDATE TO '5.1-3';
+ALTER EXTENSION citus UPDATE TO '5.1-4';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;


### PR DESCRIPTION
Fixes #565
Fixes #626

To add schema support to citus, we need to schema-prefix all table names, object names etc.
in the queries sent to worker nodes. However; query deparsing is not available for most of
DDL commands, therefore it is not easy to generate worker query in the master node.

As a solution we are sending schema names along with shard id and query to run to worker
nodes with worker_apply_shard_ddl_command.

Since \STAGE will be deprecated anyway, we use public schema while calling 
worker_apply_shard_ddl_command everything to make it work with new signature. Please note 
that if user specifies schema name, this will not override it, because we prioritize schema names
given in the query in worker_apply_shard_ddl_command.