### PR TITLE
Fix ALTER TABLE SET SCHEMA

### DIFF
--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -1045,3 +1045,9 @@ WHERE
 
 -- set task_executor back to real-time
 SET citus.task_executor_type TO "real-time";
+-- test ALTER TABLE SET SCHEMA
+-- we expect that it will warn out
+SET search_path TO public;
+ALTER TABLE test_schema_support.nation_hash SET SCHEMA public;
+WARNING:  not propagating ALTER ... SET SCHEMA commands to worker nodes
+HINT:  Connect to worker nodes directly to manually change schemas of affected objects.

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -249,6 +249,13 @@ SELECT  indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
 SELECT  indexname, tablename FROM pg_indexes WHERE tablename like 'lineitem_alter_%';
 \c - - - :master_port
 
+-- test ALTER TABLE ALL IN TABLESPACE
+-- we expect that it will warn out
+CREATE TABLESPACE super_fast_ssd LOCATION '@abs_srcdir@/data';
+ALTER TABLE ALL IN TABLESPACE pg_default SET TABLESPACE super_fast_ssd;
+ALTER TABLE ALL IN TABLESPACE super_fast_ssd SET TABLESPACE pg_default;
+DROP TABLESPACE super_fast_ssd;
+
 -- Cleanup the table and its shards
 SET citus.enable_ddl_propagation to true;
 SELECT master_apply_delete_command('DELETE FROM lineitem_alter');

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -639,6 +639,16 @@ SELECT  indexname, tablename FROM pg_indexes WHERE tablename like 'lineitem_alte
 (0 rows)
 
 \c - - - :master_port
+-- test ALTER TABLE ALL IN TABLESPACE
+-- we expect that it will warn out
+CREATE TABLESPACE super_fast_ssd LOCATION '@abs_srcdir@/data';
+ALTER TABLE ALL IN TABLESPACE pg_default SET TABLESPACE super_fast_ssd;
+WARNING:  not propagating ALTER TABLE ALL IN TABLESPACE commands to worker nodes
+HINT:  Connect to worker nodes directly to manually move all tables.
+ALTER TABLE ALL IN TABLESPACE super_fast_ssd SET TABLESPACE pg_default;
+WARNING:  not propagating ALTER TABLE ALL IN TABLESPACE commands to worker nodes
+HINT:  Connect to worker nodes directly to manually move all tables.
+DROP TABLESPACE super_fast_ssd;
 -- Cleanup the table and its shards
 SET citus.enable_ddl_propagation to true;
 SELECT master_apply_delete_command('DELETE FROM lineitem_alter');

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -728,3 +728,9 @@ WHERE
 
 -- set task_executor back to real-time
 SET citus.task_executor_type TO "real-time";
+
+
+-- test ALTER TABLE SET SCHEMA
+-- we expect that it will warn out
+SET search_path TO public;
+ALTER TABLE test_schema_support.nation_hash SET SCHEMA public;


### PR DESCRIPTION
Fixes #132

We hook into ALTER ... SET SCHEMA and warn out if user tries to change schema of a
distributed table.

We also hook into ALTER TABLE ALL IN TABLE SPACE statements and warn out if citus has
been loaded.