### PR TITLE
Support (CREATE|DROP) INDEX CONCURRENTLY

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -870,13 +870,13 @@ ExecuteModifyTasksWithoutResults(List *taskList)
 
 
 /*
- * ExecuteSequentialTasksWithoutResults basically calls ExecuteModifyTasks in a
- * loop in order to simulate sequential execution of a list of tasks. Useful in
- * cases where issuing commands in parallel before waiting for results could
+ * ExecuteTasksSequentiallyWithoutResults basically calls ExecuteModifyTasks in
+ * a loop in order to simulate sequential execution of a list of tasks. Useful
+ * in cases where issuing commands in parallel before waiting for results could
  * result in deadlocks (such as CREATE INDEX CONCURRENTLY).
  */
-int64
-ExecuteSequentialTasksWithoutResults(List *taskList)
+void
+ExecuteTasksSequentiallyWithoutResults(List *taskList)
 {
 	ListCell *taskCell = NULL;
 
@@ -885,10 +885,8 @@ ExecuteSequentialTasksWithoutResults(List *taskList)
 		Task *task = (Task *) lfirst(taskCell);
 		List *singleTask = list_make1(task);
 
-		ExecuteModifyTasks(singleTask, false, NULL, NULL);
+		ExecuteModifyTasksWithoutResults(singleTask);
 	}
-
-	return 0;
 }
 
 

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -869,6 +869,23 @@ ExecuteModifyTasksWithoutResults(List *taskList)
 }
 
 
+int64
+ExecuteSequentialTasksWithoutResults(List *taskList)
+{
+	ListCell *taskCell = NULL;
+
+	foreach(taskCell, taskList)
+	{
+		Task *task = (Task *) lfirst(taskCell);
+		List *singleTask = list_make1(task);
+
+		ExecuteModifyTasks(singleTask, false, NULL, NULL);
+	}
+
+	return 0;
+}
+
+
 /*
  * ExecuteModifyTasks executes a list of tasks on remote nodes, and
  * optionally retrieves the results and stores them in a tuple store.

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -869,6 +869,12 @@ ExecuteModifyTasksWithoutResults(List *taskList)
 }
 
 
+/*
+ * ExecuteSequentialTasksWithoutResults basically calls ExecuteModifyTasks in a
+ * loop in order to simulate sequential execution of a list of tasks. Useful in
+ * cases where issuing commands in parallel before waiting for results could
+ * result in deadlocks (such as CREATE INDEX CONCURRENTLY).
+ */
 int64
 ExecuteSequentialTasksWithoutResults(List *taskList)
 {

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -2090,8 +2090,8 @@ DDLTaskList(Oid relationId, const char *commandString)
 
 
 /*
- * DDLTaskList builds a list of tasks to execute a DDL command on a
- * given list of shards.
+ * IndexTaskList builds a list of tasks to execute a CREATE INDEX command
+ * against a specified distributed table.
  */
 static List *
 IndexTaskList(Oid relationId, IndexStmt *indexStmt)
@@ -2144,8 +2144,8 @@ IndexTaskList(Oid relationId, IndexStmt *indexStmt)
 
 
 /*
- * DDLTaskList builds a list of tasks to execute a DDL command on a
- * given list of shards.
+ * DropIndexTaskList builds a list of tasks to execute a DROP INDEX command
+ * against a specified distributed table.
  */
 static List *
 DropIndexTaskList(Oid relationId, Oid indexId, DropStmt *dropStmt)
@@ -2174,6 +2174,7 @@ DropIndexTaskList(Oid relationId, Oid indexId, DropStmt *dropStmt)
 
 		AppendShardIdToName(&shardIndexName, shardId);
 
+		/* deparse shard-specific DROP INDEX command */
 		appendStringInfo(&ddlString, "DROP INDEX %s %s %s %s",
 						 (dropStmt->concurrent ? "CONCURRENTLY" : ""),
 						 (dropStmt->missing_ok ? "IF EXISTS" : ""),

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -68,6 +68,13 @@ SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command)
 }
 
 
