### PR TITLE
Don't change parse tree of DDL commands

### DIFF
--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1185,6 +1185,58 @@ SELECT key, seq FROM func_parameter_test ORDER BY seq;
 
 DROP FUNCTION insert_with_max(text);
 DROP TABLE func_parameter_test;
+-- test prepared DDL, mainly to verify we don't mess up the query tree
+SET citus.multi_shard_commit_protocol TO '2pc';
+CREATE TABLE prepare_ddl (x int, y int);
+SELECT create_distributed_table('prepare_ddl', 'x');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE OR REPLACE FUNCTION ddl_in_plpgsql()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    CREATE INDEX prepared_index ON public.prepare_ddl(x);
+    DROP INDEX prepared_index;
+END;
+$BODY$ LANGUAGE plpgsql;
+SELECT ddl_in_plpgsql();
+ ddl_in_plpgsql 
+----------------
+ 
+(1 row)
+
+SELECT ddl_in_plpgsql();
+ ddl_in_plpgsql 
+----------------
+ 
+(1 row)
+
+-- test prepared COPY
+CREATE OR REPLACE FUNCTION copy_in_plpgsql()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    COPY prepare_ddl (x) FROM PROGRAM 'echo 1' WITH CSV;
+END;
+$BODY$ LANGUAGE plpgsql;
+SELECT copy_in_plpgsql();
+ copy_in_plpgsql 
+-----------------
+ 
+(1 row)
+
+SELECT copy_in_plpgsql();
+ copy_in_plpgsql 
+-----------------
+ 
+(1 row)
+
+DROP FUNCTION ddl_in_plpgsql();
+DROP FUNCTION copy_in_plpgsql();
+DROP TABLE prepare_ddl;
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();
 DROP FUNCTION plpgsql_test_2();

--- a/src/test/regress/sql/multi_prepare_plsql.sql
+++ b/src/test/regress/sql/multi_prepare_plsql.sql
@@ -537,6 +537,39 @@ SELECT key, seq FROM func_parameter_test ORDER BY seq;
 DROP FUNCTION insert_with_max(text);
 DROP TABLE func_parameter_test;
 
+-- test prepared DDL, mainly to verify we don't mess up the query tree
+SET citus.multi_shard_commit_protocol TO '2pc';
+CREATE TABLE prepare_ddl (x int, y int);
+SELECT create_distributed_table('prepare_ddl', 'x');
+
+CREATE OR REPLACE FUNCTION ddl_in_plpgsql()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    CREATE INDEX prepared_index ON public.prepare_ddl(x);
+    DROP INDEX prepared_index;
+END;
+$BODY$ LANGUAGE plpgsql;
+
+SELECT ddl_in_plpgsql();
+SELECT ddl_in_plpgsql();
+
+-- test prepared COPY
+CREATE OR REPLACE FUNCTION copy_in_plpgsql()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    COPY prepare_ddl (x) FROM PROGRAM 'echo 1' WITH CSV;
+END;
+$BODY$ LANGUAGE plpgsql;
+
+SELECT copy_in_plpgsql();
+SELECT copy_in_plpgsql();
+
+DROP FUNCTION ddl_in_plpgsql();
+DROP FUNCTION copy_in_plpgsql();
+DROP TABLE prepare_ddl;
+
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();
 DROP FUNCTION plpgsql_test_2();


### PR DESCRIPTION
Previously we scribbled on the parse tree in ProcessUtility, which may be used across multiple statements/transactions by PL/pgSQL.

Fixes #1358