### PR TITLE
Subquery pushdown - Unions Phase - 2

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -150,7 +150,8 @@ static bool GroupedByColumn(List *groupClauseList, List *targetList, Var *column
 /* Local functions forward declarations for subquery pushdown checks */
 static void ErrorIfContainsUnsupportedSubquery(MultiNode *logicalPlanNode,
 											   PlannerRestrictionContext *
-											   plannerRestrictionContext);
+											   plannerRestrictionContext,
+											   Query *originalQuery);
 static void ErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerQueryHasLimit);
 static void ErrorIfUnsupportedSetOperation(Query *subqueryTree, bool outerQueryHasLimit);
 static bool ExtractSetOperationStatmentWalker(Node *node, List **setOperationList);
@@ -191,14 +192,15 @@ static bool HasOrderByHllType(List *sortClauseList, List *targetList);
  * function finds the extended operator node, and splits this node into master
  * and worker extended operator nodes.
  *
- * We also pass plannerRestrictionContext to the optimizer. The context
- * is primarily used to decide whether the subquery is safe to pushdown.
+ * We also pass plannerRestrictionContext and originalQuery to the optimizer.
+ * These are primarily used to decide whether the subquery is safe to pushdown.
  * If not, it helps to produce meaningful error messages for subquery
  * pushdown planning.
  */
 void
 MultiLogicalPlanOptimize(MultiTreeRoot *multiLogicalPlan,
-						 PlannerRestrictionContext *plannerRestrictionContext)
+						 PlannerRestrictionContext *plannerRestrictionContext,
+						 Query *originalQuery)
 {
 	bool hasOrderByHllType = false;
 	List *selectNodeList = NIL;
@@ -218,7 +220,8 @@ MultiLogicalPlanOptimize(MultiTreeRoot *multiLogicalPlan,
 	ErrorIfContainsUnsupportedAggregate(logicalPlanNode);
 
 	/* check that we can pushdown subquery in the plan */
-	ErrorIfContainsUnsupportedSubquery(logicalPlanNode, plannerRestrictionContext);
+	ErrorIfContainsUnsupportedSubquery(logicalPlanNode, plannerRestrictionContext,
+									   originalQuery);
 
 	/*
 	 * If a select node exists, we use the idempower property to split the node
@@ -2807,20 +2810,22 @@ GroupedByColumn(List *groupClauseList, List *targetList, Var *column)
 
 /*
  * ErrorIfContainsUnsupportedSubquery extracts subquery multi table from the
- * logical plan and uses helper functions to check if we can push down subquery
- * to worker nodes. These helper functions error out if we cannot push down the
- * the subquery.
+ * logical plan using plannerRestrictionContext and the original query. It uses
+ * some helper functions to check if we can push down subquery to worker nodes.
+ * These helper functions error out if we cannot push down the subquery.
  */
 static void
 ErrorIfContainsUnsupportedSubquery(MultiNode *logicalPlanNode,
-								   PlannerRestrictionContext *plannerRestrictionContext)
+								   PlannerRestrictionContext *plannerRestrictionContext,
+								   Query *originalQuery)
 {
 	Query *subquery = NULL;
 	List *extendedOpNodeList = NIL;
 	MultiTable *multiTable = NULL;
 	MultiExtendedOp *extendedOpNode = NULL;
 	bool outerQueryHasLimit = false;
-	bool restrictionEquivalenceForPartitionKeys = false;
+	RelationRestrictionContext *relationRestrictionContext =
+		plannerRestrictionContext->relationRestrictionContext;
 
 	/* check if logical plan includes a subquery */
 	List *subqueryMultiTableList = SubqueryMultiTableList(logicalPlanNode);
@@ -2832,9 +2837,26 @@ ErrorIfContainsUnsupportedSubquery(MultiNode *logicalPlanNode,
 	/* currently in the planner we only allow one subquery in from-clause*/
 	Assert(list_length(subqueryMultiTableList) == 1);
 
-	restrictionEquivalenceForPartitionKeys =
-		RestrictionEquivalenceForPartitionKeys(plannerRestrictionContext);
-	if (!restrictionEquivalenceForPartitionKeys)
+	/*
+	 * We're checking two things here:
+	 *    (i)   If the query contains a top level union, ensure that all leaves
+	 *          return the partition key at the same position
+	 *    (ii)  Else, check whether all relations joined on the partition key or not
+	 */
+	if (ContainsUnionSubquery(originalQuery))
+	{
+		if (!SafeToPushdownUnionSubquery(relationRestrictionContext))
+		{
+			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("cannot pushdown the subquery since all leaves of "
+								   "the UNION does not include partition key at the "
+								   "same position"),
+							errdetail("Each leaf query of the UNION should return "
+									  "partition key at the same position on its "
+									  "target list.")));
+		}
+	}
+	else if (!RestrictionEquivalenceForPartitionKeys(plannerRestrictionContext))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot pushdown the subquery since all relations are not "

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2008,14 +2008,6 @@ SubquerySqlTaskList(Job *job, PlannerRestrictionContext *plannerRestrictionConte
 	DistTableCacheEntry *targetCacheEntry = NULL;
 	RelationRestrictionContext *relationRestrictionContext =
 		plannerRestrictionContext->relationRestrictionContext;
-	bool restrictionEquivalenceForPartitionKeys PG_USED_FOR_ASSERTS_ONLY =
-		RestrictionEquivalenceForPartitionKeys(plannerRestrictionContext);
-
-	/*
-	 * If we're going to create tasks for subquery pushdown, all
-	 * relations needs to be joined on the partition key.
-	 */
-	Assert(restrictionEquivalenceForPartitionKeys);
 
 	/* get list of all range tables in subquery tree */
 	ExtractRangeTableRelationWalker((Node *) subquery, &rangeTableList);
@@ -2052,6 +2044,7 @@ SubquerySqlTaskList(Job *job, PlannerRestrictionContext *plannerRestrictionConte
 
 		subqueryTask = SubqueryTaskCreate(subquery, targetShardInterval,
 										  relationRestrictionContext, taskIdIndex);
+
 
 		/* add the task if it could be created */
 		if (subqueryTask != NULL)

--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -296,7 +296,8 @@ CreateDistributedPlan(PlannedStmt *localPlan, Query *originalQuery, Query *query
 		{
 			/* Create and optimize logical plan */
 			MultiTreeRoot *logicalPlan = MultiLogicalPlanCreate(originalQuery, query);
-			MultiLogicalPlanOptimize(logicalPlan, plannerRestrictionContext);
+			MultiLogicalPlanOptimize(logicalPlan, plannerRestrictionContext,
+									 originalQuery);
 
 			/*
 			 * This check is here to make it likely that all node types used in
@@ -751,11 +752,10 @@ CopyPlanParamList(List *originalPlanParamList)
 
 
 /*
- * CreateAndPushPlannerRestrictionContext creates a new planner restriction context.
- * Later, it creates a relation restriction context and a join restriction
- * context, and sets those contexts in the planner restriction context. Finally,
- * the planner restriction context is inserted to the beginning of the
- * plannerRestrictionContextList and it is returned.
+ * CreateAndPushPlannerRestrictionContext creates a new relation restriction context
+ * and a new join context, inserts it to the beginning of the
+ * plannerRestrictionContextList. Finally, the planner restriction context is
+ * inserted to the beginning of the plannerRestrictionContextList and it is returned.
  */
 static PlannerRestrictionContext *
 CreateAndPushPlannerRestrictionContext(void)

--- a/src/include/distributed/multi_logical_optimizer.h
+++ b/src/include/distributed/multi_logical_optimizer.h
@@ -108,7 +108,8 @@ extern double CountDistinctErrorRate;
 
 /* Function declaration for optimizing logical plans */
 extern void MultiLogicalPlanOptimize(MultiTreeRoot *multiTree,
-									 PlannerRestrictionContext *plannerRestrictionContext);
+									 PlannerRestrictionContext *plannerRestrictionContext,
+									 Query *originalQuery);
 
 /* Function declaration for getting partition method for the given relation */
 extern char PartitionMethod(Oid relationId);

--- a/src/include/distributed/relation_restriction_equivalence.h
+++ b/src/include/distributed/relation_restriction_equivalence.h
@@ -15,8 +15,10 @@
 #include "distributed/multi_planner.h"
 
 
+extern bool ContainsUnionSubquery(Query *queryTree);
 extern bool RestrictionEquivalenceForPartitionKeys(PlannerRestrictionContext *
 												   plannerRestrictionContext);
+extern bool SafeToPushdownUnionSubquery(RelationRestrictionContext *restrictionContext);
 
 
 #endif /* RELATION_RESTRICTION_EQUIVALENCE_H */

--- a/src/test/regress/expected/multi_subquery_union.out
+++ b/src/test/regress/expected/multi_subquery_union.out
@@ -1,0 +1,777 @@
+--
+-- multi subquery toplevel union queries aims to expand existing subquery pushdown
+-- regression tests to cover more cases
+-- the tables that are used depends to multi_insert_select_behavioral_analytics_create_table.sql
+-- We don't need shard id sequence here, so commented out to prevent conflicts with concurrent tests
+-- ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1400000;
+SET citus.subquery_pushdown TO true;
+SET citus.enable_router_execution TO false;
+-- a very simple union query
+SELECT user_id, counter
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION 
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+ORDER BY 2 DESC,1
+LIMIT 5;
+ user_id | counter 
+---------+---------
+       7 |       9
+       8 |       9
+      15 |       9
+      16 |       9
+      20 |       9
+(5 rows)
+
+-- the same query with union all
+SELECT user_id, counter
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION ALL
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+ORDER BY 2 DESC,1
+LIMIT 5;
+ user_id | counter 
+---------+---------
+       7 |       9
+       7 |       9
+       8 |       9
+      15 |       9
+      15 |       9
+(5 rows)
+
+-- the same query with group by
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION 
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+GROUP BY 1
+ORDER BY 2 DESC,1
+LIMIT 5;
+ user_id | sum 
+---------+-----
+      49 |  22
+      15 |  19
+      26 |  17
+      48 |  17
+      61 |  17
+(5 rows)
+
+-- the same query with UNION ALL clause
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION ALL
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+GROUP BY 1
+ORDER BY 2 DESC,1
+LIMIT 5;
+ user_id | sum 
+---------+-----
+      48 |  35
+      61 |  30
+      15 |  28
+      49 |  25
+      80 |  24
+(5 rows)
+
+-- the same query target list entries shuffled
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT value_2 % 10 AS counter, user_id FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION 
+    SELECT value_2 % 10 AS counter, user_id FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+GROUP BY 1
+ORDER BY 2 DESC,1
+LIMIT 5;
+ user_id | sum 
+---------+-----
+      49 |  22
+      15 |  19
+      26 |  17
+      48 |  17
+      61 |  17
+(5 rows)
+
+-- same query with GROUP BY
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, value_2 AS counter FROM events_table WHERE event_type IN (1, 2) 
+      UNION 
+    SELECT user_id, value_2 AS counter FROM events_table WHERE event_type IN (5, 6) 
+) user_id 
+GROUP BY 
+  user_id 
+--HAVING sum(counter) > 900 
+ORDER BY 1,2 DESC LIMIT 5;
+ user_id | sum  
+---------+------
+       1 |  518
+       2 |  637
+       4 |  343
+       6 |  354
+       7 | 1374
+(5 rows)
+
+-- the same query target list entries shuffled but this time the subqueries target list
+-- is shuffled
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT value_2 AS counter, user_id FROM events_table WHERE event_type IN (1, 2) 
+      UNION 
+    SELECT value_2 AS counter, user_id FROM events_table WHERE event_type IN (5, 6) 
+) user_id 
+GROUP BY 
+  user_id 
+--HAVING sum(counter) > 900 
+ORDER BY 1,2 DESC LIMIT 5;
+ user_id | sum  
+---------+------
+       1 |  518
+       2 |  637
+       4 |  343
+       6 |  354
+       7 | 1374
+(5 rows)
+
+-- similar query this time more subqueries and target list contains a resjunk entry
+SELECT sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 20 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION 
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 40 and value_1 < 60 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 60 and value_1 < 80 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 80 and value_1 < 100 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 100 and value_1 < 120 GROUP BY user_id HAVING sum(value_2) > 500
+) user_id 
+GROUP BY user_id ORDER BY 1 DESC LIMIT 5;
+  sum  
+-------
+ 27772
+ 25720
+ 24993
+ 24968
+ 23508
+(5 rows)
+
+-- similar query as above, with UNION ALL
+SELECT sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 20 GROUP BY user_id HAVING sum(value_2) > 5000
+      UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 40 and value_1 < 60 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 60 and value_1 < 80 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 80 and value_1 < 100 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 100 and value_1 < 120 GROUP BY user_id HAVING sum(value_2) > 500
+) user_id 
+GROUP BY user_id ORDER BY 1 DESC LIMIT 5;
+  sum  
+-------
+ 27667
+ 25080
+ 24814
+ 24365
+ 23508
+(5 rows)
+
+-- unions within unions
+SELECT *
+FROM (
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT user_id,
+                    sum(value_2) AS counter
+            FROM users_table
+            GROUP BY user_id
+              
+          UNION 
+            SELECT user_id,
+                         sum(value_2) AS counter
+            FROM events_table
+            GROUP BY user_id ) user_id_1
+         GROUP BY user_id)
+      UNION
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT 
+                    user_id, sum(value_2) AS counter
+            FROM users_table
+            GROUP BY user_id
+            
+          UNION 
+            SELECT user_id,  sum(value_2) AS counter
+                        
+            FROM events_table
+            GROUP BY user_id) user_id_2
+         GROUP BY user_id)) AS ftop 
+ORDER BY 2 DESC, 1 DESC 
+LIMIT 5;
+ user_id |  sum   
+---------+--------
+      23 | 126017
+      45 | 117323
+      25 | 116595
+      17 | 116520
+      90 | 115843
+(5 rows)
+
+-- top level unions are wrapped into top level aggregations
+SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
+FROM
+  ( SELECT *, random()
+   FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15) ) events_subquery_1) 
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) ) events_subquery_2)
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) ) events_subquery_3)
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13)) events_subquery_4)) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+) as final_query
+GROUP BY types
+ORDER BY types;
+ types | sumofeventtype 
+-------+----------------
+     0 |             55
+     1 |             38
+     2 |             70
+     3 |             58
+(4 rows)
+
+-- exactly the same query
+-- but wrapper unions are removed from the inner part of the query
+SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
+FROM
+  ( SELECT *, random()
+   FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+               (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15))
+               UNION 
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION 
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION 
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+) as final_query
+GROUP BY types
+ORDER BY types;
+ types | sumofeventtype 
+-------+----------------
+     0 |             55
+     1 |             38
+     2 |             70
+     3 |             58
+(4 rows)
+
+-- again excatly the same query with top level wrapper removed
+SELECT ("q"."event_types") as types, count(*) AS sumOfEventType
+FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15) 
+                     ) 
+               UNION 
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION 
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION 
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+GROUP BY types
+ORDER BY types;
+ types | sumofeventtype 
+-------+----------------
+     0 |             55
+     1 |             38
+     2 |             70
+     3 |             58
+(4 rows)
+
+-- again same query but with only two top level empty queries (i.e., no group bys)
+SELECT *
+FROM
+     ( SELECT * 
+      FROM
+        ( SELECT "t1"."user_id"
+         FROM (
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15)
+                     )
+               UNION 
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION 
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION 
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+        ) AS t) "q" ORDER BY 1 LIMIT 5;
+ user_id 
+---------
+       0
+       0
+       0
+       1
+       1
+(5 rows)
+
+-- a very similar query UNION ALL
+SELECT ("q"."event_types") as types, count(*) AS sumOfEventType
+FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15) 
+                     ) 
+               UNION ALL
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION ALL
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION ALL
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+GROUP BY types
+ORDER BY types;
+ types | sumofeventtype 
+-------+----------------
+     0 |             55
+     1 |             38
+     2 |             70
+     3 |             58
+(4 rows)
+
+-- some UNION ALL queries that are going to be pulled up
+SELECT 
+  count(*)
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT user_id FROM events_table)
+) b;
+ count 
+-------
+ 20002
+(1 row)
+
+-- similar query without top level agg
+SELECT 
+  user_id
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT user_id FROM events_table)
+) b
+ORDER BY 1 DESC
+LIMIT 5;
+ user_id 
+---------
+     100
+     100
+     100
+     100
+     100
+(5 rows)
+
+-- similar query with multiple target list entries
+SELECT 
+  user_id, value_3
+FROM 
+(
+  (SELECT value_3, user_id FROM users_table)
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table)
+) b
+ORDER BY 1 DESC, 2 DESC
+LIMIT 5;
+ user_id | value_3 
+---------+---------
+     100 |     999
+     100 |     997
+     100 |     991
+     100 |     989
+     100 |     988
+(5 rows)
+
+-- similar query group by inside the subqueries
+SELECT 
+  user_id, value_3_sum
+FROM 
+(
+  (SELECT sum(value_3) as value_3_sum, user_id FROM users_table GROUP BY user_id)
+    UNION ALL
+  (SELECT sum(value_3) as value_3_sum, user_id FROM users_table GROUP BY user_id)
+) b
+ORDER BY 2 DESC, 1 DESC
+LIMIT 5;
+ user_id | value_3_sum 
+---------+-------------
+      10 |       64060
+      10 |       64060
+      62 |       62445
+      62 |       62445
+      26 |       60536
+(5 rows)
+
+-- similar query top level group by
+SELECT 
+  user_id, sum(value_3)
+FROM 
+(
+  (SELECT value_3, user_id FROM users_table)
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table)
+) b
+GROUP BY 1
+ORDER BY 2 DESC, 1 DESC
+LIMIT 5;
+ user_id |  sum   
+---------+--------
+      23 | 123923
+      25 | 118087
+      69 | 115828
+      26 | 114705
+       3 | 113915
+(5 rows)
+
+-- a long set operation list
+SELECT 
+  user_id, value_3
+FROM 
+(
+  (SELECT value_3, user_id FROM events_table where event_type IN (1, 2, 3, 4, 5))
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (6, 7, 8, 9, 10))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (11, 12, 13, 14, 15))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (16, 17, 18, 19, 20))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (21, 22, 23, 24, 25))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (26, 27, 28, 29, 30))
+) b
+ORDER BY 1 DESC, 2 DESC
+LIMIT 5;
+ user_id | value_3 
+---------+---------
+     100 |     951
+      99 |     558
+      99 |      14
+      98 |     987
+      98 |     577
+(5 rows)
+
+-- no partition key on the top
+SELECT 
+  max(value_3)
+FROM 
+(
+  (SELECT value_3, user_id FROM events_table where event_type IN (1, 2, 3, 4, 5))
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (6, 7, 8, 9, 10))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (11, 12, 13, 14, 15))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (16, 17, 18, 19, 20))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (21, 22, 23, 24, 25))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (26, 27, 28, 29, 30))
+) b
+GROUP BY user_id
+ORDER BY 1 DESC
+LIMIT 5;
+ max 
+-----
+ 997
+ 997
+ 996
+ 995
+ 995
+(5 rows)
+
+-- now lets also have some unsupported queries
+-- group by is not on the partition key
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+      UNION
+    SELECT value_1 as user_id, sum(value_2) AS counter FROM users_table GROUP BY value_1
+) user_id 
+GROUP BY user_id;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- partition key is not selected
+SELECT sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 20 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION 
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 40 and value_1 < 60 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 60 and value_1 < 80 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 80 and value_1 < 100 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT 2 * user_id, sum(value_2) AS counter FROM users_table where value_1 < 100 and value_1 < 120 GROUP BY user_id HAVING sum(value_2) > 500
+) user_id 
+GROUP BY user_id ORDER BY 1 DESC LIMIT 5;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- excepts within unions are not supported
+SELECT * FROM
+(
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+     SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+     UNION 
+     SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+  ) user_id_1
+  GROUP BY user_id
+) 
+UNION
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+      SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+        EXCEPT 
+      SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+) user_id_2
+  GROUP BY user_id)
+) as ftop;
+ERROR:  cannot push down this subquery
+DETAIL:  Intersect and Except are currently unsupported
+-- joins inside unions are not supported
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+    UNION 
+    SELECT events_table.user_id, sum(events_table.value_2) AS counter FROM events_table, users_table WHERE users_table.user_id > events_table.user_id GROUP BY 1
+) user_id 
+GROUP BY user_id;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- joins inside unions are not supported -- slightly more comlex than the above
+SELECT * FROM
+(
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+     SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+     UNION 
+     SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+  ) user_id_1
+  GROUP BY user_id
+) 
+UNION
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+      SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+        UNION 
+      SELECT events_table.user_id, sum(events_table.value_2) AS counter FROM events_table, users_table WHERE (events_table.user_id = users_table.user_id) GROUP BY events_table.user_id
+) user_id_2
+  GROUP BY user_id)
+) as ftop;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- offset inside the union
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+      UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id OFFSET 4
+) user_id 
+GROUP BY user_id;
+ERROR:  cannot push down this subquery
+DETAIL:  Offset clause is currently unsupported
+-- lower level union does not return partition key with the other relations
+SELECT *
+FROM (
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT user_id,
+                    sum(value_2) AS counter
+            FROM users_table
+            GROUP BY user_id
+              
+          UNION 
+            SELECT user_id,
+                         sum(value_2) AS counter
+            FROM events_table
+            GROUP BY user_id ) user_id_1
+         GROUP BY user_id)
+      UNION
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT sum(value_2) AS counter,
+                    user_id
+            FROM users_table
+            GROUP BY user_id
+            
+          UNION 
+            SELECT user_id,
+                         sum(value_2) AS counter
+            FROM events_table
+            GROUP BY user_id) user_id_2
+         GROUP BY user_id)) AS ftop;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- some UNION all queries that are going to be pulled up
+SELECT 
+  count(*)
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT 2 * user_id FROM events_table)
+) b;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- last query does not have partition key
+SELECT 
+  user_id, value_3
+FROM 
+(
+  (SELECT value_3, user_id FROM events_table where event_type IN (1, 2, 3, 4, 5))
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (6, 7, 8, 9, 10))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (11, 12, 13, 14, 15))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (16, 17, 18, 19, 20))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (21, 22, 23, 24, 25))
+  UNION ALL
+  (SELECT value_3, value_2 FROM events_table where event_type IN (26, 27, 28, 29, 30))
+) b
+ORDER BY 1 DESC, 2 DESC
+LIMIT 5;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+-- we don't allow joins within unions
+SELECT 
+  count(*)
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT users_table.user_id FROM events_table, users_table WHERE events_table.user_id = users_table.user_id)
+) b;
+ERROR:  cannot pushdown the subquery since all leaves of the UNION does not include partition key at the same position
+DETAIL:  Each leaf query of the UNION should return partition key at the same position on its target list.
+SET citus.subquery_pushdown TO false;
+SET citus.enable_router_execution TO true;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -41,6 +41,7 @@ test: multi_deparse_shard_query
 test: multi_basic_queries multi_complex_expressions multi_verify_no_subquery
 test: multi_explain
 test: multi_subquery multi_subquery_complex_queries multi_subquery_behavioral_analytics
