### PR TITLE
Add colocate_with option to create_distributed_table()

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -9,7 +9,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
-	6.1-1 6.1-2 6.1-3 6.1-4
+	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -103,6 +103,8 @@ $(EXTENSION)--6.1-3.sql: $(EXTENSION)--6.1-2.sql $(EXTENSION)--6.1-2--6.1-3.sql
 	cat $^ > $@
 $(EXTENSION)--6.1-4.sql: $(EXTENSION)--6.1-3.sql $(EXTENSION)--6.1-3--6.1-4.sql
 	cat $^ > $@
+$(EXTENSION)--6.1-5.sql: $(EXTENSION)--6.1-4.sql $(EXTENSION)--6.1-4--6.1-5.sql
+	cat $^ > $@	
 
 NO_PGXS = 1
 

--- a/src/backend/distributed/citus--6.1-4--6.1-5.sql
+++ b/src/backend/distributed/citus--6.1-4--6.1-5.sql
@@ -1,0 +1,20 @@
+/* citus--6.1-4--6.1-5.sql */
+
+SET search_path = 'pg_catalog';
+
+DROP FUNCTION create_distributed_table(regclass, text, citus.distribution_type);
+
+CREATE FUNCTION create_distributed_table(table_name regclass,
+										 distribution_column text,
+										 distribution_type citus.distribution_type DEFAULT 'hash',
+										 colocate_with text DEFAULT 'default')
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$create_distributed_table$$;
+COMMENT ON FUNCTION create_distributed_table(table_name regclass,
+											 distribution_column text,
+											 distribution_type citus.distribution_type,
+											 colocate_with text)
+    IS 'creates a distributed table';
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.1-4'
+default_version = '6.1-5'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -10,20 +10,24 @@
  */
 
 #include "postgres.h"
+#include "miscadmin.h"
 
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/xact.h"
 #include "catalog/indexing.h"
+#include "commands/sequence.h"
 #include "distributed/colocation_utils.h"
 #include "distributed/listutils.h"
 #include "distributed/master_protocol.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_logical_planner.h"
+#include "distributed/pg_dist_colocation.h"
 #include "distributed/resource_lock.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/worker_protocol.h"
+#include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -36,6 +40,7 @@ static bool ShardsIntervalsEqual(ShardInterval *leftShardInterval,
 								 ShardInterval *rightShardInterval);
 static int CompareShardPlacementsByNode(const void *leftElement,
 										const void *rightElement);
+static uint32 GetNextColocationId(void);
 static void UpdateRelationColocationGroup(Oid distributedRelationId, uint32 colocationId);
 
 
@@ -336,6 +341,129 @@ CompareShardPlacementsByNode(const void *leftElement, const void *rightElement)
 	{
 		return 0;
 	}
