### PR TITLE
Remove Pruning Debug Output

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2655,12 +2655,7 @@ PruneShardList(Oid relationId, Index tableId, List *whereClauseList,
 			shardPruned = predicate_refuted_by(constraintList, restrictInfoList);
 		}
 
-		if (shardPruned)
-		{
-			ereport(DEBUG2, (errmsg("predicate pruning for shardId "
-									UINT64_FORMAT, shardInterval->shardId)));
-		}
-		else
+		if (!shardPruned)
 		{
 			remainingShardList = lappend(remainingShardList, shardInterval);
 		}

--- a/src/test/regress/expected/multi_hash_pruning.out
+++ b/src/test/regress/expected/multi_hash_pruning.out
@@ -39,9 +39,6 @@ SELECT count(*) FROM orders_hash_partitioned;
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 1;
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -50,9 +47,6 @@ DEBUG:  Plan is router executable
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 2;
-DEBUG:  predicate pruning for shardId 630000
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -61,9 +55,6 @@ DEBUG:  Plan is router executable
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 3;
-DEBUG:  predicate pruning for shardId 630000
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -72,9 +63,6 @@ DEBUG:  Plan is router executable
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 4;
-DEBUG:  predicate pruning for shardId 630000
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -84,9 +72,6 @@ DEBUG:  Plan is router executable
 
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 AND o_clerk = 'aaa';
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -95,9 +80,6 @@ DEBUG:  Plan is router executable
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = abs(-1);
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -114,36 +96,24 @@ SELECT count(*) FROM orders_hash_partitioned;
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 1;
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
  count 
 -------
      0
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 2;
-DEBUG:  predicate pruning for shardId 630000
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
  count 
 -------
      0
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 3;
-DEBUG:  predicate pruning for shardId 630000
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
  count 
 -------
      0
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 4;
-DEBUG:  predicate pruning for shardId 630000
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
  count 
 -------
      0
@@ -151,18 +121,12 @@ DEBUG:  predicate pruning for shardId 630003
 
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 AND o_clerk = 'aaa';
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
  count 
 -------
      0
 (1 row)
 
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = abs(-1);
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
  count 
 -------
      0
@@ -189,10 +153,6 @@ SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey > 2;
 
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 OR o_orderkey = 2;
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
  count 
 -------
      0
@@ -207,10 +167,6 @@ SELECT count(*) FROM orders_hash_partitioned
 
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 OR (o_orderkey = 3 AND o_clerk = 'aaa');
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
  count 
 -------
      0
@@ -225,9 +181,6 @@ SELECT count(*) FROM orders_hash_partitioned
 
 SELECT count(*) FROM
        (SELECT o_orderkey FROM orders_hash_partitioned WHERE o_orderkey = 1) AS orderkeys;
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -282,9 +235,6 @@ SELECT count(*) FROM orders_hash_partitioned
 
 SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = random() AND o_orderkey = 1;
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -318,12 +268,6 @@ SELECT count(*)
 	WHERE orders1.o_orderkey = orders2.o_orderkey
 	AND orders1.o_orderkey = 1
 	AND orders2.o_orderkey is NULL;
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
-DEBUG:  predicate pruning for shardId 630001
-DEBUG:  predicate pruning for shardId 630002
-DEBUG:  predicate pruning for shardId 630003
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -59,21 +59,9 @@ INSERT INTO raw_events_first (user_id, time, value_1, value_2, value_3, value_4)
 SET client_min_messages TO DEBUG2;
 -- raw table to raw table
 INSERT INTO raw_events_second  SELECT * FROM raw_events_first;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- see that our first multi shard INSERT...SELECT works expected
@@ -183,24 +171,9 @@ INSERT INTO raw_events_first (user_id, time) VALUES
 -- try a single shard query
 SET client_min_messages TO DEBUG2;
 INSERT INTO raw_events_second (user_id, time) SELECT user_id, time FROM raw_events_first WHERE user_id = 7;
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300004 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id, "time") SELECT user_id, "time" FROM public.raw_events_first_13300001 raw_events_first WHERE ((user_id = 7) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300006 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300007 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -216,24 +189,9 @@ FROM
    raw_events_first
 WHERE
    user_id = 8;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_first_13300000 raw_events_first WHERE ((user_id = 8) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300005 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300006 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300007 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
 -- a zero shard select
@@ -276,21 +234,9 @@ FROM
 WHERE
    value_3 = 9000 
 RETURNING *;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300000 raw_events_first WHERE ((value_3 = (9000)::double precision) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300001 raw_events_first WHERE ((value_3 = (9000)::double precision) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300002 raw_events_first WHERE ((value_3 = (9000)::double precision) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300003 raw_events_first WHERE ((value_3 = (9000)::double precision) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  Plan is router executable
  user_id | time | value_1 | value_2 | value_3 | value_4 
@@ -307,23 +253,9 @@ FROM
 WHERE
    user_id = 9 OR user_id = 16 
 RETURNING *;
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300004 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300001 raw_events_first WHERE (((user_id = 9) OR (user_id = 16)) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300006 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300003 raw_events_first WHERE (((user_id = 9) OR (user_id = 16)) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "raw_events_second_user_id_value_1_key_13300007"
@@ -337,21 +269,9 @@ FROM
    raw_events_first
 GROUP BY
    user_id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg, value_2_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, avg(value_2) AS avg, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg, value_2_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, avg(value_2) AS avg, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg, value_2_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, avg(value_2) AS avg, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg, value_2_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, avg(value_2) AS avg, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)) GROUP BY user_id
 DEBUG:  Plan is router executable
 -- group by column not exists on the SELECT target list
@@ -363,21 +283,9 @@ FROM
 GROUP BY
    value_2, user_id
 RETURNING *;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)) GROUP BY value_2, user_id RETURNING citus_table_alias.user_id, citus_table_alias.value_1_agg, citus_table_alias.value_2_agg, citus_table_alias.value_3_agg, citus_table_alias.value_4_agg, citus_table_alias.agg_time
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)) GROUP BY value_2, user_id RETURNING citus_table_alias.user_id, citus_table_alias.value_1_agg, citus_table_alias.value_2_agg, citus_table_alias.value_3_agg, citus_table_alias.value_4_agg, citus_table_alias.agg_time
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)) GROUP BY value_2, user_id RETURNING citus_table_alias.user_id, citus_table_alias.value_1_agg, citus_table_alias.value_2_agg, citus_table_alias.value_3_agg, citus_table_alias.value_4_agg, citus_table_alias.agg_time
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)) GROUP BY value_2, user_id RETURNING citus_table_alias.user_id, citus_table_alias.value_1_agg, citus_table_alias.value_2_agg, citus_table_alias.value_3_agg, citus_table_alias.value_4_agg, citus_table_alias.agg_time
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "agg_events_user_id_value_1_agg_key_13300008"
@@ -395,33 +303,9 @@ FROM   (SELECT raw_events_second.user_id AS id,
                raw_events_second 
         WHERE  raw_events_first.user_id = raw_events_second.user_id) AS foo 
 GROUP  BY id; 
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT id, sum(value_1) AS sum FROM (SELECT raw_events_second.user_id AS id, raw_events_second.value_1 FROM public.raw_events_first_13300000 raw_events_first, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id)) foo WHERE ((worker_hash(id) >= '-2147483648'::integer) AND (worker_hash(id) <= '-1073741825'::integer)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT id, sum(value_1) AS sum FROM (SELECT raw_events_second.user_id AS id, raw_events_second.value_1 FROM public.raw_events_first_13300001 raw_events_first, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id)) foo WHERE ((worker_hash(id) >= '-1073741824'::integer) AND (worker_hash(id) <= '-1'::integer)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT id, sum(value_1) AS sum FROM (SELECT raw_events_second.user_id AS id, raw_events_second.value_1 FROM public.raw_events_first_13300002 raw_events_first, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id)) foo WHERE ((worker_hash(id) >= 0) AND (worker_hash(id) <= 1073741823)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT id, sum(value_1) AS sum FROM (SELECT raw_events_second.user_id AS id, raw_events_second.value_1 FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id)) foo WHERE ((worker_hash(id) >= 1073741824) AND (worker_hash(id) <= 2147483647)) GROUP BY id
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "agg_events_user_id_value_1_agg_key_13300008"
@@ -442,33 +326,9 @@ FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
                raw_events_second 
         WHERE  raw_events_first.user_id = raw_events_second.user_id 
         GROUP  BY raw_events_second.user_id) AS foo; 
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg, value_4_agg) SELECT id, v1, v4 FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id) foo WHERE ((worker_hash(id) >= '-2147483648'::integer) AND (worker_hash(id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg, value_4_agg) SELECT id, v1, v4 FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id) foo WHERE ((worker_hash(id) >= '-1073741824'::integer) AND (worker_hash(id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg, value_4_agg) SELECT id, v1, v4 FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id) foo WHERE ((worker_hash(id) >= 0) AND (worker_hash(id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg, value_4_agg) SELECT id, v1, v4 FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id) foo WHERE ((worker_hash(id) >= 1073741824) AND (worker_hash(id) <= 2147483647))
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "agg_events_user_id_value_1_agg_key_13300008"
@@ -497,45 +357,9 @@ FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
         GROUP  BY raw_events_second.user_id
         HAVING SUM(raw_events_second.value_4) > 10) AS foo2 ) as f2
 ON (f.id = f2.id);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((worker_hash(f2.id) >= '-2147483648'::integer) AND (worker_hash(f2.id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((worker_hash(f2.id) >= '-1073741824'::integer) AND (worker_hash(f2.id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((worker_hash(f2.id) >= 0) AND (worker_hash(f2.id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((worker_hash(f2.id) >= 1073741824) AND (worker_hash(f2.id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- add one more level subqueris on top of subquery JOINs
@@ -567,45 +391,9 @@ FROM
 ON (f.id = f2.id)) as outer_most
 GROUP BY
   outer_most.id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= '-2147483648'::integer) AND (worker_hash(id) <= '-1073741825'::integer)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= '-1073741824'::integer) AND (worker_hash(id) <= '-1'::integer)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= 0) AND (worker_hash(id) <= 1073741823)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= 1073741824) AND (worker_hash(id) <= 2147483647)) GROUP BY id
 DEBUG:  Plan is router executable
 -- subqueries in WHERE clause
@@ -616,39 +404,9 @@ FROM   raw_events_first
 WHERE  user_id IN (SELECT user_id
                    FROM   raw_events_second
                    WHERE  user_id = 2);
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300004 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300005 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300006 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300003 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300007 raw_events_second WHERE (raw_events_second.user_id = 2))) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
 INSERT INTO raw_events_second
@@ -659,33 +417,9 @@ WHERE  user_id IN (SELECT user_id
                    FROM   raw_events_second
                    WHERE  user_id != 2 AND value_1 = 2000)
 ON conflict (user_id, value_1) DO NOTHING;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300000 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300004 raw_events_second WHERE ((raw_events_second.user_id <> 2) AND (raw_events_second.value_1 = 2000)))) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))) ON CONFLICT(user_id, value_1) DO NOTHING
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300001 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300005 raw_events_second WHERE ((raw_events_second.user_id <> 2) AND (raw_events_second.value_1 = 2000)))) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))) ON CONFLICT(user_id, value_1) DO NOTHING
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300002 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300006 raw_events_second WHERE ((raw_events_second.user_id <> 2) AND (raw_events_second.value_1 = 2000)))) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))) ON CONFLICT(user_id, value_1) DO NOTHING
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300003 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300007 raw_events_second WHERE ((raw_events_second.user_id <> 2) AND (raw_events_second.value_1 = 2000)))) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))) ON CONFLICT(user_id, value_1) DO NOTHING
 DEBUG:  Plan is router executable
 INSERT INTO raw_events_second
@@ -706,33 +440,9 @@ FROM   raw_events_first
 WHERE  user_id IN (SELECT user_id
                   FROM   raw_events_second
                    WHERE value_1 = 1000 OR value_1 = 2000 OR value_1 = 3000);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300000 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300004 raw_events_second WHERE ((raw_events_second.value_1 = 1000) OR (raw_events_second.value_1 = 2000) OR (raw_events_second.value_1 = 3000)))) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300001 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300005 raw_events_second WHERE ((raw_events_second.value_1 = 1000) OR (raw_events_second.value_1 = 2000) OR (raw_events_second.value_1 = 3000)))) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300002 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300006 raw_events_second WHERE ((raw_events_second.value_1 = 1000) OR (raw_events_second.value_1 = 2000) OR (raw_events_second.value_1 = 3000)))) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300003 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300007 raw_events_second WHERE ((raw_events_second.value_1 = 1000) OR (raw_events_second.value_1 = 2000) OR (raw_events_second.value_1 = 3000)))) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
 -- lets mix subqueries in FROM clause and subqueries in WHERE
@@ -760,57 +470,9 @@ FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
 ON (f.id = f2.id)
 WHERE f.id IN (SELECT user_id
                FROM   raw_events_second);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (1000)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300004 raw_events_second)) AND ((worker_hash(f2.id) >= '-2147483648'::integer) AND (worker_hash(f2.id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (1000)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300005 raw_events_second)) AND ((worker_hash(f2.id) >= '-1073741824'::integer) AND (worker_hash(f2.id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (1000)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300006 raw_events_second)) AND ((worker_hash(f2.id) >= 0) AND (worker_hash(f2.id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.reference_table_13300012 reference_table WHERE (raw_events_first.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (1000)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE ((f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300007 raw_events_second)) AND ((worker_hash(f2.id) >= 1073741824) AND (worker_hash(f2.id) <= 2147483647)))
 DEBUG:  Plan is router executable
 -- some UPSERTS
@@ -828,21 +490,9 @@ ON conflict (user_id, value_1_agg)
 DO UPDATE
    SET    agg_time = EXCLUDED.agg_time 
    WHERE  ae.agg_time < EXCLUDED.agg_time;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time)
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time)
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time)
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time)
 DEBUG:  Plan is router executable
 -- upserts with returning
@@ -861,21 +511,9 @@ DO UPDATE
    SET    agg_time = EXCLUDED.agg_time 
    WHERE  ae.agg_time < EXCLUDED.agg_time
 RETURNING user_id, value_1_agg;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time) RETURNING ae.user_id, ae.value_1_agg
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time) RETURNING ae.user_id, ae.value_1_agg
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time) RETURNING ae.user_id, ae.value_1_agg
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS ae (user_id, value_1_agg, agg_time) SELECT user_id, value_1, "time" FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)) ON CONFLICT(user_id, value_1_agg) DO UPDATE SET agg_time = excluded.agg_time WHERE (ae.agg_time < excluded.agg_time) RETURNING ae.user_id, ae.value_1_agg
 DEBUG:  Plan is router executable
  user_id | value_1_agg 
@@ -888,21 +526,9 @@ SELECT
    user_id, sum(value_1 + value_2)
 FROM
    raw_events_first GROUP BY user_id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) AS sum FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) AS sum FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) AS sum FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) AS sum FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)) GROUP BY user_id
 DEBUG:  Plan is router executable
 --  FILTER CLAUSE
@@ -911,21 +537,9 @@ SELECT
    user_id, sum(value_1 + value_2) FILTER (where value_3 = 15)
 FROM
    raw_events_first GROUP BY user_id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) FILTER (WHERE (value_3 = (15)::double precision)) AS sum FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) FILTER (WHERE (value_3 = (15)::double precision)) AS sum FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) FILTER (WHERE (value_3 = (15)::double precision)) AS sum FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)) GROUP BY user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT user_id, sum((value_1 + value_2)) FILTER (WHERE (value_3 = (15)::double precision)) AS sum FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)) GROUP BY user_id
 DEBUG:  Plan is router executable
 -- a test with reference table JOINs
