### PR TITLE
Expand router planner coverage for single worker queries

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1410,8 +1410,41 @@ FindNodesOfType(MultiNode *node, int type)
 
 
 /*
- * NeedsDistributedPlanning checks if the passed in query is a Select query
- * running on partitioned relations. If it is, we start distributed planning.
+ * IdentifyRTE assigns an identifier to an RTE, for tracking purposes.
+ *
+ * To be able to track RTEs through postgres' query planning, which copies and
+ * duplicate, and modifies them, we sometimes need to figure out whether two
+ * RTEs are copies of the same original RTE. For that we, hackishly, use a
+ * field normally unused in RTE_RELATION RTEs.
+ *
+ * The assigned identifier better be unique within a plantree.
+ */
+void
+IdentifyRTE(RangeTblEntry *rte, int identifier)
+{
+	Assert(rte->rtekind == RTE_RELATION);
+	Assert(rte->values_lists == NIL);
+	rte->values_lists = list_make1_int(identifier);
+}
+
+
+/* GetRTEIdentity returns the identity assigned with IdentifyRTE. */
+int
+GetRTEIdentity(RangeTblEntry *rte)
+{
+	Assert(rte->rtekind == RTE_RELATION);
+	Assert(IsA(rte->values_lists, IntList));
+	Assert(list_length(rte->values_lists) == 1);
+
+	return linitial_int(rte->values_lists);
+}
+
+
+/*
+ * NeedsDistributedPlanning checks if the passed in query is a query running
+ * on a distributed table. If it is, we start distributed planning.
+ *
+ * For distributed relations it also assigns identifiers to the relevant RTEs.
  */
 bool
 NeedsDistributedPlanning(Query *queryTree)
@@ -1421,6 +1454,7 @@ NeedsDistributedPlanning(Query *queryTree)
 	ListCell *rangeTableCell = NULL;
 	bool hasLocalRelation = false;
 	bool hasDistributedRelation = false;
+	int rteIdentifier = 1;
 
 	if (commandType != CMD_SELECT && commandType != CMD_INSERT &&
 		commandType != CMD_UPDATE && commandType != CMD_DELETE)
@@ -1441,6 +1475,17 @@ NeedsDistributedPlanning(Query *queryTree)
 		if (IsDistributedTable(relationId))
 		{
 			hasDistributedRelation = true;
+
+			/*
+			 * To be able to track individual RTEs through postgres' query
+			 * planning, we need to be able to figure out whether an RTE is
+			 * actually a copy of another, rather than a different one. We
+			 * simply number the RTEs starting from 1.
+			 */
+			if (rangeTableEntry->rtekind == RTE_RELATION)
+			{
+				IdentifyRTE(rangeTableEntry, rteIdentifier++);
+			}
 		}
 		else
 		{

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -35,6 +35,7 @@
 #include "distributed/worker_protocol.h"
 #include "postmaster/postmaster.h"
 #include "optimizer/planner.h"
+#include "optimizer/paths.h"
 #include "utils/guc.h"
 #include "utils/guc_tables.h"
 
@@ -141,6 +142,9 @@ _PG_init(void)
 
 	/* register utility hook */
 	ProcessUtility_hook = multi_ProcessUtility;
+
+	/* register for planner hook */
+	set_rel_pathlist_hook = multi_relation_restriction_hook;
 
 	/* organize that task tracker is started once server is up */
 	TaskTrackerRegister();

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -181,6 +181,8 @@ extern bool SubqueryPushdown;
 /* Function declarations for building logical plans */
 extern MultiTreeRoot * MultiLogicalPlanCreate(Query *queryTree);
 extern bool NeedsDistributedPlanning(Query *queryTree);
+extern int GetRTEIdentity(RangeTblEntry *rte);
+extern void IdentifyRTE(RangeTblEntry *rte, int identifier);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);
 extern MultiNode * GrandChildNode(MultiUnaryNode *multiNode);

--- a/src/include/distributed/multi_planner.h
+++ b/src/include/distributed/multi_planner.h
@@ -13,14 +13,41 @@
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 
+
+typedef struct RelationRestrictionContext
+{
+	bool hasDistributedRelation;
+	bool hasLocalRelation;
+	List *relationRestrictionList;
+} RelationRestrictionContext;
+
+typedef struct RelationRestriction
+{
+	Index index;
+	Oid relationId;
+	bool distributedRelation;
+	RangeTblEntry *rte;
+	RelOptInfo *relOptInfo;
+	PlannerInfo *plannerInfo;
+	List *prunedShardIntervalList;
+} RelationRestriction;
+
+
 extern PlannedStmt * multi_planner(Query *parse, int cursorOptions,
 								   ParamListInfo boundParams);
 
 extern bool HasCitusToplevelNode(PlannedStmt *planStatement);
 struct MultiPlan;
-extern struct MultiPlan * CreatePhysicalPlan(Query *originalQuery, Query *query);
+extern struct MultiPlan * CreatePhysicalPlan(Query *originalQuery, Query *query,
+											 RelationRestrictionContext *
+											 restrictionContext);
 extern struct MultiPlan * GetMultiPlan(PlannedStmt *planStatement);
 extern PlannedStmt * MultiQueryContainerNode(PlannedStmt *result,
 											 struct MultiPlan *multiPlan);
+extern void multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
+											Index index, RangeTblEntry *rte);
+extern RelationRestrictionContext * CreateAndPushRestrictionContext(void);
+extern RelationRestrictionContext * CurrentRestrictionContext(void);
+extern void PopRestrictionContext(void);
 
 #endif /* MULTI_PLANNER_H */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -16,6 +16,7 @@
 
 #include "distributed/multi_logical_planner.h"
 #include "distributed/multi_physical_planner.h"
