### PR TITLE
Fix segmentation fault in case of joins with WHERE false

### DIFF
--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -231,6 +231,7 @@ extern StringInfo ShardFetchQueryString(uint64 shardId);
 /* Function declarations for shard pruning */
 extern List * PruneShardList(Oid relationId, Index tableId, List *whereClauseList,
 							 List *shardList);
+extern bool ContainsFalseClause(List *whereClauseList);
 extern OpExpr * MakeOpExpression(Var *variable, int16 strategyNumber);
 
 /*

--- a/src/test/regress/expected/multi_complex_expressions.out
+++ b/src/test/regress/expected/multi_complex_expressions.out
@@ -224,7 +224,7 @@ SELECT count(*) FROM lineitem
 	WHERE 0 != 0;
  count 
 -------
-     0
+      
 (1 row)
 
 -- distinct expressions can be pushed down

--- a/src/test/regress/expected/multi_join_pruning.out
+++ b/src/test/regress/expected/multi_join_pruning.out
@@ -75,6 +75,22 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
      |    
 (1 row)
 
+-- Make sure that we can handle filters without a column
+SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
+	WHERE l_orderkey = o_orderkey AND false;
+ sum | avg 
+-----+-----
+     |    
+(1 row)
+
+SELECT sum(l_linenumber), avg(l_linenumber)
+    FROM lineitem INNER JOIN orders ON (l_orderkey = o_orderkey)
+	WHERE false;
+ sum | avg 
+-----+-----
+     |    
+(1 row)
+
 -- These tests check that we can do join pruning for tables partitioned over
 -- different type of columns including varchar, array types, composite types
 -- etc. This is in response to a bug we had where we were not able to resolve
@@ -110,4 +126,3 @@ DEBUG:  join prunable for intervals [BA1000U2AMO4ZGX,BZZXSP27F21T6] and [AA1000U
  explain statements for distributed queries are not enabled
 (1 row)
 
-SET client_min_messages TO NOTICE;

--- a/src/test/regress/expected/multi_large_table_pruning.out
+++ b/src/test/regress/expected/multi_large_table_pruning.out
@@ -130,5 +130,42 @@ DEBUG:  predicate pruning for shardId 290007
       
 (1 row)
 
--- Reset client logging level to its previous value
-SET client_min_messages TO NOTICE;
+-- Test cases with false in the WHERE clause
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey)
+WHERE
+	false;
+ o_orderkey 
+------------
+(0 rows)
+
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey)
+WHERE
+	1=0 AND c_custkey < 0;
+ o_orderkey 
+------------
+(0 rows)
+
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey AND false);
+ o_orderkey 
+------------
+(0 rows)
+
+SELECT
+	o_orderkey
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey AND false;
+ o_orderkey 
+------------
+(0 rows)
+

--- a/src/test/regress/sql/multi_join_pruning.sql
+++ b/src/test/regress/sql/multi_join_pruning.sql
@@ -36,6 +36,14 @@ SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey AND l_orderkey > 6000 AND o_orderkey < 6000;
 
+-- Make sure that we can handle filters without a column
+SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
+	WHERE l_orderkey = o_orderkey AND false;
+
+SELECT sum(l_linenumber), avg(l_linenumber)
+    FROM lineitem INNER JOIN orders ON (l_orderkey = o_orderkey)
+	WHERE false;
+
 -- These tests check that we can do join pruning for tables partitioned over
 -- different type of columns including varchar, array types, composite types
 -- etc. This is in response to a bug we had where we were not able to resolve
@@ -54,5 +62,3 @@ EXPLAIN SELECT count(*)
 EXPLAIN SELECT count(*)
 	FROM varchar_partitioned_table table1, varchar_partitioned_table table2
 	WHERE table1.varchar_column = table2.varchar_column;
-
-SET client_min_messages TO NOTICE;

--- a/src/test/regress/sql/multi_large_table_pruning.sql
+++ b/src/test/regress/sql/multi_large_table_pruning.sql
@@ -67,6 +67,29 @@ WHERE
 	l_partkey = c_nationkey AND
 	l_orderkey < 0;
 
--- Reset client logging level to its previous value
+-- Test cases with false in the WHERE clause
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey)
+WHERE
+	false;
 
-SET client_min_messages TO NOTICE;
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey)
+WHERE
+	1=0 AND c_custkey < 0;
+
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey AND false);
+
+SELECT
+	o_orderkey
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey AND false;


### PR DESCRIPTION
Fix several issues with joins that have WHERE false (AND ..) or equivalent (e.g. 1=0). More details in #803.  

Fixes #803 