### PR TITLE
Fix failures during pg_upgrade

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -157,6 +157,13 @@ _PG_init(void)
 	/* initialize transaction callbacks */
 	RegisterRouterExecutorXactCallbacks();
 	RegisterShardPlacementXactCallbacks();
+
+	/* enable modification of pg_catalog tables during pg_upgrade */
+	if (IsBinaryUpgrade)
+	{
+		SetConfigOption("allow_system_table_mods", "true", PGC_POSTMASTER,
+						PGC_S_OVERRIDE);
+	}
 }
 
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -642,7 +642,8 @@ CitusHasBeenLoaded(void)
 			}
 		}
 
-		extensionLoaded = extensionPresent && extensionScriptExecuted;
+		/* we disable extension features during pg_upgrade */
+		extensionLoaded = extensionPresent && extensionScriptExecuted && !IsBinaryUpgrade;
 
 		if (extensionLoaded)
 		{
@@ -653,6 +654,9 @@ CitusHasBeenLoaded(void)
 			 *
 			 * Ensure InvalidateDistRelationCacheCallback will notice those changes
 			 * by caching pg_dist_partition's oid.
+			 *
+			 * We skip these checks during upgrade since pg_dist_partition is not
+			 * present during early stages of upgrade operation.
 			 */
 			DistPartitionRelationId();
 		}


### PR DESCRIPTION
- fix error in CitusHasBeenLoaded()
- allow creation of pg_catalog tables during upgrade

Fixes #963 and #964. metadata tables are created but not populated with old data after pg_upgrade 