+#include "distributed/multi_planner.h"
 #include "distributed/multi_server_executor.h"
 #include "nodes/parsenodes.h"
 
@@ -29,7 +30,8 @@
 
 
 extern MultiPlan * MultiRouterPlanCreate(Query *originalQuery, Query *query,
-										 MultiExecutorType taskExecutorType);
+										 MultiExecutorType taskExecutorType,
+										 RelationRestrictionContext *restrictionContext);
 extern void ErrorIfModifyQueryNotSupported(Query *queryTree);
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/test/regress/expected/multi_hash_pruning_0.out
+++ b/src/test/regress/expected/multi_hash_pruning_0.out
@@ -199,8 +199,6 @@ SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 OR o_orderkey = 2;
 DEBUG:  predicate pruning for shardId 630001
 DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
  count 
 -------
      0
@@ -215,8 +213,6 @@ SELECT count(*) FROM orders_hash_partitioned
 
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 OR (o_orderkey = 3 AND o_clerk = 'aaa');
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  predicate pruning for shardId 630002
 DEBUG:  predicate pruning for shardId 630003
  count 
@@ -236,8 +232,6 @@ SELECT count(*) FROM
 DEBUG:  predicate pruning for shardId 630001
 DEBUG:  predicate pruning for shardId 630002
 DEBUG:  predicate pruning for shardId 630003
-DEBUG:  Creating router plan
-DEBUG:  Plan is router executable
  count 
 -------
      0
@@ -247,8 +241,6 @@ DEBUG:  Plan is router executable
 -- a notice message when used with the partition column
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = ANY ('{1,2,3}');
-NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
-HINT:  Consider rewriting the expression with OR/AND clauses.
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
  count 
@@ -293,8 +285,6 @@ SELECT count(*) FROM orders_hash_partitioned
 DEBUG:  predicate pruning for shardId 630001
 DEBUG:  predicate pruning for shardId 630002
 DEBUG:  predicate pruning for shardId 630003
-DEBUG:  Creating router plan
-DEBUG:  Plan is router executable
  count 
 -------
      0
@@ -329,11 +319,9 @@ SELECT count(*)
 DEBUG:  predicate pruning for shardId 630001
 DEBUG:  predicate pruning for shardId 630002
 DEBUG:  predicate pruning for shardId 630003
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
-DEBUG:  Creating router plan
-DEBUG:  Plan is router executable
+DEBUG:  join prunable for intervals [-2147483648,-1073741825] and [-1073741824,-1]
+DEBUG:  join prunable for intervals [-2147483648,-1073741825] and [0,1073741823]
+DEBUG:  join prunable for intervals [-2147483648,-1073741825] and [1073741824,2147483647]
  count 
 -------
      0

--- a/src/test/regress/expected/multi_join_order_additional.out
+++ b/src/test/regress/expected/multi_join_order_additional.out
@@ -90,7 +90,7 @@ SELECT master_create_distributed_table('customer_hash', 'c_custkey', 'hash');
  
 (1 row)
 
