### PR TITLE
Suggested Connection Lifecycle Management Changes

### DIFF
--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -69,7 +69,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			/* close connections etc. */
 			if (CurrentCoordinatedTransactionState != COORD_TRANS_NONE)
 			{
-				AfterXactConnectionHandling(true);
+				AfterXactResetConnections(true);
 			}
 
 			Assert(!subXactAbortAttempted);
@@ -83,7 +83,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			/* close connections etc. */
 			if (CurrentCoordinatedTransactionState != COORD_TRANS_NONE)
 			{
-				AfterXactConnectionHandling(false);
+				AfterXactResetConnections(false);
 			}
 
 			CurrentCoordinatedTransactionState = COORD_TRANS_NONE;

--- a/src/backend/distributed/utils/connection_cache.c
+++ b/src/backend/distributed/utils/connection_cache.c
@@ -51,19 +51,17 @@ static void ReportRemoteError(PGconn *connection, PGresult *result, bool raiseEr
 PGconn *
 GetOrEstablishConnection(char *nodeName, int32 nodePort)
 {
-	int connectionFlags = NEW_CONNECTION | CACHED_CONNECTION | SESSION_LIFESPAN;
 	PGconn *connection = NULL;
-	MultiConnection *mconnection =
-		GetNodeConnection(connectionFlags, nodeName, nodePort);
+	MultiConnection *multiConnection = GetNodeConnection(nodeName, nodePort, 0);
 
-	if (PQstatus(mconnection->conn) == CONNECTION_OK)
+	if (PQstatus(multiConnection->conn) == CONNECTION_OK)
 	{
-		connection = mconnection->conn;
+		connection = multiConnection->conn;
 	}
 	else
 	{
-		ReportConnectionError(mconnection, WARNING);
-		CloseConnection(mconnection);
+		ReportConnectionError(multiConnection, WARNING);
+		CloseConnectionByPGconn(multiConnection->conn);
 		connection = NULL;
 	}
 
@@ -79,11 +77,7 @@ GetOrEstablishConnection(char *nodeName, int32 nodePort)
 void
 PurgeConnection(PGconn *connection)
 {
-	NodeConnectionKey nodeConnectionKey;
-
-	BuildKeyForConnection(connection, &nodeConnectionKey);
-
-	PurgeConnectionByKey(&nodeConnectionKey);
+	CloseConnectionByPGconn(connection);
 }
 
 
@@ -127,27 +121,6 @@ BuildKeyForConnection(PGconn *connection, NodeConnectionKey *connectionKey)
 	pfree(nodeNameString);
 	pfree(nodePortString);
 	pfree(nodeUserString);
-}
-
-
-void
-PurgeConnectionByKey(NodeConnectionKey *nodeConnectionKey)
-{
-	int connectionFlags = CACHED_CONNECTION;
-	MultiConnection *connection;
-
-	connection =
-		StartNodeUserDatabaseConnection(
-			connectionFlags,
-			nodeConnectionKey->nodeName,
-			nodeConnectionKey->nodePort,
-			nodeConnectionKey->nodeUser,
-			NULL);
-
-	if (connection)
-	{
-		CloseConnection(connection);
-	}
 }
 
 

--- a/src/include/distributed/connection_cache.h
+++ b/src/include/distributed/connection_cache.h
@@ -56,7 +56,6 @@ typedef struct NodeConnectionEntry
 extern PGconn * GetOrEstablishConnection(char *nodeName, int32 nodePort);
 extern void PurgeConnection(PGconn *connection);
 extern void BuildKeyForConnection(PGconn *connection, NodeConnectionKey *connectionKey);
-extern void PurgeConnectionByKey(NodeConnectionKey *nodeConnectionKey);
 extern void WarnRemoteError(PGconn *connection, PGresult *result);
 extern void ReraiseRemoteError(PGconn *connection, PGresult *result);
 extern PGconn * ConnectToNode(char *nodeName, int nodePort, char *nodeUser);


### PR DESCRIPTION
Some suggested changes to the lifecycle management PR to simplify the API flags and make the StartNodeUserDatabaseConnection implementation easier to understand.

Mainly, I replaced the flags with ones that are functionally relevant to the caller:
- IN_TRANSACTION: If set, return a connection that is part of the coordinated transaction. If not set, return an out-of-band connection and let the caller manage transactions. (e.g. certain UDFs).
- CLAIM_EXCLUSIVELY: If set, claim a connection exclusively (e.g. for COPY).

I considered removing the flags entirely since they don't seem necessary, but I figured they might come in handy at some point. Also fine with removing them. It did seem more appropriate to move them to the back of the parameter list.

Since the CACHED_CONNECTION flag is gone, I did a very quick-and-dirty implementation of CloseConnectionByPGconn just for sanity. Should be improved.