### PR TITLE
Cause an Assertion Failure

### DIFF
--- a/repro.sh
+++ b/repro.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -uex
+# Set POSTGRES_DIR and CITUS_DIR environment variables.
+
+pushd "$POSTGRES_DIR"
+git checkout REL9_5_3
+./configure --prefix=/tmp/pg --enable-cassert --enable-debug
+make -sj6 install
+popd
+
+
+pushd "$CITUS_DIR"
+PATH="/tmp/pg/bin:$PATH" ./configure
+make install && make -C src/test/regress check-multi || true # because it fails
+cat ./src/test/regress/tmp_check/master/log/postmaster.log
+# [...]
+# ERROR:  replication_factor must be positive
+# STATEMENT:  SELECT master_create_worker_shards('test_schema_support.nation_hash', 4, -1);
+# ERROR:  could not find any shards
+# DETAIL:  No shards exist for distributed table "nation_hash".
+# HINT:  Run master_create_worker_shards to create shards and try again.
+# STATEMENT:  INSERT INTO test_schema_support.nation_hash(n_nationkey, n_name, n_regionkey) VALUES (6, 'FRANCE', 3);
+# TRAP: BadArgument("!(shardId != 0)", File: "utils/resource_lock.c", Line: 75)
+# LOG:  server process (PID 32504) was terminated by signal 6: Aborted
+# DETAIL:  Failed process was running: SELECT * FROM test_schema_support.nation_hash WHERE n_nationkey = 6;
+# LOG:  terminating any other active server processes
+# WARNING:  terminating connection because of crash of another server process
+# DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
+# HINT:  In a moment you should be able to reconnect to the database and repeat your command
+# [...]
+popd
+

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -15,148 +15,147 @@
 # ---
 # Tests around schema changes, these are run first, so there's no preexisting objects.
 # ---
-test: multi_extension
-test: multi_table_ddl
+# test: multi_extension
+# test: multi_table_ddl
 
-# ----------
-# The following distributed tests depend on creating a partitioned table and
-# uploading data to it.
-# ----------
-test: multi_create_table
-test: multi_master_protocol
-test: multi_stage_data
+# # ----------
+# # The following distributed tests depend on creating a partitioned table and
+# # uploading data to it.
+# # ----------
+# test: multi_create_table
+# test: multi_master_protocol
+# test: multi_stage_data
 
-# ----------
-# Miscellaneous tests to check our query planning behavior
-# ----------
-test: multi_basic_queries multi_complex_expressions multi_verify_no_subquery
-test: multi_explain
-test: multi_subquery
-test: multi_single_relation_subquery
-test: multi_agg_distinct multi_limit_clause multi_limit_clause_approximate
-test: multi_average_expression multi_working_columns
-test: multi_array_agg
-test: multi_agg_type_conversion multi_count_type_conversion
-test: multi_partition_pruning
-test: multi_join_pruning multi_hash_pruning
-test: multi_null_minmax_value_pruning
-test: multi_query_directory_cleanup
-test: multi_task_assignment_policy
-test: multi_utility_statements
-test: multi_dropped_column_aliases
-test: multi_verify_no_join_with_alias
-test: multi_binary_master_copy_format
-test: multi_prepare_sql multi_prepare_plsql
+# # ----------
+# # Miscellaneous tests to check our query planning behavior
+# # ----------
+# test: multi_basic_queries multi_complex_expressions multi_verify_no_subquery
+# test: multi_explain
+# test: multi_subquery
+# test: multi_single_relation_subquery
+# test: multi_agg_distinct multi_limit_clause multi_limit_clause_approximate
+# test: multi_average_expression multi_working_columns
+# test: multi_array_agg
+# test: multi_agg_type_conversion multi_count_type_conversion
+# test: multi_partition_pruning
+# test: multi_join_pruning multi_hash_pruning
+# test: multi_null_minmax_value_pruning
+# test: multi_query_directory_cleanup
+# test: multi_task_assignment_policy
+# test: multi_utility_statements
+# test: multi_dropped_column_aliases
+# test: multi_verify_no_join_with_alias
+# test: multi_binary_master_copy_format
+# test: multi_prepare_sql multi_prepare_plsql
 
-# ----------
-# Parallel TPC-H tests to check our distributed execution behavior
-# ----------
-test: multi_tpch_query1 multi_tpch_query3 multi_tpch_query6 multi_tpch_query10
-test: multi_tpch_query12 multi_tpch_query14 multi_tpch_query19
-test: multi_tpch_query7 multi_tpch_query7_nested
+# # ----------
+# # Parallel TPC-H tests to check our distributed execution behavior
+# # ----------
+# test: multi_tpch_query1 multi_tpch_query3 multi_tpch_query6 multi_tpch_query10
+# test: multi_tpch_query12 multi_tpch_query14 multi_tpch_query19
+# test: multi_tpch_query7 multi_tpch_query7_nested
 
