### PR TITLE
Fix Random Fails on Travis

### DIFF
--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -24,6 +24,8 @@ test: multi_mx_tpch_query3 multi_mx_tpch_query6 multi_mx_tpch_query7
 test: multi_mx_tpch_query7_nested multi_mx_ddl
 test: multi_mx_repartition_udt_prepare
 test: multi_mx_repartition_join_w1 multi_mx_repartition_join_w2 multi_mx_repartition_udt_w1 multi_mx_repartition_udt_w2
-test: multi_mx_metadata multi_mx_modifications multi_mx_modifying_xacts
+test: multi_mx_metadata 
+test: multi_mx_modifications 
+test: multi_mx_modifying_xacts
 test: multi_mx_explain
 test: multi_mx_reference_table


### PR DESCRIPTION
This change fixes the random failures on Travis, which is a bug introduced
with citus/#1124. Before this fix, travis was failing randomly on `check_multi_mx`
test schedule, specifically in the parallel group of `multi_mx_metadata`,
'multi_mx_modifications` and `multi_mx_modifying_xacts` tests. This change fixes this
by serializing these three test cases.