### PR TITLE
Improve WorkerShardStats to avoid invalid value bugs

### DIFF
--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -321,9 +321,7 @@ MultiClientExecute(int32 connectionId, const char *query, void **queryResult,
 				   int *rowCount, int *columnCount)
 {
 	bool querySent = false;
-	bool queryReady = false;
 	bool queryOK = false;
-	WaitInfo *waitInfo = NULL;
 
 	querySent = MultiClientSendQuery(connectionId, query);
 	if (!querySent)
@@ -331,32 +329,7 @@ MultiClientExecute(int32 connectionId, const char *query, void **queryResult,
 		return false;
 	}
 
-	waitInfo = MultiClientCreateWaitInfo(1);
-
-	while (!queryReady)
-	{
-		ResultStatus resultStatus = MultiClientResultStatus(connectionId);
-		if (resultStatus == CLIENT_RESULT_READY)
-		{
-			queryReady = true;
-		}
-		else if (resultStatus == CLIENT_RESULT_BUSY)
-		{
-			/* wait for results, errors, or interrupts */
-			MultiClientResetWaitInfo(waitInfo);
-			MultiClientRegisterWait(waitInfo, TASK_STATUS_SOCKET_READ, connectionId);
-			MultiClientWait(waitInfo);
-		}
-		else
-		{
-			MultiClientFreeWaitInfo(waitInfo);
-			return false;
-		}
-	}
-
 	queryOK = MultiClientQueryResult(connectionId, queryResult, rowCount, columnCount);
-
-	MultiClientFreeWaitInfo(waitInfo);
 
 	return queryOK;
 }

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -58,8 +58,7 @@
 	"SELECT worker_apply_shard_ddl_command (" UINT64_FORMAT ", %s)"
 #define WORKER_APPEND_TABLE_TO_SHARD \
 	"SELECT worker_append_table_to_shard (%s, %s, %s, %u)"
-#define SHARD_MIN_VALUE_QUERY "SELECT min(%s) FROM %s"
-#define SHARD_MAX_VALUE_QUERY "SELECT max(%s) FROM %s"
+#define SHARD_RANGE_QUERY "SELECT min(%s), max(%s) FROM %s"
 #define SHARD_TABLE_SIZE_QUERY "SELECT pg_table_size(%s)"
 #define SHARD_CSTORE_TABLE_SIZE_QUERY "SELECT cstore_table_size(%s)"
 #define DROP_REGULAR_TABLE_COMMAND "DROP TABLE IF EXISTS %s"

