### PR TITLE
For Review:  Fix 581 and 582

### DIFF
--- a/src/backend/distributed/utils/ruleutils_95.c
+++ b/src/backend/distributed/utils/ruleutils_95.c
@@ -3621,22 +3621,15 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 		attname = colinfo->colnames[attnum - 1];
 		Assert(attname != NULL);
 	}
+	else if (GetRangeTblKind(rte) == CITUS_RTE_SHARD)
+	{
+		/* System column on a Citus shared/remote relation */
+		attname = get_relid_attribute_name(rte->relid, attnum);
+	}
 	else
 	{
-		CitusRTEKind rtekind;
-
-		rtekind = GetRangeTblKind(rte);
-
-		if (rtekind == CITUS_RTE_SHARD || rtekind == CITUS_RTE_REMOTE_QUERY)
-		{
-			/* System column on a Citus shared/remote relation */
-			attname = get_relid_attribute_name(rte->relid, attnum);
-		}
-		else
-		{
-			/* System column - name is fixed, get it from the catalog */
-			attname = get_rte_attribute_name(rte, attnum);
-		}
+		/* System column - name is fixed, get it from the catalog */
+		attname = get_rte_attribute_name(rte, attnum);
 	}
 
 	if (refname && (context->varprefix || attname == NULL))

--- a/src/backend/distributed/utils/ruleutils_95.c
+++ b/src/backend/distributed/utils/ruleutils_95.c
@@ -3624,7 +3624,7 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 	else
 	{
 		/* System column - name is fixed, get it from the catalog */
-		attname = get_rte_attribute_name(rte, attnum);
+		attname = get_relid_attribute_name(rte->relid, attnum);
 	}
 
 	if (refname && (context->varprefix || attname == NULL))

--- a/src/backend/distributed/utils/ruleutils_95.c
+++ b/src/backend/distributed/utils/ruleutils_95.c
@@ -3623,8 +3623,20 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 	}
 	else
 	{
-		/* System column - name is fixed, get it from the catalog */
-		attname = get_relid_attribute_name(rte->relid, attnum);
+		CitusRTEKind rtekind;
+
+		rtekind = GetRangeTblKind(rte);
+
+		if (rtekind == CITUS_RTE_SHARD || rtekind == CITUS_RTE_REMOTE_QUERY)
+		{
+			/* System column on a Citus shared/remote relation */
+			attname = get_relid_attribute_name(rte->relid, attnum);
+		}
+		else
+		{
+			/* System column - name is fixed, get it from the catalog */
+			attname = get_rte_attribute_name(rte, attnum);
+		}
 	}
 
 	if (refname && (context->varprefix || attname == NULL))

--- a/src/backend/distributed/utils/ruleutils_95.c
+++ b/src/backend/distributed/utils/ruleutils_95.c
@@ -3623,7 +3623,7 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 	}
 	else if (GetRangeTblKind(rte) == CITUS_RTE_SHARD)
 	{
-		/* System column on a Citus shared/remote relation */
+		/* System column on a Citus shard */
 		attname = get_relid_attribute_name(rte->relid, attnum);
 	}
 	else

--- a/src/test/regress/expected/multi_create_shards.out
+++ b/src/test/regress/expected/multi_create_shards.out
@@ -40,6 +40,12 @@ CREATE TABLE table_to_distribute (
 	json_data json,
 	test_type_data dummy_type
 );
+-- use the table WITH (OIDS) set
+ALTER TABLE table_to_distribute SET WITH OIDS;
+SELECT master_create_distributed_table('table_to_distribute', 'id', 'hash');
+ERROR:  WITH (OIDS) not supported on distributed tables
+-- revert WITH (OIDS) from above
+ALTER TABLE table_to_distribute SET WITHOUT OIDS;
 -- use an index instead of table name
 SELECT master_create_distributed_table('table_to_distribute_pkey', 'id', 'hash');
 ERROR:  cannot distribute relation: table_to_distribute_pkey

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -70,6 +70,7 @@ HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_sh
 CREATE INDEX lineitem_partkey_desc_index ON lineitem (l_partkey DESC);
 CREATE INDEX lineitem_partial_index ON lineitem (l_shipdate)
 	WHERE l_shipdate < '1995-01-01';
