### PR TITLE
Support truncate command for distributed relations

### DIFF
--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -59,7 +59,10 @@ static void LockShardsForModify(List *shardIntervalList);
 static bool HasReplication(List *shardIntervalList);
 static int SendQueryToShards(Query *query, List *shardIntervalList, Oid relationId);
 static int SendQueryToPlacements(char *shardQueryString,
-								 ShardConnections *shardConnections);
+								 ShardConnections *shardConnections,
+								 bool returnTupleCount);
+static void deparse_truncate_query(Query *query, Oid distrelid, int64 shardid, StringInfo
+								   buffer);
 
 PG_FUNCTION_INFO_V1(master_modify_multiple_shards);
 
@@ -88,6 +91,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	List *shardIntervalList = NIL;
 	List *prunedShardIntervalList = NIL;
 	int32 affectedTupleCount = 0;
+	bool validateModifyQuery = true;
 
 	PreventTransactionChain(isTopLevel, "master_modify_multiple_shards");
 
@@ -104,10 +108,29 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 		relationId = RangeVarGetRelid(updateStatement->relation, NoLock, failOK);
 		EnsureTablePermissions(relationId, ACL_UPDATE);
 	}
+	else if (IsA(queryTreeNode, TruncateStmt))
+	{
+		TruncateStmt *truncateStatement = (TruncateStmt *) queryTreeNode;
+		List *relationList = truncateStatement->relations;
+		RangeVar *rangeVar = NULL;
+
+		if (list_length(relationList) != 1)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("master_modify_multiple_shards() can truncate only "
+							"one table")));
+		}
+
+		rangeVar = (RangeVar *) linitial(relationList);
+		relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
+		EnsureTablePermissions(relationId, ACL_TRUNCATE);
+		validateModifyQuery = false;
+	}
 	else
 	{
-		ereport(ERROR, (errmsg("query \"%s\" is not a delete nor update statement",
-							   queryString)));
+		ereport(ERROR, (errmsg("query \"%s\" is not a delete, update, or truncate "
+							   "statement", queryString)));
 	}
 
 	CheckDistributedTable(relationId);
@@ -115,7 +138,10 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	queryTreeList = pg_analyze_and_rewrite(queryTreeNode, queryString, NULL, 0);
 	modifyQuery = (Query *) linitial(queryTreeList);
 
-	ErrorIfModifyQueryNotSupported(modifyQuery);
+	if (validateModifyQuery)
+	{
+		ErrorIfModifyQueryNotSupported(modifyQuery);
+	}
 
 	/* reject queries with a returning list */
 	if (list_length(modifyQuery->returningList) > 0)
@@ -216,6 +242,9 @@ SendQueryToShards(Query *query, List *shardIntervalList, Oid relationId)
 	char *relationOwner = TableOwner(relationId);
 	HTAB *shardConnectionHash = NULL;
 	ListCell *shardIntervalCell = NULL;
+	bool truncateCommand = false;
+	bool requestTupleCount = true;
+
 
 	MemoryContext oldContext = MemoryContextSwitchTo(TopTransactionContext);
 
@@ -223,6 +252,12 @@ SendQueryToShards(Query *query, List *shardIntervalList, Oid relationId)
 															   relationOwner);
 
 	MemoryContextSwitchTo(oldContext);
+
+	if (query->commandType == CMD_UTILITY && IsA(query->utilityStmt, TruncateStmt))
+	{
+		truncateCommand = true;
+		requestTupleCount = false;
+	}
 
 	foreach(shardIntervalCell, shardIntervalList)
 	{
@@ -241,10 +276,19 @@ SendQueryToShards(Query *query, List *shardIntervalList, Oid relationId)
 											   &shardConnectionsFound);
 		Assert(shardConnectionsFound);
 
-		deparse_shard_query(query, relationId, shardId, shardQueryString);
+		if (truncateCommand)
+		{
+			deparse_truncate_query(query, relationId, shardId, shardQueryString);
+		}
+		else
+		{
+			deparse_shard_query(query, relationId, shardId, shardQueryString);
+		}
+
 		shardQueryStringData = shardQueryString->data;
 		shardAffectedTupleCount = SendQueryToPlacements(shardQueryStringData,
-														shardConnections);
+														shardConnections,
+														requestTupleCount);
 		affectedTupleCount += shardAffectedTupleCount;
 	}
 
