### PR TITLE
Allow noop updates of the partition column

### DIFF
--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -396,6 +396,12 @@ ERROR:  distributed modifications must target exactly one shard
 -- attempting to change the partition key is unsupported
 UPDATE limit_orders SET id = 0 WHERE id = 246;
 ERROR:  modifying the partition value of rows is not allowed
+UPDATE limit_orders SET id = 0 WHERE id = 0 OR id = 246;
+ERROR:  modifying the partition value of rows is not allowed
+-- setting the partition column value to itself is allowed
+UPDATE limit_orders SET id = 246 WHERE id = 246;
+UPDATE limit_orders SET id = 246 WHERE id = 246 AND symbol = 'GM';
+UPDATE limit_orders SET id = limit_orders.id WHERE id = 246;
 -- UPDATEs with a FROM clause are unsupported
 UPDATE limit_orders SET limit_price = 0.00 FROM bidders
 					WHERE limit_orders.id = 246 AND

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -284,6 +284,12 @@ UPDATE limit_orders SET limit_price = 0.00;
 
 -- attempting to change the partition key is unsupported
 UPDATE limit_orders SET id = 0 WHERE id = 246;
+UPDATE limit_orders SET id = 0 WHERE id = 0 OR id = 246;
+
+-- setting the partition column value to itself is allowed
+UPDATE limit_orders SET id = 246 WHERE id = 246;
+UPDATE limit_orders SET id = 246 WHERE id = 246 AND symbol = 'GM';
+UPDATE limit_orders SET id = limit_orders.id WHERE id = 246;
 
 -- UPDATEs with a FROM clause are unsupported
 UPDATE limit_orders SET limit_price = 0.00 FROM bidders


### PR DESCRIPTION
Currently Citus does not allow queries of the form UPDATE SET part_col = X, .. WHERE part_col = X AND .. 

This is a major blocker for using Django with Citus, as found by @lithp @begriffs and [others](http://stackoverflow.com/questions/38776538/django-never-update-a-column-when-saving/38776776#38776776).

This change allows such UPDATE queries by adding an additional check: If part_col = X is implied by the WHERE clause then the query is allowed through. In addition, it also allows queries of the form UPDATE table SET part_col = table.part_col, which were already allowed for upserts.

Fixes #722
