### PR TITLE
Fix function schemas

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -8,7 +8,7 @@ EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
-	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13
+	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -83,6 +83,8 @@ $(EXTENSION)--6.0-11.sql: $(EXTENSION)--6.0-10.sql $(EXTENSION)--6.0-10--6.0-11.
 $(EXTENSION)--6.0-12.sql: $(EXTENSION)--6.0-11.sql $(EXTENSION)--6.0-11--6.0-12.sql
 	cat $^ > $@
 $(EXTENSION)--6.0-13.sql: $(EXTENSION)--6.0-12.sql $(EXTENSION)--6.0-12--6.0-13.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-14.sql: $(EXTENSION)--6.0-13.sql $(EXTENSION)--6.0-13--6.0-14.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.0-13--6.0-14.sql
+++ b/src/backend/distributed/citus--6.0-13--6.0-14.sql
@@ -1,0 +1,25 @@
+/* citus--6.0-13--6.0-14.sql */
+
+DO $ff$
+BEGIN
+	-- fix functions created in wrong namespace
+	ALTER FUNCTION public.recover_prepared_transactions()
+	SET SCHEMA pg_catalog;
+
+	ALTER FUNCTION public.column_name_to_column(table_name regclass, column_name text)
+	SET SCHEMA pg_catalog;
+
+	ALTER FUNCTION public.worker_drop_distributed_table(logicalrelid Oid)
+	SET SCHEMA pg_catalog;
+
+	ALTER FUNCTION public.master_get_new_placementid()
+	SET SCHEMA pg_catalog;
+
+	ALTER FUNCTION public.master_expire_table_cache(table_name regclass)
+	SET SCHEMA pg_catalog;
+
+-- some installations don't need this corrective, so just skip...
+EXCEPTION WHEN undefined_function THEN
+	-- do nothing
+END
+$ff$;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.0-13'
+default_version = '6.0-14'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -7,6 +7,20 @@
 -- not done yet.
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 580000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 580000;
+-- ensure no objects were created outside pg_catalog
+SELECT COUNT(*)
+FROM pg_depend AS pgd,
+	 pg_extension AS pge,
+	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
+WHERE pgd.refclassid = 'pg_extension'::regclass AND
+	  pgd.refobjid   = pge.oid AND
+	  pge.extname    = 'citus' AND
+	  pgio.schema    NOT IN ('pg_catalog', 'citus');
+ count 
+-------
+     0
+(1 row)
+
 -- DROP EXTENSION pre-created by the regression suite
 DROP EXTENSION citus;
 \c
@@ -39,6 +53,21 @@ ALTER EXTENSION citus UPDATE TO '6.0-10';
 ALTER EXTENSION citus UPDATE TO '6.0-11';
 ALTER EXTENSION citus UPDATE TO '6.0-12';
 ALTER EXTENSION citus UPDATE TO '6.0-13';
+ALTER EXTENSION citus UPDATE TO '6.0-14';
+-- ensure no objects were created outside pg_catalog
+SELECT COUNT(*)
+FROM pg_depend AS pgd,
+	 pg_extension AS pge,
+	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
+WHERE pgd.refclassid = 'pg_extension'::regclass AND
+	  pgd.refobjid   = pge.oid AND
+	  pge.extname    = 'citus' AND
+	  pgio.schema    NOT IN ('pg_catalog', 'citus');
+ count 
+-------
+     0
+(1 row)
+
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;
 \c

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -10,6 +10,15 @@
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 580000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 580000;
 
+-- ensure no objects were created outside pg_catalog
+SELECT COUNT(*)
+FROM pg_depend AS pgd,
+	 pg_extension AS pge,
+	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
+WHERE pgd.refclassid = 'pg_extension'::regclass AND
+	  pgd.refobjid   = pge.oid AND
+	  pge.extname    = 'citus' AND
+	  pgio.schema    NOT IN ('pg_catalog', 'citus');
 
 -- DROP EXTENSION pre-created by the regression suite
 DROP EXTENSION citus;
@@ -44,6 +53,17 @@ ALTER EXTENSION citus UPDATE TO '6.0-10';
 ALTER EXTENSION citus UPDATE TO '6.0-11';
 ALTER EXTENSION citus UPDATE TO '6.0-12';
 ALTER EXTENSION citus UPDATE TO '6.0-13';
+ALTER EXTENSION citus UPDATE TO '6.0-14';
+
+-- ensure no objects were created outside pg_catalog
+SELECT COUNT(*)
+FROM pg_depend AS pgd,
+	 pg_extension AS pge,
+	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
+WHERE pgd.refclassid = 'pg_extension'::regclass AND
+	  pgd.refobjid   = pge.oid AND
+	  pge.extname    = 'citus' AND
+	  pgio.schema    NOT IN ('pg_catalog', 'citus');
 
 -- drop extension an re-create in newest version
 DROP EXTENSION citus;


### PR DESCRIPTION
We'd been relying on a single `SET search_path` command in an earlier script, but a subsequent script `RESET search_path`, causing any further bare functions to be created in the first schema on the search path.

However, starting with an older extension version and executing `ALTER` scripts one at a time **does** avoid putting any functions in the public namespace, so I wrote my own upgrade script by  specifying a `search_path` and not qualifying function names in my `ALTER FUNCTION` statements.

Fixes #882