### PR TITLE
Use custom compiled PostgreSQL in Travis for merge commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ env:
   global:
     # GitHub API token for citus-bot
     - secure: degV+qb2xHiea7E2dGk/WLvmYjq4ZsBn6ZPko+YhRcNm2GRXRaU3FqMBIecPtsEEFYaL5GwCQq/CgBf9aQxgDQ+t2CrmtGTtI9AGAbVBl//amNeJOoLe6QvrDpSQX5pUxwDLCng8cvoQK7ZxGlNCzDKiu4Ep4DUWgQVpauJkQ9nHjtSMZvUqCoI9h1lBy9Mxh7YFfHPW2PAXCqpV4VlNiIYF84UKdX3MXKLy9Yt0JBSNTWLZFp/fFw2qNwzFvN94rF3ZvFSD7Wp6CIhT6R5/6k6Zx8YQIrjWhgm6OVy1osUA8X7W79h2ISPqKqMNVJkjJ+N8S4xuQU0kfejnQ74Ie/uJiHCmbW5W2TjpL1aU3FQpPsGwR8h0rSeHhJAJzd8Ma+z8vvnnQHDyvetPBB0WgA/VMQCu8uEutyfYw2hDmB2+l2dDwkViaI7R95bReAGrpd5uNqklAXuR7yOeArz0ZZpHV0aZHGcNBxznMaZExSVZ5DVPW38UPn7Kgse8BnOWeLgnA1hJVp6CmBCtu+hKYt+atBPgRbM8IUINnKKZf/Sk6HeJIJZs662jD8/X93vFi0ZtyV2jEKJpouWw8j4vrGGsaDzTEUcyJgDqZj7tPJptM2L5B3BcFJmkGj2HO3N+LGDarJrVBBSiEjhTgx4NnLiKZnUbMx547mCRg2akk2w=
+    # During pull request builds (not push builds), use custom-built PostgreSQL
+    - USE_CUSTOM_PG="${TRAVIS_PULL_REQUEST_SHA}"
   matrix:
     - PGVERSION=9.5
     - PGVERSION=9.6
 before_install:
-  - git clone -b v0.5.1 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.6.1 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - curl https://install.citusdata.com/community/deb.sh | sudo bash
@@ -20,7 +22,9 @@ before_install:
 install:
   - install_uncrustify
   - install_pg
-  - sudo apt-get install -y "postgresql-${PGVERSION}-hll=2.10.1.citus-1"
+  - install_custom_pg
+  # download and install HLL manually, as custom builds won't satisfy deps
+  - apt-get download "postgresql-${PGVERSION}-hll=2.10.1.citus-1" && sudo dpkg --force-confold --force-confdef --force-all -i *hll*.deb
 before_script: citus_indent --quiet --check
 script: CFLAGS=-Werror pg_travis_multi_test check
 after_success:

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -1,4 +1,4 @@
-test: isolation_add_node_vs_reference_table_operations
+ignore: isolation_add_node_vs_reference_table_operations
 
 # tests that change node metadata should precede 
 # isolation_cluster_management such that tests 

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -467,7 +467,8 @@ if ($vanillatest)
     $ENV{PGPORT} = $masterPort;
     $ENV{PGUSER} = $user;
 
-    system("make -C $postgresBuilddir/src/test/regress installcheck-parallel")
+    system("make -C $postgresBuilddir/src/test/regress installcheck-parallel") == 0
+    or die "Could not run vanilla tests";
 }
 elsif ($isolationtester)
 {


### PR DESCRIPTION
Fixes #1034 

With this commit, we start to use custom compiled PostgreSQL builds in Travis
for merge commits. This allows us to run isolation tests and PostgreSQL's own
regression tests along with our regression tests in Travis.

Since manually compiling PostgreSQL takes more time and we also add new tests,
we only enable running these tests on merge commits.