### PR TITLE
Enable distributed ALTER TABLE ... RENAME COLUMN

### DIFF
--- a/src/test/regress/expected/multi_name_lengths.out
+++ b/src/test/regress/expected/multi_name_lengths.out
@@ -125,9 +125,9 @@ DETAIL:  Citus cannot execute ADD CONSTRAINT command other than ADD CONSTRAINT F
 \c - - - :master_port
 -- Placeholders for RENAME operations
 ALTER TABLE name_lengths RENAME TO name_len_12345678901234567890123456789012345678901234567890;
-ERROR:  renaming distributed tables or their objects is currently unsupported
+ERROR:  renaming distributed tables is currently unsupported
 ALTER TABLE name_lengths RENAME CONSTRAINT unique_12345678901234567890123456789012345678901234567890 TO unique2_12345678901234567890123456789012345678901234567890;
-ERROR:  renaming distributed tables or their objects is currently unsupported
+ERROR:  renaming constraints belonging to distributed tables is currently unsupported
 -- Verify that CREATE INDEX on already distributed table has proper shard names.
 CREATE INDEX tmp_idx_12345678901234567890123456789012345678901234567890 ON name_lengths(col2);
 NOTICE:  using one-phase commit for distributed DDL commands

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1359,7 +1359,7 @@ HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_sh
 \c - - - :master_port
 -- as we expect, renaming and setting WITH OIDS does not work for reference tables
 ALTER TABLE reference_table_ddl RENAME TO reference_table_ddl_test;
-ERROR:  renaming distributed tables or their objects is currently unsupported
+ERROR:  renaming distributed tables is currently unsupported
 ALTER TABLE reference_table_ddl SET WITH OIDS;
 ERROR:  alter table command is currently unsupported
 DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT, ADD|DROP CONSTRAINT FOREIGN KEY and TYPE subcommands are supported.

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -98,6 +98,10 @@ ALTER TABLE lineitem_alter DROP COLUMN int_column1;
 ALTER TABLE lineitem_alter DROP COLUMN float_column;
 ALTER TABLE lineitem_alter DROP COLUMN date_column;
 
+-- Verify that RENAME COLUMN works
+ALTER TABLE lineitem_alter RENAME COLUMN l_orderkey TO l_orderkey_renamed;
+SELECT SUM(l_orderkey_renamed) FROM lineitem_alter;
+
 -- Verify that IF EXISTS works as expected
 
 ALTER TABLE non_existent_table ADD COLUMN new_column INTEGER;
@@ -107,6 +111,11 @@ ALTER TABLE IF EXISTS lineitem_alter ALTER COLUMN int_column2 SET DATA TYPE INTE
 ALTER TABLE lineitem_alter DROP COLUMN non_existent_column;
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS int_column2;
+
+-- Verify with IF EXISTS for extant table
+ALTER TABLE IF EXISTS lineitem_alter RENAME COLUMN l_orderkey_renamed TO l_orderkey;
+SELECT SUM(l_orderkey) FROM lineitem_alter;
+
 \d lineitem_alter
 
 -- Verify that we can execute commands with multiple subcommands
@@ -139,10 +148,9 @@ ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 
--- Verify that we error out on statements involving RENAME
+-- Verify that we error out on non-column RENAME statements
 
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
-ALTER TABLE lineitem_alter RENAME COLUMN l_orderkey TO l_orderkey_renamed;
 ALTER TABLE lineitem_alter RENAME CONSTRAINT constraint_a TO constraint_b;
 
 -- Verify that IF EXISTS works as expected with RENAME statements
@@ -150,7 +158,6 @@ ALTER TABLE lineitem_alter RENAME CONSTRAINT constraint_a TO constraint_b;
 ALTER TABLE non_existent_table RENAME TO non_existent_table_renamed;
 ALTER TABLE IF EXISTS non_existent_table RENAME TO non_existent_table_renamed;
 ALTER TABLE IF EXISTS non_existent_table RENAME COLUMN column1 TO column2;