+/*
+ * SendBareCommandListToWorkers sends a list of commands to a set of target
+ * workers in serial. Commands are committed immediately: new connections are
+ * always used and no transaction block is used (hence "bare"). The connections
+ * are made as the extension owner to ensure write access to the Citus metadata
+ * tables. Primarly useful for INDEX commands using CONCURRENTLY.
+ */
 void
 SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
 {

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -83,13 +83,6 @@ SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
 	char *nodeUser = CitusExtensionOwnerName();
 	ListCell *commandCell = NULL;
 
-	if (XactModificationLevel > XACT_MODIFICATION_NONE)
-	{
-		ereport(ERROR, (errcode(ERRCODE_ACTIVE_SQL_TRANSACTION),
-						errmsg("cannot open new connections after the first modification "
-							   "command within a transaction")));
-	}
-
 	/* run commands serially */
 	foreach(workerNodeCell, workerNodeList)
 	{

--- a/src/backend/distributed/utils/citus_ruleutils.c
+++ b/src/backend/distributed/utils/citus_ruleutils.c
@@ -590,7 +590,12 @@ pg_get_tablecolumnoptionsdef_string(Oid tableRelationId)
 }
 
 
-char *
+/*
+ * deparse_shard_index_statement uses the provided CREATE INDEX node, dist.
+ * relation, and shard identifier to populate a provided buffer with a string
+ * representation of a shard-extended version of that command.
+ */
+void
 deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64 shardid,
 							  StringInfo buffer)
 {
@@ -680,8 +685,6 @@ deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64 shardid,
 																deparseContext, false,
 																false));
 	}
-
-	return buffer->data;
 }
 
 

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -32,6 +32,8 @@ extern char * pg_get_sequencedef_string(Oid sequenceRelid);
 extern Form_pg_sequence pg_get_sequencedef(Oid sequenceRelationId);
 extern char * pg_get_tableschemadef_string(Oid tableRelationId, bool forShardCreation);
 extern char * pg_get_tablecolumnoptionsdef_string(Oid tableRelationId);
+extern char * deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64
+											shardid, StringInfo buffer);
 extern char * pg_get_indexclusterdef_string(Oid indexRelationId);
 extern List * pg_get_table_grants(Oid relationId);
 

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -32,15 +32,15 @@ extern char * pg_get_sequencedef_string(Oid sequenceRelid);
 extern Form_pg_sequence pg_get_sequencedef(Oid sequenceRelationId);
 extern char * pg_get_tableschemadef_string(Oid tableRelationId, bool forShardCreation);
 extern char * pg_get_tablecolumnoptionsdef_string(Oid tableRelationId);
-extern char * deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64
-											shardid, StringInfo buffer);
+extern void deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid,
+										  int64 shardid, StringInfo buffer);
 extern char * pg_get_indexclusterdef_string(Oid indexRelationId);
 extern List * pg_get_table_grants(Oid relationId);
 
 /* Function declarations for version dependent PostgreSQL ruleutils functions */
 extern void pg_get_query_def(Query *query, StringInfo buffer);
-extern void deparse_shard_query(Query *query, Oid distrelid, int64 shardid, StringInfo
-								buffer);
+extern void deparse_shard_query(Query *query, Oid distrelid, int64 shardid,
+								StringInfo buffer);
 extern char * generate_relation_name(Oid relid, List *namespaces);
 extern char * generate_qualified_relation_name(Oid relid);
 

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -41,6 +41,7 @@ extern TupleTableSlot * RouterSelectExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterMultiModifyExecScan(CustomScanState *node);
 
 extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
+extern int64 ExecuteSequentialTasksWithoutResults(List *taskList);
 
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -41,7 +41,7 @@ extern TupleTableSlot * RouterSelectExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterMultiModifyExecScan(CustomScanState *node);
 
 extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