@@ -939,21 +553,9 @@ WHERE
   raw_events_first.user_id = reference_table.user_id
 GROUP BY
   raw_events_first.user_id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT raw_events_first.user_id, sum(raw_events_first.value_1) AS sum FROM public.reference_table_13300012 reference_table, public.raw_events_first_13300000 raw_events_first WHERE ((raw_events_first.user_id = reference_table.user_id) AND ((worker_hash(raw_events_first.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1073741825'::integer))) GROUP BY raw_events_first.user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT raw_events_first.user_id, sum(raw_events_first.value_1) AS sum FROM public.reference_table_13300012 reference_table, public.raw_events_first_13300001 raw_events_first WHERE ((raw_events_first.user_id = reference_table.user_id) AND ((worker_hash(raw_events_first.user_id) >= '-1073741824'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1'::integer))) GROUP BY raw_events_first.user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT raw_events_first.user_id, sum(raw_events_first.value_1) AS sum FROM public.reference_table_13300012 reference_table, public.raw_events_first_13300002 raw_events_first WHERE ((raw_events_first.user_id = reference_table.user_id) AND ((worker_hash(raw_events_first.user_id) >= 0) AND (worker_hash(raw_events_first.user_id) <= 1073741823))) GROUP BY raw_events_first.user_id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT raw_events_first.user_id, sum(raw_events_first.value_1) AS sum FROM public.reference_table_13300012 reference_table, public.raw_events_first_13300003 raw_events_first WHERE ((raw_events_first.user_id = reference_table.user_id) AND ((worker_hash(raw_events_first.user_id) >= 1073741824) AND (worker_hash(raw_events_first.user_id) <= 2147483647))) GROUP BY raw_events_first.user_id
 DEBUG:  Plan is router executable
 -- a note on the outer joins is that
@@ -1000,33 +602,9 @@ SELECT t1.user_id AS col1,
 FROM   raw_events_first t1
        FULL JOIN raw_events_second t2
               ON t1.user_id = t2.user_id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT t1.user_id AS col1, t2.user_id AS col2 FROM (public.raw_events_first_13300000 t1 FULL JOIN public.raw_events_second_13300004 t2 ON ((t1.user_id = t2.user_id))) WHERE ((worker_hash(t1.user_id) >= '-2147483648'::integer) AND (worker_hash(t1.user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT t1.user_id AS col1, t2.user_id AS col2 FROM (public.raw_events_first_13300001 t1 FULL JOIN public.raw_events_second_13300005 t2 ON ((t1.user_id = t2.user_id))) WHERE ((worker_hash(t1.user_id) >= '-1073741824'::integer) AND (worker_hash(t1.user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT t1.user_id AS col1, t2.user_id AS col2 FROM (public.raw_events_first_13300002 t1 FULL JOIN public.raw_events_second_13300006 t2 ON ((t1.user_id = t2.user_id))) WHERE ((worker_hash(t1.user_id) >= 0) AND (worker_hash(t1.user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT t1.user_id AS col1, t2.user_id AS col2 FROM (public.raw_events_first_13300003 t1 FULL JOIN public.raw_events_second_13300007 t2 ON ((t1.user_id = t2.user_id))) WHERE ((worker_hash(t1.user_id) >= 1073741824) AND (worker_hash(t1.user_id) <= 2147483647))
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -1060,21 +638,9 @@ INSERT INTO agg_events (value_1_agg, user_id)
     DISTINCT value_1, user_id
   FROM
     raw_events_first;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT user_id, value_1 FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT user_id, value_1 FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT user_id, value_1 FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT user_id, value_1 FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- we don't want to see constraint vialotions, so truncate first
@@ -1106,21 +672,9 @@ INSERT INTO agg_events
     raw_events_first.user_id, (SELECT * FROM sub_cte)
   FROM
     raw_events_first;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) WITH sub_cte AS (SELECT 1) SELECT user_id, (SELECT sub_cte."?column?" FROM sub_cte) FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) WITH sub_cte AS (SELECT 1) SELECT user_id, (SELECT sub_cte."?column?" FROM sub_cte) FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) WITH sub_cte AS (SELECT 1) SELECT user_id, (SELECT sub_cte."?column?" FROM sub_cte) FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) WITH sub_cte AS (SELECT 1) SELECT user_id, (SELECT sub_cte."?column?" FROM sub_cte) FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- We do not support any set operations
@@ -1153,33 +707,9 @@ ERROR:  Set operations are not allowed in INSERT ... SELECT queries
    raw_events_first.user_id
  FROM
    raw_events_first  LEFT JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.user_id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300000 raw_events_first LEFT JOIN public.raw_events_second_13300004 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_first.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300001 raw_events_first LEFT JOIN public.raw_events_second_13300005 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_first.user_id) >= '-1073741824'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300002 raw_events_first LEFT JOIN public.raw_events_second_13300006 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_first.user_id) >= 0) AND (worker_hash(raw_events_first.user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300003 raw_events_first LEFT JOIN public.raw_events_second_13300007 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_first.user_id) >= 1073741824) AND (worker_hash(raw_events_first.user_id) <= 2147483647))
 DEBUG:  Plan is router executable
  
@@ -1188,21 +718,9 @@ DEBUG:  Plan is router executable
    raw_events_second.user_id
  FROM
    reference_table LEFT JOIN raw_events_second ON reference_table.user_id = raw_events_second.user_id;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT raw_events_second.user_id FROM (public.reference_table_13300012 reference_table LEFT JOIN public.raw_events_second_13300004 raw_events_second ON ((reference_table.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_second.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_second.user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT raw_events_second.user_id FROM (public.reference_table_13300012 reference_table LEFT JOIN public.raw_events_second_13300005 raw_events_second ON ((reference_table.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_second.user_id) >= '-1073741824'::integer) AND (worker_hash(raw_events_second.user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT raw_events_second.user_id FROM (public.reference_table_13300012 reference_table LEFT JOIN public.raw_events_second_13300006 raw_events_second ON ((reference_table.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_second.user_id) >= 0) AND (worker_hash(raw_events_second.user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT raw_events_second.user_id FROM (public.reference_table_13300012 reference_table LEFT JOIN public.raw_events_second_13300007 raw_events_second ON ((reference_table.user_id = raw_events_second.user_id))) WHERE ((worker_hash(raw_events_second.user_id) >= 1073741824) AND (worker_hash(raw_events_second.user_id) <= 2147483647))
 DEBUG:  Plan is router executable
  
@@ -1212,39 +730,9 @@ DEBUG:  Plan is router executable
  FROM
    raw_events_first LEFT JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.user_id
    WHERE raw_events_first.user_id = 10;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300000 raw_events_first LEFT JOIN public.raw_events_second_13300004 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_first.user_id = 10) AND ((worker_hash(raw_events_first.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300009 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300010 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300011 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
  
@@ -1254,35 +742,9 @@ DEBUG:  Plan is router executable
  FROM
    raw_events_first LEFT JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.user_id
    WHERE raw_events_second.user_id = 10 OR raw_events_second.user_id = 11;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300000 raw_events_first LEFT JOIN public.raw_events_second_13300004 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE (((raw_events_second.user_id = 10) OR (raw_events_second.user_id = 11)) AND ((worker_hash(raw_events_first.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300001 raw_events_first LEFT JOIN (SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", NULL::integer AS value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 WHERE false) raw_events_second(user_id, "time", value_1, value_2, value_3, value_4) ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE (((raw_events_second.user_id = 10) OR (raw_events_second.user_id = 11)) AND ((worker_hash(raw_events_first.user_id) >= '-1073741824'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300002 raw_events_first LEFT JOIN (SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", NULL::integer AS value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 WHERE false) raw_events_second(user_id, "time", value_1, value_2, value_3, value_4) ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE (((raw_events_second.user_id = 10) OR (raw_events_second.user_id = 11)) AND ((worker_hash(raw_events_first.user_id) >= 0) AND (worker_hash(raw_events_first.user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300003 raw_events_first LEFT JOIN public.raw_events_second_13300007 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE (((raw_events_second.user_id = 10) OR (raw_events_second.user_id = 11)) AND ((worker_hash(raw_events_first.user_id) >= 1073741824) AND (worker_hash(raw_events_first.user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
  
@@ -1318,39 +780,15 @@ DEBUG:  Plan is router executable
    WHERE raw_events_first.user_id IN (19, 20, 21);
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300000 raw_events_first LEFT JOIN public.raw_events_second_13300004 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_first.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1073741825'::integer)))
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300001 raw_events_first LEFT JOIN public.raw_events_second_13300005 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_first.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= '-1073741824'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1'::integer)))
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300002 raw_events_first LEFT JOIN public.raw_events_second_13300006 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_first.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= 0) AND (worker_hash(raw_events_first.user_id) <= 1073741823)))
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300003 raw_events_first LEFT JOIN public.raw_events_second_13300007 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_first.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= 1073741824) AND (worker_hash(raw_events_first.user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
  
@@ -1360,41 +798,17 @@ DEBUG:  Plan is router executable
  FROM
    raw_events_first INNER JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.user_id
    WHERE raw_events_second.user_id IN (19, 20, 21);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300000 raw_events_first JOIN public.raw_events_second_13300004 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_second.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= '-2147483648'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300001 raw_events_first JOIN public.raw_events_second_13300005 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_second.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= '-1073741824'::integer) AND (worker_hash(raw_events_first.user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300002 raw_events_first JOIN public.raw_events_second_13300006 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_second.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= 0) AND (worker_hash(raw_events_first.user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 NOTICE:  cannot use shard pruning with ANY/ALL (array expression)
 HINT:  Consider rewriting the expression with OR/AND clauses.
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id) SELECT raw_events_first.user_id FROM (public.raw_events_first_13300003 raw_events_first JOIN public.raw_events_second_13300007 raw_events_second ON ((raw_events_first.user_id = raw_events_second.user_id))) WHERE ((raw_events_second.user_id = ANY (ARRAY[19, 20, 21])) AND ((worker_hash(raw_events_first.user_id) >= 1073741824) AND (worker_hash(raw_events_first.user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
  
@@ -1471,9 +885,6 @@ FROM
   raw_events_first LEFT JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.value_1
 WHERE 
   raw_events_first.user_id = 10;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Select query cannot be pushed down to the worker.
  
@@ -1484,9 +895,6 @@ DETAIL:  Select query cannot be pushed down to the worker.
  FROM
    raw_events_first INNER JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.value_1
  WHERE raw_events_first.user_id = 10;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Select query cannot be pushed down to the worker.
  
@@ -1915,54 +1323,9 @@ FROM   raw_events_first
 WHERE  user_id IN (SELECT raw_events_second.user_id
                    FROM   raw_events_second, raw_events_first
                    WHERE  raw_events_second.user_id = raw_events_first.user_id AND raw_events_first.user_id = 200);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300000 raw_events_first WHERE ((user_id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300004 raw_events_second, public.raw_events_first_13300000 raw_events_first_1 WHERE ((raw_events_second.user_id = raw_events_first_1.user_id) AND (raw_events_first_1.user_id = 200)))) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300005 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300006 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  Skipping target shard interval 13300007 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
 -- we cannot push this down since it is NOT IN
@@ -1973,12 +1336,6 @@ FROM   raw_events_first
 WHERE  user_id NOT IN (SELECT raw_events_second.user_id
                    FROM   raw_events_second, raw_events_first
                    WHERE  raw_events_second.user_id = raw_events_first.user_id AND raw_events_first.user_id = 200);
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Select query cannot be pushed down to the worker.
 -- safe to push down
@@ -1989,33 +1346,9 @@ FROM   raw_events_first
 WHERE  EXISTS (SELECT 1
                    FROM   raw_events_second
                    WHERE  raw_events_second.user_id =raw_events_first.user_id);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300000 raw_events_first WHERE ((EXISTS (SELECT 1 FROM public.raw_events_second_13300004 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id))) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300001 raw_events_first WHERE ((EXISTS (SELECT 1 FROM public.raw_events_second_13300005 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id))) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300002 raw_events_first WHERE ((EXISTS (SELECT 1 FROM public.raw_events_second_13300006 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id))) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300003 raw_events_first WHERE ((EXISTS (SELECT 1 FROM public.raw_events_second_13300007 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id))) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
 -- we cannot push down
@@ -2026,33 +1359,9 @@ FROM   raw_events_first
 WHERE  NOT EXISTS (SELECT 1
                    FROM   raw_events_second
                    WHERE  raw_events_second.user_id =raw_events_first.user_id);
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300000 raw_events_first WHERE ((NOT (EXISTS (SELECT 1 FROM public.raw_events_second_13300004 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id)))) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300001 raw_events_first WHERE ((NOT (EXISTS (SELECT 1 FROM public.raw_events_second_13300005 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id)))) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300002 raw_events_first WHERE ((NOT (EXISTS (SELECT 1 FROM public.raw_events_second_13300006 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id)))) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300003 raw_events_first WHERE ((NOT (EXISTS (SELECT 1 FROM public.raw_events_second_13300007 raw_events_second WHERE (raw_events_second.user_id = raw_events_first.user_id)))) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
 -- more complex LEFT JOINs 
@@ -2084,45 +1393,9 @@ DEBUG:  Plan is router executable
  ON (f.id = f2.id)) as outer_most
  GROUP BY
    outer_most.id;
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT raw_events_first.user_id AS id FROM (public.raw_events_first_13300000 raw_events_first LEFT JOIN public.reference_table_13300012 reference_table ON ((raw_events_first.user_id = reference_table.user_id)))) foo) f LEFT JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300000 raw_events_first, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= '-2147483648'::integer) AND (worker_hash(id) <= '-1073741825'::integer)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT raw_events_first.user_id AS id FROM (public.raw_events_first_13300001 raw_events_first LEFT JOIN public.reference_table_13300012 reference_table ON ((raw_events_first.user_id = reference_table.user_id)))) foo) f LEFT JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300001 raw_events_first, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= '-1073741824'::integer) AND (worker_hash(id) <= '-1'::integer)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT raw_events_first.user_id AS id FROM (public.raw_events_first_13300002 raw_events_first LEFT JOIN public.reference_table_13300012 reference_table ON ((raw_events_first.user_id = reference_table.user_id)))) foo) f LEFT JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300002 raw_events_first, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= 0) AND (worker_hash(id) <= 1073741823)) GROUP BY id
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_4_agg) SELECT id, max(value) AS max FROM (SELECT f2.id, f2.v4 AS value FROM ((SELECT foo.id FROM (SELECT raw_events_first.user_id AS id FROM (public.raw_events_first_13300003 raw_events_first LEFT JOIN public.reference_table_13300012 reference_table ON ((raw_events_first.user_id = reference_table.user_id)))) foo) f LEFT JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id)))) outer_most WHERE ((worker_hash(id) >= 1073741824) AND (worker_hash(id) <= 2147483647)) GROUP BY id
 DEBUG:  Plan is router executable
 -- cannot push down since the f.id IN is matched with value_1
@@ -2184,69 +1457,9 @@ FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
 ON (f.id = f2.id)
 WHERE f.id IN (SELECT user_id
                FROM   raw_events_second));
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300004 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300000 raw_events_first WHERE ((user_id IN (SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300000 raw_events_first_1, public.reference_table_13300012 reference_table WHERE (raw_events_first_1.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first_1.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300000 raw_events_first_1, public.raw_events_second_13300004 raw_events_second WHERE (raw_events_first_1.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE (f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300004 raw_events_second)))) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300005 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300001 raw_events_first WHERE ((user_id IN (SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300001 raw_events_first_1, public.reference_table_13300012 reference_table WHERE (raw_events_first_1.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first_1.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300001 raw_events_first_1, public.raw_events_second_13300005 raw_events_second WHERE (raw_events_first_1.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE (f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300005 raw_events_second)))) AND ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300003
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300006 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300002 raw_events_first WHERE ((user_id IN (SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300002 raw_events_first_1, public.reference_table_13300012 reference_table WHERE (raw_events_first_1.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first_1.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300002 raw_events_first_1, public.raw_events_second_13300006 raw_events_second WHERE (raw_events_first_1.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE (f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300006 raw_events_second)))) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300000
-DEBUG:  predicate pruning for shardId 13300001
-DEBUG:  predicate pruning for shardId 13300002
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id) SELECT user_id FROM public.raw_events_first_13300003 raw_events_first WHERE ((user_id IN (SELECT f2.id FROM ((SELECT foo.id FROM (SELECT reference_table.user_id AS id FROM public.raw_events_first_13300003 raw_events_first_1, public.reference_table_13300012 reference_table WHERE (raw_events_first_1.user_id = reference_table.user_id)) foo) f JOIN (SELECT foo2.v4, foo2.v1, foo2.id FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first_1.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first_1, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first_1.user_id = raw_events_second.user_id) GROUP BY raw_events_second.user_id HAVING (sum(raw_events_second.value_4) > (10)::numeric)) foo2) f2 ON ((f.id = f2.id))) WHERE (f.id IN (SELECT raw_events_second.user_id FROM public.raw_events_second_13300007 raw_events_second)))) AND ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647)))
 DEBUG:  Plan is router executable
 -- cannot push down since top level user_id is matched with NOT IN
@@ -2400,21 +1613,9 @@ truncate raw_events_first;
 SET client_min_messages TO DEBUG2;
 -- first show that the query works now
 INSERT INTO raw_events_first SELECT * FROM raw_events_second;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300004 raw_events_second WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300001 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300005 raw_events_second WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300006 raw_events_second WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300003 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300007 raw_events_second WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -2422,24 +1623,9 @@ truncate raw_events_first;
 SET client_min_messages TO DEBUG2;
 -- now show that it works for a single shard query as well
 INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 5;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300004 raw_events_second WHERE ((user_id = 5) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300001 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300002 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300003 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -2449,38 +1635,17 @@ truncate raw_events_first;
 SET client_min_messages TO DEBUG2;
 -- this should fail
 INSERT INTO raw_events_first SELECT * FROM raw_events_second;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Insert query cannot be executed on all placements for shard 13300000
 -- this should also fail
 INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 5;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 ERROR:  cannot perform distributed planning for the given modification
 DETAIL:  Insert query cannot be executed on all placements for shard 13300000
 -- but this should work given that it hits different shard
 INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 6;
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300000 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300001 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300006 raw_events_second WHERE ((user_id = 6) AND ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823)))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300003 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -2492,21 +1657,9 @@ truncate raw_events_first;
 SET client_min_messages TO DEBUG2;
 -- this should work
 INSERT INTO raw_events_first SELECT * FROM raw_events_second;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300004 raw_events_second WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300001 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300005 raw_events_second WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300006 raw_events_second WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300003 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300007 raw_events_second WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -2514,24 +1667,9 @@ truncate raw_events_first;
 SET client_min_messages TO DEBUG2;
 -- this should also work
 INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 5;
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, "time", value_1, value_2, value_3, value_4) SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.raw_events_second_13300004 raw_events_second WHERE ((user_id = 5) AND ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer)))
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300001 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300002 since SELECT query for it pruned away
-DEBUG:  predicate pruning for shardId 13300004
-DEBUG:  predicate pruning for shardId 13300005
-DEBUG:  predicate pruning for shardId 13300006
-DEBUG:  predicate pruning for shardId 13300007
 DEBUG:  Skipping target shard interval 13300003 since SELECT query for it pruned away
 DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
@@ -2584,9 +1722,7 @@ SELECT create_distributed_table('table_with_defaults', 'store_id');
 SET client_min_messages TO DEBUG2;
 -- a very simple query
 INSERT INTO table_with_defaults SELECT * FROM table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, first_name, default_1, last_name, default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, first_name, default_1, last_name, default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- see that defaults are filled
@@ -2595,9 +1731,7 @@ SELECT
   store_id, first_name
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, first_name, 1 AS default_1, '2'::text AS default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, first_name, 1 AS default_1, '2'::text AS default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- shuffle one of the defaults and skip the other
@@ -2606,9 +1740,7 @@ SELECT
   default_2, store_id, first_name
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, first_name, 1 AS default_1, default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, first_name, 1 AS default_1, default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- shuffle both defaults
@@ -2617,9 +1749,7 @@ SELECT
   default_2, store_id, default_1, first_name
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, first_name, default_1, default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, first_name, default_1, default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- use constants instead of non-default column
@@ -2628,9 +1758,7 @@ SELECT
   default_2, 'Freund', store_id, 'Andres'
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, 'Andres'::text AS first_name, 1 AS default_1, 'Freund'::text AS last_name, default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, 'Andres'::text AS first_name, 1 AS default_1, 'Freund'::text AS last_name, default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- use constants instead of non-default column and skip both defauls
@@ -2639,9 +1767,7 @@ SELECT
   'Freund', store_id, 'Andres'
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, 'Andres'::text AS first_name, 1 AS default_1, 'Freund'::text AS last_name, '2'::text AS default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, 'Andres'::text AS first_name, 1 AS default_1, 'Freund'::text AS last_name, '2'::text AS default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- use constants instead of default columns
@@ -2650,9 +1776,7 @@ SELECT
   20, last_name, store_id, first_name, 10
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, first_name, 10, last_name, 20 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, first_name, 10, last_name, 20 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- use constants instead of both default columns and non-default columns
@@ -2661,9 +1785,7 @@ SELECT
   20, 'Freund', store_id, 'Andres', 10
 FROM
   table_with_defaults;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, 'Andres'::text AS first_name, 10, 'Freund'::text AS last_name, 20 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer))
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, last_name, default_2) SELECT store_id, 'Andres'::text AS first_name, 10, 'Freund'::text AS last_name, 20 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647))
 DEBUG:  Plan is router executable
 -- some of the the ultimate queries where we have constants,
@@ -2675,9 +1797,7 @@ FROM
   table_with_defaults
 GROUP BY
   last_name, store_id;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1 AS default_1, '2000'::text AS default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer)) GROUP BY last_name, store_id
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1 AS default_1, '2000'::text AS default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647)) GROUP BY last_name, store_id
 DEBUG:  Plan is router executable
 INSERT INTO table_with_defaults (default_1, store_id, first_name, default_2)
@@ -2687,9 +1807,7 @@ FROM
   table_with_defaults
 GROUP BY
   last_name, store_id, first_name;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1000, '2000'::text AS default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer)) GROUP BY last_name, store_id, first_name
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1000, '2000'::text AS default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647)) GROUP BY last_name, store_id, first_name
 DEBUG:  Plan is router executable
 INSERT INTO table_with_defaults (default_1, store_id, first_name, default_2)