+CREATE INDEX lineitem_colref_index ON lineitem (record_ne(lineitem.*, NULL));
 SET client_min_messages = ERROR; -- avoid version dependant warning about WAL
 CREATE INDEX lineitem_orderkey_hash_index ON lineitem USING hash (l_partkey);
 CREATE UNIQUE INDEX index_test_range_index_a ON index_test_range(a);
@@ -85,19 +86,20 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | index_test_hash  | index_test_hash_index_a_b    |            | CREATE UNIQUE INDEX index_test_hash_index_a_b ON index_test_hash USING btree (a, b)
  public     | index_test_range | index_test_range_index_a     |            | CREATE UNIQUE INDEX index_test_range_index_a ON index_test_range USING btree (a)
  public     | index_test_range | index_test_range_index_a_b   |            | CREATE UNIQUE INDEX index_test_range_index_a_b ON index_test_range USING btree (a, b)
+ public     | lineitem         | lineitem_colref_index        |            | CREATE INDEX lineitem_colref_index ON lineitem USING btree (record_ne(lineitem.*, NULL::record))
  public     | lineitem         | lineitem_orderkey_hash_index |            | CREATE INDEX lineitem_orderkey_hash_index ON lineitem USING hash (l_partkey)
  public     | lineitem         | lineitem_orderkey_index      |            | CREATE INDEX lineitem_orderkey_index ON lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_partial_index       |            | CREATE INDEX lineitem_partial_index ON lineitem USING btree (l_shipdate) WHERE (l_shipdate < '01-01-1995'::date)
  public     | lineitem         | lineitem_partkey_desc_index  |            | CREATE INDEX lineitem_partkey_desc_index ON lineitem USING btree (l_partkey DESC)
  public     | lineitem         | lineitem_pkey                |            | CREATE UNIQUE INDEX lineitem_pkey ON lineitem USING btree (l_orderkey, l_linenumber)
  public     | lineitem         | lineitem_time_index          |            | CREATE INDEX lineitem_time_index ON lineitem USING btree (l_shipdate)
-(10 rows)
+(11 rows)
 
 \c - - - :worker_1_port
 SELECT count(*) FROM pg_indexes WHERE tablename = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1);
  count 
 -------
-     6
+     7
 (1 row)
 
 SELECT count(*) FROM pg_indexes WHERE tablename LIKE 'index_test_hash%';
@@ -161,13 +163,14 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | index_test_hash  | index_test_hash_index_a_b    |            | CREATE UNIQUE INDEX index_test_hash_index_a_b ON index_test_hash USING btree (a, b)
  public     | index_test_range | index_test_range_index_a     |            | CREATE UNIQUE INDEX index_test_range_index_a ON index_test_range USING btree (a)
  public     | index_test_range | index_test_range_index_a_b   |            | CREATE UNIQUE INDEX index_test_range_index_a_b ON index_test_range USING btree (a, b)
+ public     | lineitem         | lineitem_colref_index        |            | CREATE INDEX lineitem_colref_index ON lineitem USING btree (record_ne(lineitem.*, NULL::record))
  public     | lineitem         | lineitem_orderkey_hash_index |            | CREATE INDEX lineitem_orderkey_hash_index ON lineitem USING hash (l_partkey)
  public     | lineitem         | lineitem_orderkey_index      |            | CREATE INDEX lineitem_orderkey_index ON lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_partial_index       |            | CREATE INDEX lineitem_partial_index ON lineitem USING btree (l_shipdate) WHERE (l_shipdate < '01-01-1995'::date)
  public     | lineitem         | lineitem_partkey_desc_index  |            | CREATE INDEX lineitem_partkey_desc_index ON lineitem USING btree (l_partkey DESC)
  public     | lineitem         | lineitem_pkey                |            | CREATE UNIQUE INDEX lineitem_pkey ON lineitem USING btree (l_orderkey, l_linenumber)
  public     | lineitem         | lineitem_time_index          |            | CREATE INDEX lineitem_time_index ON lineitem USING btree (l_shipdate)