-extern int64 ExecuteSequentialTasksWithoutResults(List *taskList);
+extern void ExecuteTasksSequentiallyWithoutResults(List *taskList);
 
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -23,7 +23,7 @@ extern bool EnableDDLPropagation;
 typedef struct DDLJob
 {
 	Oid targetRelationId;      /* oid of the target distributed relation */
-	bool preventTransaction;
+	bool preventTransaction;   /* prevent use of worker transactions? */
 	const char *commandString; /* initial (coordinator) DDL command string */
 	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -23,6 +23,7 @@ extern bool EnableDDLPropagation;
 typedef struct DDLJob
 {
 	Oid targetRelationId;      /* oid of the target distributed relation */
+	bool preventTransaction;
 	const char *commandString; /* initial (coordinator) DDL command string */
 	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -23,7 +23,7 @@ extern bool EnableDDLPropagation;
 typedef struct DDLJob
 {
 	Oid targetRelationId;      /* oid of the target distributed relation */
-	bool concurrent;           /* related to a CONCURRENTLY index command? */
+	bool concurrentIndexCmd;   /* related to a CONCURRENTLY index command? */
 	const char *commandString; /* initial (coordinator) DDL command string */
 	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -23,7 +23,7 @@ extern bool EnableDDLPropagation;
 typedef struct DDLJob
 {
 	Oid targetRelationId;      /* oid of the target distributed relation */
-	bool preventTransaction;   /* prevent use of worker transactions? */
+	bool concurrent;           /* related to a CONCURRENTLY index command? */
 	const char *commandString; /* initial (coordinator) DDL command string */
 	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -30,6 +30,8 @@ typedef enum TargetWorkerSet
 extern List * GetWorkerTransactions(void);
 extern void SendCommandToWorker(char *nodeName, int32 nodePort, char *command);
 extern void SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command);
+extern void SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet,
+										 List *commandList);
 extern void SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
 									   int parameterCount, const Oid *parameterTypes,
 									   const char *const *parameterValues);

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -245,7 +245,45 @@ SELECT * FROM pg_indexes WHERE tablename LIKE 'index_test_%' ORDER BY indexname;
 ------------+-----------+-----------+------------+----------
 (0 rows)
 
+-- create index that will conflict with master operations
+CREATE INDEX CONCURRENTLY ith_b_idx_102089 ON index_test_hash_102089(b);
 \c - - - :master_port
+-- should fail because worker index already exists
+CREATE INDEX CONCURRENTLY ith_b_idx ON index_test_hash(b);
+ERROR:  relation "ith_b_idx_102089" already exists
+CONTEXT:  while executing command on localhost:57637
+-- the failure results in an INVALID index
+SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
+ Index Valid? 
+--------------
+ f
+(1 row)
+
+-- we can clean it up and recreate with an DROP IF EXISTS
+DROP INDEX CONCURRENTLY IF EXISTS ith_b_idx;
+CREATE INDEX CONCURRENTLY ith_b_idx ON index_test_hash(b);
+SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
+ Index Valid? 
+--------------
+ t
+(1 row)
+
+\c - - - :worker_1_port
+-- now drop shard index to test partial master DROP failure
+DROP INDEX CONCURRENTLY ith_b_idx_102089;
+\c - - - :master_port
+DROP INDEX CONCURRENTLY ith_b_idx;
+ERROR:  index "ith_b_idx_102089" does not exist
+CONTEXT:  while executing command on localhost:57637
+-- the failure results in an INVALID index
+SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
+ Index Valid? 
+--------------
+ f
+(1 row)
+
+-- final clean up
+DROP INDEX CONCURRENTLY IF EXISTS ith_b_idx;
 -- Drop created tables
 DROP TABLE index_test_range;
 DROP TABLE index_test_hash;

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -91,6 +91,8 @@ CREATE INDEX lineitem_orderkey_index on index_test_hash(a);
 ERROR:  relation "lineitem_orderkey_index" already exists
 CREATE INDEX IF NOT EXISTS lineitem_orderkey_index on index_test_hash(a);
 NOTICE:  relation "lineitem_orderkey_index" already exists, skipping
+-- Verify that we can create indexes concurrently
+CREATE INDEX CONCURRENTLY lineitem_concurrently_index ON lineitem (l_orderkey);
 -- Verify that all indexes got created on the master node and one of the workers
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
  schemaname |    tablename     |             indexname              | tablespace |                                                      indexdef                                                       
@@ -102,6 +104,7 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | index_test_range | index_test_range_index_a_b         |            | CREATE UNIQUE INDEX index_test_range_index_a_b ON index_test_range USING btree (a, b)
  public     | index_test_range | index_test_range_index_a_b_partial |            | CREATE UNIQUE INDEX index_test_range_index_a_b_partial ON index_test_range USING btree (a, b) WHERE (c IS NOT NULL)
  public     | lineitem         | lineitem_colref_index              |            | CREATE INDEX lineitem_colref_index ON lineitem USING btree (record_ne(lineitem.*, NULL::record))
+ public     | lineitem         | lineitem_concurrently_index        |            | CREATE INDEX lineitem_concurrently_index ON lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_orderkey_hash_index       |            | CREATE INDEX lineitem_orderkey_hash_index ON lineitem USING hash (l_partkey)
  public     | lineitem         | lineitem_orderkey_index            |            | CREATE INDEX lineitem_orderkey_index ON lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_orderkey_index_new        |            | CREATE INDEX lineitem_orderkey_index_new ON lineitem USING btree (l_orderkey)
@@ -109,13 +112,13 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | lineitem         | lineitem_partkey_desc_index        |            | CREATE INDEX lineitem_partkey_desc_index ON lineitem USING btree (l_partkey DESC)
  public     | lineitem         | lineitem_pkey                      |            | CREATE UNIQUE INDEX lineitem_pkey ON lineitem USING btree (l_orderkey, l_linenumber)
  public     | lineitem         | lineitem_time_index                |            | CREATE INDEX lineitem_time_index ON lineitem USING btree (l_shipdate)
-(14 rows)
+(15 rows)
 
 \c - - - :worker_1_port
 SELECT count(*) FROM pg_indexes WHERE tablename = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1);
  count 
 -------