-SELECT master_create_worker_shards('customer_hash', 1, 1);
+SELECT master_create_worker_shards('customer_hash', 2, 1);
  master_create_worker_shards 
 -----------------------------
  

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -31,7 +31,7 @@ SELECT master_create_distributed_table('articles_single_shard_hash', 'author_id'
 SELECT count(*) from articles_hash;
  count 
 -------
-      
+     0
 (1 row)
 
 SELECT master_create_worker_shards('articles_hash', 2, 1);
@@ -104,20 +104,11 @@ SET client_min_messages TO 'DEBUG2';
 INSERT INTO articles_single_shard_hash VALUES (50, 10, 'anjanette', 19519);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
--- first, test zero-shard SELECT, which should return an empty row
-SELECT COUNT(*) FROM articles_hash WHERE author_id = 1 AND author_id = 2;
-DEBUG:  predicate pruning for shardId 840000
-DEBUG:  predicate pruning for shardId 840001
- count 
--------
-      
-(1 row)
-
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles_hash WHERE author_id = 10 AND id = 50;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |   title   | word_count 
 ----+-----------+-----------+------------
@@ -126,8 +117,8 @@ DEBUG:  Plan is router executable
 
 -- get all titles by a single author
 SELECT title FROM articles_hash WHERE author_id = 10;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    title    
 ------------
@@ -142,8 +133,8 @@ DEBUG:  Plan is router executable
 SELECT title, word_count FROM articles_hash
 	WHERE author_id = 10
 	ORDER BY word_count DESC NULLS LAST;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    title    | word_count 
 ------------+------------
@@ -159,8 +150,8 @@ SELECT title, id FROM articles_hash
 	WHERE author_id = 5
 	ORDER BY id
 	LIMIT 2;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   title  | id 
 ---------+----
@@ -174,6 +165,8 @@ SELECT title, author_id FROM articles_hash
 	WHERE author_id = 7 OR author_id = 8
 	ORDER BY author_id ASC, id;
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
     title    | author_id 
 -------------+-----------
  aseptic     |         7
@@ -192,6 +185,7 @@ DEBUG:  predicate pruning for shardId 840001
 SELECT title, author_id FROM articles_hash
 	WHERE author_id = 7 OR author_id = 8;
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title    | author_id 
 -------------+-----------
@@ -214,28 +208,31 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash
 	GROUP BY author_id
 	HAVING sum(word_count) > 1000
 	ORDER BY sum(word_count) DESC;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Having qual is currently unsupported
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ author_id | corpus_size 
+-----------+-------------
+        10 |       59955
+         8 |       55410
+         7 |       36756
+         1 |       35894
+(4 rows)
+
 -- however having clause is supported if it goes to a single shard
 SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash
 	WHERE author_id = 1
 	GROUP BY author_id
 	HAVING sum(word_count) > 1000
 	ORDER BY sum(word_count) DESC;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  author_id | corpus_size 
 -----------+-------------
          1 |       35894
 (1 row)
 
--- UNION/INTERSECT queries are unsupported
--- this is rejected by router planner and handled by multi_logical_planner
-SELECT * FROM articles_hash WHERE author_id = 10 UNION
-SELECT * FROM articles_hash WHERE author_id = 1; 
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Union, Intersect, or Except are currently unsupported
 -- query is a single shard query but can't do shard pruning,
 -- not router-plannable due to <= and IN
 SELECT * FROM articles_hash WHERE author_id <= 1; 
@@ -249,6 +246,8 @@ SELECT * FROM articles_hash WHERE author_id <= 1;
 (5 rows)
 
 SELECT * FROM articles_hash WHERE author_id IN (1, 3); 
+NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
+HINT:  Consider rewriting the expression with OR/AND clauses.
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
  id | author_id |    title     | word_count 
@@ -265,18 +264,266 @@ HINT:  Consider rewriting the expression with OR/AND clauses.
  43 |         3 | affixal      |      12723
 (10 rows)
 
--- queries using CTEs are unsupported
+-- queries with CTEs are supported
+WITH first_author AS ( SELECT id FROM articles_hash WHERE author_id = 1)
+SELECT * FROM first_author;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id 
+----
+  1
+ 11
+ 21
+ 31
+ 41
+(5 rows)
+
+-- queries with CTEs are supported even if CTE is not referenced inside query
 WITH first_author AS ( SELECT id FROM articles_hash WHERE author_id = 1)
 SELECT title FROM articles_hash WHERE author_id = 1;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+    title     
+--------------
+ arsenous
+ alamo
+ arcading
+ athwartships
+ aznavour
+(5 rows)
+
+-- two CTE joins are supported if they go to the same worker
+WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
+id_title AS (SELECT id, title from articles_hash WHERE author_id = 1)
+SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id | id |    title     
+----+-----------+----+--------------
+  1 |         1 |  1 | arsenous
+ 11 |         1 | 11 | alamo
+ 21 |         1 | 21 | arcading
+ 31 |         1 | 31 | athwartships
+ 41 |         1 | 41 | aznavour
+(5 rows)
+
+WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
+id_title AS (SELECT id, title from articles_hash WHERE author_id = 3)
+SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id | id | title 
+----+-----------+----+-------
+(0 rows)
+
+-- CTE joins are not supported if table shards are at different workers
+WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
+id_title AS (SELECT id, title from articles_hash WHERE author_id = 2)
+SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840000
+DEBUG:  Found no worker with all shard placements
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Common Table Expressions are currently unsupported
--- queries which involve functions in FROM clause are unsupported.
+DETAIL:  Complex table expressions are currently unsupported
+-- recursive CTEs are supported when filtered on partition column
+CREATE TABLE company_employees (company_id int, employee_id int, manager_id int); 
+SELECT master_create_distributed_table('company_employees', 'company_id', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('company_employees', 4, 1);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+INSERT INTO company_employees values(1, 1, 0);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(1, 2, 1);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(1, 3, 1);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(1, 4, 2);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(1, 5, 4);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(3, 1, 0);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(3, 15, 1);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+INSERT INTO company_employees values(3, 3, 1);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+-- find employees at top 2 level within company hierarchy
+WITH RECURSIVE hierarchy as (
+	SELECT *, 1 AS level
+		FROM company_employees
+		WHERE company_id = 1 and manager_id = 0 
+	UNION
+	SELECT ce.*, (h.level+1)
+		FROM hierarchy h JOIN company_employees ce
+			ON (h.employee_id = ce.manager_id AND
+				h.company_id = ce.company_id AND
+				ce.company_id = 1))
+SELECT * FROM hierarchy WHERE LEVEL <= 2;
+DEBUG:  predicate pruning for shardId 840004
+DEBUG:  predicate pruning for shardId 840005
+DEBUG:  predicate pruning for shardId 840006
+DEBUG:  predicate pruning for shardId 840004
+DEBUG:  predicate pruning for shardId 840005
+DEBUG:  predicate pruning for shardId 840006
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ company_id | employee_id | manager_id | level 
+------------+-------------+------------+-------
+          1 |           1 |          0 |     1
+          1 |           2 |          1 |     2
+          1 |           3 |          1 |     2
+(3 rows)
+
+-- query becomes not router plannble and gets rejected
+-- if filter on company is dropped
+WITH RECURSIVE hierarchy as (
+	SELECT *, 1 AS level
+		FROM company_employees
+		WHERE company_id = 1 and manager_id = 0 
+	UNION
+	SELECT ce.*, (h.level+1)
+		FROM hierarchy h JOIN company_employees ce
+			ON (h.employee_id = ce.manager_id AND
+				h.company_id = ce.company_id))
+SELECT * FROM hierarchy WHERE LEVEL <= 2;
+DEBUG:  predicate pruning for shardId 840004
+DEBUG:  predicate pruning for shardId 840005
+DEBUG:  predicate pruning for shardId 840006
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Complex table expressions are currently unsupported
+-- logically wrong query, query involves different shards
+-- from the same table, but still router plannable due to
+-- shard being placed on the same worker.
+WITH RECURSIVE hierarchy as (
+	SELECT *, 1 AS level
+		FROM company_employees
+		WHERE company_id = 3 and manager_id = 0 
+	UNION
+	SELECT ce.*, (h.level+1)
+		FROM hierarchy h JOIN company_employees ce
+			ON (h.employee_id = ce.manager_id AND
+				h.company_id = ce.company_id AND
+				ce.company_id = 2))
+SELECT * FROM hierarchy WHERE LEVEL <= 2;
+DEBUG:  predicate pruning for shardId 840003
+DEBUG:  predicate pruning for shardId 840005
+DEBUG:  predicate pruning for shardId 840006
+DEBUG:  predicate pruning for shardId 840003
+DEBUG:  predicate pruning for shardId 840004
+DEBUG:  predicate pruning for shardId 840005
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ company_id | employee_id | manager_id | level 
+------------+-------------+------------+-------
+          3 |           1 |          0 |     1
+(1 row)
+
+-- grouping sets are supported on single shard
+SELECT
+	id, substring(title, 2, 1) AS subtitle, count(*)
+	FROM articles_hash
+	WHERE author_id = 1 or author_id = 3
+	GROUP BY GROUPING SETS ((id),(subtitle));
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | subtitle | count 
+----+----------+-------
+  1 |          |     1
+  3 |          |     1
+ 11 |          |     1
+ 13 |          |     1
+ 21 |          |     1
+ 23 |          |     1
+ 31 |          |     1
+ 33 |          |     1
+ 41 |          |     1
+ 43 |          |     1
+    | b        |     1
+    | f        |     1
+    | l        |     1
+    | r        |     2
+    | s        |     2
+    | t        |     1
+    | u        |     1
+    | z        |     1
+(18 rows)
+
+-- grouping sets are not supported on multiple shards
+SELECT
+	id, substring(title, 2, 1) AS subtitle, count(*)
+	FROM articles_hash
+	WHERE author_id = 1 or author_id = 2
+	GROUP BY GROUPING SETS ((id),(subtitle));
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Grouping sets, cube, and rollup is currently unsupported
+-- queries which involve functions in FROM clause are supported if it goes to a single worker.
 SELECT * FROM articles_hash, position('om' in 'Thomas') WHERE author_id = 1;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id |    title     | word_count | position 
+----+-----------+--------------+------------+----------
+  1 |         1 | arsenous     |       9572 |        3
+ 11 |         1 | alamo        |       1347 |        3
+ 21 |         1 | arcading     |       5890 |        3
+ 31 |         1 | athwartships |       7271 |        3
+ 41 |         1 | aznavour     |      11814 |        3
+(5 rows)
+
+SELECT * FROM articles_hash, position('om' in 'Thomas') WHERE author_id = 1 or author_id = 3;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id |    title     | word_count | position 
+----+-----------+--------------+------------+----------
+  1 |         1 | arsenous     |       9572 |        3
+  3 |         3 | asternal     |      10480 |        3
+ 11 |         1 | alamo        |       1347 |        3
+ 13 |         3 | aseyev       |       2255 |        3
+ 21 |         1 | arcading     |       5890 |        3
+ 23 |         3 | abhorring    |       6799 |        3
+ 31 |         1 | athwartships |       7271 |        3
+ 33 |         3 | autochrome   |       8180 |        3
+ 41 |         1 | aznavour     |      11814 |        3
+ 43 |         3 | affixal      |      12723 |        3
+(10 rows)
+
+-- they are not supported if multiple workers are involved
+SELECT * FROM articles_hash, position('om' in 'Thomas') WHERE author_id = 1 or author_id = 2;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Complex table expressions are currently unsupported
 -- subqueries are not supported in WHERE clause in Citus
 SELECT * FROM articles_hash WHERE author_id IN (SELECT id FROM authors_hash WHERE name LIKE '%a');
 ERROR:  cannot plan queries that include both regular and partitioned relations
+SELECT * FROM articles_hash WHERE author_id IN (SELECT author_id FROM articles_hash WHERE author_id = 1 or author_id = 3);
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Join types other than inner/outer joins are currently unsupported
+SELECT * FROM articles_hash WHERE author_id = (SELECT 1);
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries other than in from-clause are currently unsupported
 -- subqueries are supported in FROM clause but they are not router plannable
 SELECT articles_hash.id,test.word_count
 FROM articles_hash, (SELECT id, word_count FROM articles_hash) AS test WHERE test.id = articles_hash.id
@@ -311,6 +558,42 @@ DEBUG:  pruning merge fetch taskId 11
 DETAIL:  Creating dependency on merge taskId 14
 ERROR:  cannot use real time executor with repartition jobs
 HINT:  Set citus.task_executor_type to "task-tracker".
+SELECT articles_hash.id,test.word_count
+FROM articles_hash, (SELECT id, word_count FROM articles_hash) AS test 
+WHERE test.id = articles_hash.id and articles_hash.author_id = 1
+ORDER BY articles_hash.id;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  join prunable for task partitionId 0 and 1
+DEBUG:  join prunable for task partitionId 0 and 2
+DEBUG:  join prunable for task partitionId 0 and 3
+DEBUG:  join prunable for task partitionId 1 and 0
+DEBUG:  join prunable for task partitionId 1 and 2
+DEBUG:  join prunable for task partitionId 1 and 3
+DEBUG:  join prunable for task partitionId 2 and 0
+DEBUG:  join prunable for task partitionId 2 and 1
+DEBUG:  join prunable for task partitionId 2 and 3
+DEBUG:  join prunable for task partitionId 3 and 0
+DEBUG:  join prunable for task partitionId 3 and 1
+DEBUG:  join prunable for task partitionId 3 and 2
+DEBUG:  pruning merge fetch taskId 1
+DETAIL:  Creating dependency on merge taskId 3
+DEBUG:  pruning merge fetch taskId 2
+DETAIL:  Creating dependency on merge taskId 5
+DEBUG:  pruning merge fetch taskId 4
+DETAIL:  Creating dependency on merge taskId 5
+DEBUG:  pruning merge fetch taskId 5
+DETAIL:  Creating dependency on merge taskId 8
+DEBUG:  pruning merge fetch taskId 7
+DETAIL:  Creating dependency on merge taskId 7
+DEBUG:  pruning merge fetch taskId 8
+DETAIL:  Creating dependency on merge taskId 11
+DEBUG:  pruning merge fetch taskId 10
+DETAIL:  Creating dependency on merge taskId 9
+DEBUG:  pruning merge fetch taskId 11
+DETAIL:  Creating dependency on merge taskId 14
+ERROR:  cannot use real time executor with repartition jobs
+HINT:  Set citus.task_executor_type to "task-tracker".
 -- subqueries are not supported in SELECT clause
 SELECT a.title AS name, (SELECT a2.id FROM articles_single_shard_hash a2 WHERE a.id = a2.id  LIMIT 1)
 						 AS special_price FROM articles_hash a;
@@ -320,8 +603,8 @@ DETAIL:  Subqueries other than in from-clause are currently unsupported
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -332,12 +615,12 @@ DEBUG:  Plan is router executable
  41 |         1 | aznavour     |      11814
 (5 rows)
 
--- below query hits a single shard, but it is not router plannable
--- still router executable
+-- below query hits a single shard, router plannable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 OR author_id = 17;
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -366,8 +649,8 @@ SELECT *
 SELECT id as article_id, word_count * id as random_value
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  article_id | random_value 
 ------------+--------------
@@ -379,15 +662,13 @@ DEBUG:  Plan is router executable
 (5 rows)
 
 -- we can push down co-located joins to a single worker
--- this is not router plannable but router executable
--- handled by real-time executor
 SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash a, articles_hash b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  push down of limit count: 3
 DEBUG:  predicate pruning for shardId 840001
-DEBUG:  join prunable for intervals [-2147483648,-1] and [0,2147483647]
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
 --------------+-------------------
@@ -396,13 +677,15 @@ DEBUG:  Plan is router executable
            10 |              6363
 (3 rows)
 
--- following join is neither router plannable, nor router executable
+-- following join is router plannable since the same worker 
+-- has both shards
 SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash a, articles_single_shard_hash b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  push down of limit count: 3
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -410,13 +693,26 @@ DEBUG:  predicate pruning for shardId 840001
            10 |             19519
 (3 rows)
 
+	
+-- following join is not router plannable since there are no
+-- workers containing both shards, added a CTE to make this fail
+-- at logical planner
+WITH single_shard as (SELECT * FROM articles_single_shard_hash)
+SELECT a.author_id as first_author, b.word_count as second_word_count
+	FROM articles_hash a, single_shard b
+	WHERE a.author_id = 2 and a.author_id = b.author_id
+	LIMIT 3;
+DEBUG:  predicate pruning for shardId 840000
+DEBUG:  Found no worker with all shard placements
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Complex table expressions are currently unsupported
 -- single shard select with limit is router plannable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1
 	LIMIT 3;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -431,8 +727,8 @@ SELECT *
 	WHERE author_id = 1
 	LIMIT 2
 	OFFSET 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -447,8 +743,8 @@ SELECT *
 	ORDER BY id desc
 	LIMIT 2
 	OFFSET 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -462,8 +758,8 @@ SELECT id
 	FROM articles_hash
 	WHERE author_id = 1
 	GROUP BY id;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
 ----
@@ -478,8 +774,8 @@ DEBUG:  Plan is router executable
 SELECT distinct id
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
 ----
@@ -494,8 +790,8 @@ DEBUG:  Plan is router executable
 SELECT avg(word_count)
 	FROM articles_hash
 	WHERE author_id = 2;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840000
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
         avg         
 --------------------
@@ -507,8 +803,8 @@ SELECT max(word_count) as max, min(word_count) as min,
 	   sum(word_count) as sum, count(word_count) as cnt
 	FROM articles_hash
 	WHERE author_id = 2;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840000
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  | min  |  sum  | cnt 
 -------+------+-------+-----
@@ -520,15 +816,113 @@ SELECT max(word_count)
 	FROM articles_hash
 	WHERE author_id = 1
 	GROUP BY author_id;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  
 -------
  11814
 (1 row)
 
+	
+-- router plannable union queries are supported
+(SELECT * FROM articles_hash WHERE author_id = 1)
+UNION
+(SELECT * FROM articles_hash WHERE author_id = 3);
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id |    title     | word_count 
+----+-----------+--------------+------------
+  3 |         3 | asternal     |      10480
+ 43 |         3 | affixal      |      12723
+ 23 |         3 | abhorring    |       6799
+ 13 |         3 | aseyev       |       2255
+ 11 |         1 | alamo        |       1347
+ 41 |         1 | aznavour     |      11814
+  1 |         1 | arsenous     |       9572
+ 21 |         1 | arcading     |       5890
+ 31 |         1 | athwartships |       7271
+ 33 |         3 | autochrome   |       8180
+(10 rows)
+
+SELECT * FROM (
+	(SELECT * FROM articles_hash WHERE author_id = 1)
+	UNION
+	(SELECT * FROM articles_hash WHERE author_id = 3)) uu;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id |    title     | word_count 
+----+-----------+--------------+------------
+  3 |         3 | asternal     |      10480
+ 43 |         3 | affixal      |      12723
+ 23 |         3 | abhorring    |       6799
+ 13 |         3 | aseyev       |       2255
+ 11 |         1 | alamo        |       1347
+ 41 |         1 | aznavour     |      11814
+  1 |         1 | arsenous     |       9572
+ 21 |         1 | arcading     |       5890
+ 31 |         1 | athwartships |       7271
+ 33 |         3 | autochrome   |       8180
+(10 rows)
+
+(SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 1)
+UNION
+(SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 3);
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ left 
+------
+ a
+(1 row)
+
+(SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 1)
+INTERSECT
+(SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 3);
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ left 
+------
+ a
+(1 row)
+
+(SELECT LEFT(title, 2) FROM articles_hash WHERE author_id = 1)
+EXCEPT
+(SELECT LEFT(title, 2) FROM articles_hash WHERE author_id = 3);
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ left 
+------
+ at
+ az
+ ar
+ al
+(4 rows)
+
+-- union queries are not supported if not router plannable
+-- there is an inconsistency on shard pruning between
+-- ubuntu/mac disabling log messages for this queries only
 SET client_min_messages to 'NOTICE';
+(SELECT * FROM articles_hash WHERE author_id = 1)
+UNION
+(SELECT * FROM articles_hash WHERE author_id = 2);
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Union, Intersect, or Except are currently unsupported
+SELECT * FROM (
+	(SELECT * FROM articles_hash WHERE author_id = 1)
+	UNION
+	(SELECT * FROM articles_hash WHERE author_id = 2)) uu;
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries without group by clause are not supported yet
 -- error out for queries with repartition jobs
 SELECT *
 	FROM articles_hash a, articles_hash b
@@ -563,11 +957,12 @@ SET citus.task_executor_type TO 'real-time';
 -- Test various filtering options for router plannable check
 SET client_min_messages to 'DEBUG2';
 -- this is definitely single shard
--- but not router plannable
+-- and router plannable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and author_id >= 1;
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -596,8 +991,8 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and (id = 1 or id = 41);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -609,8 +1004,8 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and (id = random()::int  * 0);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count 
 ----+-----------+-------+------------
@@ -647,8 +1042,8 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE author_id = abs(-1);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -689,8 +1084,8 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and (id = abs(id - 2));
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -714,8 +1109,8 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE (author_id = 1) = true;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -730,8 +1125,8 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (author_id = 1) and id between 0 and 20;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -743,8 +1138,8 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (author_id = 1) and (id = 1 or id = 31) and title like '%s';
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -756,8 +1151,8 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (id = 1 or id = 31) and title like '%s' and (author_id = 1);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -769,8 +1164,8 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -785,8 +1180,8 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1) and (word_count < 3000 or word_count > 8000);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -799,8 +1194,8 @@ DEBUG:  Plan is router executable
 SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count 
 	FROM articles_hash
 	WHERE author_id = 5;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    prev   |  title   | word_count 
 ----------+----------+------------
@@ -815,8 +1210,8 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	FROM articles_hash
 	WHERE author_id = 5
 	ORDER BY word_count DESC;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    prev   |  title   | word_count 
 ----------+----------+------------
@@ -830,8 +1225,8 @@ DEBUG:  Plan is router executable
 SELECT id, MIN(id) over (order by word_count)
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | min 
 ----+-----
@@ -845,8 +1240,8 @@ DEBUG:  Plan is router executable
 SELECT id, word_count, AVG(word_count) over (order by word_count)
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | word_count |          avg          
 ----+------------+-----------------------
@@ -860,8 +1255,8 @@ DEBUG:  Plan is router executable
 SELECT word_count, rank() OVER (PARTITION BY author_id ORDER BY word_count)  
 	FROM articles_hash 
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  word_count | rank 
 ------------+------
@@ -878,11 +1273,9 @@ SELECT id, MIN(id) over (order by word_count)
 	WHERE author_id = 1 or author_id = 2;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Window functions are currently unsupported
-	
--- but they are not supported for not router plannable queries
 SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count 
 	FROM articles_hash
-	WHERE author_id = 5 or author_id = 1;
+	WHERE author_id = 5 or author_id = 2;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Window functions are currently unsupported
 -- complex query hitting a single shard 	
@@ -899,8 +1292,8 @@ SELECT
 		articles_hash
 	WHERE
 		author_id = 5;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  c 
 ---
@@ -941,8 +1334,8 @@ SELECT *
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -961,8 +1354,8 @@ DECLARE test_cursor CURSOR FOR
 		FROM articles_hash
 		WHERE author_id = 1
 		ORDER BY id;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 FETCH test_cursor;
  id | author_id |  title   | word_count 
@@ -983,8 +1376,8 @@ COPY (
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id) TO STDOUT;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 1	1	arsenous	9572
 11	1	alamo	1347
@@ -998,15 +1391,15 @@ CREATE TEMP TABLE temp_articles_hash as
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 -- router plannable queries may include filter for aggragates
 SELECT count(*), count(*) FILTER (WHERE id < 3)
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count | count 
 -------+-------
@@ -1028,8 +1421,8 @@ PREPARE author_1_articles as
 	FROM articles_hash
 	WHERE author_id = 1;
 EXECUTE author_1_articles;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -1046,8 +1439,8 @@ PREPARE author_articles(int) as
 	FROM articles_hash
 	WHERE author_id = $1;
 EXECUTE author_articles(1);
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -1070,11 +1463,19 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT author_articles_max_id();
-DEBUG:  Creating router plan
+DEBUG:  predicate pruning for shardId 840001
 CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_max_id() line 5 at SQL statement
 DEBUG:  predicate pruning for shardId 840001
+CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
+		WHERE author_id = 1"
+PL/pgSQL function author_articles_max_id() line 5 at SQL statement
+DEBUG:  predicate pruning for shardId 840001
+CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
+		WHERE author_id = 1"
+PL/pgSQL function author_articles_max_id() line 5 at SQL statement
+DEBUG:  Creating router plan
 CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_max_id() line 5 at SQL statement
@@ -1099,12 +1500,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT * FROM author_articles_id_word_count();
-DEBUG:  Creating router plan
+DEBUG:  predicate pruning for shardId 840001
 CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		FROM articles_hash ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
-DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
 CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		FROM articles_hash ah
 		WHERE author_id = 1"
@@ -1113,6 +1514,37 @@ DEBUG:  Plan is router executable
 CONTEXT:  PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 ERROR:  scan directions other than forward scans are unsupported
 CONTEXT:  PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
+-- materialized views can be created for router plannable queries
+CREATE MATERIALIZED VIEW mv_articles_hash AS
+	SELECT * FROM articles_hash WHERE author_id = 1;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+SELECT * FROM mv_articles_hash;
+ id | author_id |    title     | word_count 
+----+-----------+--------------+------------
+  1 |         1 | arsenous     |       9572
+ 11 |         1 | alamo        |       1347
+ 21 |         1 | arcading     |       5890
+ 31 |         1 | athwartships |       7271
+ 41 |         1 | aznavour     |      11814
+(5 rows)
+
+CREATE MATERIALIZED VIEW mv_articles_hash_error AS
+	SELECT * FROM articles_hash WHERE author_id in (1,2);
+NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
+HINT:  Consider rewriting the expression with OR/AND clauses.
+NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
+HINT:  Consider rewriting the expression with OR/AND clauses.
+ERROR:  cannot create temporary table within security-restricted operation
+-- materialized views with (NO DATA) is still not supported
+CREATE MATERIALIZED VIEW mv_articles_hash AS
+	SELECT * FROM articles_hash WHERE author_id = 1 WITH NO DATA;
+DEBUG:  predicate pruning for shardId 840001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ERROR:  scan directions other than forward scans are unsupported
+	
 -- router planner/executor is disabled for task-tracker executor
 -- following query is router plannable, but router planner is disabled
 SET citus.task_executor_type to 'task-tracker';
@@ -1151,6 +1583,8 @@ DEBUG:  predicate pruning for shardId 840001
 SET client_min_messages to 'NOTICE';
 DROP FUNCTION author_articles_max_id();
 DROP FUNCTION author_articles_id_word_count();
+DROP MATERIALIZED VIEW mv_articles_hash;
 DROP TABLE articles_hash;
 DROP TABLE articles_single_shard_hash;
 DROP TABLE authors_hash;
+DROP TABLE company_employees;

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -25,13 +25,6 @@ SELECT master_create_distributed_table('articles_single_shard', 'author_id', 'ha
  
 (1 row)
 
--- test when a table is distributed but no shards created yet
-SELECT count(*) from articles;
- count 
--------
-      
-(1 row)
-
 SELECT master_create_worker_shards('articles', 2, 1);
  master_create_worker_shards 
 -----------------------------
@@ -97,13 +90,6 @@ INSERT INTO articles VALUES (49,  9, 'anyone', 2681);
 INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
 -- insert a single row for the test
 INSERT INTO articles_single_shard VALUES (50, 10, 'anjanette', 19519);
--- first, test zero-shard SELECT, which should return an empty row
-SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
- count 
--------
-      
-(1 row)
-
 -- zero-shard modifications should fail
 UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
 ERROR:  distributed modifications must target exactly one shard
@@ -170,18 +156,20 @@ SELECT title, author_id FROM articles
  alkylic     |         8
 (10 rows)
 
--- add in some grouping expressions, still on same shard
+-- add in some grouping expressions.
+-- it is supported if it is on the same shard, but not supported if it
+-- involves multiple shards.
 -- having queries unsupported in Citus
 SELECT author_id, sum(word_count) AS corpus_size FROM articles
-	WHERE author_id = 1 OR author_id = 7 OR author_id = 8 OR author_id = 10
+	WHERE author_id = 1 OR author_id = 2 OR author_id = 8 OR author_id = 10
 	GROUP BY author_id
 	HAVING sum(word_count) > 40000
 	ORDER BY sum(word_count) DESC;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Having qual is currently unsupported
--- UNION/INTERSECT queries are unsupported
+-- UNION/INTERSECT queries are unsupported if on multiple shards
 SELECT * FROM articles WHERE author_id = 10 UNION
-SELECT * FROM articles WHERE author_id = 1; 
+SELECT * FROM articles WHERE author_id = 2; 
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Union, Intersect, or Except are currently unsupported
 -- queries using CTEs are unsupported
@@ -324,8 +312,8 @@ SET citus.task_executor_type TO 'real-time';
 SELECT *
 	FROM articles
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -341,6 +329,7 @@ SELECT *
 	FROM articles
 	WHERE author_id = 1 OR author_id = 17;
 DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -368,8 +357,8 @@ SELECT *
 SELECT id as article_id, word_count * id as random_value
 	FROM articles
 	WHERE author_id = 1;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  article_id | random_value 
 ------------+--------------
@@ -386,9 +375,9 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles a, articles b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  push down of limit count: 3
 DEBUG:  predicate pruning for shardId 850001
-DEBUG:  join prunable for intervals [-2147483648,-1] and [0,2147483647]
+DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
 --------------+-------------------
@@ -403,8 +392,9 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles a, articles_single_shard b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  push down of limit count: 3
 DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -417,8 +407,8 @@ SELECT *
 	FROM articles
 	WHERE author_id = 1
 	LIMIT 2;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -433,8 +423,8 @@ SELECT id
 	FROM articles
 	WHERE author_id = 1
 	GROUP BY id;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 850001
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
 ----
@@ -447,14 +437,15 @@ DEBUG:  Plan is router executable
 
 -- copying from a single shard table does not require the master query
 COPY articles_single_shard TO stdout;
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 50	10	anjanette	19519
 -- error out for queries with aggregates
 SELECT avg(word_count)
 	FROM articles
 	WHERE author_id = 2;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 850000
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
         avg         
 --------------------
@@ -467,8 +458,8 @@ SELECT max(word_count) as max, min(word_count) as min,
 	   sum(word_count) as sum, count(word_count) as cnt
 	FROM articles
 	WHERE author_id = 2;
-DEBUG:  Creating router plan
 DEBUG:  predicate pruning for shardId 850000
+DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  | min  |  sum  | cnt 
 -------+------+-------+-----
@@ -479,6 +470,7 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles a, articles b
 	WHERE a.id = b.id  AND a.author_id = 1;
+DEBUG:  predicate pruning for shardId 850001
 DEBUG:  predicate pruning for shardId 850001
 DEBUG:  join prunable for task partitionId 0 and 1
 DEBUG:  join prunable for task partitionId 0 and 2

--- a/src/test/regress/input/multi_agg_distinct.source
+++ b/src/test/regress/input/multi_agg_distinct.source
@@ -60,7 +60,7 @@ SELECT count(distinct (l_orderkey + 1)) FROM lineitem_range;
 -- sharded table.
 
 SELECT count(distinct p_mfgr) FROM part;
-SELECT p_mfgr, count(distinct p_partkey) FROM part GROUP BY p_mfgr;
+SELECT p_mfgr, count(distinct p_partkey) FROM part GROUP BY p_mfgr ORDER BY p_mfgr;
 
 -- We don't support count(distinct) queries if table is append partitioned and
 -- has multiple shards

--- a/src/test/regress/input/multi_outer_join.source
+++ b/src/test/regress/input/multi_outer_join.source
@@ -105,12 +105,13 @@ WHERE
 
 
 -- This query is an INNER JOIN in disguise since there cannot be NULL results
+-- Added extra filter to make query not router plannable
 SELECT
 	min(l_custkey), max(l_custkey)
 FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b ON (l_custkey = r_custkey)
 WHERE
-	r_custkey = 5;
+	r_custkey = 5 or r_custkey > 15;
 
 
 -- Apply a filter before the join
@@ -204,12 +205,13 @@ WHERE
 
 
 -- This query is an INNER JOIN in disguise since there cannot be NULL results (21)
+-- Added extra filter to make query not router plannable
 SELECT
 	min(l_custkey), max(l_custkey)
 FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b ON (l_custkey = r_custkey)
 WHERE
-	r_custkey = 21;
+	r_custkey = 21 or r_custkey < 10;
 
 
 -- Apply a filter before the join

--- a/src/test/regress/output/multi_agg_distinct.source
+++ b/src/test/regress/output/multi_agg_distinct.source
@@ -85,14 +85,14 @@ SELECT count(distinct p_mfgr) FROM part;
      5
 (1 row)
 
-SELECT p_mfgr, count(distinct p_partkey) FROM part GROUP BY p_mfgr;
+SELECT p_mfgr, count(distinct p_partkey) FROM part GROUP BY p_mfgr ORDER BY p_mfgr;
           p_mfgr           | count 
 ---------------------------+-------
  Manufacturer#1            |   193
- Manufacturer#3            |   228
- Manufacturer#5            |   185
  Manufacturer#2            |   190
+ Manufacturer#3            |   228
  Manufacturer#4            |   204
+ Manufacturer#5            |   185
 (5 rows)
 
 -- We don't support count(distinct) queries if table is append partitioned and

--- a/src/test/regress/output/multi_outer_join.source
+++ b/src/test/regress/output/multi_outer_join.source
@@ -134,12 +134,13 @@ LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_
 (1 row)
 
 -- This query is an INNER JOIN in disguise since there cannot be NULL results
+-- Added extra filter to make query not router plannable
 SELECT
 	min(l_custkey), max(l_custkey)
 FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b ON (l_custkey = r_custkey)
 WHERE
-	r_custkey = 5;
+	r_custkey = 5 or r_custkey > 15;
 LOG:  join order: [ "multi_outer_join_left" ][ broadcast join "multi_outer_join_right" ]
  min | max 
 -----+-----
@@ -273,12 +274,13 @@ LOG:  join order: [ "multi_outer_join_left" ][ local partition join "multi_outer
 (1 row)
 
 -- This query is an INNER JOIN in disguise since there cannot be NULL results (21)
+-- Added extra filter to make query not router plannable
 SELECT
 	min(l_custkey), max(l_custkey)
 FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b ON (l_custkey = r_custkey)
 WHERE
-	r_custkey = 21;
+	r_custkey = 21 or r_custkey < 10;
 LOG:  join order: [ "multi_outer_join_left" ][ local partition join "multi_outer_join_right" ]
  min | max 
 -----+-----

--- a/src/test/regress/sql/multi_join_order_additional.sql
+++ b/src/test/regress/sql/multi_join_order_additional.sql
@@ -63,7 +63,7 @@ CREATE TABLE customer_hash (
 	c_mktsegment char(10) not null,
 	c_comment varchar(117) not null);
 SELECT master_create_distributed_table('customer_hash', 'c_custkey', 'hash');
-SELECT master_create_worker_shards('customer_hash', 1, 1);
+SELECT master_create_worker_shards('customer_hash', 2, 1);
 
 -- The following query checks that we can correctly handle self-joins
 


### PR DESCRIPTION
We are expanding router planner coverage with this PR.

Router plannable decision logic is changed from static analysis of a query tree to actual shard pruning. Now we can tap into postgresql planner hook to get "restrictions" on relations, and use these restrictions for shard pruning. After we prune shards for each relations in the query we check whether : 1 - all relations are pruned down to a single shard, 2 - there is a one or more worker containing all shards referenced in the query.

If both conditions are satisfied, we append shard id's to relation names and send to worker containing the shards. If there are more than one workers, then the query is sent to the first one.  Task assignment policy is not honored.

Expanded coverage include subqueries, CTEs, joins as long as the query could be executed on the single worker with a single task.

There is a known side effect with shard pruning. When we perform a shard pruning and decide that the query is not router plannable, we fall back to regular planning. We perform shard pruning again during multi_physical_planner. We should be addressing that as a separate fix.

Fixes #501 

Update:  We will loose PG 9.4 support with this PR.