### PR TITLE
Propagate MX Metadata Changes

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -9,7 +9,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
-	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8
+	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -110,6 +110,8 @@ $(EXTENSION)--6.1-6.sql: $(EXTENSION)--6.1-5.sql $(EXTENSION)--6.1-5--6.1-6.sql
 $(EXTENSION)--6.1-7.sql: $(EXTENSION)--6.1-6.sql $(EXTENSION)--6.1-6--6.1-7.sql
 	cat $^ > $@
 $(EXTENSION)--6.1-8.sql: $(EXTENSION)--6.1-7.sql $(EXTENSION)--6.1-7--6.1-8.sql
+	cat $^ > $@
+$(EXTENSION)--6.1-9.sql: $(EXTENSION)--6.1-8.sql $(EXTENSION)--6.1-8--6.1-9.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.1-8--6.1-9.sql
+++ b/src/backend/distributed/citus--6.1-8--6.1-9.sql
@@ -1,0 +1,89 @@
+/* citus--6.1-8--6.1-9.sql */
+
+SET search_path = 'pg_catalog';
+
+CREATE FUNCTION master_drop_distributed_table_metadata(logicalrelid regclass,
+                                          			   schema_name text,
+                                          			   table_name text)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$master_drop_distributed_table_metadata$$;
+COMMENT ON FUNCTION master_drop_distributed_table_metadata(logicalrelid regclass,
+                                              			   schema_name text,
+                                              			   table_name text)
+    IS 'delete metadata of the distributed table';
+
+CREATE OR REPLACE FUNCTION pg_catalog.citus_drop_trigger()
+    RETURNS event_trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $cdbdt$
+DECLARE
+    v_obj record;
+    sequence_names text[] := '{}';
+    node_names text[] := '{}';
+    node_ports bigint[] := '{}';
+    node_name text;
+    node_port bigint;
+    table_colocation_id integer;
+BEGIN
+    -- collect set of dropped sequences to drop on workers later
+    SELECT array_agg(object_identity) INTO sequence_names
+    FROM pg_event_trigger_dropped_objects()
+    WHERE object_type = 'sequence';
+
+    -- Must accumulate set of affected nodes before deleting placements, as
+    -- master_drop_all_shards will erase their rows, making it impossible for
+    -- us to know where to drop sequences (which must be dropped after shards,
+    -- since they have default value expressions which depend on sequences).
+    SELECT array_agg(sp.nodename), array_agg(sp.nodeport)
+    INTO node_names, node_ports
+    FROM pg_event_trigger_dropped_objects() AS dobj,
+         pg_dist_shard AS s,
+         pg_dist_shard_placement AS sp
+    WHERE dobj.object_type IN ('table', 'foreign table')
+      AND dobj.objid = s.logicalrelid
+      AND s.shardid = sp.shardid;
+
+    FOR v_obj IN SELECT * FROM pg_event_trigger_dropped_objects() LOOP
+        IF v_obj.object_type NOT IN ('table', 'foreign table') THEN
+           CONTINUE;
+        END IF;
+
+        -- nothing to do if not a distributed table
+        IF NOT EXISTS(SELECT * FROM pg_dist_partition WHERE logicalrelid = v_obj.objid) THEN
+            CONTINUE;
+        END IF;
+        
+        -- get colocation group
+        SELECT colocationid INTO table_colocation_id FROM pg_dist_partition WHERE logicalrelid = v_obj.objid;
+
+        -- ensure all shards are dropped
+        PERFORM master_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name);
+        
+        PERFORM master_drop_distributed_table_metadata(v_obj.objid, v_obj.schema_name, v_obj.object_name);
+
+        -- drop colocation group if all referencing tables are dropped
+        IF NOT EXISTS(SELECT * FROM pg_dist_partition WHERE colocationId = table_colocation_id) THEN
+            DELETE FROM pg_dist_colocation WHERE colocationId = table_colocation_id;
+        END IF;
+    END LOOP;
+
+    IF cardinality(sequence_names) = 0 THEN
+        RETURN;
+    END IF;
+
+    FOR node_name, node_port IN
+    SELECT DISTINCT name, port
+    FROM unnest(node_names, node_ports) AS nodes(name, port)
+    LOOP
+        PERFORM master_drop_sequences(sequence_names, node_name, node_port);
+    END LOOP;
+END;
+$cdbdt$;
+
+COMMENT ON FUNCTION citus_drop_trigger()
+    IS 'perform checks and actions at the end of DROP actions';
+    
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.1-8'
+default_version = '6.1-9'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -180,9 +180,7 @@ create_distributed_table(PG_FUNCTION_ARGS)
 		List *commandList = GetDistributedTableDDLEvents(relationId);
 		ListCell *commandCell = NULL;
 
-		/* disable DDL propagation on workers */
-		SendCommandToWorkers(WORKERS_WITH_METADATA,
-							 "SET citus.enable_ddl_propagation TO off");
+		SendCommandToWorkers(WORKERS_WITH_METADATA, DISABLE_DDL_PROPAGATION);
 
 		/* send the commands one by one */
 		foreach(commandCell, commandList)