+test: multi_subquery_union
 test: multi_reference_table
 test: multi_outer_join_reference
 test: multi_single_relation_subquery

--- a/src/test/regress/sql/multi_subquery_union.sql
+++ b/src/test/regress/sql/multi_subquery_union.sql
@@ -1,0 +1,609 @@
+--
+-- multi subquery toplevel union queries aims to expand existing subquery pushdown
+-- regression tests to cover more cases
+-- the tables that are used depends to multi_insert_select_behavioral_analytics_create_table.sql
+
+-- We don't need shard id sequence here, so commented out to prevent conflicts with concurrent tests
+-- ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1400000;
+
+SET citus.subquery_pushdown TO true;
+SET citus.enable_router_execution TO false;
+-- a very simple union query
+SELECT user_id, counter
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION 
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+ORDER BY 2 DESC,1
+LIMIT 5;
+
+-- the same query with union all
+SELECT user_id, counter
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION ALL
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+ORDER BY 2 DESC,1
+LIMIT 5;
+
+-- the same query with group by
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION 
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+GROUP BY 1
+ORDER BY 2 DESC,1
+LIMIT 5;
+
+-- the same query with UNION ALL clause
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION ALL
+    SELECT user_id, value_2 % 10 AS counter FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+GROUP BY 1
+ORDER BY 2 DESC,1
+LIMIT 5;
+
+-- the same query target list entries shuffled
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT value_2 % 10 AS counter, user_id FROM events_table WHERE event_type IN (1, 2, 3, 4, 5) 
+      UNION 
+    SELECT value_2 % 10 AS counter, user_id FROM events_table WHERE event_type IN (5, 6, 7, 8, 9, 10) 
+) user_id 
+GROUP BY 1
+ORDER BY 2 DESC,1
+LIMIT 5;
+
+-- same query with GROUP BY
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, value_2 AS counter FROM events_table WHERE event_type IN (1, 2) 
+      UNION 
+    SELECT user_id, value_2 AS counter FROM events_table WHERE event_type IN (5, 6) 
+) user_id 
+GROUP BY 
+  user_id 
+--HAVING sum(counter) > 900 
+ORDER BY 1,2 DESC LIMIT 5;
+
+
+-- the same query target list entries shuffled but this time the subqueries target list
+-- is shuffled
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT value_2 AS counter, user_id FROM events_table WHERE event_type IN (1, 2) 
+      UNION 
+    SELECT value_2 AS counter, user_id FROM events_table WHERE event_type IN (5, 6) 
+) user_id 
+GROUP BY 
+  user_id 
+--HAVING sum(counter) > 900 
+ORDER BY 1,2 DESC LIMIT 5;
+
+
+-- similar query this time more subqueries and target list contains a resjunk entry
+SELECT sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 20 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION 
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 40 and value_1 < 60 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 60 and value_1 < 80 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 80 and value_1 < 100 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 100 and value_1 < 120 GROUP BY user_id HAVING sum(value_2) > 500
+) user_id 
+GROUP BY user_id ORDER BY 1 DESC LIMIT 5;
+
+-- similar query as above, with UNION ALL
+SELECT sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 20 GROUP BY user_id HAVING sum(value_2) > 5000
+      UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 40 and value_1 < 60 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 60 and value_1 < 80 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 80 and value_1 < 100 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION ALL
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 100 and value_1 < 120 GROUP BY user_id HAVING sum(value_2) > 500
+) user_id 
+GROUP BY user_id ORDER BY 1 DESC LIMIT 5;
+
+-- unions within unions
+SELECT *
+FROM (
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT user_id,
+                    sum(value_2) AS counter
+            FROM users_table
+            GROUP BY user_id
+              
+          UNION 
+
+            SELECT user_id,
+                         sum(value_2) AS counter
+            FROM events_table
+            GROUP BY user_id ) user_id_1
+         GROUP BY user_id)
+      UNION
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT 
+                    user_id, sum(value_2) AS counter
+            FROM users_table
+            GROUP BY user_id
+            
+          UNION 
+
+            SELECT user_id,  sum(value_2) AS counter
+                        
+            FROM events_table
+            GROUP BY user_id) user_id_2
+         GROUP BY user_id)) AS ftop 
+ORDER BY 2 DESC, 1 DESC 
+LIMIT 5;
+
+-- top level unions are wrapped into top level aggregations
+SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
+FROM
+  ( SELECT *, random()
+   FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15) ) events_subquery_1) 
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) ) events_subquery_2)
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) ) events_subquery_3)
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13)) events_subquery_4)) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+) as final_query
+GROUP BY types
+ORDER BY types;
+
+-- exactly the same query
+-- but wrapper unions are removed from the inner part of the query
+SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
+FROM
+  ( SELECT *, random()
+   FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+               (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15))
+               UNION 
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION 
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION 
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+) as final_query
+GROUP BY types
+ORDER BY types;
+
+-- again excatly the same query with top level wrapper removed
+SELECT ("q"."event_types") as types, count(*) AS sumOfEventType
+FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15) 
+                     ) 
+               UNION 
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION 
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION 
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+GROUP BY types
+ORDER BY types;
+
+-- again same query but with only two top level empty queries (i.e., no group bys)
+SELECT *
+FROM
+     ( SELECT * 
+      FROM
+        ( SELECT "t1"."user_id"
+         FROM (
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15)
+                     )
+               UNION 
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION 
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION 
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+        ) AS t) "q" ORDER BY 1 LIMIT 5;
+
+-- a very similar query UNION ALL
+SELECT ("q"."event_types") as types, count(*) AS sumOfEventType
+FROM
+     ( SELECT "t"."user_id",
+              "t"."time",
+              unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT "t1"."user_id",
+                 min("t1"."time") AS "time",
+                 array_agg(("t1"."event")
+                           ORDER BY TIME ASC, event DESC) AS collected_events
+         FROM (
+                    (SELECT "events"."user_id",
+                            "events"."time",
+                            0 AS event
+                     FROM events_table as  "events"
+                     WHERE event_type IN (10, 11, 12, 13, 14, 15) 
+                     ) 
+               UNION ALL
+                    (SELECT "events"."user_id", "events"."time", 1 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (15, 16, 17, 18, 19) )
+               UNION ALL
+                
+                    (SELECT "events"."user_id", "events"."time", 2 AS event
+                     FROM events_table as  "events"
+                      WHERE event_type IN (20, 21, 22, 23, 24, 25) )
+               UNION ALL
+               
+                    (SELECT "events"."user_id", "events"."time", 3 AS event
+                     FROM events_table as "events"
+                     WHERE event_type IN (26, 27, 28, 29, 30, 13))) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+GROUP BY types
+ORDER BY types;
+
+-- some UNION ALL queries that are going to be pulled up
+SELECT 
+  count(*)
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT user_id FROM events_table)
+) b;
+
+-- similar query without top level agg
+SELECT 
+  user_id
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT user_id FROM events_table)
+) b
+ORDER BY 1 DESC
+LIMIT 5;
+
+-- similar query with multiple target list entries
+SELECT 
+  user_id, value_3
+FROM 
+(
+  (SELECT value_3, user_id FROM users_table)
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table)
+) b
+ORDER BY 1 DESC, 2 DESC
+LIMIT 5;
+
+-- similar query group by inside the subqueries
+SELECT 
+  user_id, value_3_sum
+FROM 
+(
+  (SELECT sum(value_3) as value_3_sum, user_id FROM users_table GROUP BY user_id)
+    UNION ALL
+  (SELECT sum(value_3) as value_3_sum, user_id FROM users_table GROUP BY user_id)
+) b
+ORDER BY 2 DESC, 1 DESC
+LIMIT 5;
+
+-- similar query top level group by
+SELECT 
+  user_id, sum(value_3)
+FROM 
+(
+  (SELECT value_3, user_id FROM users_table)
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table)
+) b
+GROUP BY 1
+ORDER BY 2 DESC, 1 DESC
+LIMIT 5;
+
+-- a long set operation list
+SELECT 
+  user_id, value_3
+FROM 
+(
+  (SELECT value_3, user_id FROM events_table where event_type IN (1, 2, 3, 4, 5))
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (6, 7, 8, 9, 10))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (11, 12, 13, 14, 15))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (16, 17, 18, 19, 20))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (21, 22, 23, 24, 25))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (26, 27, 28, 29, 30))
+) b
+ORDER BY 1 DESC, 2 DESC
+LIMIT 5;
+
+-- no partition key on the top
+SELECT 
+  max(value_3)
+FROM 
+(
+  (SELECT value_3, user_id FROM events_table where event_type IN (1, 2, 3, 4, 5))
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (6, 7, 8, 9, 10))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (11, 12, 13, 14, 15))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (16, 17, 18, 19, 20))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (21, 22, 23, 24, 25))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (26, 27, 28, 29, 30))
+) b
+GROUP BY user_id
+ORDER BY 1 DESC
+LIMIT 5;
+
+
+-- now lets also have some unsupported queries
+
+-- group by is not on the partition key
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+      UNION
+    SELECT value_1 as user_id, sum(value_2) AS counter FROM users_table GROUP BY value_1
+) user_id 
+GROUP BY user_id;
+
+-- partition key is not selected
+SELECT sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 20 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION 
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 40 and value_1 < 60 GROUP BY user_id HAVING sum(value_2) > 500
+      UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 60 and value_1 < 80 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table where value_1 < 80 and value_1 < 100 GROUP BY user_id HAVING sum(value_2) > 500
+        UNION
+    SELECT 2 * user_id, sum(value_2) AS counter FROM users_table where value_1 < 100 and value_1 < 120 GROUP BY user_id HAVING sum(value_2) > 500
+) user_id 
+GROUP BY user_id ORDER BY 1 DESC LIMIT 5;
+
+-- excepts within unions are not supported
+SELECT * FROM
+(
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+     SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+     UNION 
+     SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+  ) user_id_1
+  GROUP BY user_id
+) 
+UNION
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+      SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+        EXCEPT 
+      SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+) user_id_2
+  GROUP BY user_id)
+) as ftop;
+
+-- joins inside unions are not supported
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+    UNION 
+    SELECT events_table.user_id, sum(events_table.value_2) AS counter FROM events_table, users_table WHERE users_table.user_id > events_table.user_id GROUP BY 1
+) user_id 
+GROUP BY user_id;
+
+-- joins inside unions are not supported -- slightly more comlex than the above
+SELECT * FROM
+(
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+     SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+     UNION 
+     SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+  ) user_id_1
+  GROUP BY user_id
+) 
+UNION
+(
+  SELECT user_id, sum(counter) 
+    FROM (
+      SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id
+        UNION 
+      SELECT events_table.user_id, sum(events_table.value_2) AS counter FROM events_table, users_table WHERE (events_table.user_id = users_table.user_id) GROUP BY events_table.user_id
+) user_id_2
+  GROUP BY user_id)
+) as ftop;
+
+-- offset inside the union
+SELECT user_id, sum(counter) 
+FROM (
+    SELECT user_id, sum(value_2) AS counter FROM events_table GROUP BY user_id
+      UNION
+    SELECT user_id, sum(value_2) AS counter FROM users_table GROUP BY user_id OFFSET 4
+) user_id 
+GROUP BY user_id;
+
+-- lower level union does not return partition key with the other relations
+SELECT *
+FROM (
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT user_id,
+                    sum(value_2) AS counter
+            FROM users_table
+            GROUP BY user_id
+              
+          UNION 
+
+            SELECT user_id,
+                         sum(value_2) AS counter
+            FROM events_table
+            GROUP BY user_id ) user_id_1
+         GROUP BY user_id)
+      UNION
+        ( SELECT user_id,
+                 sum(counter)
+         FROM
+           ( SELECT sum(value_2) AS counter,
+                    user_id
+            FROM users_table
+            GROUP BY user_id
+            
+          UNION 
+
+            SELECT user_id,
+                         sum(value_2) AS counter
+            FROM events_table
+            GROUP BY user_id) user_id_2
+         GROUP BY user_id)) AS ftop;
+
+-- some UNION all queries that are going to be pulled up
+SELECT 
+  count(*)
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT 2 * user_id FROM events_table)
+) b;
+
+-- last query does not have partition key
+SELECT 
+  user_id, value_3
+FROM 
+(
+  (SELECT value_3, user_id FROM events_table where event_type IN (1, 2, 3, 4, 5))
+    UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (6, 7, 8, 9, 10))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (11, 12, 13, 14, 15))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (16, 17, 18, 19, 20))
+  UNION ALL
+  (SELECT value_3, user_id FROM events_table where event_type IN (21, 22, 23, 24, 25))
+  UNION ALL
+  (SELECT value_3, value_2 FROM events_table where event_type IN (26, 27, 28, 29, 30))
+) b
+ORDER BY 1 DESC, 2 DESC
+LIMIT 5;
+
+-- we don't allow joins within unions
+SELECT 
+  count(*)
+FROM 
+(
+  (SELECT user_id FROM users_table)
+    UNION ALL
+  (SELECT users_table.user_id FROM events_table, users_table WHERE events_table.user_id = users_table.user_id)
+) b;
+
+SET citus.subquery_pushdown TO false;
+SET citus.enable_router_execution TO true;


### PR DESCRIPTION
(The PR currently is based on a branch which is not rebased to its parent branch. Thus, we see some older commits. As we progress to review this patch, I'll rebase all PRs accordingly):

    Add top level union support
    
    This commit adds support for UNION/UNION ALL subqueries that are
    in the following form:
    
         .... (Q1 UNION Q2 UNION ...) as union_query ....
    
    In other words, Citus supports allow top level
    unions being wrapped into aggregations queries
    and/or simple projection queries that only selects
    some fields from the lower level queries.