### PR TITLE
Replicate reference tables when new node is added

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -9,7 +9,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.1-1 5.1-2 5.1-3 5.1-4 5.1-5 5.1-6 5.1-7 5.1-8 \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
-	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12
+	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12 6.1-13
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -118,6 +118,8 @@ $(EXTENSION)--6.1-10.sql: $(EXTENSION)--6.1-9.sql $(EXTENSION)--6.1-9--6.1-10.sq
 $(EXTENSION)--6.1-11.sql: $(EXTENSION)--6.1-10.sql $(EXTENSION)--6.1-10--6.1-11.sql
 	cat $^ > $@
 $(EXTENSION)--6.1-12.sql: $(EXTENSION)--6.1-11.sql $(EXTENSION)--6.1-11--6.1-12.sql
+	cat $^ > $@
+$(EXTENSION)--6.1-13.sql: $(EXTENSION)--6.1-12.sql $(EXTENSION)--6.1-12--6.1-13.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.1-12--6.1-13.sql
+++ b/src/backend/distributed/citus--6.1-12--6.1-13.sql
@@ -1,0 +1,8 @@
+/* citus--6.1-12--6.1-13.sql */
+
+SET search_path = 'pg_catalog';
+
+CREATE INDEX pg_dist_partition_partmethod_index
+ON pg_dist_partition using btree(partmethod);
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.1-12'
+default_version = '6.1-13'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -58,9 +58,11 @@ static Oid distNodeRelationId = InvalidOid;
 static Oid distLocalGroupRelationId = InvalidOid;
 static Oid distColocationRelationId = InvalidOid;
 static Oid distColocationConfigurationIndexId = InvalidOid;
+static Oid distColocationColocationidIndexId = InvalidOid;
 static Oid distPartitionRelationId = InvalidOid;
 static Oid distPartitionLogicalRelidIndexId = InvalidOid;
 static Oid distPartitionColocationidIndexId = InvalidOid;
+static Oid distPartitionPartitionMethodIndexId = InvalidOid;
 static Oid distShardLogicalRelidIndexId = InvalidOid;
 static Oid distShardShardidIndexId = InvalidOid;
 static Oid distShardPlacementShardidIndexId = InvalidOid;
@@ -762,6 +764,17 @@ DistColocationConfigurationIndexId(void)
 }
 
 
+/* return oid of pg_dist_colocation_pkey index */
+Oid
+DistColocationColocationidIndexId(void)
+{
+	CachedRelationLookup("pg_dist_colocation_pkey",
+						 &distColocationColocationidIndexId);
+
+	return distColocationColocationidIndexId;
+}
+
+
 /* return oid of pg_dist_partition relation */
 Oid
 DistPartitionRelationId(void)
@@ -791,6 +804,17 @@ DistPartitionColocationidIndexId(void)
 						 &distPartitionColocationidIndexId);
 
 	return distPartitionColocationidIndexId;
+}
+
+
+/* return oid of pg_dist_partition_partmethod_index index */
+Oid
+DistPartitionPartitionMethodIndexId(void)
+{
+	CachedRelationLookup("pg_dist_partition_partmethod_index",
+						 &distPartitionPartitionMethodIndexId);
+
+	return distPartitionPartitionMethodIndexId;
 }
 
 
@@ -1565,8 +1589,10 @@ InvalidateDistRelationCacheCallback(Datum argument, Oid relationId)
 		distNodeRelationId = InvalidOid;
 		distColocationRelationId = InvalidOid;
 		distColocationConfigurationIndexId = InvalidOid;
+		distColocationColocationidIndexId = InvalidOid;
 		distPartitionRelationId = InvalidOid;
 		distPartitionLogicalRelidIndexId = InvalidOid;
+		distPartitionPartitionMethodIndexId = InvalidOid;
 		distPartitionColocationidIndexId = InvalidOid;
 		distShardLogicalRelidIndexId = InvalidOid;
 		distShardShardidIndexId = InvalidOid;

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -30,6 +30,7 @@
 #include "distributed/metadata_sync.h"
 #include "distributed/multi_join_order.h"
 #include "distributed/pg_dist_node.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
@@ -81,6 +82,14 @@ master_add_node(PG_FUNCTION_ARGS)
 
 	Datum returnData = AddNodeMetadata(nodeNameString, nodePort, groupId, nodeRack,
 									   hasMetadata);