--- a/src/backend/distributed/commands/drop_distributed_table.c
+++ b/src/backend/distributed/commands/drop_distributed_table.c
@@ -1,0 +1,56 @@
+/*-------------------------------------------------------------------------
+ *
+ * drop_distributed_table.c
+ *	  Routines related to dropping distributed relations from a trigger.
+ *
+ * Copyright (c) 2012-2016, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "miscadmin.h"
+
+#include "distributed/master_metadata_utility.h"
+#include "distributed/master_protocol.h"
+#include "distributed/metadata_sync.h"
+#include "distributed/worker_transaction.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(master_drop_distributed_table_metadata);
+
+
+/*
+ * master_drop_distributed_table_metadata removes the entry of the specified distributed
+ * table from pg_dist_partition and drops the table from the workers if needed.
+ */
+Datum
+master_drop_distributed_table_metadata(PG_FUNCTION_ARGS)
+{
+	Oid relationId = PG_GETARG_OID(0);
+	text *schemaNameText = PG_GETARG_TEXT_P(1);
+	text *tableNameText = PG_GETARG_TEXT_P(2);
+	bool shouldSyncMetadata = false;
+
+	char *schemaName = text_to_cstring(schemaNameText);
+	char *tableName = text_to_cstring(tableNameText);
+
+	CheckTableSchemaNameForDrop(relationId, &schemaName, &tableName);
+
+	DeletePartitionRow(relationId);
+
+	shouldSyncMetadata = ShouldSyncTableMetadata(relationId);
+	if (shouldSyncMetadata)
+	{
+		char *deleteDistributionCommand = NULL;
+
+		/* drop the distributed table metadata on the workers */
+		deleteDistributionCommand = DistributionDeleteCommand(schemaName, tableName);
+		SendCommandToWorkers(WORKERS_WITH_METADATA, deleteDistributionCommand);
+	}
+
+	PG_RETURN_VOID();
+}

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -848,6 +848,17 @@ ShardStorageType(Oid relationId)
 
 
 /*
+ * SchemaNode function returns true if this node is identified as the
+ * schema/coordinator/master node of the cluster.
+ */
+bool
+SchemaNode(void)
+{
+	return (GetLocalGroupId() == 0);
+}
+
+
+/*
  * WorkerNodeGetDatum converts the worker node passed to it into its datum
  * representation. To do this, the function first creates the heap tuple from
  * the worker node name and port. Then, the function converts the heap tuple

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -595,6 +595,25 @@ NodeDeleteCommand(uint32 nodeId)
 
 
 /*
+ * ColocationIdUpdateCommand creates the SQL command to change the colocationId
+ * of the table with the given name to the given colocationId in pg_dist_partition
+ * table.
+ */
+char *
+ColocationIdUpdateCommand(Oid relationId, uint32 colocationId)
+{
+	StringInfo command = makeStringInfo();
+	char *qualifiedRelationName = generate_qualified_relation_name(relationId);
+	appendStringInfo(command, "UPDATE pg_dist_partition "
+							  "SET colocationid = %d "
+							  "WHERE logicalrelid = %s::regclass",
+					 colocationId, quote_literal_cstr(qualifiedRelationName));
+
+	return command->data;
+}
+
+
+/*
  * LocalGroupIdUpdateCommand creates the SQL command required to set the local group id
  * of a worker and returns the command in a string.
  */

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -1377,6 +1377,7 @@ GetLocalGroupId(void)
 	TupleDesc tupleDescriptor = NULL;
 	Oid groupId = InvalidOid;
 	Relation pgDistLocalGroupId = NULL;
+	Oid localGroupTableOid = InvalidOid;
 
 	/*
 	 * Already set the group id, no need to read the heap again.
@@ -1386,7 +1387,13 @@ GetLocalGroupId(void)
 		return LocalGroupId;
 	}
 
-	pgDistLocalGroupId = heap_open(DistLocalGroupIdRelationId(), AccessShareLock);
+	localGroupTableOid = get_relname_relid("pg_dist_local_group", PG_CATALOG_NAMESPACE);
+	if (localGroupTableOid == InvalidOid)
+	{
+		return 0;
+	}
+
+	pgDistLocalGroupId = heap_open(localGroupTableOid, AccessShareLock);
 
 	scanDescriptor = systable_beginscan(pgDistLocalGroupId,
 										InvalidOid, false,

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -76,6 +76,7 @@ extern void DeleteShardRow(uint64 shardId);
 extern void InsertShardPlacementRow(uint64 shardId, uint64 placementId,
 									char shardState, uint64 shardLength,
 									char *nodeName, uint32 nodePort);
+extern void DeletePartitionRow(Oid distributedRelationId);
 extern void DeleteShardRow(uint64 shardId);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern uint64 DeleteShardPlacementRow(uint64 shardId, char *workerName, uint32

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -91,6 +91,8 @@ extern int ShardMaxSize;
 extern int ShardPlacementPolicy;
 
 
+extern bool SchemaNode(void);
+
 /* Function declarations local to the distributed module */
 extern bool CStoreTable(Oid relationId);
 extern uint64 GetNextShardId(void);

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -114,6 +114,8 @@ extern bool WorkerCreateShard(Oid relationId, char *nodeName, uint32 nodePort,
 							  List *ddlCommandList, List *foreignConstraintCommadList);
 extern Oid ForeignConstraintGetReferencedTableId(char *queryString);
 extern void CheckHashPartitionedTable(Oid distributedTableId);