@@ -2699,9 +1817,7 @@ FROM
   table_with_defaults
 GROUP BY
   last_name, store_id, first_name, default_2;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1000, '2000'::text AS default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer)) GROUP BY last_name, store_id, first_name, default_2
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1000, '2000'::text AS default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647)) GROUP BY last_name, store_id, first_name, default_2
 DEBUG:  Plan is router executable
 INSERT INTO table_with_defaults (default_1, store_id, first_name)
@@ -2711,9 +1827,7 @@ FROM
   table_with_defaults
 GROUP BY
   last_name, store_id, first_name, default_2;
-DEBUG:  predicate pruning for shardId 13300018
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300017 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1000, '2'::text AS default_2 FROM public.table_with_defaults_13300017 table_with_defaults WHERE ((worker_hash(store_id) >= '-2147483648'::integer) AND (worker_hash(store_id) <= '-1'::integer)) GROUP BY last_name, store_id, first_name, default_2
-DEBUG:  predicate pruning for shardId 13300017
 DEBUG:  distributed statement: INSERT INTO public.table_with_defaults_13300018 AS citus_table_alias (store_id, first_name, default_1, default_2) SELECT store_id, 'Andres'::text AS first_name, 1000, '2'::text AS default_2 FROM public.table_with_defaults_13300018 table_with_defaults WHERE ((worker_hash(store_id) >= 0) AND (worker_hash(store_id) <= 2147483647)) GROUP BY last_name, store_id, first_name, default_2
 DEBUG:  Plan is router executable
 RESET client_min_messages;

--- a/src/test/regress/expected/multi_join_pruning.out
+++ b/src/test/regress/expected/multi_join_pruning.out
@@ -25,10 +25,6 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
 
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey AND l_orderkey > 9030;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
 DEBUG:  join prunable for intervals [8997,10560] and [1,5986]
 DEBUG:  join prunable for intervals [10560,12036] and [1,5986]
 DEBUG:  join prunable for intervals [12036,13473] and [1,5986]
@@ -42,14 +38,6 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
 -- works as expected in this case.
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey AND l_orderkey > 20000;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290004
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  sum | avg 
 -----+-----
      |    
@@ -60,11 +48,6 @@ DEBUG:  predicate pruning for shardId 290007
 -- out all the shards, and leave us with an empty task list.
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey AND l_orderkey > 6000 AND o_orderkey < 6000;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290009
 DEBUG:  join prunable for intervals [8997,10560] and [1,5986]
 DEBUG:  join prunable for intervals [10560,12036] and [1,5986]
 DEBUG:  join prunable for intervals [12036,13473] and [1,5986]

--- a/src/test/regress/expected/multi_large_table_pruning.out
+++ b/src/test/regress/expected/multi_large_table_pruning.out
@@ -9,6 +9,36 @@ SET citus.large_table_shard_count TO 2;
 SET client_min_messages TO DEBUG2;
 SET citus.task_executor_type TO 'task-tracker';
 -- Single range-repartition join to test join-pruning behaviour.
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey;
+DEBUG:  join prunable for intervals [1,1000] and [1001,2000]
+DEBUG:  join prunable for intervals [1,1000] and [6001,7000]
+DEBUG:  join prunable for intervals [1001,2000] and [1,1000]
+DEBUG:  join prunable for intervals [1001,2000] and [6001,7000]
+DEBUG:  join prunable for intervals [6001,7000] and [1,1000]
+DEBUG:  join prunable for intervals [6001,7000] and [1001,2000]
+DEBUG:  pruning merge fetch taskId 1
+DETAIL:  Creating dependency on merge taskId 5
+DEBUG:  pruning merge fetch taskId 4
+DETAIL:  Creating dependency on merge taskId 8
+DEBUG:  pruning merge fetch taskId 7
+DETAIL:  Creating dependency on merge taskId 11
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Task-Tracker)
+         Task Count: 3
+         Tasks Shown: None, not supported for re-partition queries
+         ->  MapMergeJob
+               Map Task Count: 2
+               Merge Task Count: 3
+(7 rows)
+
 SELECT
 	count(*)
 FROM
@@ -34,6 +64,25 @@ DETAIL:  Creating dependency on merge taskId 11
 
 -- Single range-repartition join with a selection clause on the partitioned
 -- table to test the case when all map tasks are pruned away.
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey AND
+	o_orderkey < 0;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Task-Tracker)
+         Task Count: 0
+         Tasks Shown: None, not supported for re-partition queries
+         ->  MapMergeJob
+               Map Task Count: 0
+               Merge Task Count: 0
+(7 rows)
+
 SELECT
 	count(*)
 FROM
@@ -48,6 +97,25 @@ WHERE
 
 -- Single range-repartition join with a selection clause on the base table to
 -- test the case when all sql tasks are pruned away.
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey AND
+	c_custkey < 0;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Task-Tracker)
+         Task Count: 0
+         Tasks Shown: None, not supported for re-partition queries
+         ->  MapMergeJob
+               Map Task Count: 2
+               Merge Task Count: 3
+(7 rows)
+
 SELECT
 	count(*)
 FROM
@@ -63,6 +131,55 @@ WHERE
 -- Dual hash-repartition join test case. Note that this query doesn't produce
 -- meaningful results and is only to test hash-partitioning of two large tables
 -- on non-partition columns.
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	lineitem, customer
+WHERE
+	l_partkey = c_nationkey;
+DEBUG:  join prunable for task partitionId 0 and 1
+DEBUG:  join prunable for task partitionId 0 and 2
+DEBUG:  join prunable for task partitionId 0 and 3
+DEBUG:  join prunable for task partitionId 1 and 0
+DEBUG:  join prunable for task partitionId 1 and 2
+DEBUG:  join prunable for task partitionId 1 and 3
+DEBUG:  join prunable for task partitionId 2 and 0
+DEBUG:  join prunable for task partitionId 2 and 1
+DEBUG:  join prunable for task partitionId 2 and 3
+DEBUG:  join prunable for task partitionId 3 and 0
+DEBUG:  join prunable for task partitionId 3 and 1
+DEBUG:  join prunable for task partitionId 3 and 2
+DEBUG:  pruning merge fetch taskId 1
+DETAIL:  Creating dependency on merge taskId 17
+DEBUG:  pruning merge fetch taskId 2
+DETAIL:  Creating dependency on merge taskId 7
+DEBUG:  pruning merge fetch taskId 4
+DETAIL:  Creating dependency on merge taskId 26
+DEBUG:  pruning merge fetch taskId 5
+DETAIL:  Creating dependency on merge taskId 11
+DEBUG:  pruning merge fetch taskId 7
+DETAIL:  Creating dependency on merge taskId 35
+DEBUG:  pruning merge fetch taskId 8
+DETAIL:  Creating dependency on merge taskId 15
+DEBUG:  pruning merge fetch taskId 10
+DETAIL:  Creating dependency on merge taskId 44
+DEBUG:  pruning merge fetch taskId 11
+DETAIL:  Creating dependency on merge taskId 19
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Task-Tracker)
+         Task Count: 4
+         Tasks Shown: None, not supported for re-partition queries
+         ->  MapMergeJob
+               Map Task Count: 8
+               Merge Task Count: 4
+         ->  MapMergeJob
+               Map Task Count: 3
+               Merge Task Count: 4
+(10 rows)
+
 SELECT
 	count(*)
 FROM
@@ -104,6 +221,28 @@ DETAIL:  Creating dependency on merge taskId 19
 
 -- Dual hash-repartition join with a selection clause on one of the tables to
 -- test the case when all map tasks are pruned away.
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	lineitem, customer
+WHERE
+	l_partkey = c_nationkey AND
+	l_orderkey < 0;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Task-Tracker)
+         Task Count: 0
+         Tasks Shown: None, not supported for re-partition queries
+         ->  MapMergeJob
+               Map Task Count: 0
+               Merge Task Count: 0
+         ->  MapMergeJob
+               Map Task Count: 3
+               Merge Task Count: 4
+(10 rows)
+
 SELECT
 	count(*)
 FROM
@@ -117,6 +256,24 @@ WHERE
 (1 row)
 
 -- Test cases with false in the WHERE clause
+EXPLAIN (COSTS OFF)
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey)
+WHERE
+	false;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Custom Scan (Citus Task-Tracker)
+   Task Count: 0
+   Tasks Shown: None, not supported for re-partition queries
+   ->  MapMergeJob
+         Map Task Count: 0
+         Merge Task Count: 0
+(6 rows)
+
+-- execute once, to verify that's handled
 SELECT
 	o_orderkey
 FROM
@@ -127,31 +284,46 @@ WHERE
 ------------
 (0 rows)
 
+EXPLAIN (COSTS OFF)
 SELECT
 	o_orderkey
 FROM
 	orders INNER JOIN customer ON (o_custkey = c_custkey)
 WHERE
 	1=0 AND c_custkey < 0;
- o_orderkey 
-------------
-(0 rows)
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Custom Scan (Citus Task-Tracker)
+   Task Count: 0
+   Tasks Shown: None, not supported for re-partition queries
+   ->  MapMergeJob
+         Map Task Count: 0
+         Merge Task Count: 0
+(6 rows)
 
+EXPLAIN (COSTS OFF)
 SELECT
 	o_orderkey
 FROM
 	orders INNER JOIN customer ON (o_custkey = c_custkey AND false);
- o_orderkey 
-------------
-(0 rows)
+            QUERY PLAN            
+----------------------------------
+ Custom Scan (Citus Task-Tracker)
+   Task Count: 0
+   Tasks Shown: All
+(3 rows)
 