@@ -256,12 +300,40 @@ SendQueryToShards(Query *query, List *shardIntervalList, Oid relationId)
 
 
 /*
+ * deparse_truncate_query creates sql representation of a truncate statement. The
+ * function only generated basic truncate statement of the form
+ * 'truncate table <table_name>' it ignores all options. It also assumes that
+ * there is only one relation in the relation list.
+ */
+void
+deparse_truncate_query(Query *query, Oid distrelid, int64 shardid, StringInfo buffer)
+{
+	TruncateStmt *truncateStatement = NULL;
+	RangeVar *relation = NULL;
+	char *qualifiedName = NULL;
+
+	Assert(query->commandType == CMD_UTILITY);
+	Assert(IsA(query->utilityStmt, TruncateStmt));
+
+	truncateStatement = (TruncateStmt *) query->utilityStmt;
+
+	Assert(list_length(truncateStatement->relations) == 1);
+
+	relation = (RangeVar *) linitial(truncateStatement->relations);
+	qualifiedName = quote_qualified_identifier(relation->schemaname,
+											   relation->relname);
+	appendStringInfo(buffer, "TRUNCATE TABLE %s_" UINT64_FORMAT, qualifiedName, shardid);
+}
+
+
+/*
  * SendQueryToPlacements sends the given query string to all given placement
  * connections of a shard. CommitRemoteTransactions or AbortRemoteTransactions
  * should be called after all queries have been sent successfully.
  */
 static int
