### PR TITLE
Don't access pg_dist_partition->partkey directly, use heap_getattr().

### DIFF
--- a/src/include/distributed/pg_dist_partition.h
+++ b/src/include/distributed/pg_dist_partition.h
@@ -23,7 +23,9 @@ typedef struct FormData_pg_dist_partition
 {
 	Oid logicalrelid;              /* logical relation id; references pg_class oid */
 	char partmethod;               /* partition method; see codes below */
+#ifdef CATALOG_VARLEN              /* variable-length fields start here */
 	text partkey;                  /* partition key expression */
+#endif
 } FormData_pg_dist_partition;
 
 /* ----------------


### PR DESCRIPTION
Text datums can't be directly accessed via the struct equivalence trick
used to access catalogs. That's because, as an optimization, they're
sometimes aligned to 1 byte ("text"'s alignment), and sometimes to 4
bytes. That depends on it being a short
varlena (cf. VARATT_NOT_PAD_BYTE) or not.

In the case at hand here, partkey became longer than 127 characters -
the boundary for short varlenas (cf. VARATT_CAN_MAKE_SHORT()). Thus it
became 4 byte/int aligned. Which lead to the direct struct access
accessing the wrong data.

The fix is simply to never access partkey that way - to enforce that,
hide partkey ehind the usual ifdef.

Fixes: #674