### PR TITLE
Make git ignore multi_outer_join_reference test outputs

### DIFF
--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -8,6 +8,7 @@
 /multi_large_shardid.out
 /multi_master_delete_protocol.out
 /multi_outer_join.out
+/multi_outer_join_reference.out
 /multi_load_data.out
 /multi_load_large_records.out
 /multi_load_more_data.out

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -7,6 +7,7 @@
 /multi_large_shardid.sql
 /multi_master_delete_protocol.sql
 /multi_outer_join.sql
+/multi_outer_join_reference.sql
 /multi_load_data.sql
 /multi_load_large_records.sql
 /multi_load_more_data.sql


### PR DESCRIPTION
This change adds `multi_outer_join_reference` regression test outputs to their .gitignore files.