### PR TITLE
 Support expressions in the partition column in INSERTs

### DIFF
--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -298,6 +298,17 @@ EvaluateNodeIfReferencesFunction(Node *expression, PlanState *planState)
 											planState);
 	}
 
+	if (IsA(expression, Param))
+	{
+		Param *param = (Param *) expression;
+
+		return (Node *) citus_evaluate_expr((Expr *) param,
+											param->paramtype,
+											param->paramtypmod,
+											param->paramcollid,
+											planState);
+	}
+
 	return expression;
 }
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -396,6 +396,7 @@ OutJobFields(StringInfo str, const Job *node)
 	WRITE_NODE_FIELD(dependedJobList);
 	WRITE_BOOL_FIELD(subqueryPushdown);
 	WRITE_BOOL_FIELD(requiresMasterEvaluation);
+	WRITE_BOOL_FIELD(deferredPruning);
 }
 
 

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -164,6 +164,7 @@ readJobInfo(Job *local_node)
 	READ_NODE_FIELD(dependedJobList);
 	READ_BOOL_FIELD(subqueryPushdown);
 	READ_BOOL_FIELD(requiresMasterEvaluation);
+	READ_BOOL_FIELD(deferredPruning);
 }
 
 

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -122,6 +122,7 @@ typedef struct Job
 	List *dependedJobList;
 	bool subqueryPushdown;
 	bool requiresMasterEvaluation; /* only applies to modify jobs */
+	bool deferredPruning;
 } Job;
 
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -42,6 +42,8 @@ extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
+extern ShardInterval * FindShardForInsert(Query *query,
+										  DeferredErrorMessage **planningError);
 extern ShardInterval * FastShardPruning(Oid distributedTableId, Datum partitionValue);
 
 

--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -361,7 +361,7 @@ ERROR:  null value in column "name" violates not-null constraint
 DETAIL:  Failing row contains (1, null, 5).
 CONTEXT:  while executing command on localhost:57638
 INSERT INTO products VALUES(NULL,'product_1', 5);
-ERROR:  cannot plan INSERT using row with NULL value in partition column
+ERROR:  cannot perform an INSERT with NULL in the partition column
 DROP TABLE products;
 -- Check "NOT NULL" with reference table
 CREATE TABLE products_ref (

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -166,12 +166,12 @@ SELECT COUNT(*) FROM limit_orders WHERE id = 430;
 
 -- INSERT without partition key
 INSERT INTO limit_orders DEFAULT VALUES;
-ERROR:  cannot plan INSERT using row with NULL value in partition column
+ERROR:  cannot perform an INSERT without a partition column value
 -- squelch WARNINGs that contain worker_port
 SET client_min_messages TO ERROR;
 -- INSERT violating NOT NULL constraint
 INSERT INTO limit_orders VALUES (NULL, 'T', 975234, DEFAULT);
-ERROR:  cannot plan INSERT using row with NULL value in partition column
+ERROR:  cannot perform an INSERT with NULL in the partition column
 -- INSERT violating column constraint
 INSERT INTO limit_orders VALUES (18811, 'BUD', 14962, '2014-04-05 08:32:16', 'sell',
 								 -5.00);
@@ -195,7 +195,6 @@ SET client_min_messages TO DEFAULT;
 -- commands with non-constant partition values are unsupported
 INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:45',
 								 'sell', 0.58);
-ERROR:  values given for the partition column must be constants or constant expressions
 -- values for other columns are totally fine
 INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 -- commands with mutable functions in their quals
@@ -632,3 +631,31 @@ INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *
   3 |    103 | Mynt
 (1 row)
 
+DROP TABLE app_analytics_events;
+-- again with serial in the partition column
+CREATE TABLE app_analytics_events (id serial, app_id integer, name text);
+SELECT create_distributed_table('app_analytics_events', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO app_analytics_events VALUES (DEFAULT, 101, 'Fauxkemon Geaux') RETURNING id;
+ id 
+----
+  1
+(1 row)
+
+INSERT INTO app_analytics_events (app_id, name) VALUES (102, 'Wayz') RETURNING id;
+ id 
+----
+  2
+(1 row)
+
+INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *;
+ id | app_id | name 
+----+--------+------
+  3 |    103 | Mynt
+(1 row)
+
+DROP TABLE app_analytics_events;

--- a/src/test/regress/expected/multi_mx_modifications.out
+++ b/src/test/regress/expected/multi_mx_modifications.out
@@ -67,12 +67,12 @@ SELECT * FROM limit_orders_mx WHERE id = 430;
 
 -- INSERT without partition key
 INSERT INTO limit_orders_mx DEFAULT VALUES;
-ERROR:  cannot plan INSERT using row with NULL value in partition column
+ERROR:  cannot perform an INSERT without a partition column value
 -- squelch WARNINGs that contain worker_port
 SET client_min_messages TO ERROR;
 -- INSERT violating NOT NULL constraint
 INSERT INTO limit_orders_mx VALUES (NULL, 'T', 975234, DEFAULT);
-ERROR:  cannot plan INSERT using row with NULL value in partition column
+ERROR:  cannot perform an INSERT with NULL in the partition column
 -- INSERT violating column constraint
 INSERT INTO limit_orders_mx VALUES (18811, 'BUD', 14962, '2014-04-05 08:32:16', 'sell',
 								 -5.00);
@@ -96,7 +96,6 @@ SET client_min_messages TO DEFAULT;
 -- commands with non-constant partition values are unsupported
 INSERT INTO limit_orders_mx VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:45',
 								 'sell', 0.58);
-ERROR:  values given for the partition column must be constants or constant expressions
 -- values for other columns are totally fine
 INSERT INTO limit_orders_mx VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 -- commands with mutable functions in their quals

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -417,3 +417,15 @@ SELECT master_create_worker_shards('app_analytics_events', 4, 1);
 INSERT INTO app_analytics_events VALUES (DEFAULT, 101, 'Fauxkemon Geaux') RETURNING id;
 INSERT INTO app_analytics_events (app_id, name) VALUES (102, 'Wayz') RETURNING id;
 INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *;
+
+DROP TABLE app_analytics_events;
+
+-- again with serial in the partition column
+CREATE TABLE app_analytics_events (id serial, app_id integer, name text);
+SELECT create_distributed_table('app_analytics_events', 'id');
+
+INSERT INTO app_analytics_events VALUES (DEFAULT, 101, 'Fauxkemon Geaux') RETURNING id;
+INSERT INTO app_analytics_events (app_id, name) VALUES (102, 'Wayz') RETURNING id;
+INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *;
+
+DROP TABLE app_analytics_events;


### PR DESCRIPTION
This PR defers shard pruning to the executor for INSERTs that contain an expression in the partition column until after function evaluation. In that case, `TargetShardIntervalForModify` now returns `NULL`. 
For simplicity, the planner still generates a task for the insert in the planner, but leaves assigning the shard ID and shard placements to the executor. 

A more general approach would be to generate the list of tasks after function evaluation, which would allow us to defer shard pruning for other commands as well, but that would have required more code changes and is not possible for all commands nor are there many use-cases for it, so it didn't seem worthwhile.

All the shard pruning logic for INSERTs has been encapsulated in `FindShardForInsert`, such that it can be called both from `TargetShardIntervalForModify` and from the executor.

We no longer generate an error if the partition column contains a non-Const, but still generate an error when it contains a parameter, since that will cause our planner to automagically pick a plan that has no parameters.

Fixes #687 