### PR TITLE
Foreign key support for create table

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -8,7 +8,7 @@ EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
-	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12
+	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -81,6 +81,8 @@ $(EXTENSION)--6.0-10.sql: $(EXTENSION)--6.0-9.sql $(EXTENSION)--6.0-9--6.0-10.sq
 $(EXTENSION)--6.0-11.sql: $(EXTENSION)--6.0-10.sql $(EXTENSION)--6.0-10--6.0-11.sql
 	cat $^ > $@
 $(EXTENSION)--6.0-12.sql: $(EXTENSION)--6.0-11.sql $(EXTENSION)--6.0-11--6.0-12.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-13.sql: $(EXTENSION)--6.0-12.sql $(EXTENSION)--6.0-12--6.0-13.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.0-12--6.0-13.sql
+++ b/src/backend/distributed/citus--6.0-12--6.0-13.sql
@@ -1,0 +1,16 @@
+/* citus--6.0-12--6.0-13.sql */
+
+CREATE FUNCTION pg_catalog.worker_apply_inter_shard_ddl_command(referencing_shard bigint,
+																referencing_schema_name text,
+																referenced_shard bigint,
+																referenced_schema_name text,
+																command text)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$worker_apply_inter_shard_ddl_command$$;
+COMMENT ON FUNCTION pg_catalog.worker_apply_inter_shard_ddl_command(referencing_shard bigint,
+																	referencing_schema_name text,
+																	referenced_shard bigint,
+																	referenced_schema_name text,
+																	command text)
+    IS 'executes inter shard ddl command';

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.0-12'
+default_version = '6.0-13'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -31,6 +31,10 @@
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_class.h"
+#include "catalog/pg_constraint.h"
+#if (PG_VERSION_NUM >= 90600)
+#include "catalog/pg_constraint_fn.h"
+#endif
 #include "catalog/pg_index.h"
 #include "catalog/pg_type.h"
 #include "commands/sequence.h"
@@ -579,7 +583,7 @@ ResolveRelationId(text *relationName)
  * GetTableDDLEvents takes in a relationId, and returns the list of DDL commands
  * needed to reconstruct the relation. These DDL commands are all palloced; and
  * include the table's schema definition, optional column storage and statistics
- * definitions, and index and constraint defitions.
+ * definitions, and index and constraint definitions.
  */
 List *
 GetTableDDLEvents(Oid relationId)
@@ -727,6 +731,67 @@ GetTableDDLEvents(Oid relationId)
 	PopOverrideSearchPath();
 
 	return tableDDLEventList;
+}
+
+
+/*
+ * GetTableForeignConstraints takes in a relationId, and returns the list of foreign
+ * constraint commands needed to reconstruct foreign constraints of that table.
+ */
+List *
+GetTableForeignConstraintCommands(Oid relationId)
+{
+	List *tableForeignConstraints = NIL;
+
+	Relation pgConstraint = NULL;
+	SysScanDesc scanDescriptor = NULL;
+	ScanKeyData scanKey[1];
+	int scanKeyCount = 1;
+	HeapTuple heapTuple = NULL;
+
+	/*
+	 * Set search_path to NIL so that all objects outside of pg_catalog will be
+	 * schema-prefixed. pg_catalog will be added automatically when we call
+	 * PushOverrideSearchPath(), since we set addCatalog to true;
+	 */
+	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
+	overridePath->schemas = NIL;
+	overridePath->addCatalog = true;
+	PushOverrideSearchPath(overridePath);
+
+	/* open system catalog and scan all constraints that belong to this table */
+	pgConstraint = heap_open(ConstraintRelationId, AccessShareLock);
+	ScanKeyInit(&scanKey[0], Anum_pg_constraint_conrelid, BTEqualStrategyNumber, F_OIDEQ,
+				relationId);
+	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidIndexId, true, NULL,
+										scanKeyCount, scanKey);
+
+	heapTuple = systable_getnext(scanDescriptor);
+	while (HeapTupleIsValid(heapTuple))
+	{
+		Form_pg_constraint constraintForm = (Form_pg_constraint) GETSTRUCT(heapTuple);
+
+		if (constraintForm->contype == CONSTRAINT_FOREIGN)
+		{
+			Oid constraintId = get_relation_constraint_oid(relationId,
+														   constraintForm->conname.data,
+														   true);
+			char *statementDef = pg_get_constraintdef_command(constraintId);
+
+			tableForeignConstraints = lappend(tableForeignConstraints, statementDef);
+		}
+
+		heapTuple = systable_getnext(scanDescriptor);
+	}
+
+	/* clean up scan and close system catalog */
+	systable_endscan(scanDescriptor);
+	heap_close(pgConstraint, AccessShareLock);
+
+	/* revert back to original search_path */
+	PopOverrideSearchPath();
+
+	return tableForeignConstraints;
 }
 
 

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -260,3 +260,16 @@ ColocatedTableId(Oid colocationId)
 
 	return colocatedTableId;
 }
