### PR TITLE
Refactor CheckShardPlacements() and improve support for node removal

### DIFF
--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -381,8 +381,8 @@ RemoveNodeFromCluster(char *nodeName, int32 nodePort, bool forceRemove)
 
 	nodeDeleteCommand = NodeDeleteCommand(workerNode->nodeId);
 
-	/* make sure we don't have any open connections */
-	CloseNodeConnections(nodeName, nodePort);
+	/* make sure we don't have any lingering session lifespan connections */
+	CloseNodeConnectionsAfterTransaction(nodeName, nodePort);
 
 	SendCommandToWorkers(WORKERS_WITH_METADATA, nodeDeleteCommand);
 }

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -131,7 +131,7 @@ extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 const char *user,
 														 const char *database);
 extern MultiConnection * GetConnectionFromPGconn(struct pg_conn *pqConn);
-extern void CloseNodeConnections(char *nodeName, int nodePort);
+extern void CloseNodeConnectionsAfterTransaction(char *nodeName, int nodePort);
 extern void CloseConnection(MultiConnection *connection);
 extern void CloseConnectionByPGconn(struct pg_conn *pqConn);
 


### PR DESCRIPTION
This commit refactors CheckShardPlacements() so that it only considers
modifyingConnection. Also, it skips nodes which are removed from the
cluster.

@anarazel or @marcocitus could one of you look to this? This again came up for #1105. 