### PR TITLE
Parallelise DDL commands

### DIFF
--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -162,7 +162,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 
 	taskList = ModifyMultipleShardsTaskList(modifyQuery, prunedShardIntervalList,
 											relationId);
-	affectedTupleCount = ExecuteModifyTasks(taskList, false, NULL, NULL, NULL);
+	affectedTupleCount = ExecuteModifyTasksWithoutResults(taskList);
 
 	PG_RETURN_INT32(affectedTupleCount);
 }

--- a/src/include/distributed/multi_planner.h
+++ b/src/include/distributed/multi_planner.h
@@ -14,6 +14,11 @@
 #include "nodes/relation.h"
 
 
+/* values used by jobs and tasks which do not require identifiers */
+#define INVALID_JOB_ID 0
+#define INVALID_TASK_ID 0
+
+
 typedef struct RelationRestrictionContext
 {
 	bool hasDistributedRelation;

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -39,8 +39,6 @@ extern void RouterExecutorFinish(QueryDesc *queryDesc);
 extern void RouterExecutorEnd(QueryDesc *queryDesc);
 extern void RegisterRouterExecutorXactCallbacks(void);
 
-extern int64 ExecuteModifyTasks(List *taskList, bool expectResults,
-								ParamListInfo paramListInfo, MaterialState *routerState,
-								TupleDesc tupleDescriptor);
+extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -21,10 +21,6 @@
 #include "nodes/parsenodes.h"
 
 
-/* values used by jobs and tasks which do not require identifiers */
-#define INVALID_JOB_ID 0
-#define INVALID_TASK_ID 0
-
 /* reserved alias name for UPSERTs */
 #define UPSERT_ALIAS "citus_table_alias"
 

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -153,14 +153,12 @@ ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-WARNING:  data type bigint has no default operator class for access method "gist"
+ERROR:  data type bigint has no default operator class for access method "gist"
 HINT:  You must specify an operator class for the index or define a default operator class for the data type.
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX try_index ON lineitem (non_existent_column);
-WARNING:  column "non_existent_column" does not exist
+ERROR:  column "non_existent_column" does not exist
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 CREATE INDEX ON lineitem (l_orderkey);
 ERROR:  creating index without a name on a distributed table is currently unsupported
 -- Verify that none of failed indexes got created on the master node

--- a/src/test/regress/expected/multi_join_order_additional.out
+++ b/src/test/regress/expected/multi_join_order_additional.out
@@ -44,8 +44,6 @@ SELECT master_create_worker_shards('lineitem_hash', 2, 1);
 CREATE INDEX lineitem_hash_time_index ON lineitem_hash (l_shipdate);
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-DEBUG:  applied command on shard 650000 on node localhost:57637
-DEBUG:  applied command on shard 650001 on node localhost:57638
 DEBUG:  building index "lineitem_hash_time_index" on table "lineitem_hash"
 DEBUG:  sent COMMIT over connection 650000
 DEBUG:  sent COMMIT over connection 650001

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -261,9 +261,8 @@ ALTER TABLE IF EXISTS non_existent_table ADD COLUMN new_column INTEGER;
 NOTICE:  relation "non_existent_table" does not exist, skipping
 ALTER TABLE IF EXISTS lineitem_alter ALTER COLUMN int_column2 SET DATA TYPE INTEGER;
 ALTER TABLE lineitem_alter DROP COLUMN non_existent_column;
-WARNING:  column "non_existent_column" of relation "lineitem_alter_220000" does not exist
+ERROR:  column "non_existent_column" of relation "lineitem_alter_220000" does not exist
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 NOTICE:  column "non_existent_column" of relation "lineitem_alter" does not exist, skipping
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS int_column2;
@@ -361,17 +360,14 @@ DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT and TYPE subc
 -- Verify that we error out in case of postgres errors on supported statement
 -- types
 ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
-WARNING:  type "non_existent_type" does not exist
+ERROR:  type "non_existent_type" does not exist
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
-WARNING:  column "null_column" contains null values
+ERROR:  column "null_column" contains null values
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
-WARNING:  invalid input syntax for integer: "a"
+ERROR:  invalid input syntax for integer: "a"
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 -- Verify that we error out on statements involving RENAME
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
 ERROR:  renaming distributed tables or their objects is currently unsupported
@@ -518,9 +514,8 @@ CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 ALTER TABLE lineitem_alter ADD COLUMN first integer;
-WARNING:  column "first" of relation "lineitem_alter_220000" already exists
+ERROR:  column "first" of relation "lineitem_alter_220000" already exists
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 COMMIT;
 -- Nothing from the block should have committed
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
@@ -651,10 +646,9 @@ SELECT master_create_worker_shards('test_ab', 8, 2);
 INSERT INTO test_ab VALUES (2, 10);
 INSERT INTO test_ab VALUES (2, 11);
 CREATE UNIQUE INDEX temp_unique_index_1 ON test_ab(a);
-WARNING:  could not create unique index "temp_unique_index_1_220022"
+ERROR:  could not create unique index "temp_unique_index_1_220022"
 DETAIL:  Key (a)=(2) is duplicated.
 CONTEXT:  while executing command on localhost:57638
-ERROR:  could not execute DDL command on worker node shards
 SELECT shardid FROM pg_dist_shard_placement NATURAL JOIN pg_dist_shard 
 WHERE logicalrelid='test_ab'::regclass AND shardstate=3;
  shardid 


### PR DESCRIPTION
I had already written this while working on #855. We can now use the new ExecuteModifyTasks infrastructure for parallel DDL. As a side-effect, this make error messages slightly cleaner.

Fixes #131