### PR TITLE
Disable EXPLAIN EXECUTE under citus

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -181,6 +181,23 @@ multi_ProcessUtility(Node *parsetree,
 		return;
 	}
 
+	if (IsA(parsetree, ExplainStmt))
+	{
+		ExplainStmt *explainStmt = (ExplainStmt *) parsetree;
+
+		if (IsA(explainStmt->query, Query))
+		{
+			Query *query = (Query *) explainStmt->query;
+
+			if (query->commandType == CMD_UTILITY &&
+				IsA(query->utilityStmt, ExecuteStmt))
+			{
+				/* Due to a postgres limitation these cause crashes. Skip them for now */
+				ereport(ERROR, (errmsg("Citus does not support EXPLAIN EXECUTE")));
+			}
+		}
+	}
+
 	if (IsA(parsetree, CopyStmt))
 	{
 		parsetree = ProcessCopyStmt((CopyStmt *) parsetree, completionTag,


### PR DESCRIPTION
Fix #886, although terribly. Disables `EXPLAIN EXECUTE` system-wide, regardless of whether the planned query is a distributed one or not.

Proposing it so we can have a version of Citus which doesn't crash. If we have time for a real fix we might either:
- see why the crash happens and fix that
- only disable `EXPLAIN EXECUTE` where the cached plan came from one of our distributed planners