### PR TITLE
Remove default clause from shard DDL when sequences are used

### DIFF
--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -97,6 +97,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	uint64 hashTokenIncrement = 0;
 	List *existingShardList = NIL;
 	int64 shardIndex = 0;
+	bool includeSequenceDefaults = false;
 	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
 
 	/* make sure table is hash partitioned */
@@ -165,7 +166,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	HOLD_INTERRUPTS();
 
 	/* retrieve the DDL commands for the table */
-	ddlCommandList = GetTableDDLEvents(distributedTableId);
+	ddlCommandList = GetTableDDLEvents(distributedTableId, includeSequenceDefaults);
 
 	workerNodeCount = list_length(workerNodeList);
 	if (replicationFactor > workerNodeCount)
@@ -247,6 +248,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId)
 	List *targetTableDDLEvents = NIL;
 	List *targetTableForeignConstraintCommands = NIL;
 	ListCell *sourceShardCell = NULL;
+	bool includeSequenceDefaults = false;
 
 	/* make sure that tables are hash partitioned */
 	CheckHashPartitionedTable(targetRelationId);
@@ -281,7 +283,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId)
 	}
 
 	targetTableRelationOwner = TableOwner(targetRelationId);
-	targetTableDDLEvents = GetTableDDLEvents(targetRelationId);
+	targetTableDDLEvents = GetTableDDLEvents(targetRelationId, includeSequenceDefaults);
 	targetTableForeignConstraintCommands = GetTableForeignConstraintCommands(
 		targetRelationId);
 	targetShardStorageType = ShardStorageType(targetRelationId);
@@ -355,6 +357,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	int replicationFactor = 0;
 	text *shardMinValue = NULL;
 	text *shardMaxValue = NULL;
+	bool includeSequenceDefaults = false;
 
 	/*
 	 * In contrast to append/range partitioned tables it makes more sense to
@@ -390,7 +393,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	shardId = GetNextShardId();
 
 	/* retrieve the DDL commands for the table */
-	ddlCommandList = GetTableDDLEvents(distributedTableId);
+	ddlCommandList = GetTableDDLEvents(distributedTableId, includeSequenceDefaults);
 
 	/* set the replication factor equal to the number of worker nodes */
 	workerNodeCount = list_length(workerNodeList);

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -385,6 +385,7 @@ RecreateTableDDLCommandList(Oid relationId)
 	List *dropCommandList = NIL;
 	List *recreateCommandList = NIL;
 	char relationKind = get_rel_relkind(relationId);
+	bool includeSequenceDefaults = false;
 
 	/* build appropriate DROP command based on relation kind */
 	if (relationKind == RELKIND_RELATION)
@@ -405,7 +406,7 @@ RecreateTableDDLCommandList(Oid relationId)
 
 	dropCommandList = list_make1(dropCommand->data);
 
-	createCommandList = GetTableDDLEvents(relationId);
+	createCommandList = GetTableDDLEvents(relationId, includeSequenceDefaults);
 
 	recreateCommandList = list_concat(dropCommandList, createCommandList);
 

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -88,6 +88,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	char relationKind = get_rel_relkind(relationId);
 	char *relationOwner = TableOwner(relationId);
 	char replicationModel = REPLICATION_MODEL_INVALID;
+	bool includeSequenceDefaults = false;
 
 	EnsureTablePermissions(relationId, ACL_INSERT);
 	CheckDistributedTable(relationId);
@@ -136,7 +137,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	shardId = GetNextShardId();
 
 	/* get table DDL commands to replay on the worker node */
-	ddlEventList = GetTableDDLEvents(relationId);
+	ddlEventList = GetTableDDLEvents(relationId, includeSequenceDefaults);
 
 	/* if enough live nodes, add an extra candidate node as backup */
 	attemptableNodeCount = ShardReplicationFactor;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -209,6 +209,7 @@ MetadataCreateCommands(void)
 	List *workerNodeList = WorkerNodeList();
 	ListCell *distributedTableCell = NULL;
 	char *nodeListInsertCommand = NULL;
+	bool includeSequenceDefaults = true;
 
 	/* generate insert command for pg_dist_node table */
 	nodeListInsertCommand = NodeListInsertCommand(workerNodeList);
@@ -234,7 +235,7 @@ MetadataCreateCommands(void)
 		Oid relationId = cacheEntry->relationId;
 
 		List *workerSequenceDDLCommands = SequenceDDLCommandsForTable(relationId);
