### PR TITLE
Add old version(without schema name parameter) of api functions back

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -6,7 +6,7 @@ citus_top_builddir = ../../..
 MODULE_big = citus
 EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
-	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6
+	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -44,6 +44,8 @@ $(EXTENSION)--5.1-4.sql: $(EXTENSION)--5.1-3.sql $(EXTENSION)--5.1-3--5.1-4.sql
 $(EXTENSION)--5.1-5.sql: $(EXTENSION)--5.1-4.sql $(EXTENSION)--5.1-4--5.1-5.sql
 	cat $^ > $@
 $(EXTENSION)--5.1-6.sql: $(EXTENSION)--5.1-5.sql $(EXTENSION)--5.1-5--5.1-6.sql
+	cat $^ > $@
+$(EXTENSION)--5.1-7.sql: $(EXTENSION)--5.1-6.sql $(EXTENSION)--5.1-6--5.1-7.sql
 	cat $^ > $@
 	
 NO_PGXS = 1

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -6,7 +6,7 @@ citus_top_builddir = ../../..
 MODULE_big = citus
 EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
-	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5
+	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -42,6 +42,8 @@ $(EXTENSION)--5.1-3.sql: $(EXTENSION)--5.1-2.sql $(EXTENSION)--5.1-2--5.1-3.sql
 $(EXTENSION)--5.1-4.sql: $(EXTENSION)--5.1-3.sql $(EXTENSION)--5.1-3--5.1-4.sql
 	cat $^ > $@
 $(EXTENSION)--5.1-5.sql: $(EXTENSION)--5.1-4.sql $(EXTENSION)--5.1-4--5.1-5.sql
+	cat $^ > $@
+$(EXTENSION)--5.1-6.sql: $(EXTENSION)--5.1-5.sql $(EXTENSION)--5.1-5--5.1-6.sql
 	cat $^ > $@
 	
 NO_PGXS = 1

--- a/src/backend/distributed/citus--5.1-5--5.1-6.sql
+++ b/src/backend/distributed/citus--5.1-5--5.1-6.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION pg_catalog.worker_apply_shard_ddl_command(bigint, text)
+    RETURNS void
+    LANGUAGE sql
+AS $worker_apply_shard_ddl_command$
+    SELECT pg_catalog.worker_apply_shard_ddl_command($1, 'public', $2);
+$worker_apply_shard_ddl_command$;
+COMMENT ON FUNCTION worker_apply_shard_ddl_command(bigint, text)
+    IS 'extend ddl command with shardId and apply on database';
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_fetch_foreign_file(text, bigint, text[], integer[])
+    RETURNS void
+    LANGUAGE sql
+AS $worker_fetch_foreign_file$
+    SELECT pg_catalog.worker_fetch_foreign_file('public', $1, $2, $3, $4);
+$worker_fetch_foreign_file$;
+COMMENT ON FUNCTION pg_catalog.worker_fetch_foreign_file(text, bigint, text[], integer[])
+    IS 'fetch foreign file from remote node and apply file';
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_fetch_regular_table(text, bigint, text[], integer[])
+    RETURNS void
+    LANGUAGE sql
+AS $worker_fetch_regular_table$
+    SELECT pg_catalog.worker_fetch_regular_table('public', $1, $2, $3, $4);
+$worker_fetch_regular_table$;
+COMMENT ON FUNCTION pg_catalog.worker_fetch_regular_table(text, bigint, text[], integer[])
+    IS 'fetch PostgreSQL table from remote node';

--- a/src/backend/distributed/citus--5.1-6--5.1-7.sql
+++ b/src/backend/distributed/citus--5.1-6--5.1-7.sql
@@ -1,0 +1,17 @@
+DROP FUNCTION IF EXISTS pg_catalog.worker_fetch_foreign_file(text, text, bigint, text[], integer[]);
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_fetch_foreign_file(text, bigint, text[], integer[])
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$worker_fetch_foreign_file$$;
+COMMENT ON FUNCTION pg_catalog.worker_fetch_foreign_file(text, bigint, text[], integer[])
+    IS 'fetch foreign file from remote node and apply file';
+
+DROP FUNCTION IF EXISTS pg_catalog.worker_fetch_regular_table(text, text, bigint, text[], integer[]);
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_fetch_regular_table(text, bigint, text[], integer[])
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$worker_fetch_regular_table$$;
+COMMENT ON FUNCTION pg_catalog.worker_fetch_regular_table(text, bigint, text[], integer[])
+    IS 'fetch PostgreSQL table from remote node';

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '5.1-5'
+default_version = '5.1-6'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '5.1-6'
+default_version = '5.1-7'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -954,13 +954,14 @@ CreateLocalTable(RangeVar *relation, char *nodeName, int32 nodePort)
 
 	char *relationName = relation->relname;
 	char *schemaName = relation->schemaname;
