### PR TITLE
[WIP] Add UDF which returns the currently running version of the code

### DIFF
--- a/Makefile.global.in
+++ b/Makefile.global.in
@@ -44,8 +44,8 @@ $(citus_top_builddir)/Makefile.global: $(citus_abs_top_srcdir)/configure $(citus
 $(citus_top_builddir)/config.status: $(citus_abs_top_srcdir)/configure
 	cd @abs_top_builddir@ && ./config.status --recheck
 
-# Regenerate configure if configure.in changed
-$(citus_abs_top_srcdir)/configure: $(citus_abs_top_srcdir)/configure.in
+# Regenerate configure if configure.in or citus.control (which has our version #) changed
+$(citus_abs_top_srcdir)/configure: $(citus_abs_top_srcdir)/configure.in $(citus_abs_top_srcdir)/src/backend/distributed/citus.control
 	cd ${citus_abs_top_srcdir} && ./autogen.sh
 
 # If specified via configure, replace the default compiler. Normally

--- a/configure
+++ b/configure
@@ -618,6 +618,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -689,6 +690,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -941,6 +943,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1078,7 +1089,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1231,6 +1242,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1921,6 +1933,14 @@ else
    { $as_echo "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num" >&5
 $as_echo "$as_me: building against PostgreSQL $version_num" >&6;}
 fi;
+
+citus_version=$(grep "default_version" src/backend/distributed/citus.control | cut -d\' -f2)
+format_check=$(echo "$citus_version" | grep -E "^[0-9]+\.[0-9]+-[0-9]+$")
+if (( $? )); then
+  as_fn_error $? "Citus version \"$citus_version\", found in citus.control, is in the wrong format" "$LINENO" 5
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: Citus version \"$citus_version\"" >&5
+$as_echo "$as_me: Citus version \"$citus_version\"" >&6;}
 
 # Check whether we're building inside the source tree, if not, prepare
 # the build directory.
@@ -2943,6 +2963,11 @@ ac_config_files="$ac_config_files Makefile.global"
 
 ac_config_headers="$ac_config_headers src/include/citus_config.h"
 
+
+
+cat >>confdefs.h <<_ACEOF
+#define CITUS_VERSION "$citus_version"
+_ACEOF
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure

--- a/configure.in
+++ b/configure.in
@@ -42,6 +42,13 @@ else
    AC_MSG_NOTICE([building against PostgreSQL $version_num])
 fi;
 
+citus_version=$(grep "default_version" src/backend/distributed/citus.control | cut -d\' -f2)
+format_check=$(echo "$citus_version" | grep -E "^@<:@0-9@:>@+\.@<:@0-9@:>@+-@<:@0-9@:>@+$")
+if (( $? )); then
+  AC_MSG_ERROR([Citus version "$citus_version", found in citus.control, is in the wrong format])
+fi
+AC_MSG_NOTICE([Citus version "$citus_version"])
+
 # Check whether we're building inside the source tree, if not, prepare
 # the build directory.
 if test "$srcdir" -ef '.' ; then
@@ -114,4 +121,5 @@ AH_TOP([
  * Do not manually edit!
  */
 ])
+AC_DEFINE_UNQUOTED([CITUS_VERSION], "$citus_version", [so the shared-library knows its own version])
 AC_OUTPUT

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -8,7 +8,21 @@ EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
-	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15
+	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 \
+	6.0-13 6.0-14 6.0-15 6.0-16
+
+ifeq ($(wildcard citus.control),)
+  $(error citus.control not found!)
+endif
+MODVERSION = $(shell grep "default_version" citus.control | grep -oE "'[0-9]+\.[0-9]+-[0-9]+'")
+ifeq ($(MODVERSION),)
+WRONGVERSION = $(shell grep "default_version" citus.control | grep -oE "'.*'")
+  $(warning version $(WRONGVERSION) is incorrect)
+  $(error the version in citus.control should match: \d+.\d+-\d+)
+endif
+CITUS_VERSION = $(shell echo $(MODVERSION) | sed "s/\'//")
+$(info building citus version $(CITUS_VERSION))
+override CFLAGS+=-DCITUS_VERSION=$(CITUS_VERSION)
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -87,6 +101,8 @@ $(EXTENSION)--6.0-13.sql: $(EXTENSION)--6.0-12.sql $(EXTENSION)--6.0-12--6.0-13.
 $(EXTENSION)--6.0-14.sql: $(EXTENSION)--6.0-13.sql $(EXTENSION)--6.0-13--6.0-14.sql
 	cat $^ > $@
 $(EXTENSION)--6.0-15.sql: $(EXTENSION)--6.0-14.sql $(EXTENSION)--6.0-14--6.0-15.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-16.sql: $(EXTENSION)--6.0-15.sql $(EXTENSION)--6.0-15--6.0-16.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -11,19 +11,6 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 \
 	6.0-13 6.0-14 6.0-15 6.0-16
 
-ifeq ($(wildcard citus.control),)
-  $(error citus.control not found!)
-endif
-MODVERSION = $(shell grep "default_version" citus.control | grep -oE "'[0-9]+\.[0-9]+-[0-9]+'")
-ifeq ($(MODVERSION),)
-WRONGVERSION = $(shell grep "default_version" citus.control | grep -oE "'.*'")
-  $(warning version $(WRONGVERSION) is incorrect)
-  $(error the version in citus.control should match: \d+.\d+-\d+)
-endif
-CITUS_VERSION = $(shell echo $(MODVERSION) | sed "s/\'//")
-$(info building citus version $(CITUS_VERSION))
-override CFLAGS+=-DCITUS_VERSION=$(CITUS_VERSION)
-
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
 # Generated files for each version

--- a/src/backend/distributed/citus--6.0-15--6.0-16.sql
+++ b/src/backend/distributed/citus--6.0-15--6.0-16.sql
@@ -1,0 +1,8 @@
+/* citus--6.0-9--6.0-10.sql */
+
+CREATE FUNCTION citus_running_version()
+  RETURNS text
+  LANGUAGE C IMMUTABLE
+  AS 'MODULE_PATHNAME', $$citus_running_version$$;
+COMMENT ON FUNCTION citus_running_version()
+  IS 'Get the version of the loaded citus module';

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.0-15'
+default_version = '6.0-16'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/citus_version.c
+++ b/src/backend/distributed/commands/citus_version.c
@@ -1,0 +1,40 @@
+/*-------------------------------------------------------------------------
+ *
+ * create_distributed_relation.c
+ *	  Routines relation to the creation of distributed relations.
+ *
+ * Copyright (c) 2012-2016, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+
+#include "utils/builtins.h"
+
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(citus_running_version);
+
+#if !defined(CITUS_VERSION)
+#error Something went wrong, CITUS_VERSION is not set!
+#endif
+
+#define STRINGIFY(x) #x
+#define MACRO(x) STRINGIFY(x)
+
+/*
+ * citus_running_version returns the version string the currently running code was built
+ * with.
+ */
+Datum
+citus_running_version(PG_FUNCTION_ARGS)
+{
+	const char *versionStr = MACRO(CITUS_VERSION);
+	text *versionText = cstring_to_text(versionStr);
+
+	PG_RETURN_TEXT_P(versionText);
+}

--- a/src/backend/distributed/commands/citus_version.c
+++ b/src/backend/distributed/commands/citus_version.c
@@ -11,9 +11,9 @@
 #include "postgres.h"
 
 #include "fmgr.h"
-#include "lib/stringinfo.h"
 
 #include "utils/builtins.h"
+#include "citus_config.h"
 
 
 /* exports for SQL callable functions */
@@ -23,9 +23,6 @@ PG_FUNCTION_INFO_V1(citus_running_version);
 #error Something went wrong, CITUS_VERSION is not set!
 #endif
 
-#define STRINGIFY(x) #x
-#define MACRO(x) STRINGIFY(x)
-
 /*
  * citus_running_version returns the version string the currently running code was built
  * with.
@@ -33,7 +30,7 @@ PG_FUNCTION_INFO_V1(citus_running_version);
 Datum
 citus_running_version(PG_FUNCTION_ARGS)
 {
-	const char *versionStr = MACRO(CITUS_VERSION);
+	const char *versionStr = CITUS_VERSION;
 	text *versionText = cstring_to_text(versionStr);
 
 	PG_RETURN_TEXT_P(versionText);

--- a/src/include/citus_config.h.in
+++ b/src/include/citus_config.h.in
@@ -10,6 +10,9 @@
  */
 
 
+/* so the shared-library knows its own version */
+#undef CITUS_VERSION
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 


### PR DESCRIPTION
Starting with our next upgrade script, we can add a check which makes sure the code is running the new version before the script attempts to upgrade.

TODO: This should instead accept a version string and return whether it's safe to continue with an `ALTER EXTENSION citus UPDATE`. Opened a PR to see what you thought of this approach for passing the version in.

TODO: rebase, fix some comments, clean up imports, better commit message. This is very sloppy, it's made public solely to get feedback on the approach :)
