### PR TITLE
Change checks with built-in type (omit ltree)

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -46,11 +46,11 @@ check-worker: all
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/worker_schedule $(EXTRA_TESTS)
 
 check-multi: all tempinstall-main
-	$(pg_regress_multi_check) --load-extension=citus --load-extension=ltree \
+	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
 check-multi-vg: all tempinstall-main
-	$(pg_regress_multi_check) --load-extension=citus --valgrind --load-extension=ltree \
+	$(pg_regress_multi_check) --load-extension=citus --valgrind \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
 check-isolation: all tempinstall-main
@@ -65,14 +65,14 @@ check-multi-mx: all tempinstall-main
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_mx_schedule $(EXTRA_TESTS)
 
 check-multi-task-tracker-extra: all tempinstall-main
-	$(pg_regress_multi_check) --load-extension=citus --load-extension=ltree \
+	$(pg_regress_multi_check) --load-extension=citus \
 	--server-option=citus.task_executor_type=task-tracker \
 	--server-option=citus.large_table_shard_count=1 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_task_tracker_extra_schedule $(EXTRA_TESTS)
 
 
 check-multi-binary: all tempinstall-main
-	$(pg_regress_multi_check) --load-extension=citus --load-extension=ltree \
+	$(pg_regress_multi_check) --load-extension=citus \
 	--server-option=citus.binary_worker_copy_format=on \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_binary_schedule $(EXTRA_TESTS)
 

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -750,16 +750,18 @@ DROP TABLE numbers_hash;
 SELECT * FROM run_command_on_workers('DROP USER test_user');
 DROP USER test_user;
 
--- Test with ltree column
-CREATE TABLE test_ltree (path ltree);
-SELECT create_reference_table('test_ltree');
+-- Test copy with built-in type without binary output function
+CREATE TABLE test_smgr (
+col1 smgr NOT NULL,
+col2 character varying(255) NOT NULL
+);
 
-COPY test_ltree FROM STDIN DELIMITER AS ',';
-Top
-Top.Science
-Top.Science.Astronomy
+SELECT create_reference_table('test_smgr');
+
+\COPY test_smgr FROM STDIN WITH (format CSV)
+magnetic disk, test
 \.
 
-SELECT path, nlevel(path) AS depth FROM test_ltree ORDER BY depth;
+SELECT * FROM test_smgr;
 
-DROP TABLE test_ltree;
+DROP TABLE test_smgr;

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -1017,21 +1017,22 @@ SELECT * FROM run_command_on_workers('DROP USER test_user');
 (2 rows)
 
 DROP USER test_user;
--- Test with ltree column
-CREATE TABLE test_ltree (path ltree);
-SELECT create_reference_table('test_ltree');
+-- Test copy with built-in type without binary output function
+CREATE TABLE test_smgr (
+col1 smgr NOT NULL,
+col2 character varying(255) NOT NULL
+);
+SELECT create_reference_table('test_smgr');
  create_reference_table 
 ------------------------
  
 (1 row)
 
-COPY test_ltree FROM STDIN DELIMITER AS ',';
-SELECT path, nlevel(path) AS depth FROM test_ltree ORDER BY depth;
-         path          | depth 
------------------------+-------
- Top                   |     1
- Top.Science           |     2
- Top.Science.Astronomy |     3
-(3 rows)
+\COPY test_smgr FROM STDIN WITH (format CSV)
+SELECT * FROM test_smgr;
+     col1      | col2  
+---------------+-------
+ magnetic disk |  test
+(1 row)
 
-DROP TABLE test_ltree;
+DROP TABLE test_smgr;


### PR DESCRIPTION
This commit checks copying data to the table which has a column without binary output function. 