### PR TITLE
Allow dropping sequences on mx workers

### DIFF
--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -235,14 +235,13 @@ master_drop_sequences(PG_FUNCTION_ARGS)
 	Datum sequenceText = 0;
 	bool isNull = false;
 	StringInfo dropSeqCommand = makeStringInfo();
+	bool coordinator = IsCoordinator();
 
-	/* do nothing if DDL propagation is switched off */
-	if (!EnableDDLPropagation)
+	/* do nothing if DDL propagation is switched off or this is not the coordinator */
+	if (!EnableDDLPropagation || !coordinator)
 	{
 		PG_RETURN_VOID();
 	}
-
-	EnsureCoordinator();
 
 	/* iterate over sequence names to build single command to DROP them all */
 	sequenceIterator = array_create_iterator(sequenceNamesArray, 0, NULL);

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -385,6 +385,36 @@ DELETE FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port AND shardid 
 SELECT master_get_new_placementid();
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
+-- Show that sequences can be created and dropped on worker nodes
+CREATE TABLE some_table_with_sequence(a int, b BIGSERIAL, c BIGSERIAL);
+DROP TABLE some_table_with_sequence;
+CREATE SEQUENCE some_sequence;
+DROP SEQUENCE some_sequence;
+-- Show that dropping the sequence of an MX table with cascade harms the table and shards
+BEGIN;
+\d mx_table
+                           Table "public.mx_table"
+ Column |  Type   |                        Modifiers                         
+--------+---------+----------------------------------------------------------
+ col_1  | integer | 
+ col_2  | text    | 
+ col_3  | bigint  | not null default nextval('mx_table_col_3_seq'::regclass)
+
+DROP SEQUENCE mx_table_col_3_seq CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to default for table mx_table_1270000 column col_3
+drop cascades to default for table mx_table_1270002 column col_3
+drop cascades to default for table mx_table_1270004 column col_3
+drop cascades to default for table mx_table column col_3
+\d mx_table
+   Table "public.mx_table"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col_1  | integer | 
+ col_2  | text    | 
+ col_3  | bigint  | not null
+
+ROLLBACK;
 -- Cleanup
 \c - - - :master_port
 DROP TABLE mx_table;

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -204,6 +204,19 @@ DELETE FROM pg_dist_shard_placement WHERE nodeport = :worker_2_port AND shardid 
 -- master_get_new_placementid
 SELECT master_get_new_placementid();
 
+-- Show that sequences can be created and dropped on worker nodes
+CREATE TABLE some_table_with_sequence(a int, b BIGSERIAL, c BIGSERIAL);
+DROP TABLE some_table_with_sequence;
+CREATE SEQUENCE some_sequence;
+DROP SEQUENCE some_sequence;
+
+-- Show that dropping the sequence of an MX table with cascade harms the table and shards
+BEGIN;
+\d mx_table
+DROP SEQUENCE mx_table_col_3_seq CASCADE;
+\d mx_table
+ROLLBACK;
+
 -- Cleanup
 \c - - - :master_port
 DROP TABLE mx_table;


### PR DESCRIPTION
Fixes #1181 

This change allows users to drop sequences on MX workers. Previously, Citus didn't allow dropping
sequences on MX workers because it could cause shards to be dropped if `DROP SEQUENCE ... CASCADE` is used. We now allow that since allowing sequence creation but not dropping hurts user experience and also may cause problems with custom Citus solutions.