### PR TITLE
Fix Unused Parameter isTopLevel in ExecuteDistributedDDLCommand

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1014,7 +1014,7 @@ ExecuteDistributedDDLCommand(Oid relationId, const char *ddlCommandString,
 	bool executionOK = false;
 	bool allPlacementsAccessible = false;
 
-	PreventTransactionChain(true, "distributed DDL commands");
+	PreventTransactionChain(isTopLevel, "distributed DDL commands");
 	SetLocalCommitProtocolTo2PC();
 
 	allPlacementsAccessible = AllFinalizedPlacementsAccessible(relationId);


### PR DESCRIPTION
This change fixes the unused variable problem in
`ExecuteDistributedDDLCommand` function (multi_utility.c). The
parameter is meant to be used in PreventTransactionChain call.