-# ----------
-# Parallel tests to check our join order planning logic. Note that we stage data
-# below; and therefore these tests should come after the execution tests.
-# ----------
-test: multi_join_order_tpch_small multi_join_order_additional
-test: multi_stage_more_data
-test: multi_join_order_tpch_large
+# # ----------
+# # Parallel tests to check our join order planning logic. Note that we stage data
+# # below; and therefore these tests should come after the execution tests.
+# # ----------
+# test: multi_join_order_tpch_small multi_join_order_additional
+# test: multi_stage_more_data
+# test: multi_join_order_tpch_large
 
-# ----------
-# Tests for large-table join planning and execution.
-# Be careful when staging new data before these tests, as they
-# expect specific shard identifiers in the output.
-# ----------
-test: multi_large_table_join_planning
-test: multi_large_table_pruning
-test: multi_large_table_task_assignment
+# # ----------
+# # Tests for large-table join planning and execution.
+# # Be careful when staging new data before these tests, as they
+# # expect specific shard identifiers in the output.
+# # ----------
+# test: multi_large_table_join_planning
+# test: multi_large_table_pruning
+# test: multi_large_table_task_assignment
 
-# ----------
-# Tests to check our large record staging and shard deletion behavior
-# ----------
-test: multi_stage_large_records
-test: multi_master_delete_protocol
-test: multi_shard_modify
+# # ----------
+# # Tests to check our large record staging and shard deletion behavior
+# # ----------
+# test: multi_stage_large_records
+# test: multi_master_delete_protocol
+# test: multi_shard_modify
 
-# ----------
-# Tests around DDL statements run on distributed tables
-# ----------
-test: multi_index_statements
-test: multi_alter_table_statements
+# # ----------
+# # Tests around DDL statements run on distributed tables
+# # ----------
+# test: multi_index_statements
+# test: multi_alter_table_statements
 
-# ----------
-# multi_create_schema tests creation, staging and querying of a table in a new
-# schema (namespace).
-# ----------
-test: multi_create_schema
+# # ----------
+# # multi_create_schema tests creation, staging and querying of a table in a new
+# # schema (namespace).
+# # ----------
+# test: multi_create_schema
 
-# ----------
-# Tests to check if we inform the user about potential caveats of creating new
-# databases, schemas, and roles.
-# ----------
-test: multi_utility_warnings
+# # ----------
+# # Tests to check if we inform the user about potential caveats of creating new
+# # databases, schemas, and roles.
+# # ----------
+# test: multi_utility_warnings
 
-# ---------
-# multi_append_table_to_shard stages shards in a way that forces
-# shard caching.
-# ---------
-test: multi_append_table_to_shard
+# # ---------
+# # multi_append_table_to_shard stages shards in a way that forces
+# # shard caching.
+# # ---------
+# test: multi_append_table_to_shard
 
-# ---------
-# multi_outer_join stages shards to create different mappings for outer joins
-# ---------
-test: multi_outer_join
+# # ---------
+# # multi_outer_join stages shards to create different mappings for outer joins
+# # ---------
+# test: multi_outer_join
 
-# ---
-# Tests covering mostly modification queries and required preliminary
-# functionality related to metadata, shard creation, shard pruning and
-# "hacky" copy script for hash partitioned tables.
-# Note that the order of the following tests are important. multi_complex_count_distinct
-# is independed from the rest of the group, it is added to increase parallelism.
-# ---
-test: multi_create_fdw
-test: multi_connection_cache multi_complex_count_distinct
-test: multi_distribution_metadata
-test: multi_generate_ddl_commands
-test: multi_create_shards
-test: multi_prune_shard_list
-test: multi_repair_shards
-test: multi_modifications
-test: multi_upsert
-test: multi_simple_queries
-test: multi_utilities
-test: multi_create_insert_proxy
-test: multi_data_types
-test: multi_repartitioned_subquery_udf
-test: multi_modifying_xacts
+# # ---
+# # Tests covering mostly modification queries and required preliminary
+# # functionality related to metadata, shard creation, shard pruning and
+# # "hacky" copy script for hash partitioned tables.
+# # Note that the order of the following tests are important. multi_complex_count_distinct
+# # is independed from the rest of the group, it is added to increase parallelism.
+# # ---
+# test: multi_create_fdw
+# test: multi_connection_cache multi_complex_count_distinct
+# test: multi_distribution_metadata
+# test: multi_generate_ddl_commands
+# test: multi_create_shards
+# test: multi_prune_shard_list
+# test: multi_modifications
+# test: multi_upsert
+# test: multi_simple_queries
+# test: multi_utilities
+# test: multi_create_insert_proxy
+# test: multi_data_types
+# test: multi_repartitioned_subquery_udf
+# test: multi_modifying_xacts
 