+	char *qualifiedRelationName = quote_qualified_identifier(schemaName, relationName);
 
 	/*
 	 * The warning message created in TableDDLCommandList() is descriptive
 	 * enough; therefore, we just throw an error which says that we could not
 	 * run the copy operation.
 	 */
-	ddlCommandList = TableDDLCommandList(nodeName, nodePort, schemaName, relationName);
+	ddlCommandList = TableDDLCommandList(nodeName, nodePort, qualifiedRelationName);
 	if (ddlCommandList == NIL)
 	{
 		ereport(ERROR, (errmsg("could not run copy from the worker node")));

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -3781,14 +3781,17 @@ ShardFetchQueryString(uint64 shardId)
 	{
 		if (strcmp(shardSchemaName, "public") != 0)
 		{
-			appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND, shardSchemaName,
-							 shardTableName, shardLength, nodeNameArrayString->data,
+			char *qualifiedTableName = quote_qualified_identifier(shardSchemaName,
+																  shardTableName);
+
+			appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND, qualifiedTableName,
+							 shardLength, nodeNameArrayString->data,
 							 nodePortArrayString->data);
 		}
 		else
 		{
-			appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND_WITHOUT_SCHEMA,
-							 shardTableName, shardLength, nodeNameArrayString->data,
+			appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND, shardTableName,
+							 shardLength, nodeNameArrayString->data,
 							 nodePortArrayString->data);
 		}
 	}
@@ -3796,14 +3799,17 @@ ShardFetchQueryString(uint64 shardId)
 	{
 		if (strcmp(shardSchemaName, "public") != 0)
 		{
-			appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND, shardSchemaName,
-							 shardTableName, shardLength, nodeNameArrayString->data,
+			char *qualifiedTableName = quote_qualified_identifier(shardSchemaName,
+																  shardTableName);
+
+			appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND, qualifiedTableName,
+							 shardLength, nodeNameArrayString->data,
 							 nodePortArrayString->data);
 		}
 		else
 		{
-			appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND_WITHOUT_SCHEMA,
-							 shardTableName, shardLength, nodeNameArrayString->data,
+			appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND, shardTableName,
+							 shardLength, nodeNameArrayString->data,
 							 nodePortArrayString->data);
 		}
 	}

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -3779,15 +3779,33 @@ ShardFetchQueryString(uint64 shardId)
 	if (storageType == SHARD_STORAGE_TABLE || storageType == SHARD_STORAGE_RELAY ||
 		storageType == SHARD_STORAGE_COLUMNAR)
 	{
-		appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND,
-						 shardSchemaName, shardTableName, shardLength,
-						 nodeNameArrayString->data, nodePortArrayString->data);
+		if (strcmp(shardSchemaName, "public") != 0)
+		{
+			appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND, shardSchemaName,
+							 shardTableName, shardLength, nodeNameArrayString->data,
+							 nodePortArrayString->data);
+		}
+		else
+		{
+			appendStringInfo(shardFetchQuery, TABLE_FETCH_COMMAND_WITHOUT_SCHEMA,
+							 shardTableName, shardLength, nodeNameArrayString->data,
+							 nodePortArrayString->data);
+		}
 	}
 	else if (storageType == SHARD_STORAGE_FOREIGN)
 	{
-		appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND,
-						 shardSchemaName, shardTableName, shardLength,
-						 nodeNameArrayString->data, nodePortArrayString->data);
+		if (strcmp(shardSchemaName, "public") != 0)
+		{
+			appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND, shardSchemaName,
+							 shardTableName, shardLength, nodeNameArrayString->data,
+							 nodePortArrayString->data);
+		}
+		else
+		{
+			appendStringInfo(shardFetchQuery, FOREIGN_FETCH_COMMAND_WITHOUT_SCHEMA,
+							 shardTableName, shardLength, nodeNameArrayString->data,
+							 nodePortArrayString->data);
+		}
 	}
 
 	return shardFetchQuery;

