### PR TITLE
Pass down the correct type for null parameters

### DIFF
--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1041,6 +1041,21 @@ SELECT * FROM plpgsql_table ORDER BY key, value;
    0 |      
 (6 rows)
 
+-- check whether we can handle execute parameters
+CREATE TABLE execute_parameter_test (key int, val date);
+SELECT create_distributed_table('execute_parameter_test', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+DO $$
+BEGIN
+ EXECUTE 'INSERT INTO execute_parameter_test VALUES (3, $1)' USING date '2000-01-01';
+ EXECUTE 'INSERT INTO execute_parameter_test VALUES (3, $1)' USING NULL::date;
+END;
+$$;
+DROP TABLE execute_parameter_test;
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();
 DROP FUNCTION plpgsql_test_2();

--- a/src/test/regress/sql/multi_prepare_plsql.sql
+++ b/src/test/regress/sql/multi_prepare_plsql.sql
@@ -497,6 +497,17 @@ SELECT non_partition_parameter_delete(62);
 -- check table after deletes
 SELECT * FROM plpgsql_table ORDER BY key, value;
 
+-- check whether we can handle execute parameters
+CREATE TABLE execute_parameter_test (key int, val date);
+SELECT create_distributed_table('execute_parameter_test', 'key');
+DO $$
+BEGIN
+ EXECUTE 'INSERT INTO execute_parameter_test VALUES (3, $1)' USING date '2000-01-01';
+ EXECUTE 'INSERT INTO execute_parameter_test VALUES (3, $1)' USING NULL::date;
+END;
+$$;
+DROP TABLE execute_parameter_test;
+
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();
 DROP FUNCTION plpgsql_test_2();


### PR DESCRIPTION
#770 changes the type of the parameters we pass down via libpq to text when the parameter is not referenced or the value is null. However, in the latter case we still want to pass down the type. Otherwise, we might not be able to insert the data into the table on the worker.

Fixes #978