+extern void CheckTableSchemaNameForDrop(Oid relationId, char **schemaName,
+										char **tableName);
 
 /* Function declarations for generating metadata for shard and placement creation */
 extern Datum master_get_table_metadata(PG_FUNCTION_ARGS);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -29,6 +29,7 @@ extern char * TableOwnerResetCommand(Oid distributedRelationId);
 extern char * NodeListInsertCommand(List *workerNodeList);
 extern List * ShardListInsertCommand(List *shardIntervalList);
 extern char * NodeDeleteCommand(uint32 nodeId);
+extern char * ColocationIdUpdateCommand(Oid relationId, uint32 colocationId);
 
 
 #define DELETE_ALL_NODES "TRUNCATE pg_dist_node"

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -34,6 +34,7 @@ extern char * NodeDeleteCommand(uint32 nodeId);
 #define DELETE_ALL_NODES "TRUNCATE pg_dist_node"
 #define REMOVE_ALL_CLUSTERED_TABLES_COMMAND \
 	"SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition"
+#define DISABLE_DDL_PROPAGATION "SET citus.enable_ddl_propagation TO 'off'"
 
 
 #endif /* METADATA_SYNC_H */

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -20,6 +20,7 @@
 /* Functions declarations for metadata syncing */
 extern bool ShouldSyncTableMetadata(Oid relationId);
 extern List * MetadataCreateCommands(void);