--- a/src/bin/csql/stage.c
+++ b/src/bin/csql/stage.c
@@ -1387,23 +1387,15 @@ static bool
 ApplyShardDDLCommand(PGconn *workerNode, uint64 shardId, const char *ddlCommand)
 {
 	const char *remoteCommand = APPLY_SHARD_DDL_COMMAND;
-	const char *parameterValue[3];
-	const int parameterCount = 3;
+	const char *parameterValue[2];
+	const int parameterCount = 2;
 	PGresult *ddlResult = NULL;
 
 	char shardIdString[NAMEDATALEN];
 	snprintf(shardIdString, NAMEDATALEN, UINT64_FORMAT, shardId);
 
-	/*
-	 * We changed worker_apply_shard_ddl_command and now it requires schema name. Since
-	 * \STAGE will be deprecated anyway, we use public schema for everything to make it
-	 * work with worker_apply_shard_ddl_command. Please note that if user specifies
-	 * schema name, this will not override it, because we prioritize schema names given
-	 * in the query in worker_apply_shard_ddl_command.
-	 */
 	parameterValue[0] = shardIdString;
-	parameterValue[1] = "public";
-	parameterValue[2] = ddlCommand;
+	parameterValue[1] = ddlCommand;
 
 	ddlResult = ExecuteRemoteCommand(workerNode, remoteCommand,
 									 parameterValue, parameterCount);

--- a/src/bin/csql/stage.h
+++ b/src/bin/csql/stage.h
@@ -65,7 +65,7 @@
 	"SELECT * FROM (SELECT (pg_options_to_table(ftoptions)).* FROM pg_foreign_table " \
 	"WHERE ftrelid = %u) AS Q WHERE option_name = 'filename';"
 #define APPLY_SHARD_DDL_COMMAND \
-	"SELECT * FROM worker_apply_shard_ddl_command ($1::int8, $2::text, $3::text)"
+	"SELECT * FROM worker_apply_shard_ddl_command ($1::int8, $2::text)"
 #define REMOTE_FILE_SIZE_COMMAND "SELECT size FROM pg_stat_file('%s')"
 #define SHARD_COLUMNAR_TABLE_SIZE_COMMAND "SELECT cstore_table_size('%s')"
 

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -51,6 +51,8 @@
 /* Remote call definitions to help with data staging and deletion */
 #define WORKER_APPLY_SHARD_DDL_COMMAND \
 	"SELECT worker_apply_shard_ddl_command (" UINT64_FORMAT ", %s, %s)"
+#define WORKER_APPLY_SHARD_DDL_COMMAND_WITHOUT_SCHEMA \
+	"SELECT worker_apply_shard_ddl_command (" UINT64_FORMAT ", %s)"
 #define WORKER_APPEND_TABLE_TO_SHARD \
 	"SELECT worker_append_table_to_shard (%s, %s, %s, %u)"
 #define SHARD_MIN_VALUE_QUERY "SELECT min(%s) FROM %s"

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -34,8 +34,12 @@
 #define MERGE_COLUMN_FORMAT "merge_column_%u"
 #define TABLE_FETCH_COMMAND "SELECT worker_fetch_regular_table \
  ('%s', '%s', " UINT64_FORMAT ", '%s', '%s')"
+#define TABLE_FETCH_COMMAND_WITHOUT_SCHEMA "SELECT worker_fetch_regular_table \
+ ('%s', " UINT64_FORMAT ", '%s', '%s')"
 #define FOREIGN_FETCH_COMMAND "SELECT worker_fetch_foreign_file \
  ('%s', '%s', " UINT64_FORMAT ", '%s', '%s')"
+#define FOREIGN_FETCH_COMMAND_WITHOUT_SCHEMA "SELECT worker_fetch_foreign_file \
+ ('%s', " UINT64_FORMAT ", '%s', '%s')"
 #define MAP_OUTPUT_FETCH_COMMAND "SELECT worker_fetch_partition_file \
  (" UINT64_FORMAT ", %u, %u, %u, '%s', %u)"
 #define RANGE_PARTITION_COMMAND "SELECT worker_range_partition_table \

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -33,12 +33,8 @@
 #define RESERVED_HASHED_COLUMN_ID MaxAttrNumber
 #define MERGE_COLUMN_FORMAT "merge_column_%u"
 #define TABLE_FETCH_COMMAND "SELECT worker_fetch_regular_table \
- ('%s', '%s', " UINT64_FORMAT ", '%s', '%s')"
-#define TABLE_FETCH_COMMAND_WITHOUT_SCHEMA "SELECT worker_fetch_regular_table \
  ('%s', " UINT64_FORMAT ", '%s', '%s')"
 #define FOREIGN_FETCH_COMMAND "SELECT worker_fetch_foreign_file \
- ('%s', '%s', " UINT64_FORMAT ", '%s', '%s')"
-#define FOREIGN_FETCH_COMMAND_WITHOUT_SCHEMA "SELECT worker_fetch_foreign_file \
  ('%s', " UINT64_FORMAT ", '%s', '%s')"
 #define MAP_OUTPUT_FETCH_COMMAND "SELECT worker_fetch_partition_file \
  (" UINT64_FORMAT ", %u, %u, %u, '%s', %u)"

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -120,7 +120,7 @@ extern Datum * DeconstructArrayObject(ArrayType *arrayObject);
 extern int32 ArrayObjectCount(ArrayType *arrayObject);
 extern FmgrInfo * GetFunctionInfo(Oid typeId, Oid accessMethodId, int16 procedureId);
 extern List * TableDDLCommandList(const char *nodeName, uint32 nodePort,
-								  const char *schemaName, const char *tableName);
+								  const char *tableName);
 
 /* Function declarations shared with the master planner */
 extern StringInfo TaskFilename(StringInfo directoryName, uint32 taskId);