-ALTER TABLE IF EXISTS lineitem_alter RENAME l_orderkey TO l_orderkey_renamed;
 
 -- Verify that none of the failed alter table commands took effect on the master
 -- node

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -253,6 +253,14 @@ SELECT int_column2, pg_typeof(int_column2), count(*) from lineitem_alter GROUP B
 ALTER TABLE lineitem_alter DROP COLUMN int_column1;
 ALTER TABLE lineitem_alter DROP COLUMN float_column;
 ALTER TABLE lineitem_alter DROP COLUMN date_column;
+-- Verify that RENAME COLUMN works
+ALTER TABLE lineitem_alter RENAME COLUMN l_orderkey TO l_orderkey_renamed;
+SELECT SUM(l_orderkey_renamed) FROM lineitem_alter;
+   sum    
+----------
+ 53620791
+(1 row)
+
 -- Verify that IF EXISTS works as expected
 ALTER TABLE non_existent_table ADD COLUMN new_column INTEGER;
 ERROR:  relation "non_existent_table" does not exist
@@ -264,6 +272,14 @@ ERROR:  column "non_existent_column" of relation "lineitem_alter" does not exist
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS non_existent_column;
 NOTICE:  column "non_existent_column" of relation "lineitem_alter" does not exist, skipping
 ALTER TABLE lineitem_alter DROP COLUMN IF EXISTS int_column2;
+-- Verify with IF EXISTS for extant table
+ALTER TABLE IF EXISTS lineitem_alter RENAME COLUMN l_orderkey_renamed TO l_orderkey;
+SELECT SUM(l_orderkey) FROM lineitem_alter;
+   sum    
+----------
+ 53620791
+(1 row)
+
 \d lineitem_alter
             Table "public.lineitem_alter"
      Column      |         Type          | Modifiers 
@@ -365,13 +381,11 @@ ERROR:  column "null_column" contains null values
 CONTEXT:  while executing command on localhost:57638
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 ERROR:  invalid input syntax for integer: "a"
--- Verify that we error out on statements involving RENAME
+-- Verify that we error out on non-column RENAME statements
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
-ERROR:  renaming distributed tables or their objects is currently unsupported
-ALTER TABLE lineitem_alter RENAME COLUMN l_orderkey TO l_orderkey_renamed;
-ERROR:  renaming distributed tables or their objects is currently unsupported
+ERROR:  renaming distributed tables is currently unsupported
 ALTER TABLE lineitem_alter RENAME CONSTRAINT constraint_a TO constraint_b;
-ERROR:  renaming distributed tables or their objects is currently unsupported
+ERROR:  renaming constraints belonging to distributed tables is currently unsupported
 -- Verify that IF EXISTS works as expected with RENAME statements
 ALTER TABLE non_existent_table RENAME TO non_existent_table_renamed;
 ERROR:  relation "non_existent_table" does not exist
@@ -379,8 +393,6 @@ ALTER TABLE IF EXISTS non_existent_table RENAME TO non_existent_table_renamed;
 NOTICE:  relation "non_existent_table" does not exist, skipping
 ALTER TABLE IF EXISTS non_existent_table RENAME COLUMN column1 TO column2;
 NOTICE:  relation "non_existent_table" does not exist, skipping
-ALTER TABLE IF EXISTS lineitem_alter RENAME l_orderkey TO l_orderkey_renamed;
-ERROR:  renaming distributed tables or their objects is currently unsupported
 -- Verify that none of the failed alter table commands took effect on the master
 -- node
 \d lineitem_alter


### PR DESCRIPTION
Pretty straightforward. Had some concerns about locking, but due to the fact that all distributed operations use either some level of deparsing or need to enumerate column names, they all block during any concurrent column renames (due to the AccessExclusive lock).

In addition, I had some misgivings about permitting renames of the distribution column, but nothing bad comes from just allowing them.

Finally, I tried to trigger any sort of error using prepared statements and could not trigger any errors not also exhibited by plain PostgreSQL tables.

Fixes #633