### PR TITLE
Re-acquire metadata locks in RouterExecutorStart

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -57,6 +57,7 @@ multi_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		executorType = JobExecutorType(multiPlan);
 		if (executorType == MULTI_EXECUTOR_ROUTER)
 		{
+			List *taskList = workerJob->taskList;
 			TupleDesc tupleDescriptor = ExecCleanTypeFromTL(
 				planStatement->planTree->targetlist, false);
 			List *dependendJobList PG_USED_FOR_ASSERTS_ONLY = workerJob->dependedJobList;
@@ -68,7 +69,7 @@ multi_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			queryDesc->tupDesc = tupleDescriptor;
 
 			/* drop into the router executor */
-			RouterExecutorStart(queryDesc, eflags);
+			RouterExecutorStart(queryDesc, eflags, taskList);
 		}
 		else
 		{

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -46,6 +46,28 @@ LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode)
 
 
 /*
+ * TryLockShardDistributionMetadata tries to grab a lock for distribution
+ * metadata related to the specified shard, returning false if the lock
+ * is currently taken. Any locks acquired using this method are released
+ * at transaction end.
+ */
+bool
+TryLockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode)
+{
+	LOCKTAG tag;
+	const bool sessionLock = false;
+	const bool dontWait = true;
+	bool lockAcquired = false;
+
+	SET_LOCKTAG_SHARD_METADATA_RESOURCE(tag, MyDatabaseId, shardId);
+
+	lockAcquired = LockAcquire(&tag, lockMode, sessionLock, dontWait);
+
+	return lockAcquired;
+}
+
+
+/*
  * LockRelationDistributionMetadata returns after getting a the lock used for a
  * relation's distribution metadata, blocking if required. Only ExclusiveLock
  * and ShareLock modes are supported. Any locks acquired using this method are

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -33,7 +33,7 @@ typedef struct XactShardConnSet
 extern bool AllModificationsCommutative;
 
 
-extern void RouterExecutorStart(QueryDesc *queryDesc, int eflags);
+extern void RouterExecutorStart(QueryDesc *queryDesc, int eflags, List *taskList);
 extern void RouterExecutorRun(QueryDesc *queryDesc, ScanDirection direction, long count);
 extern void RouterExecutorFinish(QueryDesc *queryDesc);
 extern void RouterExecutorEnd(QueryDesc *queryDesc);

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -65,6 +65,7 @@ typedef enum AdvisoryLocktagClass
 
 /* Lock shard/relation metadata for safe modifications */
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
+extern bool TryLockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
 extern void LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode);
 
 /* Lock shard data, for DML commands or remote fetches */


### PR DESCRIPTION
We currently allow prepared modifications to execute concurrently with master_copy_shard_placement because shard metadata locks are only acquired during planning. This may cause modifications to target the wrong set of shard placements, or a copy to start before a write completes, in either case the replicas could diverge.

This change prevents master_copy_shard_placement and prepared modifications from running concurrently by re-acquiring the shard metadata locks in RouterExecutorStart. If the locks cannot be reacquired because master_copy_shard_placement is already running, then we error out to prevent a stale plan from being executed.

We can be in any of these scenarios in RouterExecutorStart:

1. Locks were already acquired in the current transaction, master_copy_shard_placement could not have started: Re-acquire locks to no avail.
2. Locks were not yet acquired in the current transaction and master_copy_shard_placement is not running: Re-acquire locks to prevent master_copy_shard_placement from starting during the write.
3. Locks were not yet acquired in the current transaction and master_copy_shard_placement finished before fetching the plan from cache: As of #914 we replan the query and thus acquire the locks during planning and then go to scenario 1. 
4. Locks were not yet acquired in the current transaction and master_copy_shard_placement finished in between fetching a plan from cache and re-acquiring locks: We might execute a stale plan.
5. Locks were not yet acquired in the current transaction and master_copy_shard_placement is running: Re-acquiring locks fails, error out to prevent executing a stale plan.

Makes #127 less severe.