### PR TITLE
Set default value of isactive to true

### DIFF
--- a/src/backend/distributed/citus--6.2-2--6.2-3.sql
+++ b/src/backend/distributed/citus--6.2-2--6.2-3.sql
@@ -2,7 +2,7 @@
 
 SET search_path = 'pg_catalog';
 
-ALTER TABLE pg_dist_node ADD isactive bool;
+ALTER TABLE pg_dist_node ADD isactive bool NOT NULL DEFAULT true;
 
 DROP FUNCTION IF EXISTS master_add_node(text, integer);
 


### PR DESCRIPTION
Fixes #1330 

With this change, we set to default value of isactive column to true so that upgrading users' all nodes will be marked as active to not break their environment.