### PR TITLE
Decouple reference table replication

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -10,7 +10,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	5.2-1 5.2-2 5.2-3 5.2-4 \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
 	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12 6.1-13 6.1-14 6.1-15 6.1-16 6.1-17 \
-	6.2-1 6.2-2
+	6.2-1 6.2-2 6.2-3
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -133,6 +133,8 @@ $(EXTENSION)--6.1-17.sql: $(EXTENSION)--6.1-16.sql $(EXTENSION)--6.1-16--6.1-17.
 $(EXTENSION)--6.2-1.sql: $(EXTENSION)--6.1-17.sql $(EXTENSION)--6.1-17--6.2-1.sql
 	cat $^ > $@
 $(EXTENSION)--6.2-2.sql: $(EXTENSION)--6.2-1.sql $(EXTENSION)--6.2-1--6.2-2.sql
+	cat $^ > $@
+$(EXTENSION)--6.2-3.sql: $(EXTENSION)--6.2-2.sql $(EXTENSION)--6.2-2--6.2-3.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--6.2-2--6.2-3.sql
+++ b/src/backend/distributed/citus--6.2-2--6.2-3.sql
@@ -1,0 +1,54 @@
+/* citus--6.2-2--6.2-3.sql */
+
+SET search_path = 'pg_catalog';
+
+ALTER TABLE pg_dist_node ADD isactive bool;
+
+DROP FUNCTION IF EXISTS master_add_node(text, integer);
+
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                OUT nodeid integer,
+                                OUT groupid integer,
+                                OUT nodename text,
+                                OUT nodeport integer,
+                                OUT noderack text,
+                                OUT hasmetadata boolean,
+                                OUT isactive bool)
+    RETURNS record 
+    LANGUAGE C STRICT 
+    AS 'MODULE_PATHNAME',$$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer)
+    IS 'add node to the cluster'; 
+
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         OUT nodeid integer,
+                                         OUT groupid integer,
+                                         OUT nodename text,
+                                         OUT nodeport integer,
+                                         OUT noderack text,
+                                         OUT hasmetadata boolean,
+                                         OUT isactive bool)
+    RETURNS record 
+    LANGUAGE C STRICT 
+    AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text,nodeport integer)
+    IS 'prepare node by adding it to pg_dist_node';
+
+CREATE FUNCTION master_activate_node(nodename text,
+                                     nodeport integer,
+                                     OUT nodeid integer,
+                                     OUT groupid integer,
+                                     OUT nodename text,
+                                     OUT nodeport integer,
+                                     OUT noderack text,
+                                     OUT hasmetadata boolean,
+                                     OUT isactive bool)
+    RETURNS record 
+    LANGUAGE C STRICT 
+    AS 'MODULE_PATHNAME',$$master_activate_node$$;
+COMMENT ON FUNCTION master_activate_node(nodename text, nodeport integer)
+    IS 'activate a node which is in the cluster'; 
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '6.2-2'
+default_version = '6.2-3'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -242,7 +242,7 @@ static void
 CreateReferenceTable(Oid relationId)
 {
 	uint32 colocationId = INVALID_COLOCATION_ID;
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	int replicationFactor = list_length(workerNodeList);
 	char *distributionColumnName = NULL;
 	bool requireEmpty = true;

--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -82,7 +82,7 @@ MultiRealTimeExecute(Job *job)
 	const char *workerHashName = "Worker node hash";
 	WaitInfo *waitInfo = MultiClientCreateWaitInfo(list_length(taskList));
 
-	workerNodeList = WorkerNodeList();
+	workerNodeList = ActiveWorkerNodeList();
 	workerHash = WorkerHash(workerHashName, workerNodeList);
 
 	/* initialize task execution structures for remote execution */

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -43,7 +43,7 @@ JobExecutorType(MultiPlan *multiPlan)
 {
 	Job *job = multiPlan->workerJob;
 	List *workerTaskList = job->taskList;
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	int taskCount = list_length(workerTaskList);
 	int workerNodeCount = list_length(workerNodeList);
 	double tasksPerNode = taskCount / ((double) workerNodeCount);

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -191,7 +191,7 @@ MultiTaskTrackerExecute(Job *job)
 	 * assigning and checking the status of tasks. The second (temporary) hash
 	 * helps us in fetching results data from worker nodes to the master node.
 	 */
-	workerNodeList = WorkerNodeList();
+	workerNodeList = ActiveWorkerNodeList();
 	taskTrackerCount = (uint32) list_length(workerNodeList);
 
 	taskTrackerHash = TrackerHash(taskTrackerHashName, workerNodeList);

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -33,6 +33,7 @@
 #include "distributed/multi_join_order.h"
 #include "distributed/pg_dist_partition.h"
 #include "distributed/pg_dist_shard.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/resource_lock.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/worker_manager.h"
@@ -159,7 +160,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	hashTokenIncrement = HASH_TOKEN_COUNT / shardCount;
 
 	/* load and sort the worker node list for deterministic placement */
-	workerNodeList = WorkerNodeList();
+	workerNodeList = ActiveWorkerNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* make sure we don't process cancel signals until all shards are created */
@@ -386,7 +387,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	}
 
 	/* load and sort the worker node list for deterministic placement */
-	workerNodeList = WorkerNodeList();
+	workerNodeList = ActiveWorkerNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* get the next shard id */

--- a/src/backend/distributed/master/master_expire_table_cache.c
+++ b/src/backend/distributed/master/master_expire_table_cache.c
@@ -47,7 +47,7 @@ master_expire_table_cache(PG_FUNCTION_ARGS)
 {
 	Oid relationId = PG_GETARG_OID(0);
 	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	ListCell *workerNodeCell = NULL;
 	int shardCount = cacheEntry->shardIntervalArrayLength;
 	ShardInterval **shardIntervalArray = cacheEntry->sortedShardIntervalArray;

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -150,7 +150,7 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 
 	pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
 
-	workerNodeList = WorkerNodeList();
+	workerNodeList = ActiveWorkerNodeList();
 
 	foreach(workerNodeCell, workerNodeList)
 	{

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -390,7 +390,7 @@ master_get_active_worker_nodes(PG_FUNCTION_ARGS)
 		/* switch to memory context appropriate for multiple function calls */
 		oldContext = MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
 
-		workerNodeList = WorkerNodeList();
+		workerNodeList = ActiveWorkerNodeList();
 		workerNodeCount = (uint32) list_length(workerNodeList);
 
 		functionContext->user_fctx = workerNodeList;

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -71,7 +71,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 {
 	text *relationNameText = PG_GETARG_TEXT_P(0);
 	char *relationName = text_to_cstring(relationNameText);
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	uint64 shardId = INVALID_SHARD_ID;
 	List *ddlEventList = NULL;
 	uint32 attemptableNodeCount = 0;

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -302,19 +302,19 @@ WorkerGetNodeWithName(const char *hostname)
 uint32
 WorkerGetLiveNodeCount(void)
 {
-	HTAB *workerNodeHash = GetWorkerNodeHash();
-	uint32 liveWorkerCount = hash_get_num_entries(workerNodeHash);
+	List *workerNodeList = ActiveWorkerNodeList();
+	uint32 liveWorkerCount = workerNodeList->length;
 
 	return liveWorkerCount;
 }
 
 
 /*
- * WorkerNodeList iterates over the hash table that includes the worker nodes, and adds
- * them to a list which is returned.
+ * ActiveWorkerNodeList iterates over the hash table that includes the worker
+ * nodes and adds active nodes to a list, which is returned.
  */
 List *
-WorkerNodeList(void)
+ActiveWorkerNodeList(void)
 {
 	List *workerNodeList = NIL;
 	WorkerNode *workerNode = NULL;
@@ -325,9 +325,12 @@ WorkerNodeList(void)
 
 	while ((workerNode = hash_seq_search(&status)) != NULL)
 	{
-		WorkerNode *workerNodeCopy = palloc0(sizeof(WorkerNode));
-		memcpy(workerNodeCopy, workerNode, sizeof(WorkerNode));
-		workerNodeList = lappend(workerNodeList, workerNodeCopy);
+		if (workerNode->isActive)
+		{
+			WorkerNode *workerNodeCopy = palloc0(sizeof(WorkerNode));
+			memcpy(workerNodeCopy, workerNode, sizeof(WorkerNode));
+			workerNodeList = lappend(workerNodeList, workerNodeCopy);
+		}
 	}
 
 	return workerNodeList;

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4912,7 +4912,7 @@ GreedyAssignTaskList(List *taskList)
 	uint32 taskCount = list_length(taskList);
 
 	/* get the worker node list and sort the list */
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/*
@@ -5344,7 +5344,7 @@ AssignDualHashTaskList(List *taskList)
 	 * if subsequent jobs have a small number of tasks, we won't allocate the
 	 * tasks to the same worker repeatedly.
 	 */
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	uint32 workerNodeCount = (uint32) list_length(workerNodeList);
 	uint32 beginningNodeIndex = jobId % workerNodeCount;
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2295,7 +2295,7 @@ RouterSelectQuery(Query *originalQuery, RelationRestrictionContext *restrictionC
 	}
 	else if (replacePrunedQueryWithDummy)
 	{
-		List *workerNodeList = WorkerNodeList();
+		List *workerNodeList = ActiveWorkerNodeList();
 		if (workerNodeList != NIL)
 		{
 			WorkerNode *workerNode = (WorkerNode *) linitial(workerNodeList);

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -125,7 +125,7 @@ RecoverPreparedTransactions(void)
 	 */
 	LockRelationOid(DistTransactionRelationId(), ExclusiveLock);
 
-	workerList = WorkerNodeList();
+	workerList = ActiveWorkerNodeList();
 
 	foreach(workerNodeCell, workerList)
 	{

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -78,7 +78,7 @@ SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command)
 void
 SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
 {
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	ListCell *workerNodeCell = NULL;
 	char *nodeUser = CitusExtensionOwnerName();
 	ListCell *commandCell = NULL;
@@ -128,7 +128,7 @@ SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
 {
 	List *connectionList = NIL;
 	ListCell *connectionCell = NULL;
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	ListCell *workerNodeCell = NULL;
 	char *nodeUser = CitusExtensionOwnerName();
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -1909,6 +1909,7 @@ InitializeWorkerNodeCache(void)
 		workerNode->nodeId = currentNode->nodeId;
 		strlcpy(workerNode->workerRack, currentNode->workerRack, WORKER_LENGTH);
 		workerNode->hasMetadata = currentNode->hasMetadata;
+		workerNode->isActive = currentNode->isActive;
 
 		if (handleFound)
 		{

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -36,6 +36,8 @@
 /* local function forward declarations */
 static void ReplicateSingleShardTableToAllWorkers(Oid relationId);
 static void ReplicateShardToAllWorkers(ShardInterval *shardInterval);
+static void ReplicateShardToNode(ShardInterval *shardInterval, char *nodeName,
+								 int nodePort);
 static void ConvertToReferenceTableMetadata(Oid relationId, uint64 shardId);
 static int CompareOids(const void *leftElement, const void *rightElement);
 
@@ -114,22 +116,19 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 
 
 /*
- * ReplicateAllReferenceTablesToAllNodes function finds all reference tables and
- * replicates them to all worker nodes. It also modifies pg_dist_colocation table to
- * update the replication factor column. This function skips a worker node if that node
- * already has healthy placement of a particular reference table to prevent unnecessary
- * data transfer.
+ * ReplicateAllReferenceTablesToNode function finds all reference tables and
+ * replicates them to the given worker node. It also modifies pg_dist_colocation
+ * table to update the replication factor column when necessary. This function
+ * skips reference tables if that node already has healthy placement of that
+ * reference table to prevent unnecessary data transfer.
  */
 void
-ReplicateAllReferenceTablesToAllNodes()
+ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort)
 {
 	List *referenceTableList = ReferenceTableOidList();
 	ListCell *referenceTableCell = NULL;
-
-	Relation pgDistNode = NULL;
-	List *workerNodeList = NIL;
-	int workerCount = 0;
-
+	List *workerNodeList = ActiveWorkerNodeList();
+	uint32 workerCount = 0;
 	Oid firstReferenceTableId = InvalidOid;
 	uint32 referenceTableColocationId = INVALID_COLOCATION_ID;
 
@@ -138,12 +137,6 @@ ReplicateAllReferenceTablesToAllNodes()
 	{
 		return;
 	}
-
-	/* we do not use pgDistNode, we only obtain a lock on it to prevent modifications */
-	pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
-	workerNodeList = WorkerNodeList();
-	workerCount = list_length(workerNodeList);
-
 
 	/*
 	 * We sort the reference table list to prevent deadlocks in concurrent
@@ -156,14 +149,10 @@ ReplicateAllReferenceTablesToAllNodes()
 		List *shardIntervalList = LoadShardIntervalList(referenceTableId);
 		ShardInterval *shardInterval = (ShardInterval *) linitial(shardIntervalList);
 		uint64 shardId = shardInterval->shardId;
-		char *relationName = get_rel_name(referenceTableId);
 
 		LockShardDistributionMetadata(shardId, ExclusiveLock);
 
-		ereport(NOTICE, (errmsg("Replicating reference table \"%s\" to all workers",
-								relationName)));
-
-		ReplicateShardToAllWorkers(shardInterval);
+		ReplicateShardToNode(shardInterval, nodeName, nodePort);
 	}
 
 	/*
@@ -171,10 +160,10 @@ ReplicateAllReferenceTablesToAllNodes()
 	 * colocation group of reference tables so that worker count will be equal to
 	 * replication factor again.
 	 */
+	workerCount = list_length(workerNodeList);
 	firstReferenceTableId = linitial_oid(referenceTableList);
 	referenceTableColocationId = TableColocationId(firstReferenceTableId);
 	UpdateColocationGroupReplicationFactor(referenceTableColocationId, workerCount);
-	heap_close(pgDistNode, NoLock);
 }
 
 
@@ -228,28 +217,18 @@ ReplicateSingleShardTableToAllWorkers(Oid relationId)
 
 
 /*
- * ReplicateShardToAllWorkers function replicates given shard to the given worker nodes
- * in a separate transactions. While replicating, it only replicates the shard to the
- * workers which does not have a healthy replica of the shard. This function also modifies
- * metadata by inserting/updating related rows in pg_dist_shard_placement. However, this
- * function does not obtain any lock on shard resource and shard metadata. It is caller's
+ * ReplicateShardToAllWorkers function replicates given shard to the all worker nodes
+ * in separate transactions. While replicating, it only replicates the shard to the
+ * workers which does not have a healthy replica of the shard. However, this function
+ * does not obtain any lock on shard resource and shard metadata. It is caller's
  * responsibility to take those locks.
  */
 static void
 ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 {
-	uint64 shardId = shardInterval->shardId;
-	List *shardPlacementList = ShardPlacementList(shardId);
-	bool missingOk = false;
-	ShardPlacement *sourceShardPlacement = FinalizedShardPlacement(shardId, missingOk);
-	char *srcNodeName = sourceShardPlacement->nodeName;
-	uint32 srcNodePort = sourceShardPlacement->nodePort;
-	char *tableOwner = TableOwner(shardInterval->relationId);
-	List *ddlCommandList = CopyShardCommandList(shardInterval, srcNodeName, srcNodePort);
-
 	/* we do not use pgDistNode, we only obtain a lock on it to prevent modifications */
 	Relation pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	ListCell *workerNodeCell = NULL;
 
 	/*
@@ -263,56 +242,83 @@ ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
 		char *nodeName = workerNode->workerName;
 		uint32 nodePort = workerNode->workerPort;
-		bool missingWorkerOk = true;
 
-		ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
-																	 nodeName, nodePort,
-																	 missingWorkerOk);
-
-		/*
-		 * Although this function is used for reference tables and reference table shard
-		 * placements always have shardState = FILE_FINALIZED, in case of an upgrade of
-		 * a non-reference table to reference table, unhealty placements may exist. In
-		 * this case, we repair the shard placement and update its state in
-		 * pg_dist_shard_placement table.
-		 */
-		if (targetPlacement == NULL || targetPlacement->shardState != FILE_FINALIZED)
-		{
-			uint64 placementId = 0;
-
-			SendCommandListToWorkerInSingleTransaction(nodeName, nodePort, tableOwner,
-													   ddlCommandList);
-			if (targetPlacement == NULL)
-			{
-				placementId = GetNextPlacementId();
-				InsertShardPlacementRow(shardId, placementId, FILE_FINALIZED, 0,
-										nodeName, nodePort);
-			}
-			else
-			{
-				placementId = targetPlacement->placementId;
-				UpdateShardPlacementState(placementId, FILE_FINALIZED);
-			}
-
-			/*
-			 * Although ReplicateShardToAllWorkers is used only for reference tables,
-			 * during the upgrade phase, the placements are created before the table is
-			 * marked as a reference table. All metadata (including the placement
-			 * metadata) will be copied to workers after all reference table changed
-			 * are finished.
-			 */
-			if (ShouldSyncTableMetadata(shardInterval->relationId))
-			{
-				char *placementCommand = PlacementUpsertCommand(shardId, placementId,
-																FILE_FINALIZED, 0,
-																nodeName, nodePort);
-
-				SendCommandToWorkers(WORKERS_WITH_METADATA, placementCommand);
-			}
-		}
+		ReplicateShardToNode(shardInterval, nodeName, nodePort);
 	}
 
 	heap_close(pgDistNode, NoLock);
+}
+
+
+/*
+ * ReplicateShardToNode function replicates given shard to the given worker node
+ * in a separate transaction. While replicating, it only replicates the shard to the
+ * workers which does not have a healthy replica of the shard. This function also modifies
+ * metadata by inserting/updating related rows in pg_dist_shard_placement.
+ */
+static void
+ReplicateShardToNode(ShardInterval *shardInterval, char *nodeName, int nodePort)
+{
+	uint64 shardId = shardInterval->shardId;
+
+	bool missingOk = false;
+	ShardPlacement *sourceShardPlacement = FinalizedShardPlacement(shardId, missingOk);
+	char *srcNodeName = sourceShardPlacement->nodeName;
+	uint32 srcNodePort = sourceShardPlacement->nodePort;
+	List *ddlCommandList = CopyShardCommandList(shardInterval, srcNodeName, srcNodePort);
+
+	List *shardPlacementList = ShardPlacementList(shardId);
+	bool missingWorkerOk = true;
+	ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
+																 nodeName, nodePort,
+																 missingWorkerOk);
+	char *tableOwner = TableOwner(shardInterval->relationId);
+
+	/*
+	 * Although this function is used for reference tables and reference table shard
+	 * placements always have shardState = FILE_FINALIZED, in case of an upgrade of
+	 * a non-reference table to reference table, unhealty placements may exist. In
+	 * this case, we repair the shard placement and update its state in
+	 * pg_dist_shard_placement table.
+	 */
+	if (targetPlacement == NULL || targetPlacement->shardState != FILE_FINALIZED)
+	{
+		uint64 placementId = 0;
+
+		ereport(NOTICE, (errmsg("Replicating reference table \"%s\" to the node %s:%d",
+								get_rel_name(shardInterval->relationId), nodeName,
+								nodePort)));
+
+		SendCommandListToWorkerInSingleTransaction(nodeName, nodePort, tableOwner,
+												   ddlCommandList);
+		if (targetPlacement == NULL)
+		{
+			placementId = GetNextPlacementId();
+			InsertShardPlacementRow(shardId, placementId, FILE_FINALIZED, 0,
+									nodeName, nodePort);
+		}
+		else
+		{
+			placementId = targetPlacement->placementId;
+			UpdateShardPlacementState(placementId, FILE_FINALIZED);
+		}
+
+		/*
+		 * Although ReplicateShardToAllWorkers is used only for reference tables,
+		 * during the upgrade phase, the placements are created before the table is
+		 * marked as a reference table. All metadata (including the placement
+		 * metadata) will be copied to workers after all reference table changed
+		 * are finished.
+		 */
+		if (ShouldSyncTableMetadata(shardInterval->relationId))
+		{
+			char *placementCommand = PlacementUpsertCommand(shardId, placementId,
+															FILE_FINALIZED, 0,
+															nodeName, nodePort);
+
+			SendCommandToWorkers(WORKERS_WITH_METADATA, placementCommand);
+		}
+	}
 }
 
 
@@ -355,7 +361,7 @@ uint32
 CreateReferenceTableColocationId()
 {
 	uint32 colocationId = INVALID_COLOCATION_ID;
-	List *workerNodeList = WorkerNodeList();
+	List *workerNodeList = ActiveWorkerNodeList();
 	int shardCount = 1;
 	int replicationFactor = list_length(workerNodeList);
 	Oid distributionColumnType = InvalidOid;

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -30,6 +30,7 @@ extern char * NodeListInsertCommand(List *workerNodeList);
 extern List * ShardListInsertCommand(List *shardIntervalList);
 extern List * ShardDeleteCommandList(ShardInterval *shardInterval);
 extern char * NodeDeleteCommand(uint32 nodeId);
+extern char * NodeStateUpdateCommand(uint32 nodeId, bool isActive);
 extern char * ColocationIdUpdateCommand(Oid relationId, uint32 colocationId);
 extern char * CreateSchemaDDLCommand(Oid schemaId);
 extern char * PlacementUpsertCommand(uint64 shardId, uint64 placementId, int shardState,

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -23,6 +23,7 @@ typedef struct FormData_pg_dist_node
 	text nodename;
 	int nodeport;
 	bool hasmetadata;
+	bool isactive
 #endif
 } FormData_pg_dist_node;
 
@@ -37,13 +38,14 @@ typedef FormData_pg_dist_node *Form_pg_dist_node;
  *      compiler constants for pg_dist_node
  * ----------------
  */
-#define Natts_pg_dist_node 6
+#define Natts_pg_dist_node 7
 #define Anum_pg_dist_node_nodeid 1
 #define Anum_pg_dist_node_groupid 2
 #define Anum_pg_dist_node_nodename 3
 #define Anum_pg_dist_node_nodeport 4
 #define Anum_pg_dist_node_noderack 5
 #define Anum_pg_dist_node_hasmetadata 6
+#define Anum_pg_dist_node_isactive 7
 
 #define GROUPID_SEQUENCE_NAME "pg_dist_groupid_seq"
 #define NODEID_SEQUENCE_NAME "pg_dist_node_nodeid_seq"

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -13,7 +13,7 @@
 #define REFERENCE_TABLE_UTILS_H_
 
 extern uint32 CreateReferenceTableColocationId(void);
-extern void ReplicateAllReferenceTablesToAllNodes(void);
+extern void ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort);
 extern void DeleteAllReferenceTablePlacementsFromNode(char *workerName,
 													  uint32 workerPort);
 extern List * ReferenceTableOidList(void);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -30,7 +30,6 @@
 #define WORKER_RACK_TRIES 5
 #define WORKER_DEFAULT_RACK "default"
 
-
 /*
  * In memory representation of pg_dist_node table elements. The elements are hold in
  * WorkerNodeHash table.
@@ -43,6 +42,7 @@ typedef struct WorkerNode
 	uint32 groupId;                     /* node's groupId; same for the nodes that are in the same group */
 	char workerRack[WORKER_LENGTH];     /* node's network location */
 	bool hasMetadata;                   /* node gets metadata changes */
+	bool isActive;                      /* node's state */
 } WorkerNode;
 
 
@@ -59,7 +59,7 @@ extern WorkerNode * WorkerGetRoundRobinCandidateNode(List *workerNodeList,
 extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern WorkerNode * WorkerGetNodeWithName(const char *hostname);
 extern uint32 WorkerGetLiveNodeCount(void);
-extern List * WorkerNodeList(void);
+extern List * ActiveWorkerNodeList(void);
 extern WorkerNode * FindWorkerNode(char *nodeName, int32 nodePort);
 extern List * ReadWorkerNodes(void);
 extern void EnsureCoordinator(void);

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -9,15 +9,15 @@ ERROR:  cannot create reference table "test_reference_table"
 DETAIL:  There are no active worker nodes.
 -- add the nodes to the cluster
 SELECT master_add_node('localhost', :worker_1_port);
-         master_add_node         
----------------------------------
- (1,1,localhost,57637,default,f)
+          master_add_node          
+-----------------------------------
+ (1,1,localhost,57637,default,f,t)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (2,2,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (2,2,localhost,57638,default,f,t)
 (1 row)
 
 -- get the active nodes
@@ -30,9 +30,9 @@ SELECT master_get_active_worker_nodes();
 
 -- try to add a node that is already in the cluster
 SELECT * FROM master_add_node('localhost', :worker_1_port);
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata 
---------+---------+-----------+----------+----------+-------------
-      1 |       1 | localhost |    57637 | default  | f
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
+--------+---------+-----------+----------+----------+-------------+----------
+      1 |       1 | localhost |    57637 | default  | f           | t
 (1 row)
 
 -- get the active nodes
@@ -59,9 +59,9 @@ SELECT master_get_active_worker_nodes();
 
 -- try to disable a node with no placements see that node is removed
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (3,3,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (3,3,localhost,57638,default,f,t)
 (1 row)
 
 SELECT master_disable_node('localhost', :worker_2_port); 
@@ -77,10 +77,10 @@ SELECT master_get_active_worker_nodes();
 (1 row)
 
 -- add some shard placements to the cluster
-SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (4,4,localhost,57638,default,f)
+SELECT master_activate_node('localhost', :worker_2_port);
+       master_activate_node        
+-----------------------------------
+ (3,3,localhost,57638,default,f,t)
 (1 row)
 
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
@@ -125,7 +125,7 @@ INSERT INTO test_reference_table VALUES (1, '1');
 -- try to disable a node with active placements see that node is removed
 -- observe that a notification is displayed
 SELECT master_disable_node('localhost', :worker_2_port); 
-NOTICE:  Node localhost:57638 has active shard placements. Some queries may fail after this operation. Use select master_add_node('localhost', 57638) to add this node back.
+NOTICE:  Node localhost:57638 has active shard placements. Some queries may fail after this operation. Use SELECT master_activate_node('localhost', 57638) to activate this node back.
  master_disable_node 
 ---------------------
  
@@ -139,9 +139,9 @@ SELECT master_get_active_worker_nodes();
 
 -- restore the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (5,5,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (3,3,localhost,57638,default,f,f)
 (1 row)
 
 -- try to remove a node with active placements and see that node removal is failed
@@ -177,9 +177,9 @@ SELECT master_get_active_worker_nodes();
 
 -- clean-up
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (6,6,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (4,4,localhost,57638,default,f,t)
 (1 row)
 
 UPDATE pg_dist_shard_placement SET shardstate=1 WHERE nodeport=:worker_2_port;
@@ -193,9 +193,9 @@ SELECT master_remove_node('localhost', :worker_2_port);
 
 UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (7,7,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (5,5,localhost,57638,default,f,t)
 (1 row)
 
 \c - - - :worker_1_port
@@ -222,9 +222,9 @@ SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodep
 -- check that added nodes are not propagated to nodes with hasmetadata=false
 UPDATE pg_dist_node SET hasmetadata=false WHERE nodeport=:worker_1_port;
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (8,8,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (6,6,localhost,57638,default,f,t)
 (1 row)
 
 \c - - - :worker_1_port
@@ -244,24 +244,24 @@ SELECT
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata 
---------+---------+----------+----------+----------+-------------
+ nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive 
+--------+---------+----------+----------+----------+-------------+----------
 (0 rows)
 
 -- check that adding two nodes in the same transaction works
 SELECT
 	master_add_node('localhost', :worker_1_port),
 	master_add_node('localhost', :worker_2_port);
-         master_add_node         |          master_add_node          
----------------------------------+-----------------------------------
- (9,9,localhost,57637,default,f) | (10,10,localhost,57638,default,f)
+          master_add_node          |          master_add_node          
+-----------------------------------+-----------------------------------
+ (7,7,localhost,57637,default,f,t) | (8,8,localhost,57638,default,f,t)
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata 
---------+---------+-----------+----------+----------+-------------
-      9 |       9 | localhost |    57637 | default  | f
-     10 |      10 | localhost |    57638 | default  | f
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
+--------+---------+-----------+----------+----------+-------------+----------
+      7 |       7 | localhost |    57637 | default  | f           | t
+      8 |       8 | localhost |    57638 | default  | f           | t
 (2 rows)
 
 -- check that mixed add/remove node commands work fine inside transaction
@@ -275,7 +275,7 @@ SELECT master_remove_node('localhost', :worker_2_port);
 SELECT master_add_node('localhost', :worker_2_port);
           master_add_node          
 -----------------------------------
- (11,11,localhost,57638,default,f)
+ (9,9,localhost,57638,default,f,t)
 (1 row)
 
 SELECT master_remove_node('localhost', :worker_2_port);
@@ -293,9 +293,9 @@ SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodep
 UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (12,12,localhost,57638,default,f)
+           master_add_node           
+-------------------------------------
+ (10,10,localhost,57638,default,f,t)
 (1 row)
 
 SELECT master_remove_node('localhost', :worker_2_port);
@@ -305,9 +305,9 @@ SELECT master_remove_node('localhost', :worker_2_port);
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (13,13,localhost,57638,default,f)
+           master_add_node           
+-------------------------------------
+ (11,11,localhost,57638,default,f,t)
 (1 row)
 
 COMMIT;
@@ -333,15 +333,15 @@ SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node;
 (2 rows)
 
 SELECT master_add_node('localhost', :worker_1_port);
-          master_add_node          
------------------------------------
- (14,14,localhost,57637,default,f)
+           master_add_node           
+-------------------------------------
+ (12,12,localhost,57637,default,f,t)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (15,15,localhost,57638,default,f)
+           master_add_node           
+-------------------------------------
+ (13,13,localhost,57638,default,f,t)
 (1 row)
 
 -- check that a distributed table can be created after adding a node in a transaction
@@ -353,9 +353,9 @@ SELECT master_remove_node('localhost', :worker_2_port);
 
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (16,16,localhost,57638,default,f)
+           master_add_node           
+-------------------------------------
+ (14,14,localhost,57638,default,f,t)
 (1 row)
 
 CREATE TABLE temp(col1 text, col2 int);

--- a/src/test/regress/expected/multi_drop_extension.out
+++ b/src/test/regress/expected/multi_drop_extension.out
@@ -21,15 +21,15 @@ RESET client_min_messages;
 CREATE EXTENSION citus;
 -- re-add the nodes to the cluster
 SELECT master_add_node('localhost', :worker_1_port);
-         master_add_node         
----------------------------------
- (1,1,localhost,57637,default,f)
+          master_add_node          
+-----------------------------------
+ (1,1,localhost,57637,default,f,t)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (2,2,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (2,2,localhost,57638,default,f,t)
 (1 row)
 
 -- verify that a table can be created after the extension has been dropped and recreated

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -78,6 +78,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-16';
 ALTER EXTENSION citus UPDATE TO '6.1-17';
 ALTER EXTENSION citus UPDATE TO '6.2-1';
 ALTER EXTENSION citus UPDATE TO '6.2-2';
+ALTER EXTENSION citus UPDATE TO '6.2-3';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -28,11 +28,11 @@ SELECT * FROM pg_dist_partition WHERE partmethod='h' AND repmodel='s';
 -- Show that, with no MX tables, metadata snapshot contains only the delete commands,
 -- pg_dist_node entries and reference tables
 SELECT unnest(master_metadata_snapshot());
-                                                                                         unnest                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    unnest                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRUNCATE pg_dist_node
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata) VALUES (2, 2, 'localhost', 57638, 'default', FALSE),(1, 1, 'localhost', 57637, 'default', FALSE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
 (3 rows)
 
 -- Create a test table with constraints and SERIAL
@@ -58,7 +58,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRUNCATE pg_dist_node
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata) VALUES (2, 2, 'localhost', 57638, 'default', FALSE),(1, 1, 'localhost', 57637, 'default', FALSE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
@@ -80,7 +80,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRUNCATE pg_dist_node
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata) VALUES (2, 2, 'localhost', 57638, 'default', FALSE),(1, 1, 'localhost', 57637, 'default', FALSE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
@@ -104,7 +104,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRUNCATE pg_dist_node
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata) VALUES (2, 2, 'localhost', 57638, 'default', FALSE),(1, 1, 'localhost', 57637, 'default', FALSE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -134,7 +134,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRUNCATE pg_dist_node
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata) VALUES (2, 2, 'localhost', 57638, 'default', FALSE),(1, 1, 'localhost', 57637, 'default', FALSE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -157,7 +157,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  TRUNCATE pg_dist_node
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata) VALUES (2, 2, 'localhost', 57638, 'default', FALSE),(1, 1, 'localhost', 57637, 'default', FALSE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -203,10 +203,10 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata 
---------+---------+-----------+----------+----------+-------------
-      1 |       1 | localhost |    57637 | default  | t
-      2 |       2 | localhost |    57638 | default  | f
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
+--------+---------+-----------+----------+----------+-------------+----------
+      1 |       1 | localhost |    57637 | default  | t           | t
+      2 |       2 | localhost |    57638 | default  | f           | t
 (2 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -333,10 +333,10 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata 
---------+---------+-----------+----------+----------+-------------
-      1 |       1 | localhost |    57637 | default  | t
-      2 |       2 | localhost |    57638 | default  | f
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
+--------+---------+-----------+----------+----------+-------------+----------
+      1 |       1 | localhost |    57637 | default  | t           | t
+      2 |       2 | localhost |    57638 | default  | f           | t
 (2 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -1133,9 +1133,9 @@ SELECT create_distributed_table('mx_table', 'a');
 
 \c - postgres - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (4,4,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (4,4,localhost,57638,default,f,t)
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
@@ -1316,10 +1316,10 @@ WHERE logicalrelid='mx_ref'::regclass;
 
 \c - - - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "mx_ref" to all workers
-         master_add_node         
----------------------------------
- (5,5,localhost,57638,default,f)
+NOTICE:  Replicating reference table "mx_ref" to the node localhost:57638
+          master_add_node          
+-----------------------------------
+ (5,5,localhost,57638,default,f,t)
 (1 row)
 
 SELECT shardid, nodename, nodeport 

--- a/src/test/regress/expected/multi_mx_ddl.out
+++ b/src/test/regress/expected/multi_mx_ddl.out
@@ -205,6 +205,19 @@ SELECT create_distributed_table('mx_sequence', 'key');
 SELECT groupid FROM pg_dist_local_group;
  groupid 
 ---------
+      12
+(1 row)
+
+SELECT * FROM mx_sequence_value_seq;
+     sequence_name     |    last_value    |   start_value    | increment_by |    max_value     |    min_value     | cache_value | log_cnt | is_cycled | is_called 
+-----------------------+------------------+------------------+--------------+------------------+------------------+-------------+---------+-----------+-----------
+ mx_sequence_value_seq | 3377699720527873 | 3377699720527873 |            1 | 3659174697238529 | 3377699720527873 |           1 |       0 | f         | f
+(1 row)
+
+\c - - - :worker_2_port
+SELECT groupid FROM pg_dist_local_group;
+ groupid 
+---------
       14
 (1 row)
 
@@ -212,19 +225,6 @@ SELECT * FROM mx_sequence_value_seq;
      sequence_name     |    last_value    |   start_value    | increment_by |    max_value     |    min_value     | cache_value | log_cnt | is_cycled | is_called 
 -----------------------+------------------+------------------+--------------+------------------+------------------+-------------+---------+-----------+-----------
  mx_sequence_value_seq | 3940649673949185 | 3940649673949185 |            1 | 4222124650659841 | 3940649673949185 |           1 |       0 | f         | f
-(1 row)
-
-\c - - - :worker_2_port
-SELECT groupid FROM pg_dist_local_group;
- groupid 
----------
-      16
-(1 row)
-
-SELECT * FROM mx_sequence_value_seq;
-     sequence_name     |    last_value    |   start_value    | increment_by |    max_value     |    min_value     | cache_value | log_cnt | is_cycled | is_called 
------------------------+------------------+------------------+--------------+------------------+------------------+-------------+---------+-----------+-----------
- mx_sequence_value_seq | 4503599627370497 | 4503599627370497 |            1 | 4785074604081153 | 4503599627370497 |           1 |       0 | f         | f
 (1 row)
 
 \c - - - :master_port

--- a/src/test/regress/expected/multi_mx_metadata.out
+++ b/src/test/regress/expected/multi_mx_metadata.out
@@ -233,8 +233,8 @@ CREATE TABLE should_be_sorted_into_middle (value int);
 PREPARE TRANSACTION 'citus_0_should_be_sorted_into_middle';
 \c - - - :master_port
 -- Add "fake" pg_dist_transaction records and run recovery
-INSERT INTO pg_dist_transaction VALUES (14, 'citus_0_should_commit');
-INSERT INTO pg_dist_transaction VALUES (14, 'citus_0_should_be_forgotten');
+INSERT INTO pg_dist_transaction VALUES (12, 'citus_0_should_commit');
+INSERT INTO pg_dist_transaction VALUES (12, 'citus_0_should_be_forgotten');
 SELECT recover_prepared_transactions();
 NOTICE:  recovered a prepared transaction on localhost:57637
 CONTEXT:  ROLLBACK PREPARED 'citus_0_should_abort'

--- a/src/test/regress/expected/multi_mx_modifications.out
+++ b/src/test/regress/expected/multi_mx_modifications.out
@@ -440,18 +440,18 @@ SELECT * FROM multiple_hash_mx WHERE category = '2' ORDER BY category, data;
 INSERT INTO app_analytics_events_mx VALUES (DEFAULT, 101, 'Fauxkemon Geaux') RETURNING id;
         id        
 ------------------
- 4503599627370497
+ 3940649673949185
 (1 row)
 
 INSERT INTO app_analytics_events_mx (app_id, name) VALUES (102, 'Wayz') RETURNING id;
         id        
 ------------------
- 4503599627370498
+ 3940649673949186
 (1 row)
 
 INSERT INTO app_analytics_events_mx (app_id, name) VALUES (103, 'Mynt') RETURNING *;
         id        | app_id | name 
 ------------------+--------+------
- 4503599627370499 |    103 | Mynt
+ 3940649673949187 |    103 | Mynt
 (1 row)
 

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -43,9 +43,9 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-               master_add_node               
----------------------------------------------
- (1380000,1380000,localhost,57638,default,f)
+                master_add_node                
+-----------------------------------------------
+ (1380000,1380000,localhost,57638,default,f,t)
 (1 row)
 
 -- remove a node with reference table
@@ -164,10 +164,10 @@ SELECT master_remove_node('localhost', :worker_2_port);
 ERROR:  could not find valid entry for node "localhost:57638"
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "remove_node_reference_table" to all workers
-               master_add_node               
----------------------------------------------
- (1380001,1380001,localhost,57638,default,f)
+NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1380001,1380001,localhost,57638,default,f,t)
 (1 row)
 
 -- remove node in a transaction and ROLLBACK
@@ -387,10 +387,10 @@ WHERE
 \c - - - :master_port
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "remove_node_reference_table" to all workers
-               master_add_node               
----------------------------------------------
- (1380002,1380002,localhost,57638,default,f)
+NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1380002,1380002,localhost,57638,default,f,t)
 (1 row)
 
 -- test inserting a value then removing a node in a transaction
@@ -516,10 +516,10 @@ SELECT * FROM remove_node_reference_table;
 \c - - - :master_port
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "remove_node_reference_table" to all workers
-               master_add_node               
----------------------------------------------
- (1380003,1380003,localhost,57638,default,f)
+NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1380003,1380003,localhost,57638,default,f,t)
 (1 row)
 
 -- test executing DDL command then removing a node in a transaction
@@ -641,10 +641,10 @@ Table "public.remove_node_reference_table"
 
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "remove_node_reference_table" to all workers
-               master_add_node               
----------------------------------------------
- (1380004,1380004,localhost,57638,default,f)
+NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1380004,1380004,localhost,57638,default,f,t)
 (1 row)
 
 -- test DROP table after removing a node in a transaction
@@ -710,9 +710,9 @@ SELECT * FROM pg_dist_colocation WHERE colocationid = 1380000;
 
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-               master_add_node               
----------------------------------------------
- (1380005,1380005,localhost,57638,default,f)
+                master_add_node                
+-----------------------------------------------
+ (1380005,1380005,localhost,57638,default,f,t)
 (1 row)
 
 -- re-create remove_node_reference_table
@@ -843,11 +843,11 @@ WHERE
      
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "remove_node_reference_table" to all workers
-NOTICE:  Replicating reference table "table1" to all workers
-               master_add_node               
----------------------------------------------
- (1380006,1380006,localhost,57638,default,f)
+NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
+NOTICE:  Replicating reference table "table1" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1380006,1380006,localhost,57638,default,f,t)
 (1 row)
 
 -- test with master_disable_node
@@ -915,7 +915,7 @@ SELECT master_disable_node('localhost', :worker_2_port);
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
  count 
 -------
-     0
+     1
 (1 row)
 
 SELECT
@@ -936,14 +936,14 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1380001 |          1 |                 1 |                      0
+      1380001 |          1 |                 2 |                      0
 (1 row)
 
 \c - - - :worker_1_port
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
  count 
 -------
-     0
+     1
 (1 row)
 
 SELECT
@@ -959,12 +959,12 @@ WHERE
     
 \c - - - :master_port
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "remove_node_reference_table" to all workers
-NOTICE:  Replicating reference table "table1" to all workers
-               master_add_node               
----------------------------------------------
- (1380007,1380007,localhost,57638,default,f)
+SELECT master_activate_node('localhost', :worker_2_port);
+NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
+NOTICE:  Replicating reference table "table1" to the node localhost:57638
+             master_activate_node              
+-----------------------------------------------
+ (1380006,1380006,localhost,57638,default,f,t)
 (1 row)
 
 -- DROP tables to clean workspace

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -25,9 +25,9 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-               master_add_node               
----------------------------------------------
- (1370000,1370000,localhost,57638,default,f)
+                master_add_node                
+-----------------------------------------------
+ (1370000,1370000,localhost,57638,default,f,t)
 (1 row)
 
 -- verify node is added
@@ -71,7 +71,6 @@ SELECT create_reference_table('replicate_reference_table_unhealthy');
 
 UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1370000;
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_unhealthy" to all workers
 ERROR:  could not find any healthy placement for shard 1370000
 -- verify node is not added
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
@@ -123,10 +122,10 @@ WHERE colocationid IN
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_valid" to all workers
-               master_add_node               
----------------------------------------------
- (1370002,1370002,localhost,57638,default,f)
+NOTICE:  Replicating reference table "replicate_reference_table_valid" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1370002,1370002,localhost,57638,default,f,t)
 (1 row)
 
 -- status after master_add_node
@@ -177,9 +176,9 @@ WHERE colocationid IN
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-               master_add_node               
----------------------------------------------
- (1370002,1370002,localhost,57638,default,f)
+                master_add_node                
+-----------------------------------------------
+ (1370002,1370002,localhost,57638,default,f,t)
 (1 row)
 
 -- status after master_add_node
@@ -244,10 +243,10 @@ WHERE colocationid IN
 
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_rollback" to all workers
-               master_add_node               
----------------------------------------------
- (1370003,1370003,localhost,57638,default,f)
+NOTICE:  Replicating reference table "replicate_reference_table_rollback" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1370003,1370003,localhost,57638,default,f,t)
 (1 row)
 
 ROLLBACK;
@@ -306,10 +305,10 @@ WHERE colocationid IN
 
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_commit" to all workers
-               master_add_node               
----------------------------------------------
- (1370004,1370004,localhost,57638,default,f)
+NOTICE:  Replicating reference table "replicate_reference_table_commit" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1370004,1370004,localhost,57638,default,f,t)
 (1 row)
 
 COMMIT;
@@ -401,13 +400,14 @@ ORDER BY logicalrelid;
 
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_reference_one" to all workers
-               master_add_node               
----------------------------------------------
- (1370005,1370005,localhost,57638,default,f)
+NOTICE:  Replicating reference table "replicate_reference_table_reference_one" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1370005,1370005,localhost,57638,default,f,t)
 (1 row)
 
 SELECT upgrade_to_reference_table('replicate_reference_table_hash');
+NOTICE:  Replicating reference table "replicate_reference_table_hash" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -482,7 +482,7 @@ SELECT create_reference_table('replicate_reference_table_insert');
 BEGIN;
 INSERT INTO replicate_reference_table_insert VALUES(1);
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_insert" to all workers
+NOTICE:  Replicating reference table "replicate_reference_table_insert" to the node localhost:57638
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
 DROP TABLE replicate_reference_table_insert;
@@ -497,7 +497,7 @@ SELECT create_reference_table('replicate_reference_table_copy');
 BEGIN;
 COPY replicate_reference_table_copy FROM STDIN;
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_copy" to all workers
+NOTICE:  Replicating reference table "replicate_reference_table_copy" to the node localhost:57638
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
 DROP TABLE replicate_reference_table_copy;
@@ -514,7 +514,7 @@ ALTER TABLE replicate_reference_table_ddl ADD column2 int;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_ddl" to all workers
+NOTICE:  Replicating reference table "replicate_reference_table_ddl" to the node localhost:57638
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
 DROP TABLE replicate_reference_table_ddl;
@@ -550,10 +550,10 @@ WHERE colocationid IN
 
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_drop" to all workers
-               master_add_node               
----------------------------------------------
- (1370009,1370009,localhost,57638,default,f)
+NOTICE:  Replicating reference table "replicate_reference_table_drop" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1370009,1370009,localhost,57638,default,f,t)
 (1 row)
 
 DROP TABLE replicate_reference_table_drop;
@@ -612,10 +612,10 @@ WHERE colocationid IN
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "table1" to all workers
-               master_add_node               
----------------------------------------------
- (1370010,1370010,localhost,57638,default,f)
+NOTICE:  Replicating reference table "table1" to the node localhost:57638
+                master_add_node                
+-----------------------------------------------
+ (1370010,1370010,localhost,57638,default,f,t)
 (1 row)
 
 -- status after master_add_node
@@ -643,6 +643,79 @@ WHERE colocationid IN
 
 DROP TABLE replicate_reference_table_schema.table1;
 DROP SCHEMA replicate_reference_table_schema CASCADE;
+-- do some tests with inactive node
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+CREATE TABLE initially_not_replicated_reference_table (key int);
+SELECT create_reference_table('initially_not_replicated_reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT master_add_inactive_node('localhost', :worker_2_port);
+           master_add_inactive_node            
+-----------------------------------------------
+ (1370011,1370011,localhost,57638,default,f,f)
+(1 row)
+
+-- we should see only one shard placements
+SELECT
+    shardid, shardstate, shardlength, nodename, nodeport
+FROM
+    pg_dist_shard_placement
+WHERE
+    shardid IN (SELECT 
+                    shardid 
+                FROM 
+                    pg_dist_shard 
+                WHERE 
+                    logicalrelid = 'initially_not_replicated_reference_table'::regclass)
+ORDER BY 1,4,5;
+ shardid | shardstate | shardlength | nodename  | nodeport 
+---------+------------+-------------+-----------+----------
+ 1370012 |          1 |           0 | localhost |    57637
+(1 row)
+
+-- we should see the two shard placements after activation
+SELECT master_activate_node('localhost', :worker_2_port);
+NOTICE:  Replicating reference table "initially_not_replicated_reference_table" to the node localhost:57638
+             master_activate_node              
+-----------------------------------------------
+ (1370011,1370011,localhost,57638,default,f,t)
+(1 row)
+
+SELECT
+    shardid, shardstate, shardlength, nodename, nodeport
+FROM
+    pg_dist_shard_placement
+WHERE
+    shardid IN (SELECT 
+                    shardid 
+                FROM 
+                    pg_dist_shard 
+                WHERE 
+                    logicalrelid = 'initially_not_replicated_reference_table'::regclass)
+ORDER BY 1,4,5;
+ shardid | shardstate | shardlength | nodename  | nodeport 
+---------+------------+-------------+-----------+----------
+ 1370012 |          1 |           0 | localhost |    57637
+ 1370012 |          1 |           0 | localhost |    57638
+(2 rows)
+
+-- this should have no effect
+SELECT master_add_node('localhost', :worker_2_port);
+                master_add_node                
+-----------------------------------------------
+ (1370011,1370011,localhost,57638,default,f,t)
+(1 row)
+
+-- drop unnecassary tables
+DROP TABLE initially_not_replicated_reference_table;
 -- reload pg_dist_shard_placement table
 INSERT INTO pg_dist_shard_placement (SELECT * FROM tmp_shard_placement);
 DROP TABLE tmp_shard_placement;

--- a/src/test/regress/expected/multi_table_ddl.out
+++ b/src/test/regress/expected/multi_table_ddl.out
@@ -78,15 +78,15 @@ DROP EXTENSION citus;
 CREATE EXTENSION citus;
 -- re-add the nodes to the cluster
 SELECT master_add_node('localhost', :worker_1_port);
-         master_add_node         
----------------------------------
- (1,1,localhost,57637,default,f)
+          master_add_node          
+-----------------------------------
+ (1,1,localhost,57637,default,f,t)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-         master_add_node         
----------------------------------
- (2,2,localhost,57638,default,f)
+          master_add_node          
+-----------------------------------
+ (2,2,localhost,57638,default,f,t)
 (1 row)
 
 -- create a table with a SERIAL column

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -224,8 +224,8 @@ SELECT master_add_node('localhost', 5432);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
 SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata 
---------+---------+----------+----------+----------+-------------
+ nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive 
+--------+---------+----------+----------+----------+-------------+----------
 (0 rows)
 
 -- master_remove_node
@@ -234,9 +234,9 @@ DROP INDEX mx_test_uniq_index;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 SELECT master_add_node('localhost', 5432);
-              master_add_node               
---------------------------------------------
- (1370000,1370000,localhost,5432,default,f)
+               master_add_node                
+----------------------------------------------
+ (1370000,1370000,localhost,5432,default,f,t)
 (1 row)
 
 \c - - - :worker_1_port
@@ -244,9 +244,9 @@ SELECT master_remove_node('localhost', 5432);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
 SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
- nodeid  | groupid | nodename  | nodeport | noderack | hasmetadata 
----------+---------+-----------+----------+----------+-------------
- 1370000 | 1370000 | localhost |     5432 | default  | f
+ nodeid  | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
+---------+---------+-----------+----------+----------+-------------+----------
+ 1370000 | 1370000 | localhost |     5432 | default  | f           | t
 (1 row)
 
 \c - - - :master_port

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -95,6 +95,7 @@ SELECT create_distributed_table('upgrade_reference_table_composite', 'column1');
 
 UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='upgrade_reference_table_composite'::regclass;
 SELECT upgrade_to_reference_table('upgrade_reference_table_composite');
+NOTICE:  Replicating reference table "upgrade_reference_table_composite" to the node localhost:57638
 ERROR:  type "public.upgrade_test_composite_type" does not exist
 CONTEXT:  while executing command on localhost:57638
 DROP TABLE upgrade_reference_table_composite;
@@ -165,6 +166,7 @@ WHERE shardid IN
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_append');
+NOTICE:  Replicating reference table "upgrade_reference_table_append" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -277,6 +279,7 @@ WHERE shardid IN
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_one_worker');
+NOTICE:  Replicating reference table "upgrade_reference_table_one_worker" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -621,6 +624,7 @@ WHERE shardid IN
 
 BEGIN;
 SELECT upgrade_to_reference_table('upgrade_reference_table_transaction_rollback');
+NOTICE:  Replicating reference table "upgrade_reference_table_transaction_rollback" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -733,6 +737,7 @@ WHERE shardid IN
 
 BEGIN;
 SELECT upgrade_to_reference_table('upgrade_reference_table_transaction_commit');
+NOTICE:  Replicating reference table "upgrade_reference_table_transaction_commit" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -980,6 +985,7 @@ ORDER BY nodeport;
 
      
 SELECT upgrade_to_reference_table('upgrade_reference_table_mx');
+NOTICE:  Replicating reference table "upgrade_reference_table_mx" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -586,7 +586,7 @@ SELECT shardid, nodename, nodeport
 	WHERE logicalrelid = 'numbers_append'::regclass order by placementid;
 
 -- add the node back
-SELECT master_add_node('localhost', :worker_1_port);
+SELECT master_activate_node('localhost', :worker_1_port);
 RESET citus.shard_replication_factor;
 -- add two new shards and verify they are created at both workers
 COPY numbers_append FROM STDIN WITH (FORMAT 'csv');

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -740,7 +740,7 @@ SELECT shardid, nodename, nodeport
 
 -- disable the first node
 SELECT master_disable_node('localhost', :worker_1_port);
-NOTICE:  Node localhost:57637 has active shard placements. Some queries may fail after this operation. Use select master_add_node('localhost', 57637) to add this node back.
+NOTICE:  Node localhost:57637 has active shard placements. Some queries may fail after this operation. Use SELECT master_activate_node('localhost', 57637) to activate this node back.
  master_disable_node 
 ---------------------
  
@@ -766,12 +766,12 @@ SELECT shardid, nodename, nodeport
 (6 rows)
 
 -- add the node back
-SELECT master_add_node('localhost', :worker_1_port);
-NOTICE:  Replicating reference table "nation" to all workers
-NOTICE:  Replicating reference table "supplier" to all workers
-         master_add_node         
----------------------------------
- (3,3,localhost,57637,default,f)
+SELECT master_activate_node('localhost', :worker_1_port);
+NOTICE:  Replicating reference table "nation" to the node localhost:57637
+NOTICE:  Replicating reference table "supplier" to the node localhost:57637
+       master_activate_node        
+-----------------------------------
+ (1,1,localhost,57637,default,f,t)
 (1 row)
 
 RESET citus.shard_replication_factor;

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -33,7 +33,7 @@ SELECT master_disable_node('localhost', :worker_2_port);
 SELECT master_get_active_worker_nodes();
 
 -- add some shard placements to the cluster
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT master_activate_node('localhost', :worker_2_port);
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
 SELECT master_create_distributed_table('cluster_management_test', 'col_1', 'hash');
 SELECT master_create_worker_shards('cluster_management_test', 16, 1);

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -79,6 +79,7 @@ ALTER EXTENSION citus UPDATE TO '6.1-16';
 ALTER EXTENSION citus UPDATE TO '6.1-17';
 ALTER EXTENSION citus UPDATE TO '6.2-1';
 ALTER EXTENSION citus UPDATE TO '6.2-2';
+ALTER EXTENSION citus UPDATE TO '6.2-3';
 
 -- show running version
 SHOW citus.version;

--- a/src/test/regress/sql/multi_mx_metadata.sql
+++ b/src/test/regress/sql/multi_mx_metadata.sql
@@ -150,8 +150,8 @@ PREPARE TRANSACTION 'citus_0_should_be_sorted_into_middle';
 
 \c - - - :master_port
 -- Add "fake" pg_dist_transaction records and run recovery
-INSERT INTO pg_dist_transaction VALUES (14, 'citus_0_should_commit');
-INSERT INTO pg_dist_transaction VALUES (14, 'citus_0_should_be_forgotten');
+INSERT INTO pg_dist_transaction VALUES (12, 'citus_0_should_commit');
+INSERT INTO pg_dist_transaction VALUES (12, 'citus_0_should_be_forgotten');
 
 SELECT recover_prepared_transactions();
 SELECT count(*) FROM pg_dist_transaction;

--- a/src/test/regress/sql/multi_remove_node_reference_table.sql
+++ b/src/test/regress/sql/multi_remove_node_reference_table.sql
@@ -575,7 +575,7 @@ WHERE
 \c - - - :master_port
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT master_activate_node('localhost', :worker_2_port);
 
 
 -- DROP tables to clean workspace


### PR DESCRIPTION
Fixes #1200 

With this change we add an option to add a node without replicating all reference tables to that node. If a node is added with this option, we mark the node as inactive and no queries will sent to that node.

We also added two new UDFs;
 - master_activate_node(host, port):
    - marks node as active and replicates all reference tables to that node
 - master_add_inactive_node(host, port):
    - only adds node to pg_dist_node