### PR TITLE
Make prepared transactions available if not configured.

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -129,7 +129,6 @@ push(@pgOptions, '-c', "listen_addresses='${host}'");
 push(@pgOptions, '-c', "unix_socket_directories=");
 push(@pgOptions, '-c', "fsync=off");
 push(@pgOptions, '-c', "shared_preload_libraries=citus");
-push(@pgOptions, '-c', "max_prepared_transactions=100");
 
 # Citus options set for the tests
 push(@pgOptions, '-c', "citus.shard_max_size=300kB");


### PR DESCRIPTION
As we're likely to use 2PC more heavily after this release (e.g. for reference tables - #879) it seems helpful to configure them to be available by default.

This PR sets max_prepared_transactions to max_connections * 2 if max_connections == 0. Otherwise it remains untouched.

I think after that we should also consider making 2PC the default for DDL etc.