### PR TITLE
Tidy Up multi_ProcessUtility

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -92,7 +92,6 @@ static void SetLocalCommitProtocolTo2PC(void);
 static bool ExecuteCommandOnWorkerShards(Oid relationId, const char *commandString);
 static void ExecuteCommandOnShardPlacements(StringInfo applyCommand, uint64 shardId,
 											ShardConnections *shardConnections);
-static bool AllFinalizedPlacementsAccessible(Oid relationId);
 static void RangeVarCallbackForDropIndex(const RangeVar *rel, Oid relOid, Oid oldRelOid,
 										 void *arg);
 static void CheckCopyPermissions(CopyStmt *copyStatement);
@@ -1057,18 +1056,9 @@ ExecuteDistributedDDLCommand(Oid relationId, const char *ddlCommandString,
 							 bool isTopLevel)
 {
 	bool executionOK = false;
-	bool allPlacementsAccessible = false;
 
 	PreventTransactionChain(isTopLevel, "distributed DDL commands");
 	SetLocalCommitProtocolTo2PC();
-
-	allPlacementsAccessible = AllFinalizedPlacementsAccessible(relationId);
-	if (!allPlacementsAccessible)
-	{
-		ereport(ERROR, (errmsg("cannot execute command: %s", ddlCommandString),
-						errdetail("All finalized shard placements need to be accessible "
-								  "to execute DDL commands on distributed tables.")));
-	}
 
 	executionOK = ExecuteCommandOnWorkerShards(relationId, ddlCommandString);
 
@@ -1217,64 +1207,6 @@ ExecuteCommandOnShardPlacements(StringInfo applyCommand, uint64 shardId,
 
 		CHECK_FOR_INTERRUPTS();
 	}
-}
-
-
-/*
- * AllFinalizedPlacementsAccessible returns true if all the finalized shard
- * placements for a given relation are accessible. Otherwise, the function
- * returns false. To do so, the function first gets a list of responsive
- * worker nodes and then checks if all the finalized shard placements lie
- * on those worker nodes.
- */
-static bool
-AllFinalizedPlacementsAccessible(Oid relationId)
-{
-	bool allPlacementsAccessible = true;
-	ListCell *shardCell = NULL;
-	List *responsiveNodeList = ResponsiveWorkerNodeList();
-
-	List *shardList = LoadShardList(relationId);
-	foreach(shardCell, shardList)
-	{
-		List *shardPlacementList = NIL;
-		ListCell *shardPlacementCell = NULL;
-		uint64 *shardIdPointer = (uint64 *) lfirst(shardCell);
-		uint64 shardId = (*shardIdPointer);
-
-		shardPlacementList = FinalizedShardPlacementList(shardId);
-		foreach(shardPlacementCell, shardPlacementList)
-		{
-			ListCell *responsiveNodeCell = NULL;
-			bool placementAccessible = false;
-			ShardPlacement *placement = (ShardPlacement *) lfirst(shardPlacementCell);
-
-			/* verify that the placement lies on one of the responsive worker nodes */
-			foreach(responsiveNodeCell, responsiveNodeList)
-			{
-				WorkerNode *node = (WorkerNode *) lfirst(responsiveNodeCell);
-				if (strncmp(node->workerName, placement->nodeName, WORKER_LENGTH) == 0 &&
-					node->workerPort == placement->nodePort)
-				{
-					placementAccessible = true;
-					break;
-				}
-			}
-
-			if (!placementAccessible)
-			{
-				allPlacementsAccessible = false;
-				break;
-			}
-		}
-
-		if (!allPlacementsAccessible)
-		{
-			break;
-		}
-	}
-
-	return allPlacementsAccessible;
 }
 
 


### PR DESCRIPTION
This change allows users to interrupt long running DDL commands. Interrupt requests are handled after each DDL command being propagated to a shard placement, which means that generally the cancel request will be processed right after the execution of the DDL is finished in the current placement.

This change also removes AllFinalizedPlacementsAccessible function since we open connections to all shard placements before any command is sent so we immediately error out if a shard placement is not accessible.