### PR TITLE
Quick fix for possible segfault in PurgeConnection

### DIFF
--- a/src/include/distributed/test_helper_functions.h
+++ b/src/include/distributed/test_helper_functions.h
@@ -39,6 +39,7 @@ extern Datum fake_fdw_handler(PG_FUNCTION_ARGS);
 extern Datum initialize_remote_temp_table(PG_FUNCTION_ARGS);
 extern Datum count_remote_temp_table_rows(PG_FUNCTION_ARGS);
 extern Datum get_and_purge_connection(PG_FUNCTION_ARGS);
+extern Datum connect_and_purge_connection(PG_FUNCTION_ARGS);
 extern Datum set_connection_status_bad(PG_FUNCTION_ARGS);
 
 /* function declarations for exercising metadata functions */

--- a/src/test/regress/expected/multi_connection_cache.out
+++ b/src/test/regress/expected/multi_connection_cache.out
@@ -15,6 +15,10 @@ CREATE FUNCTION get_and_purge_connection(cstring, integer)
 	RETURNS bool
 	AS 'citus'
 	LANGUAGE C STRICT;
+CREATE FUNCTION connect_and_purge_connection(cstring, integer)
+	RETURNS bool
+	AS 'citus'
+	LANGUAGE C STRICT;
 CREATE FUNCTION set_connection_status_bad(cstring, integer)
 	RETURNS bool
 	AS 'citus'
@@ -104,3 +108,11 @@ SELECT get_and_purge_connection('localhost', :worker_port);
 (1 row)
 
 SET client_min_messages TO DEFAULT;
+\c
+-- purge existing connection to localhost
+SELECT connect_and_purge_connection('localhost', :worker_port);
+ connect_and_purge_connection 
+------------------------------
+ t
+(1 row)
+

--- a/src/test/regress/sql/multi_connection_cache.sql
+++ b/src/test/regress/sql/multi_connection_cache.sql
@@ -22,6 +22,11 @@ CREATE FUNCTION get_and_purge_connection(cstring, integer)
 	AS 'citus'
 	LANGUAGE C STRICT;
 
+CREATE FUNCTION connect_and_purge_connection(cstring, integer)
+	RETURNS bool
+	AS 'citus'
+	LANGUAGE C STRICT;
+
 CREATE FUNCTION set_connection_status_bad(cstring, integer)
 	RETURNS bool
 	AS 'citus'
@@ -76,3 +81,8 @@ SELECT count_remote_temp_table_rows('localhost', :worker_port);
 SELECT get_and_purge_connection('localhost', :worker_port);
 
 SET client_min_messages TO DEFAULT;
+
+\c
+
+-- purge existing connection to localhost
+SELECT connect_and_purge_connection('localhost', :worker_port);


### PR DESCRIPTION
Now that connections can be acquired without going through the cache, we have to handle cases where functions assume the cache has been initialized.

Fixes #664