+EXPLAIN (COSTS OFF)
 SELECT
 	o_orderkey
 FROM
 	orders, customer
 WHERE
 	o_custkey = c_custkey AND false;
- o_orderkey 
-------------
-(0 rows)
+            QUERY PLAN            
+----------------------------------
+ Custom Scan (Citus Task-Tracker)
+   Task Count: 0
+   Tasks Shown: All
+(3 rows)
 

--- a/src/test/regress/expected/multi_large_table_pruning.out
+++ b/src/test/regress/expected/multi_large_table_pruning.out
@@ -41,8 +41,6 @@ FROM
 WHERE
 	o_custkey = c_custkey AND
 	o_orderkey < 0;
-DEBUG:  predicate pruning for shardId 290008
-DEBUG:  predicate pruning for shardId 290009
  count 
 -------
      0
@@ -57,9 +55,6 @@ FROM
 WHERE
 	o_custkey = c_custkey AND
 	c_custkey < 0;
-DEBUG:  predicate pruning for shardId 290010
-DEBUG:  predicate pruning for shardId 280001
-DEBUG:  predicate pruning for shardId 280000
  count 
 -------
      0
@@ -116,14 +111,6 @@ FROM
 WHERE
 	l_partkey = c_nationkey AND
 	l_orderkey < 0;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290004
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  count 
 -------
      0

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -118,7 +118,6 @@ INSERT INTO append_partitioned VALUES (414123, 'AAPL', 9580, '2004-10-19 10:23:5
 SET client_min_messages TO 'DEBUG2';
 SET citus.task_executor_type TO 'real-time';
 SELECT * FROM range_partitioned WHERE id = 32743;
-DEBUG:  predicate pruning for shardId 750006
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   id   | symbol | bidder_id |        placed_at         | kind | limit_price 
@@ -127,7 +126,6 @@ DEBUG:  Plan is router executable
 (1 row)
 
 SELECT * FROM append_partitioned WHERE id = 414123;
-DEBUG:  predicate pruning for shardId 750008
 DEBUG:  Plan is router executable
    id   | symbol | bidder_id |        placed_at         | kind | limit_price 
 --------+--------+-----------+--------------------------+------+-------------

--- a/src/test/regress/expected/multi_mx_router_planner.out
+++ b/src/test/regress/expected/multi_mx_router_planner.out
@@ -67,7 +67,6 @@ DEBUG:  Plan is router executable
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles_hash_mx WHERE author_id = 10 AND id = 50;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |   title   | word_count 
@@ -77,7 +76,6 @@ DEBUG:  Plan is router executable
 
 -- get all titles by a single author
 SELECT title FROM articles_hash_mx WHERE author_id = 10;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    title    
@@ -93,7 +91,6 @@ DEBUG:  Plan is router executable
 SELECT title, word_count FROM articles_hash_mx
 	WHERE author_id = 10
 	ORDER BY word_count DESC NULLS LAST;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    title    | word_count 
@@ -110,7 +107,6 @@ SELECT title, id FROM articles_hash_mx
 	WHERE author_id = 5
 	ORDER BY id
 	LIMIT 2;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   title  | id 
@@ -124,7 +120,6 @@ DEBUG:  Plan is router executable
 SELECT title, author_id FROM articles_hash_mx
 	WHERE author_id = 7 OR author_id = 8
 	ORDER BY author_id ASC, id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title    | author_id 
@@ -144,7 +139,6 @@ DEBUG:  Plan is router executable
 -- same query is router executable with no order by
 SELECT title, author_id FROM articles_hash_mx
 	WHERE author_id = 7 OR author_id = 8;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title    | author_id 
@@ -168,7 +162,6 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash_mx
 	GROUP BY author_id
 	HAVING sum(word_count) > 1000
 	ORDER BY sum(word_count) DESC;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  author_id | corpus_size 
@@ -185,7 +178,6 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash_mx
 	GROUP BY author_id
 	HAVING sum(word_count) > 1000
 	ORDER BY sum(word_count) DESC;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  author_id | corpus_size 
@@ -227,7 +219,6 @@ HINT:  Consider rewriting the expression with OR/AND clauses.
 -- queries with CTEs are supported
 WITH first_author AS ( SELECT id FROM articles_hash_mx WHERE author_id = 1)
 SELECT * FROM first_author;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -242,7 +233,6 @@ DEBUG:  Plan is router executable
 -- queries with CTEs are supported even if CTE is not referenced inside query
 WITH first_author AS ( SELECT id FROM articles_hash_mx WHERE author_id = 1)
 SELECT title FROM articles_hash_mx WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title     
@@ -258,8 +248,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash_mx WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash_mx WHERE author_id = 1)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | id |    title     
@@ -274,8 +262,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash_mx WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash_mx WHERE author_id = 3)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | id | title 
@@ -286,8 +272,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash_mx WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash_mx WHERE author_id = 2)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220104
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- recursive CTEs are supported when filtered on partition column
@@ -327,12 +311,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 1))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 1220108
-DEBUG:  predicate pruning for shardId 1220109
-DEBUG:  predicate pruning for shardId 1220110
-DEBUG:  predicate pruning for shardId 1220108
-DEBUG:  predicate pruning for shardId 1220109
-DEBUG:  predicate pruning for shardId 1220110
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  company_id | employee_id | manager_id | level 
@@ -354,9 +332,6 @@ WITH RECURSIVE hierarchy as (
 			ON (h.employee_id = ce.manager_id AND
 				h.company_id = ce.company_id))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 1220108
-DEBUG:  predicate pruning for shardId 1220109
-DEBUG:  predicate pruning for shardId 1220110
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- logically wrong query, query involves different shards
@@ -373,12 +348,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 2))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 1220107
-DEBUG:  predicate pruning for shardId 1220109
-DEBUG:  predicate pruning for shardId 1220110
-DEBUG:  predicate pruning for shardId 1220107
-DEBUG:  predicate pruning for shardId 1220108
-DEBUG:  predicate pruning for shardId 1220109
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- grouping sets are supported on single shard
@@ -387,7 +356,6 @@ SELECT
 	FROM articles_hash_mx
 	WHERE author_id = 1 or author_id = 3
 	GROUP BY GROUPING SETS ((id),(subtitle));
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | subtitle | count 
@@ -422,7 +390,6 @@ ERROR:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- queries which involve functions in FROM clause are supported if it goes to a single worker.
 SELECT * FROM articles_hash_mx, position('om' in 'Thomas') WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count | position 
@@ -435,7 +402,6 @@ DEBUG:  Plan is router executable
 (5 rows)
 
 SELECT * FROM articles_hash_mx, position('om' in 'Thomas') WHERE author_id = 1 or author_id = 3;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count | position 
@@ -503,8 +469,6 @@ SELECT articles_hash_mx.id,test.word_count
 FROM articles_hash_mx, (SELECT id, word_count FROM articles_hash_mx) AS test 
 WHERE test.id = articles_hash_mx.id and articles_hash_mx.author_id = 1
 ORDER BY articles_hash_mx.id;
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  join prunable for task partitionId 0 and 1
 DEBUG:  join prunable for task partitionId 0 and 2
 DEBUG:  join prunable for task partitionId 0 and 3
@@ -544,7 +508,6 @@ HINT:  Consider using an equality filter on the distributed table's partition co
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -560,7 +523,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1 OR author_id = 17;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -590,7 +552,6 @@ SELECT *
 SELECT id as article_id, word_count * id as random_value
 	FROM articles_hash_mx
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  article_id | random_value 
@@ -607,8 +568,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash_mx a, articles_hash_mx b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -624,7 +583,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash_mx a, articles_single_shard_hash_mx b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -643,7 +601,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash_mx a, single_shard b
 	WHERE a.author_id = 2 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 1220104
 DEBUG:  Found no worker with all shard placements
 ERROR:  could not run distributed query with complex table expressions
 -- single shard select with limit is router plannable
@@ -651,7 +608,6 @@ SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -667,7 +623,6 @@ SELECT *
 	WHERE author_id = 1
 	LIMIT 2
 	OFFSET 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -683,7 +638,6 @@ SELECT *
 	ORDER BY id desc
 	LIMIT 2
 	OFFSET 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -699,7 +653,6 @@ SELECT id
 	WHERE author_id = 1
 	GROUP BY id
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -716,7 +669,6 @@ SELECT distinct id
 	FROM articles_hash_mx
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -732,7 +684,6 @@ DEBUG:  Plan is router executable
 SELECT avg(word_count)
 	FROM articles_hash_mx
 	WHERE author_id = 2;
-DEBUG:  predicate pruning for shardId 1220104
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
         avg         
@@ -745,7 +696,6 @@ SELECT max(word_count) as max, min(word_count) as min,
 	   sum(word_count) as sum, count(word_count) as cnt
 	FROM articles_hash_mx
 	WHERE author_id = 2;
-DEBUG:  predicate pruning for shardId 1220104
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  | min  |  sum  | cnt 
@@ -758,7 +708,6 @@ SELECT max(word_count)
 	FROM articles_hash_mx
 	WHERE author_id = 1
 	GROUP BY author_id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  
