### PR TITLE
Fix escaping of workerrack in NodeListInsertCommand

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -384,12 +384,12 @@ NodeListInsertCommand(List *workerNodeList)
 		char *hasMetadaString = workerNode->hasMetadata ? "TRUE" : "FALSE";
 
 		appendStringInfo(nodeListInsertCommand,
-						 "(%d, %d, %s, %d, '%s', %s)",
+						 "(%d, %d, %s, %d, %s, %s)",
 						 workerNode->nodeId,
 						 workerNode->groupId,
 						 quote_literal_cstr(workerNode->workerName),
 						 workerNode->workerPort,
-						 workerNode->workerRack,
+						 quote_literal_cstr(workerNode->workerRack),
 						 hasMetadaString);
 
 		processedWorkerNodeCount++;


### PR DESCRIPTION
This change fixes a small bug about quoting of workerrack column in
NodeListInsertCommand:

Previous: `"..., '%s'", workerRack`
Now: `"..., %s", quote_literal_cstr(workerRack)`