### PR TITLE
Avoid attempting to lock invalid shard identifier

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -294,7 +294,10 @@ AcquireExecutorShardLock(Task *task, LOCKMODE lockMode)
 {
 	int64 shardId = task->anchorShardId;
 
-	LockShardResource(shardId, lockMode);
+	if (shardId != INVALID_SHARD_ID)
+	{
+		LockShardResource(shardId, lockMode);
+	}
 }
 
 


### PR DESCRIPTION
A recent change generates a "dummy" shard placement with its identifier set to `INVALID_SHARD_ID` for `SELECT` queries against distributed tables with no shards. Normally, no lock is acquired for `SELECT` statements, but if `all_modifications_commutative` is set to `true`, we will acquire a shared lock, triggering an assertion failure within `LockShardResource` in the above case.

The "dummy" shard placement is actually necessary to ensure such empty queries have somewhere to execute, and `INVALID_SHARD_ID` seems the most appropriate value for the dummy's shard identifier field, so the most straightforward fix is to just avoid locking invalid shard identifiers.