### PR TITLE
Return false in MultiClientQueryResult() on failing query

### DIFF
--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -469,6 +469,8 @@ MultiClientQueryResult(int32 connectionId, void **queryResult, int *rowCount,
 	{
 		WarnRemoteError(connection, result);
 		PQclear(result);
+
+		return false;
 	}
 
 	/* clear extra result objects */

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -523,3 +523,18 @@ COPY super_packed_numbers_append FROM '/tmp/copy_test_composite_of_composite';
 
 -- Verify data is actually copied
 SELECT * FROM super_packed_numbers_append;
+
+
+-- Test copy on append for composite type partition column
+
+CREATE TABLE composite_partition_column_table(
+        id integer,
+        composite_column number_pack
+);
+
+SELECT master_create_distributed_table('composite_partition_column_table', 'composite_column', 'append');
+
+\COPY composite_partition_column_table FROM STDIN WITH (FORMAT 'csv');
+1,"(1,1)"
+2,"(2,2)"
+\.

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -687,3 +687,23 @@ SELECT * FROM super_packed_numbers_append;
   1 | ("(42,42)","(42,42)")
 (1 row)
 
+-- Test copy on append for composite type partition column
+CREATE TABLE composite_partition_column_table(
+        id integer,
+        composite_column number_pack
+);
+SELECT master_create_distributed_table('composite_partition_column_table', 'composite_column', 'append');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+\COPY composite_partition_column_table FROM STDIN WITH (FORMAT 'csv');
+WARNING:  function min(number_pack) does not exist
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+CONTEXT:  while executing command on localhost:57637
+WARNING:  function min(number_pack) does not exist
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+CONTEXT:  while executing command on localhost:57638
+WARNING:  could not get statistics for shard public.composite_partition_column_table_560164
+DETAIL:  Setting shard statistics to NULL


### PR DESCRIPTION
We should return false in MultiClientQueryResult() on a failing query.

Fixes #728 