### PR TITLE
Convert multi_shard_transaction to the new connection API

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -950,7 +950,7 @@ ExecuteModifyTasks(List *taskList, bool expectResults, ParamListInfo paramListIn
 			bool shardConnectionsFound = false;
 			ShardConnections *shardConnections = NULL;
 			List *connectionList = NIL;
-			TransactionConnection *transactionConnection = NULL;
+			MultiConnection *multiConnection = NULL;
 			PGconn *connection = NULL;
 			bool queryOK = false;
 
@@ -963,9 +963,9 @@ ExecuteModifyTasks(List *taskList, bool expectResults, ParamListInfo paramListIn
 				continue;
 			}
 
-			transactionConnection =
-				(TransactionConnection *) list_nth(connectionList, placementIndex);
-			connection = transactionConnection->connection;
+			multiConnection =
+				(MultiConnection *) list_nth(connectionList, placementIndex);
+			connection = multiConnection->pgConn;
 
 			queryOK = SendQueryInSingleRowMode(connection, queryString, paramListInfo);
 			if (!queryOK)
@@ -982,7 +982,7 @@ ExecuteModifyTasks(List *taskList, bool expectResults, ParamListInfo paramListIn
 			bool shardConnectionsFound = false;
 			ShardConnections *shardConnections = NULL;
 			List *connectionList = NIL;
-			TransactionConnection *transactionConnection = NULL;
+			MultiConnection *multiConnection = NULL;
 			PGconn *connection = NULL;
 			int64 currentAffectedTupleCount = 0;
 			bool failOnError = true;
@@ -1001,9 +1001,9 @@ ExecuteModifyTasks(List *taskList, bool expectResults, ParamListInfo paramListIn
 				continue;
 			}
 
-			transactionConnection =
-				(TransactionConnection *) list_nth(connectionList, placementIndex);
-			connection = transactionConnection->connection;
+			multiConnection =
+				(MultiConnection *) list_nth(connectionList, placementIndex);
+			connection = multiConnection->pgConn;
 
 			/*
 			 * If caller is interested, store query results the first time

--- a/src/include/distributed/multi_shard_transaction.h
+++ b/src/include/distributed/multi_shard_transaction.h
@@ -21,13 +21,18 @@
 typedef struct ShardConnections
 {
 	int64 shardId;
+
+	/*
+	 * XXX: this list contains MultiConnection for multi-shard transactions
+	 * or TransactionConnection for COPY, the latter should be converted to
+	 * use MultiConnection as well.
+	 */
 	List *connectionList;
 } ShardConnections;
 
 
 extern void OpenTransactionsToAllShardPlacements(List *shardIdList, char *relationOwner);
 extern HTAB * CreateShardConnectionHash(MemoryContext memoryContext);
-extern void BeginTransactionOnShardPlacements(uint64 shardId, char *nodeUser);
 extern ShardConnections * GetShardConnections(int64 shardId, bool *shardConnectionsFound);
 extern ShardConnections * GetShardHashConnections(HTAB *connectionHash, int64 shardId,
 												  bool *connectionsFound);


### PR DESCRIPTION
Start using `MultiConnection` instead of `TransactionConnection` in multi-shard transactions. It uses a slightly sneaky trick of simply putting MultiConnections instead of TransactionConnections in the `connectionList` in `ShardConnections`, which works since there is no overlap between the COPY and multi-shard code paths anymore. This will allow us to convert the router executor to MultiConnection (see #1053) and as a bonus adds parallel connection establishment for multi-shard commands.

Once #1057 is merged, `COPY` will be the only TransactionConnection user, which should make the conversion much simpler.