@@ -771,8 +720,6 @@ DEBUG:  Plan is router executable
 (SELECT * FROM articles_hash_mx WHERE author_id = 1)
 UNION
 (SELECT * FROM articles_hash_mx WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -793,8 +740,6 @@ SELECT * FROM (
 	(SELECT * FROM articles_hash_mx WHERE author_id = 1)
 	UNION
 	(SELECT * FROM articles_hash_mx WHERE author_id = 3)) uu;
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -814,8 +759,6 @@ DEBUG:  Plan is router executable
 (SELECT LEFT(title, 1) FROM articles_hash_mx WHERE author_id = 1)
 UNION
 (SELECT LEFT(title, 1) FROM articles_hash_mx WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  left 
@@ -826,8 +769,6 @@ DEBUG:  Plan is router executable
 (SELECT LEFT(title, 1) FROM articles_hash_mx WHERE author_id = 1)
 INTERSECT
 (SELECT LEFT(title, 1) FROM articles_hash_mx WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  left 
@@ -838,8 +779,6 @@ DEBUG:  Plan is router executable
 (SELECT LEFT(title, 2) FROM articles_hash_mx WHERE author_id = 1)
 EXCEPT
 (SELECT LEFT(title, 2) FROM articles_hash_mx WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 1220105
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  left 
@@ -903,7 +842,6 @@ SET client_min_messages to 'DEBUG2';
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1 and author_id >= 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -933,7 +871,6 @@ SELECT *
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1 and (id = 1 or id = 41);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -946,7 +883,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1 and (id = random()::int  * 0);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count 
@@ -984,7 +920,6 @@ SELECT *
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = abs(-1);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1026,7 +961,6 @@ SELECT *
 SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1 and (id = abs(id - 2));
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1051,7 +985,6 @@ SELECT *
 SELECT *
 	FROM articles_hash_mx
 	WHERE (author_id = 1) = true;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1067,7 +1000,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE (author_id = 1) and id between 0 and 20;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1080,7 +1012,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE (author_id = 1) and (id = 1 or id = 31) and title like '%s';
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1093,7 +1024,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE (id = 1 or id = 31) and title like '%s' and (author_id = 1);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1106,7 +1036,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1122,7 +1051,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash_mx
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1) and (word_count < 3000 or word_count > 8000);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1136,7 +1064,6 @@ DEBUG:  Plan is router executable
 SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count 
 	FROM articles_hash_mx
 	WHERE author_id = 5;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    prev   |  title   | word_count 
@@ -1152,7 +1079,6 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	FROM articles_hash_mx
 	WHERE author_id = 5
 	ORDER BY word_count DESC;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    prev   |  title   | word_count 
@@ -1167,7 +1093,6 @@ DEBUG:  Plan is router executable
 SELECT id, MIN(id) over (order by word_count)
 	FROM articles_hash_mx
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | min 
@@ -1182,7 +1107,6 @@ DEBUG:  Plan is router executable
 SELECT id, word_count, AVG(word_count) over (order by word_count)
 	FROM articles_hash_mx
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | word_count |          avg          
@@ -1197,7 +1121,6 @@ DEBUG:  Plan is router executable
 SELECT word_count, rank() OVER (PARTITION BY author_id ORDER BY word_count)  
 	FROM articles_hash_mx 
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  word_count | rank 
@@ -1234,7 +1157,6 @@ SELECT
 		articles_hash_mx
 	WHERE
 		author_id = 5;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  c 
@@ -1276,7 +1198,6 @@ SELECT *
 	FROM articles_hash_mx
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1296,7 +1217,6 @@ DECLARE test_cursor CURSOR FOR
 		FROM articles_hash_mx
 		WHERE author_id = 1
 		ORDER BY id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 FETCH test_cursor;
@@ -1324,7 +1244,6 @@ COPY (
 	FROM articles_hash_mx
 	WHERE author_id = 1
 	ORDER BY id) TO STDOUT;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 1	1	arsenous	9572
@@ -1339,14 +1258,12 @@ CREATE TEMP TABLE temp_articles_hash_mx as
 	FROM articles_hash_mx
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 -- router plannable queries may include filter for aggragates
 SELECT count(*), count(*) FILTER (WHERE id < 3)
 	FROM articles_hash_mx
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count | count 
@@ -1369,7 +1286,6 @@ PREPARE author_1_articles as
 	FROM articles_hash_mx
 	WHERE author_id = 1;
 EXECUTE author_1_articles;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1387,7 +1303,6 @@ PREPARE author_articles(int) as
 	FROM articles_hash_mx
 	WHERE author_id = $1;
 EXECUTE author_articles(1);
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1411,18 +1326,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT author_articles_max_id();
-DEBUG:  predicate pruning for shardId 1220105
-CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash_mx ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_max_id() line 5 at SQL statement
-DEBUG:  predicate pruning for shardId 1220105
-CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash_mx ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_max_id() line 5 at SQL statement
-DEBUG:  predicate pruning for shardId 1220105
-CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash_mx ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_max_id() line 5 at SQL statement
 DEBUG:  Creating router plan
 CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash_mx ah
 		WHERE author_id = 1"
@@ -1448,11 +1351,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT * FROM author_articles_id_word_count();
-DEBUG:  predicate pruning for shardId 1220105
-CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
-		FROM articles_hash_mx ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 DEBUG:  Creating router plan
 CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		FROM articles_hash_mx ah
@@ -1475,7 +1373,6 @@ PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 -- materialized views can be created for router plannable queries
 CREATE MATERIALIZED VIEW mv_articles_hash_mx AS
 	SELECT * FROM articles_hash_mx WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 SELECT * FROM mv_articles_hash_mx;
@@ -1513,7 +1410,6 @@ DEBUG:  Plan is router executable
 SELECT id
 	FROM articles_hash_mx
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 1220105
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 

--- a/src/test/regress/expected/multi_null_minmax_value_pruning.out
+++ b/src/test/regress/expected/multi_null_minmax_value_pruning.out
@@ -22,12 +22,6 @@ SELECT shardminvalue, shardmaxvalue from pg_dist_shard WHERE shardid = 290001;
 -- Check that partition and join pruning works when min/max values exist
 -- Adding l_orderkey = 1 to make the query not router executable
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030 or l_orderkey = 1;
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  l_orderkey | l_linenumber | l_shipdate 
 ------------+--------------+------------
           1 |            1 | 03-13-1996
@@ -63,12 +57,6 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
 -- partition or join pruning for the shard with null min value.
 UPDATE pg_dist_shard SET shardminvalue = NULL WHERE shardid = 290000;
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030;
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  l_orderkey | l_linenumber | l_shipdate 
 ------------+--------------+------------
        9030 |            1 | 09-02-1998
@@ -97,11 +85,6 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
 -- don't apply partition or join pruning for this other shard either.
 UPDATE pg_dist_shard SET shardmaxvalue = NULL WHERE shardid = 290001;
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030;
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  l_orderkey | l_linenumber | l_shipdate 
 ------------+--------------+------------
        9030 |            1 | 09-02-1998
@@ -129,12 +112,6 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
 -- should apply partition and join pruning for this shard now.
 UPDATE pg_dist_shard SET shardminvalue = '0' WHERE shardid = 290000;
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  l_orderkey | l_linenumber | l_shipdate 
 ------------+--------------+------------
        9030 |            1 | 09-02-1998

--- a/src/test/regress/expected/multi_null_minmax_value_pruning.out
+++ b/src/test/regress/expected/multi_null_minmax_value_pruning.out
@@ -5,6 +5,10 @@
 -- and that we don't partition or join prune shards that have null values.
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 760000;
 SET client_min_messages TO DEBUG2;
+SET citus.explain_all_tasks TO on;
+-- to avoid differing explain output - executor doesn't matter,
+-- because were testing pruning here.
+SET citus.task_executor_type TO 'real-time';
 -- Change configuration to treat lineitem and orders tables as large
 SET citus.large_table_shard_count TO 2;
 SELECT shardminvalue, shardmaxvalue from pg_dist_shard WHERE shardid = 290000;
@@ -21,23 +25,34 @@ SELECT shardminvalue, shardmaxvalue from pg_dist_shard WHERE shardid = 290001;
 
 -- Check that partition and join pruning works when min/max values exist
 -- Adding l_orderkey = 1 to make the query not router executable
+EXPLAIN (COSTS FALSE)
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030 or l_orderkey = 1;
- l_orderkey | l_linenumber | l_shipdate 
-------------+--------------+------------
-          1 |            1 | 03-13-1996
-          1 |            2 | 04-12-1996
-          1 |            3 | 01-29-1996
-          1 |            4 | 04-21-1996
-          1 |            5 | 03-30-1996
-          1 |            6 | 01-30-1996
-       9030 |            1 | 09-02-1998
-       9030 |            2 | 08-19-1998
-       9030 |            3 | 08-27-1998
-       9030 |            4 | 07-20-1998
-       9030 |            5 | 09-29-1998
-       9030 |            6 | 09-03-1998
-(12 rows)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Custom Scan (Citus Real-Time)
+   Task Count: 2
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Bitmap Heap Scan on lineitem_290000 lineitem
+               Recheck Cond: ((l_orderkey = 9030) OR (l_orderkey = 1))
+               ->  BitmapOr
+                     ->  Bitmap Index Scan on lineitem_pkey_290000
+                           Index Cond: (l_orderkey = 9030)
+                     ->  Bitmap Index Scan on lineitem_pkey_290000
+                           Index Cond: (l_orderkey = 1)
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Bitmap Heap Scan on lineitem_290004 lineitem
+               Recheck Cond: ((l_orderkey = 9030) OR (l_orderkey = 1))
+               ->  BitmapOr
+                     ->  Bitmap Index Scan on lineitem_pkey_290004
+                           Index Cond: (l_orderkey = 9030)
+                     ->  Bitmap Index Scan on lineitem_pkey_290004
+                           Index Cond: (l_orderkey = 1)
+(21 rows)
 
+EXPLAIN (COSTS FALSE)
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey;
 DEBUG:  join prunable for intervals [1,1509] and [8997,14946]
@@ -48,25 +63,91 @@ DEBUG:  join prunable for intervals [8997,10560] and [1,5986]
 DEBUG:  join prunable for intervals [10560,12036] and [1,5986]
 DEBUG:  join prunable for intervals [12036,13473] and [1,5986]
 DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
-  sum  |        avg         
--------+--------------------
- 36086 | 3.0076679446574429
-(1 row)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 8
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+(60 rows)
 
 -- Now set the minimum value for a shard to null. Then check that we don't apply
 -- partition or join pruning for the shard with null min value.
 UPDATE pg_dist_shard SET shardminvalue = NULL WHERE shardid = 290000;
+EXPLAIN (COSTS FALSE)
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030;
- l_orderkey | l_linenumber | l_shipdate 
-------------+--------------+------------
-       9030 |            1 | 09-02-1998
-       9030 |            2 | 08-19-1998
-       9030 |            3 | 08-27-1998
-       9030 |            4 | 07-20-1998
-       9030 |            5 | 09-29-1998
-       9030 |            6 | 09-03-1998
-(6 rows)
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (Citus Real-Time)
+   Task Count: 2
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+               Index Cond: (l_orderkey = 9030)
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Index Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+               Index Cond: (l_orderkey = 9030)
+(11 rows)
 
+EXPLAIN (COSTS FALSE)
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey;
 DEBUG:  join prunable for intervals [1509,2951] and [8997,14946]
@@ -76,25 +157,102 @@ DEBUG:  join prunable for intervals [8997,10560] and [1,5986]
 DEBUG:  join prunable for intervals [10560,12036] and [1,5986]
 DEBUG:  join prunable for intervals [12036,13473] and [1,5986]
 DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
-  sum  |        avg         
--------+--------------------
- 36086 | 3.0076679446574429
-(1 row)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 9
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+(67 rows)
 
 -- Next, set the maximum value for another shard to null. Then check that we
 -- don't apply partition or join pruning for this other shard either.
 UPDATE pg_dist_shard SET shardmaxvalue = NULL WHERE shardid = 290001;
+EXPLAIN (COSTS FALSE)
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030;
- l_orderkey | l_linenumber | l_shipdate 
-------------+--------------+------------
-       9030 |            1 | 09-02-1998
-       9030 |            2 | 08-19-1998
-       9030 |            3 | 08-27-1998
-       9030 |            4 | 07-20-1998
-       9030 |            5 | 09-29-1998
-       9030 |            6 | 09-03-1998
-(6 rows)
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (Citus Real-Time)
+   Task Count: 3
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Index Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+               Index Cond: (l_orderkey = 9030)
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+               Index Cond: (l_orderkey = 9030)
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Index Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+               Index Cond: (l_orderkey = 9030)
+(15 rows)
 
+EXPLAIN (COSTS FALSE)
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey;
 DEBUG:  join prunable for intervals [2951,4455] and [8997,14946]
@@ -103,25 +261,105 @@ DEBUG:  join prunable for intervals [8997,10560] and [1,5986]
 DEBUG:  join prunable for intervals [10560,12036] and [1,5986]
 DEBUG:  join prunable for intervals [12036,13473] and [1,5986]
 DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
-  sum  |        avg         
--------+--------------------
- 36086 | 3.0076679446574429
-(1 row)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 10
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+(74 rows)
 
 -- Last, set the minimum value to 0 and check that we don't treat it as null. We
 -- should apply partition and join pruning for this shard now.
 UPDATE pg_dist_shard SET shardminvalue = '0' WHERE shardid = 290000;
+EXPLAIN (COSTS FALSE)
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030;
- l_orderkey | l_linenumber | l_shipdate 
-------------+--------------+------------
-       9030 |            1 | 09-02-1998
-       9030 |            2 | 08-19-1998
-       9030 |            3 | 08-27-1998
-       9030 |            4 | 07-20-1998
-       9030 |            5 | 09-29-1998
-       9030 |            6 | 09-03-1998
-(6 rows)
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (Citus Real-Time)
+   Task Count: 2
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Index Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+               Index Cond: (l_orderkey = 9030)
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Index Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+               Index Cond: (l_orderkey = 9030)
+(11 rows)
 
+EXPLAIN (COSTS FALSE)
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem, orders
 	WHERE l_orderkey = o_orderkey;
 DEBUG:  join prunable for intervals [0,1509] and [8997,14946]
@@ -131,10 +369,76 @@ DEBUG:  join prunable for intervals [8997,10560] and [1,5986]
 DEBUG:  join prunable for intervals [10560,12036] and [1,5986]
 DEBUG:  join prunable for intervals [12036,13473] and [1,5986]
 DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
-  sum  |        avg         
--------+--------------------
- 36086 | 3.0076679446574429
-(1 row)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 9
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (orders.o_orderkey = lineitem.l_orderkey)
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+(67 rows)
 
 -- Set minimum and maximum values for two shards back to their original values
 UPDATE pg_dist_shard SET shardminvalue = '1' WHERE shardid = 290000;

--- a/src/test/regress/expected/multi_partition_pruning.out
+++ b/src/test/regress/expected/multi_partition_pruning.out
@@ -8,12 +8,6 @@ SET citus.explain_distributed_queries TO off;
 SET client_min_messages TO DEBUG2;
 -- Adding additional l_orderkey = 1 to make this query not router executable
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030 or l_orderkey = 1;
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  l_orderkey | l_linenumber | l_shipdate 
 ------------+--------------+------------
           1 |            1 | 03-13-1996
@@ -36,10 +30,6 @@ DEBUG:  predicate pruning for shardId 290007
 -- trigger the the creation of toasted tables and indexes. This in turn prints
 -- non-deterministic debug messages. To avoid this chain, we use l_linenumber.
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
   sum  |        avg         
 -------+--------------------
  17999 | 3.0189533713518953
@@ -47,7 +37,6 @@ DEBUG:  predicate pruning for shardId 290003
 
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem
 	WHERE (l_orderkey < 4000 OR l_orderkey > 9030);
-DEBUG:  predicate pruning for shardId 290003
   sum  |        avg         
 -------+--------------------
  30184 | 3.0159872102318145
@@ -55,14 +44,6 @@ DEBUG:  predicate pruning for shardId 290003
 
 -- The following query should prune out all shards and return empty results
 SELECT sum(l_linenumber), avg(l_linenumber) FROM lineitem WHERE l_orderkey > 20000;
-DEBUG:  predicate pruning for shardId 290000
-DEBUG:  predicate pruning for shardId 290001
-DEBUG:  predicate pruning for shardId 290002
-DEBUG:  predicate pruning for shardId 290003
-DEBUG:  predicate pruning for shardId 290004
-DEBUG:  predicate pruning for shardId 290005
-DEBUG:  predicate pruning for shardId 290006
-DEBUG:  predicate pruning for shardId 290007
  sum | avg 
 -----+-----
      |    
@@ -168,7 +149,6 @@ INSERT INTO pg_dist_shard_placement (shardid, shardstate, shardlength, nodename,
 -- Verify that shard pruning works. Note that these queries should all prune
 -- one shard.
 EXPLAIN SELECT count(*) FROM varchar_partitioned_table WHERE varchar_column = 'BA2';
-DEBUG:  predicate pruning for shardId 100
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate  (cost=0.00..0.00 rows=0 width=0)
@@ -178,7 +158,6 @@ DEBUG:  predicate pruning for shardId 100
 
 EXPLAIN SELECT count(*) FROM array_partitioned_table
 	WHERE array_column > '{BA1000U2AMO4ZGX, BZZXSP27F21T6}';
-DEBUG:  predicate pruning for shardId 102
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate  (cost=0.00..0.00 rows=0 width=0)
@@ -188,7 +167,6 @@ DEBUG:  predicate pruning for shardId 102
 
 EXPLAIN SELECT count(*) FROM composite_partitioned_table
 	WHERE composite_column < '(b,5,c)'::composite_type;
-DEBUG:  predicate pruning for shardId 105
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate  (cost=0.00..0.00 rows=0 width=0)

--- a/src/test/regress/expected/multi_partition_pruning.out
+++ b/src/test/regress/expected/multi_partition_pruning.out
@@ -4,8 +4,6 @@
 -- Tests to verify that we correctly prune unreferenced shards. For this, we
 -- need to increase the logging verbosity of messages displayed on the client.
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 770000;
-SET citus.explain_distributed_queries TO off;
-SET client_min_messages TO DEBUG2;
 -- Adding additional l_orderkey = 1 to make this query not router executable
 SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 9030 or l_orderkey = 1;
  l_orderkey | l_linenumber | l_shipdate 
@@ -146,32 +144,46 @@ INSERT INTO pg_dist_shard_placement (shardid, shardstate, shardlength, nodename,
 	GROUP BY nodename, nodeport
 	ORDER BY nodename, nodeport ASC
 	LIMIT 1;
--- Verify that shard pruning works. Note that these queries should all prune
--- one shard.
-EXPLAIN SELECT count(*) FROM varchar_partitioned_table WHERE varchar_column = 'BA2';
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Aggregate  (cost=0.00..0.00 rows=0 width=0)
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
-         explain statements for distributed queries are not enabled
-(3 rows)
+-- Verify that shard pruning works. Note that these queries should all
+-- prune one shard (see task count).  As these tables don't exist
+-- remotely, temporarily disable WARNING messages.
+SET client_min_messages TO ERROR;
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM varchar_partitioned_table WHERE varchar_column = 'BA2';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Error: Could not get remote plan.
+(6 rows)
 
-EXPLAIN SELECT count(*) FROM array_partitioned_table
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM array_partitioned_table
 	WHERE array_column > '{BA1000U2AMO4ZGX, BZZXSP27F21T6}';
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Aggregate  (cost=0.00..0.00 rows=0 width=0)
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
-         explain statements for distributed queries are not enabled
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Error: Could not get remote plan.
+(6 rows)
 
-EXPLAIN SELECT count(*) FROM composite_partitioned_table
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM composite_partitioned_table
 	WHERE composite_column < '(b,5,c)'::composite_type;
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Aggregate  (cost=0.00..0.00 rows=0 width=0)
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
-         explain statements for distributed queries are not enabled
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Error: Could not get remote plan.
+(6 rows)
 
 SET client_min_messages TO NOTICE;

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -126,7 +126,6 @@ DEBUG:  Plan is router executable
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles_hash WHERE author_id = 10 AND id = 50;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |   title   | word_count 
@@ -136,7 +135,6 @@ DEBUG:  Plan is router executable
 
 -- get all titles by a single author
 SELECT title FROM articles_hash WHERE author_id = 10;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    title    
@@ -152,7 +150,6 @@ DEBUG:  Plan is router executable
 SELECT title, word_count FROM articles_hash
 	WHERE author_id = 10
 	ORDER BY word_count DESC NULLS LAST;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    title    | word_count 
@@ -169,7 +166,6 @@ SELECT title, id FROM articles_hash
 	WHERE author_id = 5
 	ORDER BY id
 	LIMIT 2;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   title  | id 
@@ -183,7 +179,6 @@ DEBUG:  Plan is router executable
 SELECT title, author_id FROM articles_hash
 	WHERE author_id = 7 OR author_id = 8
 	ORDER BY author_id ASC, id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title    | author_id 
@@ -203,7 +198,6 @@ DEBUG:  Plan is router executable
 -- same query is router executable with no order by
 SELECT title, author_id FROM articles_hash
 	WHERE author_id = 7 OR author_id = 8;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title    | author_id 
@@ -227,7 +221,6 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash
 	GROUP BY author_id
 	HAVING sum(word_count) > 1000
 	ORDER BY sum(word_count) DESC;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  author_id | corpus_size 
@@ -244,7 +237,6 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash
 	GROUP BY author_id
 	HAVING sum(word_count) > 1000
 	ORDER BY sum(word_count) DESC;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  author_id | corpus_size 
@@ -286,7 +278,6 @@ HINT:  Consider rewriting the expression with OR/AND clauses.
 -- queries with CTEs are supported
 WITH first_author AS ( SELECT id FROM articles_hash WHERE author_id = 1)
 SELECT * FROM first_author;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -301,7 +292,6 @@ DEBUG:  Plan is router executable
 -- queries with CTEs are supported even if CTE is not referenced inside query
 WITH first_author AS ( SELECT id FROM articles_hash WHERE author_id = 1)
 SELECT title FROM articles_hash WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
     title     
@@ -317,8 +307,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash WHERE author_id = 1)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | id |    title     
@@ -333,8 +321,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash WHERE author_id = 3)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | id | title 
@@ -345,8 +331,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash WHERE author_id = 2)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840000
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- recursive CTEs are supported when filtered on partition column
@@ -399,12 +383,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 1))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  company_id | employee_id | manager_id | level 
@@ -426,9 +404,6 @@ WITH RECURSIVE hierarchy as (
 			ON (h.employee_id = ce.manager_id AND
 				h.company_id = ce.company_id))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- logically wrong query, query involves different shards
