### PR TITLE
Support query parameters in combination with function evaluation

### DIFF
--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -154,7 +154,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 				 errmsg("master_modify_multiple_shards() does not support RETURNING")));
 	}
 
-	ExecuteMasterEvaluableFunctions(modifyQuery);
+	ExecuteMasterEvaluableFunctions(modifyQuery, NULL);
 
 	shardIntervalList = LoadShardIntervalList(relationId);
 	restrictClauseList = WhereClauseList(modifyQuery->jointree);

--- a/src/include/distributed/citus_clauses.h
+++ b/src/include/distributed/citus_clauses.h
@@ -11,10 +11,11 @@
 #ifndef CITUS_CLAUSES_H
 #define CITUS_CLAUSES_H
 
+#include "nodes/execnodes.h"
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 
 extern bool RequiresMasterEvaluation(Query *query);
-extern void ExecuteMasterEvaluableFunctions(Query *query);
+extern void ExecuteMasterEvaluableFunctions(Query *query, PlanState *planState);
 
 #endif /* CITUS_CLAUSES_H */

--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1106,6 +1106,86 @@ BEGIN
 END;
 $$;
 DROP TABLE execute_parameter_test;
+-- check whether we can handle parameters + default
+CREATE TABLE func_parameter_test (
+    key text NOT NULL,
+    seq int4 NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (key, seq)
+);
+SELECT create_distributed_table('func_parameter_test', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE OR REPLACE FUNCTION insert_with_max(pkey text) RETURNS VOID AS
+$BODY$
+    DECLARE
+        max_seq int4;
+    BEGIN
+        SELECT MAX(seq) INTO max_seq
+        FROM func_parameter_test
+        WHERE func_parameter_test.key = pkey;
+
+        IF max_seq IS NULL THEN
+            max_seq := 0;
+        END IF;
+
+        INSERT INTO func_parameter_test(key, seq) VALUES (pkey, max_seq + 1);
+    END;
+$BODY$
+LANGUAGE plpgsql;
+SELECT insert_with_max('key');
+ insert_with_max 
+-----------------
+ 
+(1 row)
+
+SELECT insert_with_max('key');
+ insert_with_max 
+-----------------
+ 
+(1 row)
+
+SELECT insert_with_max('key');
+ insert_with_max 
+-----------------
+ 
+(1 row)
+
+SELECT insert_with_max('key');
+ insert_with_max 
+-----------------
+ 
+(1 row)
+
+SELECT insert_with_max('key');
+ insert_with_max 
+-----------------
+ 
+(1 row)
+
+SELECT insert_with_max('key');
+ insert_with_max 
+-----------------
+ 
+(1 row)
+
+SELECT key, seq FROM func_parameter_test ORDER BY seq;
+ key | seq 
+-----+-----
+ key |   1
+ key |   2
+ key |   3
+ key |   4
+ key |   5
+ key |   6
+(6 rows)
+
+DROP FUNCTION insert_with_max(text);
+DROP TABLE func_parameter_test;
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();
 DROP FUNCTION plpgsql_test_2();

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -851,6 +851,62 @@ SELECT * FROM prepare_table ORDER BY key, value;
    6 |      
 (8 rows)
 
+-- Testing parameters + function evaluation
+CREATE TABLE prepare_func_table (
+    key text,
+    value1 int,
+    value2 text,
+    value3 timestamptz DEFAULT now()
+);
+SELECT create_distributed_table('prepare_func_table', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- test function evaluation with parameters in an expression
+PREPARE prepared_function_evaluation_insert(int) AS
+	INSERT INTO prepare_func_table (key, value1) VALUES ($1+1, 0*random());
+-- execute 6 times to trigger prepared statement usage
+EXECUTE prepared_function_evaluation_insert(1);
+EXECUTE prepared_function_evaluation_insert(2);
+EXECUTE prepared_function_evaluation_insert(3);
+EXECUTE prepared_function_evaluation_insert(4);
+EXECUTE prepared_function_evaluation_insert(5);
+EXECUTE prepared_function_evaluation_insert(6);
+SELECT key, value1 FROM prepare_func_table ORDER BY key;
+ key | value1 
+-----+--------
+ 2   |      0
+ 3   |      0
+ 4   |      0
+ 5   |      0
+ 6   |      0
+ 7   |      0
+(6 rows)
+
+TRUNCATE prepare_func_table;
+-- make it a bit harder: parameter wrapped in a function call
+PREPARE wrapped_parameter_evaluation(text,text[]) AS
+	INSERT INTO prepare_func_table (key,value2) VALUES ($1,array_to_string($2,''));
+EXECUTE wrapped_parameter_evaluation('key', ARRAY['value']);
+EXECUTE wrapped_parameter_evaluation('key', ARRAY['value']);
+EXECUTE wrapped_parameter_evaluation('key', ARRAY['value']);
+EXECUTE wrapped_parameter_evaluation('key', ARRAY['value']);
+EXECUTE wrapped_parameter_evaluation('key', ARRAY['value']);
+EXECUTE wrapped_parameter_evaluation('key', ARRAY['value']);
+SELECT key, value2 FROM prepare_func_table;
+ key | value2 
+-----+--------
+ key | value
+ key | value
+ key | value
+ key | value
+ key | value
+ key | value
+(6 rows)
+
+DROP TABLE prepare_func_table;
 -- verify placement state updates invalidate shard state
 --
 -- We use a immutable function to check for that. The planner will


### PR DESCRIPTION
Currently, prepared statements which require function evaluation (e.g. have a default `now()`) don't work because the function evaluation logic throws an error when it runs into an unbound parameter.

This change passes down the PlanState from the executor into the function evaluation logic to be able to evaluate parameters.

Fixes #1317
Fixes #1304 
Fixes #983 