### PR TITLE
Remove HAVE_INTTYPES_H ifdefs

### DIFF
--- a/src/backend/distributed/worker/worker_merge_protocol.c
+++ b/src/backend/distributed/worker/worker_merge_protocol.c
@@ -17,10 +17,6 @@
 #include "funcapi.h"
 #include "miscadmin.h"
 
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
-
 #include "access/htup_details.h"
 #include "access/xact.h"
 #include "catalog/dependency.h"
@@ -253,19 +249,9 @@ worker_cleanup_job_schema_cache(PG_FUNCTION_ARGS)
 StringInfo
 JobSchemaName(uint64 jobId)
 {
-	/*
-	 * We need to apply padding on our 64-bit job id, and therefore cannot use
-	 * UINT64_FORMAT here.
-	 */
-#ifdef HAVE_INTTYPES_H
 	StringInfo jobSchemaName = makeStringInfo();
-	appendStringInfo(jobSchemaName, "%s%0*" PRIu64, JOB_SCHEMA_PREFIX,
+	appendStringInfo(jobSchemaName, "%s%0*" INT64_MODIFIER "u", JOB_SCHEMA_PREFIX,
 					 MIN_JOB_DIRNAME_WIDTH, jobId);
-#else
-	StringInfo jobSchemaName = makeStringInfo();
-	appendStringInfo(jobSchemaName, "%s%0*llu",
-					 JOB_SCHEMA_PREFIX, MIN_JOB_DIRNAME_WIDTH, jobId);
-#endif
 
 	return jobSchemaName;
 }

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -18,9 +18,6 @@
 #include "funcapi.h"
 
 #include <arpa/inet.h>
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
 #include <netinet/in.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -449,20 +446,12 @@ StringInfo
 JobDirectoryName(uint64 jobId)
 {
 	/*
-	 * We use the default tablespace in {datadir}/base. Further, we need to
-	 * apply padding on our 64-bit job id, and hence can't use UINT64_FORMAT.
+	 * We use the default tablespace in {datadir}/base.
 	 */
-#ifdef HAVE_INTTYPES_H
 	StringInfo jobDirectoryName = makeStringInfo();
-	appendStringInfo(jobDirectoryName, "base/%s/%s%0*" PRIu64,
+	appendStringInfo(jobDirectoryName, "base/%s/%s%0*" INT64_MODIFIER "u",
 					 PG_JOB_CACHE_DIR, JOB_DIRECTORY_PREFIX,
 					 MIN_JOB_DIRNAME_WIDTH, jobId);
-#else
-	StringInfo jobDirectoryName = makeStringInfo();
-	appendStringInfo(jobDirectoryName, "base/%s/%s%0*llu",
-					 PG_JOB_CACHE_DIR, JOB_DIRECTORY_PREFIX,
-					 MIN_JOB_DIRNAME_WIDTH, jobId);
-#endif
 
 	return jobDirectoryName;
 }


### PR DESCRIPTION
I've been seeing warnings on OS X/`clang` for a while about these lines and finally got tired of it. The main problem is that `PRIu64` expects a `uint64_t` but we were passing a `uint64` (a PostgreSQL-defined type). In PostgreSQL 9.5, we now have `INT64_MODIFIER`, so can build our own zero- padded unsigned 64-bit int format modifier that expects a PostgreSQL- provided `uint64` type.

This simplifies the code slightly (no more `#ifdef`) and gets rid of the warning that's been annoying me since April (my TODO creation time).