### PR TITLE
Allow start_metadata_sync_to_node in a transaction block

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -86,8 +86,6 @@ start_metadata_sync_to_node(PG_FUNCTION_ARGS)
 	EnsureSchemaNode();
 	EnsureSuperUser();
 
-	PreventTransactionChain(true, "start_metadata_sync_to_node");
-
 	workerNode = FindWorkerNode(nodeNameString, nodePort);
 
 	if (workerNode == NULL)

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -313,6 +313,7 @@ RESET citus.shard_replication_factor;
 RESET citus.replication_model;
 -- Check that repeated calls to start_metadata_sync_to_node has no side effects
 \c - - - :master_port
+BEGIN;
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  start_metadata_sync_to_node 
 -----------------------------
@@ -325,6 +326,7 @@ SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  
 (1 row)
 
+COMMIT;
 \c - - - :worker_1_port
 SELECT * FROM pg_dist_local_group;
  groupid 
@@ -386,18 +388,6 @@ SELECT count(*) FROM pg_trigger WHERE tgrelid='mx_testing_schema.mx_test_table':
  count 
 -------
      1
-(1 row)
-
--- Make sure that start_metadata_sync_to_node cannot be called inside a transaction
-\c - - - :master_port
-BEGIN;
-SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
-ERROR:  start_metadata_sync_to_node cannot run inside a transaction block
-ROLLBACK;
-SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_port;
- hasmetadata 
--------------
- f
 (1 row)
 
 -- Check that the distributed table can be queried from the worker

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -119,8 +119,10 @@ RESET citus.replication_model;
 
 -- Check that repeated calls to start_metadata_sync_to_node has no side effects
 \c - - - :master_port
+BEGIN;
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+COMMIT;
 \c - - - :worker_1_port
 SELECT * FROM pg_dist_local_group;
 SELECT * FROM pg_dist_node ORDER BY nodeid;
@@ -129,14 +131,6 @@ SELECT * FROM pg_dist_shard ORDER BY shardid;
 SELECT * FROM pg_dist_shard_placement ORDER BY shardid;
 \d mx_testing_schema.mx_test_table
 SELECT count(*) FROM pg_trigger WHERE tgrelid='mx_testing_schema.mx_test_table'::regclass;
-
--- Make sure that start_metadata_sync_to_node cannot be called inside a transaction
-\c - - - :master_port
-BEGIN;
-SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
-ROLLBACK;
-
-SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_port;
 
 -- Check that the distributed table can be queried from the worker
 \c - - - :master_port


### PR DESCRIPTION
After the worker_transaction conversion to the connection API, we no longer need to prevent transaction blocks.