### PR TITLE
Reword error message for outer joins requiring repartition

### DIFF
--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -244,9 +244,10 @@ FixedJoinOrderList(FromExpr *fromExpr, List *tableEntryList)
 		{
 			/* re-partitioning for OUTER joins is not implemented */
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("cannot perform distributed planning on this query"),
-							errdetail("Shards of relations in outer join queries must "
-									  "have 1-to-1 shard partitioning")));
+							errmsg("cannot run outer join query if join is not on the "
+								   "partition column"),
+							errdetail("Outer joins requiring repartitioning are not "
+									  "supported.")));
 		}
 
 		if (joinType != JOIN_INNER)

--- a/src/test/regress/expected/multi_dropped_column_aliases.out
+++ b/src/test/regress/expected/multi_dropped_column_aliases.out
@@ -62,5 +62,5 @@ FROM   (customer LEFT OUTER JOIN orders ON (c_custkey = o_custkey)) AS
        test(c_custkey, c_nationkey)
        INNER JOIN lineitem ON (test.c_custkey = l_orderkey)
 LIMIT 10;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.

--- a/src/test/regress/output/multi_outer_join.source
+++ b/src/test/regress/output/multi_outer_join.source
@@ -245,8 +245,8 @@ SELECT
 	count(*)
 FROM
 	multi_outer_join_left a LEFT JOIN multi_outer_join_right b ON (l_nationkey = r_nationkey);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.
 -- Anti-join should return customers for which there is no row in the right table
 SELECT
 	min(l_custkey), max(l_custkey)

--- a/src/test/regress/output/multi_outer_join_reference.source
+++ b/src/test/regress/output/multi_outer_join_reference.source
@@ -214,8 +214,8 @@ SELECT
 	min(r_custkey), max(r_custkey)
 FROM
 	multi_outer_join_left_hash a RIGHT JOIN multi_outer_join_right_reference b ON (l_custkey = r_custkey);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.
 -- Reverse right join should be same as left join
 SELECT
 	min(l_custkey), max(l_custkey)
@@ -278,8 +278,8 @@ SELECT
 	count(*)
 FROM
 	multi_outer_join_left_hash a LEFT JOIN multi_outer_join_right_hash b ON (l_nationkey = r_nationkey);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.
 -- Anti-join should return customers for which there is no row in the right table
 SELECT
 	min(l_custkey), max(l_custkey)
@@ -337,8 +337,8 @@ SELECT
 	min(r_custkey), max(r_custkey)
 FROM
 	multi_outer_join_left_hash a RIGHT JOIN multi_outer_join_right_reference b ON (l_custkey = r_custkey);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.
 -- Reverse right join should be same as left join
 SELECT
 	min(l_custkey), max(l_custkey)
@@ -601,8 +601,8 @@ SELECT
 FROM
 	multi_outer_join_left_hash l1
 	FULL JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.
 -- inner join  + single shard left join should work
 SELECT
 	l_custkey, r_custkey, t_custkey
@@ -676,8 +676,8 @@ FROM
 	multi_outer_join_third_reference t1
 	INNER JOIN multi_outer_join_left_hash l1 ON (l1.l_custkey = t1.t_custkey)
 	LEFT JOIN multi_outer_join_right_reference r1 ON (l1.l_custkey  = r1.r_custkey);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Shards of relations in outer join queries must have 1-to-1 shard partitioning
+ERROR:  cannot run outer join query if join is not on the partition column
+DETAIL:  Outer joins requiring repartitioning are not supported.
 -- inner (local) join  + 2 shards left (dual partition) join should work
 SELECT
 	l_custkey, t_custkey, r_custkey


### PR DESCRIPTION
Part of #310 

We changed error message which appears when user tries to execute outer join command and
that command requires repartitioning. Old error message mentioned about 1-to-1 shard
partitioning which may not be clear to user.