### PR TITLE
Add Column Definition List for Output Columns for master_add_node

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -8,7 +8,7 @@ EXTENSION = citus
 EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
-	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17
+	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -91,6 +91,8 @@ $(EXTENSION)--6.0-15.sql: $(EXTENSION)--6.0-14.sql $(EXTENSION)--6.0-14--6.0-15.
 $(EXTENSION)--6.0-16.sql: $(EXTENSION)--6.0-15.sql $(EXTENSION)--6.0-15--6.0-16.sql
 	cat $^ > $@
 $(EXTENSION)--6.0-17.sql: $(EXTENSION)--6.0-16.sql $(EXTENSION)--6.0-16--6.0-17.sql
+	cat $^ > $@
+$(EXTENSION)--6.0-18.sql: $(EXTENSION)--6.0-17.sql $(EXTENSION)--6.0-17--6.0-18.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.0-17--6.0-18.sql
+++ b/src/backend/distributed/citus--6.0-17--6.0-18.sql
@@ -1,0 +1,21 @@
+/* citus--6.0-17--6.0-18.sql */
+
+SET search_path = 'pg_catalog';
+
+DROP FUNCTION IF EXISTS master_add_node(text, integer);
+
+CREATE FUNCTION master_add_node(nodename text,                                                
+                                nodeport integer,                                             
+                                OUT nodeid integer,                                           
+                                OUT groupid integer,                                          
+                                OUT nodename text,                                            
+                                OUT nodeport integer,                                         
+                                OUT noderack text,                                            
+                                OUT hasmetadata boolean)                                      
+    RETURNS record                                                                            
+    LANGUAGE C STRICT                                                                         
+    AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer)                                         
+    IS 'add node to the cluster';
+    
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.0-17'
+default_version = '6.0-18'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -22,11 +22,11 @@ SELECT master_get_active_worker_nodes();
  (localhost,57637)
 (2 rows)
 
--- try to add the node again when it is activated
-SELECT master_add_node('localhost', :worker_1_port);
-         master_add_node         
----------------------------------
- (1,1,localhost,57637,default,f)
+-- try to add a node that is already in the cluster
+SELECT * FROM master_add_node('localhost', :worker_1_port);
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata 
+--------+---------+-----------+----------+----------+-------------
+      1 |       1 | localhost |    57637 | default  | f
 (1 row)
 
 -- get the active nodes

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -57,6 +57,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-14';
 ALTER EXTENSION citus UPDATE TO '6.0-15';
 ALTER EXTENSION citus UPDATE TO '6.0-16';
 ALTER EXTENSION citus UPDATE TO '6.0-17';
+ALTER EXTENSION citus UPDATE TO '6.0-18';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -10,8 +10,8 @@ SELECT master_add_node('localhost', :worker_2_port);
 -- get the active nodes
 SELECT master_get_active_worker_nodes();
 
--- try to add the node again when it is activated
-SELECT master_add_node('localhost', :worker_1_port);
+-- try to add a node that is already in the cluster
+SELECT * FROM master_add_node('localhost', :worker_1_port);
 
 -- get the active nodes
 SELECT master_get_active_worker_nodes();

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -57,6 +57,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-14';
 ALTER EXTENSION citus UPDATE TO '6.0-15';
 ALTER EXTENSION citus UPDATE TO '6.0-16';
 ALTER EXTENSION citus UPDATE TO '6.0-17';
+ALTER EXTENSION citus UPDATE TO '6.0-18';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)


### PR DESCRIPTION
This change allows seeing the names of columns of `master_add_node`,
using `SELECT * FROM master_add_node(...)` by specifying output
columns in UDF definition.

Fixes #946