### PR TITLE
Fix EXPLAIN EXECUTE for simple queries

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -181,6 +181,23 @@ multi_ProcessUtility(Node *parsetree,
 		return;
 	}
 
+	if (IsA(parsetree, ExplainStmt))
+	{
+		ExplainStmt *explainStmt = (ExplainStmt *) parsetree;
+
+		if (IsA(explainStmt->query, Query))
+		{
+			Query *query = (Query *) explainStmt->query;
+
+			if (query->commandType == CMD_UTILITY &&
+				IsA(query->utilityStmt, ExecuteStmt))
+			{
+				/* Due to a postgres limitation these cause crashes. Skip them for now */
+				ereport(ERROR, (errmsg("Citus does not support EXPLAIN EXECUTE")));
+			}
+		}
+	}
+
 	if (IsA(parsetree, CopyStmt))
 	{
 		parsetree = ProcessCopyStmt((CopyStmt *) parsetree, completionTag,


### PR DESCRIPTION
Some drawbacks:
- Doesn't support parameters for distributed queries (even for queries like INSERT where Citus usually supports them)
- Might interact badly with query rewriting? I think it tries to rewrite rewritten queries.

An alternative to PR #897 