### PR TITLE
Evaluate functions in INSERT..SELECT

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -382,7 +382,7 @@ AcquireExecutorShardLock(Task *task, CmdType commandType)
 		 * concurrently.
 		 */
 
-		LockShardListResources(task->selectShardList, ExclusiveLock);
+		LockRelationShardListResources(task->relationShardList, ExclusiveLock);
 	}
 }
 
@@ -462,7 +462,7 @@ AcquireExecutorMultiShardLocks(List *taskList)
 			 * concurrently.
 			 */
 
-			LockShardListResources(task->selectShardList, ExclusiveLock);
+			LockRelationShardListResources(task->relationShardList, ExclusiveLock);
 		}
 	}
 }

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -1,0 +1,238 @@
+/*-------------------------------------------------------------------------
+ *
+ * deparse_shard_query.c
+ *
+ * This file contains functions for deparsing shard queries.
+ *
+ * Copyright (c) 2014-2016, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "c.h"
+
+#include "access/heapam.h"
+#include "distributed/citus_nodefuncs.h"
+#include "distributed/citus_ruleutils.h"
+#include "distributed/deparse_shard_query.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_physical_planner.h"
+#include "distributed/multi_router_planner.h"
+#include "lib/stringinfo.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/nodes.h"
+#include "nodes/parsenodes.h"
+#include "nodes/pg_list.h"
+#include "storage/lock.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+
+
+static void ConvertRteToSubqueryWithEmptyResult(RangeTblEntry *rte);
+
+
+/*
+ * RebuildQueryStrings deparses the job query for each task to
+ * include execution-time changes such as function evaluation.
+ */
+void
+RebuildQueryStrings(Query *originalQuery, List *taskList)
+{
+	ListCell *taskCell = NULL;
+	Oid relationId = ((RangeTblEntry *) linitial(originalQuery->rtable))->relid;
+
+	foreach(taskCell, taskList)
+	{
+		Task *task = (Task *) lfirst(taskCell);
+		StringInfo newQueryString = makeStringInfo();
+		Query *query = originalQuery;
+
+		if (task->insertSelectQuery)
+		{
+			/* for INSERT..SELECT, adjust shard names in SELECT part */
+			RangeTblEntry *copiedInsertRte = NULL;
+			RangeTblEntry *copiedSubqueryRte = NULL;
+			Query *copiedSubquery = NULL;
+			List *relationShardList = task->relationShardList;
+			ShardInterval *shardInterval = LoadShardInterval(task->anchorShardId);
+
+			query = copyObject(originalQuery);
+
+			copiedInsertRte = ExtractInsertRangeTableEntry(query);
+			copiedSubqueryRte = ExtractSelectRangeTableEntry(query);
+			copiedSubquery = copiedSubqueryRte->subquery;
+
+			AddShardIntervalRestrictionToSelect(copiedSubquery, shardInterval);
+			ReorderInsertSelectTargetLists(query, copiedInsertRte, copiedSubqueryRte);
+
+			/* setting an alias simplifies deparsing of RETURNING */
+			if (copiedInsertRte->alias == NULL)
+			{
+				Alias *alias = makeAlias(CITUS_TABLE_ALIAS, NIL);
+				copiedInsertRte->alias = alias;
+			}
+
+			UpdateRelationToShardNames((Node *) copiedSubquery, relationShardList);
+		}
+
+		deparse_shard_query(query, relationId, task->anchorShardId,
+							newQueryString);
+
+		ereport(DEBUG4, (errmsg("query before rebuilding: %s",
+								task->queryString)));
+		ereport(DEBUG4, (errmsg("query after rebuilding:  %s",
+								newQueryString->data)));
+
+		task->queryString = newQueryString->data;
+	}
+}
+
+
+/*
+ * UpdateRelationToShardNames walks over the query tree and appends shard ids to
+ * relations. It uses unique identity value to establish connection between a
+ * shard and the range table entry. If the range table id is not given a
+ * identity, than the relation is not referenced from the query, no connection
+ * could be found between a shard and this relation. Therefore relation is replaced
+ * by set of NULL values so that the query would work at worker without any problems.
+ *
+ */
+bool
+UpdateRelationToShardNames(Node *node, List *relationShardList)
+{
+	RangeTblEntry *newRte = NULL;
+	uint64 shardId = INVALID_SHARD_ID;
+	Oid relationId = InvalidOid;
+	Oid schemaId = InvalidOid;
+	char *relationName = NULL;
+	char *schemaName = NULL;
+	bool replaceRteWithNullValues = false;
+	ListCell *relationShardCell = NULL;
+	RelationShard *relationShard = NULL;
+
+	if (node == NULL)
+	{
+		return false;
+	}
+
+	/* want to look at all RTEs, even in subqueries, CTEs and such */
+	if (IsA(node, Query))
+	{
+		return query_tree_walker((Query *) node, UpdateRelationToShardNames,
+								 relationShardList, QTW_EXAMINE_RTES);
+	}
+
+	if (!IsA(node, RangeTblEntry))
+	{
+		return expression_tree_walker(node, UpdateRelationToShardNames,
+									  relationShardList);
+	}
+
+	newRte = (RangeTblEntry *) node;
+
+	if (newRte->rtekind != RTE_RELATION)
+	{
+		return false;
+	}
+
+	/*
+	 * Search for the restrictions associated with the RTE. There better be
+	 * some, otherwise this query wouldn't be elegible as a router query.
+	 *
+	 * FIXME: We should probably use a hashtable here, to do efficient
+	 * lookup.
+	 */
+	foreach(relationShardCell, relationShardList)
+	{
+		relationShard = (RelationShard *) lfirst(relationShardCell);
+
+		if (newRte->relid == relationShard->relationId)
+		{
+			break;
+		}
+
+		relationShard = NULL;
+	}
+
+	replaceRteWithNullValues = relationShard == NULL ||
+							   relationShard->shardId == INVALID_SHARD_ID;
+	if (replaceRteWithNullValues)
+	{
+		ConvertRteToSubqueryWithEmptyResult(newRte);
+		return false;
+	}
+
+	shardId = relationShard->shardId;
+	relationId = relationShard->relationId;
+
+	relationName = get_rel_name(relationId);
+	AppendShardIdToName(&relationName, shardId);
+
+	schemaId = get_rel_namespace(relationId);
+	schemaName = get_namespace_name(schemaId);
+
+	ModifyRangeTblExtraData(newRte, CITUS_RTE_SHARD, schemaName, relationName, NIL);
+
+	return false;
+}
+
+
+/*
+ * ConvertRteToSubqueryWithEmptyResult converts given relation RTE into
+ * subquery RTE that returns no results.
+ */
+static void
+ConvertRteToSubqueryWithEmptyResult(RangeTblEntry *rte)
+{
+	Relation relation = heap_open(rte->relid, NoLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(relation);
+	int columnCount = tupleDescriptor->natts;
+	int columnIndex = 0;
+	Query *subquery = NULL;
+	List *targetList = NIL;
+	FromExpr *joinTree = NULL;
+
+	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	{
+		FormData_pg_attribute *attributeForm = tupleDescriptor->attrs[columnIndex];
+		TargetEntry *targetEntry = NULL;
+		StringInfo resname = NULL;
+		Const *constValue = NULL;
+
+		if (attributeForm->attisdropped)
+		{
+			continue;
+		}
+
+		resname = makeStringInfo();
+		constValue = makeNullConst(attributeForm->atttypid, attributeForm->atttypmod,
+								   attributeForm->attcollation);
+
+		appendStringInfo(resname, "%s", attributeForm->attname.data);
+
+		targetEntry = makeNode(TargetEntry);
+		targetEntry->expr = (Expr *) constValue;
+		targetEntry->resno = columnIndex;
+		targetEntry->resname = resname->data;
+
+		targetList = lappend(targetList, targetEntry);
+	}
+
+	heap_close(relation, NoLock);
+
+	joinTree = makeNode(FromExpr);
+	joinTree->quals = makeBoolConst(false, false);
+
+	subquery = makeNode(Query);
+	subquery->commandType = CMD_SELECT;
+	subquery->querySource = QSRC_ORIGINAL;
+	subquery->canSetTag = true;
+	subquery->targetList = targetList;
+	subquery->jointree = joinTree;
+
+	rte->rtekind = RTE_SUBQUERY;
+	rte->subquery = subquery;
+	rte->alias = copyObject(rte->eref);
+}

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1478,6 +1478,11 @@ GetRTEIdentity(RangeTblEntry *rte)
 	Assert(IsA(rte->values_lists, IntList));
 	Assert(list_length(rte->values_lists) == 1);
 
+	if (rte->values_lists == NULL)
+	{
+		return 0;
+	}
+
 	return linitial_int(rte->values_lists);
 }
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -289,8 +289,6 @@ CreateInsertSelectRouterPlan(Query *originalQuery,
 	workerJob->dependedJobList = NIL;
 	workerJob->jobId = jobId;
 	workerJob->jobQuery = originalQuery;
-
-	/* for now we do not support any function evaluation */
 	workerJob->requiresMasterEvaluation = RequiresMasterEvaluation(originalQuery);
 
 	/* and finally the multi plan */

--- a/src/backend/distributed/utils/citus_nodefuncs.c
+++ b/src/backend/distributed/utils/citus_nodefuncs.c
@@ -14,6 +14,7 @@
 #include "distributed/citus_nodes.h"
 #include "distributed/citus_nodefuncs.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/multi_planner.h"
 
 static const char *CitusNodeTagNamesD[] = {
 	"MultiNode",
@@ -31,7 +32,8 @@ static const char *CitusNodeTagNamesD[] = {
 	"MultiPlan",
 	"Task",
 	"ShardInterval",
-	"ShardPlacement"
+	"ShardPlacement",
+	"RelationShard"
 };
 
 const char **CitusNodeTagNames = CitusNodeTagNamesD;
@@ -379,6 +381,7 @@ const ExtensibleNodeMethods nodeMethods[] =
 	DEFINE_NODE_METHODS(ShardInterval),
 	DEFINE_NODE_METHODS(MapMergeJob),
 	DEFINE_NODE_METHODS(ShardPlacement),
+	DEFINE_NODE_METHODS(RelationShard),
 	DEFINE_NODE_METHODS(Task),
 
 	/* nodes with only output support */

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -24,6 +24,7 @@
 #include "distributed/citus_nodes.h"
 #include "distributed/multi_logical_planner.h"
 #include "distributed/multi_physical_planner.h"
+#include "distributed/multi_planner.h"
 #include "distributed/master_metadata_utility.h"
 #include "lib/stringinfo.h"
 #include "nodes/plannodes.h"
@@ -476,6 +477,17 @@ OutShardPlacement(OUTFUNC_ARGS)
 
 
 void
+OutRelationShard(OUTFUNC_ARGS)
+{
+	WRITE_LOCALS(RelationShard);
+	WRITE_NODE_TYPE("RELATIONSHARD");
+
+	WRITE_OID_FIELD(relationId);
+	WRITE_UINT64_FIELD(shardId);
+}
+
+
+void
 OutTask(OUTFUNC_ARGS)
 {
 	WRITE_LOCALS(Task);
@@ -495,7 +507,7 @@ OutTask(OUTFUNC_ARGS)
 	WRITE_NODE_FIELD(taskExecution);
 	WRITE_BOOL_FIELD(upsertQuery);
 	WRITE_BOOL_FIELD(insertSelectQuery);
-	WRITE_NODE_FIELD(selectShardList);
+	WRITE_NODE_FIELD(relationShardList);
 }
 
 #if (PG_VERSION_NUM < 90600)
@@ -609,6 +621,12 @@ outNode(StringInfo str, const void *obj)
 		case T_ShardPlacement:
 			appendStringInfoChar(str, '{');
 			OutShardPlacement(str, obj);
+			appendStringInfoChar(str, '}');
+			break;
+
+		case T_RelationShard:
+			appendStringInfoChar(str, '{');
+			OutRelationShard(str, obj);
 			appendStringInfoChar(str, '}');
 			break;
 

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -14,6 +14,7 @@
 #include <math.h>
 
 #include "distributed/citus_nodefuncs.h"
+#include "distributed/multi_planner.h"
 #include "nodes/parsenodes.h"
 #include "nodes/readfuncs.h"
 
@@ -273,6 +274,18 @@ ReadShardPlacement(READFUNC_ARGS)
 
 
 READFUNC_RET
+ReadRelationShard(READFUNC_ARGS)
+{
+	READ_LOCALS(RelationShard);
+
+	READ_OID_FIELD(relationId);
+	READ_UINT64_FIELD(shardId);
+
+	READ_DONE();
+}
+
+
+READFUNC_RET
 ReadTask(READFUNC_ARGS)
 {
 	READ_LOCALS(Task);
@@ -291,7 +304,7 @@ ReadTask(READFUNC_ARGS)
 	READ_NODE_FIELD(taskExecution);
 	READ_BOOL_FIELD(upsertQuery);
 	READ_BOOL_FIELD(insertSelectQuery);
-	READ_NODE_FIELD(selectShardList);
+	READ_NODE_FIELD(relationShardList);
 
 	READ_DONE();
 }

--- a/src/backend/distributed/utils/citus_readfuncs_95.c
+++ b/src/backend/distributed/utils/citus_readfuncs_95.c
@@ -1515,6 +1515,8 @@ CitusParseNodeString(void)
 		return_value = ReadMapMergeJob();
 	else if (MATCH("SHARDPLACEMENT", 14))
 		return_value = ReadShardPlacement();
+	else if (MATCH("RELATIONSHARD", 13))
+		return_value = ReadRelationShard();
 	else if (MATCH("TASK", 4))
 		return_value = ReadTask();
 /* XXX: END Citus Nodes */

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -21,6 +21,7 @@
 #include "distributed/master_metadata_utility.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_router_executor.h"
+#include "distributed/multi_planner.h"
 #include "distributed/relay_utility.h"
 #include "distributed/resource_lock.h"
 #include "distributed/shardinterval_utils.h"
@@ -299,6 +300,31 @@ LockShardListResources(List *shardIntervalList, LOCKMODE lockMode)
 		int64 shardId = shardInterval->shardId;
 
 		LockShardResource(shardId, lockMode);
+	}
+}
+
+
+/*
+ * LockRelationShards takes locks on all shards in a list of RelationShards
+ * to prevent concurrent DML statements on those shards.
+ */
+void
+LockRelationShardListResources(List *relationShardList, LOCKMODE lockMode)
+{
+	ListCell *relationShardCell = NULL;
+
+	/* lock shards in a consistent order to prevent deadlock */
+	relationShardList = SortList(relationShardList, CompareRelationShards);
+
+	foreach(relationShardCell, relationShardList)
+	{
+		RelationShard *relationShard = (RelationShard *) lfirst(relationShardCell);
+		uint64 shardId = relationShard->shardId;
+
+		if (shardId != INVALID_SHARD_ID)
+		{
+			LockShardResource(shardId, lockMode);
+		}
 	}
 }
 

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -305,11 +305,11 @@ LockShardListResources(List *shardIntervalList, LOCKMODE lockMode)
 
 
 /*
- * LockRelationShards takes locks on all shards in a list of RelationShards
+ * LockRelationShardResources takes locks on all shards in a list of RelationShards
  * to prevent concurrent DML statements on those shards.
  */
 void