@@ -444,12 +419,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 2))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 840004
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
-DEBUG:  predicate pruning for shardId 840004
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- CTE with queries other than SELECT is not supported
@@ -485,7 +454,6 @@ SELECT
 	FROM articles_hash
 	WHERE author_id = 1 or author_id = 3
 	GROUP BY GROUPING SETS ((id),(subtitle));
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | subtitle | count 
@@ -520,7 +488,6 @@ ERROR:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
 HINT:  Consider using an equality filter on the distributed table's partition column.
 -- queries which involve functions in FROM clause are supported if it goes to a single worker.
 SELECT * FROM articles_hash, position('om' in 'Thomas') WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count | position 
@@ -533,7 +500,6 @@ DEBUG:  Plan is router executable
 (5 rows)
 
 SELECT * FROM articles_hash, position('om' in 'Thomas') WHERE author_id = 1 or author_id = 3;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count | position 
@@ -567,8 +533,6 @@ HINT:  Consider using an equality filter on the distributed table's partition co
 SELECT * FROM articles_hash
 WHERE author_id IN (SELECT author_id FROM articles_hash WHERE author_id = 2)
 ORDER BY articles_hash.id;
-DEBUG:  predicate pruning for shardId 840000
-DEBUG:  predicate pruning for shardId 840000
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |   title    | word_count 
@@ -618,8 +582,6 @@ SELECT articles_hash.id,test.word_count
 FROM articles_hash, (SELECT id, word_count FROM articles_hash) AS test 
 WHERE test.id = articles_hash.id and articles_hash.author_id = 1
 ORDER BY articles_hash.id;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  join prunable for task partitionId 0 and 1
 DEBUG:  join prunable for task partitionId 0 and 2
 DEBUG:  join prunable for task partitionId 0 and 3
@@ -659,7 +621,6 @@ HINT:  Consider using an equality filter on the distributed table's partition co
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -675,7 +636,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 OR author_id = 17;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -705,7 +665,6 @@ SELECT *
 SELECT id as article_id, word_count * id as random_value
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  article_id | random_value 
@@ -722,8 +681,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash a, articles_hash b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -739,7 +696,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash a, articles_single_shard_hash b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -758,7 +714,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash a, single_shard b
 	WHERE a.author_id = 2 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 840000
 DEBUG:  Found no worker with all shard placements
 ERROR:  could not run distributed query with complex table expressions
 HINT:  Consider using an equality filter on the distributed table's partition column.
@@ -767,7 +722,6 @@ SELECT *
 	FROM articles_hash
 	WHERE author_id = 1
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -783,7 +737,6 @@ SELECT *
 	WHERE author_id = 1
 	LIMIT 2
 	OFFSET 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -799,7 +752,6 @@ SELECT *
 	ORDER BY id desc
 	LIMIT 2
 	OFFSET 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -815,7 +767,6 @@ SELECT id
 	WHERE author_id = 1
 	GROUP BY id
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -832,7 +783,6 @@ SELECT DISTINCT id
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -848,7 +798,6 @@ DEBUG:  Plan is router executable
 SELECT avg(word_count)
 	FROM articles_hash
 	WHERE author_id = 2;
-DEBUG:  predicate pruning for shardId 840000
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
         avg         
@@ -861,7 +810,6 @@ SELECT max(word_count) as max, min(word_count) as min,
 	   sum(word_count) as sum, count(word_count) as cnt
 	FROM articles_hash
 	WHERE author_id = 2;
-DEBUG:  predicate pruning for shardId 840000
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  | min  |  sum  | cnt 
@@ -874,7 +822,6 @@ SELECT max(word_count)
 	FROM articles_hash
 	WHERE author_id = 1
 	GROUP BY author_id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  
@@ -887,8 +834,6 @@ DEBUG:  Plan is router executable
 (SELECT * FROM articles_hash WHERE author_id = 1)
 UNION
 (SELECT * FROM articles_hash WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -909,8 +854,6 @@ SELECT * FROM (
 	(SELECT * FROM articles_hash WHERE author_id = 1)
 	UNION
 	(SELECT * FROM articles_hash WHERE author_id = 3)) uu;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -930,8 +873,6 @@ DEBUG:  Plan is router executable
 (SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 1)
 UNION
 (SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  left 
@@ -942,8 +883,6 @@ DEBUG:  Plan is router executable
 (SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 1)
 INTERSECT
 (SELECT LEFT(title, 1) FROM articles_hash WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  left 
@@ -954,8 +893,6 @@ DEBUG:  Plan is router executable
 (SELECT LEFT(title, 2) FROM articles_hash WHERE author_id = 1)
 EXCEPT
 (SELECT LEFT(title, 2) FROM articles_hash WHERE author_id = 3);
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  left 
@@ -1019,7 +956,6 @@ SET client_min_messages to 'DEBUG2';
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and author_id >= 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1049,7 +985,6 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and (id = 1 or id = 41);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1062,7 +997,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and (id = random()::int  * 0);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count 
@@ -1100,7 +1034,6 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE author_id = abs(-1);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1142,7 +1075,6 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and (id = abs(id - 2));
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1167,7 +1099,6 @@ SELECT *
 SELECT *
 	FROM articles_hash
 	WHERE (author_id = 1) = true;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1183,7 +1114,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (author_id = 1) and id between 0 and 20;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1196,7 +1126,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (author_id = 1) and (id = 1 or id = 31) and title like '%s';
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1209,7 +1138,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (id = 1 or id = 31) and title like '%s' and (author_id = 1);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1222,7 +1150,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1238,7 +1165,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1) and (word_count < 3000 or word_count > 8000);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -1252,7 +1178,6 @@ DEBUG:  Plan is router executable
 SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count 
 	FROM articles_hash
 	WHERE author_id = 5;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    prev   |  title   | word_count 
@@ -1268,7 +1193,6 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	FROM articles_hash
 	WHERE author_id = 5
 	ORDER BY word_count DESC;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
    prev   |  title   | word_count 
@@ -1283,7 +1207,6 @@ DEBUG:  Plan is router executable
 SELECT id, MIN(id) over (order by word_count)
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | min 
@@ -1298,7 +1221,6 @@ DEBUG:  Plan is router executable
 SELECT id, word_count, AVG(word_count) over (order by word_count)
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | word_count |          avg          
@@ -1313,7 +1235,6 @@ DEBUG:  Plan is router executable
 SELECT word_count, rank() OVER (PARTITION BY author_id ORDER BY word_count)  
 	FROM articles_hash 
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  word_count | rank 
@@ -1404,7 +1325,6 @@ DEBUG:  Plan is router executable
 SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles_hash a, articles_single_shard_hash b
 	WHERE a.author_id = 10 and a.author_id = b.author_id and int4eq(1, 1);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -1471,7 +1391,6 @@ DEBUG:  Plan is router executable
 (SELECT * FROM articles_hash WHERE author_id = 1)
 UNION
 (SELECT * FROM articles_hash WHERE author_id = 2 and 1=0);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1486,7 +1405,6 @@ DEBUG:  Plan is router executable
 (SELECT * FROM articles_hash WHERE author_id = 1)
 EXCEPT
 (SELECT * FROM articles_hash WHERE author_id = 2 and 1=0);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -1501,7 +1419,6 @@ DEBUG:  Plan is router executable
 (SELECT * FROM articles_hash WHERE author_id = 1)
 INTERSECT
 (SELECT * FROM articles_hash WHERE author_id = 2 and 1=0);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count 
@@ -1512,7 +1429,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash WHERE author_id = 1 and 1=0)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | id | title 
@@ -1522,8 +1438,6 @@ DEBUG:  Plan is router executable
 WITH id_author AS ( SELECT id, author_id FROM articles_hash WHERE author_id = 1),
 id_title AS (SELECT id, title from articles_hash WHERE author_id = 1)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id and 1=0;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | id | title 
@@ -1541,12 +1455,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 1))
 SELECT * FROM hierarchy WHERE LEVEL <= 2 and 1=0;
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  company_id | employee_id | manager_id | level 
@@ -1564,9 +1472,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 1 AND 1=0))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  company_id | employee_id | manager_id | level 
@@ -1585,9 +1490,6 @@ WITH RECURSIVE hierarchy as (
 				h.company_id = ce.company_id AND
 				ce.company_id = 1))
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
-DEBUG:  predicate pruning for shardId 840005
-DEBUG:  predicate pruning for shardId 840006
-DEBUG:  predicate pruning for shardId 840007
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  company_id | employee_id | manager_id | level 
@@ -1665,9 +1567,6 @@ SELECT master_create_empty_shard('articles_range') as shard_id \gset
 UPDATE pg_dist_shard SET shardminvalue = 31, shardmaxvalue=40 WHERE shardid = :shard_id;
 -- single shard select queries are router plannable
 SELECT * FROM articles_range where author_id = 1;
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count 
@@ -1675,9 +1574,6 @@ DEBUG:  Plan is router executable
 (0 rows)
 
 SELECT * FROM articles_range where author_id = 1 or author_id = 5;
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count 
@@ -1695,12 +1591,6 @@ DEBUG:  Plan is router executable
 -- single shard joins on range partitioned table are router plannable
 SELECT * FROM articles_range ar join authors_range au on (ar.author_id = au.id) 
 	WHERE ar.author_id = 1;
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
-DEBUG:  predicate pruning for shardId 840009
-DEBUG:  predicate pruning for shardId 840010
-DEBUG:  predicate pruning for shardId 840011
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count | name | id 
@@ -1719,10 +1609,6 @@ DEBUG:  Plan is router executable
 -- multi-shard join is not router plannable
 SELECT * FROM articles_range ar join authors_range au on (ar.author_id = au.id)
 	WHERE ar.author_id = 35;
-DEBUG:  predicate pruning for shardId 840012
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840012
-DEBUG:  predicate pruning for shardId 840013
 DEBUG:  join prunable for intervals [21,40] and [1,10]
 DEBUG:  join prunable for intervals [31,40] and [1,10]
 DEBUG:  join prunable for intervals [31,40] and [11,30]
@@ -1748,12 +1634,6 @@ DEBUG:  join prunable for intervals [31,40] and [11,30]
 -- bogus query, join on non-partition column, but router plannable due to filters
 SELECT * FROM articles_range ar join authors_range au on (ar.id = au.id) 
 	WHERE ar.author_id = 1 and au.id < 10;
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
-DEBUG:  predicate pruning for shardId 840009
-DEBUG:  predicate pruning for shardId 840010
-DEBUG:  predicate pruning for shardId 840011
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count | name | id 
@@ -1766,10 +1646,6 @@ DEBUG:  Plan is router executable
 -- router plannable
 SELECT * FROM articles_hash ar join authors_range au on (ar.author_id = au.id)
 	WHERE ar.author_id = 2;
-DEBUG:  predicate pruning for shardId 840000
-DEBUG:  predicate pruning for shardId 840009
-DEBUG:  predicate pruning for shardId 840010
-DEBUG:  predicate pruning for shardId 840011
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count | name | id 
@@ -1779,12 +1655,7 @@ DEBUG:  Plan is router executable
 -- not router plannable
 SELECT * FROM articles_hash ar join authors_range au on (ar.author_id = au.id)
 	WHERE ar.author_id = 3;
-DEBUG:  predicate pruning for shardId 840001
-DEBUG:  predicate pruning for shardId 840009
-DEBUG:  predicate pruning for shardId 840010
-DEBUG:  predicate pruning for shardId 840011
 DEBUG:  Found no worker with all shard placements
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  join prunable for intervals [1,10] and [11,30]
 DEBUG:  join prunable for intervals [1,10] and [21,40]
 DEBUG:  join prunable for intervals [1,10] and [31,40]
@@ -1814,9 +1685,6 @@ HINT:  Set citus.task_executor_type to "task-tracker".
 -- join between a range partitioned table and reference table is router plannable
 SELECT * FROM articles_range ar join authors_reference au on (ar.author_id = au.id)
 	WHERE ar.author_id = 1;
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count | name | id 
@@ -1826,9 +1694,6 @@ DEBUG:  Plan is router executable
 -- still hits a single shard and router plannable
 SELECT * FROM articles_range ar join authors_reference au on (ar.author_id = au.id)
 	WHERE ar.author_id = 1 or ar.author_id = 5;
-DEBUG:  predicate pruning for shardId 840013
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count | name | id 
@@ -1838,10 +1703,6 @@ DEBUG:  Plan is router executable
 -- it is not router plannable if hit multiple shards
 SELECT * FROM articles_range ar join authors_reference au on (ar.author_id = au.id)
 	WHERE ar.author_id = 1 or ar.author_id = 15;
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
-DEBUG:  predicate pruning for shardId 840014
-DEBUG:  predicate pruning for shardId 840015
  id | author_id | title | word_count | name | id 
 ----+-----------+-------+------------+------+----
 (0 rows)
@@ -1907,7 +1768,6 @@ SELECT author_id FROM articles_hash
 	ORDER BY
 		author_id
 	LIMIT 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 WARNING:  relation "public.articles_hash" does not exist
@@ -1945,7 +1805,6 @@ SELECT * FROM articles_hash
 	ORDER BY
 		author_id, id
 	LIMIT 5;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 WARNING:  relation "public.articles_hash" does not exist
@@ -1969,7 +1828,6 @@ SELECT
 		articles_hash
 	WHERE
 		author_id = 5;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  c 
@@ -2011,7 +1869,6 @@ SELECT *
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -2031,7 +1888,6 @@ SELECT *
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -2051,7 +1907,6 @@ DECLARE test_cursor CURSOR FOR
 		FROM articles_hash
 		WHERE author_id = 1
 		ORDER BY id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 FETCH test_cursor;
@@ -2087,7 +1942,6 @@ COPY (
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id) TO STDOUT;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 1	1	arsenous	9572
@@ -2102,14 +1956,12 @@ CREATE TEMP TABLE temp_articles_hash as
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 -- router plannable queries may include filter for aggragates
 SELECT count(*), count(*) FILTER (WHERE id < 3)
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count | count 
@@ -2132,7 +1984,6 @@ PREPARE author_1_articles as
 	FROM articles_hash
 	WHERE author_id = 1;
 EXECUTE author_1_articles;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -2150,7 +2001,6 @@ PREPARE author_articles(int) as
 	FROM articles_hash
 	WHERE author_id = $1;
 EXECUTE author_articles(1);
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -2174,18 +2024,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT author_articles_max_id();
-DEBUG:  predicate pruning for shardId 840001
-CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_max_id() line 5 at SQL statement
-DEBUG:  predicate pruning for shardId 840001
-CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_max_id() line 5 at SQL statement
-DEBUG:  predicate pruning for shardId 840001
-CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_max_id() line 5 at SQL statement
 DEBUG:  Creating router plan
 CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
 		WHERE author_id = 1"
@@ -2211,11 +2049,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT * FROM author_articles_id_word_count();
-DEBUG:  predicate pruning for shardId 840001
-CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
-		FROM articles_hash ah
-		WHERE author_id = 1"
-PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 DEBUG:  Creating router plan
 CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		FROM articles_hash ah
@@ -2238,7 +2071,6 @@ PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 -- materialized views can be created for router plannable queries
 CREATE MATERIALIZED VIEW mv_articles_hash_empty AS
 	SELECT * FROM articles_hash WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 SELECT * FROM mv_articles_hash_empty;
@@ -2277,7 +2109,6 @@ SET citus.task_executor_type to 'task-tracker';
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -2297,7 +2128,6 @@ DEBUG:  Plan is router executable
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 840001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 