-(10 rows)
+(11 rows)
 
 --
 -- DROP INDEX
@@ -183,6 +186,7 @@ ERROR:  dropping indexes concurrently on distributed tables is currently unsuppo
 DROP INDEX lineitem_orderkey_index;
 DROP INDEX lineitem_partkey_desc_index;
 DROP INDEX lineitem_partial_index;
+DROP INDEX lineitem_colref_index;
 -- Verify that we handle if exists statements correctly
 DROP INDEX non_existent_index;
 ERROR:  index "non_existent_index" does not exist

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -502,7 +502,7 @@ DEBUG:  pruning merge fetch taskId 11
 DETAIL:  Creating dependency on merge taskId 14
 ERROR:  cannot use real time executor with repartition jobs
 HINT:  Set citus.task_executor_type to "task-tracker".
--- system columns from shard tables can be queried retrieved
+-- system columns from shard tables can be queried and retrieved
 SELECT count(*) FROM (
     SELECT tableoid, ctid, cmin, cmax, xmin, xmax
         FROM articles

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -502,4 +502,20 @@ DEBUG:  pruning merge fetch taskId 11
 DETAIL:  Creating dependency on merge taskId 14
 ERROR:  cannot use real time executor with repartition jobs
 HINT:  Set citus.task_executor_type to "task-tracker".
+-- system columns from shard tables can be queried retrieved
+SELECT count(*) FROM (
+    SELECT tableoid, ctid, cmin, cmax, xmin, xmax
+        FROM articles
+        WHERE tableoid IS NOT NULL OR
+                  ctid IS NOT NULL OR
+                  cmin IS NOT NULL OR
+                  cmax IS NOT NULL OR
+                  xmin IS NOT NULL OR
+                  xmax IS NOT NULL
+) x;
+ count 
+-------
+    50
+(1 row)
+
 SET client_min_messages to 'NOTICE';

--- a/src/test/regress/sql/multi_create_shards.sql
+++ b/src/test/regress/sql/multi_create_shards.sql
@@ -52,6 +52,13 @@ CREATE TABLE table_to_distribute (
 	test_type_data dummy_type
 );
 
+-- use the table WITH (OIDS) set
+ALTER TABLE table_to_distribute SET WITH OIDS;
+SELECT master_create_distributed_table('table_to_distribute', 'id', 'hash');
+
+-- revert WITH (OIDS) from above
+ALTER TABLE table_to_distribute SET WITHOUT OIDS;
+
 -- use an index instead of table name
 SELECT master_create_distributed_table('table_to_distribute_pkey', 'id', 'hash');
 

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -43,6 +43,8 @@ CREATE INDEX lineitem_partkey_desc_index ON lineitem (l_partkey DESC);
 CREATE INDEX lineitem_partial_index ON lineitem (l_shipdate)
 	WHERE l_shipdate < '1995-01-01';
 
+CREATE INDEX lineitem_colref_index ON lineitem (record_ne(lineitem.*, NULL));
+
 SET client_min_messages = ERROR; -- avoid version dependant warning about WAL
 CREATE INDEX lineitem_orderkey_hash_index ON lineitem USING hash (l_partkey);
 CREATE UNIQUE INDEX index_test_range_index_a ON index_test_range(a);
@@ -97,6 +99,7 @@ DROP INDEX CONCURRENTLY lineitem_orderkey_index;
 DROP INDEX lineitem_orderkey_index;
 DROP INDEX lineitem_partkey_desc_index;
 DROP INDEX lineitem_partial_index;
+DROP INDEX lineitem_colref_index;
 
 -- Verify that we handle if exists statements correctly
 

--- a/src/test/regress/sql/multi_simple_queries.sql
+++ b/src/test/regress/sql/multi_simple_queries.sql
@@ -260,4 +260,16 @@ SELECT *
 	FROM articles a, articles b
 	WHERE a.id = b.id  AND a.author_id = 1;
 
+-- system columns from shard tables can be queried retrieved
+SELECT count(*) FROM (
+    SELECT tableoid, ctid, cmin, cmax, xmin, xmax
+        FROM articles
+        WHERE tableoid IS NOT NULL OR
+                  ctid IS NOT NULL OR
+                  cmin IS NOT NULL OR
+                  cmax IS NOT NULL OR
+                  xmin IS NOT NULL OR
+                  xmax IS NOT NULL
+) x;
+
 SET client_min_messages to 'NOTICE';

--- a/src/test/regress/sql/multi_simple_queries.sql
+++ b/src/test/regress/sql/multi_simple_queries.sql
@@ -260,7 +260,7 @@ SELECT *
 	FROM articles a, articles b
 	WHERE a.id = b.id  AND a.author_id = 1;
 
--- system columns from shard tables can be queried retrieved
+-- system columns from shard tables can be queried and retrieved
 SELECT count(*) FROM (
     SELECT tableoid, ctid, cmin, cmax, xmin, xmax
         FROM articles


### PR DESCRIPTION
This Pull Request implements basic support for both #581 and #582.  I realize we had previously discussed making this two separate Pull Requests, but the bulk of the work for this is shared in a new function in `relay_event_utility.c#AppendShardIdToRelationReferences`, and it just didn't make sense to me to try and split that into two separate functions.

This gets very minimal integration between @ZomboDB and Citus working by allowing these two types of statements to work correctly:

```sql
CREATE INDEX idxchanges ON wikipedia_changes 
   USING zombodb (zdb('wikipedia_changes'::regclass, ctid), zdb(wikipedia_changes.*)) 
   WITH (url='http://localhost:9200/')
```

and

```sql
SELECT * FROM wikipedia_changes WHERE zdb('wikipedia_changes', ctid) ==> 'mario';
```

The latter successfully distributes the query to each worker node/shard, and the resulting queries properly plan an Index Scan.

I've limited the scope of rewriting `::regclass` references to only those that are arguments to function calls and further, to only those that are quals of the query.  No targetlist, orderby, groupby, etc, support because @ZomboDB doesn't need it.

It's not exactly clear to me how we should test this in Citus' regression test suite, so I'm open to thoughts there.

Please let me know what else I should do -- I'm happy to do it.

# Review Tasks
  - [x] Rename `struct` to `ColumnRefWalkerState`
  - [x] Change walker name to `UpdateWholeRowColumnReferencesWalker`
  - [x] Document walker with function comment
  - [x] Add `bool walkIsComplete` to walker, change to `if`/`else if`/`else` blocks with `return walkIsComplete` outside all blocks at end
  - [x] Change extension logic to extend the penultimate `field` string element iff the last element is `A_Star`
  - [x] Remove `AppendShardIdToRowReferences`; inline its logic
  - [x] Add an `else if` case inside of `get_variable` to detect Citus RTE nodes (using `GetRangeTblKind`) rather than modifying the `else` statement
  - [x] Add tests
    - [x] In `multi_index_statements.sql`, create an expression index (in the CREATE INDEX section) that uses `record_ne(rel.*, NULL)` on a distributed table. This is a useless index, but will test your deparse logic and uses a record-taking `IMMUTABLE` function without us having to make one at test-time
    - [x] Toward the end of `multi_simple_queries.sql`, add a `SELECT` query that uses `tableoid` in the `WHERE` clause. Maybe something silly like `tableoid IS NOT NULL`. Maybe include it in the targetlist too.
  - [x] Ensure your branch is up-to-date with the lates changes in `master` (`git rebase`)
