### PR TITLE
Add targeted VACUUM/ANALYZE support

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -980,6 +980,7 @@ DeparseVacuumStmtPrefix(VacuumStmt *vacuumStmt)
 {
 	StringInfo vacuumPrefix = makeStringInfo();
 	const int supportedFlags = (
+		VACOPT_ANALYZE |
 #if (PG_VERSION_NUM >= 90600)
 		VACOPT_DISABLE_PAGE_SKIPPING |
 #endif
@@ -997,6 +998,18 @@ DeparseVacuumStmtPrefix(VacuumStmt *vacuumStmt)
 
 	appendStringInfoChar(vacuumPrefix, '(');
 
+	if (vacuumFlags & VACOPT_ANALYZE)
+	{
+		appendStringInfoString(vacuumPrefix, "ANALYZE,");
+	}
+
+#if (PG_VERSION_NUM >= 90600)
+	if (vacuumFlags & VACOPT_DISABLE_PAGE_SKIPPING)
+	{
+		appendStringInfoString(vacuumPrefix, "DISABLE_PAGE_SKIPPING,");
+	}
+#endif
+
 	if (vacuumFlags & VACOPT_FREEZE)
 	{
 		appendStringInfoString(vacuumPrefix, "FREEZE,");
@@ -1006,13 +1019,6 @@ DeparseVacuumStmtPrefix(VacuumStmt *vacuumStmt)
 	{
 		appendStringInfoString(vacuumPrefix, "FULL,");
 	}
-
-#if (PG_VERSION_NUM >= 90600)
-	if (vacuumFlags & VACOPT_DISABLE_PAGE_SKIPPING)
-	{
-		appendStringInfoString(vacuumPrefix, "DISABLE_PAGE_SKIPPING,");
-	}
-#endif
 
 	vacuumPrefix->data[vacuumPrefix->len - 1] = ')';
 

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -896,7 +896,16 @@ ProcessAlterObjectSchemaStmt(AlterObjectSchemaStmt *alterObjectSchemaStmt,
 }
 
 
-/* TODO: Write function comments */
+/*
+ * ProcessVacuumStmt processes vacuum statements that may need propagation to
+ * distributed tables. If a VACUUM or ANALYZE command references a distributed
+ * table, it is propagated to all involved nodes; otherwise, this function will
+ * immediately exit after some error checking.
+ *
+ * Unlike other Process functions within this file, this function does not
+ * return a modified parse node, as it is expected that the local VACUUM or
+ * ANALYZE has already been processed.
+ */
 static void
 ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand)
 {
@@ -923,6 +932,15 @@ ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand)
 }
 
 
+/*
+ * IsSupportedDistributedVacuumStmt returns whether distributed execution of a
+ * given VacuumStmt is supported. The provided relationId (if valid) represents
+ * the table targeted by the provided statement.
+ *
+ * Returns true if the statement requires distributed execution and returns
+ * false otherwise; however, this function will raise errors if the provided
+ * statement needs distributed execution but contains unsupported options.
+ */
 static bool
 IsSupportedDistributedVacuumStmt(Oid relationId, VacuumStmt *vacuumStmt)
 {
@@ -970,7 +988,10 @@ IsSupportedDistributedVacuumStmt(Oid relationId, VacuumStmt *vacuumStmt)
 }
 
 
-/* TODO: Write function comments */
+/*
+ * VacuumTaskList returns a list of tasks to be executed as part of processing
+ * a VacuumStmt which targets a distributed relation.
+ */
 static List *
 VacuumTaskList(Oid relationId, VacuumStmt *vacuumStmt)
 {
@@ -1017,7 +1038,12 @@ VacuumTaskList(Oid relationId, VacuumStmt *vacuumStmt)
 }
 
 
-/* TODO: Write function comments */
+/*
+ * DeparseVacuumStmtPrefix returns a StringInfo appropriate for use as a prefix
+ * during distributed execution of a VACUUM or ANALYZE statement. Callers may
+ * reuse this prefix within a loop to generate shard-specific VACUUM or ANALYZE
+ * statements.
+ */
 static StringInfo
 DeparseVacuumStmtPrefix(VacuumStmt *vacuumStmt)
 {

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -377,11 +377,7 @@ multi_ProcessUtility(Node *parsetree,
 	{
 		VacuumStmt *vacuumStmt = (VacuumStmt *) parsetree;
 
-		/* must check fields to know whether actually a vacuum */
-		if (vacuumStmt->options | VACOPT_VACUUM)
-		{
-			ProcessVacuumStmt(vacuumStmt, queryString);
-		}
+		ProcessVacuumStmt(vacuumStmt, queryString);
 	}
 }
 
@@ -988,6 +984,13 @@ DeparseVacuumStmtPrefix(VacuumStmt *vacuumStmt)
 		VACOPT_FULL
 		);
 	const int vacuumFlags = vacuumStmt->options;
+
+	if (!(vacuumStmt->options & VACOPT_VACUUM))
+	{
+		appendStringInfoString(vacuumPrefix, "ANALYZE ");
+
+		return vacuumPrefix;
+	}
 
 	appendStringInfoString(vacuumPrefix, "VACUUM ");
 

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1049,7 +1049,7 @@ DeparseVacuumStmtPrefix(VacuumStmt *vacuumStmt)
 {
 	StringInfo vacuumPrefix = makeStringInfo();
 	int vacuumFlags = vacuumStmt->options;
-	const int unsupportedFlags = ~(
+	const int unsupportedFlags PG_USED_FOR_ASSERTS_ONLY = ~(
 		VACOPT_ANALYZE |
 #if (PG_VERSION_NUM >= 90600)
 		VACOPT_DISABLE_PAGE_SKIPPING |

--- a/src/backend/distributed/transaction/multi_shard_transaction.c
+++ b/src/backend/distributed/transaction/multi_shard_transaction.c
@@ -175,9 +175,11 @@ BeginTransactionOnShardPlacements(uint64 shardId, char *userName)
 		 * transaction to fail.
 		 */
 		MarkRemoteTransactionCritical(connection);
-
-		/* issue BEGIN */
-		RemoteTransactionBegin(connection);
+		if (MultiShardCommitProtocol > COMMIT_PROTOCOL_BARE)
+		{
+			/* issue BEGIN */
+			RemoteTransactionBegin(connection);
+		}
 	}
 }
 
@@ -270,6 +272,11 @@ ResetShardPlacementTransactionState(void)
 	 * round.
 	 */
 	shardConnectionHash = NULL;
+
+	if (MultiShardCommitProtocol == COMMIT_PROTOCOL_BARE)
+	{
+		MultiShardCommitProtocol = SavedMultiShardCommitProtocol;
+	}
 }
 
 

--- a/src/backend/distributed/transaction/multi_shard_transaction.c
+++ b/src/backend/distributed/transaction/multi_shard_transaction.c
@@ -175,6 +175,8 @@ BeginTransactionOnShardPlacements(uint64 shardId, char *userName)
 		 * transaction to fail.
 		 */
 		MarkRemoteTransactionCritical(connection);
+
+		/* the special BARE mode (for e.g. VACUUM/ANALYZE) skips BEGIN */
 		if (MultiShardCommitProtocol > COMMIT_PROTOCOL_BARE)
 		{
 			/* issue BEGIN */
@@ -276,6 +278,7 @@ ResetShardPlacementTransactionState(void)
 	if (MultiShardCommitProtocol == COMMIT_PROTOCOL_BARE)
 	{
 		MultiShardCommitProtocol = SavedMultiShardCommitProtocol;
+		SavedMultiShardCommitProtocol = COMMIT_PROTOCOL_BARE;
 	}
 }
 

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -32,6 +32,7 @@ CoordinatedTransactionState CurrentCoordinatedTransactionState = COORD_TRANS_NON
 
 /* GUC, the commit protocol to use for commands affecting more than one connection */
 int MultiShardCommitProtocol = COMMIT_PROTOCOL_1PC;
+int SavedMultiShardCommitProtocol = COMMIT_PROTOCOL_BARE;
 
 /* state needed to keep track of operations used during a transaction */
 XactModificationType XactModificationLevel = XACT_MODIFICATION_NONE;

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -47,12 +47,16 @@ typedef enum CoordinatedTransactionState
 /* Enumeration that defines the different commit protocols available */
 typedef enum
 {
-	COMMIT_PROTOCOL_1PC = 0,
-	COMMIT_PROTOCOL_2PC = 1
+	COMMIT_PROTOCOL_BARE = 0,
+	COMMIT_PROTOCOL_1PC = 1,
+	COMMIT_PROTOCOL_2PC = 2
 } CommitProtocolType;
 
 /* config variable managed via guc.c */
 extern int MultiShardCommitProtocol;
+
+/* state needed to restore multi-shard commit protocol during VACUUM/ANALYZE */
+extern int SavedMultiShardCommitProtocol;
 
 /* state needed to prevent new connections during modifying transactions */
 extern XactModificationType XactModificationLevel;

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -66,3 +66,37 @@ SELECT master_apply_delete_command('DELETE FROM sharded_table');
 
 -- drop table
 DROP TABLE sharded_table;
+-- VACUUM tests
+-- create a table with a single shard (for convenience)
+CREATE TABLE dustbunnies (id integer, name text);
+SELECT master_create_distributed_table('dustbunnies', 'id', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('dustbunnies', 1, 2);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+-- add some data to the distributed table
+\copy dustbunnies from stdin with csv
+-- delete all rows from the shard, then run VACUUM against the table on the master
+DELETE FROM dustbunnies;
+VACUUM dustbunnies;
+-- update statistics, then verify that the four dead rows are gone
+\c - - - :worker_1_port
+SELECT pg_sleep(.500);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT pg_stat_get_vacuum_count('dustbunnies_990002'::regclass);
+ pg_stat_get_vacuum_count 
+--------------------------
+                        1
+(1 row)
+

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -68,7 +68,7 @@ SELECT master_apply_delete_command('DELETE FROM sharded_table');
 DROP TABLE sharded_table;
 -- VACUUM tests
 -- create a table with a single shard (for convenience)
-CREATE TABLE dustbunnies (id integer, name text);
+CREATE TABLE dustbunnies (id integer, name text, age integer);
 SELECT master_create_distributed_table('dustbunnies', 'id', 'hash');
  master_create_distributed_table 
 ---------------------------------
@@ -82,7 +82,7 @@ SELECT master_create_worker_shards('dustbunnies', 1, 2);
 (1 row)
 
 -- add some data to the distributed table
-\copy dustbunnies from stdin with csv
+\copy dustbunnies (id, name) from stdin with csv
 -- following approach adapted from PostgreSQL's stats.sql file
 -- save relevant stat counter values in refreshable view
 \c - - - :worker_1_port
@@ -201,6 +201,31 @@ WHERE oid='dustbunnies_990002'::regclass;
  t
 (1 row)
 
+-- check there are no nulls in either column
+SELECT attname, null_frac FROM pg_stats
+WHERE tablename = 'dustbunnies_990002' ORDER BY attname;
+ attname | null_frac 
+---------+-----------
+ age     |         1
+ id      |         0
+ name    |         0
+(3 rows)
+
+-- add NULL values, then perform column-specific ANALYZE
+\c - - - :master_port
+INSERT INTO dustbunnies VALUES (6, NULL, NULL);
+ANALYZE dustbunnies (name);
+-- verify that name's NULL ratio is updated but age's is not
+\c - - - :worker_1_port
+SELECT attname, null_frac FROM pg_stats
+WHERE tablename = 'dustbunnies_990002' ORDER BY attname;
+ attname | null_frac 
+---------+-----------
+ age     |         1
+ id      |         0
+ name    |  0.166667
+(3 rows)
+
 \c - - - :master_port
 -- verify warning for unqualified VACUUM
 VACUUM;
@@ -212,11 +237,6 @@ VACUUM dustbunnies;
 WARNING:  not propagating VACUUM command to worker nodes
 HINT:  Set citus.enable_ddl_propagation to true in order to send targeted VACUUM commands to worker nodes.
 SET citus.enable_ddl_propagation to DEFAULT;
--- verify error messages for unsupported options
-VACUUM (ANALYZE) dustbunnies (id);
-ERROR:  specifying a column list is currently unsupported in distributed VACUUM commands
-ANALYZE dustbunnies (id);
-ERROR:  specifying a column list is currently unsupported in distributed ANALYZE commands
 -- TODO: support VERBOSE
 -- VACUUM VERBOSE dustbunnies;
 -- VACUUM (FULL, VERBOSE) dustbunnies;

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -83,9 +83,9 @@ SELECT master_create_worker_shards('dustbunnies', 1, 2);
 
 -- add some data to the distributed table
 \copy dustbunnies from stdin with csv
--- delete all rows from the shard, then run VACUUM against the table on the master
-DELETE FROM dustbunnies;
+-- run VACUUM and ANALYZE against the table on the master
 VACUUM dustbunnies;
+ANALYZE dustbunnies;
 -- update statistics, then verify that the four dead rows are gone
 \c - - - :worker_1_port
 SELECT pg_sleep(.500);
@@ -98,5 +98,11 @@ SELECT pg_stat_get_vacuum_count('dustbunnies_990002'::regclass);
  pg_stat_get_vacuum_count 
 --------------------------
                         1
+(1 row)
+
+SELECT pg_stat_get_analyze_count('dustbunnies_990002'::regclass);
+ pg_stat_get_analyze_count 
+---------------------------
+                         1
 (1 row)
 

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -83,17 +83,60 @@ SELECT master_create_worker_shards('dustbunnies', 1, 2);
 
 -- add some data to the distributed table
 \copy dustbunnies from stdin with csv
+-- following approach adapted from PostgreSQL's stats.sql file
+-- save relevant stat counter values in refreshable view
+\c - - - :worker_1_port
+CREATE MATERIALIZED VIEW prevcounts AS
+SELECT analyze_count, vacuum_count FROM pg_stat_user_tables
+WHERE relname='dustbunnies_990002';
+-- create function that sleeps until those counters increment
+create function wait_for_stats() returns void as $$
+declare
+  start_time timestamptz := clock_timestamp();
+  analyze_updated bool;
+  vacuum_updated bool;
+begin
+  -- we don't want to wait forever; loop will exit after 10 seconds
+  for i in 1 .. 100 loop
+
+    -- check to see if analyze has been updated
+    SELECT (st.analyze_count >= pc.analyze_count + 1) INTO analyze_updated
+      FROM pg_stat_user_tables AS st, pg_class AS cl, prevcounts AS pc
+     WHERE st.relname='dustbunnies_990002' AND cl.relname='dustbunnies_990002';
+
+     -- check to see if vacuum has been updated
+    SELECT (st.vacuum_count >= pc.vacuum_count + 1) INTO vacuum_updated
+      FROM pg_stat_user_tables AS st, pg_class AS cl, prevcounts AS pc
+     WHERE st.relname='dustbunnies_990002' AND cl.relname='dustbunnies_990002';
+
+    exit when analyze_updated or vacuum_updated;
+
+    -- wait a little
+    perform pg_sleep(0.1);
+
+    -- reset stats snapshot so we can test again
+    perform pg_stat_clear_snapshot();
+
+  end loop;
+
+  -- report time waited in postmaster log (where it won't change test output)
+  raise log 'wait_for_stats delayed % seconds',
+    extract(epoch from clock_timestamp() - start_time);
+end
+$$ language plpgsql;
 -- run VACUUM and ANALYZE against the table on the master
+\c - - - :master_port
 VACUUM dustbunnies;
 ANALYZE dustbunnies;
 -- verify that the VACUUM and ANALYZE ran
 \c - - - :worker_1_port
-SELECT pg_sleep(.500);
- pg_sleep 
-----------
+SELECT wait_for_stats();
+ wait_for_stats 
+----------------
  
 (1 row)
 
+REFRESH MATERIALIZED VIEW prevcounts;
 SELECT pg_stat_get_vacuum_count('dustbunnies_990002'::regclass);
  pg_stat_get_vacuum_count 
 --------------------------
@@ -123,9 +166,9 @@ WHERE oid='dustbunnies_990002'::regclass;
 (1 row)
 
 -- verify the VACUUM ANALYZE incremented both vacuum and analyze counts
-SELECT pg_sleep(.500);
- pg_sleep 
-----------
+SELECT wait_for_stats();
+ wait_for_stats 
+----------------
  
 (1 row)
 

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -138,3 +138,23 @@ WHERE oid='dustbunnies_990002'::regclass;
  t
 (1 row)
 
+\c - - - :master_port
+-- verify warning for unqualified VACUUM
+VACUUM;
+WARNING:  not propagating VACUUM command to worker nodes
+HINT:  Provide a specific table in order to VACUUM distributed tables.
+-- and warning when using targeted VACUUM without DDL propagation
+SET citus.enable_ddl_propagation to false;
+VACUUM dustbunnies;
+WARNING:  not propagating VACUUM command to worker nodes
+HINT:  Set citus.enable_ddl_propagation to true in order to send targeted VACUUM commands to worker nodes.
+SET citus.enable_ddl_propagation to DEFAULT;
+-- verify error messages for unsupported options
+VACUUM (ANALYZE) dustbunnies (id);
+ERROR:  specifying a column list is currently unsupported in distributed VACUUM commands
+ANALYZE dustbunnies (id);
+ERROR:  specifying a column list is currently unsupported in distributed ANALYZE commands
+-- TODO: support VERBOSE
+-- VACUUM VERBOSE dustbunnies;
+-- VACUUM (FULL, VERBOSE) dustbunnies;
+-- ANALYZE VERBOSE dustbunnies;

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -106,6 +106,41 @@ SELECT pg_stat_get_analyze_count('dustbunnies_990002'::regclass);
                          1
 (1 row)
 
+-- get file node to verify VACUUM FULL
+SELECT relfilenode AS oldnode FROM pg_class WHERE oid='dustbunnies_990002'::regclass
+\gset
+-- send a VACUUM FULL and a VACUUM ANALYZE
+\c - - - :master_port
+VACUUM (FULL) dustbunnies;
+VACUUM ANALYZE dustbunnies;
+-- verify that relfilenode changed
+\c - - - :worker_1_port
+SELECT relfilenode != :oldnode AS table_rewritten FROM pg_class
+WHERE oid='dustbunnies_990002'::regclass;
+ table_rewritten 
+-----------------
+ t
+(1 row)
+
+-- verify the VACUUM ANALYZE incremented both vacuum and analyze counts
+SELECT pg_sleep(.500);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT pg_stat_get_vacuum_count('dustbunnies_990002'::regclass);
+ pg_stat_get_vacuum_count 
+--------------------------
+                        2
+(1 row)
+
+SELECT pg_stat_get_analyze_count('dustbunnies_990002'::regclass);
+ pg_stat_get_analyze_count 
+---------------------------
+                         2
+(1 row)
+
 -- disable auto-VACUUM for next test
 ALTER TABLE dustbunnies_990002 SET (autovacuum_enabled = false);
 SELECT relfrozenxid AS frozenxid FROM pg_class WHERE oid='dustbunnies_990002'::regclass
@@ -120,21 +155,6 @@ SELECT relfrozenxid::text::integer > :frozenxid AS frozen_performed FROM pg_clas
 WHERE oid='dustbunnies_990002'::regclass;
  frozen_performed 
 ------------------
- t
-(1 row)
-
--- get file node to verify VACUUM FULL
-SELECT relfilenode AS oldnode FROM pg_class WHERE oid='dustbunnies_990002'::regclass
-\gset
--- send a VACUUM FULL
-\c - - - :master_port
-VACUUM (FULL) dustbunnies;
--- verify that relfrozenxid increased
-\c - - - :worker_1_port
-SELECT relfilenode != :oldnode AS table_rewritten FROM pg_class
-WHERE oid='dustbunnies_990002'::regclass;
- table_rewritten 
------------------
  t
 (1 row)
 

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -86,7 +86,7 @@ SELECT master_create_worker_shards('dustbunnies', 1, 2);
 -- run VACUUM and ANALYZE against the table on the master
 VACUUM dustbunnies;
 ANALYZE dustbunnies;
--- update statistics, then verify that the four dead rows are gone
+-- verify that the VACUUM and ANALYZE ran
 \c - - - :worker_1_port
 SELECT pg_sleep(.500);
  pg_sleep 
@@ -104,5 +104,37 @@ SELECT pg_stat_get_analyze_count('dustbunnies_990002'::regclass);
  pg_stat_get_analyze_count 
 ---------------------------
                          1
+(1 row)
+
+-- disable auto-VACUUM for next test
+ALTER TABLE dustbunnies_990002 SET (autovacuum_enabled = false);
+SELECT relfrozenxid AS frozenxid FROM pg_class WHERE oid='dustbunnies_990002'::regclass
+\gset
+-- send a VACUUM FREEZE after adding a new row
+\c - - - :master_port
+INSERT INTO dustbunnies VALUES (5, 'peter');
+VACUUM (FREEZE) dustbunnies;
+-- verify that relfrozenxid increased
+\c - - - :worker_1_port
+SELECT relfrozenxid::text::integer > :frozenxid AS frozen_performed FROM pg_class
+WHERE oid='dustbunnies_990002'::regclass;
+ frozen_performed 
+------------------
+ t
+(1 row)
+
+-- get file node to verify VACUUM FULL
+SELECT relfilenode AS oldnode FROM pg_class WHERE oid='dustbunnies_990002'::regclass
+\gset
+-- send a VACUUM FULL
+\c - - - :master_port
+VACUUM (FULL) dustbunnies;
+-- verify that relfrozenxid increased
+\c - - - :worker_1_port
+SELECT relfilenode != :oldnode AS table_rewritten FROM pg_class
+WHERE oid='dustbunnies_990002'::regclass;
+ table_rewritten 
+-----------------
+ t
 (1 row)
 

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -93,3 +93,21 @@ VACUUM (FULL) dustbunnies;
 \c - - - :worker_1_port
 SELECT relfilenode != :oldnode AS table_rewritten FROM pg_class
 WHERE oid='dustbunnies_990002'::regclass;
+
+\c - - - :master_port
+-- verify warning for unqualified VACUUM
+VACUUM;
+
+-- and warning when using targeted VACUUM without DDL propagation
+SET citus.enable_ddl_propagation to false;
+VACUUM dustbunnies;
+SET citus.enable_ddl_propagation to DEFAULT;
+
+-- verify error messages for unsupported options
+VACUUM (ANALYZE) dustbunnies (id);
+ANALYZE dustbunnies (id);
+
+-- TODO: support VERBOSE
+-- VACUUM VERBOSE dustbunnies;
+-- VACUUM (FULL, VERBOSE) dustbunnies;
+-- ANALYZE VERBOSE dustbunnies;


### PR DESCRIPTION
Discussed this implementation with @anarazel on Slack, but essentially it piggybacks on the existing multi-shard transaction framework, inheriting the parallelism and cancellation capabilities thereof. This also means it inherits some limitations (such as having a one-to-one host-to-placement connection ratio).

Because `VACUUM` must not run within a transaction, I introduced a new multi-shard commit protocol ("bare"), to be used internally while a `VACUUM` is in progress.

`ANALYZE` is essentially just a special case of `VACUUM` (they use the same node type) and is also fully covered by this review.

Fixes #719