-SendQueryToPlacements(char *shardQueryString, ShardConnections *shardConnections)
+SendQueryToPlacements(char *shardQueryString, ShardConnections *shardConnections,
+					  bool returnTupleCount)
 {
 	uint64 shardId = shardConnections->shardId;
 	List *connectionList = shardConnections->connectionList;
@@ -269,6 +341,11 @@ SendQueryToPlacements(char *shardQueryString, ShardConnections *shardConnections
 	int32 shardAffectedTupleCount = -1;
 
 	Assert(connectionList != NIL);
+
+	if (!returnTupleCount)
+	{
+		shardAffectedTupleCount = 0;
+	}
 
 	foreach(connectionCell, connectionList)
 	{
@@ -290,21 +367,25 @@ SendQueryToPlacements(char *shardQueryString, ShardConnections *shardConnections
 		}
 
 		placementAffectedTupleString = PQcmdTuples(result);
-		placementAffectedTupleCount = pg_atoi(placementAffectedTupleString,
-											  sizeof(int32), 0);
 
-		if ((shardAffectedTupleCount == -1) ||
-			(shardAffectedTupleCount == placementAffectedTupleCount))
+		if (returnTupleCount)
 		{
-			shardAffectedTupleCount = placementAffectedTupleCount;
-		}
-		else
-		{
-			ereport(ERROR,
-					(errmsg("modified %d tuples, but expected to modify %d",
-							placementAffectedTupleCount, shardAffectedTupleCount),
-					 errdetail("Affected tuple counts at placements of shard "
-							   UINT64_FORMAT " are different.", shardId)));
+			placementAffectedTupleCount = pg_atoi(placementAffectedTupleString,
+												  sizeof(int32), 0);
+
+			if ((shardAffectedTupleCount == -1) ||
+				(shardAffectedTupleCount == placementAffectedTupleCount))
+			{
+				shardAffectedTupleCount = placementAffectedTupleCount;
+			}
+			else
+			{
+				ereport(ERROR,
+						(errmsg("modified %d tuples, but expected to modify %d",
+								placementAffectedTupleCount, shardAffectedTupleCount),
+						 errdetail("Affected tuple counts at placements of shard "
+								   UINT64_FORMAT " are different.", shardId)));
+			}
 		}
 
 		PQclear(result);

--- a/src/test/regress/expected/multi_truncate.out
+++ b/src/test/regress/expected/multi_truncate.out
@@ -1,0 +1,219 @@
+--
+-- MULTI_TRUNCATE
+--
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1210000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1210000;
+--
+-- truncate for append distribution
+-- expect all shards to be dropped
+--
+CREATE TABLE test_truncate_append(a int);
+SELECT master_create_distributed_table('test_truncate_append', 'a', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- verify no error is thrown when no shards are present
+TRUNCATE TABLE test_truncate_append;
+SELECT master_create_empty_shard('test_truncate_append') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 1, shardmaxvalue = 500
+WHERE shardid = :new_shard_id;
+SELECT count(*) FROM test_truncate_append;
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO test_truncate_append values (1);
+SELECT count(*) FROM test_truncate_append;
+ count 
+-------
+     1
+(1 row)
+
+-- create some more shards
+SELECT master_create_empty_shard('test_truncate_append');
+ master_create_empty_shard 
+---------------------------
+                   1210001
+(1 row)
+
+SELECT master_create_empty_shard('test_truncate_append');
+ master_create_empty_shard 
+---------------------------
+                   1210002
+(1 row)
+
+-- verify 3 shards are presents
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_append'::regclass;
+ shardid 
+---------
+ 1210000
+ 1210001
+ 1210002
+(3 rows)
+
+TRUNCATE TABLE test_truncate_append;
+-- verify data is truncated from the table
+SELECT count(*) FROM test_truncate_append;
+ count 
+-------
+      
+(1 row)
+
+-- verify no shard exists anymore
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_append'::regclass;
+ shardid 
+---------
+(0 rows)
+
+DROP TABLE test_truncate_append;
+--
+-- truncate for range distribution
+-- expect shard to be present, data to be truncated
+--
+CREATE TABLE test_truncate_range(a int);
+SELECT master_create_distributed_table('test_truncate_range', 'a', 'range');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- verify no error is thrown when no shards are present
+TRUNCATE TABLE test_truncate_range;
+SELECT master_create_empty_shard('test_truncate_range') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 1, shardmaxvalue = 500
+WHERE shardid = :new_shard_id;
+SELECT master_create_empty_shard('test_truncate_range') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 501, shardmaxvalue = 1500
+WHERE shardid = :new_shard_id;
+SELECT master_create_empty_shard('test_truncate_range') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 1501, shardmaxvalue = 2500
+WHERE shardid = :new_shard_id;
+SELECT count(*) FROM test_truncate_range;
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO test_truncate_range values (1);
+INSERT INTO test_truncate_range values (1001);
+INSERT INTO test_truncate_range values (2000);
+INSERT INTO test_truncate_range values (100);
+SELECT count(*) FROM test_truncate_range;
+ count 
+-------
+     4
+(1 row)
+
+-- verify 3 shards are presents
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_range'::regclass;
+ shardid 
+---------
+ 1210003
+ 1210004
+ 1210005
+(3 rows)
+
+TRUNCATE TABLE test_truncate_range;
+-- verify data is truncated from the table
+SELECT count(*) FROM test_truncate_range;
+ count 
+-------
+     0
+(1 row)
+
+-- verify 3 shards are still present
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_range'::regclass;
+ shardid 
+---------
+ 1210003
+ 1210004
+ 1210005
+(3 rows)
+
+DROP TABLE test_truncate_range;
+--
+-- truncate for hash distribution.
+-- expect shard to be present, data to be truncated
+--
+CREATE TABLE test_truncate_hash(a int);
+SELECT master_create_distributed_table('test_truncate_hash', 'a', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+-- verify no error is thrown when no shards are present
+TRUNCATE TABLE test_truncate_hash;
+SELECT count(*) FROM test_truncate_hash;
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO test_truncate_hash values (1);
+ERROR:  could not find any shards
+DETAIL:  No shards exist for distributed table "test_truncate_hash".
+HINT:  Run master_create_worker_shards to create shards and try again.
+INSERT INTO test_truncate_hash values (1001);
+ERROR:  could not find any shards
+DETAIL:  No shards exist for distributed table "test_truncate_hash".
+HINT:  Run master_create_worker_shards to create shards and try again.
+INSERT INTO test_truncate_hash values (2000);
+ERROR:  could not find any shards
+DETAIL:  No shards exist for distributed table "test_truncate_hash".
+HINT:  Run master_create_worker_shards to create shards and try again.
+INSERT INTO test_truncate_hash values (100);
+ERROR:  could not find any shards
+DETAIL:  No shards exist for distributed table "test_truncate_hash".
+HINT:  Run master_create_worker_shards to create shards and try again.
+SELECT count(*) FROM test_truncate_hash;
+ count 
+-------
+     0
+(1 row)
+
+-- verify 4 shards are present
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_hash'::regclass;
+ shardid 
+---------
+(0 rows)
+
+TRUNCATE TABLE test_truncate_hash;
+SELECT master_create_worker_shards('test_truncate_hash', 4, 1);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+INSERT INTO test_truncate_hash values (1);
+INSERT INTO test_truncate_hash values (1001);
+INSERT INTO test_truncate_hash values (2000);
+INSERT INTO test_truncate_hash values (100);
+SELECT count(*) FROM test_truncate_hash;
+ count 
+-------
+     4
+(1 row)
+
+TRUNCATE TABLE test_truncate_hash;
+-- verify data is truncated from the table
+SELECT count(*) FROM test_truncate_hash;
+ count 
+-------
+     0
+(1 row)
+
+-- verify 4 shards are still presents
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_hash'::regclass;
+ shardid 
+---------
+ 1210006
+ 1210007
+ 1210008
+ 1210009
+(4 rows)
+
+DROP TABLE test_truncate_hash;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -160,3 +160,8 @@ test: multi_schema_support
 # multi_function_evaluation tests edge-cases in master-side function pre-evaluation
 # ----------
 test: multi_function_evaluation
+
+# ----------
+# multi_truncate tests truncate functionality for distributed tables
+# ----------
+test: multi_truncate

--- a/src/test/regress/sql/multi_truncate.sql
+++ b/src/test/regress/sql/multi_truncate.sql
@@ -1,0 +1,133 @@
+--
+-- MULTI_TRUNCATE
+--
+
+
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1210000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1210000;
+
+--
+-- truncate for append distribution
+-- expect all shards to be dropped
+--
+CREATE TABLE test_truncate_append(a int);
+SELECT master_create_distributed_table('test_truncate_append', 'a', 'append');
+
+-- verify no error is thrown when no shards are present
+TRUNCATE TABLE test_truncate_append;
+
+SELECT master_create_empty_shard('test_truncate_append') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 1, shardmaxvalue = 500
+WHERE shardid = :new_shard_id;
+
+SELECT count(*) FROM test_truncate_append;
+
+INSERT INTO test_truncate_append values (1);
+
+SELECT count(*) FROM test_truncate_append;
+
+-- create some more shards
+SELECT master_create_empty_shard('test_truncate_append');
+SELECT master_create_empty_shard('test_truncate_append');
+
+-- verify 3 shards are presents
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_append'::regclass;
+
+TRUNCATE TABLE test_truncate_append;
+
+-- verify data is truncated from the table
+SELECT count(*) FROM test_truncate_append;
+
+-- verify no shard exists anymore
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_append'::regclass;
+
+DROP TABLE test_truncate_append;
+
+--
+-- truncate for range distribution
+-- expect shard to be present, data to be truncated
+--
+CREATE TABLE test_truncate_range(a int);
+SELECT master_create_distributed_table('test_truncate_range', 'a', 'range');
+
+-- verify no error is thrown when no shards are present
+TRUNCATE TABLE test_truncate_range;
+
+SELECT master_create_empty_shard('test_truncate_range') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 1, shardmaxvalue = 500
+WHERE shardid = :new_shard_id;
+
+SELECT master_create_empty_shard('test_truncate_range') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 501, shardmaxvalue = 1500
+WHERE shardid = :new_shard_id;
+
+SELECT master_create_empty_shard('test_truncate_range') AS new_shard_id \gset
+UPDATE pg_dist_shard SET shardminvalue = 1501, shardmaxvalue = 2500
+WHERE shardid = :new_shard_id;
+
+
+SELECT count(*) FROM test_truncate_range;
+
+INSERT INTO test_truncate_range values (1);
+INSERT INTO test_truncate_range values (1001);
+INSERT INTO test_truncate_range values (2000);
+INSERT INTO test_truncate_range values (100);
+
+SELECT count(*) FROM test_truncate_range;
+
+-- verify 3 shards are presents
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_range'::regclass;
+
+TRUNCATE TABLE test_truncate_range;
+
+-- verify data is truncated from the table
+SELECT count(*) FROM test_truncate_range;
+
+-- verify 3 shards are still present
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_range'::regclass;
+
+DROP TABLE test_truncate_range;
+
+
+--
+-- truncate for hash distribution.
+-- expect shard to be present, data to be truncated
+--
+CREATE TABLE test_truncate_hash(a int);
+SELECT master_create_distributed_table('test_truncate_hash', 'a', 'hash');
+
+-- verify no error is thrown when no shards are present
+TRUNCATE TABLE test_truncate_hash;
+
+SELECT count(*) FROM test_truncate_hash;
+
+INSERT INTO test_truncate_hash values (1);
+INSERT INTO test_truncate_hash values (1001);
+INSERT INTO test_truncate_hash values (2000);
+INSERT INTO test_truncate_hash values (100);
+
+SELECT count(*) FROM test_truncate_hash;
+
+-- verify 4 shards are present
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_hash'::regclass;
+
+TRUNCATE TABLE test_truncate_hash;
+
+SELECT master_create_worker_shards('test_truncate_hash', 4, 1);
+
+INSERT INTO test_truncate_hash values (1);
+INSERT INTO test_truncate_hash values (1001);
+INSERT INTO test_truncate_hash values (2000);
+INSERT INTO test_truncate_hash values (100);
+
+SELECT count(*) FROM test_truncate_hash;
+
+TRUNCATE TABLE test_truncate_hash;
+
+-- verify data is truncated from the table
+SELECT count(*) FROM test_truncate_hash;
+
+-- verify 4 shards are still presents
+SELECT shardid FROM pg_dist_shard where logicalrelid = 'test_truncate_hash'::regclass;
+
+DROP TABLE test_truncate_hash;


### PR DESCRIPTION
This is an alternate implementation to #721 

It solves the same problem by using utility hook for truncate.

Fixes #86 