-     8
+     9
 (1 row)
 
 SELECT count(*) FROM pg_indexes WHERE tablename LIKE 'index_test_hash%';
@@ -138,8 +141,6 @@ SELECT count(*) FROM pg_indexes WHERE tablename LIKE 'index_test_append%';
 
 \c - - - :master_port
 -- Verify that we error out on unsupported statement types
-CREATE INDEX CONCURRENTLY try_index ON lineitem (l_orderkey);
-ERROR:  creating indexes concurrently on distributed tables is currently unsupported
 CREATE UNIQUE INDEX try_index ON lineitem (l_orderkey);
 ERROR:  creating unique indexes on append-partitioned tables is currently unsupported
 CREATE INDEX try_index ON lineitem (l_orderkey) TABLESPACE newtablespace;
@@ -180,6 +181,7 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | index_test_range | index_test_range_index_a_b         |            | CREATE UNIQUE INDEX index_test_range_index_a_b ON index_test_range USING btree (a, b)
  public     | index_test_range | index_test_range_index_a_b_partial |            | CREATE UNIQUE INDEX index_test_range_index_a_b_partial ON index_test_range USING btree (a, b) WHERE (c IS NOT NULL)
  public     | lineitem         | lineitem_colref_index              |            | CREATE INDEX lineitem_colref_index ON lineitem USING btree (record_ne(lineitem.*, NULL::record))
+ public     | lineitem         | lineitem_concurrently_index        |            | CREATE INDEX lineitem_concurrently_index ON lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_orderkey_hash_index       |            | CREATE INDEX lineitem_orderkey_hash_index ON lineitem USING hash (l_partkey)
  public     | lineitem         | lineitem_orderkey_index            |            | CREATE INDEX lineitem_orderkey_index ON lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_orderkey_index_new        |            | CREATE INDEX lineitem_orderkey_index_new ON lineitem USING btree (l_orderkey)
@@ -187,7 +189,7 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | lineitem         | lineitem_partkey_desc_index        |            | CREATE INDEX lineitem_partkey_desc_index ON lineitem USING btree (l_partkey DESC)
  public     | lineitem         | lineitem_pkey                      |            | CREATE UNIQUE INDEX lineitem_pkey ON lineitem USING btree (l_orderkey, l_linenumber)
  public     | lineitem         | lineitem_time_index                |            | CREATE INDEX lineitem_time_index ON lineitem USING btree (l_shipdate)
