### PR TITLE
Propagate node add/remove to the nodes with hasmetadata=true

### DIFF
--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -35,6 +35,7 @@ extern void SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *co
 									   const char *const *parameterValues);
 extern void SendCommandListToWorkerInSingleTransaction(char *nodeName, int32 nodePort,
 													   char *nodeUser, List *commandList);
+extern void RemoveWorkerTransaction(char *nodeName, int32 nodePort);
 
 /* helper functions for worker transactions */
 extern bool IsWorkerTransactionActive(void);

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -132,3 +132,209 @@ SELECT master_add_node('localhost', :worker_2_port);
 
 UPDATE pg_dist_shard_placement SET shardstate=1 WHERE nodeport=:worker_2_port;
 DROP TABLE cluster_management_test;
+-- check that adding/removing nodes are propagated to nodes with hasmetadata=true
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
+SELECT master_add_node('localhost', :worker_2_port);
+         master_add_node         
+---------------------------------
+ (5,5,localhost,57638,default,f)
+(1 row)
+
+\c - - - :worker_1_port
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
+ nodename  | nodeport 
+-----------+----------
+ localhost |    57638
+(1 row)
+
+\c - - - :master_port
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+\c - - - :worker_1_port
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
+ nodename | nodeport 
+----------+----------
+(0 rows)
+
+\c - - - :master_port
+-- check that added nodes are not propagated to nodes with hasmetadata=false
+UPDATE pg_dist_node SET hasmetadata=false WHERE nodeport=:worker_1_port;
+SELECT master_add_node('localhost', :worker_2_port);
+         master_add_node         
+---------------------------------
+ (6,6,localhost,57638,default,f)
+(1 row)
+
+\c - - - :worker_1_port
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
+ nodename | nodeport 
+----------+----------
+(0 rows)
+
+\c - - - :master_port
+-- check that removing two nodes in the same transaction works
+SELECT 
+	master_remove_node('localhost', :worker_1_port), 
+	master_remove_node('localhost', :worker_2_port);
+ master_remove_node | master_remove_node 
+--------------------+--------------------
+                    | 
+(1 row)
+
+SELECT * FROM pg_dist_node ORDER BY nodeid;
+ nodeid | groupid | nodename | nodeport | noderack | hasmetadata 
+--------+---------+----------+----------+----------+-------------
+(0 rows)
+
+-- check that adding two nodes in the same transaction works
+SELECT
+	master_add_node('localhost', :worker_1_port),
+	master_add_node('localhost', :worker_2_port);
+         master_add_node         |         master_add_node         
+---------------------------------+---------------------------------
+ (7,7,localhost,57637,default,f) | (8,8,localhost,57638,default,f)
+(1 row)
+
+SELECT * FROM pg_dist_node ORDER BY nodeid;
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata 
+--------+---------+-----------+----------+----------+-------------
+      7 |       7 | localhost |    57637 | default  | f
+      8 |       8 | localhost |    57638 | default  | f
+(2 rows)
+
+-- check that mixed add/remove node commands work fine inside transaction
+BEGIN;
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+SELECT master_add_node('localhost', :worker_2_port);
+         master_add_node         
+---------------------------------
+ (9,9,localhost,57638,default,f)
+(1 row)
+
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+COMMIT;
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
+ nodename | nodeport 
+----------+----------
+(0 rows)
+
+UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+          master_add_node          
+-----------------------------------
+ (10,10,localhost,57638,default,f)
+(1 row)
+
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+SELECT master_add_node('localhost', :worker_2_port);
+          master_add_node          
+-----------------------------------
+ (11,11,localhost,57638,default,f)
+(1 row)
+
+COMMIT;
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
+ nodename  | nodeport 
+-----------+----------
+ localhost |    57638
+(1 row)
+
+\c - - - :worker_1_port
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
+ nodename  | nodeport 
+-----------+----------
+ localhost |    57638
+(1 row)
+
+\c - - - :master_port
+SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node;
+ master_remove_node 
+--------------------
+ 
+ 
+(2 rows)
+
+SELECT master_add_node('localhost', :worker_1_port);
+          master_add_node          
+-----------------------------------
+ (12,12,localhost,57637,default,f)
+(1 row)
+
+SELECT master_add_node('localhost', :worker_2_port);
+          master_add_node          
+-----------------------------------
+ (13,13,localhost,57638,default,f)
+(1 row)
+
+-- check that a distributed table can be created after adding a node in a transaction
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+          master_add_node          
+-----------------------------------
+ (14,14,localhost,57638,default,f)
+(1 row)
+
+CREATE TABLE temp(col1 text, col2 int);
+SELECT create_distributed_table('temp', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO temp VALUES ('row1', 1);
+INSERT INTO temp VALUES ('row2', 2);
+COMMIT;
+SELECT col1, col2 FROM temp ORDER BY col1;
+ col1 | col2 
+------+------
+ row1 |    1
+ row2 |    2
+(2 rows)
+
+SELECT 
+	count(*) 
+FROM 
+	pg_dist_shard_placement, pg_dist_shard 
+WHERE 
+	pg_dist_shard_placement.shardid = pg_dist_shard.shardid
+	AND pg_dist_shard.logicalrelid = 'temp'::regclass
+	AND pg_dist_shard_placement.nodeport = :worker_2_port;
+ count 
+-------
+    32
+(1 row)
+
+	
+DROP TABLE temp;


### PR DESCRIPTION
Related to #797

This change propagates the changes done by `master_add_node` and `master_remove_node`
to the workers that contain metadata.

- [x] Remove the connection to the removed node
- [x] Test `master_add_node` and `master_remove_node` with various other queries in the same transaction.