-LockRelationShardListResources(List *relationShardList, LOCKMODE lockMode)
+LockRelationShardResources(List *relationShardList, LOCKMODE lockMode)
 {
 	ListCell *relationShardCell = NULL;
 

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -15,6 +15,7 @@
 #include "catalog/pg_collation.h"
 #include "catalog/pg_type.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/multi_planner.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/pg_dist_partition.h"
 #include "distributed/worker_protocol.h"
@@ -118,6 +119,43 @@ CompareShardIntervalsById(const void *leftElement, const void *rightElement)
 
 	/* we compare 64-bit integers, instead of casting their difference to int */
 	if (leftShardId > rightShardId)
+	{
+		return 1;
+	}
+	else if (leftShardId < rightShardId)
+	{
+		return -1;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+
+/*
+ * CompareRelationShards is a comparison function for sorting relation
+ * to shard mappings by their relation ID and then shard ID.
+ */
+int
+CompareRelationShards(const void *leftElement, const void *rightElement)
+{
+	RelationShard *leftRelationShard = *((RelationShard **) leftElement);
+	RelationShard *rightRelationShard = *((RelationShard **) rightElement);
+	Oid leftRelationId = leftRelationShard->relationId;
+	Oid rightRelationId = rightRelationShard->relationId;
+	int64 leftShardId = leftRelationShard->shardId;
+	int64 rightShardId = rightRelationShard->shardId;
+
+	if (leftRelationId > rightRelationId)
+	{
+		return 1;
+	}
+	else if (leftRelationId < rightRelationId)
+	{
+		return -1;
+	}
+	else if (leftShardId > rightShardId)
 	{
 		return 1;
 	}

--- a/src/include/distributed/citus_nodefuncs.h
+++ b/src/include/distributed/citus_nodefuncs.h
@@ -66,6 +66,7 @@ extern READFUNC_RET ReadMultiPlan(READFUNC_ARGS);
 extern READFUNC_RET ReadShardInterval(READFUNC_ARGS);
 extern READFUNC_RET ReadMapMergeJob(READFUNC_ARGS);
 extern READFUNC_RET ReadShardPlacement(READFUNC_ARGS);
+extern READFUNC_RET ReadRelationShard(READFUNC_ARGS);
 extern READFUNC_RET ReadTask(READFUNC_ARGS);
 
 extern READFUNC_RET ReadUnsupportedCitusNode(READFUNC_ARGS);
@@ -75,6 +76,7 @@ extern void OutMultiPlan(OUTFUNC_ARGS);
 extern void OutShardInterval(OUTFUNC_ARGS);
 extern void OutMapMergeJob(OUTFUNC_ARGS);
 extern void OutShardPlacement(OUTFUNC_ARGS);
+extern void OutRelationShard(OUTFUNC_ARGS);
 extern void OutTask(OUTFUNC_ARGS);
 
 extern void OutMultiNode(OUTFUNC_ARGS);

--- a/src/include/distributed/citus_nodes.h
+++ b/src/include/distributed/citus_nodes.h
@@ -55,7 +55,8 @@ typedef enum CitusNodeTag
 	T_MultiPlan,
 	T_Task,
 	T_ShardInterval,
-	T_ShardPlacement
+	T_ShardPlacement,
+	T_RelationShard
 } CitusNodeTag;
 
 

--- a/src/include/distributed/deparse_shard_query.h
+++ b/src/include/distributed/deparse_shard_query.h
@@ -1,0 +1,27 @@
+/*-------------------------------------------------------------------------
+ *
+ * deparse_shard_query.h
+ *
+ * Declarations for public functions and types related to deparsing shard
+ * queries.
+ *
+ * Copyright (c) 2014-2016, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef DEPARSE_SHARD_QUERY_H
+#define DEPARSE_SHARD_QUERY_H
+
+#include "c.h"
+
+#include "nodes/nodes.h"
+#include "nodes/parsenodes.h"
+#include "nodes/pg_list.h"
+
+
+extern void RebuildQueryStrings(Query *originalQuery, List *taskList);
+extern bool UpdateRelationToShardNames(Node *node, List *relationShardList);
+
+
+#endif /* DEPARSE_SHARD_QUERY_H */

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -182,8 +182,6 @@ extern bool SubqueryPushdown;
 /* Function declarations for building logical plans */
 extern MultiTreeRoot * MultiLogicalPlanCreate(Query *queryTree);
 extern bool NeedsDistributedPlanning(Query *queryTree);
-extern int GetRTEIdentity(RangeTblEntry *rte);
-extern void IdentifyRTE(RangeTblEntry *rte, int identifier);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);
 extern MultiNode * GrandChildNode(MultiUnaryNode *multiNode);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -171,7 +171,7 @@ typedef struct Task
 	bool upsertQuery;              /* only applies to modify tasks */
 
 	bool insertSelectQuery;
-	List *selectShardList;         /* only applies INSERT/SELECT tasks */
+	List *relationShardList;       /* only applies INSERT/SELECT tasks */
 } Task;
 
 

