### PR TITLE
Check style during Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ env:
   matrix:
     - PGVERSION=9.5
 before_install:
-  - git clone -b v0.3.3 --depth 1 https://github.com/citusdata/tools.git
-  - tools/travis/setup_apt.sh
-  - tools/travis/nuke_pg.sh
+  - git clone -b v0.4.0 --depth 1 https://github.com/citusdata/tools.git
+  - sudo make -C tools install
+  - setup_apt
+  - nuke_pg
 install:
-  - tools/travis/install_pg.sh
-script: tools/travis/pg_travis_multi_test.sh
-after_success: tools/travis/sync_to_enterprise
+  - install_uncrustify
+  - install_pg
+before_script: citus_indent --quiet --check
+script: pg_travis_multi_test
+after_success: sync_to_enterprise


### PR DESCRIPTION
This bumps the Citus tools to 0.4.0, which include support for adding a recent (0.6.3) uncrustify to Travis in addition to support for fully installing Travis scripts to system locations. For brevity, suffixes have been removed from Travis shell scripts.

The main additional logic here is just ensuring Travis CI gets a newer uncrustify install and that `citus_indent` is called with the `--check` flag, which exits with a nonzero status if any files don't comply.