### PR TITLE
Invalidate relcache after pg_dist_shard_placement changes.

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -8,7 +8,7 @@ EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
-	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14
+	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -85,6 +85,8 @@ $(EXTENSION)--6.0-12.sql: $(EXTENSION)--6.0-11.sql $(EXTENSION)--6.0-11--6.0-12.
 $(EXTENSION)--6.0-13.sql: $(EXTENSION)--6.0-12.sql $(EXTENSION)--6.0-12--6.0-13.sql
 	cat $^ > $@
 $(EXTENSION)--6.0-14.sql: $(EXTENSION)--6.0-13.sql $(EXTENSION)--6.0-13--6.0-14.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-15.sql: $(EXTENSION)--6.0-14.sql $(EXTENSION)--6.0-14--6.0-15.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.0-14--6.0-15.sql
+++ b/src/backend/distributed/citus--6.0-14--6.0-15.sql
@@ -1,0 +1,14 @@
+/* citus--6.0-14--6.0-15.sql */
+
+
+CREATE FUNCTION pg_catalog.master_dist_placement_cache_invalidate()
+    RETURNS trigger
+    LANGUAGE C
+    AS 'MODULE_PATHNAME', $$master_dist_placement_cache_invalidate$$;
+COMMENT ON FUNCTION master_dist_placement_cache_invalidate()
+    IS 'register relcache invalidation for changed placements';
+
+CREATE TRIGGER dist_placement_cache_invalidate
+    AFTER INSERT OR UPDATE OR DELETE
+    ON pg_catalog.pg_dist_shard_placement
+    FOR EACH ROW EXECUTE PROCEDURE master_dist_placement_cache_invalidate();

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.0-14'
+default_version = '6.0-15'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -58,6 +58,7 @@ extern ShardInterval * LoadShardInterval(uint64 shardId);
 extern DistTableCacheEntry * DistributedTableCacheEntry(Oid distributedRelationId);
 extern int GetLocalGroupId(void);
 extern void CitusInvalidateRelcacheByRelid(Oid relationId);
+extern void CitusInvalidateRelcacheByShardId(int64 shardId);
 extern void CitusInvalidateNodeCache(void);
 
 extern bool CitusHasBeenLoaded(void);

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -54,6 +54,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-11';
 ALTER EXTENSION citus UPDATE TO '6.0-12';
 ALTER EXTENSION citus UPDATE TO '6.0-13';
 ALTER EXTENSION citus UPDATE TO '6.0-14';
+ALTER EXTENSION citus UPDATE TO '6.0-15';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -820,5 +820,95 @@ SELECT * FROM prepare_table ORDER BY key, value;
    0 |      
 (6 rows)
 
+-- verify placement state updates invalidate shard state
+--
+-- We use a immutable function to check for that. The planner will
+-- evaluate it once during planning, during execution it should never
+-- be reached (no rows). That way we'll see a NOTICE when
+-- (re-)planning, but not when executing.
+-- first create helper function
+CREATE OR REPLACE FUNCTION immutable_bleat(text) RETURNS int LANGUAGE plpgsql IMMUTABLE AS $$BEGIN RAISE NOTICE '%', $1;RETURN 1;END$$;
+\c - - - :worker_1_port
+CREATE OR REPLACE FUNCTION immutable_bleat(text) RETURNS int LANGUAGE plpgsql IMMUTABLE AS $$BEGIN RAISE NOTICE '%', $1;RETURN 1;END$$;
+\c - - - :worker_2_port
+CREATE OR REPLACE FUNCTION immutable_bleat(text) RETURNS int LANGUAGE plpgsql IMMUTABLE AS $$BEGIN RAISE NOTICE '%', $1;RETURN 1;END$$;
+\c - - - :master_port
+-- test table
+CREATE TABLE test_table (test_id integer NOT NULL, data text);
+SELECT master_create_distributed_table('test_table', 'test_id', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('test_table', 2, 2);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+-- avoid 9.6+ only context messages
+\set VERBOSITY terse
+--plain statement, needs planning
+SELECT count(*) FROM test_table HAVING COUNT(*) = immutable_bleat('replanning');
+NOTICE:  replanning
+ count 
+-------
+(0 rows)
+
+--prepared statement
+PREPARE countsome AS SELECT count(*) FROM test_table HAVING COUNT(*) = immutable_bleat('replanning');
+EXECUTE countsome; -- should indicate planning
+NOTICE:  replanning
+ count 
+-------
+(0 rows)
+
+EXECUTE countsome; -- no replanning
+ count 
+-------
+(0 rows)
+
+-- invalidate half of the placements using SQL, should invalidate via trigger
+UPDATE pg_dist_shard_placement SET shardstate = '3'
+WHERE shardid IN (
+        SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_table'::regclass)
+    AND nodeport = :worker_1_port;
+EXECUTE countsome; -- should indicate replanning
+NOTICE:  replanning
+ count 
+-------
+(0 rows)
+
+EXECUTE countsome; -- no replanning
+ count 
+-------
+(0 rows)
+
+-- repair shards, should invalidate via master_metadata_utility.c
+SELECT master_copy_shard_placement(shardid, 'localhost', :worker_2_port, 'localhost', :worker_1_port)
+FROM pg_dist_shard_placement
+WHERE shardid IN (
+        SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_table'::regclass)
+    AND nodeport = :worker_1_port;
+ master_copy_shard_placement 
+-----------------------------
+ 
+ 
+(2 rows)
+
+EXECUTE countsome; -- should indicate replanning
+NOTICE:  replanning
+ count 
+-------
+(0 rows)
+
+EXECUTE countsome; -- no replanning
+ count 
+-------
+(0 rows)
+
+-- reset
+\set VERBOSITY default
 -- clean-up prepared statements
 DEALLOCATE ALL;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -54,6 +54,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-11';
 ALTER EXTENSION citus UPDATE TO '6.0-12';
 ALTER EXTENSION citus UPDATE TO '6.0-13';
 ALTER EXTENSION citus UPDATE TO '6.0-14';
+ALTER EXTENSION citus UPDATE TO '6.0-15';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)


### PR DESCRIPTION
This forces prepared statements to be re-planned after changes of the
placement metadata. There's some locking issues remaining, but that's a
a separate task.

See: #127 