+
+
+/*
+ * ColocatedShardIdInRelation returns shardId of the shard from given relation, so that
+ * returned shard is co-located with given shard.
+ */
+uint64
+ColocatedShardIdInRelation(Oid relationId, int shardIndex)
+{
+	DistTableCacheEntry *tableCacheEntry = DistributedTableCacheEntry(relationId);
+
+	return tableCacheEntry->sortedShardIntervalArray[shardIndex]->shardId;
+}

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -256,3 +256,30 @@ SearchCachedShardInterval(Datum partitionColumnValue, ShardInterval **shardInter
 
 	return NULL;
 }
+
+
+/*
+ * SingleReplicatedTable checks whether all shards of a distributed table, do not have
+ * more than one replica. If even one shard has more than one replica, this function
+ * returns false, otherwise it returns true.
+ */
+bool
+SingleReplicatedTable(Oid relationId)
+{
+	List *shardIntervalList = LoadShardList(relationId);
+	ListCell *shardIntervalCell = NULL;
+
+	foreach(shardIntervalCell, shardIntervalList)
+	{
+		uint64 *shardIdPointer = (uint64 *) lfirst(shardIntervalCell);
+		uint64 shardId = (*shardIdPointer);
+		List *shardPlacementList = ShardPlacementList(shardId);
+
+		if (shardPlacementList->length > 1)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -24,6 +24,6 @@ extern bool ShardsColocated(ShardInterval *leftShardInterval,
 extern List * ColocatedTableList(Oid distributedTableId);
 extern List * ColocatedShardIntervalList(ShardInterval *shardInterval);
 extern Oid ColocatedTableId(Oid colocationId);
-
+extern uint64 ColocatedShardIdInRelation(Oid relationId, int shardIndex);
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -58,6 +58,9 @@
 	"SELECT worker_apply_shard_ddl_command (" UINT64_FORMAT ", %s)"
 #define WORKER_APPEND_TABLE_TO_SHARD \
 	"SELECT worker_append_table_to_shard (%s, %s, %s, %u)"
+#define WORKER_APPLY_INTER_SHARD_DDL_COMMAND \
+	"SELECT worker_apply_inter_shard_ddl_command (" UINT64_FORMAT ", %s, " UINT64_FORMAT \
+	", %s, %s)"
 #define SHARD_RANGE_QUERY "SELECT min(%s), max(%s) FROM %s"
 #define SHARD_TABLE_SIZE_QUERY "SELECT pg_table_size(%s)"
 #define SHARD_CSTORE_TABLE_SIZE_QUERY "SELECT cstore_table_size(%s)"
@@ -93,6 +96,7 @@ extern bool CStoreTable(Oid relationId);
 extern uint64 GetNextShardId(void);
 extern Oid ResolveRelationId(text *relationName);
 extern List * GetTableDDLEvents(Oid relationId);
+extern List * GetTableForeignConstraintCommands(Oid relationId);
 extern char ShardStorageType(Oid relationId);
 extern void CheckDistributedTable(Oid relationId);
 extern void CreateShardPlacements(Oid relationId, int64 shardId, List *ddlEventList,
@@ -103,7 +107,9 @@ extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shard
 											 int32 replicationFactor);
 extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId);
 extern bool WorkerCreateShard(Oid relationId, char *nodeName, uint32 nodePort,
-							  uint64 shardId, char *newShardOwner, List *ddlCommandList);
+							  int shardIndex, uint64 shardId, char *newShardOwner,
+							  List *ddlCommandList, List *foreignConstraintCommadList);
+extern Oid ForeignConstraintGetReferencedTableId(char *queryString);
 
 /* Function declarations for generating metadata for shard and placement creation */
 extern Datum master_get_table_metadata(PG_FUNCTION_ARGS);

--- a/src/include/distributed/relay_utility.h
+++ b/src/include/distributed/relay_utility.h
@@ -42,6 +42,11 @@ typedef enum
 
 /* Function declarations to extend names in DDL commands */
 extern void RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId);
