### PR TITLE
Stop serializing/de-serializing router target list element

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -842,6 +842,13 @@ RouterQueryJob(Query *query, Task *task)
 	job->jobQuery = query;
 	job->taskList = taskList;
 
+	/*
+	 * Router query jobs do not require jobQuery's target list. Setting it to NIL
+	 * enables us not to serialize/de-serialize while the query is passed to the
+	 * executor. This improves planning times significantly.
+	 */
+	job->jobQuery->targetList = NIL;
+
 	return job;
 }
 


### PR DESCRIPTION
This commit prevents the target list entries for router plans
to be added in the serialized plan since they are not required.
The aim of this change is to improve performance with skipping
some of the unnecessary serializations.

Some test results on a 1 + 2 c4.2xlarge cluster (inserts per second):

					|master     |  performance/reduce_serialization_cost
------------------------|----------|---------------------
1 Column:			|34090	|	36200
16 Columns:			|18184|		26101
128 Columns:			|7020	|	13200
512 Columns:			|1088|		2488
1024 Columns:                | 485  |               963

On the average, (excluding 1 column case), we get **1.5x** to **2x** improvement. 