--- a/src/include/distributed/multi_client_executor.h
+++ b/src/include/distributed/multi_client_executor.h
@@ -104,6 +104,8 @@ extern int32 MultiClientConnectStart(const char *nodeName, uint32 nodePort,
 extern ConnectStatus MultiClientConnectPoll(int32 connectionId);
 extern void MultiClientDisconnect(int32 connectionId);
 extern bool MultiClientConnectionUp(int32 connectionId);
+extern bool MultiClientExecute(int32 connectionId, const char *query, void **queryResult,
+							   int *rowCount, int *columnCount);
 extern bool MultiClientSendQuery(int32 connectionId, const char *query);
 extern bool MultiClientCancel(int32 connectionId);
 extern ResultStatus MultiClientResultStatus(int32 connectionId);
@@ -114,6 +116,7 @@ extern bool MultiClientQueryResult(int32 connectionId, void **queryResult,
 extern BatchQueryStatus MultiClientBatchResult(int32 connectionId, void **queryResult,
 											   int *rowCount, int *columnCount);
 extern char * MultiClientGetValue(void *queryResult, int rowIndex, int columnIndex);
+extern bool MultiClientValueIsNull(void *queryResult, int rowIndex, int columnIndex);
 extern void MultiClientClearResult(void *queryResult);
 extern WaitInfo * MultiClientCreateWaitInfo(int maxConnections);
 

--- a/src/test/regress/input/multi_append_table_to_shard.source
+++ b/src/test/regress/input/multi_append_table_to_shard.source
@@ -97,3 +97,46 @@ SELECT master_apply_delete_command('DELETE FROM multi_append_table_to_shard_left
 DROP TABLE multi_append_table_to_shard_stage;
 DROP TABLE multi_append_table_to_shard_right;
 DROP TABLE multi_append_table_to_shard_left;
+
+-- Check partitioning by date
+CREATE TABLE multi_append_table_to_shard_date
+(
+	event_date DATE,
+	value INT
+);
+SELECT master_create_distributed_table('multi_append_table_to_shard_date', 'event_date', 'append');
+
+-- Create an empty shard and check that we can query the table
+SELECT master_create_empty_shard('multi_append_table_to_shard_date');
+
+SELECT * FROM multi_append_table_to_shard_date;
+
+-- Stage an empty table and check that we can query the distributed table
+CREATE TABLE multi_append_table_to_shard_stage (LIKE multi_append_table_to_shard_date);
+SELECT	master_append_table_to_shard(shardid, 'multi_append_table_to_shard_stage', 'localhost', 57636)
+FROM
+		pg_dist_shard
+WHERE	'multi_append_table_to_shard_date'::regclass::oid = logicalrelid;
+
+SELECT * FROM multi_append_table_to_shard_date;
+
+-- Stage NULL values and check that we can query the table
+INSERT INTO multi_append_table_to_shard_stage VALUES (NULL, NULL);
+SELECT	master_append_table_to_shard(shardid, 'multi_append_table_to_shard_stage', 'localhost', 57636)
+FROM
+		pg_dist_shard
+WHERE	'multi_append_table_to_shard_date'::regclass::oid = logicalrelid;
+
+SELECT * FROM multi_append_table_to_shard_date;
+
+-- Stage regular values and check that we can query the table
+INSERT INTO multi_append_table_to_shard_stage VALUES ('2016-01-01', 3);
+SELECT	master_append_table_to_shard(shardid, 'multi_append_table_to_shard_stage', 'localhost', 57636)
+FROM
+		pg_dist_shard
+WHERE	'multi_append_table_to_shard_date'::regclass::oid = logicalrelid;
+
+SELECT * FROM multi_append_table_to_shard_date;
+
+DROP TABLE multi_append_table_to_shard_stage;
+DROP TABLE multi_append_table_to_shard_date;

--- a/src/test/regress/output/multi_append_table_to_shard.source
+++ b/src/test/regress/output/multi_append_table_to_shard.source
@@ -151,3 +151,81 @@ SELECT master_apply_delete_command('DELETE FROM multi_append_table_to_shard_left
 DROP TABLE multi_append_table_to_shard_stage;
 DROP TABLE multi_append_table_to_shard_right;
 DROP TABLE multi_append_table_to_shard_left;
+-- Check partitioning by date
+CREATE TABLE multi_append_table_to_shard_date
+(
+	event_date DATE,
+	value INT
+);
+SELECT master_create_distributed_table('multi_append_table_to_shard_date', 'event_date', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- Create an empty shard and check that we can query the table
+SELECT master_create_empty_shard('multi_append_table_to_shard_date');
+ master_create_empty_shard 
+---------------------------
+                    230004
+(1 row)
+
+SELECT * FROM multi_append_table_to_shard_date;
+ event_date | value 
+------------+-------
+(0 rows)
+
+-- Stage an empty table and check that we can query the distributed table
+CREATE TABLE multi_append_table_to_shard_stage (LIKE multi_append_table_to_shard_date);
+SELECT	master_append_table_to_shard(shardid, 'multi_append_table_to_shard_stage', 'localhost', 57636)
+FROM
+		pg_dist_shard
+WHERE	'multi_append_table_to_shard_date'::regclass::oid = logicalrelid;
+ master_append_table_to_shard 
+------------------------------
+                            0
+(1 row)
+
+SELECT * FROM multi_append_table_to_shard_date;
+ event_date | value 
+------------+-------
+(0 rows)
+
+-- Stage NULL values and check that we can query the table
+INSERT INTO multi_append_table_to_shard_stage VALUES (NULL, NULL);
+SELECT	master_append_table_to_shard(shardid, 'multi_append_table_to_shard_stage', 'localhost', 57636)
+FROM
+		pg_dist_shard
+WHERE	'multi_append_table_to_shard_date'::regclass::oid = logicalrelid;
+ master_append_table_to_shard 
+------------------------------
+                    0.0266667
+(1 row)
+
+SELECT * FROM multi_append_table_to_shard_date;
+ event_date | value 
+------------+-------
+            |      
+(1 row)
+
+-- Stage regular values and check that we can query the table
+INSERT INTO multi_append_table_to_shard_stage VALUES ('2016-01-01', 3);
+SELECT	master_append_table_to_shard(shardid, 'multi_append_table_to_shard_stage', 'localhost', 57636)
+FROM
+		pg_dist_shard
+WHERE	'multi_append_table_to_shard_date'::regclass::oid = logicalrelid;
+ master_append_table_to_shard 
+------------------------------
+                    0.0266667
+(1 row)
+
+SELECT * FROM multi_append_table_to_shard_date;
+ event_date | value 
+------------+-------
+            |      
+            |      
+ 01-01-2016 |     3
+(3 rows)
+
+DROP TABLE multi_append_table_to_shard_stage;
+DROP TABLE multi_append_table_to_shard_date;


### PR DESCRIPTION
This is a rewrite of WorkerShardStats to avoid ExecuteRemoteQuery and introduce some better infrastructure for executing remote commands. ExecuteRemoteQuery doesn't check whether return values are NULL, which makes it impossible to distinguish between empty string and NULL results and both are valid min/max results. ExecuteRemoteQuery was always a poor choice for WorkerShardStats, since it can only return 1 column and WorkerShardStats needs several (min, max). As a side-effect of the rewrite, updating the shard statistics we now use only 1 query for min and max, which makes updating shard statistics much faster.

The change does not affect any other code paths that currently rely on ExecuteRemoteQuery or MultiClient* functions.

Fixes #126 
Fixes #669 