### PR TITLE
Expose the column_to_column_name UDF

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -9,7 +9,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
-	6.1-1 6.1-2 6.1-3
+	6.1-1 6.1-2 6.1-3 6.1-4
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -100,6 +100,8 @@ $(EXTENSION)--6.1-1.sql: $(EXTENSION)--6.0-18.sql $(EXTENSION)--6.0-18--6.1-1.sq
 $(EXTENSION)--6.1-2.sql: $(EXTENSION)--6.1-1.sql $(EXTENSION)--6.1-1--6.1-2.sql
 	cat $^ > $@
 $(EXTENSION)--6.1-3.sql: $(EXTENSION)--6.1-2.sql $(EXTENSION)--6.1-2--6.1-3.sql
+	cat $^ > $@
+$(EXTENSION)--6.1-4.sql: $(EXTENSION)--6.1-3.sql $(EXTENSION)--6.1-3--6.1-4.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.1-3--6.1-4.sql
+++ b/src/backend/distributed/citus--6.1-3--6.1-4.sql
@@ -1,0 +1,12 @@
+/* citus--6.1-3--6.1-4.sql */
+
+SET search_path = 'pg_catalog';
+
+CREATE FUNCTION column_to_column_name(table_name regclass, column_var_text text)
+    RETURNS text
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$column_to_column_name$$;
+COMMENT ON FUNCTION column_to_column_name(table_name regclass, column_var_text text)
+    IS 'convert the textual Var representation to a column name';
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.1-3'
+default_version = '6.1-4'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -211,11 +211,11 @@ CREATE TABLE customers (
 INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey)
 VALUES
 	('customers'::regclass, 'h', column_name_to_column('customers'::regclass, 'id'));
-SELECT partmethod, partkey FROM pg_dist_partition
+SELECT partmethod, column_to_column_name(logicalrelid, partkey) FROM pg_dist_partition
 	WHERE logicalrelid = 'customers'::regclass;
- partmethod |                                                        partkey                                                         
-------------+------------------------------------------------------------------------------------------------------------------------
- h          | {VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
+ partmethod | column_to_column_name 
+------------+-----------------------
+ h          | id
 (1 row)
 
 -- make one huge shard and manually inspect shard row

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -61,6 +61,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-18';
 ALTER EXTENSION citus UPDATE TO '6.1-1';
 ALTER EXTENSION citus UPDATE TO '6.1-2';
 ALTER EXTENSION citus UPDATE TO '6.1-3';
+ALTER EXTENSION citus UPDATE TO '6.1-4';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/sql/multi_distribution_metadata.sql
+++ b/src/test/regress/sql/multi_distribution_metadata.sql
@@ -160,7 +160,7 @@ CREATE TABLE customers (
 INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey)
 VALUES
 	('customers'::regclass, 'h', column_name_to_column('customers'::regclass, 'id'));
-SELECT partmethod, partkey FROM pg_dist_partition
+SELECT partmethod, column_to_column_name(logicalrelid, partkey) FROM pg_dist_partition
 	WHERE logicalrelid = 'customers'::regclass;
 
 -- make one huge shard and manually inspect shard row

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -61,6 +61,7 @@ ALTER EXTENSION citus UPDATE TO '6.0-18';
 ALTER EXTENSION citus UPDATE TO '6.1-1';
 ALTER EXTENSION citus UPDATE TO '6.1-2';
 ALTER EXTENSION citus UPDATE TO '6.1-3';
+ALTER EXTENSION citus UPDATE TO '6.1-4';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)


### PR DESCRIPTION
Per #1028, instead of removing `column_to_column_name`, expose it as a debugging help to translate `partkey` to a human-readable column name.

```
# CREATE VIEW distributed_tables AS SELECT logicalrelid AS table_name, column_to_column_name(logicalrelid, partkey) AS distribution_column FROM pg_dist_partition;
CREATE VIEW
# SELECT * FROM distributed_tables ;
    table_name    | distribution_column 
------------------+---------------------
 test             | x
 customer_reviews | customer_id
(2 rows)
```