### PR TITLE
Add citus.node_connection_timeout GUC

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -28,6 +28,7 @@
 #include "utils/memutils.h"
 
 
+int NodeConnectionTimeout = 5000;
 HTAB *ConnectionHash = NULL;
 MemoryContext ConnectionContext = NULL;
 
@@ -455,10 +456,10 @@ FinishConnectionEstablishment(MultiConnection *connection)
 
 				if (TimestampDifferenceExceeds(connection->connectionStart,
 											   GetCurrentTimestamp(),
-											   CLIENT_CONNECT_TIMEOUT_SECONDS_INT * 1000))
+											   NodeConnectionTimeout))
 				{
 					ereport(WARNING, (errmsg("could not establish connection after %u ms",
-											 CLIENT_CONNECT_TIMEOUT_SECONDS_INT * 1000)));
+											 NodeConnectionTimeout)));
 
 					/* close connection, otherwise we take up resource on the other side */
 					PQfinish(connection->pgConn);

--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -24,6 +24,7 @@
 #include <poll.h>
 
 #include "commands/dbcommands.h"
+#include "distributed/connection_management.h"
 #include "distributed/multi_client_executor.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/multi_server_executor.h"
@@ -332,11 +333,11 @@ ManageTaskExecution(Task *task, TaskExecution *taskExecution,
 			{
 				if (TimestampDifferenceExceeds(taskExecution->connectStartTime,
 											   GetCurrentTimestamp(),
-											   REMOTE_NODE_CONNECT_TIMEOUT))
+											   NodeConnectionTimeout))
 				{
 					ereport(WARNING, (errmsg("could not establish asynchronous "
 											 "connection after %u ms",
-											 REMOTE_NODE_CONNECT_TIMEOUT)));
+											 NodeConnectionTimeout)));
 
 					taskStatusArray[currentIndex] = EXEC_TASK_FAILED;
 				}

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -19,6 +19,7 @@
 #include "commands/explain.h"
 #include "executor/executor.h"
 #include "distributed/citus_nodefuncs.h"
+#include "distributed/connection_management.h"
 #include "distributed/commit_protocol.h"
 #include "distributed/connection_management.h"
 #include "distributed/master_protocol.h"
@@ -203,6 +204,16 @@ CreateRequiredDirectories(void)
 static void
 RegisterCitusConfigVariables(void)
 {
+	DefineCustomIntVariable(
+		"citus.node_connection_timeout",
+		gettext_noop("Sets the maximum duration to connect to worker nodes."),
+		NULL,
+		&NodeConnectionTimeout,
+		5000, 10, 60 * 60 * 1000,
+		PGC_USERSET,
+		GUC_UNIT_MS,
+		NULL, NULL, NULL);
+
 	/* keeping temporarily for updates from pre-6.0 versions */
 	DefineCustomStringVariable(
 		"citus.worker_list_file",
@@ -422,7 +433,7 @@ RegisterCitusConfigVariables(void)
 					 "progress. This configuration value sets the time "
 					 "interval between two consequent checks."),
 		&RemoteTaskCheckInterval,
-		10, 1, REMOTE_NODE_CONNECT_TIMEOUT,
+		10, 1, INT_MAX,
 		PGC_USERSET,
 		GUC_UNIT_MS,
 		NULL, NULL, NULL);

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -20,8 +20,6 @@
 /* maximum (textual) lengths of hostname and port */
 #define MAX_NODE_LENGTH 255 /* includes 0 byte */
 
-#define CLIENT_CONNECT_TIMEOUT_SECONDS_INT 5
-
 /* forward declare, to avoid forcing large headers on everyone */
 struct pg_conn; /* target of the PGconn typedef */
 struct MemoryContextData;
@@ -97,6 +95,9 @@ typedef struct ConnectionHashEntry
 	ConnectionHashKey key;
 	dlist_head *connections;
 } ConnectionHashEntry;
+
+/* maximum duration to wait for connection */
+extern int NodeConnectionTimeout;
 
 /* the hash table */
 extern HTAB *ConnectionHash;

--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -21,7 +21,6 @@
 
 #define MAX_TASK_EXECUTION_FAILURES 3 /* allowed failure count for one task */
 #define MAX_TRACKER_FAILURE_COUNT 3   /* allowed failure count for one tracker */
-#define REMOTE_NODE_CONNECT_TIMEOUT 4000 /* async connect timeout in ms */
 #define RESERVED_FD_COUNT 64           /* file descriptors unavailable to executor */
 
 /* copy out query results */


### PR DESCRIPTION
This change adds a new GUC `citus.node_connection_timeout` and replaces previously used three `#define`s about connection timeouts:
- `CLIENT_CONNECTION_TIMEOUT`
- `CLIENT_CONNECTION_TIMEOUT_SECONDS`
- `REMOTE_NODE_CONNECT_TIMEOUT`

Fixes #72 
Fixes #158 
Fixes #180
