### PR TITLE
Add schema to shard_name output

### DIFF
--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -657,6 +657,9 @@ shard_name(PG_FUNCTION_ARGS)
 	Oid relationId = InvalidOid;
 	int64 shardId = 0;
 	char *relationName = NULL;
+	Oid schemaId = InvalidOid;
+	char *schemaName = NULL;
+	char *qualifiedName = NULL;
 
 	/*
 	 * Have to check arguments for NULLness as it can't be declared STRICT
@@ -683,7 +686,6 @@ shard_name(PG_FUNCTION_ARGS)
 						errmsg("shard_id cannot be zero or negative value")));
 	}
 
-
 	if (!OidIsValid(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -691,7 +693,6 @@ shard_name(PG_FUNCTION_ARGS)
 	}
 
 	relationName = get_rel_name(relationId);
-
 	if (relationName == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -699,5 +700,10 @@ shard_name(PG_FUNCTION_ARGS)
 	}
 
 	AppendShardIdToName(&relationName, shardId);
-	PG_RETURN_TEXT_P(cstring_to_text(relationName));
+
+	schemaId = get_rel_namespace(relationId);
+	schemaName = get_namespace_name(schemaId);
+	qualifiedName = quote_qualified_identifier(schemaName, relationName);
+
+	PG_RETURN_TEXT_P(cstring_to_text(qualifiedName));
 }

--- a/src/test/regress/expected/multi_name_lengths.out
+++ b/src/test/regress/expected/multi_name_lengths.out
@@ -41,9 +41,9 @@ ERROR:  object_name cannot be null
 SELECT shard_name(0, 666666);
 ERROR:  object_name does not reference a valid relation
 SELECT shard_name('too_long_12345678901234567890123456789012345678901234567890'::regclass, 666666);
-                           shard_name                            
------------------------------------------------------------------
- too_long_12345678901234567890123456789012345678_e0119164_666666
+                               shard_name                               
+------------------------------------------------------------------------
+ public.too_long_12345678901234567890123456789012345678_e0119164_666666
 (1 row)
 
 SELECT shard_name('too_long_12345678901234567890123456789012345678901234567890'::regclass, NULL);
@@ -362,6 +362,15 @@ SELECT master_create_worker_shards(U&'elephant_!0441!043B!043E!043D!0441!043B!04
  
 (1 row)
 
+-- Verify that quoting is used in shard_name
+SELECT shard_name(U&'elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D' UESCAPE '!'::regclass, min(shardid))
+FROM pg_dist_shard
+WHERE logicalrelid = U&'elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D' UESCAPE '!'::regclass;
+                        shard_name                        
+----------------------------------------------------------
+ public."elephant_слонслонслонсло_c8b737c2_2250000000002"
+(1 row)
+
 \c - - - :worker_1_port
 \d elephant_*
 Index "public.elephant_слонслонслонсло_14d34928_2250000000002"
@@ -393,6 +402,32 @@ Indexes:
     "elephant_слонслонслонсло_14d34928_2250000000003" PRIMARY KEY, btree (col1)
 
 \c - - - :master_port
+-- Verify that the shard_name UDF supports schemas
+CREATE SCHEMA multi_name_lengths;
+CREATE TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890 (
+        col1 integer not null,
+        col2 integer not null);
+SELECT master_create_distributed_table('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890', 'col1', 'hash');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890', 2, 1);
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+SELECT shard_name('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass, min(shardid))
+FROM pg_dist_shard
+WHERE logicalrelid = 'multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass;
+                                     shard_name                                     
+------------------------------------------------------------------------------------
+ multi_name_lengths.too_long_1234567890123456789012345678901_e0119164_2250000000004
+(1 row)
+
+DROP TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890;
 -- Clean up.
 DROP TABLE name_lengths CASCADE;
 DROP TABLE U&"elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D" UESCAPE '!' CASCADE;

--- a/src/test/regress/sql/multi_name_lengths.sql
+++ b/src/test/regress/sql/multi_name_lengths.sql
@@ -148,9 +148,28 @@ CREATE TABLE U&"elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E
 SELECT master_create_distributed_table(U&'elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D' UESCAPE '!', 'col1', 'hash');
 SELECT master_create_worker_shards(U&'elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D' UESCAPE '!', '2', '2');
 
+-- Verify that quoting is used in shard_name
+SELECT shard_name(U&'elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D' UESCAPE '!'::regclass, min(shardid))
+FROM pg_dist_shard
+WHERE logicalrelid = U&'elephant_!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D!0441!043B!043E!043D' UESCAPE '!'::regclass;
+
 \c - - - :worker_1_port
 \d elephant_*
 \c - - - :master_port
+
+-- Verify that the shard_name UDF supports schemas
+CREATE SCHEMA multi_name_lengths;
+CREATE TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890 (
+        col1 integer not null,
+        col2 integer not null);
+SELECT master_create_distributed_table('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890', 'col1', 'hash');
+SELECT master_create_worker_shards('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890', 2, 1);
+
+SELECT shard_name('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass, min(shardid))
+FROM pg_dist_shard
+WHERE logicalrelid = 'multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass;
+
+DROP TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890;
 
 -- Clean up.
 DROP TABLE name_lengths CASCADE;


### PR DESCRIPTION
Currently shard_name only gives the (unquoted) relation name of a shard, which limits its usefulness in scripting. This change prefixes the shard name with a schema and adds quotes when necessary.