### PR TITLE
colocation_utils.c: PVS-Studio: underflow of the buffer 'values'

### DIFF
--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -638,7 +638,7 @@ UpdateRelationColocationGroup(Oid distributedRelationId, uint32 colocationId)
 							   distributedRelationName)));
 	}
 
-	memset(values, 0, sizeof(replace));
+	memset(values, 0, sizeof(values));
 	memset(isNull, false, sizeof(isNull));
 	memset(replace, false, sizeof(replace));
 


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V512](https://www.viva64.com/en/w/V512/) A call of the 'memset' function will lead to underflow of the buffer 'values'. colocation_utils.c 641