### PR TITLE
Error out on foreign keys with reference tables

### DIFF
--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -773,3 +773,64 @@ SELECT * FROM self_referencing_table2;
 
 -- we no longer need those tables
 DROP TABLE self_referencing_table2;
+-- test reference tables
+-- test foreign key creation on CREATE TABLE from reference table
+CREATE TABLE referenced_by_reference_table(id int PRIMARY KEY, other_column int);
+SELECT create_distributed_table('referenced_by_reference_table', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_by_reference_table(id));
+SELECT create_reference_table('reference_table');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on CREATE TABLE to reference table
+DROP TABLE reference_table;
+CREATE TABLE reference_table(id int PRIMARY KEY, referencing_column int);
+SELECT create_reference_table('reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+CREATE TABLE references_to_reference_table(id int, referencing_column int REFERENCES reference_table(id));
+SELECT create_distributed_table('references_to_reference_table', 'referencing_column');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on CREATE TABLE from + to reference table
+CREATE TABLE reference_table2(id int, referencing_column int REFERENCES reference_table(id));
+SELECT create_reference_table('reference_table2');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on ALTER TABLE from reference table
+ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_by_reference_table(id);
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on ALTER TABLE to reference table
+DROP TABLE references_to_reference_table;
+CREATE TABLE references_to_reference_table(id int, referencing_column int);
+SELECT create_distributed_table('references_to_reference_table', 'referencing_column');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE references_to_reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES reference_table(id);
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on ALTER TABLE from + to reference table
+DROP TABLE reference_table2;
+CREATE TABLE reference_table2(id int, referencing_column int);
+SELECT create_reference_table('reference_table2');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+ALTER TABLE reference_table2 ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES reference_table(id);
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- we no longer need those tables
+DROP TABLE referenced_by_reference_table, references_to_reference_table, reference_table, reference_table2;

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -800,11 +800,40 @@ SELECT create_distributed_table('references_to_reference_table', 'referencing_co
 ERROR:  cannot create foreign key constraint
 DETAIL:  Foreign key constraints are not allowed from or to reference tables.
 -- test foreign key creation on CREATE TABLE from + to reference table
-CREATE TABLE reference_table2(id int, referencing_column int REFERENCES reference_table(id));
-SELECT create_reference_table('reference_table2');
+CREATE TABLE reference_table_second(id int, referencing_column int REFERENCES reference_table(id));
+SELECT create_reference_table('reference_table_second');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on CREATE TABLE from reference table to local table
+CREATE TABLE referenced_local_table(id int PRIMARY KEY, other_column int);
+DROP TABLE reference_table CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to constraint references_to_reference_table_referencing_column_fkey on table references_to_reference_table
+drop cascades to constraint reference_table_second_referencing_column_fkey on table reference_table_second
+CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_local_table(id));
+SELECT create_reference_table('reference_table');
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on CREATE TABLE on self referencing reference table
+CREATE TABLE self_referencing_reference_table(
+    id int,
+    other_column int,
+    other_column_ref int,
+    PRIMARY KEY(id, other_column),
+    FOREIGN KEY(id, other_column_ref) REFERENCES self_referencing_reference_table(id, other_column)
+);
+SELECT create_reference_table('self_referencing_reference_table');
 ERROR:  cannot create foreign key constraint
 DETAIL:  Foreign key constraints are not allowed from or to reference tables.
 -- test foreign key creation on ALTER TABLE from reference table
+DROP TABLE reference_table;
+CREATE TABLE reference_table(id int PRIMARY KEY, referencing_column int);
+SELECT create_reference_table('reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_by_reference_table(id);
 ERROR:  cannot create foreign key constraint
 DETAIL:  Foreign key constraints are not allowed from or to reference tables.
@@ -821,16 +850,45 @@ ALTER TABLE references_to_reference_table ADD CONSTRAINT fk FOREIGN KEY(referenc
 ERROR:  cannot create foreign key constraint
 DETAIL:  Foreign key constraints are not allowed from or to reference tables.
 -- test foreign key creation on ALTER TABLE from + to reference table
-DROP TABLE reference_table2;
-CREATE TABLE reference_table2(id int, referencing_column int);
-SELECT create_reference_table('reference_table2');
+DROP TABLE reference_table_second;
+CREATE TABLE reference_table_second(id int, referencing_column int);
+SELECT create_reference_table('reference_table_second');
  create_reference_table 
 ------------------------
  
 (1 row)
 
-ALTER TABLE reference_table2 ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES reference_table(id);
+ALTER TABLE reference_table_second ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES reference_table(id);
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on ALTER TABLE from reference table to local table
+DROP TABLE reference_table;
+CREATE TABLE reference_table(id int PRIMARY KEY, referencing_column int);
+SELECT create_reference_table('reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_local_table(id);
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints are not allowed from or to reference tables.
+-- test foreign key creation on ALTER TABLE on self referencing reference table
+DROP TABLE self_referencing_reference_table;
+CREATE TABLE self_referencing_reference_table(
+    id int,
+    other_column int,
+    other_column_ref int,
+    PRIMARY KEY(id, other_column)
+);
+SELECT create_reference_table('self_referencing_reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+ALTER TABLE self_referencing_reference_table ADD CONSTRAINT fk FOREIGN KEY(id, other_column_ref) REFERENCES self_referencing_reference_table(id, other_column);
 ERROR:  cannot create foreign key constraint
 DETAIL:  Foreign key constraints are not allowed from or to reference tables.
 -- we no longer need those tables
-DROP TABLE referenced_by_reference_table, references_to_reference_table, reference_table, reference_table2;
+DROP TABLE referenced_by_reference_table, references_to_reference_table, reference_table, reference_table_second, referenced_local_table, self_referencing_reference_table;

--- a/src/test/regress/sql/multi_foreign_key.sql
+++ b/src/test/regress/sql/multi_foreign_key.sql
@@ -449,3 +449,42 @@ SELECT * FROM self_referencing_table2;
 
 -- we no longer need those tables
 DROP TABLE self_referencing_table2;
+
+
+-- test reference tables
+-- test foreign key creation on CREATE TABLE from reference table
+CREATE TABLE referenced_by_reference_table(id int PRIMARY KEY, other_column int);
+SELECT create_distributed_table('referenced_by_reference_table', 'id');
+
+CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_by_reference_table(id));
+SELECT create_reference_table('reference_table');
+
+-- test foreign key creation on CREATE TABLE to reference table
+DROP TABLE reference_table;
+CREATE TABLE reference_table(id int PRIMARY KEY, referencing_column int);
+SELECT create_reference_table('reference_table');
+
+CREATE TABLE references_to_reference_table(id int, referencing_column int REFERENCES reference_table(id));
+SELECT create_distributed_table('references_to_reference_table', 'referencing_column');
+
+-- test foreign key creation on CREATE TABLE from + to reference table
+CREATE TABLE reference_table2(id int, referencing_column int REFERENCES reference_table(id));
+SELECT create_reference_table('reference_table2');
+
+-- test foreign key creation on ALTER TABLE from reference table
+ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_by_reference_table(id);
+
+-- test foreign key creation on ALTER TABLE to reference table
+DROP TABLE references_to_reference_table;
+CREATE TABLE references_to_reference_table(id int, referencing_column int);
+SELECT create_distributed_table('references_to_reference_table', 'referencing_column');
+ALTER TABLE references_to_reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES reference_table(id);
+
+-- test foreign key creation on ALTER TABLE from + to reference table
+DROP TABLE reference_table2;
+CREATE TABLE reference_table2(id int, referencing_column int);
+SELECT create_reference_table('reference_table2');
+ALTER TABLE reference_table2 ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES reference_table(id);
+
+-- we no longer need those tables
+DROP TABLE referenced_by_reference_table, references_to_reference_table, reference_table, reference_table2;


### PR DESCRIPTION
Fixes #968 

We have one replication of reference table for each node. Therefore all problems with
replication factor > 1 also applies to reference table. As a solution we will not allow
foreign keys on reference tables. It is not possible to define foreign key from, to or
between reference tables.