### PR TITLE
Add ORDER BY clause to shard state tests to have consistent output

### DIFF
--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -420,7 +420,9 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY
+    shardid;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370004 |          1 |           0 | localhost |    57638

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -790,11 +790,11 @@ SELECT master_copy_shard_placement(1190000, 'localhost', :worker_2_port, 'localh
 (1 row)
 
 -- verify shardstate
-SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000;
+SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000 ORDER BY nodeport;
  shardstate | nodename  | nodeport 
 ------------+-----------+----------
-          1 | localhost |    57638
           1 | localhost |    57637
+          1 | localhost |    57638
 (2 rows)
 
 --test with search_path is set
@@ -808,11 +808,11 @@ SELECT master_copy_shard_placement(1190000, 'localhost', :worker_2_port, 'localh
 (1 row)
 
 -- verify shardstate
-SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000;
+SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000 ORDER BY nodeport;
  shardstate | nodename  | nodeport 
 ------------+-----------+----------
-          1 | localhost |    57638
           1 | localhost |    57637
+          1 | localhost |    57638
 (2 rows)
 
 -- test master_apply_delete_command with schemas

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -197,7 +197,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360009 |          1 |        8192 | localhost |    57637
@@ -304,7 +306,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360010 |          1 |           0 | localhost |    57637
@@ -361,7 +365,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360011 |          1 |           0 | localhost |    57637
@@ -414,7 +420,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360011 |          1 |           0 | localhost |    57637
@@ -469,7 +477,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360012 |          1 |           0 | localhost |    57637
@@ -522,7 +532,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360012 |          1 |           0 | localhost |    57637
@@ -741,7 +753,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass)
+ORDER BY
+    nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1360014 |          1 |           0 | localhost |    57637

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -265,7 +265,9 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY
+    shardid;
 
 SELECT *
 FROM pg_dist_colocation

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -504,7 +504,7 @@ UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1190000 and no
 SELECT master_copy_shard_placement(1190000, 'localhost', :worker_2_port, 'localhost', :worker_1_port);
 
 -- verify shardstate
-SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000;
+SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000 ORDER BY nodeport;
 
 
 --test with search_path is set
@@ -515,7 +515,7 @@ UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1190000 and no
 SELECT master_copy_shard_placement(1190000, 'localhost', :worker_2_port, 'localhost', :worker_1_port);
 
 -- verify shardstate
-SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000;
+SELECT shardstate, nodename, nodeport FROM pg_dist_shard_placement WHERE shardid = 1190000 ORDER BY nodeport;
 
 
 -- test master_apply_delete_command with schemas

--- a/src/test/regress/sql/multi_upgrade_reference_table.sql
+++ b/src/test/regress/sql/multi_upgrade_reference_table.sql
@@ -130,7 +130,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass)
+ORDER BY
+    nodeport;
 
 -- test valid cases, shard exists at one worker
 CREATE TABLE upgrade_reference_table_one_worker(column1 int);
@@ -196,7 +198,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass)
+ORDER BY
+    nodeport;
 
 -- test valid cases, shard exists at both workers but one is unhealthy
 SET citus.shard_replication_factor TO 2;
@@ -232,7 +236,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass)
+ORDER BY
+    nodeport;
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_one_unhealthy');
 
@@ -264,7 +270,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass)
+ORDER BY
+    nodeport;
 
 -- test valid cases, shard exists at both workers and both are healthy
 CREATE TABLE upgrade_reference_table_both_healthy(column1 int);
@@ -298,7 +306,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass)
+ORDER BY
+    nodeport;
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_both_healthy');
 
@@ -330,7 +340,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass)
+ORDER BY
+    nodeport;
 
 -- test valid cases, do it in transaction and ROLLBACK
 SET citus.shard_replication_factor TO 1;
@@ -468,7 +480,9 @@ FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
+     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass)
+ORDER BY
+    nodeport;
 
 -- verify that shard is replicated to other worker
 \c - - - :worker_2_port


### PR DESCRIPTION
Fixes #1126 

In tests related to automatic reference table creation and deletion, there were some
tests whose output may change order thus creating inconsistent test results. With this
change we add ORDER BY clause to related tests to have consistent output.