### PR TITLE
Add binary search capability to ShardIndex()

### DIFF
--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -277,7 +277,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId)
 		uint64 sourceShardId = sourceShardInterval->shardId;
 		uint64 newShardId = GetNextShardId();
 		ListCell *sourceShardPlacementCell = NULL;
-		int sourceShardIndex = FindShardIntervalIndex(sourceShardInterval);
+		int sourceShardIndex = ShardIndex(sourceShardInterval);
 
 		int32 shardMinValue = DatumGetInt32(sourceShardInterval->minValue);
 		int32 shardMaxValue = DatumGetInt32(sourceShardInterval->maxValue);

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -307,7 +307,7 @@ CopyShardForeignConstraintCommandList(ShardInterval *shardInterval)
 	/* we will only use shardIndex if there is a foreign constraint */
 	if (commandList != NIL)
 	{
-		shardIndex = FindShardIntervalIndex(shardInterval);
+		shardIndex = ShardIndex(shardInterval);
 	}
 
 	foreach(commandCell, commandList)

--- a/src/backend/distributed/test/colocation_utils.c
+++ b/src/backend/distributed/test/colocation_utils.c
@@ -153,7 +153,7 @@ find_shard_interval_index(PG_FUNCTION_ARGS)
 {
 	uint32 shardId = PG_GETARG_UINT32(0);
 	ShardInterval *shardInterval = LoadShardInterval(shardId);
-	uint32 shardIndex = FindShardIntervalIndex(shardInterval);
+	uint32 shardIndex = ShardIndex(shardInterval);
 
 	PG_RETURN_INT32(shardIndex);
 }

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -348,7 +348,7 @@ ShardsIntervalsEqual(ShardInterval *leftShardInterval, ShardInterval *rightShard
  * partitioned table's shards.
  *
  * We do min/max value check here to decide whether two shards are colocated,
- * instead we can simply use FindShardIntervalIndex function on both shards then
+ * instead we can simply use ShardIndex function on both shards then
  * but do index check, but we avoid it because this way it is more cheaper.
  */
 static bool
@@ -852,10 +852,10 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 		return colocatedShardList;
 	}
 
-	shardIntervalIndex = FindShardIntervalIndex(shardInterval);
+	shardIntervalIndex = ShardIndex(shardInterval);
 	colocatedTableList = ColocatedTableList(distributedTableId);
 
-	/* FindShardIntervalIndex have to find index of given shard */
+	/* ShardIndex have to find index of given shard */
 	Assert(shardIntervalIndex >= 0);
 
 	foreach(colocatedTableCell, colocatedTableList)

--- a/src/include/distributed/shardinterval_utils.h
+++ b/src/include/distributed/shardinterval_utils.h
@@ -15,6 +15,8 @@
 #include "distributed/master_metadata_utility.h"
 #include "nodes/primnodes.h"
 
+#define INVALID_SHARD_INDEX -1
+
 /* OperatorCacheEntry contains information for each element in OperatorCache */
 typedef struct ShardIntervalCompareFunctionCacheEntry
 {
@@ -29,7 +31,7 @@ extern int CompareShardIntervals(const void *leftElement, const void *rightEleme
 extern int CompareShardIntervalsById(const void *leftElement, const void *rightElement);
 extern int CompareRelationShards(const void *leftElement,
 								 const void *rightElement);
-extern int FindShardIntervalIndex(ShardInterval *shardInterval);
+extern int ShardIndex(ShardInterval *shardInterval);
 extern ShardInterval * FindShardInterval(Datum partitionColumnValue,
 										 ShardInterval **shardIntervalCache,
 										 int shardCount, char partitionMethod,

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -107,9 +107,8 @@ INSERT INTO limit_orders VALUES (32744, 'AAPL', 9580, '2004-10-19 10:23:54', 'bu
 -- try a single-row INSERT with no shard to receive it
 INSERT INTO insufficient_shards VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
 										20.69);
-ERROR:  distributed modifications must target exactly one shard
-DETAIL:  This command modifies no shards.
-HINT:  Make sure the value for partition column "id" falls into a single shard.
+ERROR:  cannot find shard interval
+DETAIL:  Hash of the partition column value does not fall into any shards.
 -- try an insert to a range-partitioned table
 INSERT INTO range_partitioned VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
 									  20.69);


### PR DESCRIPTION
Renamed FindShardIntervalIndex() to ShardIndex() and added binary search
capability. It used to assume that hash partition tables are always
uniformly distributed which is not true if upcoming tenant isolation
feature is applied. This commit also reduces code duplication.

This is a prerequisite for #844.