-(14 rows)
+(15 rows)
 
 --
 -- DROP INDEX
@@ -196,9 +198,6 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 DROP INDEX lineitem_orderkey_index, lineitem_partial_index;
 ERROR:  cannot drop multiple distributed objects in a single command
 HINT:  Try dropping each object in a separate DROP command.
--- Verify that we error out on the CONCURRENTLY clause
-DROP INDEX CONCURRENTLY lineitem_orderkey_index;
-ERROR:  dropping indexes concurrently on distributed tables is currently unsupported
 -- Verify that we can succesfully drop indexes
 DROP INDEX lineitem_orderkey_index;
 NOTICE:  using one-phase commit for distributed DDL commands
@@ -221,6 +220,8 @@ DROP INDEX index_test_range_index_a_b_partial;
 DROP INDEX index_test_hash_index_a;
 DROP INDEX index_test_hash_index_a_b;
 DROP INDEX index_test_hash_index_a_b_partial;
+-- Verify that we can drop indexes concurrently
+DROP INDEX CONCURRENTLY lineitem_concurrently_index;
 -- Verify that all the indexes are dropped from the master and one worker node.
 -- As there's a primary key, so exclude those from this check.
 SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%';

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -252,7 +252,7 @@ CREATE INDEX CONCURRENTLY ith_b_idx_102089 ON index_test_hash_102089(b);
 CREATE INDEX CONCURRENTLY ith_b_idx ON index_test_hash(b);
 ERROR:  CONCURRENTLY-enabled index command failed
 DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX IF EXISTS to remove the invalid index, then retry the original command.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid? 
@@ -276,7 +276,7 @@ DROP INDEX CONCURRENTLY ith_b_idx_102089;
 DROP INDEX CONCURRENTLY ith_b_idx;
 ERROR:  CONCURRENTLY-enabled index command failed
 DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX IF EXISTS to remove the invalid index, then retry the original command.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid? 

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -250,8 +250,9 @@ CREATE INDEX CONCURRENTLY ith_b_idx_102089 ON index_test_hash_102089(b);
 \c - - - :master_port
 -- should fail because worker index already exists
 CREATE INDEX CONCURRENTLY ith_b_idx ON index_test_hash(b);
-ERROR:  relation "ith_b_idx_102089" already exists
-CONTEXT:  while executing command on localhost:57637
+ERROR:  CONCURRENTLY-enabled index command failed
+DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX IF EXISTS to remove the invalid index, then retry the original command.
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid? 
@@ -273,8 +274,9 @@ SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::
 DROP INDEX CONCURRENTLY ith_b_idx_102089;
 \c - - - :master_port
 DROP INDEX CONCURRENTLY ith_b_idx;
-ERROR:  index "ith_b_idx_102089" does not exist
-CONTEXT:  while executing command on localhost:57637
+ERROR:  CONCURRENTLY-enabled index command failed
+DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX IF EXISTS to remove the invalid index, then retry the original command.
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid? 

--- a/src/test/regress/expected/multi_mx_ddl.out
+++ b/src/test/regress/expected/multi_mx_ddl.out
@@ -18,6 +18,7 @@ SELECT * FROM mx_ddl_table ORDER BY key;
 CREATE INDEX ddl_test_index ON mx_ddl_table(value);
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+CREATE INDEX CONCURRENTLY ddl_test_concurrent_index ON mx_ddl_table(value);
 -- ADD COLUMN
 ALTER TABLE mx_ddl_table ADD COLUMN version INTEGER;
 -- SET DEFAULT
@@ -40,6 +41,7 @@ ALTER TABLE mx_ddl_table ALTER COLUMN version SET NOT NULL;
  version | integer | not null default 1
 Indexes:
     "mx_ddl_table_pkey" PRIMARY KEY, btree (key)
+    "ddl_test_concurrent_index" btree (value)
     "ddl_test_index" btree (value)
 
 \c - - - :worker_1_port
@@ -52,9 +54,21 @@ Indexes:
  version | integer | not null default 1
 Indexes:
     "mx_ddl_table_pkey" PRIMARY KEY, btree (key)
