### PR TITLE
Prevent outer join crash when subquery is flatten

### DIFF
--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -163,9 +163,20 @@ FixedJoinOrderList(FromExpr *fromExpr, List *tableEntryList)
 		TableEntry *nextTable = NULL;
 		JoinOrderNode *nextJoinNode = NULL;
 		List *candidateShardList = NIL;
+		Node *rightArg = joinExpr->rarg;
 
 		/* get the table on the right hand side of the join */
-		nextRangeTableRef = (RangeTblRef *) joinExpr->rarg;
+		if (IsA(rightArg, RangeTblRef))
+		{
+			nextRangeTableRef = (RangeTblRef *) rightArg;
+		}
+		else
+		{
+			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("cannot perform distributed planning on this query"),
+							errdetail("Subqueries in outer joins are not supported")));
+		}
+
 		nextTable = FindTableEntry(tableEntryList, nextRangeTableRef->rtindex);
 
 		if (joinType == JOIN_INNER)

--- a/src/test/regress/input/multi_outer_join.source
+++ b/src/test/regress/input/multi_outer_join.source
@@ -388,6 +388,24 @@ FROM
     test(c_custkey, c_nationkey)
     INNER JOIN multi_outer_join_third t1 ON (test.c_custkey = t1.t_custkey);
 
+-- flattened out subqueries with outer joins are not supported
+SELECT
+  l1.l_custkey,
+  count(*) as cnt
+FROM (
+  SELECT l_custkey, l_nationkey
+  FROM multi_outer_join_left
+  WHERE l_comment like '%a%'
+) l1
+LEFT JOIN (
+  SELECT r_custkey, r_name
+  FROM multi_outer_join_right
+  WHERE r_comment like '%b%'
+) l2 ON l1.l_custkey = l2.r_custkey
+GROUP BY l1.l_custkey
+ORDER BY cnt DESC, l1.l_custkey DESC
+LIMIT 20;
+
 -- Add a shard to the left table that overlaps with multiple shards in the right
 \STAGE multi_outer_join_left FROM '@abs_srcdir@/data/customer.1.data' with delimiter '|'
 

--- a/src/test/regress/output/multi_outer_join.source
+++ b/src/test/regress/output/multi_outer_join.source
@@ -732,6 +732,25 @@ LOG:  join order: [ "multi_outer_join_right" ][ local partition join "multi_oute
         20
 (20 rows)
 
+-- flattened out subqueries with outer joins are not supported
+SELECT
+  l1.l_custkey,
+  count(*) as cnt
+FROM (
+  SELECT l_custkey, l_nationkey
+  FROM multi_outer_join_left
+  WHERE l_comment like '%a%'
+) l1
+LEFT JOIN (
+  SELECT r_custkey, r_name
+  FROM multi_outer_join_right
+  WHERE r_comment like '%b%'
+) l2 ON l1.l_custkey = l2.r_custkey
+GROUP BY l1.l_custkey
+ORDER BY cnt DESC, l1.l_custkey DESC
+LIMIT 20;
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries in outer joins are not supported
 -- Add a shard to the left table that overlaps with multiple shards in the right
 \STAGE multi_outer_join_left FROM '@abs_srcdir@/data/customer.1.data' with delimiter '|'
 -- All outer joins should error out


### PR DESCRIPTION
This fixes crash in multi_join_order::FixedJoinOrderList function due to dereferencing a null pointer.

postgresql standand planner leaves some recursive structure in Query->joinExpr after flattening out a subquery.  In this case a subquery outer join is get flattened to a single level query.  We expect a join tree where each right child is a ```RangeTblRef *``` but in this case we found another ```FromExpr*``` with expected ```RangeTblRef *``` is inside ```FromExpr->fromList``` list as the only element. Depending on the flattening level of a subquery ```FromExpr->fromList``` may contain another ```FromExpr *```.

Full fix involves better selection of where clauses when outer join is present and recursively looking for RangeTblRef inside joinExpr->rarg. 

This work only detects the unexpected structure an errors out.

Also added a regression test to cover the query that caused the crash.

fixes #657 
Fixes #601 