### PR TITLE
Only repair given shard

### DIFF
--- a/src/test/regress/expected/multi_colocated_shard_transfer.out
+++ b/src/test/regress/expected/multi_colocated_shard_transfer.out
@@ -63,7 +63,7 @@ ORDER BY s.shardid;
  1300002 | table1_group1 |    57637 |         1000 |          1
  1300003 | table1_group1 |    57637 |         1000 |          1
  1300003 | table1_group1 |    57638 |         1000 |          1
- 1300004 | table2_group1 |    57638 |         1000 |          1
+ 1300004 | table2_group1 |    57638 |         1000 |          3
  1300004 | table2_group1 |    57637 |         1000 |          1
  1300005 | table2_group1 |    57637 |         1000 |          1
  1300005 | table2_group1 |    57638 |         1000 |          1
@@ -187,7 +187,7 @@ ORDER BY s.shardid;
  1300002 | table1_group1 |    57637 |         1000 |          1
  1300003 | table1_group1 |    57637 |         1000 |          1
  1300003 | table1_group1 |    57638 |         1000 |          1
- 1300004 | table2_group1 |    57638 |         1000 |          1
+ 1300004 | table2_group1 |    57638 |         1000 |          3
  1300004 | table2_group1 |    57637 |         1000 |          1
  1300005 | table2_group1 |    57637 |         1000 |          1
  1300005 | table2_group1 |    57638 |         1000 |          1
@@ -219,7 +219,7 @@ ORDER BY s.shardid;
  1300002 | table1_group1 |    57637 |         1000 |          1
  1300003 | table1_group1 |    57637 |         1000 |          1
  1300003 | table1_group1 |    57638 |         1000 |          1
- 1300004 | table2_group1 |    57638 |         1000 |          1
+ 1300004 | table2_group1 |    57638 |         1000 |          3
  1300004 | table2_group1 |    57637 |         1000 |          1
  1300005 | table2_group1 |    57637 |         1000 |          1
  1300005 | table2_group1 |    57638 |         1000 |          1


### PR DESCRIPTION
Previously, when a repair is requested on a shard, we also repair all co-located shards
of given shard, which may cause repairing already healthy shards. With this change, we
only repair given shard.