### PR TITLE
Change logicalrelid type to regclass

### DIFF
--- a/src/backend/distributed/.gitignore
+++ b/src/backend/distributed/.gitignore
@@ -10,6 +10,6 @@
 /tmp_check*
 
 # ignore latest install file
-citus--5.0.sql
-citus--5.?-*.sql
-!citus--5.?-*--5.?-*.sql
+citus--?.?.sql
+citus--?.?-*.sql
+!citus--?.?-*--?.?-*.sql

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -7,7 +7,8 @@ MODULE_big = citus
 EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
-	5.2-1 5.2-2 5.2-3 5.2-4
+	5.2-1 5.2-2 5.2-3 5.2-4 \
+	6.0-1
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -56,6 +57,8 @@ $(EXTENSION)--5.2-2.sql: $(EXTENSION)--5.2-1.sql $(EXTENSION)--5.2-1--5.2-2.sql
 $(EXTENSION)--5.2-3.sql: $(EXTENSION)--5.2-2.sql $(EXTENSION)--5.2-2--5.2-3.sql
 	cat $^ > $@
 $(EXTENSION)--5.2-4.sql: $(EXTENSION)--5.2-3.sql $(EXTENSION)--5.2-3--5.2-4.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-1.sql: $(EXTENSION)--5.2-4.sql $(EXTENSION)--5.2-4--6.0-1.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--5.2-4--6.0-1.sql
+++ b/src/backend/distributed/citus--5.2-4--6.0-1.sql
@@ -1,0 +1,5 @@
+/* citus--5.2-4--6.0-1.sql */
+
+/* change logicalrelid type to regclass to allow implicit casts to text */
+ALTER TABLE pg_catalog.pg_dist_partition ALTER COLUMN logicalrelid TYPE regclass;
+ALTER TABLE pg_catalog.pg_dist_shard ALTER COLUMN logicalrelid TYPE regclass;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '5.2-4'
+default_version = '6.0-1'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/citus.sql
+++ b/src/backend/distributed/citus.sql
@@ -29,7 +29,7 @@ CREATE TYPE citus.distribution_type AS ENUM (
  * Citus tables & corresponding indexes
  *****************************************************************************/
 CREATE TABLE citus.pg_dist_partition(
-    logicalrelid Oid NOT NULL,
+    logicalrelid Oid NOT NULL,    /* type changed to regclass as of version 6.0-1 */
     partmethod "char" NOT NULL,
     partkey text NOT NULL
 );
@@ -39,7 +39,7 @@ ON citus.pg_dist_partition using btree(logicalrelid);
 ALTER TABLE citus.pg_dist_partition SET SCHEMA pg_catalog;
 
 CREATE TABLE citus.pg_dist_shard(
-    logicalrelid oid NOT NULL,
+    logicalrelid oid NOT NULL,    /* type changed to regclass as of version 6.0-1 */
     shardid int8 NOT NULL,
     shardstorage "char" NOT NULL,
     shardalias text,

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -26,6 +26,7 @@ ALTER EXTENSION citus UPDATE TO '5.2-1';
 ALTER EXTENSION citus UPDATE TO '5.2-2';
 ALTER EXTENSION citus UPDATE TO '5.2-3';
 ALTER EXTENSION citus UPDATE TO '5.2-4';
+ALTER EXTENSION citus UPDATE TO '6.0-1';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -31,6 +31,7 @@ ALTER EXTENSION citus UPDATE TO '5.2-1';
 ALTER EXTENSION citus UPDATE TO '5.2-2';
 ALTER EXTENSION citus UPDATE TO '5.2-3';
 ALTER EXTENSION citus UPDATE TO '5.2-4';
+ALTER EXTENSION citus UPDATE TO '6.0-1';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;


### PR DESCRIPTION
Since this is a life-changing feature (and we should stop using 5.2- as a version number), also bump the version number to 6.0.

Before:
```
postgres=# SELECT * FROM pg_dist_shard;
 logicalrelid | shardid | shardstorage | shardalias | shardminvalue | shardmaxvalue 
--------------+---------+--------------+------------+---------------+---------------
        52086 |  102008 | t            |            | -2147483648   | -1610612737
        52086 |  102009 | t            |            | -1610612736   | -1073741825
        52086 |  102010 | t            |            | -1073741824   | -536870913
        52086 |  102011 | t            |            | -536870912    | -1
        52086 |  102012 | t            |            | 0             | 536870911
        52086 |  102013 | t            |            | 536870912     | 1073741823
        52086 |  102014 | t            |            | 1073741824    | 1610612735
        52086 |  102015 | t            |            | 1610612736    | 2147483647
(8 rows)
```
After:
```
postgres=# SELECT * FROM pg_dist_shard;
 logicalrelid | shardid | shardstorage | shardalias | shardminvalue | shardmaxvalue 
--------------+---------+--------------+------------+---------------+---------------
 test         |  102008 | t            |            | -2147483648   | -1610612737
 test         |  102009 | t            |            | -1610612736   | -1073741825
 test         |  102010 | t            |            | -1073741824   | -536870913
 test         |  102011 | t            |            | -536870912    | -1
 test         |  102012 | t            |            | 0             | 536870911
 test         |  102013 | t            |            | 536870912     | 1073741823
 test         |  102014 | t            |            | 1073741824    | 1610612735
 test         |  102015 | t            |            | 1610612736    | 2147483647
(8 rows)
```