+
+	/*
+	 * After adding new node, we also replicate all existing reference tables to the new
+	 * node. ReplicateAllReferenceTablesToAllNodes replicates reference tables to all
+	 * nodes however, it skips nodes which already has healthy placement of particular
+	 * reference table.
+	 */
+	ReplicateAllReferenceTablesToAllNodes();
 
 	PG_RETURN_CSTRING(returnData);
 }

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -85,6 +85,8 @@ extern void DeleteShardRow(uint64 shardId);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern uint64 DeleteShardPlacementRow(uint64 shardId, char *workerName, uint32
 									  workerPort);
+extern void UpdateColocationGroupReplicationFactor(uint32 colocationId,
+												   int replicationFactor);
 extern void CreateTruncateTrigger(Oid relationId);
 
 /* Remaining metadata utility functions  */

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -68,6 +68,7 @@ extern HTAB * GetWorkerNodeHash(void);
 /* relation oids */
 extern Oid DistColocationRelationId(void);
 extern Oid DistColocationConfigurationIndexId(void);
+extern Oid DistColocationColocationidIndexId(void);
 extern Oid DistPartitionRelationId(void);
 extern Oid DistShardRelationId(void);
 extern Oid DistShardPlacementRelationId(void);
@@ -77,6 +78,7 @@ extern Oid DistLocalGroupIdRelationId(void);
 /* index oids */
 extern Oid DistPartitionLogicalRelidIndexId(void);
 extern Oid DistPartitionColocationidIndexId(void);
+extern Oid DistPartitionPartitionMethodIndexId(void);
 extern Oid DistShardLogicalRelidIndexId(void);
 extern Oid DistShardShardidIndexId(void);
 extern Oid DistShardPlacementShardidIndexId(void);

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -13,5 +13,6 @@
 #define REFERENCE_TABLE_UTILS_H_
 
 extern uint32 CreateReferenceTableColocationId(void);
+extern void ReplicateAllReferenceTablesToAllNodes(void);
 
 #endif /* REFERENCE_TABLE_UTILS_H_ */

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -70,6 +70,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-9';
 ALTER EXTENSION citus UPDATE TO '6.1-10';
 ALTER EXTENSION citus UPDATE TO '6.1-11';
 ALTER EXTENSION citus UPDATE TO '6.1-12';
