### PR TITLE
EXPLAIN EXECUTE no longer segfaults

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -69,7 +69,6 @@ typedef struct WalkerState
 	bool badCoalesce;
 } WalkerState;
 
-
 /* planner functions forward declarations */
 static MultiPlan * CreateSingleTaskRouterPlan(Query *originalQuery, Query *query,
 											  RelationRestrictionContext *
@@ -98,7 +97,6 @@ static List * QueryRestrictList(Query *query);
 static bool FastShardPruningPossible(CmdType commandType, char partitionMethod);
 static ShardInterval * FastShardPruning(Oid distributedTableId,
 										Const *partionColumnValue);
-static Oid ExtractFirstDistributedTableId(Query *query);
 static Const * ExtractInsertPartitionValue(Query *query, Var *partitionColumn);
 static Task * RouterSelectTask(Query *originalQuery,
 							   RelationRestrictionContext *restrictionContext,
@@ -1754,7 +1752,7 @@ QueryRestrictList(Query *query)
  * for the first distributed table in that query. If the function cannot find a
  * distributed table, it returns InvalidOid.
  */
-static Oid
+Oid
 ExtractFirstDistributedTableId(Query *query)
 {
 	List *rangeTableList = NIL;

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -37,5 +37,6 @@ extern Query * ReorderInsertSelectTargetLists(Query *originalQuery,
 											  RangeTblEntry *insertRte,
 											  RangeTblEntry *subqueryRte);
 extern bool InsertSelectQuery(Query *query);
+extern Oid ExtractFirstDistributedTableId(Query *query);
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -670,3 +670,47 @@ Distributed Query into pg_merge_job_570037
 Master Query
   ->  Aggregate
         ->  Seq Scan on pg_merge_job_570037
+-- ensure EXPLAIN EXECUTE doesn't crash
+PREPARE task_tracker_query AS
+	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
+EXPLAIN (COSTS FALSE) EXECUTE task_tracker_query;
+Distributed Query into pg_merge_job_570038
+  Executor: Task-Tracker
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Aggregate
+              ->  Seq Scan on lineitem_290005 lineitem
+                    Filter: (l_orderkey > 9030)
+Master Query
+  ->  Aggregate
+        ->  Seq Scan on pg_merge_job_570038
+SET citus.task_executor_type TO 'real-time';
+PREPARE router_executor_query AS SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;
+EXPLAIN EXECUTE router_executor_query;
+Distributed Query into pg_merge_job_570039
+  Executor: Router
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Bitmap Heap Scan on lineitem_290000 lineitem  (cost=4.30..13.44 rows=3 width=18)
+              Recheck Cond: (l_orderkey = 5)
+              ->  Bitmap Index Scan on lineitem_pkey_290000  (cost=0.00..4.30 rows=3 width=0)
+                    Index Cond: (l_orderkey = 5)
+PREPARE real_time_executor_query AS
+	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
+EXPLAIN (COSTS FALSE) EXECUTE real_time_executor_query;
+Distributed Query into pg_merge_job_570040
+  Executor: Real-Time
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Aggregate
+              ->  Seq Scan on lineitem_290005 lineitem
+                    Filter: (l_orderkey > 9030)
+Master Query
+  ->  Aggregate
+        ->  Seq Scan on pg_merge_job_570040

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -641,3 +641,47 @@ Distributed Query into pg_merge_job_570037
 Master Query
   ->  Aggregate
         ->  Seq Scan on pg_merge_job_570037
+-- ensure EXPLAIN EXECUTE doesn't crash
+PREPARE task_tracker_query AS
+	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
+EXPLAIN (COSTS FALSE) EXECUTE task_tracker_query;
+Distributed Query into pg_merge_job_570038
+  Executor: Task-Tracker
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Aggregate
+              ->  Seq Scan on lineitem_290005 lineitem
+                    Filter: (l_orderkey > 9030)
+Master Query
+  ->  Aggregate
+        ->  Seq Scan on pg_merge_job_570038
+SET citus.task_executor_type TO 'real-time';
+PREPARE router_executor_query AS SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;
+EXPLAIN EXECUTE router_executor_query;
+Distributed Query into pg_merge_job_570039
+  Executor: Router
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Bitmap Heap Scan on lineitem_290000 lineitem  (cost=4.30..13.44 rows=3 width=18)
+              Recheck Cond: (l_orderkey = 5)
+              ->  Bitmap Index Scan on lineitem_pkey_290000  (cost=0.00..4.30 rows=3 width=0)
+                    Index Cond: (l_orderkey = 5)
+PREPARE real_time_executor_query AS
+	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
+EXPLAIN (COSTS FALSE) EXECUTE real_time_executor_query;
+Distributed Query into pg_merge_job_570040
+  Executor: Real-Time
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Aggregate
+              ->  Seq Scan on lineitem_290005 lineitem
+                    Filter: (l_orderkey > 9030)
+Master Query
+  ->  Aggregate
+        ->  Seq Scan on pg_merge_job_570040

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -200,3 +200,17 @@ EXPLAIN (COSTS FALSE) SELECT avg(l_linenumber) FROM lineitem_clone;
 
 -- ensure distributed plans don't break
 EXPLAIN (COSTS FALSE) SELECT avg(l_linenumber) FROM lineitem;
+
+-- ensure EXPLAIN EXECUTE doesn't crash
+PREPARE task_tracker_query AS
+	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
+EXPLAIN (COSTS FALSE) EXECUTE task_tracker_query;
+
+SET citus.task_executor_type TO 'real-time';
+
+PREPARE router_executor_query AS SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;
+EXPLAIN EXECUTE router_executor_query;
+
+PREPARE real_time_executor_query AS
+	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
+EXPLAIN (COSTS FALSE) EXECUTE real_time_executor_query;


### PR DESCRIPTION
Fix #886

The way postgres' explain hook is designed means our hook is never called during
EXPLAIN EXECUTE. So, we special-case EXPLAIN EXECUTE by catching it in the utility hook.
We then replace the EXECUTE with the original query and pass it back to Postgres.

TODO:
- Does this leak memory?
- Add some regression tests!

It doesn't work with parameterized queries (even ones which would have worked if they weren't run under EXPLAIN, such as INSERT) but that's a much larger commit.