### PR TITLE
master_citus_tools.c: PVS-Studio: CWE-476 (NULL Pointer Dereference)

### DIFF
--- a/src/backend/distributed/master/master_citus_tools.c
+++ b/src/backend/distributed/master/master_citus_tools.c
@@ -435,18 +435,21 @@ static void
 StoreErrorMessage(PGconn *connection, StringInfo queryResultString)
 {
 	char *errorMessage = PQerrorMessage(connection);
-	char *firstNewlineIndex = strchr(errorMessage, '\n');
-
-	/* trim the error message at the line break */
-	if (firstNewlineIndex != NULL)
-	{
-		*firstNewlineIndex = '\0';
-	}
 
 	/* put a default error message if no error message is reported */
 	if (errorMessage == NULL)
 	{
 		errorMessage = "An error occurred while running the query";
+	}
+	else
+	{
+		char *firstNewlineIndex = strchr(errorMessage, '\n');
+
+		/* trim the error message at the line break */
+		if (firstNewlineIndex != NULL)
+		{
+			*firstNewlineIndex = '\0';
+		}
 	}
 
 	appendStringInfo(queryResultString, "%s", errorMessage);


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com. 

Analyzer warning: [V595](https://www.viva64.com/en/w/V595/) The 'errorMessage' pointer was utilized before it was verified against nullptr. Check lines: 438, 447. master_citus_tools.c 438
