### PR TITLE
Remove pg_toast_* references from regression tests

### DIFF
--- a/src/test/regress/expected/multi_complex_expressions.out
+++ b/src/test/regress/expected/multi_complex_expressions.out
@@ -376,7 +376,6 @@ SELECT o_orderkey FROM orders ORDER BY o_orderkey LIMIT 10 OFFSET 20;
 (10 rows)
 
 -- LIMIT/OFFSET with a subquery
-SET client_min_messages TO 'debug1';
 SET citus.task_executor_type TO 'task-tracker';
 SELECT 
 	customer_keys.o_custkey,
@@ -389,8 +388,6 @@ GROUP BY
 ORDER BY 
 	customer_keys.o_custkey DESC
 LIMIT 10 OFFSET 20;
-DEBUG:  push down of limit count: 30
-DEBUG:  building index "pg_toast_17022_index" on table "pg_toast_17022"
  o_custkey | total_order_count 
 -----------+-------------------
       1466 |                 1
@@ -406,6 +403,7 @@ DEBUG:  building index "pg_toast_17022_index" on table "pg_toast_17022"
 (10 rows)
 
 SET citus.task_executor_type TO 'real-time';
+SET client_min_messages TO DEBUG1;
 -- Ensure that we push down LIMIT and OFFSET properly
 -- No Group-By -> Push Down
 CREATE TEMP TABLE temp_limit_test_1 AS

--- a/src/test/regress/input/multi_subquery.source
+++ b/src/test/regress/input/multi_subquery.source
@@ -697,8 +697,6 @@ LIMIT
 
 
 -- Same queries above with explain
-SET client_min_messages TO DEBUG2;
-
 -- Simple join subquery pushdown
 EXPLAIN SELECT
 	avg(array_length(events, 1)) AS event_average
@@ -914,4 +912,3 @@ LIMIT
 	10;
 
 SET citusdb.task_executor_type TO 'real-time';
-SET client_min_messages TO NOTICE;

--- a/src/test/regress/output/multi_subquery.source
+++ b/src/test/regress/output/multi_subquery.source
@@ -731,7 +731,6 @@ LIMIT
 (3 rows)
 
 -- Same queries above with explain
-SET client_min_messages TO DEBUG2;
 -- Simple join subquery pushdown
 EXPLAIN SELECT
 	avg(array_length(events, 1)) AS event_average
@@ -758,10 +757,6 @@ FROM
 	GROUP BY
 		tenant_id,
 		user_id) AS subquery;
-DEBUG:  predicate pruning for shardId 270015
-DEBUG:  predicate pruning for shardId 270016
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Distributed Query into pg_merge_job_270014
@@ -851,17 +846,6 @@ FROM
 		hasdone) AS subquery_top
 GROUP BY
 	hasdone;
-DEBUG:  predicate pruning for shardId 270015
-DEBUG:  predicate pruning for shardId 270016
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
-DEBUG:  predicate pruning for shardId 270015
-DEBUG:  predicate pruning for shardId 270016
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
-DEBUG:  building index "pg_toast_17247_index" on table "pg_toast_17247"
                                                                                                                    QUERY PLAN                                                                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Distributed Query into pg_merge_job_270015
@@ -977,16 +961,6 @@ GROUP BY
 	count_pay
 ORDER BY
 	count_pay;
-DEBUG:  predicate pruning for shardId 270015
-DEBUG:  predicate pruning for shardId 270016
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
-DEBUG:  predicate pruning for shardId 270015
-DEBUG:  predicate pruning for shardId 270016
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
 ERROR:  bogus varattno for OUTER_VAR var: 3
 -- Lateral join subquery pushdown
 EXPLAIN SELECT
@@ -1038,12 +1012,6 @@ ORDER BY
 	user_lastseen DESC
 LIMIT
 	10;
-DEBUG:  push down of limit count: 10
-DEBUG:  predicate pruning for shardId 270015
-DEBUG:  predicate pruning for shardId 270016
-DEBUG:  predicate pruning for shardId 270011
-DEBUG:  predicate pruning for shardId 270012
-DEBUG:  building index "pg_toast_17256_index" on table "pg_toast_17256"
                                                                                                 QUERY PLAN                                                                                                
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Distributed Query into pg_merge_job_270017
@@ -1078,4 +1046,3 @@ DEBUG:  building index "pg_toast_17256_index" on table "pg_toast_17256"
 (29 rows)
 
 SET citusdb.task_executor_type TO 'real-time';
-SET client_min_messages TO NOTICE;

--- a/src/test/regress/sql/multi_complex_expressions.sql
+++ b/src/test/regress/sql/multi_complex_expressions.sql
@@ -174,7 +174,6 @@ SET citus.subquery_pushdown TO false;
 SELECT o_orderkey FROM orders ORDER BY o_orderkey LIMIT 10 OFFSET 20;
 
 -- LIMIT/OFFSET with a subquery
-SET client_min_messages TO 'debug1';
 SET citus.task_executor_type TO 'task-tracker';
 
 SELECT 
@@ -190,6 +189,7 @@ ORDER BY
 LIMIT 10 OFFSET 20;
 
 SET citus.task_executor_type TO 'real-time';
+SET client_min_messages TO DEBUG1;
 
 -- Ensure that we push down LIMIT and OFFSET properly
 -- No Group-By -> Push Down


### PR DESCRIPTION
pg_toast_* oids are constantly changing, and this causes regression tests to
fail time to time. With this commit, we remove all of the pg_toast_* references
from regression test outputs.

Fixes #771