### PR TITLE
Directly register transaction callbacks in PG_init

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -155,7 +155,7 @@ _PG_init(void)
 
 	/* initialize transaction callbacks */
 	RegisterRouterExecutorXactCallbacks();
-	InstallMultiShardXactShmemHook();
+	RegisterShardPlacementXactCallbacks();
 }
 
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -154,7 +154,7 @@ _PG_init(void)
 	WorkerNodeRegister();
 
 	/* initialize transaction callbacks */
-	InstallRouterExecutorShmemHook();
+	RegisterRouterExecutorXactCallbacks();
 	InstallMultiShardXactShmemHook();
 }
 

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -37,6 +37,6 @@ extern void RouterExecutorStart(QueryDesc *queryDesc, int eflags, Task *task);
 extern void RouterExecutorRun(QueryDesc *queryDesc, ScanDirection direction, long count);
 extern void RouterExecutorFinish(QueryDesc *queryDesc);
 extern void RouterExecutorEnd(QueryDesc *queryDesc);
-extern void InstallRouterExecutorShmemHook(void);
+extern void RegisterRouterExecutorXactCallbacks(void);
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_shard_transaction.h
+++ b/src/include/distributed/multi_shard_transaction.h
@@ -33,7 +33,7 @@ extern ShardConnections * GetShardHashConnections(HTAB *connectionHash, int64 sh
 												  bool *connectionsFound);
 extern List * ConnectionList(HTAB *connectionHash);
 extern void CloseConnections(List *connectionList);
-extern void InstallMultiShardXactShmemHook(void);
+extern void RegisterShardPlacementXactCallbacks(void);
 
 
 #endif /* MULTI_SHARD_TRANSACTION_H */


### PR DESCRIPTION
Not entirely sure why we went with the shared memory hook approach, but it causes problems (multiple registration) during crashes. Changing to a simple direct registration call from `PG_init`.

Fixes #813