### PR TITLE
Fix bug where router executor sends query to failed connections

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -733,6 +733,18 @@ ExecuteSingleModifyTask(QueryDesc *queryDesc, Task *task,
 		bool failOnError = false;
 		int64 currentAffectedTupleCount = 0;
 
+		if (connection->remoteTransaction.transactionFailed)
+		{
+			/*
+			 * If GetModifyConnections failed to send BEGIN this connection will have
+			 * been marked as failed, and should not have any more commands sent to
+			 * it! Skip it for now, at the bottom of this method we call
+			 * MarkFailedShardPlacements() to ensure future statements will not use this
+			 * placement.
+			 */
+			continue;
+		}
+
 		queryOK = SendQueryInSingleRowMode(connection, queryString, paramListInfo);
 		if (!queryOK)
 		{

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -2073,9 +2073,6 @@ INSERT INTO failure_test VALUES (1, 1);
 WARNING:  connection error: localhost:57638
 DETAIL:  no connection to the server
 
-WARNING:  connection error: localhost:57638
-DETAIL:  no connection to the server
-
 SELECT shardid, shardstate, nodename, nodeport FROM pg_dist_shard_placement
 	WHERE shardid IN (
 		SELECT shardid FROM pg_dist_shard


### PR DESCRIPTION
This commit is deeply unsatisfying because it doesn't fix the general problem (badly described in #1173), but it fixes this specific case in the router executor, which is probably worth making it into 6.1.

A better fix might be for the connection api to refuse to return failed connections to callers, and instead return `NULL`.