### PR TITLE
Add replication model column to pg_dist_partition

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -8,7 +8,7 @@ EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
-	6.0-1 6.0-2
+	6.0-1 6.0-2 6.0-3
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -61,6 +61,8 @@ $(EXTENSION)--5.2-4.sql: $(EXTENSION)--5.2-3.sql $(EXTENSION)--5.2-3--5.2-4.sql
 $(EXTENSION)--6.0-1.sql: $(EXTENSION)--5.2-4.sql $(EXTENSION)--5.2-4--6.0-1.sql
 	cat $^ > $@
 $(EXTENSION)--6.0-2.sql: $(EXTENSION)--6.0-1.sql $(EXTENSION)--6.0-1--6.0-2.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-3.sql: $(EXTENSION)--6.0-2.sql $(EXTENSION)--6.0-2--6.0-3.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.0-2--6.0-3.sql
+++ b/src/backend/distributed/citus--6.0-2--6.0-3.sql
@@ -1,0 +1,4 @@
+/* citus--6.0-2--6.0-3.sql */
+
+ALTER TABLE pg_catalog.pg_dist_partition
+ADD COLUMN repmodel "char" DEFAULT 'c' NOT NULL;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.0-2'
+default_version = '6.0-3'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -87,6 +87,7 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 
 	Relation pgDistPartition = NULL;
 	char distributionMethod = LookupDistributionMethod(distributionMethodOid);
+	const char replicationModel = 'c';
 	char *distributionColumnName = text_to_cstring(distributionColumnText);
 	Node *distributionKey = NULL;
 	Var *distributionColumn = NULL;
@@ -290,6 +291,7 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 	newValues[Anum_pg_dist_partition_partkey - 1] =
 		CStringGetTextDatum(distributionKeyString);
 	newValues[Anum_pg_dist_partition_colocationid - 1] = INVALID_COLOCATION_ID;
+	newValues[Anum_pg_dist_partition_repmodel - 1] = CharGetDatum(replicationModel);
 
 	newTuple = heap_form_tuple(RelationGetDescr(pgDistPartition), newValues, newNulls);
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -39,6 +39,7 @@ typedef struct
 	char *partitionKeyString;
 	char partitionMethod;
 	uint64 colocationId;
+	char replicationModel;
 
 	/* pg_dist_shard metadata (variable-length ShardInterval array) for this table */
 	int shardIntervalArrayLength;

--- a/src/include/distributed/pg_dist_partition.h
+++ b/src/include/distributed/pg_dist_partition.h
@@ -25,8 +25,9 @@ typedef struct FormData_pg_dist_partition
 	char partmethod;     /* partition method; see codes below */
 #ifdef CATALOG_VARLEN    /* variable-length fields start here */
 	text partkey;        /* partition key expression */
+	uint64 colocationid; /* id of the co-location group of particular table belongs to */
+	char repmodel;       /* replication model; see codes below */
 #endif
-	uint64 colocationid;    /* id of the co-location group of particular table belongs to */
 } FormData_pg_dist_partition;
 
 /* ----------------
@@ -40,17 +41,22 @@ typedef FormData_pg_dist_partition *Form_pg_dist_partition;
  *      compiler constants for pg_dist_partitions
  * ----------------
  */
-#define Natts_pg_dist_partition 4
+#define Natts_pg_dist_partition 5
 #define Anum_pg_dist_partition_logicalrelid 1
 #define Anum_pg_dist_partition_partmethod 2
 #define Anum_pg_dist_partition_partkey 3
 #define Anum_pg_dist_partition_colocationid 4
+#define Anum_pg_dist_partition_repmodel 5
 
 /* valid values for partmethod include append, hash, and range */
 #define DISTRIBUTE_BY_APPEND 'a'
 #define DISTRIBUTE_BY_HASH 'h'
 #define DISTRIBUTE_BY_RANGE 'r'
 #define REDISTRIBUTE_BY_HASH 'x'
+
+/* valid values for repmodel are 'c' for coordinator and 's' for streaming */
+#define REPLICATION_MODEL_COORDINATOR 'c'
+#define REPLICATION_MODEL_STREAMING 's'
 
 
 #endif   /* PG_DIST_PARTITION_H */

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -27,6 +27,8 @@ ALTER EXTENSION citus UPDATE TO '5.2-2';
 ALTER EXTENSION citus UPDATE TO '5.2-3';
 ALTER EXTENSION citus UPDATE TO '5.2-4';
 ALTER EXTENSION citus UPDATE TO '6.0-1';
+ALTER EXTENSION citus UPDATE TO '6.0-2';
+ALTER EXTENSION citus UPDATE TO '6.0-3';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/expected/multi_table_ddl.out
+++ b/src/test/regress/expected/multi_table_ddl.out
@@ -48,8 +48,8 @@ SELECT 1 FROM master_create_empty_shard('testtableddl');
 DROP TABLE testtableddl;
 -- ensure no metadata of distributed tables are remaining
 SELECT * FROM pg_dist_partition;
- logicalrelid | partmethod | partkey | colocationid 
---------------+------------+---------+--------------
+ logicalrelid | partmethod | partkey | colocationid | repmodel 
+--------------+------------+---------+--------------+----------
 (0 rows)
 
 SELECT * FROM pg_dist_shard;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -32,6 +32,8 @@ ALTER EXTENSION citus UPDATE TO '5.2-2';
 ALTER EXTENSION citus UPDATE TO '5.2-3';
 ALTER EXTENSION citus UPDATE TO '5.2-4';
 ALTER EXTENSION citus UPDATE TO '6.0-1';
+ALTER EXTENSION citus UPDATE TO '6.0-2';
+ALTER EXTENSION citus UPDATE TO '6.0-3';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;


### PR DESCRIPTION
This change adds a `repmodel` column to `pg_dist_partition`, specifying the replication model for each distributed table. Currently supported values are 'c' for citus and 's' for streaming. 

We can propagate metadata to workers (i.e. use MX) for tables that use the streaming replication model and are hash-distributed. We might add MX support for other partmethods, but we can only use it with the streaming replication model.

This change is agnostic to how the replication model is determined or used. It is currently set to 'c' for all new and existing tables. The current approach in Citus MX is to set it to 's' when creating a hash-distributed table while `citus.shard_replication_factor` is 1, which is always the case in Citus Cloud.

Fixes #800 