### PR TITLE
Re-disable master evaluation for SELECT

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1474,7 +1474,7 @@ RouterQueryJob(Query *query, Task *task, List *placementList)
 	Job *job = NULL;
 	List *taskList = NIL;
 	TaskType taskType = task->taskType;
-	bool requiresMasterEvaluation = RequiresMasterEvaluation(query);
+	bool requiresMasterEvaluation = false;
 
 	/*
 	 * We send modify task to the first replica, otherwise we choose the target shard
@@ -1484,6 +1484,7 @@ RouterQueryJob(Query *query, Task *task, List *placementList)
 	if (taskType == MODIFY_TASK)
 	{
 		taskList = FirstReplicaAssignTaskList(list_make1(task));
+		requiresMasterEvaluation = RequiresMasterEvaluation(query);
 	}
 	else
 	{

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -524,6 +524,23 @@ DETAIL:  Join types other than inner/outer joins are currently unsupported
 SELECT * FROM articles_hash WHERE author_id = (SELECT 1);
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Subqueries other than in from-clause are currently unsupported
+-- unless the query can be transformed into a join
+SELECT * FROM articles_hash
+WHERE author_id IN (SELECT author_id FROM articles_hash WHERE author_id = 2)
+ORDER BY articles_hash.id;
+DEBUG:  predicate pruning for shardId 840000
+DEBUG:  predicate pruning for shardId 840000
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id | author_id |   title    | word_count 
+----+-----------+------------+------------
+  2 |         2 | abducing   |      13642
+ 12 |         2 | archiblast |      18185
+ 22 |         2 | antipope   |       2728
+ 32 |         2 | amazon     |      11342
+ 42 |         2 | ausable    |      15885
+(5 rows)
+
 -- subqueries are supported in FROM clause but they are not router plannable
 SELECT articles_hash.id,test.word_count
 FROM articles_hash, (SELECT id, word_count FROM articles_hash) AS test WHERE test.id = articles_hash.id

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -250,6 +250,10 @@ SELECT * FROM articles_hash WHERE author_id IN (SELECT author_id FROM articles_h
 
 SELECT * FROM articles_hash WHERE author_id = (SELECT 1);
 
+-- unless the query can be transformed into a join
+SELECT * FROM articles_hash
+WHERE author_id IN (SELECT author_id FROM articles_hash WHERE author_id = 2)
+ORDER BY articles_hash.id;
 
 -- subqueries are supported in FROM clause but they are not router plannable
 SELECT articles_hash.id,test.word_count


### PR DESCRIPTION
#855 spuriously changed the behaviour of requiresMasterEvaluation by setting it to true for SELECTs as well, which can cause an assert failures for certain queries, but we didn't have a regression test to capture that. This change fixes the issue and adds a test.

Fixes #893 