### PR TITLE
Create indexes after worker_append_table_to_shard when copying a shard

### DIFF
--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -101,6 +101,8 @@ extern uint64 GetNextShardId(void);
 extern uint64 GetNextPlacementId(void);
 extern Oid ResolveRelationId(text *relationName);
 extern List * GetTableDDLEvents(Oid relationId, bool forShardCreation);
+extern List * GetTableCreationCommands(Oid relationId, bool forShardCreation);
+extern List * GetTableIndexAndConstraintCommands(Oid relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);
 extern char ShardStorageType(Oid relationId);
 extern void CheckDistributedTable(Oid relationId);


### PR DESCRIPTION
We ran into some performance issues while running shard rebalancer for a customer with a lot of indexes. After this change, worker_append_table_to_shard will copy data before creating indexes, which should be much faster than the current approach.