+}
+
+
+/*
+ * ColocationId searches pg_dist_colocation for shard count, replication factor
+ * and distribution column type. If a matching entry is found, it returns the
+ * colocation id, otherwise it returns INVALID_COLOCATION_ID.
+ */
+uint32
+ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType)
+{
+	uint32 colocationId = INVALID_COLOCATION_ID;
+	HeapTuple colocationTuple = NULL;
+	SysScanDesc scanDescriptor;
+	const int scanKeyCount = 3;
+	ScanKeyData scanKey[scanKeyCount];
+	bool indexOK = true;
+
+	Relation pgDistColocation = heap_open(DistColocationRelationId(), AccessShareLock);
+
+	/* set scan arguments */
+	ScanKeyInit(&scanKey[0], Anum_pg_dist_colocation_shardcount,
+				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(shardCount));
+	ScanKeyInit(&scanKey[1], Anum_pg_dist_colocation_replicationfactor,
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(replicationFactor));
+	ScanKeyInit(&scanKey[2], Anum_pg_dist_colocation_distributioncolumntype,
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(distributionColumnType));
+
+	scanDescriptor = systable_beginscan(pgDistColocation,
+										DistColocationConfigurationIndexId(),
+										indexOK, NULL, scanKeyCount, scanKey);
+
+	colocationTuple = systable_getnext(scanDescriptor);
+	if (HeapTupleIsValid(colocationTuple))
+	{
+		Form_pg_dist_colocation colocationForm =
+			(Form_pg_dist_colocation) GETSTRUCT(colocationTuple);
+
+		colocationId = colocationForm->colocationid;
+	}
+
+	systable_endscan(scanDescriptor);
+	heap_close(pgDistColocation, AccessShareLock);
+
+	return colocationId;
+}
+
+
+/*
+ * CreateColocationGroup creates a new colocation id and writes it into
+ * pg_dist_colocation with the given configuration. It also returns the created
+ * colocation id.
+ */
+uint32
+CreateColocationGroup(int shardCount, int replicationFactor, Oid distributionColumnType)
+{
+	uint32 colocationId = GetNextColocationId();
+	Relation pgDistColocation = NULL;
+	TupleDesc tupleDescriptor = NULL;
+	HeapTuple heapTuple = NULL;
+	Datum values[Natts_pg_dist_colocation];
+	bool isNulls[Natts_pg_dist_colocation];
+
+	/* form new colocation tuple */
+	memset(values, 0, sizeof(values));
+	memset(isNulls, false, sizeof(isNulls));
+
+	values[Anum_pg_dist_colocation_colocationid - 1] = UInt32GetDatum(colocationId);
+	values[Anum_pg_dist_colocation_shardcount - 1] = UInt32GetDatum(shardCount);
+	values[Anum_pg_dist_colocation_replicationfactor - 1] =
+		UInt32GetDatum(replicationFactor);
+	values[Anum_pg_dist_colocation_distributioncolumntype - 1] =
+		ObjectIdGetDatum(distributionColumnType);
+
+	/* open colocation relation and insert the new tuple */
+	pgDistColocation = heap_open(DistColocationRelationId(), RowExclusiveLock);
+
+	tupleDescriptor = RelationGetDescr(pgDistColocation);
+	heapTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
+
+	simple_heap_insert(pgDistColocation, heapTuple);
+	CatalogUpdateIndexes(pgDistColocation, heapTuple);
+
+	/* increment the counter so that next command can see the row */
+	CommandCounterIncrement();
+	heap_close(pgDistColocation, RowExclusiveLock);
+
+	return colocationId;
+}
+
+
+/*
+ * GetNextColocationId allocates and returns a unique colocationId for the
+ * colocation group to be created. This allocation occurs both in shared memory
+ * and in write ahead logs; writing to logs avoids the risk of having
+ * colocationId collisions.
+ *
+ * Please note that the caller is still responsible for finalizing colocationId
+ * with the master node. Further note that this function relies on an internal
+ * sequence created in initdb to generate unique identifiers.
+ */
+static uint32
+GetNextColocationId()
+{
+	text *sequenceName = cstring_to_text(COLOCATIONID_SEQUENCE_NAME);
+	Oid sequenceId = ResolveRelationId(sequenceName);
+	Datum sequenceIdDatum = ObjectIdGetDatum(sequenceId);
+	Oid savedUserId = InvalidOid;
+	int savedSecurityContext = 0;
+	Datum colocationIdDatum = 0;
+	uint32 colocationId = INVALID_COLOCATION_ID;
+
+	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
+	SetUserIdAndSecContext(CitusExtensionOwner(), SECURITY_LOCAL_USERID_CHANGE);
+
+	/* generate new and unique colocation id from sequence */
+	colocationIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
+
+	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
+
+	colocationId = DatumGetUInt32(colocationIdDatum);
+
+	return colocationId;
 }
 
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -260,8 +260,9 @@ DistributedTableCacheEntry(Oid distributedRelationId)
 	}
 	else
 	{
-		ereport(ERROR, (errmsg("relation %u is not distributed",
-							   distributedRelationId)));
+		char *relationName = get_rel_name(distributedRelationId);
+		ereport(ERROR, (errmsg("relation %s is not distributed",
+							   relationName)));
 	}
 }
 

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -25,6 +25,7 @@ extern List * ColocatedTableList(Oid distributedTableId);
 extern List * ColocatedShardIntervalList(ShardInterval *shardInterval);
 extern Oid ColocatedTableId(Oid colocationId);
 extern uint64 ColocatedShardIdInRelation(Oid relationId, int shardIndex);
+uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType);
 extern uint32 CreateColocationGroup(int shardCount, int replicationFactor,
 									Oid distributionColumnType);
 

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -29,6 +29,7 @@ uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColum
 extern uint32 CreateColocationGroup(int shardCount, int replicationFactor,
 									Oid distributionColumnType);
 extern uint32 GetNextColocationId(void);
+extern void CheckReplicationModel(Oid sourceRelationId, Oid targetRelationId);
 
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -30,6 +30,7 @@ extern uint32 CreateColocationGroup(int shardCount, int replicationFactor,
 									Oid distributionColumnType);
 extern uint32 GetNextColocationId(void);
 extern void CheckReplicationModel(Oid sourceRelationId, Oid targetRelationId);
+extern void CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelationId);
 
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -28,6 +28,7 @@ extern uint64 ColocatedShardIdInRelation(Oid relationId, int shardIndex);
 uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType);
 extern uint32 CreateColocationGroup(int shardCount, int replicationFactor,
 									Oid distributionColumnType);
