### PR TITLE
Fix unique-violation-in-xact segfault

### DIFF
--- a/src/include/distributed/connection_cache.h
+++ b/src/include/distributed/connection_cache.h
@@ -69,6 +69,7 @@ extern XactModificationType XactModificationLevel;
 /* function declarations for obtaining and using a connection */
 extern PGconn * GetOrEstablishConnection(char *nodeName, int32 nodePort);
 extern void PurgeConnection(PGconn *connection);
+extern void BuildKeyForConnection(PGconn *connection, NodeConnectionKey *connectionKey);
 extern PGconn * PurgeConnectionByKey(NodeConnectionKey *nodeConnectionKey);
 extern bool SqlStateMatchesCategory(char *sqlStateString, int category);
 extern void WarnRemoteError(PGconn *connection, PGresult *result);

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -36,6 +36,10 @@ SELECT master_create_worker_shards('labs', 1, 1);
  
 (1 row)
 
+-- might be confusing to have two people in the same lab with the same name
+CREATE UNIQUE INDEX avoid_name_confusion_idx ON researchers (lab_id, name);
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 -- add some data
 INSERT INTO researchers VALUES (1, 1, 'Donald Knuth');
 INSERT INTO researchers VALUES (2, 1, 'Niklaus Wirth');
@@ -62,6 +66,13 @@ SELECT name FROM researchers WHERE lab_id = 1 AND id = 1;
  Donald Knuth
 (1 row)
 
+-- trigger a unique constraint violation
+BEGIN;
+UPDATE researchers SET name = 'John Backus' WHERE id = 1 AND lab_id = 1;
+ERROR:  duplicate key value violates unique constraint "avoid_name_confusion_idx_1200000"
+DETAIL:  Key (lab_id, name)=(1, John Backus) already exists.
+CONTEXT:  while executing command on localhost:57637
+ABORT;
 -- creating savepoints should work...
 BEGIN;
 INSERT INTO researchers VALUES (5, 3, 'Dennis Ritchie');
@@ -160,8 +171,6 @@ COMMIT;
 -- whether it occurs first or second
 BEGIN;
 ALTER TABLE labs ADD COLUMN motto text;
-NOTICE:  using one-phase commit for distributed DDL commands
-HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 INSERT INTO labs VALUES (6, 'Bell Labs');
 ERROR:  distributed data modifications must not appear in transaction blocks which contain distributed DDL commands
 COMMIT;

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -24,6 +24,9 @@ SELECT master_create_worker_shards('researchers', 2, 2);
 SELECT master_create_distributed_table('labs', 'id', 'hash');
 SELECT master_create_worker_shards('labs', 1, 1);
 
+-- might be confusing to have two people in the same lab with the same name
+CREATE UNIQUE INDEX avoid_name_confusion_idx ON researchers (lab_id, name);
+
 -- add some data
 INSERT INTO researchers VALUES (1, 1, 'Donald Knuth');
 INSERT INTO researchers VALUES (2, 1, 'Niklaus Wirth');
@@ -44,6 +47,11 @@ DELETE FROM researchers WHERE lab_id = 1 AND id = 1;
 ABORT;
 
 SELECT name FROM researchers WHERE lab_id = 1 AND id = 1;
+
+-- trigger a unique constraint violation
+BEGIN;
+UPDATE researchers SET name = 'John Backus' WHERE id = 1 AND lab_id = 1;
+ABORT;
 
 -- creating savepoints should work...
 BEGIN;


### PR DESCRIPTION
An interaction between `ReraiseRemoteError` and DML transaction support causes segfaults:

  * `ReraiseRemoteError` calls `PurgeConnection`, freeing a connection...
  * That connection is still in the `xactParticipantHash`

At transaction end, the memory in the freed connection might happen to pass the "is this connection OK?" check, causing us to try to send an `ABORT` over that connection. By removing it from the transaction hash before calling `ReraiseRemoteError`, we avoid this possibility.