### PR TITLE
Improve heap access methods for upgrading to reference tables

### DIFF
--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -988,7 +988,6 @@ DeleteColocationGroup(uint32 colocationId)
 	{
 		simple_heap_delete(pgDistColocation, &(heapTuple->t_self));
 
-		CatalogUpdateIndexes(pgDistColocation, heapTuple);
 		CitusInvalidateRelcacheByRelid(DistColocationRelationId());
 		CommandCounterIncrement();
 	}

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -650,9 +650,6 @@ WHERE
  1360013 | f                   | f
 (1 row)
 
--- eliminate the duplicate intermediate duplicate rows in pg_dist_colocation
-VACUUM ANALYZE pg_dist_colocation;
-    
 SELECT *
 FROM pg_dist_colocation
 WHERE colocationid IN

--- a/src/test/regress/sql/multi_upgrade_reference_table.sql
+++ b/src/test/regress/sql/multi_upgrade_reference_table.sql
@@ -423,9 +423,6 @@ FROM
 WHERE
     logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass;
 
--- eliminate the duplicate intermediate duplicate rows in pg_dist_colocation
-VACUUM ANALYZE pg_dist_colocation;
-    
 SELECT *
 FROM pg_dist_colocation
 WHERE colocationid IN


### PR DESCRIPTION
This commit improves heap access methods for reference table
upgrade and colocation group modifications.

Fixes #1144 