### PR TITLE
Execute DDL on coordinator before workers

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -101,15 +101,15 @@ static void VerifyTransmitStmt(CopyStmt *copyStatement);
 /* Local functions forward declarations for processing distributed table commands */
 static Node * ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag,
 							  bool *commandMustRunAsOwner);
-static Node * ProcessIndexStmt(IndexStmt *createIndexStatement,
+static Node * PlanIndexStmt(IndexStmt *createIndexStatement,
 							   const char *createIndexCommand, bool isTopLevel);
-static Node * ProcessDropIndexStmt(DropStmt *dropIndexStatement,
+static Node * PlanDropIndexStmt(DropStmt *dropIndexStatement,
 								   const char *dropIndexCommand, bool isTopLevel);
-static Node * ProcessAlterTableStmt(AlterTableStmt *alterTableStatement,
+static Node * PlanAlterTableStmt(AlterTableStmt *alterTableStatement,
 									const char *alterTableCommand, bool isTopLevel);
 static Node * WorkerProcessAlterTableStmt(AlterTableStmt *alterTableStatement,
 										  const char *alterTableCommand);
-static Node * ProcessAlterObjectSchemaStmt(AlterObjectSchemaStmt *alterObjectSchemaStmt,
+static Node * PlanAlterObjectSchemaStmt(AlterObjectSchemaStmt *alterObjectSchemaStmt,
 										   const char *alterObjectSchemaCommand,
 										   bool isTopLevel);
 static void ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand);
@@ -257,7 +257,7 @@ multi_ProcessUtility(Node *parsetree,
 
 		if (IsA(parsetree, IndexStmt))
 		{
-			parsetree = ProcessIndexStmt((IndexStmt *) parsetree, queryString,
+			parsetree = PlanIndexStmt((IndexStmt *) parsetree, queryString,
 										 isTopLevel);
 		}
 
@@ -266,7 +266,7 @@ multi_ProcessUtility(Node *parsetree,
 			DropStmt *dropStatement = (DropStmt *) parsetree;
 			if (dropStatement->removeType == OBJECT_INDEX)
 			{
-				parsetree = ProcessDropIndexStmt(dropStatement, queryString, isTopLevel);
+				parsetree = PlanDropIndexStmt(dropStatement, queryString, isTopLevel);
 			}
 		}
 
@@ -275,7 +275,7 @@ multi_ProcessUtility(Node *parsetree,
 			AlterTableStmt *alterTableStmt = (AlterTableStmt *) parsetree;
 			if (alterTableStmt->relkind == OBJECT_TABLE)
 			{
-				parsetree = ProcessAlterTableStmt(alterTableStmt, queryString,
+				parsetree = PlanAlterTableStmt(alterTableStmt, queryString,
 												  isTopLevel);
 			}
 		}
@@ -300,7 +300,7 @@ multi_ProcessUtility(Node *parsetree,
 		if (IsA(parsetree, AlterObjectSchemaStmt))
 		{
 			AlterObjectSchemaStmt *setSchemaStmt = (AlterObjectSchemaStmt *) parsetree;
-			parsetree = ProcessAlterObjectSchemaStmt(setSchemaStmt, queryString,
+			parsetree = PlanAlterObjectSchemaStmt(setSchemaStmt, queryString,
 													 isTopLevel);
 		}
 
@@ -604,7 +604,7 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, bool *commandMustR
 
 
 /*
- * ProcessIndexStmt processes create index statements for distributed tables.
+ * PlanIndexStmt processes create index statements for distributed tables.
  * The function first checks if the statement belongs to a distributed table
  * or not. If it does, then it executes distributed logic for the command.
  *
@@ -612,7 +612,7 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, bool *commandMustR
  * master node table.
  */
 static Node *
-ProcessIndexStmt(IndexStmt *createIndexStatement, const char *createIndexCommand,
+PlanIndexStmt(IndexStmt *createIndexStatement, const char *createIndexCommand,
 				 bool isTopLevel)
 {
 	/*
@@ -690,7 +690,7 @@ ProcessIndexStmt(IndexStmt *createIndexStatement, const char *createIndexCommand
 
 
 /*
- * ProcessDropIndexStmt processes drop index statements for distributed tables.
+ * PlanDropIndexStmt processes drop index statements for distributed tables.
  * The function first checks if the statement belongs to a distributed table
  * or not. If it does, then it executes distributed logic for the command.
  *
@@ -698,7 +698,7 @@ ProcessIndexStmt(IndexStmt *createIndexStatement, const char *createIndexCommand
  * master node table.
  */
 static Node *
-ProcessDropIndexStmt(DropStmt *dropIndexStatement, const char *dropIndexCommand,
+PlanDropIndexStmt(DropStmt *dropIndexStatement, const char *dropIndexCommand,
 					 bool isTopLevel)
 {
 	ListCell *dropObjectCell = NULL;
@@ -782,7 +782,7 @@ ProcessDropIndexStmt(DropStmt *dropIndexStatement, const char *dropIndexCommand,
 
 
 /*
- * ProcessAlterTableStmt processes alter table statements for distributed tables.
+ * PlanAlterTableStmt processes alter table statements for distributed tables.
  * The function first checks if the statement belongs to a distributed table
  * or not. If it does, then it executes distributed logic for the command.
  *
@@ -790,7 +790,7 @@ ProcessDropIndexStmt(DropStmt *dropIndexStatement, const char *dropIndexCommand,
  * master node table.
  */
 static Node *
-ProcessAlterTableStmt(AlterTableStmt *alterTableStatement, const char *alterTableCommand,
+PlanAlterTableStmt(AlterTableStmt *alterTableStatement, const char *alterTableCommand,
 					  bool isTopLevel)
 {
 	LOCKMODE lockmode = 0;
@@ -948,13 +948,13 @@ WorkerProcessAlterTableStmt(AlterTableStmt *alterTableStatement,
 
 
 /*
- * ProcessAlterObjectSchemaStmt processes ALTER ... SET SCHEMA statements for distributed
+ * PlanAlterObjectSchemaStmt processes ALTER ... SET SCHEMA statements for distributed
  * objects. The function first checks if the statement belongs to a distributed objects
  * or not. If it does, then it checks whether given object is a table. If it is, we warn
  * out, since we do not support ALTER ... SET SCHEMA
  */
 static Node *
-ProcessAlterObjectSchemaStmt(AlterObjectSchemaStmt *alterObjectSchemaStmt,
+PlanAlterObjectSchemaStmt(AlterObjectSchemaStmt *alterObjectSchemaStmt,
 							 const char *alterObjectSchemaCommand, bool isTopLevel)
 {
 	Oid relationId = InvalidOid;

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -14,6 +14,13 @@
 
 extern bool EnableDDLPropagation;
 
+typedef struct DDLJob
+{
+	Oid targetRelationId;
+	const char *commandString;
+	List *taskList;
+} DDLJob;
+
 extern void multi_ProcessUtility(Node *parsetree, const char *queryString,
 								 ProcessUtilityContext context, ParamListInfo params,
 								 DestReceiver *dest, char *completionTag);

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -24,7 +24,7 @@ typedef struct DDLJob
 extern void multi_ProcessUtility(Node *parsetree, const char *queryString,
 								 ProcessUtilityContext context, ParamListInfo params,
 								 DestReceiver *dest, char *completionTag);
-extern void ReplicateGrantStmt(Node *parsetree);
+extern List * PlanGrantStmt(GrantStmt *grantStmt);
 
 
 #endif /* MULTI_UTILITY_H */

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -14,11 +14,17 @@
 
 extern bool EnableDDLPropagation;
 
+/*
+ * A DDLJob encapsulates the remote tasks and commands needed to process all or
+ * part of a distributed DDL command. It hold the distributed relation's oid,
+ * the original DDL command string (for MX DDL propagation), and a task list of
+ * DDL_TASK-type Tasks to be executed.
+ */
 typedef struct DDLJob
 {
-	Oid targetRelationId;
-	const char *commandString;
-	List *taskList;
+	Oid targetRelationId;      /* oid of the target distributed relation */
+	const char *commandString; /* initial (coordinator) DDL command string */
+	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;
 
 extern void multi_ProcessUtility(Node *parsetree, const char *queryString,

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -163,14 +163,10 @@ ERROR:  creating unique indexes on append-partitioned tables is currently unsupp
 CREATE INDEX lineitem_orderkey_index ON lineitem (l_orderkey);
 ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
-NOTICE:  using one-phase commit for distributed DDL commands
-HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 ERROR:  data type bigint has no default operator class for access method "gist"
 HINT:  You must specify an operator class for the index or define a default operator class for the data type.
-CONTEXT:  while executing command on localhost:57638
 CREATE INDEX try_index ON lineitem (non_existent_column);
 ERROR:  column "non_existent_column" does not exist
-CONTEXT:  while executing command on localhost:57638
 CREATE INDEX ON lineitem (l_orderkey);
 ERROR:  creating index without a name on a distributed table is currently unsupported
 -- Verify that none of failed indexes got created on the master node
@@ -205,6 +201,8 @@ DROP INDEX CONCURRENTLY lineitem_orderkey_index;
 ERROR:  dropping indexes concurrently on distributed tables is currently unsupported
 -- Verify that we can succesfully drop indexes
 DROP INDEX lineitem_orderkey_index;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 DROP INDEX lineitem_orderkey_index_new;
 DROP INDEX lineitem_partkey_desc_index;
 DROP INDEX lineitem_partial_index;

--- a/src/test/regress/expected/multi_join_order_additional.out
+++ b/src/test/regress/expected/multi_join_order_additional.out
@@ -43,9 +43,9 @@ SELECT master_create_worker_shards('lineitem_hash', 2, 1);
 (1 row)
 
 CREATE INDEX lineitem_hash_time_index ON lineitem_hash (l_shipdate);
+DEBUG:  building index "lineitem_hash_time_index" on table "lineitem_hash"
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-DEBUG:  building index "lineitem_hash_time_index" on table "lineitem_hash"
 CREATE TABLE orders_hash (
 	o_orderkey bigint not null,
 	o_custkey integer not null,

--- a/src/test/regress/expected/multi_mx_ddl.out
+++ b/src/test/regress/expected/multi_mx_ddl.out
@@ -142,9 +142,9 @@ Indexes:
 \c - - - :master_port
 SET client_min_messages TO debug2;
 CREATE INDEX ddl_test_index ON mx_ddl_table(value);
+DEBUG:  building index "ddl_test_index" on table "mx_ddl_table"
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-DEBUG:  building index "ddl_test_index" on table "mx_ddl_table"
 RESET client_min_messages;
 DROP INDEX ddl_test_index;
 -- show that sequences owned by mx tables result in unique values

--- a/src/test/regress/expected/multi_mx_modifying_xacts.out
+++ b/src/test/regress/expected/multi_mx_modifying_xacts.out
@@ -183,7 +183,7 @@ ABORT;
 -- applies to DDL
 BEGIN;
 INSERT INTO labs_mx VALUES (6, 'Bell labs_mx');
-ALTER TABLE labs_mx ADD COLUMN text motto;
+ALTER TABLE labs_mx ADD COLUMN motto text;
 ERROR:  distributed DDL commands must not appear within transaction blocks containing single-shard data modifications
 COMMIT;
 -- doesn't apply to COPY after modifications

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -610,9 +610,9 @@ HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_sh
 
 \c - - - :master_port
 ALTER TABLE test_schema_support.nation_hash DROP COLUMN IF EXISTS non_existent_column;
+NOTICE:  column "non_existent_column" of relation "nation_hash" does not exist, skipping
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-NOTICE:  column "non_existent_column" of relation "nation_hash" does not exist, skipping
 ALTER TABLE test_schema_support.nation_hash DROP COLUMN IF EXISTS new_col;
 -- verify column is dropped
 \d test_schema_support.nation_hash;
@@ -665,9 +665,9 @@ HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_sh
 \c - - - :master_port
 SET search_path TO test_schema_support;
 ALTER TABLE nation_hash DROP COLUMN IF EXISTS non_existent_column;
+NOTICE:  column "non_existent_column" of relation "nation_hash" does not exist, skipping
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-NOTICE:  column "non_existent_column" of relation "nation_hash" does not exist, skipping
 ALTER TABLE nation_hash DROP COLUMN IF EXISTS new_col;
 -- verify column is dropped
 \d test_schema_support.nation_hash;

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -140,6 +140,9 @@ SELECT * FROM mx_ref_table ORDER BY col_1;
 
 \c - - - :master_port
 DROP TABLE mx_ref_table;
+CREATE UNIQUE INDEX mx_test_uniq_index ON mx_table(col_1);
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 \c - - - :worker_1_port
 -- DDL commands
 \d mx_table
@@ -149,8 +152,10 @@ DROP TABLE mx_ref_table;
  col_1  | integer | 
  col_2  | text    | 
  col_3  | bigint  | not null default nextval('mx_table_col_3_seq'::regclass)
+Indexes:
+    "mx_test_uniq_index" UNIQUE, btree (col_1)
 
-CREATE INDEX mx_test_index ON mx_table(col_1);
+CREATE INDEX mx_test_index ON mx_table(col_2);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
 ALTER TABLE mx_table ADD COLUMN col_4 int;
@@ -166,6 +171,8 @@ HINT:  Connect to the coordinator and run it again.
  col_1  | integer | 
  col_2  | text    | 
  col_3  | bigint  | not null default nextval('mx_table_col_3_seq'::regclass)
+Indexes:
+    "mx_test_uniq_index" UNIQUE, btree (col_1)
 
 -- master_modify_multiple_shards
 SELECT master_modify_multiple_shards('UPDATE mx_table SET col_2=''none''');
@@ -223,6 +230,9 @@ SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 -- master_remove_node
 \c - - - :master_port
+DROP INDEX mx_test_uniq_index;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 SELECT master_add_node('localhost', 5432);
               master_add_node               
 --------------------------------------------

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -261,8 +261,7 @@ ALTER TABLE IF EXISTS non_existent_table ADD COLUMN new_column INTEGER;
 NOTICE:  relation "non_existent_table" does not exist, skipping
 ALTER TABLE IF EXISTS lineitem_alter ALTER COLUMN int_column2 SET DATA TYPE INTEGER;
 ALTER TABLE lineitem_alter DROP COLUMN non_existent_column;
-ERROR:  column "non_existent_column" of relation "lineitem_alter_220000" does not exist
-CONTEXT:  while executing command on localhost:57638
+ERROR:  column "non_existent_column" of relation "lineitem_alter" does not exist
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 NOTICE:  column "non_existent_column" of relation "lineitem_alter" does not exist, skipping
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS int_column2;
@@ -360,13 +359,13 @@ DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT, ADD|DROP CON
 -- types
 ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
 ERROR:  type "non_existent_type" does not exist
-CONTEXT:  while executing command on localhost:57638
+LINE 1: ALTER TABLE lineitem_alter ADD COLUMN new_column non_existen...
+                                                         ^
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
 ERROR:  column "null_column" contains null values
 CONTEXT:  while executing command on localhost:57638
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 ERROR:  invalid input syntax for integer: "a"
-CONTEXT:  while executing command on localhost:57638
 -- Verify that we error out on statements involving RENAME
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
 ERROR:  renaming distributed tables or their objects is currently unsupported

--- a/src/test/regress/sql/multi_mx_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_mx_modifying_xacts.sql
@@ -154,7 +154,7 @@ ABORT;
 -- applies to DDL
 BEGIN;
 INSERT INTO labs_mx VALUES (6, 'Bell labs_mx');
-ALTER TABLE labs_mx ADD COLUMN text motto;
+ALTER TABLE labs_mx ADD COLUMN motto text;
 COMMIT;
 
 -- doesn't apply to COPY after modifications

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -91,11 +91,12 @@ SELECT * FROM mx_ref_table ORDER BY col_1;
 
 \c - - - :master_port
 DROP TABLE mx_ref_table;
+CREATE UNIQUE INDEX mx_test_uniq_index ON mx_table(col_1);
 \c - - - :worker_1_port
 
 -- DDL commands
 \d mx_table
-CREATE INDEX mx_test_index ON mx_table(col_1);
+CREATE INDEX mx_test_index ON mx_table(col_2);
 ALTER TABLE mx_table ADD COLUMN col_4 int;
 ALTER TABLE mx_table_2 ADD CONSTRAINT mx_fk_constraint FOREIGN KEY(col_1) REFERENCES mx_table(col_1);
 \d mx_table
@@ -122,6 +123,7 @@ SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 -- master_remove_node
 \c - - - :master_port
+DROP INDEX mx_test_uniq_index;
 SELECT master_add_node('localhost', 5432);
 
 \c - - - :worker_1_port


### PR DESCRIPTION
Fixes #357

My initial pass at this had some problems with `DROP INDEX` in particular, as dropping the local index first means we can no longer look up what relation owns the index. To address this, I removed the execution portion of all the _Process-_ methods within `multi_utility` and added a `DDLJob` struct to represent the work to eventually be done on the workers.

I renamed such methods to begin with _Plan-_ instead. Their new contract is to perform any needed modifications on the query (which they already did, despite pretending to return a modified version) and return a `DDLJob`. The (possibly) modified query executes on the coordinator, then the `DDLJob` is used to perform MX metadata syncing and `DDL` propagation.

Two design decisions:

  * The concerns of the old _Process-_ methods are myriad. I think there could be some consistency here to first verify the query for distributed execution, emit messages and warnings, and create a plan. Each sub-method does this in a slightly different order, which is confusing. I avoided modifying any of their logic to keep the review focused
  * The locks taken to look up whether targeted objects are associated with distributed relations could probably be relaxed. In fact, it's possibly only some DDL commands require evaluation before coordinator DDL execution (see my comment about `DROP INDEX` above); however, for consistency, I just moved all _Plan-_ (née _Process-_) calls above the call to `standard_ProcessUtility`

These two simplifications can be revisited if the reviewer requires.

# TODO

  - [x] Documentation pass
  - [x] Fix MX test
  - [x] Change `DDLJob *` to a `List *` of `DDLJob *`s (necessary for Enterprise's `GRANT` support)
  - [x] Rebase onto `master` when the time comes