--- a/src/test/regress/expected/multi_shard_modify.out
+++ b/src/test/regress/expected/multi_shard_modify.out
@@ -129,9 +129,6 @@ SELECT count(*) FROM multi_shard_modify_test;
 -- Check that shard pruning works
 SET client_min_messages TO DEBUG2;
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = 15');
-DEBUG:  predicate pruning for shardId 350001
-DEBUG:  predicate pruning for shardId 350002
-DEBUG:  predicate pruning for shardId 350003
  master_modify_multiple_shards 
 -------------------------------
                              1

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -385,7 +385,6 @@ SET citus.task_executor_type TO 'real-time';
 SELECT *
 	FROM articles
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -401,7 +400,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles
 	WHERE author_id = 1 OR author_id = 17;
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |    title     | word_count 
@@ -430,7 +428,6 @@ SELECT *
 SELECT id as article_id, word_count * id as random_value
 	FROM articles
 	WHERE author_id = 1;
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  article_id | random_value 
@@ -448,8 +445,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles a, articles b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 850001
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -465,7 +460,6 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	FROM articles a, articles_single_shard b
 	WHERE a.author_id = 10 and a.author_id = b.author_id
 	LIMIT 3;
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  first_author | second_word_count 
@@ -480,7 +474,6 @@ SELECT *
 	FROM articles
 	WHERE author_id = 1
 	LIMIT 2;
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id |  title   | word_count 
@@ -497,7 +490,6 @@ SELECT id
 	WHERE author_id = 1
 	GROUP BY id
 	ORDER BY id;
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id 
@@ -518,7 +510,6 @@ DEBUG:  Plan is router executable
 SELECT avg(word_count)
 	FROM articles
 	WHERE author_id = 2;
-DEBUG:  predicate pruning for shardId 850000
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
         avg         
@@ -532,7 +523,6 @@ SELECT max(word_count) as max, min(word_count) as min,
 	   sum(word_count) as sum, count(word_count) as cnt
 	FROM articles
 	WHERE author_id = 2;
-DEBUG:  predicate pruning for shardId 850000
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
   max  | min  |  sum  | cnt 
@@ -544,8 +534,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles a, articles b
 	WHERE a.id = b.id  AND a.author_id = 1;
-DEBUG:  predicate pruning for shardId 850001
-DEBUG:  predicate pruning for shardId 850001
 DEBUG:  join prunable for task partitionId 0 and 1
 DEBUG:  join prunable for task partitionId 0 and 2
 DEBUG:  join prunable for task partitionId 0 and 3

--- a/src/test/regress/input/multi_subquery.source
+++ b/src/test/regress/input/multi_subquery.source
@@ -339,43 +339,43 @@ SELECT master_create_worker_shards('subquery_pruning_varchar_test_table', 4, 1);
 SET citus.subquery_pushdown TO TRUE;
 SET client_min_messages TO DEBUG2;
 
-SELECT * FROM 
-	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a) 
+SELECT * FROM
+	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a)
 AS foo;
 
-SELECT * FROM 
+SELECT * FROM
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE 'eren' = a GROUP BY a)
 AS foo;
 
 SET client_min_messages TO NOTICE;
 
--- test subquery join on VARCHAR partition column 
+-- test subquery join on VARCHAR partition column
 SELECT * FROM
-	(SELECT 
+	(SELECT
 		a_inner AS a
 	FROM
-		(SELECT 
+		(SELECT
 			subquery_pruning_varchar_test_table.a AS a_inner
-		FROM 
+		FROM
 		 	subquery_pruning_varchar_test_table
-		GROUP BY 
+		GROUP BY
 		  	subquery_pruning_varchar_test_table.a
-		HAVING 
-		  	count(subquery_pruning_varchar_test_table.a) < 3) 
+		HAVING
+		  	count(subquery_pruning_varchar_test_table.a) < 3)
 		AS f1,
 
-		(SELECT 
+		(SELECT
 		 	subquery_pruning_varchar_test_table.a
-		FROM 
+		FROM
 		  	subquery_pruning_varchar_test_table
-		GROUP BY 
+		GROUP BY
 		  	subquery_pruning_varchar_test_table.a
-		HAVING 
-		  	sum(coalesce(subquery_pruning_varchar_test_table.b,0)) > 20.0) 
+		HAVING
+		  	sum(coalesce(subquery_pruning_varchar_test_table.b,0)) > 20.0)
 		AS f2
-	WHERE 
+	WHERE
 		f1.a_inner = f2.a
-	GROUP BY 
+	GROUP BY
 		a_inner)
 AS foo;
 
@@ -702,7 +702,8 @@ LIMIT
 -- Same queries above with explain
 -- Simple join subquery pushdown
 
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	avg(array_length(events, 1)) AS event_average
 FROM
 	(SELECT
@@ -729,7 +730,8 @@ FROM
 		user_id) AS subquery;
 
 -- Union and left join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	avg(array_length(events, 1)) AS event_average,
 	hasdone
 FROM
@@ -793,7 +795,8 @@ GROUP BY
 	hasdone;
 
 -- Union, left join and having subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+  SELECT
 	avg(array_length(events, 1)) AS event_average,
 	count_pay
 	FROM (
@@ -865,7 +868,8 @@ ORDER BY
 	count_pay;
 
 -- Lateral join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	tenant_id,
 	user_id,
 	user_lastseen,

--- a/src/test/regress/multi_task_tracker_extra_schedule
+++ b/src/test/regress/multi_task_tracker_extra_schedule
@@ -34,7 +34,6 @@ test: multi_average_expression multi_working_columns
 test: multi_array_agg
 test: multi_agg_type_conversion multi_count_type_conversion
 test: multi_hash_pruning
-test: multi_null_minmax_value_pruning
 test: multi_query_directory_cleanup
 test: multi_utility_statements
 test: multi_dropped_column_aliases
@@ -50,7 +49,6 @@ test: multi_tpch_query7 multi_tpch_query7_nested
 # Parallel tests to check our join order planning logic. Note that we load data
 # below; and therefore these tests should come after the execution tests.
 # ----------
-test: multi_join_order_additional
 test: multi_load_more_data
 test: multi_join_order_tpch_large
 

--- a/src/test/regress/output/multi_subquery.source
+++ b/src/test/regress/output/multi_subquery.source
@@ -373,14 +373,14 @@ SELECT master_create_worker_shards('subquery_pruning_varchar_test_table', 4, 1);
 
 SET citus.subquery_pushdown TO TRUE;
 SET client_min_messages TO DEBUG2;
-SELECT * FROM 
-	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a) 
+SELECT * FROM
+	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a)
 AS foo;
  count 
 -------
 (0 rows)
 
-SELECT * FROM 
+SELECT * FROM
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE 'eren' = a GROUP BY a)
 AS foo;
  count 
@@ -388,32 +388,32 @@ AS foo;
 (0 rows)
 
 SET client_min_messages TO NOTICE;
--- test subquery join on VARCHAR partition column 
+-- test subquery join on VARCHAR partition column
 SELECT * FROM
-	(SELECT 
+	(SELECT
 		a_inner AS a
 	FROM
-		(SELECT 
+		(SELECT
 			subquery_pruning_varchar_test_table.a AS a_inner
-		FROM 
+		FROM
 		 	subquery_pruning_varchar_test_table
-		GROUP BY 
+		GROUP BY
 		  	subquery_pruning_varchar_test_table.a
-		HAVING 
-		  	count(subquery_pruning_varchar_test_table.a) < 3) 
+		HAVING
+		  	count(subquery_pruning_varchar_test_table.a) < 3)
 		AS f1,
-		(SELECT 
+		(SELECT
 		 	subquery_pruning_varchar_test_table.a
-		FROM 
+		FROM
 		  	subquery_pruning_varchar_test_table
-		GROUP BY 
+		GROUP BY
 		  	subquery_pruning_varchar_test_table.a
-		HAVING 
-		  	sum(coalesce(subquery_pruning_varchar_test_table.b,0)) > 20.0) 
+		HAVING
+		  	sum(coalesce(subquery_pruning_varchar_test_table.b,0)) > 20.0)
 		AS f2
-	WHERE 
+	WHERE
 		f1.a_inner = f2.a
-	GROUP BY 
+	GROUP BY
 		a_inner)
 AS foo;
  a 
@@ -732,7 +732,8 @@ LIMIT
 
 -- Same queries above with explain
 -- Simple join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	avg(array_length(events, 1)) AS event_average
 FROM
 	(SELECT
@@ -759,29 +760,30 @@ FROM
 		user_id) AS subquery;
                                                                                           QUERY PLAN                                                                                          
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..0.00 rows=0 width=0)
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
          Task Count: 2
          Tasks Shown: One of 2
          ->  Task
                Node: host=localhost port=57637 dbname=regression
-               ->  Aggregate  (cost=40.01..40.02 rows=1 width=16)
-                     ->  GroupAggregate  (cost=39.89..39.99 rows=1 width=48)
+               ->  Aggregate
+                     ->  GroupAggregate
                            Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                           ->  Merge Join  (cost=39.89..39.97 rows=1 width=540)
+                           ->  Merge Join
                                  Merge Cond: ((((users.composite_id).tenant_id) = ((events.composite_id).tenant_id)) AND (((users.composite_id).user_id) = ((events.composite_id).user_id)))
-                                 ->  Sort  (cost=28.08..28.09 rows=6 width=32)
+                                 ->  Sort
                                        Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                                       ->  Seq Scan on users_270013 users  (cost=0.00..28.00 rows=6 width=32)
+                                       ->  Seq Scan on users_270013 users
                                              Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                 ->  Sort  (cost=11.81..11.82 rows=3 width=556)
+                                 ->  Sort
                                        Sort Key: ((events.composite_id).tenant_id), ((events.composite_id).user_id)
-                                       ->  Seq Scan on events_270009 events  (cost=0.00..11.79 rows=3 width=556)
+                                       ->  Seq Scan on events_270009 events
                                              Filter: ((event_type)::text = ANY ('{click,submit,pay}'::text[]))
 (19 rows)
 
 -- Union and left join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	avg(array_length(events, 1)) AS event_average,
 	hasdone
 FROM
@@ -845,50 +847,51 @@ GROUP BY
 	hasdone;
                                                                                                                             QUERY PLAN                                                                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- HashAggregate  (cost=0.00..0.00 rows=0 width=0)
+ HashAggregate
    Group Key: remote_scan.hasdone
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+   ->  Custom Scan (Citus Real-Time)
          Task Count: 2
          Tasks Shown: One of 2
          ->  Task
                Node: host=localhost port=57637 dbname=regression
-               ->  GroupAggregate  (cost=91.93..91.98 rows=2 width=48)
+               ->  GroupAggregate
                      Group Key: subquery_top.hasdone
-                     ->  Sort  (cost=91.93..91.93 rows=2 width=64)
+                     ->  Sort
                            Sort Key: subquery_top.hasdone
-                           ->  Subquery Scan on subquery_top  (cost=91.85..91.92 rows=2 width=64)
-                                 ->  GroupAggregate  (cost=91.85..91.90 rows=2 width=112)
+                           ->  Subquery Scan on subquery_top
+                                 ->  GroupAggregate
                                        Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), ('Has done paying'::text)
-                                       ->  Sort  (cost=91.85..91.85 rows=2 width=88)
+                                       ->  Sort
                                              Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), ('Has done paying'::text)
-                                             ->  Merge Left Join  (cost=91.75..91.84 rows=2 width=88)
+                                             ->  Merge Left Join
                                                    Merge Cond: ((((users.composite_id).tenant_id) = ((events_2.composite_id).tenant_id)) AND (((users.composite_id).user_id) = ((events_2.composite_id).user_id)))
-                                                   ->  Unique  (cost=79.46..79.48 rows=2 width=56)
-                                                         ->  Sort  (cost=79.46..79.47 rows=2 width=56)
+                                                   ->  Unique
+                                                         ->  Sort
                                                                Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), ('action=>1'::text), events.event_time
-                                                               ->  Append  (cost=0.00..79.45 rows=2 width=56)
-                                                                     ->  Nested Loop  (cost=0.00..39.72 rows=1 width=56)
+                                                               ->  Append
+                                                                     ->  Nested Loop
                                                                            Join Filter: (((users.composite_id).tenant_id = (events.composite_id).tenant_id) AND ((users.composite_id).user_id = (events.composite_id).user_id))
-                                                                           ->  Seq Scan on events_270009 events  (cost=0.00..11.62 rows=1 width=40)
+                                                                           ->  Seq Scan on events_270009 events
                                                                                  Filter: ((event_type)::text = 'click'::text)
-                                                                           ->  Seq Scan on users_270013 users  (cost=0.00..28.00 rows=6 width=32)
+                                                                           ->  Seq Scan on users_270013 users
                                                                                  Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                                                     ->  Nested Loop  (cost=0.00..39.72 rows=1 width=56)
+                                                                     ->  Nested Loop
                                                                            Join Filter: (((users_1.composite_id).tenant_id = (events_1.composite_id).tenant_id) AND ((users_1.composite_id).user_id = (events_1.composite_id).user_id))
-                                                                           ->  Seq Scan on events_270009 events_1  (cost=0.00..11.62 rows=1 width=40)
+                                                                           ->  Seq Scan on events_270009 events_1
                                                                                  Filter: ((event_type)::text = 'submit'::text)
-                                                                           ->  Seq Scan on users_270013 users_1  (cost=0.00..28.00 rows=6 width=32)
+                                                                           ->  Seq Scan on users_270013 users_1
                                                                                  Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                                   ->  Materialize  (cost=12.29..12.31 rows=1 width=48)
-                                                         ->  Unique  (cost=12.29..12.30 rows=1 width=80)
-                                                               ->  Sort  (cost=12.29..12.29 rows=1 width=80)
+                                                   ->  Materialize
+                                                         ->  Unique
+                                                               ->  Sort
                                                                      Sort Key: ((events_2.composite_id).tenant_id), ((events_2.composite_id).user_id)
-                                                                     ->  Seq Scan on events_270009 events_2  (cost=0.00..12.28 rows=1 width=80)
+                                                                     ->  Seq Scan on events_270009 events_2
                                                                            Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type) AND ((event_type)::text = 'pay'::text))
 (40 rows)
 
 -- Union, left join and having subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+  SELECT
 	avg(array_length(events, 1)) AS event_average,
 	count_pay
 	FROM (
@@ -960,7 +963,8 @@ ORDER BY
 	count_pay;
 ERROR:  bogus varattno for OUTER_VAR var: 3
 -- Lateral join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	tenant_id,
 	user_id,
 	user_lastseen,
@@ -1011,31 +1015,31 @@ LIMIT
 	10;
                                                                                                       QUERY PLAN                                                                                                      
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..0.00 rows=0 width=0)
-   ->  Sort  (cost=0.00..0.00 rows=0 width=0)
+ Limit
+   ->  Sort
          Sort Key: remote_scan.user_lastseen DESC
-         ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+         ->  Custom Scan (Citus Real-Time)
                Task Count: 2
                Tasks Shown: One of 2
                ->  Task
                      Node: host=localhost port=57637 dbname=regression
-                     ->  Limit  (cost=100.43..100.44 rows=6 width=56)
-                           ->  Sort  (cost=100.43..100.44 rows=6 width=56)
+                     ->  Limit
+                           ->  Sort
                                  Sort Key: (max(users.lastseen)) DESC
-                                 ->  GroupAggregate  (cost=100.14..100.29 rows=6 width=56)
+                                 ->  GroupAggregate
                                        Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                                       ->  Sort  (cost=100.14..100.16 rows=6 width=548)
+                                       ->  Sort
                                              Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                                             ->  Nested Loop Left Join  (cost=40.04..100.06 rows=6 width=548)
-                                                   ->  Limit  (cost=28.08..28.09 rows=6 width=24)
-                                                         ->  Sort  (cost=28.08..28.09 rows=6 width=24)
+                                             ->  Nested Loop Left Join
+                                                   ->  Limit
+                                                         ->  Sort
                                                                Sort Key: users.lastseen DESC
-                                                               ->  Seq Scan on users_270013 users  (cost=0.00..28.00 rows=6 width=24)
+                                                               ->  Seq Scan on users_270013 users
                                                                      Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                                   ->  Limit  (cost=11.96..11.96 rows=1 width=524)
