### PR TITLE
Bugfix for creating foreign key

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1592,6 +1592,19 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 				}
 
 				/*
+				 * The following logic requires the referenced columns to exists in
+				 * the statement. Otherwise, we cannot apply some of the checks.
+				 */
+				if (constraint->pk_attrs == NULL)
+				{
+					ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									errmsg("cannot create foreign key constraint "
+										   "because referenced column list is empty"),
+									errhint("Add column names to \"REFERENCES\" part of "
+											"the statement.")));
+				}
+
+				/*
 				 * Referencing column's list length should be equal to referenced columns
 				 * list length.
 				 */

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -462,6 +462,10 @@ SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
  
 (1 row)
 
+-- columns for the referenced table is empty
+ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id) REFERENCES referenced_table ON DELETE CASCADE;
+ERROR:  cannot create foreign key constraint because referenced column list is empty
+HINT:  Add column names to "REFERENCES" part of the statement.
 -- test foreign constraint creation on non-partition columns
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(id) REFERENCES referenced_table(id);
 ERROR:  cannot create foreign key constraint

--- a/src/test/regress/sql/multi_foreign_key.sql
+++ b/src/test/regress/sql/multi_foreign_key.sql
@@ -254,6 +254,9 @@ CREATE TABLE referencing_table(id int, ref_id int);
 SELECT create_distributed_table('referenced_table', 'id', 'hash');
 SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 
+-- columns for the referenced table is empty
+ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id) REFERENCES referenced_table ON DELETE CASCADE;
+
 -- test foreign constraint creation on non-partition columns
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(id) REFERENCES referenced_table(id);
 


### PR DESCRIPTION
Fixes #1209 

This commit fixes crash for adding foreign keys without
specifying the referenced column crashes the backend.