+    "ddl_test_concurrent_index" btree (value)
     "ddl_test_index" btree (value)
 
-\d mx_ddl_table_1600000
+\d mx_ddl_table_1220088
+  Table "public.mx_ddl_table_1220088"
+ Column  |  Type   |     Modifiers      
+---------+---------+--------------------
+ key     | integer | not null
+ value   | integer | 
+ version | integer | not null default 1
+Indexes:
+    "mx_ddl_table_pkey_1220088" PRIMARY KEY, btree (key)
+    "ddl_test_concurrent_index_1220088" btree (value)
+    "ddl_test_index_1220088" btree (value)
+
 \c - - - :worker_2_port
 \d mx_ddl_table
       Table "public.mx_ddl_table"
@@ -65,9 +79,21 @@ Indexes:
  version | integer | not null default 1
 Indexes:
     "mx_ddl_table_pkey" PRIMARY KEY, btree (key)
+    "ddl_test_concurrent_index" btree (value)
     "ddl_test_index" btree (value)
 
-\d mx_ddl_table_1600001
+\d mx_ddl_table_1220089
+  Table "public.mx_ddl_table_1220089"
+ Column  |  Type   |     Modifiers      
+---------+---------+--------------------
+ key     | integer | not null
+ value   | integer | 
+ version | integer | not null default 1
+Indexes:
+    "mx_ddl_table_pkey_1220089" PRIMARY KEY, btree (key)
+    "ddl_test_concurrent_index_1220089" btree (value)
+    "ddl_test_index_1220089" btree (value)
+
 INSERT INTO mx_ddl_table VALUES (37, 78, 2);
 INSERT INTO mx_ddl_table VALUES (38, 78);
 -- Switch to the coordinator
@@ -100,6 +126,7 @@ SELECT * FROM mx_ddl_table ORDER BY key;
 DROP INDEX ddl_test_index;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+DROP INDEX CONCURRENTLY ddl_test_concurrent_index;
 -- DROP DEFAULT
 ALTER TABLE mx_ddl_table ALTER COLUMN version DROP DEFAULT;
 -- DROP NOT NULL
@@ -126,7 +153,15 @@ Indexes:
 Indexes:
     "mx_ddl_table_pkey" PRIMARY KEY, btree (key)
 
-\d mx_ddl_table_1600000
+\d mx_ddl_table_1220088
+Table "public.mx_ddl_table_1220088"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ key    | integer | not null
+ value  | integer | 
+Indexes:
+    "mx_ddl_table_pkey_1220088" PRIMARY KEY, btree (key)
+
 \c - - - :worker_2_port
 \d mx_ddl_table
  Table "public.mx_ddl_table"
@@ -137,7 +172,15 @@ Indexes:
 Indexes:
     "mx_ddl_table_pkey" PRIMARY KEY, btree (key)
 
-\d mx_ddl_table_1600001
+\d mx_ddl_table_1220089
+Table "public.mx_ddl_table_1220089"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ key    | integer | not null
+ value  | integer | 
+Indexes:
+    "mx_ddl_table_pkey_1220089" PRIMARY KEY, btree (key)
+
 -- Show that DDL commands are done within a two-phase commit transaction
 \c - - - :master_port
 SET client_min_messages TO debug2;

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -64,6 +64,9 @@ CREATE INDEX IF NOT EXISTS lineitem_orderkey_index_new on lineitem(l_orderkey);
 CREATE INDEX lineitem_orderkey_index on index_test_hash(a);
 CREATE INDEX IF NOT EXISTS lineitem_orderkey_index on index_test_hash(a);
 
+-- Verify that we can create indexes concurrently
+CREATE INDEX CONCURRENTLY lineitem_concurrently_index ON lineitem (l_orderkey);
+
 -- Verify that all indexes got created on the master node and one of the workers
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
 \c - - - :worker_1_port
@@ -75,7 +78,6 @@ SELECT count(*) FROM pg_indexes WHERE tablename LIKE 'index_test_append%';
 
 -- Verify that we error out on unsupported statement types
 
