### PR TITLE
Subquery pushdown planner uses original query

### DIFF
--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -295,7 +295,7 @@ CreateDistributedPlan(PlannedStmt *localPlan, Query *originalQuery, Query *query
 		if ((!distributedPlan || distributedPlan->planningError) && !hasUnresolvedParams)
 		{
 			/* Create and optimize logical plan */
-			MultiTreeRoot *logicalPlan = MultiLogicalPlanCreate(query);
+			MultiTreeRoot *logicalPlan = MultiLogicalPlanCreate(originalQuery, query);
 			MultiLogicalPlanOptimize(logicalPlan, plannerRestrictionContext);
 
 			/*

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -180,7 +180,7 @@ extern bool SubqueryPushdown;
 
 
 /* Function declarations for building logical plans */
-extern MultiTreeRoot * MultiLogicalPlanCreate(Query *queryTree);
+extern MultiTreeRoot * MultiLogicalPlanCreate(Query *originalQuery, Query *queryTree);
 extern bool NeedsDistributedPlanning(Query *queryTree);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);

--- a/src/test/regress/output/multi_subquery.source
+++ b/src/test/regress/output/multi_subquery.source
@@ -178,7 +178,8 @@ SELECT count(*) FROM
    (SELECT l_orderkey FROM lineitem_subquery) UNION ALL
    (SELECT 1::bigint)
 ) b;
-ERROR:  could not run distributed query with complex table expressions
+ERROR:  cannot push down this subquery
+DETAIL:  Union All clauses are currently unsupported
 ---
 -- TEMPORARLY DISABLE UNIONS WITHOUT JOINS
 ---

--- a/src/test/regress/output/multi_subquery_0.source
+++ b/src/test/regress/output/multi_subquery_0.source
@@ -178,7 +178,8 @@ SELECT count(*) FROM
    (SELECT l_orderkey FROM lineitem_subquery) UNION ALL
    (SELECT 1::bigint)
 ) b;
-ERROR:  could not run distributed query with complex table expressions
+ERROR:  cannot push down this subquery
+DETAIL:  Union All clauses are currently unsupported
 ---
 -- TEMPORARLY DISABLE UNIONS WITHOUT JOINS
 ---


### PR DESCRIPTION
With this commit, we change the input to the logical planner for
subquery pushdown. Before this commit, the planner was relying
on the query tree that is transformed by the postgresql planner.
After this commit, the planner uses the original query. The main
motivation behind this change is the simplify deparsing of
subqueries.

