### PR TITLE
Add support for running postgres tests against a database with citus loaded

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -53,6 +53,9 @@ check-isolation: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/isolation_schedule $(EXTRA_TESTS)
 
+check-vanilla: all tempinstall-main
+	$(pg_regress_multi_check) --load-extension=citus --vanillatest
+
 check-multi-task-tracker-extra: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
 	--server-option=citus.task_executor_type=task-tracker \


### PR DESCRIPTION
Not that this is not with the citus *extension* loaded, just the shared
library. The former runs (by adding --use-existing to the flags) but
has a bunch of trivial test differences.

Just needed that, and it was quicker to script than to do manually.

Fixes: #877