+extern uint32 GetNextColocationId(void);
 
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -504,6 +504,115 @@ SELECT create_distributed_table('schema_collocation.table4_groupE', 'id');
  
 (1 row)
 
+-- test colocate_with option
+CREATE TABLE table1_group_none_1 ( id int );
+SELECT create_distributed_table('table1_group_none_1', 'id', colocate_with => 'none');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table2_group_none_1 ( id int );
+SELECT create_distributed_table('table2_group_none_1', 'id', colocate_with => 'table1_group_none_1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table1_group_none_2 ( id int );
+SELECT create_distributed_table('table1_group_none_2', 'id', colocate_with => 'none');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table4_groupE ( id int );
+SELECT create_distributed_table('table4_groupE', 'id', colocate_with => 'default');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SET citus.shard_count = 3;
+-- check that this new configuration does not have a default group
+CREATE TABLE table1_group_none_3 ( id int );
+SELECT create_distributed_table('table1_group_none_3', 'id', colocate_with => 'NONE');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- a new table does not use a non-default group
+CREATE TABLE table1_group_default ( id int );
+SELECT create_distributed_table('table1_group_default', 'id', colocate_with => 'DEFAULT');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- check metadata
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid;
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+            2 |          2 |                 1 |                     23
+            3 |          2 |                 2 |                     25
+            4 |          4 |                 2 |                     23
+            5 |          2 |                 2 |                     23
+            9 |          3 |                 2 |                     23
+(5 rows)
+
+SELECT logicalrelid, colocationid FROM pg_dist_partition
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
+           logicalrelid           | colocationid 
+----------------------------------+--------------
+ table1_groupb                    |            2
+ table2_groupb                    |            2
+ table1_groupc                    |            3
+ table2_groupc                    |            3
+ table1_groupd                    |            4
+ table2_groupd                    |            4
+ table3_groupd                    |            4
+ table1_groupe                    |            5
+ table2_groupe                    |            5
+ table3_groupe                    |            5
+ schema_collocation.table4_groupe |            5
+ table4_groupe                    |            5
+ table1_group_none_1              |            6
+ table2_group_none_1              |            6
+ table1_group_none_2              |            7
+ table1_group_none_3              |            8
+ table1_group_default             |            9
+(17 rows)
+
+-- check failing colocate_with options
+CREATE TABLE table_postgresql( id int );
+CREATE TABLE table_failing ( id int );
+SELECT create_distributed_table('table_failing', 'id', colocate_with => 'table_append');
+ERROR:  cannot distribute relation
+DETAIL:  Currently, colocate_with option is only supported for hash distributed tables.
+SELECT create_distributed_table('table_failing', 'id', 'append', 'table1_groupE');
+ERROR:  cannot distribute relation
+DETAIL:  Currently, colocate_with option is only supported for hash distributed tables.
+SELECT create_distributed_table('table_failing', 'id', colocate_with => 'table_postgresql');
+ERROR:  relation table_postgresql is not distributed
+SELECT create_distributed_table('table_failing', 'id', colocate_with => 'no_table');
+ERROR:  relation "no_table" does not exist
+SELECT create_distributed_table('table_failing', 'id', colocate_with => '');
+ERROR:  invalid name syntax
+SELECT create_distributed_table('table_failing', 'id', colocate_with => NULL);
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- check with different distribution column types
+CREATE TABLE table_bigint ( id bigint );
+SELECT create_distributed_table('table_bigint', 'id', colocate_with => 'table1_groupE');
+ERROR:  cannot colocate with table1_groupE
+DETAIL:  Distribution column types are different.
 -- check worker table schemas
 \c - - - :worker_1_port
 \d table3_groupE_1300050
@@ -535,8 +644,8 @@ SELECT create_reference_table('table2_groupF');
 (1 row)
 
 -- check metadata
-SELECT * FROM pg_dist_colocation 
-    WHERE colocationid >= 1 AND colocationid < 1000 
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
@@ -544,8 +653,9 @@ SELECT * FROM pg_dist_colocation
             3 |          2 |                 2 |                     25
             4 |          4 |                 2 |                     23
             5 |          2 |                 2 |                     23
-            6 |          1 |                 2 |                     23
-(5 rows)
+            9 |          3 |                 2 |                     23
+           10 |          1 |                 2 |                     23
+(6 rows)
 
 -- cross check with internal colocation API
 SELECT 
@@ -563,22 +673,27 @@ WHERE
 ORDER BY
     table1,
     table2;
-    table1     |              table2              | colocated 
----------------+----------------------------------+-----------
- table1_group1 | table2_group1                    | t
- table1_groupb | table2_groupb                    | t
- table1_groupc | table2_groupc                    | t
- table1_groupd | table2_groupd                    | t
- table1_groupd | table3_groupd                    | t
- table2_groupd | table3_groupd                    | t
- table1_groupe | table2_groupe                    | t
- table1_groupe | table3_groupe                    | t
- table1_groupe | schema_collocation.table4_groupe | t
- table2_groupe | table3_groupe                    | t
- table2_groupe | schema_collocation.table4_groupe | t
- table3_groupe | schema_collocation.table4_groupe | t
- table1_groupf | table2_groupf                    | t
-(13 rows)
+              table1              |              table2              | colocated 
+----------------------------------+----------------------------------+-----------
+ table1_group1                    | table2_group1                    | t
+ table1_groupb                    | table2_groupb                    | t
+ table1_groupc                    | table2_groupc                    | t
+ table1_groupd                    | table2_groupd                    | t
+ table1_groupd                    | table3_groupd                    | t
+ table2_groupd                    | table3_groupd                    | t
+ table1_groupe                    | table2_groupe                    | t
+ table1_groupe                    | table3_groupe                    | t
+ table1_groupe                    | schema_collocation.table4_groupe | t
+ table1_groupe                    | table4_groupe                    | t
+ table2_groupe                    | table3_groupe                    | t
+ table2_groupe                    | schema_collocation.table4_groupe | t
+ table2_groupe                    | table4_groupe                    | t
+ table3_groupe                    | schema_collocation.table4_groupe | t
+ table3_groupe                    | table4_groupe                    | t
+ schema_collocation.table4_groupe | table4_groupe                    | t
+ table1_group_none_1              | table2_group_none_1              | t
+ table1_groupf                    | table2_groupf                    | t
+(18 rows)
 
 -- check created shards
 SELECT
@@ -653,11 +768,39 @@ ORDER BY
  schema_collocation.table4_groupe | 1300052 | t            |    57637 | -2147483648   | -1
  schema_collocation.table4_groupe | 1300053 | t            |    57637 | 0             | 2147483647
  schema_collocation.table4_groupe | 1300053 | t            |    57638 | 0             | 2147483647
- table1_groupf                    | 1300054 | t            |    57637 | -2147483648   | 2147483647
- table1_groupf                    | 1300054 | t            |    57638 | -2147483648   | 2147483647
- table2_groupf                    | 1300055 | t            |    57638 | -2147483648   | 2147483647
- table2_groupf                    | 1300055 | t            |    57637 | -2147483648   | 2147483647
-(56 rows)
+ table1_group_none_1              | 1300054 | t            |    57637 | -2147483648   | -1
+ table1_group_none_1              | 1300054 | t            |    57638 | -2147483648   | -1
+ table1_group_none_1              | 1300055 | t            |    57638 | 0             | 2147483647
+ table1_group_none_1              | 1300055 | t            |    57637 | 0             | 2147483647
+ table2_group_none_1              | 1300056 | t            |    57638 | -2147483648   | -1
+ table2_group_none_1              | 1300056 | t            |    57637 | -2147483648   | -1
+ table2_group_none_1              | 1300057 | t            |    57637 | 0             | 2147483647
+ table2_group_none_1              | 1300057 | t            |    57638 | 0             | 2147483647
+ table1_group_none_2              | 1300058 | t            |    57637 | -2147483648   | -1
+ table1_group_none_2              | 1300058 | t            |    57638 | -2147483648   | -1
+ table1_group_none_2              | 1300059 | t            |    57638 | 0             | 2147483647
+ table1_group_none_2              | 1300059 | t            |    57637 | 0             | 2147483647
+ table4_groupe                    | 1300060 | t            |    57637 | -2147483648   | -1
+ table4_groupe                    | 1300060 | t            |    57638 | -2147483648   | -1
+ table4_groupe                    | 1300061 | t            |    57638 | 0             | 2147483647
+ table4_groupe                    | 1300061 | t            |    57637 | 0             | 2147483647
+ table1_group_none_3              | 1300062 | t            |    57637 | -2147483648   | -715827884
+ table1_group_none_3              | 1300062 | t            |    57638 | -2147483648   | -715827884
+ table1_group_none_3              | 1300063 | t            |    57638 | -715827883    | 715827881
+ table1_group_none_3              | 1300063 | t            |    57637 | -715827883    | 715827881
+ table1_group_none_3              | 1300064 | t            |    57637 | 715827882     | 2147483647
+ table1_group_none_3              | 1300064 | t            |    57638 | 715827882     | 2147483647
+ table1_group_default             | 1300065 | t            |    57637 | -2147483648   | -715827884
+ table1_group_default             | 1300065 | t            |    57638 | -2147483648   | -715827884
+ table1_group_default             | 1300066 | t            |    57638 | -715827883    | 715827881
+ table1_group_default             | 1300066 | t            |    57637 | -715827883    | 715827881
+ table1_group_default             | 1300067 | t            |    57637 | 715827882     | 2147483647
+ table1_group_default             | 1300067 | t            |    57638 | 715827882     | 2147483647
+ table1_groupf                    | 1300068 | t            |    57637 | -2147483648   | 2147483647
+ table1_groupf                    | 1300068 | t            |    57638 | -2147483648   | 2147483647
+ table2_groupf                    | 1300069 | t            |    57638 | -2147483648   | 2147483647
+ table2_groupf                    | 1300069 | t            |    57637 | -2147483648   | 2147483647
+(84 rows)
 
 -- reset colocation ids to test mark_tables_colocated
 ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1;
@@ -666,16 +809,16 @@ DELETE FROM pg_dist_colocation
 UPDATE pg_dist_partition SET colocationid = 0
     WHERE colocationid >= 1 AND colocationid < 1000;
 -- check metadata
-SELECT * FROM pg_dist_colocation 
-    WHERE colocationid >= 1 AND colocationid < 1000 
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
 (0 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
-    WHERE colocationid >= 1 AND colocationid < 1000 
-    ORDER BY logicalrelid;
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
  logicalrelid | colocationid 
 --------------+--------------
 (0 rows)
@@ -697,16 +840,16 @@ SELECT mark_tables_colocated('table1_groupB', ARRAY['table2_groupB', 'table1_gro
 ERROR:  cannot colocate tables table1_groupb and table1_groupd
 DETAIL:  Shard counts don't match for table1_groupb and table1_groupd.
 -- check metadata to see failing calls didn't have any side effects
-SELECT * FROM pg_dist_colocation 
-    WHERE colocationid >= 1 AND colocationid < 1000 
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
 (0 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
-    WHERE colocationid >= 1 AND colocationid < 1000 
-    ORDER BY logicalrelid;
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
  logicalrelid | colocationid 
 --------------+--------------
 (0 rows)
@@ -749,6 +892,21 @@ SELECT mark_tables_colocated('table1_groupB', ARRAY['table1_groupB']);
  
 (1 row)
 
+SET citus.shard_count = 2;
+CREATE TABLE table1_group_none ( id int );
+SELECT create_distributed_table('table1_group_none', 'id', colocate_with => 'NONE');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table2_group_none ( id int );
+SELECT create_distributed_table('table2_group_none', 'id', colocate_with => 'NONE');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
 -- check metadata to see colocation groups are created successfully
 SELECT * FROM pg_dist_colocation 
     WHERE colocationid >= 1 AND colocationid < 1000 
@@ -765,18 +923,66 @@ SELECT * FROM pg_dist_colocation
 SELECT logicalrelid, colocationid FROM pg_dist_partition
     WHERE colocationid >= 1 AND colocationid < 1000 
     ORDER BY logicalrelid;
- logicalrelid  | colocationid 
----------------+--------------
- table1_groupb |            2
- table2_groupb |            2
- table1_groupc |            3
- table2_groupc |            3
- table1_groupd |            4
- table2_groupd |            4
- table1_groupe |            5
- table2_groupe |            5
- table3_groupe |            5
- table1_groupf |            6
- table2_groupf |            6
-(11 rows)
+   logicalrelid    | colocationid 
+-------------------+--------------
+ table1_groupb     |            2
+ table2_groupb     |            2
+ table1_groupc     |            3
+ table2_groupc     |            3
+ table1_groupd     |            4
+ table2_groupd     |            4
+ table1_groupe     |            5
+ table2_groupe     |            5
+ table3_groupe     |            5
+ table1_groupf     |            6
+ table2_groupf     |            6
+ table1_group_none |            7
+ table2_group_none |            8
+(13 rows)
+
+-- move the all tables in colocation group 5 to colocation group 7
+SELECT mark_tables_colocated('table1_group_none', ARRAY['table1_groupE', 'table2_groupE', 'table3_groupE']);
+ mark_tables_colocated 
+-----------------------
+ 
+(1 row)
+
+-- move a table with a colocation id which is already not in pg_dist_colocation
+SELECT mark_tables_colocated('table1_group_none', ARRAY['table2_group_none']);
+ mark_tables_colocated 
+-----------------------
+ 
+(1 row)
+
+-- check metadata to see that unused colocation group is deleted
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid;
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+            2 |          2 |                 1 |                     23
+            3 |          2 |                 2 |                     25
+            4 |          4 |                 2 |                     23
+            6 |          1 |                 2 |                     23
+(4 rows)
+
+SELECT logicalrelid, colocationid FROM pg_dist_partition
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
+   logicalrelid    | colocationid 
+-------------------+--------------
+ table1_groupb     |            2
+ table2_groupb     |            2
+ table1_groupc     |            3
+ table2_groupc     |            3
+ table1_groupd     |            4
+ table2_groupd     |            4
+ table1_groupf     |            6
+ table2_groupf     |            6
+ table1_groupe     |            7
+ table2_groupe     |            7
+ table3_groupe     |            7
+ table1_group_none |            7
+ table2_group_none |            7
+(13 rows)
 

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -611,8 +611,8 @@ SELECT create_distributed_table('table_failing', 'id', colocate_with => NULL);
 -- check with different distribution column types
 CREATE TABLE table_bigint ( id bigint );
 SELECT create_distributed_table('table_bigint', 'id', colocate_with => 'table1_groupE');
-ERROR:  cannot colocate with table1_groupE
-DETAIL:  Distribution column types are different.
+ERROR:  cannot colocate tables table1_groupe and table_bigint
+DETAIL:  Distribution column types don't match for table1_groupe and table_bigint.
 -- check worker table schemas
 \c - - - :worker_1_port
 \d table3_groupE_1300050
@@ -921,8 +921,8 @@ SELECT * FROM pg_dist_colocation
 (5 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
-    WHERE colocationid >= 1 AND colocationid < 1000 
-    ORDER BY logicalrelid;
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
    logicalrelid    | colocationid 
 -------------------+--------------
  table1_groupb     |            2
@@ -986,3 +986,49 @@ SELECT logicalrelid, colocationid FROM pg_dist_partition
  table2_group_none |            7
 (13 rows)
 
+-- try to colocate different replication models
+CREATE TABLE table1_groupG ( id int );
+SELECT create_distributed_table('table1_groupG', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- update replication model
+UPDATE pg_dist_partition SET repmodel = 's' WHERE logicalrelid = 'table1_groupG'::regclass;
+CREATE TABLE table2_groupG ( id int );
+SELECT create_distributed_table('table2_groupG', 'id', colocate_with => 'table1_groupG');
+ERROR:  cannot colocate tables table1_groupg and table2_groupg
+DETAIL:  Replication models don't match for table1_groupg and table2_groupg.
+CREATE TABLE table2_groupG ( id int );
+ERROR:  relation "table2_groupg" already exists
+SELECT create_distributed_table('table2_groupG', 'id', colocate_with => 'NONE');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT mark_tables_colocated('table1_groupG', ARRAY['table2_groupG']);
+ERROR:  cannot colocate tables table1_groupg and table2_groupg
+DETAIL:  Replication models don't match for table1_groupg and table2_groupg.
+-- drop tables to clean test space
+DROP TABLE table1_groupb;
+DROP TABLE table2_groupb;
+DROP TABLE table1_groupc;
+DROP TABLE table2_groupc;
+DROP TABLE table1_groupd;
+DROP TABLE table2_groupd;
+DROP TABLE table1_groupf;
+DROP TABLE table2_groupf;
+DROP TABLE table1_groupe;
+DROP TABLE table2_groupe;
+DROP TABLE table3_groupe;
+DROP TABLE table4_groupe;
+DROP TABLE schema_collocation.table4_groupe;
+DROP TABLE table1_group_none_1;
+DROP TABLE table2_group_none_1;
+DROP TABLE table1_group_none_2;
+DROP TABLE table1_group_none_3;
+DROP TABLE table1_group_none;
+DROP TABLE table2_group_none;
+DROP TABLE table1_group_default;

--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -156,7 +156,7 @@ SELECT partition_type('events_hash');
 (1 row)
 
 SELECT partition_type('pg_type');
-ERROR:  relation 1247 is not distributed
+ERROR:  relation pg_type is not distributed
 -- should see true for events_hash, false for others
 SELECT is_distributed_table('events_hash');
  is_distributed_table 

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -62,6 +62,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-1';
 ALTER EXTENSION citus UPDATE TO '6.1-2';
 ALTER EXTENSION citus UPDATE TO '6.1-3';
 ALTER EXTENSION citus UPDATE TO '6.1-4';
+ALTER EXTENSION citus UPDATE TO '6.1-5';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/sql/multi_colocation_utils.sql
+++ b/src/test/regress/sql/multi_colocation_utils.sql
@@ -399,8 +399,8 @@ SELECT * FROM pg_dist_colocation
     ORDER BY colocationid;
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
-    WHERE colocationid >= 1 AND colocationid < 1000 
-    ORDER BY logicalrelid;
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
 
 -- move the all tables in colocation group 5 to colocation group 7
 SELECT mark_tables_colocated('table1_group_none', ARRAY['table1_groupE', 'table2_groupE', 'table3_groupE']);
@@ -416,3 +416,40 @@ SELECT * FROM pg_dist_colocation
 SELECT logicalrelid, colocationid FROM pg_dist_partition
     WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid, logicalrelid;
+
+-- try to colocate different replication models
+CREATE TABLE table1_groupG ( id int );
+SELECT create_distributed_table('table1_groupG', 'id');
+
+-- update replication model
+UPDATE pg_dist_partition SET repmodel = 's' WHERE logicalrelid = 'table1_groupG'::regclass;
+
+CREATE TABLE table2_groupG ( id int );
+SELECT create_distributed_table('table2_groupG', 'id', colocate_with => 'table1_groupG');
+
+CREATE TABLE table2_groupG ( id int );
+SELECT create_distributed_table('table2_groupG', 'id', colocate_with => 'NONE');
+
+SELECT mark_tables_colocated('table1_groupG', ARRAY['table2_groupG']);
+
+-- drop tables to clean test space
+DROP TABLE table1_groupb;
+DROP TABLE table2_groupb;
+DROP TABLE table1_groupc;
+DROP TABLE table2_groupc;
+DROP TABLE table1_groupd;
+DROP TABLE table2_groupd;
+DROP TABLE table1_groupf;
+DROP TABLE table2_groupf;
+DROP TABLE table1_groupe;
+DROP TABLE table2_groupe;
+DROP TABLE table3_groupe;
+DROP TABLE table4_groupe;
+DROP TABLE schema_collocation.table4_groupe;
+DROP TABLE table1_group_none_1;
+DROP TABLE table2_group_none_1;
+DROP TABLE table1_group_none_2;
+DROP TABLE table1_group_none_3;
+DROP TABLE table1_group_none;
+DROP TABLE table2_group_none;
+DROP TABLE table1_group_default;

--- a/src/test/regress/sql/multi_colocation_utils.sql
+++ b/src/test/regress/sql/multi_colocation_utils.sql
@@ -241,6 +241,53 @@ CREATE SCHEMA schema_collocation;
 CREATE TABLE schema_collocation.table4_groupE ( id int );
 SELECT create_distributed_table('schema_collocation.table4_groupE', 'id');
 
+-- test colocate_with option
+CREATE TABLE table1_group_none_1 ( id int );
+SELECT create_distributed_table('table1_group_none_1', 'id', colocate_with => 'none');
+
+CREATE TABLE table2_group_none_1 ( id int );
+SELECT create_distributed_table('table2_group_none_1', 'id', colocate_with => 'table1_group_none_1');
+
+CREATE TABLE table1_group_none_2 ( id int );
+SELECT create_distributed_table('table1_group_none_2', 'id', colocate_with => 'none');
+
+CREATE TABLE table4_groupE ( id int );
+SELECT create_distributed_table('table4_groupE', 'id', colocate_with => 'default');
+
+SET citus.shard_count = 3;
+
+-- check that this new configuration does not have a default group
+CREATE TABLE table1_group_none_3 ( id int );
+SELECT create_distributed_table('table1_group_none_3', 'id', colocate_with => 'NONE');
+
+-- a new table does not use a non-default group
+CREATE TABLE table1_group_default ( id int );
+SELECT create_distributed_table('table1_group_default', 'id', colocate_with => 'DEFAULT');
+
+-- check metadata
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid;
+
+SELECT logicalrelid, colocationid FROM pg_dist_partition
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
+
+-- check failing colocate_with options
+CREATE TABLE table_postgresql( id int );
+CREATE TABLE table_failing ( id int );
+
+SELECT create_distributed_table('table_failing', 'id', colocate_with => 'table_append');
+SELECT create_distributed_table('table_failing', 'id', 'append', 'table1_groupE');
+SELECT create_distributed_table('table_failing', 'id', colocate_with => 'table_postgresql');
+SELECT create_distributed_table('table_failing', 'id', colocate_with => 'no_table');
+SELECT create_distributed_table('table_failing', 'id', colocate_with => '');
+SELECT create_distributed_table('table_failing', 'id', colocate_with => NULL);
+
+-- check with different distribution column types
+CREATE TABLE table_bigint ( id bigint );
+SELECT create_distributed_table('table_bigint', 'id', colocate_with => 'table1_groupE');
+
 -- check worker table schemas
 \c - - - :worker_1_port
 \d table3_groupE_1300050
@@ -255,8 +302,8 @@ CREATE TABLE table2_groupF ( id int );
 SELECT create_reference_table('table2_groupF');
 
 -- check metadata
-SELECT * FROM pg_dist_colocation 
-    WHERE colocationid >= 1 AND colocationid < 1000 
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
 
 -- cross check with internal colocation API
@@ -304,13 +351,13 @@ UPDATE pg_dist_partition SET colocationid = 0
     WHERE colocationid >= 1 AND colocationid < 1000;
 
 -- check metadata
-SELECT * FROM pg_dist_colocation 
-    WHERE colocationid >= 1 AND colocationid < 1000 
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
-    WHERE colocationid >= 1 AND colocationid < 1000 
-    ORDER BY logicalrelid;
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
 
 -- first check failing cases
 SELECT mark_tables_colocated('table1_groupB', ARRAY['table1_groupC']);
@@ -320,13 +367,13 @@ SELECT mark_tables_colocated('table1_groupB', ARRAY['table1_groupF']);
 SELECT mark_tables_colocated('table1_groupB', ARRAY['table2_groupB', 'table1_groupD']);
 
 -- check metadata to see failing calls didn't have any side effects
-SELECT * FROM pg_dist_colocation 
-    WHERE colocationid >= 1 AND colocationid < 1000 
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
-    WHERE colocationid >= 1 AND colocationid < 1000 
-    ORDER BY logicalrelid;
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;
 
 -- check successfully cololated tables
 SELECT mark_tables_colocated('table1_groupB', ARRAY['table2_groupB']);
@@ -338,6 +385,14 @@ SELECT mark_tables_colocated('table1_groupF', ARRAY['table2_groupF']);
 -- check to colocate with itself
 SELECT mark_tables_colocated('table1_groupB', ARRAY['table1_groupB']);
 
+SET citus.shard_count = 2;
+
+CREATE TABLE table1_group_none ( id int );
+SELECT create_distributed_table('table1_group_none', 'id', colocate_with => 'NONE');
+
+CREATE TABLE table2_group_none ( id int );
+SELECT create_distributed_table('table2_group_none', 'id', colocate_with => 'NONE');
+
 -- check metadata to see colocation groups are created successfully
 SELECT * FROM pg_dist_colocation 
     WHERE colocationid >= 1 AND colocationid < 1000 
@@ -346,3 +401,18 @@ SELECT * FROM pg_dist_colocation
 SELECT logicalrelid, colocationid FROM pg_dist_partition
     WHERE colocationid >= 1 AND colocationid < 1000 
     ORDER BY logicalrelid;
+
+-- move the all tables in colocation group 5 to colocation group 7
+SELECT mark_tables_colocated('table1_group_none', ARRAY['table1_groupE', 'table2_groupE', 'table3_groupE']);
+
+-- move a table with a colocation id which is already not in pg_dist_colocation
+SELECT mark_tables_colocated('table1_group_none', ARRAY['table2_group_none']);
+
+-- check metadata to see that unused colocation group is deleted
+SELECT * FROM pg_dist_colocation
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid;
+
+SELECT logicalrelid, colocationid FROM pg_dist_partition
+    WHERE colocationid >= 1 AND colocationid < 1000
+    ORDER BY colocationid, logicalrelid;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -62,6 +62,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-1';
 ALTER EXTENSION citus UPDATE TO '6.1-2';
 ALTER EXTENSION citus UPDATE TO '6.1-3';
 ALTER EXTENSION citus UPDATE TO '6.1-4';
+ALTER EXTENSION citus UPDATE TO '6.1-5';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)


### PR DESCRIPTION
**1- Default option:**

This is the current behavior of the distributed colocated table creation. If there is a collocation group with the same configuration, use it. Otherwise, create a new colocation group.

i. Provide colocate_with => 'default' 

``` sql
select create_distributed_table('orders', 'o_orderkey', colocate_with => 'default');
```

ii. Or does not provide colocate_with at all and use 'default' as the default value.

``` sql
select create_distributed_table('orders', 'o_orderkey');
```

**2- Colocate with a specific table**

Colocate with the given table. If not possible, error out.

``` sql
select create_distributed_table('orders', 'o_orderkey', colocate_with => 'lineitem');
```

**3- Create a new colocation group**

Create a new colocation group id, but don't add a line to pg_dist_colocation.

``` sql
select create_distributed_table('orders', 'o_orderkey', colocate_with => 'none');
```

Fixes #847