### PR TITLE
Use READ_UINT64_FIELD for placement ID in ReadShardPlacement

### DIFF
--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -261,7 +261,7 @@ ReadShardPlacement(READFUNC_ARGS)
 {
 	READ_LOCALS(ShardPlacement);
 
-	READ_OID_FIELD(placementId);
+	READ_UINT64_FIELD(placementId);
 	READ_UINT64_FIELD(shardId);
 	READ_UINT64_FIELD(shardLength);
 	READ_ENUM_FIELD(shardState, RelayFileState);


### PR DESCRIPTION
Noticed a random readfuncs bug.