-		List *ddlCommandList = GetTableDDLEvents(relationId);
+		List *ddlCommandList = GetTableDDLEvents(relationId, includeSequenceDefaults);
 		char *tableOwnerResetCommand = TableOwnerResetCommand(relationId);
 
 		metadataSnapshotCommandList = list_concat(metadataSnapshotCommandList,
@@ -312,13 +313,14 @@ GetDistributedTableDDLEvents(Oid relationId)
 	char *tableOwnerResetCommand = NULL;
 	char *metadataCommand = NULL;
 	char *truncateTriggerCreateCommand = NULL;
+	bool includeSequenceDefaults = true;
 
 	/* commands to create sequences */
 	sequenceDDLCommands = SequenceDDLCommandsForTable(relationId);
 	commandList = list_concat(commandList, sequenceDDLCommands);
 
 	/* commands to create the table */
-	tableDDLCommands = GetTableDDLEvents(relationId);
+	tableDDLCommands = GetTableDDLEvents(relationId, includeSequenceDefaults);
 	commandList = list_concat(commandList, tableDDLCommands);
 
 	/* command to reset the table owner */

--- a/src/backend/distributed/test/generate_ddl_commands.c
+++ b/src/backend/distributed/test/generate_ddl_commands.c
@@ -43,7 +43,8 @@ table_ddl_command_array(PG_FUNCTION_ARGS)
 {
 	Oid distributedTableId = PG_GETARG_OID(0);
 	ArrayType *ddlCommandArrayType = NULL;
-	List *ddlCommandList = GetTableDDLEvents(distributedTableId);
+	bool includeSequenceDefaults = true;
+	List *ddlCommandList = GetTableDDLEvents(distributedTableId, includeSequenceDefaults);
 	int ddlCommandCount = list_length(ddlCommandList);
 	Datum *ddlCommandDatumArray = palloc0(ddlCommandCount * sizeof(Datum));
 

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -30,7 +30,7 @@ extern Oid get_extension_schema(Oid ext_oid);
 extern char * pg_get_serverdef_string(Oid tableRelationId);
 extern char * pg_get_sequencedef_string(Oid sequenceRelid);
 extern Form_pg_sequence pg_get_sequencedef(Oid sequenceRelationId);
-extern char * pg_get_tableschemadef_string(Oid tableRelationId);
+extern char * pg_get_tableschemadef_string(Oid tableRelationId, bool forShardCreation);
 extern char * pg_get_tablecolumnoptionsdef_string(Oid tableRelationId);
 extern char * pg_get_indexclusterdef_string(Oid indexRelationId);
 extern List * pg_get_table_grants(Oid relationId);

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -100,7 +100,7 @@ extern bool CStoreTable(Oid relationId);
 extern uint64 GetNextShardId(void);
 extern uint64 GetNextPlacementId(void);
 extern Oid ResolveRelationId(text *relationName);
-extern List * GetTableDDLEvents(Oid relationId);
+extern List * GetTableDDLEvents(Oid relationId, bool forShardCreation);
 extern List * GetTableForeignConstraintCommands(Oid relationId);
 extern char ShardStorageType(Oid relationId);
 extern void CheckDistributedTable(Oid relationId);

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -401,11 +401,7 @@ BEGIN;
  col_3  | bigint  | not null default nextval('mx_table_col_3_seq'::regclass)
 
 DROP SEQUENCE mx_table_col_3_seq CASCADE;
-NOTICE:  drop cascades to 4 other objects
-DETAIL:  drop cascades to default for table mx_table_1270000 column col_3
-drop cascades to default for table mx_table_1270002 column col_3
-drop cascades to default for table mx_table_1270004 column col_3
-drop cascades to default for table mx_table column col_3
+NOTICE:  drop cascades to default for table mx_table column col_3
 \d mx_table
    Table "public.mx_table"
  Column |  Type   | Modifiers 

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -369,6 +369,18 @@ SELECT  indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
 SELECT  indexname, tablename FROM pg_indexes WHERE tablename like 'lineitem_alter_%';
 \c - - - :master_port
 
+-- verify alter table and drop sequence in the same transaction does not cause deadlock
+CREATE TABLE sequence_deadlock_test (a serial, b serial);
+SELECT create_distributed_table('sequence_deadlock_test', 'a');
+
+BEGIN;
+ALTER TABLE sequence_deadlock_test ADD COLUMN c int;
+DROP SEQUENCE sequence_deadlock_test_b_seq CASCADE;
+END;
+
+DROP TABLE sequence_deadlock_test;
+
+
 -- test ALTER TABLE ALL IN TABLESPACE
 -- we expect that it will warn out
 CREATE TABLESPACE super_fast_ssd LOCATION '@abs_srcdir@/data';

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -764,6 +764,22 @@ SELECT  indexname, tablename FROM pg_indexes WHERE tablename like 'lineitem_alte
 (0 rows)
 
 \c - - - :master_port
+-- verify alter table and drop sequence in the same transaction does not cause deadlock
+CREATE TABLE sequence_deadlock_test (a serial, b serial);
+SELECT create_distributed_table('sequence_deadlock_test', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+BEGIN;
+ALTER TABLE sequence_deadlock_test ADD COLUMN c int;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+DROP SEQUENCE sequence_deadlock_test_b_seq CASCADE;
+NOTICE:  drop cascades to default for table sequence_deadlock_test column b
+END;
+DROP TABLE sequence_deadlock_test;
 -- test ALTER TABLE ALL IN TABLESPACE
 -- we expect that it will warn out
 CREATE TABLESPACE super_fast_ssd LOCATION '@abs_srcdir@/data';


### PR DESCRIPTION
When a default value of a column is tied to a sequence, a dependency is created between a shard and a sequence. This dependency causes a deadlock when multiple shards on a single worker try to acquire lock on the sequence.

This fix removes DEFAULT value for a column from a shard ddl command if that column is set to receive the default value from a sequence.

Fixes: #1251 