--- a/src/include/distributed/multi_planner.h
+++ b/src/include/distributed/multi_planner.h
@@ -13,6 +13,8 @@
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 
+#include "distributed/citus_nodes.h"
+
 
 /* values used by jobs and tasks which do not require identifiers */
 #define INVALID_JOB_ID 0
@@ -37,6 +39,13 @@ typedef struct RelationRestriction
 	PlannerInfo *plannerInfo;
 	List *prunedShardIntervalList;
 } RelationRestriction;
+
+typedef struct RelationShard
+{
+	CitusNode type;
+	Oid relationId;
+	uint64 shardId;
+} RelationShard;
 
 
 extern PlannedStmt * multi_planner(Query *parse, int cursorOptions,

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -37,5 +37,10 @@ extern Query * ReorderInsertSelectTargetLists(Query *originalQuery,
 											  RangeTblEntry *subqueryRte);
 extern bool InsertSelectQuery(Query *query);
 extern Oid ExtractFirstDistributedTableId(Query *query);
+extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
+extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
+extern void AddShardIntervalRestrictionToSelect(Query *subqery,
+												ShardInterval *shardInterval);
+
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -79,6 +79,7 @@ extern void UnlockJobResource(uint64 jobId, LOCKMODE lockmode);
 /* Lock multiple shards for safe modification */
 extern void LockShardListMetadata(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockShardListResources(List *shardIntervalList, LOCKMODE lockMode);
+extern void LockRelationShardListResources(List *relationShardList, LOCKMODE lockMode);
 
 extern void LockMetadataSnapshot(LOCKMODE lockMode);
 

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -79,7 +79,7 @@ extern void UnlockJobResource(uint64 jobId, LOCKMODE lockmode);
 /* Lock multiple shards for safe modification */
 extern void LockShardListMetadata(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockShardListResources(List *shardIntervalList, LOCKMODE lockMode);
-extern void LockRelationShardListResources(List *relationShardList, LOCKMODE lockMode);
+extern void LockRelationShardResources(List *relationShardList, LOCKMODE lockMode);
 
 extern void LockMetadataSnapshot(LOCKMODE lockMode);
 

--- a/src/include/distributed/shardinterval_utils.h
+++ b/src/include/distributed/shardinterval_utils.h
@@ -27,6 +27,8 @@ extern ShardInterval * LowestShardIntervalById(List *shardIntervalList);
 extern int CompareShardIntervals(const void *leftElement, const void *rightElement,
 								 FmgrInfo *typeCompareFunction);
 extern int CompareShardIntervalsById(const void *leftElement, const void *rightElement);
+extern int CompareRelationShards(const void *leftElement,
+								 const void *rightElement);
 extern int FindShardIntervalIndex(ShardInterval *shardInterval);
 extern ShardInterval * FindShardInterval(Datum partitionColumnValue,
 										 ShardInterval **shardIntervalCache,

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -107,6 +107,86 @@ INSERT INTO raw_events_second  SELECT * FROM raw_events_first;
 ERROR:  duplicate key value violates unique constraint "raw_events_second_user_id_value_1_key_13300004"
 DETAIL:  Key (user_id, value_1)=(1, 10) already exists.
 CONTEXT:  while executing command on localhost:57637
+-- stable functions should be allowed
+INSERT INTO raw_events_second (user_id, time)
+SELECT
+  user_id, now()
+FROM
+  raw_events_first
+WHERE
+  user_id < 0;
+INSERT INTO raw_events_second (user_id)
+SELECT
+  user_id
+FROM
+  raw_events_first
+WHERE
+  time > now() + interval '1 day';
+-- hide version-dependent PL/pgSQL context messages
+\set VERBOSITY terse
+-- make sure we evaluate stable functions on the master, once
+CREATE OR REPLACE FUNCTION evaluate_on_master()
+RETURNS int LANGUAGE plpgsql STABLE
+AS $function$
+BEGIN
+  RAISE NOTICE 'evaluating on master';
+  RETURN 0;
+END;
+$function$;
+INSERT INTO raw_events_second (user_id, value_1)
+SELECT
+  user_id, evaluate_on_master()
+FROM
+  raw_events_first
+WHERE
+  user_id < 0;
+NOTICE:  evaluating on master
+-- make sure stable functions in CTEs are evaluated
+INSERT INTO raw_events_second (user_id, value_1)
+WITH sub_cte AS (SELECT evaluate_on_master())
+SELECT
+  user_id, (SELECT * FROM sub_cte)
+FROM
+  raw_events_first
+WHERE
+  user_id < 0;
+NOTICE:  evaluating on master
+-- make sure we don't evaluate stable functions with column arguments
+CREATE OR REPLACE FUNCTION evaluate_on_master(x int)
+RETURNS int LANGUAGE plpgsql STABLE
+AS $function$
+BEGIN
+  RAISE NOTICE 'evaluating on master';
+  RETURN x;
+END;
+$function$;
+INSERT INTO raw_events_second (user_id, value_1)
+SELECT
+  user_id, evaluate_on_master(value_1)
+FROM
+  raw_events_first
+WHERE
+  user_id = 0;
+WARNING:  function public.evaluate_on_master(integer) does not exist
+WARNING:  function public.evaluate_on_master(integer) does not exist
+ERROR:  could not modify any active placements
+\set VERBOSITY default
+-- volatile functions should be disallowed
+INSERT INTO raw_events_second (user_id, value_1)
+SELECT
+  user_id, (random()*10)::int
+FROM
+  raw_events_first;
+ERROR:  cannot perform distributed planning for the given modification
+DETAIL:  Volatile functions are not allowed in INSERT ... SELECT queries
+INSERT INTO raw_events_second (user_id, value_1)
+WITH sub_cte AS (SELECT (random()*10)::int)
+SELECT
+  user_id, (SELECT * FROM sub_cte)
+FROM
+  raw_events_first;
+ERROR:  cannot perform distributed planning for the given modification
+DETAIL:  Volatile functions are not allowed in INSERT ... SELECT queries
 -- add one more row
 INSERT INTO raw_events_first (user_id, time) VALUES
                          (7, now());
@@ -1861,12 +1941,44 @@ DEBUG:  Plan is router executable
 DEBUG:  CommitTransactionCommand
 DEBUG:  CommitTransaction
 DEBUG:  name: unnamed; blockState:       STARTED; state: INPROGR, xid/subid/cid: 0/1/0, nestlvl: 1, children: 
--- set back to the default
-SET citus.shard_count TO DEFAULT;
+RESET client_min_messages;
 DEBUG:  StartTransactionCommand
 DEBUG:  StartTransaction
 DEBUG:  name: unnamed; blockState:       DEFAULT; state: INPROGR, xid/subid/cid: 0/1/0, nestlvl: 1, children: 
 DEBUG:  ProcessUtility
-DEBUG:  CommitTransactionCommand
-DEBUG:  CommitTransaction
-DEBUG:  name: unnamed; blockState:       STARTED; state: INPROGR, xid/subid/cid: 0/1/0, nestlvl: 1, children: 
+-- Stable function in default should be allowed
+ALTER TABLE table_with_defaults ADD COLUMN t timestamptz DEFAULT now();
+INSERT INTO table_with_defaults (store_id, first_name, last_name)
+SELECT
+  store_id, 'first '||store_id, 'last '||store_id
+FROM
+  table_with_defaults
+GROUP BY
+  store_id, first_name, last_name;
+-- Volatile function in default should be disallowed
+CREATE TABLE table_with_serial (
+  store_id int,
+  s bigserial
+);
+SELECT create_distributed_table('table_with_serial', 'store_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO table_with_serial (store_id)
+SELECT
+  store_id
+FROM
+  table_with_defaults
+GROUP BY
+  store_id;
+ERROR:  cannot perform distributed planning for the given modification
+DETAIL:  Volatile functions are not allowed in INSERT ... SELECT queries
+DROP TABLE raw_events_first CASCADE;
+NOTICE:  drop cascades to view test_view
+DROP TABLE raw_events_second;
+DROP TABLE reference_table;
+DROP TABLE agg_events;
+DROP TABLE table_with_defaults;
+DROP TABLE table_with_serial;

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -334,7 +334,6 @@ id_title AS (SELECT id, title from articles_hash WHERE author_id = 2)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
 DEBUG:  predicate pruning for shardId 840001
 DEBUG:  predicate pruning for shardId 840000
-DEBUG:  Found no worker with all shard placements
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Complex table expressions are currently unsupported
 -- recursive CTEs are supported when filtered on partition column
@@ -420,8 +419,7 @@ DEBUG:  predicate pruning for shardId 840006
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Complex table expressions are currently unsupported
 -- logically wrong query, query involves different shards
--- from the same table, but still router plannable due to
--- shard being placed on the same worker.
+-- from the same table
 WITH RECURSIVE hierarchy as (
 	SELECT *, 1 AS level
 		FROM company_employees
@@ -439,13 +437,8 @@ DEBUG:  predicate pruning for shardId 840006
 DEBUG:  predicate pruning for shardId 840003
 DEBUG:  predicate pruning for shardId 840004
 DEBUG:  predicate pruning for shardId 840005
-DEBUG:  Creating router plan
-DEBUG:  Plan is router executable
- company_id | employee_id | manager_id | level 
-------------+-------------+------------+-------
-          3 |           1 |          0 |     1
-(1 row)
-
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Complex table expressions are currently unsupported
 -- grouping sets are supported on single shard
 SELECT
 	id, substring(title, 2, 1) AS subtitle, count(*)

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -213,8 +213,7 @@ WITH RECURSIVE hierarchy as (
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
 
 -- logically wrong query, query involves different shards
--- from the same table, but still router plannable due to
--- shard being placed on the same worker.
+-- from the same table
 WITH RECURSIVE hierarchy as (
 	SELECT *, 1 AS level
 		FROM company_employees


### PR DESCRIPTION
While writing https://www.citusdata.com/blog/2016/11/29/event-aggregation-at-scale-with-postgresql/ I ran into a number of usability issues with INSERT..SELECT. In particular, it errors out when using functions like now(), date_trunc(), the timestamptz type, or even simple string||int concatenation, which can be very inconvenient, especially for doing roll-ups.

The problem with doing function evaluation for INSERT .. SELECT is that we perform different transformation on the query trees in the planner for each shard. While we could pass the entire query tree into the plan for each task and subsequently perform function evaluation on each query tree, this can cause substantial overhead.

This PR introduces a generic list of relation<->shard mappings ("RelationShard") that gets passed down with every (router planner) task, such that the per-shard query tree can be reconstructed from the jobQuery in the router executor and applies function evaluation to the SELECT part of the INSERT .. SELECT.  The infrastructure will also allow us to deparse and thus perform function evaluation on more complex queries (e.g. SELECT) in the executor. 

The RelationShard list replaces the existing selectShardList used for INSERT..SELECT lcoking, since it contains the same information. This change reduces overhead since selectShardList was a list of ShardInterval structs, whereas RelationShard only contains a relationId and a shardId.

Part of #961