### PR TITLE
Change error message we displayed for foreign constraints if RF > 1

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -563,10 +563,13 @@ ErrorIfNotSupportedForeignConstraint(Relation relation, char distributionMethod,
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot create foreign key constraint"),
-							errdetail("Citus cannot create foreign key constrains"
-									  " if replication factor is greater than 1. "
-									  "Contact Citus Data for alternative "
-									  "deployment options.")));
+							errdetail("Citus Community Edition currently supports foreign"
+									  "key constraints only for "
+									  "\"citus.shard_replication_factor = 1\"."),
+							errhint("Please change \"citus.shard_replication_factor to "
+									"1\". To learn more about using foreign keys with "
+									"other replication factors, please contact us at "
+									"https://citusdata.com/about/contact_us.")));
 		}
 
 		heapTuple = systable_getnext(scanDescriptor);

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -63,7 +63,8 @@ DROP TABLE referencing_table;
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
 SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus cannot create foreign key constrains if replication factor is greater than 1. Contact Citus Data for alternative deployment options.
+DETAIL:  Citus Community Edition currently supports foreignkey constraints only for "citus.shard_replication_factor = 1".
+HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 DROP TABLE referencing_table;
 DROP TABLE referenced_table;
 -- test foreign constraint with correct conditions


### PR DESCRIPTION
At the moment, we do not support foreign constraints if replication factor is greater
than 1. However foreign constraints can be used in cloud with high availability option.
Therefore we do not want to create an impression such that foreign constraints with
high availability is not supported at all. We call users to action with this error
message.