+extern List * GetDistributedTableDDLEvents(Oid relationId);
 extern List * MetadataDropCommands(void);
 extern char * DistributionCreateCommand(DistTableCacheEntry *cacheEntry);
 extern char * DistributionDeleteCommand(char *schemaName,

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -371,6 +371,8 @@ SELECT create_distributed_table('table2_groupB', 'id');
  
 (1 row)
 
+UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='table1_groupB'::regclass;
+UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='table2_groupB'::regclass;
 -- revert back to default shard replication factor
 SET citus.shard_replication_factor to DEFAULT;
 -- change partition column type

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -137,3 +137,53 @@ SELECT master_create_distributed_table('supplier_single_shard', 's_suppkey', 'ap
  
 (1 row)
 
+-- Show that when a hash distributed table with replication factor=1 is created, it 
+-- automatically marked as streaming replicated
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE mx_table_test (col1 int, col2 text);
+SELECT create_distributed_table('mx_table_test', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT repmodel FROM pg_dist_partition WHERE logicalrelid='mx_table_test'::regclass;
+ repmodel 
+----------
+ s
+(1 row)
+
+DROP TABLE mx_table_test; 
+-- Show that it is not possible to create an mx table with the old 
+-- master_create_distributed_table function
+CREATE TABLE mx_table_test (col1 int, col2 text);
+SELECT master_create_distributed_table('mx_table_test', 'col1', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT repmodel FROM pg_dist_partition WHERE logicalrelid='mx_table_test'::regclass;
+ repmodel 
+----------
+ c
+(1 row)
+
+DROP TABLE mx_table_test;
+-- Show that when replication factor > 1 the table is created as coordinator-replicated
+SET citus.shard_replication_factor TO 2;
+CREATE TABLE mx_table_test (col1 int, col2 text);
+SELECT create_distributed_table('mx_table_test', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT repmodel FROM pg_dist_partition WHERE logicalrelid='mx_table_test'::regclass;
+ repmodel 
+----------
+ c
+(1 row)
+
+DROP TABLE mx_table_test; 
+SET citus.shard_replication_factor TO default;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -66,6 +66,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-5';
 ALTER EXTENSION citus UPDATE TO '6.1-6';
 ALTER EXTENSION citus UPDATE TO '6.1-7';
 ALTER EXTENSION citus UPDATE TO '6.1-8';
+ALTER EXTENSION citus UPDATE TO '6.1-9';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -288,8 +288,6 @@ Table "mx_testing_schema_2.fk_test_2"
 Foreign-key constraints:
     "fk_test_2_col1_fkey" FOREIGN KEY (col1, col2) REFERENCES mx_testing_schema.fk_test_1(col1, col3)
 
-DROP TABLE mx_testing_schema_2.fk_test_2;
-DROP TABLE mx_testing_schema.fk_test_1;
 \c - - - :master_port
 DROP TABLE mx_testing_schema_2.fk_test_2;
 DROP TABLE mx_testing_schema.fk_test_1;
@@ -435,8 +433,6 @@ SELECT * FROM mx_query_test ORDER BY a;
  6 | six   | 36
 (6 rows)
 
-\c - - - :worker_1_port
-DROP TABLE mx_query_test;
 \c - - - :master_port
 DROP TABLE mx_query_test;
 -- Check that stop_metadata_sync_to_node function sets hasmetadata of the node to false 
@@ -824,7 +820,47 @@ WHERE
 (2 rows)
 
 \c - - - :master_port	
-ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART :last_colocation_id;
+-- Check that DROP TABLE on MX tables works
+DROP TABLE mx_colocation_test_1;
+DROP TABLE mx_colocation_test_2;
+\d mx_colocation_test_1
+\d mx_colocation_test_2
+\c - - - :worker_1_port
+\d mx_colocation_test_1
+\d mx_colocation_test_2
+	
+-- Check that dropped MX table can be recreated again
+\c - - - :master_port	
+SET citus.shard_count TO 7;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE mx_temp_drop_test (a int);
+SELECT create_distributed_table('mx_temp_drop_test', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT logicalrelid, repmodel FROM pg_dist_partition WHERE logicalrelid = 'mx_temp_drop_test'::regclass;
+   logicalrelid    | repmodel 
+-------------------+----------
+ mx_temp_drop_test | s
+(1 row)
+
+DROP TABLE mx_temp_drop_test;
+CREATE TABLE mx_temp_drop_test (a int);
+SELECT create_distributed_table('mx_temp_drop_test', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT logicalrelid, repmodel FROM pg_dist_partition WHERE logicalrelid = 'mx_temp_drop_test'::regclass;
+   logicalrelid    | repmodel 
+-------------------+----------
+ mx_temp_drop_test | s
+(1 row)
+
+DROP TABLE mx_temp_drop_test;
 -- Cleanup
 \c - - - :worker_1_port
 DROP TABLE mx_test_schema_2.mx_table_2 CASCADE;
@@ -856,4 +892,5 @@ DROP TABLE mx_testing_schema.mx_test_table;
 RESET citus.shard_count;
 RESET citus.shard_replication_factor;
 RESET citus.multi_shard_commit_protocol;
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART :last_colocation_id;
 ALTER SEQUENCE pg_catalog.pg_dist_shard_placement_placementid_seq RESTART :last_placement_id;

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -737,6 +737,94 @@ Foreign-key constraints:
 Referenced by:
     TABLE "mx_test_schema_2.mx_table_2" CONSTRAINT "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
 
+-- Check that mark_tables_colocated call propagates the changes to the workers 
+\c - - - :master_port
+SELECT nextval('pg_catalog.pg_dist_colocationid_seq') AS last_colocation_id \gset
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 10000;
+SET citus.shard_count TO 7;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE mx_colocation_test_1 (a int);
+SELECT create_distributed_table('mx_colocation_test_1', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE mx_colocation_test_2 (a int);
+SELECT create_distributed_table('mx_colocation_test_2', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- Check the colocation IDs of the created tables
+SELECT 
+	logicalrelid, colocationid
+FROM 
+	pg_dist_partition 
+WHERE
+	logicalrelid = 'mx_colocation_test_1'::regclass
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY logicalrelid;
+     logicalrelid     | colocationid 
+----------------------+--------------
+ mx_colocation_test_1 |        10000
+ mx_colocation_test_2 |        10000
+(2 rows)
+
+	
+-- Reset the colocation IDs of the test tables
+DELETE FROM 
+	pg_dist_colocation
+WHERE EXISTS (
+	SELECT 1 
+	FROM pg_dist_partition 
+	WHERE 
+		colocationid = pg_dist_partition.colocationid 
+		AND pg_dist_partition.logicalrelid = 'mx_colocation_test_1'::regclass);
+UPDATE 
+	pg_dist_partition 
+SET 
+	colocationid = 0
+WHERE 
+	logicalrelid = 'mx_colocation_test_1'::regclass 
+	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+-- Mark tables colocated and see the changes on the master and the worker
+SELECT mark_tables_colocated('mx_colocation_test_1', ARRAY['mx_colocation_test_2']);
+ mark_tables_colocated 
+-----------------------
+ 
+(1 row)
+
+SELECT 
+	logicalrelid, colocationid 
+FROM 
+	pg_dist_partition 
+WHERE
+	logicalrelid = 'mx_colocation_test_1'::regclass
+	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+     logicalrelid     | colocationid 
+----------------------+--------------
+ mx_colocation_test_1 |        10001
+ mx_colocation_test_2 |        10001
+(2 rows)
+
+\c - - - :worker_1_port
+SELECT 
+	logicalrelid, colocationid 
+FROM 
+	pg_dist_partition 
+WHERE
+	logicalrelid = 'mx_colocation_test_1'::regclass
+	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+     logicalrelid     | colocationid 
+----------------------+--------------
+ mx_colocation_test_1 |        10001
+ mx_colocation_test_2 |        10001
+(2 rows)
+
+\c - - - :master_port	
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART :last_colocation_id;
 -- Cleanup
 \c - - - :worker_1_port
 DROP TABLE mx_test_schema_2.mx_table_2 CASCADE;

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -1,7 +1,8 @@
 --
--- MULTI_METADATA_SNAPSHOT
+-- MULTI_METADATA_SYNC
 --
--- Tests for metadata snapshot functions.
+-- Tests for metadata snapshot functions, metadata syncing functions and propagation of
+-- metadata changes to MX tables.
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1310000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1310000;
 SELECT nextval('pg_catalog.pg_dist_shard_placement_placementid_seq') AS last_placement_id

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -251,6 +251,7 @@ SELECT count(*) FROM pg_trigger WHERE tgrelid='mx_testing_schema.mx_test_table':
 (1 row)
 
 -- Make sure that start_metadata_sync_to_node considers foreign key constraints
+\c - - - :master_port
 SET citus.shard_replication_factor TO 1;
 CREATE SCHEMA mx_testing_schema_2;
 CREATE TABLE mx_testing_schema.fk_test_1 (col1 int, col2 text, col3 int, UNIQUE(col1, col3));
@@ -268,11 +269,6 @@ SELECT create_distributed_table('mx_testing_schema_2.fk_test_2', 'col1');
  
 (1 row)
 
-UPDATE 
-	pg_dist_partition SET repmodel='s' 
-WHERE 
-	logicalrelid='mx_testing_schema.fk_test_1'::regclass
-	OR logicalrelid='mx_testing_schema_2.fk_test_2'::regclass;
 		
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  start_metadata_sync_to_node 
@@ -292,7 +288,11 @@ Table "mx_testing_schema_2.fk_test_2"
 Foreign-key constraints:
     "fk_test_2_col1_fkey" FOREIGN KEY (col1, col2) REFERENCES mx_testing_schema.fk_test_1(col1, col3)
 
+DROP TABLE mx_testing_schema_2.fk_test_2;
+DROP TABLE mx_testing_schema.fk_test_1;
 \c - - - :master_port
+DROP TABLE mx_testing_schema_2.fk_test_2;
+DROP TABLE mx_testing_schema.fk_test_1;
 RESET citus.shard_replication_factor;
 -- Check that repeated calls to start_metadata_sync_to_node has no side effects
 \c - - - :master_port
@@ -383,6 +383,62 @@ SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_port;
  f
 (1 row)
 
+-- Check that the distributed table can be queried from the worker
+\c - - - :master_port
+SET citus.shard_replication_factor TO 1;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+CREATE TABLE mx_query_test (a int, b text, c int);
+SELECT create_distributed_table('mx_query_test', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT repmodel FROM pg_dist_partition WHERE logicalrelid='mx_query_test'::regclass;
+ repmodel 
+----------
+ s
+(1 row)
+
+INSERT INTO mx_query_test VALUES (1, 'one', 1);
+INSERT INTO mx_query_test VALUES (2, 'two', 4);
+INSERT INTO mx_query_test VALUES (3, 'three', 9);
+INSERT INTO mx_query_test VALUES (4, 'four', 16);
+INSERT INTO mx_query_test VALUES (5, 'five', 24);
+\c - - - :worker_1_port
+SELECT * FROM mx_query_test ORDER BY a;
+ a |   b   | c  
+---+-------+----
+ 1 | one   |  1
+ 2 | two   |  4
+ 3 | three |  9
+ 4 | four  | 16
+ 5 | five  | 24
+(5 rows)
+
+INSERT INTO mx_query_test VALUES (6, 'six', 36);
+UPDATE mx_query_test SET c = 25 WHERE a = 5;
+\c - - - :master_port
+SELECT * FROM mx_query_test ORDER BY a;
+ a |   b   | c  
+---+-------+----
+ 1 | one   |  1
+ 2 | two   |  4
+ 3 | three |  9
+ 4 | four  | 16
+ 5 | five  | 25
+ 6 | six   | 36
+(6 rows)
+
+\c - - - :worker_1_port
+DROP TABLE mx_query_test;
+\c - - - :master_port
+DROP TABLE mx_query_test;
 -- Check that stop_metadata_sync_to_node function sets hasmetadata of the node to false 
 \c - - - :master_port
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
@@ -417,6 +473,7 @@ SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 (1 row)
 
 SET citus.shard_count = 5;
+SET citus.multi_shard_commit_protocol TO '2pc';
 CREATE SCHEMA mx_test_schema_1;
 CREATE SCHEMA mx_test_schema_2;
 -- Create MX tables
@@ -468,7 +525,9 @@ FROM
 	pg_dist_partition 
 WHERE 
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
-	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
+ORDER BY 
+	logicalrelid;
         logicalrelid         | repmodel 
 -----------------------------+----------
  mx_test_schema_1.mx_table_1 | s
@@ -487,16 +546,16 @@ ORDER BY
 	logicalrelid, shardid;
         logicalrelid         | shardid | nodename  | nodeport 
 -----------------------------+---------+-----------+----------
- mx_test_schema_1.mx_table_1 | 1310008 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310009 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310010 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310011 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310012 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310013 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310014 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310015 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310016 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310017 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310104 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310105 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310106 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310107 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310108 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310109 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310110 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310111 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310112 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310113 | localhost |    57637
 (10 rows)
 
 	
@@ -552,16 +611,16 @@ ORDER BY
 	logicalrelid, shardid;
         logicalrelid         | shardid | nodename  | nodeport 
 -----------------------------+---------+-----------+----------
- mx_test_schema_1.mx_table_1 | 1310008 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310009 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310010 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310011 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310012 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310013 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310014 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310015 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310016 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310017 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310104 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310105 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310106 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310107 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310108 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310109 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310110 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310111 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310112 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310113 | localhost |    57637
 (10 rows)
 
 -- Check that metadata of MX tables don't exist on the non-metadata worker
@@ -583,10 +642,106 @@ SELECT * FROM pg_dist_shard_placement;
 ---------+------------+-------------+----------+----------+-------------
 (0 rows)
 
+-- Check that CREATE INDEX statement is propagated
+\c - - - :master_port
+SET citus.multi_shard_commit_protocol TO '2pc';
+CREATE INDEX mx_index_3 ON mx_test_schema_2.mx_table_2 USING hash (col1);
+WARNING:  hash indexes are not WAL-logged and their use is discouraged
+CREATE UNIQUE INDEX mx_index_4 ON mx_test_schema_2.mx_table_2(col1);
+\c - - - :worker_1_port
+\d mx_test_schema_2.mx_table_2
+Table "mx_test_schema_2.mx_table_2"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+Indexes:
+    "mx_index_4" UNIQUE, btree (col1)
+    "mx_index_2" btree (col2)
+    "mx_index_3" hash (col1)
+Foreign-key constraints:
+    "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+-- Check that DROP INDEX statement is propagated
+\c - - - :master_port
+SET citus.multi_shard_commit_protocol TO '2pc';
+DROP INDEX mx_test_schema_2.mx_index_3;
+\c - - - :worker_1_port
+\d mx_test_schema_2.mx_table_2
+Table "mx_test_schema_2.mx_table_2"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+Indexes:
+    "mx_index_4" UNIQUE, btree (col1)
+    "mx_index_2" btree (col2)
+Foreign-key constraints:
+    "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+-- Check that ALTER TABLE statements are propagated
+\c - - - :master_port
+SET citus.multi_shard_commit_protocol TO '2pc';
+ALTER TABLE mx_test_schema_1.mx_table_1 ADD COLUMN col3 NUMERIC;
+ALTER TABLE mx_test_schema_1.mx_table_1 ALTER COLUMN col3 SET DATA TYPE INT;
+ALTER TABLE 
+	mx_test_schema_1.mx_table_1 
+ADD CONSTRAINT 
+	mx_fk_constraint 
+FOREIGN KEY 
+	(col1)
+REFERENCES
+	mx_test_schema_2.mx_table_2(col1);
+\c - - - :worker_1_port
+\d mx_test_schema_1.mx_table_1
+Table "mx_test_schema_1.mx_table_1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+ col3   | integer | 
+Indexes:
+    "mx_table_1_col1_key" UNIQUE CONSTRAINT, btree (col1)
+    "mx_index_1" btree (col1)
+Foreign-key constraints:
+    "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_2.mx_table_2(col1)
+Referenced by:
+    TABLE "mx_test_schema_2.mx_table_2" CONSTRAINT "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+-- Check that foreign key constraint with NOT VALID works as well
+\c - - - :master_port
+SET citus.multi_shard_commit_protocol TO '2pc';
+ALTER TABLE mx_test_schema_1.mx_table_1 DROP CONSTRAINT mx_fk_constraint; 
+ALTER TABLE 
+	mx_test_schema_1.mx_table_1 
+ADD CONSTRAINT 
+	mx_fk_constraint_2
+FOREIGN KEY 
+	(col1)
+REFERENCES
+	mx_test_schema_2.mx_table_2(col1)
+NOT VALID;
+\c - - - :worker_1_port
+\d mx_test_schema_1.mx_table_1
+Table "mx_test_schema_1.mx_table_1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+ col3   | integer | 
+Indexes:
+    "mx_table_1_col1_key" UNIQUE CONSTRAINT, btree (col1)
+    "mx_index_1" btree (col1)
+Foreign-key constraints:
+    "mx_fk_constraint_2" FOREIGN KEY (col1) REFERENCES mx_test_schema_2.mx_table_2(col1) NOT VALID
+Referenced by:
+    TABLE "mx_test_schema_2.mx_table_2" CONSTRAINT "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
 -- Cleanup
 \c - - - :worker_1_port
-DROP TABLE mx_test_schema_2.mx_table_2;
-DROP TABLE mx_test_schema_1.mx_table_1;
+DROP TABLE mx_test_schema_2.mx_table_2 CASCADE;
+NOTICE:  drop cascades to constraint mx_fk_constraint_2 on table mx_test_schema_1.mx_table_1
+DROP TABLE mx_test_schema_1.mx_table_1 CASCADE;
 DROP TABLE mx_testing_schema.mx_test_table;
 DELETE FROM pg_dist_node;
 DELETE FROM pg_dist_partition;
@@ -606,9 +761,11 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
  
 (1 row)
 
-DROP TABLE mx_test_schema_2.mx_table_2;
-DROP TABLE mx_test_schema_1.mx_table_1;
+DROP TABLE mx_test_schema_2.mx_table_2 CASCADE;
+NOTICE:  drop cascades to constraint mx_fk_constraint_2 on table mx_test_schema_1.mx_table_1
+DROP TABLE mx_test_schema_1.mx_table_1 CASCADE;
 DROP TABLE mx_testing_schema.mx_test_table;
 RESET citus.shard_count;
 RESET citus.shard_replication_factor;
+RESET citus.multi_shard_commit_protocol;
 ALTER SEQUENCE pg_catalog.pg_dist_shard_placement_placementid_seq RESTART :last_placement_id;

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -409,8 +409,184 @@ SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_1_port;
  f
 (1 row)
 
+-- Test DDL propagation in MX tables
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+SET citus.shard_count = 5;
+CREATE SCHEMA mx_test_schema_1;
+CREATE SCHEMA mx_test_schema_2;
+-- Create MX tables
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE mx_test_schema_1.mx_table_1 (col1 int UNIQUE, col2 text);
+CREATE INDEX mx_index_1 ON mx_test_schema_1.mx_table_1 (col1);
+CREATE TABLE mx_test_schema_2.mx_table_2 (col1 int, col2 text);
+CREATE INDEX mx_index_2 ON mx_test_schema_2.mx_table_2 (col2);
+ALTER TABLE mx_test_schema_2.mx_table_2 ADD CONSTRAINT mx_fk_constraint FOREIGN KEY(col1) REFERENCES mx_test_schema_1.mx_table_1(col1);
+\d mx_test_schema_1.mx_table_1
+Table "mx_test_schema_1.mx_table_1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+Indexes:
+    "mx_table_1_col1_key" UNIQUE CONSTRAINT, btree (col1)
+    "mx_index_1" btree (col1)
+Referenced by:
+    TABLE "mx_test_schema_2.mx_table_2" CONSTRAINT "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+\d mx_test_schema_2.mx_table_2
+Table "mx_test_schema_2.mx_table_2"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+Indexes:
+    "mx_index_2" btree (col2)
+Foreign-key constraints:
+    "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+SELECT create_distributed_table('mx_test_schema_1.mx_table_1', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('mx_test_schema_2.mx_table_2', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- Check that created tables are marked as streaming replicated tables
+SELECT 
+	logicalrelid, repmodel 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
+        logicalrelid         | repmodel 
+-----------------------------+----------
+ mx_test_schema_1.mx_table_1 | s
+ mx_test_schema_2.mx_table_2 | s
+(2 rows)
+
+-- See the shards and placements of the mx tables 
+SELECT 
+	logicalrelid, shardid, nodename, nodeport
+FROM 
+	pg_dist_shard NATURAL JOIN pg_dist_shard_placement
+WHERE 
+	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
+ORDER BY 
+	logicalrelid, shardid;
+        logicalrelid         | shardid | nodename  | nodeport 
+-----------------------------+---------+-----------+----------
+ mx_test_schema_1.mx_table_1 | 1310008 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310009 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310010 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310011 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310012 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310013 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310014 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310015 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310016 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310017 | localhost |    57637
+(10 rows)
+
+	
+-- Check that metadata of MX tables exist on the metadata worker
+\c - - - :worker_1_port
+-- Check that tables are created
+\d mx_test_schema_1.mx_table_1
+Table "mx_test_schema_1.mx_table_1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+Indexes:
+    "mx_table_1_col1_key" UNIQUE CONSTRAINT, btree (col1)
+    "mx_index_1" btree (col1)
+Referenced by:
+    TABLE "mx_test_schema_2.mx_table_2" CONSTRAINT "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+\d mx_test_schema_2.mx_table_2
+Table "mx_test_schema_2.mx_table_2"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | 
+ col2   | text    | 
+Indexes:
+    "mx_index_2" btree (col2)
+Foreign-key constraints:
+    "mx_fk_constraint" FOREIGN KEY (col1) REFERENCES mx_test_schema_1.mx_table_1(col1)
+
+-- Check that table metadata are created
+SELECT 
+	logicalrelid, repmodel 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
+        logicalrelid         | repmodel 
+-----------------------------+----------
+ mx_test_schema_1.mx_table_1 | s
+ mx_test_schema_2.mx_table_2 | s
+(2 rows)
+
+-- Check that shard and placement data are created
+SELECT 
+	logicalrelid, shardid, nodename, nodeport
+FROM 
+	pg_dist_shard NATURAL JOIN pg_dist_shard_placement
+WHERE 
+	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
+ORDER BY 
+	logicalrelid, shardid;
+        logicalrelid         | shardid | nodename  | nodeport 
+-----------------------------+---------+-----------+----------
+ mx_test_schema_1.mx_table_1 | 1310008 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310009 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310010 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310011 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310012 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310013 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310014 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310015 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310016 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310017 | localhost |    57637
+(10 rows)
+
+-- Check that metadata of MX tables don't exist on the non-metadata worker
+\c - - - :worker_2_port
+\d mx_test_schema_1.mx_table_1
+\d mx_test_schema_2.mx_table_2
+SELECT * FROM pg_dist_partition;
+ logicalrelid | partmethod | partkey | colocationid | repmodel 
+--------------+------------+---------+--------------+----------
+(0 rows)
+
+SELECT * FROM pg_dist_shard;
+ logicalrelid | shardid | shardstorage | shardminvalue | shardmaxvalue 
+--------------+---------+--------------+---------------+---------------
+(0 rows)
+
+SELECT * FROM pg_dist_shard_placement;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
 -- Cleanup
 \c - - - :worker_1_port
+DROP TABLE mx_test_schema_2.mx_table_2;
+DROP TABLE mx_test_schema_1.mx_table_1;
 DROP TABLE mx_testing_schema.mx_test_table;
 DELETE FROM pg_dist_node;
 DELETE FROM pg_dist_partition;
@@ -430,5 +606,9 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
  
 (1 row)
 
-DROP TABLE mx_testing_schema.mx_test_table CASCADE;
+DROP TABLE mx_test_schema_2.mx_table_2;
+DROP TABLE mx_test_schema_1.mx_table_1;
+DROP TABLE mx_testing_schema.mx_test_table;
+RESET citus.shard_count;
+RESET citus.shard_replication_factor;
 ALTER SEQUENCE pg_catalog.pg_dist_shard_placement_placementid_seq RESTART :last_placement_id;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -139,7 +139,7 @@ test: multi_data_types
 test: multi_repartition_udt
 test: multi_repartitioned_subquery_udf
 test: multi_modifying_xacts
-test: multi_metadata_snapshot
+test: multi_metadata_sync
 test: multi_transaction_recovery
 
 # ---------

--- a/src/test/regress/sql/multi_colocation_utils.sql
+++ b/src/test/regress/sql/multi_colocation_utils.sql
@@ -175,6 +175,9 @@ SELECT create_distributed_table('table1_groupB', 'id');
 CREATE TABLE table2_groupB ( id int );
 SELECT create_distributed_table('table2_groupB', 'id');
 
+UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='table1_groupB'::regclass;
+UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='table2_groupB'::regclass;
+
 -- revert back to default shard replication factor
 SET citus.shard_replication_factor to DEFAULT;
 

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -66,6 +66,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-5';
 ALTER EXTENSION citus UPDATE TO '6.1-6';
 ALTER EXTENSION citus UPDATE TO '6.1-7';
 ALTER EXTENSION citus UPDATE TO '6.1-8';
+ALTER EXTENSION citus UPDATE TO '6.1-9';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -298,6 +298,67 @@ NOT VALID;
 \c - - - :worker_1_port
 \d mx_test_schema_1.mx_table_1
 
+-- Check that mark_tables_colocated call propagates the changes to the workers 
+\c - - - :master_port
+SELECT nextval('pg_catalog.pg_dist_colocationid_seq') AS last_colocation_id \gset
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 10000;
+SET citus.shard_count TO 7;
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE mx_colocation_test_1 (a int);
+SELECT create_distributed_table('mx_colocation_test_1', 'a');
+
+CREATE TABLE mx_colocation_test_2 (a int);
+SELECT create_distributed_table('mx_colocation_test_2', 'a');
+
+-- Check the colocation IDs of the created tables
+SELECT 
+	logicalrelid, colocationid
+FROM 
+	pg_dist_partition 
+WHERE
+	logicalrelid = 'mx_colocation_test_1'::regclass
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY logicalrelid;
+	
+-- Reset the colocation IDs of the test tables
+DELETE FROM 
+	pg_dist_colocation
+WHERE EXISTS (
+	SELECT 1 
+	FROM pg_dist_partition 
+	WHERE 
+		colocationid = pg_dist_partition.colocationid 
+		AND pg_dist_partition.logicalrelid = 'mx_colocation_test_1'::regclass);
+UPDATE 
+	pg_dist_partition 
+SET 
+	colocationid = 0
+WHERE 
+	logicalrelid = 'mx_colocation_test_1'::regclass 
+	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+
+-- Mark tables colocated and see the changes on the master and the worker
+SELECT mark_tables_colocated('mx_colocation_test_1', ARRAY['mx_colocation_test_2']);
+SELECT 
+	logicalrelid, colocationid 
+FROM 
+	pg_dist_partition 
+WHERE
+	logicalrelid = 'mx_colocation_test_1'::regclass
+	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+\c - - - :worker_1_port
+SELECT 
+	logicalrelid, colocationid 
+FROM 
+	pg_dist_partition 
+WHERE
+	logicalrelid = 'mx_colocation_test_1'::regclass
+	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+
+\c - - - :master_port	
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART :last_colocation_id;
+
 
 -- Cleanup
 \c - - - :worker_1_port

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -1,8 +1,9 @@
 --
--- MULTI_METADATA_SNAPSHOT
+-- MULTI_METADATA_SYNC
 --
 
--- Tests for metadata snapshot functions.
+-- Tests for metadata snapshot functions, metadata syncing functions and propagation of
+-- metadata changes to MX tables.
 
 
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1310000;


### PR DESCRIPTION
This change adds support for creating and maintaining MX tables by providing proper metadata propagation to workers during `create_distributed_table`, `DROP TABLE`, DDLs and other metadata changing commands.

Fixes #791 

Remaining Work:
- [x] Automatically mark hash distributed tables with RF=1 with `repmodel=s`
- [x] Propagate mx table and shard metadata in `create_distributed_table`
- [x] Propagate DDL changes (including Foreign Keys)
- [x] Propagate `mark_tables_colocated` changes
- [x] Handle `DROP TABLE`
