### PR TITLE
Fix error message of start_metadata_sync_to_node

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -76,6 +76,7 @@ start_metadata_sync_to_node(PG_FUNCTION_ARGS)
 	int32 nodePort = PG_GETARG_INT32(1);
 	char *nodeNameString = text_to_cstring(nodeName);
 	char *extensionOwner = CitusExtensionOwnerName();
+	char *escapedNodeName = quote_literal_cstr(nodeNameString);
 
 	WorkerNode *workerNode = NULL;
 	char *localGroupIdUpdateCommand = NULL;
@@ -94,8 +95,8 @@ start_metadata_sync_to_node(PG_FUNCTION_ARGS)
 	{
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 						errmsg("you cannot sync metadata to a non-existent node"),
-						errhint("First, add the node with SELECT master_add_node(%s,%d)",
-								nodeNameString, nodePort)));
+						errhint("First, add the node with SELECT master_add_node"
+								"(%s,%d)", escapedNodeName, nodePort)));
 	}
 
 	MarkNodeHasMetadata(nodeNameString, nodePort, true);


### PR DESCRIPTION
Fixes #1203.

Single quotation mark is added around nodename to make the error code consistent with master_add_node usage.