### PR TITLE
Query placementId in RemoteFinalizedShardPlacementList().

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -1163,14 +1163,16 @@ RemoteFinalizedShardPlacementList(uint64 shardId)
 
 		for (rowIndex = 0; rowIndex < rowCount; rowIndex++)
 		{
-			char *nodeName = PQgetvalue(queryResult, rowIndex, 0);
-
-			char *nodePortString = PQgetvalue(queryResult, rowIndex, 1);
+			char *placementIdString = PQgetvalue(queryResult, rowIndex, 0);
+			char *nodeName = PQgetvalue(queryResult, rowIndex, 1);
+			char *nodePortString = PQgetvalue(queryResult, rowIndex, 2);
 			uint32 nodePort = atoi(nodePortString);
+			uint64 placementId = atoll(placementIdString);
 
 			ShardPlacement *shardPlacement =
 				(ShardPlacement *) palloc0(sizeof(ShardPlacement));
 
+			shardPlacement->placementId = placementId;
 			shardPlacement->nodeName = nodeName;
 			shardPlacement->nodePort = nodePort;
 

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -70,7 +70,7 @@
 #define CREATE_SCHEMA_COMMAND "CREATE SCHEMA IF NOT EXISTS %s AUTHORIZATION %s"
 #define CREATE_EMPTY_SHARD_QUERY "SELECT master_create_empty_shard('%s')"
 #define FINALIZED_SHARD_PLACEMENTS_QUERY \
-	"SELECT nodename, nodeport FROM pg_dist_shard_placement WHERE shardstate = 1 AND shardid = %ld"
+	"SELECT placementid, nodename, nodeport FROM pg_dist_shard_placement WHERE shardstate = 1 AND shardid = %ld"
 #define UPDATE_SHARD_STATISTICS_QUERY \
 	"SELECT master_update_shard_statistics(%ld)"
 #define PARTITION_METHOD_QUERY "SELECT part_method FROM master_get_table_metadata('%s');"


### PR DESCRIPTION
Not having the id in the ShardPlacement struct causes issues while
making copy use the placement aware connection management.

Fixes: #1138 