-                                                         ->  Sort  (cost=11.96..11.96 rows=1 width=524)
+                                                   ->  Limit
+                                                         ->  Sort
                                                                Sort Key: events.event_time DESC
-                                                               ->  Seq Scan on events_270009 events  (cost=0.00..11.95 rows=1 width=524)
+                                                               ->  Seq Scan on events_270009 events
                                                                      Filter: (((composite_id).tenant_id = ((users.composite_id).tenant_id)) AND ((composite_id).user_id = ((users.composite_id).user_id)))
 (26 rows)
 

--- a/src/test/regress/output/multi_subquery.source
+++ b/src/test/regress/output/multi_subquery.source
@@ -376,9 +376,6 @@ SET client_min_messages TO DEBUG2;
 SELECT * FROM 
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a) 
 AS foo;
-DEBUG:  predicate pruning for shardId 270005
-DEBUG:  predicate pruning for shardId 270006
-DEBUG:  predicate pruning for shardId 270008
  count 
 -------
 (0 rows)
@@ -386,9 +383,6 @@ DEBUG:  predicate pruning for shardId 270008
 SELECT * FROM 
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE 'eren' = a GROUP BY a)
 AS foo;
-DEBUG:  predicate pruning for shardId 270005
-DEBUG:  predicate pruning for shardId 270007
-DEBUG:  predicate pruning for shardId 270008
  count 
 -------
 (0 rows)

--- a/src/test/regress/output/multi_subquery_0.source
+++ b/src/test/regress/output/multi_subquery_0.source
@@ -373,14 +373,14 @@ SELECT master_create_worker_shards('subquery_pruning_varchar_test_table', 4, 1);
 
 SET citus.subquery_pushdown TO TRUE;
 SET client_min_messages TO DEBUG2;
-SELECT * FROM 
-	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a) 
+SELECT * FROM
+	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a)
 AS foo;
  count 
 -------
 (0 rows)
 
-SELECT * FROM 
+SELECT * FROM
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE 'eren' = a GROUP BY a)
 AS foo;
  count 
@@ -388,32 +388,32 @@ AS foo;
 (0 rows)
 
 SET client_min_messages TO NOTICE;
--- test subquery join on VARCHAR partition column 
+-- test subquery join on VARCHAR partition column
 SELECT * FROM
-	(SELECT 
+	(SELECT
 		a_inner AS a
 	FROM
-		(SELECT 
+		(SELECT
 			subquery_pruning_varchar_test_table.a AS a_inner
-		FROM 
+		FROM
 		 	subquery_pruning_varchar_test_table
-		GROUP BY 
+		GROUP BY
 		  	subquery_pruning_varchar_test_table.a
-		HAVING 
-		  	count(subquery_pruning_varchar_test_table.a) < 3) 
+		HAVING
+		  	count(subquery_pruning_varchar_test_table.a) < 3)
 		AS f1,
-		(SELECT 
+		(SELECT
 		 	subquery_pruning_varchar_test_table.a
-		FROM 
+		FROM
 		  	subquery_pruning_varchar_test_table
-		GROUP BY 
+		GROUP BY
 		  	subquery_pruning_varchar_test_table.a
-		HAVING 
-		  	sum(coalesce(subquery_pruning_varchar_test_table.b,0)) > 20.0) 
+		HAVING
+		  	sum(coalesce(subquery_pruning_varchar_test_table.b,0)) > 20.0)
 		AS f2
-	WHERE 
+	WHERE
 		f1.a_inner = f2.a
-	GROUP BY 
+	GROUP BY
 		a_inner)
 AS foo;
  a 
@@ -732,7 +732,8 @@ LIMIT
 
 -- Same queries above with explain
 -- Simple join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	avg(array_length(events, 1)) AS event_average
 FROM
 	(SELECT
@@ -759,29 +760,30 @@ FROM
 		user_id) AS subquery;
                                                                                           QUERY PLAN                                                                                          
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..0.00 rows=0 width=0)
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+ Aggregate
+   ->  Custom Scan (Citus Real-Time)
          Task Count: 2
          Tasks Shown: One of 2
          ->  Task
                Node: host=localhost port=57637 dbname=regression
-               ->  Aggregate  (cost=40.01..40.02 rows=1 width=32)
-                     ->  GroupAggregate  (cost=39.89..39.99 rows=1 width=556)
+               ->  Aggregate
+                     ->  GroupAggregate
                            Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                           ->  Merge Join  (cost=39.89..39.97 rows=1 width=556)
+                           ->  Merge Join
                                  Merge Cond: ((((users.composite_id).tenant_id) = ((events.composite_id).tenant_id)) AND (((users.composite_id).user_id) = ((events.composite_id).user_id)))
-                                 ->  Sort  (cost=28.08..28.09 rows=6 width=32)
+                                 ->  Sort
                                        Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                                       ->  Seq Scan on users_270013 users  (cost=0.00..28.00 rows=6 width=32)
+                                       ->  Seq Scan on users_270013 users
                                              Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                 ->  Sort  (cost=11.81..11.82 rows=3 width=556)
+                                 ->  Sort
                                        Sort Key: ((events.composite_id).tenant_id), ((events.composite_id).user_id)
-                                       ->  Seq Scan on events_270009 events  (cost=0.00..11.79 rows=3 width=556)
+                                       ->  Seq Scan on events_270009 events
                                              Filter: ((event_type)::text = ANY ('{click,submit,pay}'::text[]))
 (19 rows)
 
 -- Union and left join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	avg(array_length(events, 1)) AS event_average,
 	hasdone
 FROM
@@ -845,47 +847,48 @@ GROUP BY
 	hasdone;
                                                                                                                       QUERY PLAN                                                                                                                       
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- HashAggregate  (cost=0.00..0.00 rows=0 width=0)
+ HashAggregate
    Group Key: remote_scan.hasdone
-   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+   ->  Custom Scan (Citus Real-Time)
          Task Count: 2
          Tasks Shown: One of 2
          ->  Task
                Node: host=localhost port=57637 dbname=regression
-               ->  HashAggregate  (cost=91.94..91.96 rows=2 width=64)
+               ->  HashAggregate
                      Group Key: COALESCE(('Has done paying'::text), 'Has not done paying'::text)
-                     ->  GroupAggregate  (cost=91.85..91.90 rows=2 width=88)
+                     ->  GroupAggregate
                            Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), ('Has done paying'::text)
-                           ->  Sort  (cost=91.85..91.85 rows=2 width=88)
+                           ->  Sort
                                  Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), ('Has done paying'::text)
-                                 ->  Merge Left Join  (cost=91.75..91.84 rows=2 width=88)
+                                 ->  Merge Left Join
                                        Merge Cond: ((((users.composite_id).tenant_id) = ((events_2.composite_id).tenant_id)) AND (((users.composite_id).user_id) = ((events_2.composite_id).user_id)))
-                                       ->  Unique  (cost=79.46..79.48 rows=2 width=40)
-                                             ->  Sort  (cost=79.46..79.47 rows=2 width=40)
+                                       ->  Unique
+                                             ->  Sort
                                                    Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), ('action=>1'::text), events.event_time
-                                                   ->  Append  (cost=0.00..79.45 rows=2 width=40)
-                                                         ->  Nested Loop  (cost=0.00..39.72 rows=1 width=40)
+                                                   ->  Append
+                                                         ->  Nested Loop
                                                                Join Filter: (((users.composite_id).tenant_id = (events.composite_id).tenant_id) AND ((users.composite_id).user_id = (events.composite_id).user_id))
-                                                               ->  Seq Scan on events_270009 events  (cost=0.00..11.62 rows=1 width=40)
+                                                               ->  Seq Scan on events_270009 events
                                                                      Filter: ((event_type)::text = 'click'::text)
-                                                               ->  Seq Scan on users_270013 users  (cost=0.00..28.00 rows=6 width=32)
+                                                               ->  Seq Scan on users_270013 users
                                                                      Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                                         ->  Nested Loop  (cost=0.00..39.72 rows=1 width=40)
+                                                         ->  Nested Loop
                                                                Join Filter: (((users_1.composite_id).tenant_id = (events_1.composite_id).tenant_id) AND ((users_1.composite_id).user_id = (events_1.composite_id).user_id))
-                                                               ->  Seq Scan on events_270009 events_1  (cost=0.00..11.62 rows=1 width=40)
+                                                               ->  Seq Scan on events_270009 events_1
                                                                      Filter: ((event_type)::text = 'submit'::text)
-                                                               ->  Seq Scan on users_270013 users_1  (cost=0.00..28.00 rows=6 width=32)
+                                                               ->  Seq Scan on users_270013 users_1
                                                                      Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                       ->  Materialize  (cost=12.29..12.31 rows=1 width=48)
-                                             ->  Unique  (cost=12.29..12.30 rows=1 width=32)
-                                                   ->  Sort  (cost=12.29..12.29 rows=1 width=32)
+                                       ->  Materialize
+                                             ->  Unique
+                                                   ->  Sort
                                                          Sort Key: ((events_2.composite_id).tenant_id), ((events_2.composite_id).user_id)
-                                                         ->  Seq Scan on events_270009 events_2  (cost=0.00..12.28 rows=1 width=32)
+                                                         ->  Seq Scan on events_270009 events_2
                                                                Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type) AND ((event_type)::text = 'pay'::text))
 (37 rows)
 
 -- Union, left join and having subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+  SELECT
 	avg(array_length(events, 1)) AS event_average,
 	count_pay
 	FROM (
@@ -957,7 +960,8 @@ ORDER BY
 	count_pay;
 ERROR:  bogus varattno for OUTER_VAR var: 3
 -- Lateral join subquery pushdown
-EXPLAIN SELECT
+EXPLAIN (COSTS OFF)
+SELECT
 	tenant_id,
 	user_id,
 	user_lastseen,
@@ -1008,31 +1012,31 @@ LIMIT
 	10;
                                                                                                       QUERY PLAN                                                                                                      
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..0.00 rows=0 width=0)
-   ->  Sort  (cost=0.00..0.00 rows=0 width=0)
+ Limit
+   ->  Sort
          Sort Key: remote_scan.user_lastseen DESC
-         ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+         ->  Custom Scan (Citus Real-Time)
                Task Count: 2
                Tasks Shown: One of 2
                ->  Task
                      Node: host=localhost port=57637 dbname=regression
-                     ->  Limit  (cost=100.43..100.44 rows=6 width=56)
-                           ->  Sort  (cost=100.43..100.44 rows=6 width=56)
+                     ->  Limit
+                           ->  Sort
                                  Sort Key: (max(users.lastseen)) DESC
-                                 ->  GroupAggregate  (cost=100.14..100.29 rows=6 width=548)
+                                 ->  GroupAggregate
                                        Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                                       ->  Sort  (cost=100.14..100.16 rows=6 width=548)
+                                       ->  Sort
                                              Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
-                                             ->  Nested Loop Left Join  (cost=40.04..100.06 rows=6 width=548)
-                                                   ->  Limit  (cost=28.08..28.09 rows=6 width=40)
-                                                         ->  Sort  (cost=28.08..28.09 rows=6 width=40)
+                                             ->  Nested Loop Left Join
+                                                   ->  Limit
+                                                         ->  Sort
                                                                Sort Key: users.lastseen DESC
-                                                               ->  Seq Scan on users_270013 users  (cost=0.00..28.00 rows=6 width=40)
+                                                               ->  Seq Scan on users_270013 users
                                                                      Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
-                                                   ->  Limit  (cost=11.96..11.96 rows=1 width=524)
-                                                         ->  Sort  (cost=11.96..11.96 rows=1 width=524)
+                                                   ->  Limit
+                                                         ->  Sort
                                                                Sort Key: events.event_time DESC
-                                                               ->  Seq Scan on events_270009 events  (cost=0.00..11.95 rows=1 width=524)
+                                                               ->  Seq Scan on events_270009 events
                                                                      Filter: (((composite_id).tenant_id = ((users.composite_id).tenant_id)) AND ((composite_id).user_id = ((users.composite_id).user_id)))
 (26 rows)
 

--- a/src/test/regress/output/multi_subquery_0.source
+++ b/src/test/regress/output/multi_subquery_0.source
@@ -376,9 +376,6 @@ SET client_min_messages TO DEBUG2;
 SELECT * FROM 
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a) 
 AS foo;
-DEBUG:  predicate pruning for shardId 270005
-DEBUG:  predicate pruning for shardId 270006
-DEBUG:  predicate pruning for shardId 270008
  count 
 -------
 (0 rows)
@@ -386,9 +383,6 @@ DEBUG:  predicate pruning for shardId 270008
 SELECT * FROM 
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE 'eren' = a GROUP BY a)
 AS foo;
-DEBUG:  predicate pruning for shardId 270005
-DEBUG:  predicate pruning for shardId 270007
-DEBUG:  predicate pruning for shardId 270008
  count 
 -------
 (0 rows)

--- a/src/test/regress/sql/multi_large_table_pruning.sql
+++ b/src/test/regress/sql/multi_large_table_pruning.sql
@@ -14,7 +14,13 @@ SET client_min_messages TO DEBUG2;
 SET citus.task_executor_type TO 'task-tracker';
 
 -- Single range-repartition join to test join-pruning behaviour.
-
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey;
 SELECT
 	count(*)
 FROM
@@ -24,7 +30,14 @@ WHERE
 
 -- Single range-repartition join with a selection clause on the partitioned
 -- table to test the case when all map tasks are pruned away.
-
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey AND
+	o_orderkey < 0;
 SELECT
 	count(*)
 FROM
@@ -35,7 +48,14 @@ WHERE
 
 -- Single range-repartition join with a selection clause on the base table to
 -- test the case when all sql tasks are pruned away.
-
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	orders, customer
+WHERE
+	o_custkey = c_custkey AND
+	c_custkey < 0;
 SELECT
 	count(*)
 FROM
@@ -47,7 +67,13 @@ WHERE
 -- Dual hash-repartition join test case. Note that this query doesn't produce
 -- meaningful results and is only to test hash-partitioning of two large tables
 -- on non-partition columns.
-
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	lineitem, customer
+WHERE
+	l_partkey = c_nationkey;
 SELECT
 	count(*)
 FROM
@@ -57,7 +83,14 @@ WHERE
 
 -- Dual hash-repartition join with a selection clause on one of the tables to
 -- test the case when all map tasks are pruned away.
-
+EXPLAIN (COSTS OFF)
+SELECT
+	count(*)
+FROM
+	lineitem, customer
+WHERE
+	l_partkey = c_nationkey AND
+	l_orderkey < 0;
 SELECT
 	count(*)
 FROM
@@ -67,6 +100,14 @@ WHERE
 	l_orderkey < 0;
 
 -- Test cases with false in the WHERE clause
+EXPLAIN (COSTS OFF)
+SELECT
+	o_orderkey
+FROM
+	orders INNER JOIN customer ON (o_custkey = c_custkey)
+WHERE
+	false;
+-- execute once, to verify that's handled
 SELECT
 	o_orderkey
 FROM
@@ -74,6 +115,7 @@ FROM
 WHERE
 	false;
 
+EXPLAIN (COSTS OFF)
 SELECT
 	o_orderkey
 FROM
@@ -81,11 +123,13 @@ FROM
 WHERE
 	1=0 AND c_custkey < 0;
 
+EXPLAIN (COSTS OFF)
 SELECT
 	o_orderkey
 FROM
 	orders INNER JOIN customer ON (o_custkey = c_custkey AND false);
 
+EXPLAIN (COSTS OFF)
 SELECT
 	o_orderkey
 FROM


### PR DESCRIPTION
A followup PR will optimize shard-pruning so we don't linearly walk across all shards in a lot of cases.  That changes a *lot* of debug output, and will likely continue to change further.  Therefore it seems unrealistic to rely on the `predicate pruning for shardId ...` debug messages.

Those messages also have the issue that they output shardids to a lot of places where it's not needed, preventing parallelization of tests.

I've added a second commit, that tries to re-add coverage removed by the removal of these debug messages by using explain - that's not perfect, but seems to give a reasonable coverage?