### PR TITLE
Error out at master_create_distributed_table if the table has any rows

### DIFF
--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -24,6 +24,7 @@
 
 /* total number of hash tokens (2^32) */
 #define HASH_TOKEN_COUNT INT64CONST(4294967296)
+#define SELECT_EXIST_QUERY "SELECT EXISTS (SELECT 1 FROM %s)"
 
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval

--- a/src/test/regress/expected/multi_complex_expressions.out
+++ b/src/test/regress/expected/multi_complex_expressions.out
@@ -390,7 +390,7 @@ ORDER BY
 	customer_keys.o_custkey DESC
 LIMIT 10 OFFSET 20;
 DEBUG:  push down of limit count: 30
-DEBUG:  building index "pg_toast_17021_index" on table "pg_toast_17021"
+DEBUG:  building index "pg_toast_17022_index" on table "pg_toast_17022"
  o_custkey | total_order_count 
 -----------+-------------------
       1466 |                 1

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -75,6 +75,12 @@ CREATE TABLE nation (
 	n_name char(25) not null,
 	n_regionkey integer not null,
 	n_comment varchar(152));
+\COPY nation FROM STDIN WITH CSV
+SELECT master_create_distributed_table('nation', 'n_nationkey', 'append');
+ERROR:  cannot distribute relation "nation"
+DETAIL:  Relation "nation" contains data.
+HINT:  Empty your table before distributing it.
+TRUNCATE nation;
 SELECT master_create_distributed_table('nation', 'n_nationkey', 'append');
  master_create_distributed_table 
 ---------------------------------

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -61,6 +61,19 @@ CREATE TABLE nation (
 	n_name char(25) not null,
 	n_regionkey integer not null,
 	n_comment varchar(152));
+
+\COPY nation FROM STDIN WITH CSV
+1,'name',1,'comment_1'
+2,'name',2,'comment_2'
+3,'name',3,'comment_3'
+4,'name',4,'comment_4'
+5,'name',5,'comment_5'
+\.
+
+SELECT master_create_distributed_table('nation', 'n_nationkey', 'append');
+
+TRUNCATE nation;
+
 SELECT master_create_distributed_table('nation', 'n_nationkey', 'append');
 
 CREATE TABLE part (


### PR DESCRIPTION
Fixes #510 

Before this change, we do not check whether given table which already contains any data
in master_create_distributed_table command. If that table contains any data, making it
it distributed, makes that data hidden to user. With this change, we now gave error to
user if the table contains data.