### PR TITLE
Fix CloseNodeConnections to actually close connections

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -333,12 +333,7 @@ CloseNodeConnections(char *nodeName, int nodePort)
 			MultiConnection *connection =
 				dlist_container(MultiConnection, connectionNode, currentNode);
 
-			/* same for transaction state */
-			CloseRemoteTransaction(connection);
-			CloseShardPlacementAssociation(connection);
-
-			/* we leave the per-host entry alive */
-			pfree(connection);
+			CloseConnection(connection);
 		}
 	}
 }

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -121,6 +121,8 @@ SELECT master_get_active_worker_nodes();
  (localhost,57637)
 (2 rows)
 
+-- insert a row so that master_disable_node() exercises closing connections
+INSERT INTO test_reference_table VALUES (1, '1');
 -- try to disable a node with active placements see that node is removed
 -- observe that a notification is displayed
 SELECT master_disable_node('localhost', :worker_2_port); 

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -45,6 +45,9 @@ SELECT shardid, shardstate, nodename, nodeport FROM pg_dist_shard_placement WHER
 SELECT master_remove_node('localhost', :worker_2_port); 
 SELECT master_get_active_worker_nodes();
 
+-- insert a row so that master_disable_node() exercises closing connections
+INSERT INTO test_reference_table VALUES (1, '1');
+
 -- try to disable a node with active placements see that node is removed
 -- observe that a notification is displayed
 SELECT master_disable_node('localhost', :worker_2_port); 


### PR DESCRIPTION
CloseNodeConnections() is supposed to close connections to a given node.
However, before this commit it lacks to actually call PQFinish() on the
connections. Using CloseConnection() handles closing and all other necessary
actions.