### PR TITLE
Allow to run regression tests under valgrind

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -49,6 +49,10 @@ check-multi: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
+check-multi-vg: all tempinstall-main
+	$(pg_regress_multi_check) --load-extension=citus --valgrind \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
+
 check-isolation: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/isolation_schedule $(EXTRA_TESTS)

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -35,6 +35,7 @@ sub Usage()
     print "  --pgxsdir           Path to the PGXS directory\n";
     print "  --load-extension    Extensions to install in all nodes\n";
     print "  --server-option     Config option to pass to the server\n";
+    print "  --valgrind          Run server via valgrind\n";
     exit 1;
 }
 
@@ -54,6 +55,7 @@ my %fdws = ();
 my %fdwServers = ();
 my %functions = ();
 my %operators = ();
+my $valgrind = 0;
 
 my $serversAreShutdown = "TRUE";
 
@@ -68,6 +70,7 @@ GetOptions(
     'majorversion=s' => \$majorversion,
     'load-extension=s' => \@extensions,
     'server-option=s' => \@userPgOptions,
+    'valgrind' => \$valgrind,
     'help' => sub { Usage() });
 
 # Update environment to include [DY]LD_LIBRARY_PATH/LIBDIR/etc -
@@ -124,6 +127,63 @@ and build (detected as ${postgresBuilddir}) directory corresponding to $bindir
 are present.
 MESSAGE
 }
+
+# valgrind starts slow, need to increase timeout
+if ($valgrind)
+{
+    $ENV{PGCTLTIMEOUT} = '360';
+}
+
+# We don't want valgrind to run pg_ctl itself, as that'd trigger a lot
+# of spurious OS failures, e.g. in bash. So instead we have to replace
+# the postgres binary with a wrapper that exec's valgrind, which in
+# turn then executes postgres.  That's unfortunately at the moment the
+# only reliable way to do this.
+sub replace_postgres
+{
+    if (-e "$bindir/postgres.orig")
+    {
+	print "wrapper exists\n";
+    }
+    else
+    {
+	print "moving $bindir/postgres to $bindir/postgres.orig\n";
+	rename "$bindir/postgres", "$bindir/postgres.orig"
+	    or die "Could not move postgres out of the way";
+    }
+
+    sysopen my $fh, "$bindir/postgres", O_CREAT|O_TRUNC|O_RDWR, 0700
+	or die "Could not create postgres wrapper at $bindir/postgres";
+    print $fh <<"END";
+#!/bin/bash
+exec valgrind \\
+    --quiet \\
+    --suppressions=${postgresSrcdir}/src/tools/valgrind.supp \\
+    --trace-children=yes --track-origins=yes --read-var-info=yes \\
+    --leak-check=no \\
+    --error-exitcode=128 \\
+    --error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END \\
+    $bindir/postgres.orig \\
+    "\$@"
+END
+    close $fh;
+}
+
+# revert changes replace_postgres() performed
+sub revert_replace_postgres
+{
+    if (-e "$bindir/postgres.orig")
+    {
+	print "wrapper exists, removing\n";
+	print "moving $bindir/postgres.orig to $bindir/postgres\n";
+	rename "$bindir/postgres.orig", "$bindir/postgres"
+	    or die "Could not move postgres back";
+    }
+}
+
+# always want to call initdb under normal postgres, so revert from a
+# partial run, even if we're now not using valgrind.
+revert_replace_postgres();
 
 # Set some default configuration options
 my $masterPort = 57636;
@@ -254,6 +314,18 @@ END
     {
         ShutdownServers();
     }
+
+    # At the end of a run, replace redirected binary with original again
+    if ($valgrind)
+    {
+	revert_replace_postgres();
+    }
+}
+
+# want to use valgrind, replace binary before starting server
+if ($valgrind)
+{
+    replace_postgres();
 }
 
 # Signal that servers should be shutdown


### PR DESCRIPTION
This is clearly incomplete:
- need to enforce sourcetree of postgres is locally available, to get
  valgrind.supp, need to configure path
- due to timeouts some tests still fail, we need to make
  REMOTE_NODE_CONNECT_TIMEOUT configurable.
- due to slow queries, autovacuum analyzes some tables, causing
  different plans. This probably should be fixed by adding explicit
  analyze statements to those
- should we verify that postgres was compiled with USE_VALGRIND
  specified?

Those issues are tracked in #1039

See: #1039