### PR TITLE
Support UPDATE/DELETE with parameterised partition column qual

### DIFF
--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -917,10 +917,11 @@ SELECT partition_parameter_update(5, 51);
 (1 row)
 
 SELECT partition_parameter_update(6, 61);
-ERROR:  cannot run UPDATE command which targets multiple shards
-HINT:  Consider using an equality filter on partition column "key" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
-CONTEXT:  SQL statement "UPDATE plpgsql_table SET value = $2 WHERE key = $1"
-PL/pgSQL function partition_parameter_update(integer,integer) line 3 at SQL statement
+ partition_parameter_update 
+----------------------------
+ 
+(1 row)
+
 CREATE FUNCTION non_partition_parameter_update(int, int) RETURNS void as $$
 BEGIN
 	UPDATE plpgsql_table SET value = $2 WHERE key = 0 AND value = $1;
@@ -989,8 +990,8 @@ SELECT * FROM plpgsql_table ORDER BY key, value;
    4 |    41
    5 |    51
    5 |    51
-   6 |    60
-   6 |      
+   6 |    61
+   6 |    61
 (24 rows)
 
 -- check deletes
@@ -1031,10 +1032,11 @@ SELECT partition_parameter_delete(5, 51);
 (1 row)
 
 SELECT partition_parameter_delete(6, 61);
-ERROR:  cannot run DELETE command which targets multiple shards
-HINT:  Consider using an equality filter on partition column "key" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
-CONTEXT:  SQL statement "DELETE FROM plpgsql_table WHERE key = $1 AND value = $2"
-PL/pgSQL function partition_parameter_delete(integer,integer) line 3 at SQL statement
+ partition_parameter_delete 
+----------------------------
+ 
+(1 row)
+
 CREATE FUNCTION  non_partition_parameter_delete(int) RETURNS void as $$
 BEGIN
 	DELETE FROM plpgsql_table WHERE key = 0 AND value = $1;
@@ -1087,9 +1089,7 @@ SELECT * FROM plpgsql_table ORDER BY key, value;
    0 |      
    0 |      
    0 |      
-   6 |    60
-   6 |      
-(8 rows)
+(6 rows)
 
 -- check whether we can handle execute parameters
 CREATE TABLE execute_parameter_test (key int, val date);

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -776,8 +776,6 @@ EXECUTE prepared_partition_parameter_update(3, 31);
 EXECUTE prepared_partition_parameter_update(4, 41);
 EXECUTE prepared_partition_parameter_update(5, 51);
 EXECUTE prepared_partition_parameter_update(6, 61);
-ERROR:  cannot run UPDATE command which targets multiple shards
-HINT:  Consider using an equality filter on partition column "key" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
 PREPARE prepared_non_partition_parameter_update(int, int) AS
 	UPDATE prepare_table SET value = $2 WHERE key = 0 AND value = $1;
 -- execute 6 times to trigger prepared statement usage
@@ -813,8 +811,8 @@ SELECT * FROM prepare_table ORDER BY key, value;
    4 |    41
    5 |    51
    5 |    51
-   6 |    60
-   6 |      
+   6 |    61
+   6 |    61
 (24 rows)
 
 -- check deletes
@@ -826,8 +824,6 @@ EXECUTE prepared_partition_parameter_delete(3, 31);
 EXECUTE prepared_partition_parameter_delete(4, 41);
 EXECUTE prepared_partition_parameter_delete(5, 51);
 EXECUTE prepared_partition_parameter_delete(6, 61);
-ERROR:  cannot run DELETE command which targets multiple shards
-HINT:  Consider using an equality filter on partition column "key" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
 PREPARE prepared_non_partition_parameter_delete(int) AS
 	DELETE FROM prepare_table WHERE key = 0 AND value = $1;
 -- execute 6 times to trigger prepared statement usage
@@ -847,9 +843,7 @@ SELECT * FROM prepare_table ORDER BY key, value;
    0 |      
    0 |      
    0 |      
-   6 |    60
-   6 |      
-(8 rows)
+(6 rows)
 
 -- Testing parameters + function evaluation
 CREATE TABLE prepare_func_table (

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -993,3 +993,4 @@ EXECUTE countsome; -- no replanning
 \set VERBOSITY default
 -- clean-up prepared statements
 DEALLOCATE ALL;
+DROP TABLE prepare_table;

--- a/src/test/regress/expected/multi_sql_function.out
+++ b/src/test/regress/expected/multi_sql_function.out
@@ -302,9 +302,7 @@ SELECT * FROM prepare_table ORDER BY key, value;
    0 |      
    0 |      
    0 |      
-   6 |    60
-   6 |      
-(8 rows)
+(6 rows)
 
 -- test running parameterized SQL function
 CREATE TABLE test_parameterized_sql(id integer, org_id integer);

--- a/src/test/regress/expected/multi_sql_function.out
+++ b/src/test/regress/expected/multi_sql_function.out
@@ -253,7 +253,7 @@ SELECT * FROM temp_table ORDER BY key, value;
 
 -- check deletes
 CREATE FUNCTION non_partition_parameter_delete_sql(int) RETURNS void AS $$
-	DELETE FROM prepare_table WHERE key = 0 AND value = $1;
+	DELETE FROM temp_table WHERE key = 0 AND value = $1;
 $$ LANGUAGE SQL;
 -- execute 6 times to trigger prepared statement usage
 SELECT non_partition_parameter_delete_sql(12);
@@ -293,7 +293,7 @@ SELECT non_partition_parameter_delete_sql(62);
 (1 row)
 
 -- check after deletes
-SELECT * FROM prepare_table ORDER BY key, value;
+SELECT * FROM temp_table ORDER BY key, value;
  key | value 
 -----+-------
    0 |      

--- a/src/test/regress/sql/multi_prepare_sql.sql
+++ b/src/test/regress/sql/multi_prepare_sql.sql
@@ -529,3 +529,5 @@ EXECUTE countsome; -- no replanning
 
 -- clean-up prepared statements
 DEALLOCATE ALL;
+
+DROP TABLE prepare_table;

--- a/src/test/regress/sql/multi_sql_function.sql
+++ b/src/test/regress/sql/multi_sql_function.sql
@@ -111,7 +111,7 @@ SELECT * FROM temp_table ORDER BY key, value;
 
 -- check deletes
 CREATE FUNCTION non_partition_parameter_delete_sql(int) RETURNS void AS $$
-	DELETE FROM prepare_table WHERE key = 0 AND value = $1;
+	DELETE FROM temp_table WHERE key = 0 AND value = $1;
 $$ LANGUAGE SQL;
 
 -- execute 6 times to trigger prepared statement usage
@@ -123,7 +123,7 @@ SELECT non_partition_parameter_delete_sql(52);
 SELECT non_partition_parameter_delete_sql(62);
 
 -- check after deletes
-SELECT * FROM prepare_table ORDER BY key, value;
+SELECT * FROM temp_table ORDER BY key, value;
 
 -- test running parameterized SQL function
 CREATE TABLE test_parameterized_sql(id integer, org_id integer);


### PR DESCRIPTION
Fixes #1319 by setting a `planningError` if `TargetShardIntervalForModify` fails to prune down to 1 shard instead of throwing an error. Our regression tests already covered the unsupported cases, but the expected output contained errors. We should backport this since it's a hole in the expected prepared statement support of 6.1.

@metdos assigning you as our prepared statement expert :), but feel free to hand it off. 