--- a/src/test/regress/expected/multi_complex_expressions.out
+++ b/src/test/regress/expected/multi_complex_expressions.out
@@ -390,7 +390,7 @@ ORDER BY
 	customer_keys.o_custkey DESC
 LIMIT 10 OFFSET 20;
 DEBUG:  push down of limit count: 30
-DEBUG:  building index "pg_toast_16966_index" on table "pg_toast_16966"
+DEBUG:  building index "pg_toast_16977_index" on table "pg_toast_16977"
  o_custkey | total_order_count 
 -----------+-------------------
       1466 |                 1

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -20,6 +20,7 @@ ALTER EXTENSION citus UPDATE TO '5.1-3';
 ALTER EXTENSION citus UPDATE TO '5.1-4';
 ALTER EXTENSION citus UPDATE TO '5.1-5';
 ALTER EXTENSION citus UPDATE TO '5.1-6';
+ALTER EXTENSION citus UPDATE TO '5.1-7';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -19,6 +19,7 @@ ALTER EXTENSION citus UPDATE TO '5.1-2';
 ALTER EXTENSION citus UPDATE TO '5.1-3';
 ALTER EXTENSION citus UPDATE TO '5.1-4';
 ALTER EXTENSION citus UPDATE TO '5.1-5';
+ALTER EXTENSION citus UPDATE TO '5.1-6';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -25,6 +25,7 @@ ALTER EXTENSION citus UPDATE TO '5.1-3';
 ALTER EXTENSION citus UPDATE TO '5.1-4';
 ALTER EXTENSION citus UPDATE TO '5.1-5';
 ALTER EXTENSION citus UPDATE TO '5.1-6';
+ALTER EXTENSION citus UPDATE TO '5.1-7';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -24,6 +24,7 @@ ALTER EXTENSION citus UPDATE TO '5.1-2';
 ALTER EXTENSION citus UPDATE TO '5.1-3';
 ALTER EXTENSION citus UPDATE TO '5.1-4';
 ALTER EXTENSION citus UPDATE TO '5.1-5';
+ALTER EXTENSION citus UPDATE TO '5.1-6';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;


### PR DESCRIPTION
We added old versions (i.e. without schema name) of worker_apply_shard_ddl_command,
worker_fetch_foreign_file and worker_fetch_regular_table back. During function call
of one of these functions, we set schema name as  public schema and call the newer
version of the functions.