-# ---------
-# multi_copy creates hash and range-partitioned tables and performs COPY
-# ---------
-test: multi_copy
+# # ---------
+# # multi_copy creates hash and range-partitioned tables and performs COPY
+# # ---------
+# test: multi_copy
 
-# ---------
-# multi_router_planner creates hash partitioned tables. 
-# ---------
-test: multi_router_planner
+# # ---------
+# # multi_router_planner creates hash partitioned tables. 
+# # ---------
+# test: multi_router_planner
 
-# ----------
-# multi_large_shardid stages more shards into lineitem
-# ----------
-test: multi_large_shardid
+# # ----------
+# # multi_large_shardid stages more shards into lineitem
+# # ----------
+# test: multi_large_shardid
 
-# ----------
-# multi_drop_extension makes sure we can safely drop and recreate the extension
-# ----------
-test: multi_drop_extension
+# # ----------
+# # multi_drop_extension makes sure we can safely drop and recreate the extension
+# # ----------
+# test: multi_drop_extension
 
-# ----------
-# multi_schema_support makes sure we can work with tables in schemas other than public with no problem
-# ----------
+# # ----------
+# # multi_schema_support makes sure we can work with tables in schemas other than public with no problem
+# # ----------
 test: multi_schema_support
 
-# ----------
-# multi_function_evaluation tests edge-cases in master-side function pre-evaluation
-# ----------
-test: multi_function_evaluation
+# # ----------
+# # multi_function_evaluation tests edge-cases in master-side function pre-evaluation
+# # ----------
+# test: multi_function_evaluation

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -1,7 +1,7 @@
 --
 -- MULTI_SCHEMA_SUPPORT
 --
-
+SET citus.all_modifications_commutative = true;
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1190000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1190000;
 
@@ -102,7 +102,7 @@ CREATE TABLE test_schema_support.nation_hash(
     n_comment varchar(152)
 );
 SELECT master_create_distributed_table('test_schema_support.nation_hash', 'n_nationkey', 'hash');
-SELECT master_create_worker_shards('test_schema_support.nation_hash', 4, 2);
+SELECT master_create_worker_shards('test_schema_support.nation_hash', 4, -1);
 
 
 -- test cursors
@@ -335,7 +335,7 @@ CREATE TABLE test_schema_support.nation_hash_collation(
     n_comment varchar(152)
 );
 SELECT master_create_distributed_table('test_schema_support.nation_hash_collation', 'n_nationkey', 'hash');
-SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 4, 2);
+SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 4, -1);
 
 \COPY test_schema_support.nation_hash_collation FROM STDIN with delimiter '|';
 0|ALGERIA|0|haggle. carefully final deposits detect slyly agai
@@ -358,7 +358,7 @@ CREATE TABLE nation_hash_collation_search_path(
     n_comment varchar(152)
 );
 SELECT master_create_distributed_table('nation_hash_collation_search_path', 'n_nationkey', 'hash');
-SELECT master_create_worker_shards('nation_hash_collation_search_path', 4, 2);
+SELECT master_create_worker_shards('nation_hash_collation_search_path', 4, -1);
 
 \COPY nation_hash_collation_search_path FROM STDIN with delimiter '|';
 0|ALGERIA|0|haggle. carefully final deposits detect slyly agai
@@ -393,7 +393,7 @@ CREATE TABLE test_schema_support.nation_hash_composite_types(
     test_col test_schema_support.new_composite_type
 );
 SELECT master_create_distributed_table('test_schema_support.nation_hash_composite_types', 'n_nationkey', 'hash');
-SELECT master_create_worker_shards('test_schema_support.nation_hash_composite_types', 4, 2);
+SELECT master_create_worker_shards('test_schema_support.nation_hash_composite_types', 4, -1);
 
 -- insert some data to verify composite type queries
 \COPY test_schema_support.nation_hash_composite_types FROM STDIN with delimiter '|';


### PR DESCRIPTION
commit 74a3be36073cc66bc025ad71468bb39e8ed0205e
Author: Daniel Farina <daniel@citusdata.com>
Date:   Wed Aug 3 16:12:16 2016 -0700

    Make an assertion failure
    
    If one compiles with `--enable-cassert --enable-debug`, and causes an
    `ereport` in `master_create_worker_shards`, an assertion failure
    follows.

commit 725736088097ca3b4f987bb182c9a70e81ff207f
Author: Daniel Farina <daniel@citusdata.com>
Date:   Wed Aug 3 14:36:31 2016 -0700

    Eliminate some non-failing tests
    
    To bring better focus on the diff of the bug report that is to follow,
    adjust the test schedule and break it out into this diff.
