### PR TITLE
Permit single DDL commands in transaction blocks

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -233,6 +233,8 @@ CitusCopyFrom(CopyStmt *copyStatement, char *completionTag)
 							errmsg("unsupported partition method")));
 		}
 	}
+
+	XactModificationLevel = XACT_MODIFICATION_DATA;
 }
 
 

--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -94,7 +94,7 @@ MultiClientConnect(const char *nodeName, uint32 nodePort, const char *nodeDataba
 	char *effectiveDatabaseName = NULL;
 	char *effectiveUserName = NULL;
 
-	if (IsModifyingTransaction)
+	if (XactModificationLevel > XACT_MODIFICATION_NONE)
 	{
 		ereport(ERROR, (errcode(ERRCODE_ACTIVE_SQL_TRANSACTION),
 						errmsg("cannot open new connections after the first modification "
@@ -181,7 +181,7 @@ MultiClientConnectStart(const char *nodeName, uint32 nodePort, const char *nodeD
 		return connectionId;
 	}
 
-	if (IsModifyingTransaction)
+	if (XactModificationLevel > XACT_MODIFICATION_NONE)
 	{
 		ereport(ERROR, (errcode(ERRCODE_ACTIVE_SQL_TRANSACTION),
 						errmsg("cannot open new connections after the first modification "

--- a/src/backend/distributed/transaction/multi_shard_transaction.c
+++ b/src/backend/distributed/transaction/multi_shard_transaction.c
@@ -283,6 +283,7 @@ CompleteShardPlacementTransactions(XactEvent event, void *arg)
 
 	CloseConnections(shardPlacementConnectionList);
 	shardPlacementConnectionList = NIL;
+	XactModificationLevel = XACT_MODIFICATION_NONE;
 }
 
 

--- a/src/backend/distributed/utils/connection_cache.c
+++ b/src/backend/distributed/utils/connection_cache.c
@@ -30,8 +30,8 @@
 #include "utils/palloc.h"
 
 
-/* state needed to prevent new connections during modifying transactions */
-bool IsModifyingTransaction = false;
+/* state needed to keep track of operations used during a transaction */
+XactModificationType XactModificationLevel = XACT_MODIFICATION_NONE;
 
 /*
  * NodeConnectionHash is the connection hash itself. It begins uninitialized.
@@ -377,7 +377,7 @@ ConnectToNode(char *nodeName, int32 nodePort, char *nodeUser)
 
 	sprintf(nodePortString, "%d", nodePort);
 
-	if (IsModifyingTransaction)
+	if (XactModificationLevel > XACT_MODIFICATION_NONE)
 	{
 		ereport(ERROR, (errcode(ERRCODE_ACTIVE_SQL_TRANSACTION),
 						errmsg("cannot open new connections after the first modification "

--- a/src/include/distributed/connection_cache.h
+++ b/src/include/distributed/connection_cache.h
@@ -32,7 +32,6 @@
 /* SQL statement for testing */
 #define TEST_SQL "DO $$ BEGIN RAISE EXCEPTION 'Raised remotely!'; END $$"
 
-
 /*
  * NodeConnectionKey acts as the key to index into the (process-local) hash
  * keeping track of open connections. Node name and port are sufficient.
@@ -53,8 +52,18 @@ typedef struct NodeConnectionEntry
 } NodeConnectionEntry;
 
 
+/* describes what kind of modifications have occurred in the current transaction */
+typedef enum
+{
+	XACT_MODIFICATION_INVALID = 0, /* placeholder initial value */
+	XACT_MODIFICATION_NONE,        /* no modifications have taken place */
+	XACT_MODIFICATION_DATA,        /* data modifications (DML) have occurred */
+	XACT_MODIFICATION_SCHEMA       /* schema modifications (DDL) have occurred */
+} XactModificationType;
+
+
 /* state needed to prevent new connections during modifying transactions */
-extern bool IsModifyingTransaction;
+extern XactModificationType XactModificationLevel;
 
 
 /* function declarations for obtaining and using a connection */

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -100,6 +100,7 @@ SELECT name FROM researchers WHERE lab_id = 4;
 BEGIN;
 DO $$
 BEGIN
+	INSERT INTO researchers VALUES (11, 11, 'Whitfield Diffie');
 	INSERT INTO researchers VALUES (NULL, 10, 'Edsger Dijkstra');
 EXCEPTION
     WHEN not_null_violation THEN
@@ -150,19 +151,41 @@ SELECT count(*) FROM researchers WHERE lab_id = 6;
 ERROR:  no transaction participant matches localhost:57638
 DETAIL:  Transactions which modify distributed tables may only target nodes affected by the modification command which began the transaction.
 ABORT;
--- applies to DDL or COPY, too
+-- applies to DDL, too
 BEGIN;
 INSERT INTO labs VALUES (6, 'Bell Labs');
-ALTER TABLE labs ADD COLUMN text motto;
-ERROR:  distributed DDL commands cannot run inside a transaction block
+ALTER TABLE labs ADD COLUMN motto text;
+ERROR:  distributed DDL commands must not appear within transaction blocks containing other modifications
 COMMIT;
+-- whether it occurs first or second
+BEGIN;
+ALTER TABLE labs ADD COLUMN motto text;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+INSERT INTO labs VALUES (6, 'Bell Labs');
+ERROR:  distributed data modifications must not appear in transaction blocks which contain distributed DDL commands
+COMMIT;
+-- but the DDL should correctly roll back
+\d labs
+     Table "public.labs"
+ Column |  Type  | Modifiers 
+--------+--------+-----------
+ id     | bigint | not null
+ name   | text   | not null
+
+SELECT * FROM labs WHERE id = 6;
+ id | name 
+----+------
+(0 rows)
+
+-- COPY can't happen second,
 BEGIN;
 INSERT INTO labs VALUES (6, 'Bell Labs');
 \copy labs from stdin delimiter ','
 ERROR:  cannot open new connections after the first modification command within a transaction
 CONTEXT:  COPY labs, line 1: "10,Weyland-Yutani"
 COMMIT;
--- though the copy will work if before any modifications
+-- though it will work if before any modifications
 BEGIN;
 \copy labs from stdin delimiter ','
 SELECT name FROM labs WHERE id = 10;
@@ -173,6 +196,59 @@ SELECT name FROM labs WHERE id = 10;
 
 INSERT INTO labs VALUES (6, 'Bell Labs');
 COMMIT;
+-- but a double-copy isn't allowed (the first will persist)
+BEGIN;
+\copy labs from stdin delimiter ','
+\copy labs from stdin delimiter ','
+ERROR:  cannot open new connections after the first modification command within a transaction
+CONTEXT:  COPY labs, line 1: "12,fsociety"
+COMMIT;
+SELECT name FROM labs WHERE id = 11;
+      name      
+----------------
+ Planet Express
+(1 row)
+
+-- finally, ALTER and copy aren't compatible
+BEGIN;
+ALTER TABLE labs ADD COLUMN motto text;
+\copy labs from stdin delimiter ','
+ERROR:  cannot open new connections after the first modification command within a transaction
+CONTEXT:  COPY labs, line 1: "12,fsociety,lol"
+COMMIT;
+-- but the DDL should correctly roll back
+\d labs
+     Table "public.labs"
+ Column |  Type  | Modifiers 
+--------+--------+-----------
+ id     | bigint | not null
+ name   | text   | not null
+
+SELECT * FROM labs WHERE id = 12;
+ id | name 
+----+------
+(0 rows)
+
+-- and if the copy is before the ALTER...
+BEGIN;
+\copy labs from stdin delimiter ','
+ALTER TABLE labs ADD COLUMN motto text;
+ERROR:  distributed DDL commands must not appear within transaction blocks containing other modifications
+COMMIT;
+-- the DDL fails, but copy persists
+\d labs
+     Table "public.labs"
+ Column |  Type  | Modifiers 
+--------+--------+-----------
+ id     | bigint | not null
+ name   | text   | not null
+
+SELECT * FROM labs WHERE id = 12;
+ id |   name   
+----+----------
+ 12 | fsociety
+(1 row)
+
 -- now, for some special failures...
 CREATE TABLE objects (
 	id bigint PRIMARY KEY,

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -165,9 +165,30 @@ COMMIT;
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
 DROP INDEX temp_index_1;
 
--- verify that distributed ddl commands are not allowed inside a transaction block
+-- verify that single distributed ddl commands are allowed inside a transaction block
 SET citus.enable_ddl_propagation to true;
 BEGIN;
+CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
+COMMIT;
+SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
+DROP INDEX temp_index_2;
+
+-- but that multiple ddl statements in a block results in ROLLBACK
+BEGIN;
+CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
+ALTER TABLE lineitem_alter ADD COLUMN first integer;
+COMMIT;
+SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
+
+-- and distributed SELECTs cannot appear after ALTER
+BEGIN;
+CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
+SELECT l_orderkey FROM lineitem_alter LIMIT 0;
+COMMIT;
+
+-- but are allowed before
+BEGIN;
+SELECT l_orderkey FROM lineitem_alter LIMIT 0;
 CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
 COMMIT;
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -424,19 +424,51 @@ SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
 (1 row)
 
 DROP INDEX temp_index_1;
--- verify that distributed ddl commands are not allowed inside a transaction block
+-- verify that single distributed ddl commands are allowed inside a transaction block
 SET citus.enable_ddl_propagation to true;
 BEGIN;
 CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
-ERROR:  distributed DDL commands cannot run inside a transaction block
+COMMIT;
+SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
+  indexname   |   tablename    
+--------------+----------------
+ temp_index_2 | lineitem_alter
+(1 row)
+
+DROP INDEX temp_index_2;
+-- but that multiple ddl statements in a block results in ROLLBACK
+BEGIN;
+CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
+ALTER TABLE lineitem_alter ADD COLUMN first integer;
+ERROR:  distributed DDL commands must not appear within transaction blocks containing other modifications
 COMMIT;
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
  indexname | tablename 
 -----------+-----------
 (0 rows)
 
+-- and distributed SELECTs cannot appear after ALTER
+BEGIN;
+CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
+SELECT l_orderkey FROM lineitem_alter LIMIT 0;
+ERROR:  cannot open new connections after the first modification command within a transaction
+COMMIT;
+-- but are allowed before
+BEGIN;
+SELECT l_orderkey FROM lineitem_alter LIMIT 0;
+ l_orderkey 
+------------
+(0 rows)
+
+CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
+COMMIT;
+SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
+  indexname   |   tablename    
+--------------+----------------
+ temp_index_2 | lineitem_alter
+(1 row)
+
 DROP INDEX temp_index_2;
-ERROR:  index "temp_index_2" does not exist
 --- verify that distributed ddl commands can be used with 2pc
 SET citus.multi_shard_commit_protocol TO '2pc';
 CREATE INDEX temp_index_3 ON lineitem_alter(l_orderkey);


### PR DESCRIPTION
This change adds a bit field to keep track of which operations (DDL and DML) have taken place during an open transaction block. If a DDL or DML command has already taken place and another DDL command is attempted, the code now raises an error explaining that only single DDL commands are permitted within `BEGIN`/`END` transaction blocks.

The error causes a `ROLLBACK`, resulting in the entire transaction (including previous DML or DDL commands) being undone. In a subsequent change we will further relax the DDL restrictions such that multiple DDL statements can once again run within a single transaction block (though never interleaved with DML statements), restoring the old ORM-friendly behavior, with the new semantics of rollbackability.

connected to #668