### PR TITLE
Disallow master_apply_delete_command on hash distributed table

### DIFF
--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -145,12 +145,14 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 	deleteCriteria = eval_const_expressions(NULL, whereClause);
 
 	partitionMethod = PartitionMethod(relationId);
-	if ((partitionMethod == DISTRIBUTE_BY_HASH) && (deleteCriteria != NULL))
+	if (partitionMethod == DISTRIBUTE_BY_HASH)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot delete from distributed table"),
+						errmsg("cannot delete from hash distributed table with this "
+							   "command"),
 						errdetail("Delete statements on hash-partitioned tables "
-								  "with where clause is not supported")));
+								  "are not supported with master_apply_delete_command."),
+						errhint("Use master_modify_multiple_shards command instead.")));
 	}
 	else if (partitionMethod == DISTRIBUTE_BY_NONE)
 	{

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -55,15 +55,14 @@ EXECUTE sharded_query;
 
 -- try to drop shards with where clause
 SELECT master_apply_delete_command('DELETE FROM sharded_table WHERE id > 0');
-ERROR:  cannot delete from distributed table
-DETAIL:  Delete statements on hash-partitioned tables with where clause is not supported
+ERROR:  cannot delete from hash distributed table with this command
+DETAIL:  Delete statements on hash-partitioned tables are not supported with master_apply_delete_command.
+HINT:  Use master_modify_multiple_shards command instead.
 -- drop all shards
 SELECT master_apply_delete_command('DELETE FROM sharded_table');
- master_apply_delete_command 
------------------------------
-                           2
-(1 row)
-
+ERROR:  cannot delete from hash distributed table with this command
+DETAIL:  Delete statements on hash-partitioned tables are not supported with master_apply_delete_command.
+HINT:  Use master_modify_multiple_shards command instead.
 -- lock shard metadata: take some share locks and exclusive locks
 BEGIN;
 SELECT lock_shard_metadata(5, ARRAY[999001, 999002, 999002]);


### PR DESCRIPTION
Fixes #934 

Delete operation is blocked for any table distributed by hash using master_apply_delete_command. Suggested master_modify_multiple_shards command as a hint.