### PR TITLE
Refactor COPY to not directly use cache entry

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2057,35 +2057,13 @@ ShardInterval *
 FastShardPruning(Oid distributedTableId, Datum partitionValue)
 {
 	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
-	int shardCount = cacheEntry->shardIntervalArrayLength;
-	ShardInterval **sortedShardIntervalArray = cacheEntry->sortedShardIntervalArray;
-	bool useBinarySearch = false;
-	char partitionMethod = cacheEntry->partitionMethod;
-	FmgrInfo *shardIntervalCompareFunction = cacheEntry->shardIntervalCompareFunction;
-	bool hasUniformHashDistribution = cacheEntry->hasUniformHashDistribution;
-	FmgrInfo *hashFunction = NULL;
 	ShardInterval *shardInterval = NULL;
-
-	/* determine whether to use binary search */
-	if (partitionMethod != DISTRIBUTE_BY_HASH || !hasUniformHashDistribution)
-	{
-		useBinarySearch = true;
-	}
-
-	/* we only need hash functions for hash distributed tables */
-	if (partitionMethod == DISTRIBUTE_BY_HASH)
-	{
-		hashFunction = cacheEntry->hashFunction;
-	}
 
 	/*
 	 * Call FindShardInterval to find the corresponding shard interval for the
 	 * given partition value.
 	 */
-	shardInterval = FindShardInterval(partitionValue, sortedShardIntervalArray,
-									  shardCount, partitionMethod,
-									  shardIntervalCompareFunction, hashFunction,
-									  useBinarySearch);
+	shardInterval = FindShardInterval(partitionValue, cacheEntry);
 
 	return shardInterval;
 }

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1974,8 +1974,9 @@ FindShardForInsert(Query *query, DeferredErrorMessage **planningError)
 	if (partitionMethod == DISTRIBUTE_BY_HASH || partitionMethod == DISTRIBUTE_BY_RANGE)
 	{
 		Datum partitionValue = partitionValueConst->constvalue;
-		ShardInterval *shardInterval = FastShardPruning(distributedTableId,
-														partitionValue);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+		ShardInterval *shardInterval = FindShardInterval(partitionValue, cacheEntry);
+
 		if (shardInterval != NULL)
 		{
 			prunedShardList = list_make1(shardInterval);
@@ -2044,28 +2045,6 @@ FindShardForInsert(Query *query, DeferredErrorMessage **planningError)
 	}
 
 	return (ShardInterval *) linitial(prunedShardList);
-}
-
-
-/*
- * FastShardPruning is a higher level API for FindShardInterval function. Given the
- * relationId of the distributed table and partitionValue, FastShardPruning function finds
- * the corresponding shard interval that the partitionValue should be in. FastShardPruning
- * returns NULL if no ShardIntervals exist for the given partitionValue.
- */
-ShardInterval *
-FastShardPruning(Oid distributedTableId, Datum partitionValue)
-{
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
-	ShardInterval *shardInterval = NULL;
-
-	/*
-	 * Call FindShardInterval to find the corresponding shard interval for the
-	 * given partition value.
-	 */
-	shardInterval = FindShardInterval(partitionValue, cacheEntry);
-
-	return shardInterval;
 }
 
 

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -332,6 +332,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 		char *distributionValueString = NULL;
 		Datum inputDatum = 0;
 		Datum distributionValueDatum = 0;
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 
 		/* if given table is not reference table, distributionValue cannot be NULL */
 		if (PG_ARGISNULL(1))
@@ -351,7 +352,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 		distributionValueDatum = StringToDatum(distributionValueString,
 											   distributionDataType);
 
-		shardInterval = FastShardPruning(relationId, distributionValueDatum);
+		shardInterval = FindShardInterval(distributionValueDatum, cacheEntry);
 	}
 	else
 	{

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -61,7 +61,6 @@ typedef struct CitusCopyDestReceiver
 
 	/* distributed table metadata */
 	DistTableCacheEntry *tableMetadata;
-	bool useBinarySearch;
 
 	/* open relation handle */
 	Relation distributedRelation;

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -44,7 +44,6 @@ extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
 extern ShardInterval * FindShardForInsert(Query *query,
 										  DeferredErrorMessage **planningError);
-extern ShardInterval * FastShardPruning(Oid distributedTableId, Datum partitionValue);
 
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/include/distributed/shardinterval_utils.h
+++ b/src/include/distributed/shardinterval_utils.h
@@ -13,6 +13,7 @@
 #define SHARDINTERVAL_UTILS_H_
 
 #include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
 #include "nodes/primnodes.h"
 
 #define INVALID_SHARD_INDEX -1
@@ -33,10 +34,7 @@ extern int CompareRelationShards(const void *leftElement,
 								 const void *rightElement);
 extern int ShardIndex(ShardInterval *shardInterval);
 extern ShardInterval * FindShardInterval(Datum partitionColumnValue,
-										 ShardInterval **shardIntervalCache,
-										 int shardCount, char partitionMethod,
-										 FmgrInfo *compareFunction,
-										 FmgrInfo *hashFunction, bool useBinarySearch);
+										 DistTableCacheEntry *cacheEntry);
 extern bool SingleReplicatedTable(Oid relationId);
 
 #endif /* SHARDINTERVAL_UTILS_H_ */


### PR DESCRIPTION
If the cache is invalidated during a COPY, the reference will not point to valid memory. By deep copying the fields we actually need, we can avoid that.

Fixes #1338
