### PR TITLE
Batch task_tracker_status calls to reduce task-tracker query times

### DIFF
--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -31,8 +31,8 @@
 
 /* Task tracker executor related defines */
 #define TASK_ASSIGNMENT_QUERY "SELECT task_tracker_assign_task \
- ("UINT64_FORMAT ", %u, %s)"
-#define TASK_STATUS_QUERY "SELECT task_tracker_task_status("UINT64_FORMAT ", %u)"
+ ("UINT64_FORMAT ", %u, %s);"
+#define TASK_STATUS_QUERY "SELECT task_tracker_task_status("UINT64_FORMAT ", %u);"
 #define JOB_CLEANUP_QUERY "SELECT task_tracker_cleanup_job("UINT64_FORMAT ")"
 #define JOB_CLEANUP_TASK_ID INT_MAX
 
@@ -163,6 +163,7 @@ typedef struct TaskTracker
 	int32 currentTaskIndex;
 	bool connectionBusy;
 	TrackerTaskState *connectionBusyOnTask;
+	List *connectionBusyOnTaskList;
 } TaskTracker;
 
 


### PR DESCRIPTION
Dug up an old patch. This change batches many task_tracker_task_status checks into one command, which can drastically reduce task-query times. 

Task-tracker queries currently have a lower (theoretical) bound of `#jobs * remote_task_check_interval * #shards / #workers + task_tracker_delay`. This change reduces the lower bound to `#jobs * remote_task_check_interval * ceil(#shards / 64) / #workers + task_tracker_delay`  (if I got my math right, otherwise read this as: "a lot").

Fixes #255 
