### PR TITLE
Move task tracker lwlocks into their own tranche

### DIFF
--- a/src/include/distributed/task_tracker.h
+++ b/src/include/distributed/task_tracker.h
@@ -98,7 +98,9 @@ typedef struct WorkerTasksSharedStateData
 	HTAB *taskHash;
 
 	/* Lock protecting workerNodesHash */
-	LWLock *taskHashLock;
+	int taskHashTrancheId;
+	LWLockTranche taskHashLockTranche;
+	LWLock taskHashLock;
 } WorkerTasksSharedStateData;
 
 


### PR DESCRIPTION
`RequestAddinLWLocks` and `LWLockAssign` are gone in 9.6. Luckily, all Citus-supported PostgreSQL versions support tranches, so use those.