### PR TITLE
Remove warnings on schema creation

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -243,13 +243,6 @@ multi_ProcessUtility(Node *parsetree,
 						 errhint("You can manually create a database and its "
 								 "extensions on workers.")));
 	}
-	else if (IsA(parsetree, CreateSchemaStmt) && CitusHasBeenLoaded())
-	{
-		ereport(NOTICE, (errmsg("Citus partially supports CREATE SCHEMA "
-								"for distributed databases"),
-						 errdetail("schema usage in joins and in some UDFs "
-								   "provided by Citus are not supported yet")));
-	}
 	else if (IsA(parsetree, CreateRoleStmt) && CitusHasBeenLoaded())
 	{
 		ereport(NOTICE, (errmsg("not propagating CREATE ROLE/USER commands to worker"

--- a/src/test/regress/expected/multi_agg_approximate_distinct.out
+++ b/src/test/regress/expected/multi_agg_approximate_distinct.out
@@ -105,8 +105,6 @@ SELECT count(DISTINCT l_orderkey) as distinct_order_count, l_quantity FROM linei
 -- Check that approximate count(distinct) works at a table in a schema other than public
 -- create necessary objects
 CREATE SCHEMA test_count_distinct_schema;
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 CREATE TABLE test_count_distinct_schema.nation_hash(
     n_nationkey integer not null,
     n_name char(25) not null,

--- a/src/test/regress/expected/multi_create_insert_proxy.out
+++ b/src/test/regress/expected/multi_create_insert_proxy.out
@@ -11,8 +11,6 @@ CREATE SCHEMA "A$AP Mob"
 		id bigint PRIMARY KEY,
 		data text NOT NULL DEFAULT 'lorem ipsum'
 	);
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 \set insert_target '"A$AP Mob"."Dr. Bronner''s ""Magic"" Soaps"'
 -- create proxy and save proxy table name
 SELECT create_insert_proxy_for_table(:'insert_target') AS proxy_tablename

--- a/src/test/regress/expected/multi_generate_ddl_commands.out
+++ b/src/test/regress/expected/multi_generate_ddl_commands.out
@@ -35,8 +35,6 @@ SELECT table_ddl_command_array('not_null_table');
 
 -- ensure tables not in search path are schema-prefixed
 CREATE SCHEMA not_in_path CREATE TABLE simple_table (id bigint);
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 SELECT table_ddl_command_array('not_in_path.simple_table');
                                      table_ddl_command_array                                     
 -------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -5,8 +5,6 @@ ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1190000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1190000;
 -- create schema to test schema support
 CREATE SCHEMA test_schema_support;
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 -- test master_append_table_to_shard with schema
 -- create local table to append
 CREATE TABLE public.nation_local(
@@ -831,11 +829,7 @@ SELECT master_apply_delete_command('DELETE FROM nation_append') ;
 -- so that we guarantee to have repartitions when necessary
 -- create necessary objects and load data to them
 CREATE SCHEMA test_schema_support_join_1;
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 CREATE SCHEMA test_schema_support_join_2;
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 CREATE TABLE test_schema_support_join_1.nation_hash (
     n_nationkey integer not null,
     n_name char(25) not null,

--- a/src/test/regress/expected/multi_utility_warnings.out
+++ b/src/test/regress/expected/multi_utility_warnings.out
@@ -9,9 +9,6 @@ CREATE DATABASE new_database;
 NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
 DETAIL:  Citus does not propagate CREATE DATABASE command to workers
 HINT:  You can manually create a database and its extensions on workers.
-CREATE SCHEMA new_schema;
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 CREATE ROLE new_role;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -469,8 +469,6 @@ SELECT min(c_custkey), max(c_custkey), avg(c_acctbal), count(*) FROM customer_wo
 
 -- Test schema support on append partitioned tables
 CREATE SCHEMA append;
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 CREATE TABLE append.customer_copy (
         c_custkey integer ,
         c_name varchar(25) not null,

--- a/src/test/regress/output/multi_create_schema.source
+++ b/src/test/regress/output/multi_create_schema.source
@@ -6,8 +6,6 @@ CREATE TABLE nation (
 	n_name char(25) not null,
 	n_regionkey integer not null,
 	n_comment varchar(152));
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 SELECT master_create_distributed_table('tpch.nation', 'n_nationkey', 'append');
  master_create_distributed_table 
 ---------------------------------
@@ -15,10 +13,6 @@ SELECT master_create_distributed_table('tpch.nation', 'n_nationkey', 'append');
 (1 row)
 
 \STAGE tpch.nation FROM '@abs_srcdir@/data/nation.data' with delimiter '|'
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
-NOTICE:  Citus partially supports CREATE SCHEMA for distributed databases
-DETAIL:  schema usage in joins and in some UDFs provided by Citus are not supported yet
 SELECT count(*) from tpch.nation;
  count 
 -------

--- a/src/test/regress/sql/multi_utility_warnings.sql
+++ b/src/test/regress/sql/multi_utility_warnings.sql
@@ -12,8 +12,6 @@ ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1010000;
 
 CREATE DATABASE new_database;
 
-CREATE SCHEMA new_schema;
-
 CREATE ROLE new_role;
 
 CREATE USER new_user;


### PR DESCRIPTION
Since now we support schema related operations, there is no need to warn user about
schema usage.