### PR TITLE
Add udf to get size of table

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -10,7 +10,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
 	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12 6.1-13 6.1-14 6.1-15 6.1-16 6.1-17 \
-	6.2-1
+	6.2-1 6.2-2
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -131,6 +131,8 @@ $(EXTENSION)--6.1-16.sql: $(EXTENSION)--6.1-15.sql $(EXTENSION)--6.1-15--6.1-16.
 $(EXTENSION)--6.1-17.sql: $(EXTENSION)--6.1-16.sql $(EXTENSION)--6.1-16--6.1-17.sql
 	cat $^ > $@
 $(EXTENSION)--6.2-1.sql: $(EXTENSION)--6.1-17.sql $(EXTENSION)--6.1-17--6.2-1.sql
+	cat $^ > $@
+$(EXTENSION)--6.2-2.sql: $(EXTENSION)--6.2-1.sql $(EXTENSION)--6.2-1--6.2-2.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.2-1--6.2-2.sql
+++ b/src/backend/distributed/citus--6.2-1--6.2-2.sql
@@ -1,0 +1,26 @@
+/* citus--6.2-1--6.2-2.sql */
+
+SET search_path = 'pg_catalog';
+
+CREATE FUNCTION citus_table_size(logicalrelid regclass)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_table_size$$;
+COMMENT ON FUNCTION citus_table_size(logicalrelid regclass)
+    IS 'get disk space used by the specified table, excluding indexes';
+    
+CREATE FUNCTION citus_relation_size(logicalrelid regclass)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_relation_size$$;
+COMMENT ON FUNCTION citus_relation_size(logicalrelid regclass)
+    IS 'get disk space used by the ''main'' fork';
+    
+CREATE FUNCTION citus_total_relation_size(logicalrelid regclass)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_total_relation_size$$;
+COMMENT ON FUNCTION citus_total_relation_size(logicalrelid regclass)
+    IS 'get total disk space used by the specified table';
+    
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.2-1'
+default_version = '6.2-2'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -25,6 +25,9 @@
 /* total number of hash tokens (2^32) */
 #define HASH_TOKEN_COUNT INT64CONST(4294967296)
 #define SELECT_EXIST_QUERY "SELECT EXISTS (SELECT 1 FROM %s)"
+#define PG_TABLE_SIZE_FUNCTION "pg_table_size(%s)"
+#define PG_RELATION_SIZE_FUNCTION "pg_relation_size(%s)"
+#define PG_TOTAL_RELATION_SIZE_FUNCTION "pg_total_relation_size(%s)"
 
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -76,6 +76,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-15';
 ALTER EXTENSION citus UPDATE TO '6.1-16';
 ALTER EXTENSION citus UPDATE TO '6.1-17';
 ALTER EXTENSION citus UPDATE TO '6.2-1';
+ALTER EXTENSION citus UPDATE TO '6.2-2';
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)
 FROM pg_depend AS pgd,

