### PR TITLE
Remove EventInvokeTrigger from regression test output

### DIFF
--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -1793,11 +1793,6 @@ SELECT * FROM mv_articles_hash;
  41 |         1 | aznavour     |      11814
 (5 rows)
 
-DROP MATERIALIZED VIEW mv_articles_hash;
-DEBUG:  drop auto-cascades to type mv_articles_hash
-DEBUG:  drop auto-cascades to type mv_articles_hash[]
-DEBUG:  drop auto-cascades to rule _RETURN on materialized view mv_articles_hash
-DEBUG:  EventTriggerInvoke 16761
 CREATE MATERIALIZED VIEW mv_articles_hash_error AS
 	SELECT * FROM articles_hash WHERE author_id in (1,2);
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
@@ -1844,6 +1839,7 @@ DEBUG:  predicate pruning for shardId 840001
 SET client_min_messages to 'NOTICE';
 DROP FUNCTION author_articles_max_id();
 DROP FUNCTION author_articles_id_word_count();
+DROP MATERIALIZED VIEW mv_articles_hash;
 DROP TABLE articles_hash;
 DROP TABLE articles_single_shard_hash;
 DROP TABLE authors_hash;

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -768,8 +768,6 @@ CREATE MATERIALIZED VIEW mv_articles_hash AS
 
 SELECT * FROM mv_articles_hash;
 
-DROP MATERIALIZED VIEW mv_articles_hash;
-
 CREATE MATERIALIZED VIEW mv_articles_hash_error AS
 	SELECT * FROM articles_hash WHERE author_id in (1,2);
 	
@@ -792,6 +790,8 @@ SET client_min_messages to 'NOTICE';
 
 DROP FUNCTION author_articles_max_id();
 DROP FUNCTION author_articles_id_word_count();
+
+DROP MATERIALIZED VIEW mv_articles_hash;
 
 DROP TABLE articles_hash;
 DROP TABLE articles_single_shard_hash;


### PR DESCRIPTION
The regression test output of the multi_router_planner test keeps changing when we add a new `ALTER EXTENSION` statement to the multi_extension test. Given that it comes from an irrelevant `DROP MATERIALIZED VIEW` statement we can easily hide the output. 