### PR TITLE
Avoid use of pnstrdup

### DIFF
--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -317,7 +317,7 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 		ShardInterval *shardInterval = (ShardInterval *) lfirst(shardIntervalCell);
 		uint64 shardId = shardInterval->shardId;
 		char *quotedShardName = NULL;
-		char *shardRelationName = pnstrdup(relationName, NAMEDATALEN);
+		char *shardRelationName = pstrdup(relationName);
 
 		Assert(shardInterval->relationId == relationId);
 

--- a/src/backend/distributed/master/master_expire_table_cache.c
+++ b/src/backend/distributed/master/master_expire_table_cache.c
@@ -169,7 +169,7 @@ DropShardsFromWorker(WorkerNode *workerNode, Oid relationId, List *shardInterval
 	foreach(shardIntervalCell, shardIntervalList)
 	{
 		ShardInterval *shardInterval = (ShardInterval *) lfirst(shardIntervalCell);
-		char *shardName = pnstrdup(relationName, NAMEDATALEN);
+		char *shardName = pstrdup(relationName);
 		char *quotedShardName = NULL;
 
 		AppendShardIdToName(&shardName, shardInterval->shardId);

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -483,7 +483,7 @@ TypeDropIndexConstraint(const AlterTableCmd *command,
 		return false;
 	}
 
-	searchedConstraintName = pnstrdup(command->name, NAMEDATALEN);
+	searchedConstraintName = pstrdup(command->name);
 	AppendShardIdToName(&searchedConstraintName, shardId);
 
 	pgConstraint = heap_open(ConstraintRelationId, AccessShareLock);
@@ -636,6 +636,13 @@ AppendShardIdToName(char **name, uint64 shardId)
 	int shardIdAndSeparatorLength;
 	uint32 longNameHash = 0;
 	int multiByteClipLength = 0;
+
+	if (nameLength >= NAMEDATALEN)
+	{
+		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG),
+						errmsg("identifier must be less than %d characters",
+							   NAMEDATALEN)));
+	}
 
 	snprintf(shardIdAndSeparator, NAMEDATALEN, "%c" UINT64_FORMAT,
 			 SHARD_NAME_SEPARATOR, shardId);


### PR DESCRIPTION
#819 added some calls to pnstrdup, which doesn't behave as advertised in PostgreSQL 9.5 and breaks valgrind tests. Remove calls to pnstrdup from Citus code.

Fixes #836 