--- a/src/test/regress/expected/multi_size_queries.out
+++ b/src/test/regress/expected/multi_size_queries.out
@@ -1,0 +1,106 @@
+--
+-- MULTI_SIZE_QUERIES
+--
+-- Test checks whether size of distributed tables can be obtained with citus_table_size.
+-- To find the relation size and total relation size citus_relation_size and 
+-- citus_total_relation_size are also tested.
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1390000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1390000;
+-- Tests on distributed table with replication factor > 1
+SELECT citus_table_size('lineitem_hash_part');
+ERROR:  cannot calculate the size because replication factor is greater than 1
+SELECT citus_relation_size('lineitem_hash_part');
+ERROR:  cannot calculate the size because replication factor is greater than 1
+SELECT citus_total_relation_size('lineitem_hash_part');
+ERROR:  cannot calculate the size because replication factor is greater than 1
+VACUUM (FULL) customer_copy_hash;
+-- Tests on distributed tables with streaming replication.
+SELECT citus_table_size('customer_copy_hash');
+ citus_table_size 
+------------------
+           548864
+(1 row)
+
+SELECT citus_relation_size('customer_copy_hash');
+ citus_relation_size 
+---------------------
+              548864
+(1 row)
+
+SELECT citus_total_relation_size('customer_copy_hash');
+ citus_total_relation_size 
+---------------------------
+                   1597440
+(1 row)
+
+CREATE INDEX index_1 on customer_copy_hash(c_custkey);
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+VACUUM (FULL) customer_copy_hash;
+-- Tests on distributed table with index.
+SELECT citus_table_size('customer_copy_hash');
+ citus_table_size 
+------------------
+           548864
+(1 row)
+
+SELECT citus_relation_size('customer_copy_hash');
+ citus_relation_size 
+---------------------
+              548864
+(1 row)
+
+SELECT citus_total_relation_size('customer_copy_hash');
+ citus_total_relation_size 
+---------------------------
+                   2646016
+(1 row)
+
+-- Tests on reference table
+VACUUM (FULL) supplier;
+SELECT citus_table_size('supplier');
+ citus_table_size 
+------------------
+           376832
+(1 row)
+
+SELECT citus_relation_size('supplier');
+ citus_relation_size 
+---------------------
+              376832
+(1 row)
+
+SELECT citus_total_relation_size('supplier');
+ citus_total_relation_size 
+---------------------------
+                    376832
+(1 row)
+
+CREATE INDEX index_2 on supplier(s_suppkey);
+VACUUM (FULL) supplier;
+SELECT citus_table_size('supplier');
+ citus_table_size 
+------------------
+           376832
+(1 row)
+
+SELECT citus_relation_size('supplier');
+ citus_relation_size 
+---------------------
+              376832
+(1 row)
+
+SELECT citus_total_relation_size('supplier');
+ citus_total_relation_size 
+---------------------------
+                    458752
+(1 row)
+
+-- Test inside the transaction
+BEGIN;
+ALTER TABLE supplier ALTER COLUMN s_suppkey SET NOT NULL;
+select citus_table_size('supplier');
+ERROR:  citus size functions cannot be called in transaction blocks which contain multi-shard data modifications
+END;
+DROP INDEX index_1;
+DROP INDEX index_2;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -159,6 +159,11 @@ test: multi_router_planner
 test: multi_large_shardid
 
 # ----------
+#  multi_size_queries tests various size commands on distributed tables
+# ----------
+test: multi_size_queries
+
+# ----------
 # multi_drop_extension makes sure we can safely drop and recreate the extension
 # ----------
 test: multi_drop_extension

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -76,6 +76,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-15';
 ALTER EXTENSION citus UPDATE TO '6.1-16';
 ALTER EXTENSION citus UPDATE TO '6.1-17';
 ALTER EXTENSION citus UPDATE TO '6.2-1';
+ALTER EXTENSION citus UPDATE TO '6.2-2';
 
 -- ensure no objects were created outside pg_catalog
 SELECT COUNT(*)

--- a/src/test/regress/sql/multi_size_queries.sql
+++ b/src/test/regress/sql/multi_size_queries.sql
@@ -1,0 +1,52 @@
+--
+-- MULTI_SIZE_QUERIES
+--
+-- Test checks whether size of distributed tables can be obtained with citus_table_size.
+-- To find the relation size and total relation size citus_relation_size and 
+-- citus_total_relation_size are also tested.
+
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1390000;
+ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1390000;
+
+-- Tests on distributed table with replication factor > 1
+SELECT citus_table_size('lineitem_hash_part');
+SELECT citus_relation_size('lineitem_hash_part');
+SELECT citus_total_relation_size('lineitem_hash_part');
+
+VACUUM (FULL) customer_copy_hash;
+
+-- Tests on distributed tables with streaming replication.
+SELECT citus_table_size('customer_copy_hash');
+SELECT citus_relation_size('customer_copy_hash');
+SELECT citus_total_relation_size('customer_copy_hash');
+
+CREATE INDEX index_1 on customer_copy_hash(c_custkey);
+VACUUM (FULL) customer_copy_hash;
+
+-- Tests on distributed table with index.
+SELECT citus_table_size('customer_copy_hash');
+SELECT citus_relation_size('customer_copy_hash');
+SELECT citus_total_relation_size('customer_copy_hash');
+
+-- Tests on reference table
+VACUUM (FULL) supplier;
+
+SELECT citus_table_size('supplier');
+SELECT citus_relation_size('supplier');
+SELECT citus_total_relation_size('supplier');
+
+CREATE INDEX index_2 on supplier(s_suppkey);
+VACUUM (FULL) supplier;
+
+SELECT citus_table_size('supplier');
+SELECT citus_relation_size('supplier');
+SELECT citus_total_relation_size('supplier');
+
+-- Test inside the transaction
+BEGIN;
+ALTER TABLE supplier ALTER COLUMN s_suppkey SET NOT NULL;
+select citus_table_size('supplier');
+END;
+
+DROP INDEX index_1;
+DROP INDEX index_2;


### PR DESCRIPTION
Fixes #631 

Node based size UDFs (citus_table_size, citus_relation_size and citus_total_relation_size) are implemented. Reference tables and streaming replicated tables are covered.