### PR TITLE
Don't crash when upgrading to citus 6

### DIFF
--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -338,7 +338,15 @@ LookupDistTableCacheEntry(Oid relationId)
 											 Anum_pg_dist_partition_repmodel,
 											 tupleDescriptor,
 											 &isNull);
-		Assert(!isNull);
+
+		if (isNull)
+		{
+			/*
+			 * repmodel is NOT NULL but before ALTER EXTENSION citus UPGRADE the column
+			 * doesn't exist
+			 */
+			replicationModelDatum = CharGetDatum('c');
+		}
 
 		oldContext = MemoryContextSwitchTo(CacheMemoryContext);
 		partitionKeyString = TextDatumGetCString(partitionKeyDatum);


### PR DESCRIPTION
Fixes #875. I couldn't reproduce the missing function error, but fixed the crash from https://github.com/citusdata/citus/pull/816