-CREATE INDEX CONCURRENTLY try_index ON lineitem (l_orderkey);
 CREATE UNIQUE INDEX try_index ON lineitem (l_orderkey);
 CREATE INDEX try_index ON lineitem (l_orderkey) TABLESPACE newtablespace;
 
@@ -105,9 +107,6 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 -- Verify that we can't drop multiple indexes in a single command
 DROP INDEX lineitem_orderkey_index, lineitem_partial_index;
 
--- Verify that we error out on the CONCURRENTLY clause
-DROP INDEX CONCURRENTLY lineitem_orderkey_index;
-
 -- Verify that we can succesfully drop indexes
 DROP INDEX lineitem_orderkey_index;
 DROP INDEX lineitem_orderkey_index_new;
@@ -129,6 +128,9 @@ DROP INDEX index_test_range_index_a_b_partial;
 DROP INDEX index_test_hash_index_a;
 DROP INDEX index_test_hash_index_a_b;
 DROP INDEX index_test_hash_index_a_b_partial;
+
+-- Verify that we can drop indexes concurrently
+DROP INDEX CONCURRENTLY lineitem_concurrently_index;
 
 -- Verify that all the indexes are dropped from the master and one worker node.
 -- As there's a primary key, so exclude those from this check.

--- a/src/test/regress/sql/multi_mx_ddl.sql
+++ b/src/test/regress/sql/multi_mx_ddl.sql
@@ -8,6 +8,8 @@ SELECT * FROM mx_ddl_table ORDER BY key;
 -- CREATE INDEX
 CREATE INDEX ddl_test_index ON mx_ddl_table(value);
 
+CREATE INDEX CONCURRENTLY ddl_test_concurrent_index ON mx_ddl_table(value);
+
 -- ADD COLUMN
 ALTER TABLE mx_ddl_table ADD COLUMN version INTEGER;
 
@@ -27,13 +29,13 @@ ALTER TABLE mx_ddl_table ALTER COLUMN version SET NOT NULL;
 
 \d mx_ddl_table
 
-\d mx_ddl_table_1600000
+\d mx_ddl_table_1220088
 
 \c - - - :worker_2_port
 
 \d mx_ddl_table
 
-\d mx_ddl_table_1600001
+\d mx_ddl_table_1220089
 
 INSERT INTO mx_ddl_table VALUES (37, 78, 2);
 INSERT INTO mx_ddl_table VALUES (38, 78);
@@ -56,6 +58,8 @@ SELECT * FROM mx_ddl_table ORDER BY key;
 -- DROP INDEX
 DROP INDEX ddl_test_index;
 
+DROP INDEX CONCURRENTLY ddl_test_concurrent_index;
+
 -- DROP DEFAULT
 ALTER TABLE mx_ddl_table ALTER COLUMN version DROP DEFAULT;
 
@@ -73,13 +77,13 @@ ALTER TABLE mx_ddl_table DROP COLUMN version;
 
 \d mx_ddl_table
 
-\d mx_ddl_table_1600000
+\d mx_ddl_table_1220088
 
 \c - - - :worker_2_port
 
 \d mx_ddl_table
 
-\d mx_ddl_table_1600001
+\d mx_ddl_table_1220089
 
 -- Show that DDL commands are done within a two-phase commit transaction
 \c - - - :master_port


### PR DESCRIPTION
Fixes: #1007

The changes here are as follow:

  * Modify `IndexStmt` and `DropStmt` to be deparsed on the master rather than a worker. Calling `worker_apply_shard_ddl_command` is not possible as it triggers a transaction and `CONCURRENTLY` statements must run outside a transaction
  * Remove checks preventing execution of `CONCURRENTLY` statement
  * Add flag to `DDLJob` to denote when transactions are prohibited
  * Add mode to force `Task`s to run serially rather than in parallel. `CREATE INDEX CONCURRENTLY` statements conflict with one another, _even on different tables_
  * Fix existing tests

# TODO

  - [x] Documentation pass
  - [x] Add back my failure testing
  - [x] Add slightly nicer error messaging
  - [x] (Possibly) mark index as invalid if any remote commands fail
  - [x] ~~Remove `IndextStmt` and `DropStmt` support from `RelayEventExtend`, etc.~~
  - [x] MX fix