+extern void RelayEventExtendNamesForInterShardCommands(Node *parseTree,
+													   uint64 leftShardId,
+													   char *leftShardSchemaName,
+													   uint64 rightShardId,
+													   char *rightShardSchemaName);
 extern void AppendShardIdToName(char **name, uint64 shardId);
 
 #endif   /* RELAY_UTILITY_H */

--- a/src/include/distributed/shardinterval_utils.h
+++ b/src/include/distributed/shardinterval_utils.h
@@ -32,5 +32,6 @@ extern ShardInterval * FindShardInterval(Datum partitionColumnValue,
 										 int shardCount, char partitionMethod,
 										 FmgrInfo *compareFunction,
 										 FmgrInfo *hashFunction, bool useBinarySearch);
+extern bool SingleReplicatedTable(Oid relationId);
 
 #endif /* SHARDINTERVAL_UTILS_H_ */

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -38,6 +38,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-9';
 ALTER EXTENSION citus UPDATE TO '6.0-10';
 ALTER EXTENSION citus UPDATE TO '6.0-11';
 ALTER EXTENSION citus UPDATE TO '6.0-12';
+ALTER EXTENSION citus UPDATE TO '6.0-13';
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -1,0 +1,341 @@
+--
+-- MULTI_FOREIGN_KEY
+--
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1350000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1350000;
+-- set shard_count to 4 for faster tests, because we create/drop lots of shards in this test.
+SET citus.shard_count TO 4;
+-- create tables
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- test foreign constraint creation with not supported parameters
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE SET NULL);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  SET NULL or SET DEFAULT is not supported in ON DELETE operation.
+DROP TABLE referencing_table;
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE SET DEFAULT);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  SET NULL or SET DEFAULT is not supported in ON DELETE operation.
+DROP TABLE referencing_table;
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON UPDATE SET NULL);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  SET NULL, SET DEFAULT or CASCADE is not supported in ON UPDATE operation.
+DROP TABLE referencing_table;
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON UPDATE SET DEFAULT);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  SET NULL, SET DEFAULT or CASCADE is not supported in ON UPDATE operation.
+DROP TABLE referencing_table;
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON UPDATE CASCADE);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  SET NULL, SET DEFAULT or CASCADE is not supported in ON UPDATE operation.
+DROP TABLE referencing_table;
+-- test foreign constraint creation on NOT co-located tables
+SET citus.shard_count TO 8;
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraint can only be created on co-located tables.
+DROP TABLE referencing_table;
+SET citus.shard_count TO 4;
+-- test foreign constraint creation on non-partition columns
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Partition column must exist both referencing and referenced side of the foreign constraint statement and it must be in the same ordinal in both sides.
+DROP TABLE referencing_table;
+-- test foreign constraint creation while column list are in incorrect order
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(id, ref_id) REFERENCES referenced_table(id, test_column));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Partition column must exist both referencing and referenced side of the foreign constraint statement and it must be in the same ordinal in both sides.
+DROP TABLE referencing_table;
+-- test foreign constraint with replication factor > 1
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Citus cannot create foreign key constrains if replication factor is greater than 1. Contact Citus Data for alternative deployment options.
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test foreign constraint with correct conditions
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- test inserts
+-- test insert to referencing table while there is NO corresponding value in referenced table
+INSERT INTO referencing_table VALUES(1, 1);
+ERROR:  insert or update on table "referencing_table_1350008" violates foreign key constraint "referencing_table_ref_id_fkey_1350008"
+DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350004".
+CONTEXT:  while executing command on localhost:57637
+-- test insert to referencing while there is corresponding value in referenced table
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+-- test deletes
+-- test delete from referenced table while there is corresponding value in referencing table
+DELETE FROM referenced_table WHERE id = 1;
+ERROR:  update or delete on table "referenced_table_1350004" violates foreign key constraint "referencing_table_ref_id_fkey_1350008" on table "referencing_table_1350008"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350008".
+CONTEXT:  while executing command on localhost:57637
+-- test delete from referenced table while there is NO corresponding value in referencing table
+DELETE FROM referencing_table WHERE ref_id = 1;
+DELETE FROM referenced_table WHERE id = 1;
+-- drop table for next tests
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test foreign constraint options
+-- test ON DELETE CASCADE
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE CASCADE);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+DELETE FROM referenced_table WHERE id = 1;
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+(0 rows)
+
+SELECT * FROM referenced_table;
+ id | test_column 
+----+-------------
+(0 rows)
+
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test ON DELETE NO ACTION + DEFERABLE + INITIALLY DEFERRED
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+DELETE FROM referenced_table WHERE id = 1;
+ERROR:  update or delete on table "referenced_table_1350020" violates foreign key constraint "referencing_table_ref_id_fkey_1350024" on table "referencing_table_1350024"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350024".
+CONTEXT:  while executing command on localhost:57637
+BEGIN;
+DELETE FROM referenced_table WHERE id = 1;
+DELETE FROM referencing_table WHERE ref_id = 1;
+COMMIT;
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+(0 rows)
+
+SELECT * FROM referenced_table;
+ id | test_column 
+----+-------------
+(0 rows)
+
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test ON DELETE RESTRICT
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE RESTRICT);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+BEGIN;
+DELETE FROM referenced_table WHERE id = 1;
+ERROR:  update or delete on table "referenced_table_1350028" violates foreign key constraint "referencing_table_ref_id_fkey_1350032" on table "referencing_table_1350032"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350032".
+CONTEXT:  while executing command on localhost:57637
+DELETE FROM referencing_table WHERE ref_id = 1;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+  1 |      1
+(1 row)
+
+SELECT * FROM referenced_table;
+ id | test_column 
+----+-------------
+  1 |           1
+(1 row)
+
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test ON UPDATE NO ACTION + DEFERABLE + INITIALLY DEFERRED
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) ON UPDATE NO ACTION DEFERRABLE INITIALLY DEFERRED);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+UPDATE referenced_table SET test_column = 10 WHERE id = 1;
+ERROR:  update or delete on table "referenced_table_1350036" violates foreign key constraint "referencing_table_ref_id_fkey_1350040" on table "referencing_table_1350040"
+DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350040".
+CONTEXT:  while executing command on localhost:57637
+BEGIN;
+UPDATE referenced_table SET test_column = 10 WHERE id = 1;
+UPDATE referencing_table SET id = 10 WHERE ref_id = 1;
+COMMIT;
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+ 10 |      1
+(1 row)
+
+SELECT * FROM referenced_table;
+ id | test_column 
+----+-------------
+  1 |          10
+(1 row)
+
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test ON UPDATE RESTRICT
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) ON UPDATE RESTRICT);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+BEGIN;
+UPDATE referenced_table SET test_column = 20 WHERE id = 1;
+ERROR:  update or delete on table "referenced_table_1350044" violates foreign key constraint "referencing_table_ref_id_fkey_1350048" on table "referencing_table_1350048"
+DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350048".
+CONTEXT:  while executing command on localhost:57637
+UPDATE referencing_table SET id = 20 WHERE ref_id = 1;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+  1 |      1
+(1 row)
+
+SELECT * FROM referenced_table;
+ id | test_column 
+----+-------------
+  1 |           1
+(1 row)
+
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test MATCH SIMPLE
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH SIMPLE);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referencing_table VALUES(null, 2);
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+    |      2
+(1 row)
+
+DELETE FROM referencing_table WHERE ref_id = 2;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test MATCH FULL
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH FULL);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO referencing_table VALUES(null, 2);
+ERROR:  insert or update on table "referencing_table_1350067" violates foreign key constraint "referencing_table_ref_id_fkey_1350067"
+DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
+CONTEXT:  while executing command on localhost:57638
+SELECT * FROM referencing_table;
+ id | ref_id 
+----+--------
+(0 rows)
+
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -188,3 +188,8 @@ test: multi_colocated_shard_transfer
 # multi_citus_tools tests utility functions written for citus tools
 # ----------
 test: multi_citus_tools
