### PR TITLE
Fix VPATH builds broken in 087d8427e3791.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ include Makefile.global
 all: extension
 
 # build extension
-extension: $(citus_abs_srcdir)/src/include/citus_version.h
+extension: $(citus_top_builddir)/src/include/citus_version.h
 	$(MAKE) -C src/backend/distributed/ all
 install-extension: extension
 	$(MAKE) -C src/backend/distributed/ install
 install-headers: extension
 	$(MKDIR_P) '$(DESTDIR)$(includedir_server)/distributed/'
 # generated headers are located in the build directory
-	$(INSTALL_DATA) $(citus_abs_srcdir)/src/include/citus_version.h '$(DESTDIR)$(includedir_server)/'
+	$(INSTALL_DATA) $(citus_top_builddir)/src/include/citus_version.h '$(DESTDIR)$(includedir_server)/'
 # the rest in the source tree
 	$(INSTALL_DATA) $(citus_abs_srcdir)/src/include/distributed/*.h '$(DESTDIR)$(includedir_server)/distributed/'
 clean-extension:

--- a/Makefile.global.in
+++ b/Makefile.global.in
@@ -69,7 +69,7 @@ endif
 
 # Add options passed to configure or computed therein, to CFLAGS/CPPFLAGS/...
 override CFLAGS += @CFLAGS@ @CITUS_CFLAGS@
-override CPPFLAGS := @CPPFLAGS@ -I '${citus_abs_top_srcdir}/src/include' $(CPPFLAGS)
+override CPPFLAGS := @CPPFLAGS@ -I '${citus_abs_top_srcdir}/src/include' -I'${citus_top_builddir}/src/include' $(CPPFLAGS)
 override LDFLAGS += @LDFLAGS@
 
 # optional file with user defined, additional, rules


### PR DESCRIPTION
1) Generated files reside in the build directory, not the source
   directory.
2) As a generated file is now included in the build, add it to the
   include path (-I)