### PR TITLE
Tweak coverage options

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,9 @@ coverage:
       default:
         target: 80
         threshold: 0.5
-    patch: yes
+    patch:
+      default:
+        target: 75
     changes: no
 
 parsers:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,7 +16,12 @@ coverage:
       default:
         target: 75
     changes: no
-
+  ignore:
+    - "src/backend/distributed/utils/citus_outfuncs.c"
+    - "src/backend/distributed/utils/citus_read.c"
+    - "src/backend/distributed/utils/citus_readfuncs_95.c"
+    - "src/backend/distributed/utils/ruleutils_*.c"
+    - "src/include/distributed/citus_nodes.h"
 parsers:
   gcov:
     branch_detection:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,10 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
+    project:
+      default:
+        target: 80
+        threshold: 0.5
     patch: yes
     changes: no
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ coverage:
   status:
     project:
       default:
-        target: 80
+        target: 87.5
         threshold: 0.5
 
     patch:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,21 +7,25 @@ coverage:
   round: down
   range: "70...100"
 
-  status:
-    project:
-      default:
-        target: 80
-        threshold: 0.5
-    patch:
-      default:
-        target: 75
-    changes: no
   ignore:
     - "src/backend/distributed/utils/citus_outfuncs.c"
     - "src/backend/distributed/utils/citus_read.c"
     - "src/backend/distributed/utils/citus_readfuncs_95.c"
     - "src/backend/distributed/utils/ruleutils_*.c"
     - "src/include/distributed/citus_nodes.h"
+
+  status:
+    project:
+      default:
+        target: 80
+        threshold: 0.5
+
+    patch:
+      default:
+        target: 75
+
+    changes: no
+
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
This introduces several tweaks to our new test coverage reports:

  * The "project-wide" status fails if a commit reduces coverage by more than 0.5%, or if the entire project drops beneath 80% covered
  * The "patch-specific" status fails if a patch does not have higher than 75% coverage
  * Files with large sections copy-pasted from PostgreSQL are omitted from coverage

I was also going to specify 'citus-bot' as the codecov user, but it appears their new GitHub Integrations work is complete, so I've added their integration to the Citus org.

After the build for this pull request itself completes, I may revisit the above before a merge.

The base configuration was copy-pasted from [codecov's docs](http://docs.codecov.io/docs/codecov-yaml) and tweaked from there.