### PR TITLE
Skip over unreferenced parameters when router executing prepared stat…

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -821,7 +821,12 @@ ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterT
 			(*parameterTypes)[parameterIndex] = parameterData->ptype;
 		}
 
-		if (parameterData->isnull)
+		/*
+		 * If the parameter is NULL, or is not referenced / used (ptype == 0
+		 * would otherwise have errored out inside standard_planner()),
+		 * don't pass a value to the remote side.
+		 */
+		if (parameterData->isnull || parameterData->ptype == 0)
 		{
 			(*parameterValues)[parameterIndex] = NULL;
 			continue;


### PR DESCRIPTION
…ement.

When an unreferenced prepared statement parameter does not explicitly
have a type assigned, we cannot deserialize it, to send to the remote
side.  That commonly happens inside plpgsql functions, where local
variables are passed in as unused prepared statement parameters.

Fixes: #700
Backports: #717