+ALTER EXTENSION citus UPDATE TO '6.1-13';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1574,7 +1574,7 @@ ERROR:  single-shard DML commands must not appear in transaction blocks which co
 ROLLBACK;
 -- clean up tables
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
-		   reference_table_test_fourth, reference_table_ddl;
+		   reference_table_test_fourth, reference_table_ddl, reference_table_composite;
 DROP SCHEMA reference_schema CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table reference_schema.reference_table_test_sixth

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -1,0 +1,326 @@
+--
+-- MULTI_REPLICATE_REFERENCE_TABLE
+--
+-- Tests that check the metadata returned by the master node.
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1370000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1370000;
+CREATE TABLE tmp_shard_placement(
+    shardid int8 NOT NULL,
+    shardstate int4 NOT NULL,
+    shardlength int8 NOT NULL,
+    nodename text NOT NULL,
+    nodeport int8 NOT NULL,
+    placementid bigint NOT NULL
+);
+-- remove a node for testing purposes
+INSERT INTO tmp_shard_placement (SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port);
+DELETE FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+-- test adding new node with no reference tables
+SELECT master_add_node('localhost', :worker_2_port);
+         master_add_node         
+---------------------------------
+ (3,3,localhost,57638,default,f)
+(1 row)
+
+-- verify nothing is replicated to the new node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+-- test adding new node with a reference table which does not have any healthy placement
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+CREATE TABLE replicate_reference_table_unhealthy(column1 int);
+SELECT create_reference_table('replicate_reference_table_unhealthy');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1370000;
+SELECT master_add_node('localhost', :worker_2_port);
+ERROR:  could not find any healthy placement for shard 1370000
+-- verify nothing is replicated to the new node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+DROP TABLE replicate_reference_table_unhealthy;
+-- test replicating a reference table when a new node added
+CREATE TABLE replicate_reference_table_valid(column1 int);
+SELECT create_reference_table('replicate_reference_table_valid');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           37 |          1 |                 1 |                      0
+(1 row)
+
+SELECT master_add_node('localhost', :worker_2_port);
+NOTICE:  Replicating shard 1370001 to worker localhost:57638...
+         master_add_node         
+---------------------------------
+ (5,5,localhost,57638,default,f)
+(1 row)
+
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename  | nodeport | placementid 
+---------+------------+-------------+-----------+----------+-------------
+ 1370001 |          1 |           0 | localhost |    57638 |         393
+(1 row)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           37 |          1 |                 2 |                      0
+(1 row)
+
+DROP TABLE replicate_reference_table_valid;
+-- test replicating a reference table when a new node added in TRANSACTION + ROLLBACK
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+CREATE TABLE replicate_reference_table_rollback(column1 int);
+SELECT create_reference_table('replicate_reference_table_rollback');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           38 |          1 |                 1 |                      0
+(1 row)
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+NOTICE:  Replicating shard 1370002 to worker localhost:57638...
+         master_add_node         
+---------------------------------
+ (6,6,localhost,57638,default,f)
+(1 row)
+
+ROLLBACK;
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           38 |          1 |                 1 |                      0
+(1 row)
+
+DROP TABLE replicate_reference_table_rollback;
+-- test replicating a reference table when a new node added in TRANSACTION + COMMIT
+CREATE TABLE replicate_reference_table_commit(column1 int);
+SELECT create_reference_table('replicate_reference_table_commit');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           39 |          1 |                 1 |                      0
+(1 row)
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+NOTICE:  Replicating shard 1370003 to worker localhost:57638...
+         master_add_node         
+---------------------------------
+ (7,7,localhost,57638,default,f)
+(1 row)
+
+COMMIT;
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename  | nodeport | placementid 
+---------+------------+-------------+-----------+----------+-------------
+ 1370003 |          1 |           0 | localhost |    57638 |         397
+(1 row)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           39 |          1 |                 2 |                      0
+(1 row)
+
+DROP TABLE replicate_reference_table_commit;
+-- test adding new node + upgrading another hash distributed table to reference table + creating new reference table in TRANSACTION
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+CREATE TABLE replicate_reference_table_reference_one(column1 int);
+SELECT create_reference_table('replicate_reference_table_reference_one');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SET citus.shard_count TO 1;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE replicate_reference_table_hash(column1 int);
+SELECT create_distributed_table('replicate_reference_table_hash', 'column1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE replicate_reference_table_reference_two(column1 int);
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename | nodeport | placementid 
+---------+------------+-------------+----------+----------+-------------
+(0 rows)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           40 |          1 |                 1 |                      0
+(1 row)
+
+SELECT * FROM pg_dist_partition WHERE logicalrelid IN ('replicate_reference_table_reference_one', 'replicate_reference_table_hash', 'replicate_reference_table_reference_two');
+              logicalrelid               | partmethod |                                                        partkey                                                         | colocationid | repmodel 
+-----------------------------------------+------------+------------------------------------------------------------------------------------------------------------------------+--------------+----------
+ replicate_reference_table_reference_one | n          |                                                                                                                        |           40 | t
+ replicate_reference_table_hash          | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |           41 | s
+(2 rows)
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+NOTICE:  Replicating shard 1370004 to worker localhost:57638...
+         master_add_node         
+---------------------------------
+ (8,8,localhost,57638,default,f)
+(1 row)
+
+SELECT upgrade_to_reference_table('replicate_reference_table_hash');
+NOTICE:  Replicating shard 1370005 to worker localhost:57638...
+ upgrade_to_reference_table 
+----------------------------
+ 
+(1 row)
+
+SELECT create_reference_table('replicate_reference_table_reference_two');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+COMMIT;
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+ shardid | shardstate | shardlength | nodename  | nodeport | placementid 
+---------+------------+-------------+-----------+----------+-------------
+ 1370004 |          1 |           0 | localhost |    57638 |         400
+ 1370005 |          1 |           0 | localhost |    57638 |         401
+ 1370006 |          1 |           0 | localhost |    57638 |         403
+(3 rows)
+
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
+ colocationid | shardcount | replicationfactor | distributioncolumntype 
+--------------+------------+-------------------+------------------------
+           40 |          1 |                 2 |                      0
+(1 row)
+
+SELECT * FROM pg_dist_partition WHERE logicalrelid IN ('replicate_reference_table_reference_one', 'replicate_reference_table_hash', 'replicate_reference_table_reference_two');
+              logicalrelid               | partmethod | partkey | colocationid | repmodel 
+-----------------------------------------+------------+---------+--------------+----------
+ replicate_reference_table_reference_one | n          |         |           40 | t
+ replicate_reference_table_hash          | n          |         |           40 | t
+ replicate_reference_table_reference_two | n          |         |           40 | t
+(3 rows)
+
+DROP TABLE replicate_reference_table_reference_one;
+DROP TABLE replicate_reference_table_hash;
+DROP TABLE replicate_reference_table_reference_two;
+-- reload pg_dist_shard_placement table
+INSERT INTO pg_dist_shard_placement (SELECT * FROM tmp_shard_placement);
+DROP TABLE tmp_shard_placement;

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -178,6 +178,8 @@ SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 -- master_remove_node
 \c - - - :master_port
+-- workaround for not trying to replicate reference tables
+UPDATE pg_dist_partition SET partmethod = 'x' WHERE partmethod = 'n';
 SELECT master_add_node('localhost', 5432);
         master_add_node         
 --------------------------------
@@ -201,6 +203,7 @@ SELECT master_remove_node('localhost', 5432);
  
 (1 row)
 
+UPDATE pg_dist_partition SET partmethod = 'n' WHERE partmethod = 'x';
 -- TRUNCATE
 \c - - - :worker_1_port
 TRUNCATE mx_table;

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -83,6 +83,7 @@ SELECT create_distributed_table('upgrade_reference_table_composite', 'column1');
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_composite');
+NOTICE:  Replicating shard 1360007 to worker localhost:57638...
 ERROR:  type "public.upgrade_test_composite_type" does not exist
 CONTEXT:  while executing command on localhost:57638
 -- test with reference table
@@ -150,6 +151,7 @@ WHERE shardid IN
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_append');
+NOTICE:  Replicating shard 1360009 to worker localhost:57638...
  upgrade_to_reference_table 
 ----------------------------
  
@@ -255,6 +257,7 @@ WHERE shardid IN
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_one_worker');
+NOTICE:  Replicating shard 1360010 to worker localhost:57638...
  upgrade_to_reference_table 
 ----------------------------
  
@@ -576,6 +579,7 @@ WHERE shardid IN
 
 BEGIN;
 SELECT upgrade_to_reference_table('upgrade_reference_table_transaction_rollback');
+NOTICE:  Replicating shard 1360013 to worker localhost:57638...
  upgrade_to_reference_table 
 ----------------------------
  
@@ -683,6 +687,7 @@ WHERE shardid IN
 
 BEGIN;
 SELECT upgrade_to_reference_table('upgrade_reference_table_transaction_commit');
+NOTICE:  Replicating shard 1360014 to worker localhost:57638...
  upgrade_to_reference_table 
 ----------------------------
  

--- a/src/test/regress/input/multi_outer_join_reference.source
+++ b/src/test/regress/input/multi_outer_join_reference.source
@@ -449,3 +449,9 @@ SELECT
 FROM 
 	multi_outer_join_right_reference FULL JOIN 
 	multi_outer_join_third_reference ON (t_custkey = r_custkey);
+
+-- DROP unused tables to clean up workspace
+DROP TABLE multi_outer_join_left_hash;
+DROP TABLE multi_outer_join_right_reference;
+DROP TABLE multi_outer_join_third_reference;
+DROP TABLE multi_outer_join_right_hash;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -208,5 +208,7 @@ test: multi_foreign_key
 
 # ----------
 # multi_upgrade_reference_table tests for upgrade_reference_table UDF
+# multi_replicate_reference_table tests replicating reference tables to new nodes after we add new nodes
 # ----------
 test: multi_upgrade_reference_table
+test: multi_replicate_reference_table

--- a/src/test/regress/output/multi_outer_join_reference.source
+++ b/src/test/regress/output/multi_outer_join_reference.source
@@ -834,3 +834,8 @@ FROM
          7 |          
 (30 rows)
 
+-- DROP unused tables to clean up workspace
+DROP TABLE multi_outer_join_left_hash;
+DROP TABLE multi_outer_join_right_reference;
+DROP TABLE multi_outer_join_third_reference;
+DROP TABLE multi_outer_join_right_hash;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -70,6 +70,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-9';
 ALTER EXTENSION citus UPDATE TO '6.1-10';
 ALTER EXTENSION citus UPDATE TO '6.1-11';
 ALTER EXTENSION citus UPDATE TO '6.1-12';
+ALTER EXTENSION citus UPDATE TO '6.1-13';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -986,5 +986,5 @@ ROLLBACK;
 
 -- clean up tables
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
-		   reference_table_test_fourth, reference_table_ddl;
+		   reference_table_test_fourth, reference_table_ddl, reference_table_composite;
 DROP SCHEMA reference_schema CASCADE;

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -1,0 +1,182 @@
+--
+-- MULTI_REPLICATE_REFERENCE_TABLE
+--
+-- Tests that check the metadata returned by the master node.
+
+
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1370000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1370000;
+
+
+CREATE TABLE tmp_shard_placement(
+    shardid int8 NOT NULL,
+    shardstate int4 NOT NULL,
+    shardlength int8 NOT NULL,
+    nodename text NOT NULL,
+    nodeport int8 NOT NULL,
+    placementid bigint NOT NULL
+);
+
+-- remove a node for testing purposes
+INSERT INTO tmp_shard_placement (SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port);
+DELETE FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT master_remove_node('localhost', :worker_2_port);
+
+
+-- test adding new node with no reference tables
+SELECT master_add_node('localhost', :worker_2_port);
+
+-- verify nothing is replicated to the new node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+
+
+-- test adding new node with a reference table which does not have any healthy placement
+SELECT master_remove_node('localhost', :worker_2_port);
+
+CREATE TABLE replicate_reference_table_unhealthy(column1 int);
+SELECT create_reference_table('replicate_reference_table_unhealthy');
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1370000;
+
+SELECT master_add_node('localhost', :worker_2_port);
+
+-- verify nothing is replicated to the new node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+
+DROP TABLE replicate_reference_table_unhealthy;
+
+
+-- test replicating a reference table when a new node added
+CREATE TABLE replicate_reference_table_valid(column1 int);
+SELECT create_reference_table('replicate_reference_table_valid');
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+
+SELECT master_add_node('localhost', :worker_2_port);
+
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+
+DROP TABLE replicate_reference_table_valid;
+
+
+-- test replicating a reference table when a new node added in TRANSACTION + ROLLBACK
+SELECT master_remove_node('localhost', :worker_2_port);
+
+CREATE TABLE replicate_reference_table_rollback(column1 int);
+SELECT create_reference_table('replicate_reference_table_rollback');
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+ROLLBACK;
+
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
+
+DROP TABLE replicate_reference_table_rollback;
+
+
+-- test replicating a reference table when a new node added in TRANSACTION + COMMIT
+CREATE TABLE replicate_reference_table_commit(column1 int);
+SELECT create_reference_table('replicate_reference_table_commit');
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+COMMIT;
+
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
+
+DROP TABLE replicate_reference_table_commit;
+
+
+-- test adding new node + upgrading another hash distributed table to reference table + creating new reference table in TRANSACTION
+SELECT master_remove_node('localhost', :worker_2_port);
+
+CREATE TABLE replicate_reference_table_reference_one(column1 int);
+SELECT create_reference_table('replicate_reference_table_reference_one');
+
+SET citus.shard_count TO 1;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE replicate_reference_table_hash(column1 int);
+SELECT create_distributed_table('replicate_reference_table_hash', 'column1');
+
+CREATE TABLE replicate_reference_table_reference_two(column1 int);
+
+-- status before master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
+SELECT * FROM pg_dist_partition WHERE logicalrelid IN ('replicate_reference_table_reference_one', 'replicate_reference_table_hash', 'replicate_reference_table_reference_two');
+
+BEGIN;
+SELECT master_add_node('localhost', :worker_2_port);
+SELECT upgrade_to_reference_table('replicate_reference_table_hash');
+SELECT create_reference_table('replicate_reference_table_reference_two');
+COMMIT;
+
+-- status after master_add_node
+SELECT * FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port;
+SELECT *
+FROM pg_dist_colocation
+WHERE colocationid IN
+    (SELECT colocationid
+     FROM pg_dist_partition
+     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
+SELECT * FROM pg_dist_partition WHERE logicalrelid IN ('replicate_reference_table_reference_one', 'replicate_reference_table_hash', 'replicate_reference_table_reference_two');
+
+DROP TABLE replicate_reference_table_reference_one;
+DROP TABLE replicate_reference_table_hash;
+DROP TABLE replicate_reference_table_reference_two;
+
+
+-- reload pg_dist_shard_placement table
+
+INSERT INTO pg_dist_shard_placement (SELECT * FROM tmp_shard_placement);
+DROP TABLE tmp_shard_placement;

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -94,11 +94,14 @@ SELECT master_apply_delete_command('DELETE FROM mx_table');
 SELECT count(*) FROM mx_table;
 
 -- master_add_node
+
 SELECT master_add_node('localhost', 5432);
 SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 -- master_remove_node
 \c - - - :master_port
+-- workaround for not trying to replicate reference tables
+UPDATE pg_dist_partition SET partmethod = 'x' WHERE partmethod = 'n';
 SELECT master_add_node('localhost', 5432);
 
 \c - - - :worker_1_port
@@ -107,6 +110,8 @@ SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 \c - - - :master_port
 SELECT master_remove_node('localhost', 5432);
+
+UPDATE pg_dist_partition SET partmethod = 'n' WHERE partmethod = 'x';
 
 -- TRUNCATE
 \c - - - :worker_1_port


### PR DESCRIPTION
Fixes #971 

With this change, we start to replicate all reference tables to the new node when new node
is added to the cluster with master_add_node command. We also update replication factor
of reference table's colocation group.