+
+# ----------
+# multi_foreign_key tests foreign key push down on distributed tables
+# ----------
+test: multi_foreign_key

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -43,6 +43,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-9';
 ALTER EXTENSION citus UPDATE TO '6.0-10';
 ALTER EXTENSION citus UPDATE TO '6.0-11';
 ALTER EXTENSION citus UPDATE TO '6.0-12';
+ALTER EXTENSION citus UPDATE TO '6.0-13';
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;

--- a/src/test/regress/sql/multi_foreign_key.sql
+++ b/src/test/regress/sql/multi_foreign_key.sql
@@ -1,0 +1,187 @@
+--
+-- MULTI_FOREIGN_KEY
+--
+
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1350000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1350000;
+
+-- set shard_count to 4 for faster tests, because we create/drop lots of shards in this test.
+SET citus.shard_count TO 4;
+
+-- create tables
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+
+-- test foreign constraint creation with not supported parameters
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE SET NULL);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE SET DEFAULT);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON UPDATE SET NULL);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON UPDATE SET DEFAULT);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON UPDATE CASCADE);
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+-- test foreign constraint creation on NOT co-located tables
+SET citus.shard_count TO 8;
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+SET citus.shard_count TO 4;
+
+-- test foreign constraint creation on non-partition columns
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+-- test foreign constraint creation while column list are in incorrect order
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(id, ref_id) REFERENCES referenced_table(id, test_column));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+
+-- test foreign constraint with replication factor > 1
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test foreign constraint with correct conditions
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+
+
+-- test inserts
+-- test insert to referencing table while there is NO corresponding value in referenced table
+INSERT INTO referencing_table VALUES(1, 1);
+
+-- test insert to referencing while there is corresponding value in referenced table
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+
+
+-- test deletes
+-- test delete from referenced table while there is corresponding value in referencing table
+DELETE FROM referenced_table WHERE id = 1;
+
+-- test delete from referenced table while there is NO corresponding value in referencing table
+DELETE FROM referencing_table WHERE ref_id = 1;
+DELETE FROM referenced_table WHERE id = 1;
+
+-- drop table for next tests
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test foreign constraint options
+-- test ON DELETE CASCADE
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE CASCADE);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+DELETE FROM referenced_table WHERE id = 1;
+SELECT * FROM referencing_table;
+SELECT * FROM referenced_table;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test ON DELETE NO ACTION + DEFERABLE + INITIALLY DEFERRED
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+DELETE FROM referenced_table WHERE id = 1;
+BEGIN;
+DELETE FROM referenced_table WHERE id = 1;
+DELETE FROM referencing_table WHERE ref_id = 1;
+COMMIT;
+SELECT * FROM referencing_table;
+SELECT * FROM referenced_table;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test ON DELETE RESTRICT
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE RESTRICT);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+BEGIN;
+DELETE FROM referenced_table WHERE id = 1;
+DELETE FROM referencing_table WHERE ref_id = 1;
+COMMIT;
+SELECT * FROM referencing_table;
+SELECT * FROM referenced_table;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test ON UPDATE NO ACTION + DEFERABLE + INITIALLY DEFERRED
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) ON UPDATE NO ACTION DEFERRABLE INITIALLY DEFERRED);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+UPDATE referenced_table SET test_column = 10 WHERE id = 1;
+BEGIN;
+UPDATE referenced_table SET test_column = 10 WHERE id = 1;
+UPDATE referencing_table SET id = 10 WHERE ref_id = 1;
+COMMIT;
+SELECT * FROM referencing_table;
+SELECT * FROM referenced_table;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test ON UPDATE RESTRICT
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) ON UPDATE RESTRICT);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referenced_table VALUES(1, 1);
+INSERT INTO referencing_table VALUES(1, 1);
+BEGIN;
+UPDATE referenced_table SET test_column = 20 WHERE id = 1;
+UPDATE referencing_table SET id = 20 WHERE ref_id = 1;
+COMMIT;
+SELECT * FROM referencing_table;
+SELECT * FROM referenced_table;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test MATCH SIMPLE
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH SIMPLE);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referencing_table VALUES(null, 2);
+SELECT * FROM referencing_table;
+DELETE FROM referencing_table WHERE ref_id = 2;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+
+-- test MATCH FULL
+CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
+CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH FULL);
+SELECT create_distributed_table('referenced_table', 'id', 'hash');
+SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
+INSERT INTO referencing_table VALUES(null, 2);
+SELECT * FROM referencing_table;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;


### PR DESCRIPTION
Foreign Constraint Support for create_distributed_table and shard move

With this change, we now push down foreign key constraints created during CREATE TABLE
statements. We also start to send foreign constraints during shard move along with
other DDL statements

This changes made over add_create_distributed_table branch. So first few commits are not belong to this PR. Reviewer only needs to check the final commit.

Fixes #881 