### PR TITLE
Send explain queries with savepoints

### DIFF
--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -44,6 +44,7 @@ extern int SendRemoteCommand(MultiConnection *connection, const char *command);
 extern int SendRemoteCommandParams(MultiConnection *connection, const char *command,
 								   int parameterCount, const Oid *parameterTypes,
 								   const char *const *parameterValues);
+extern List * ReadFirstColumnAsText(struct pg_result *queryResult);
 extern struct pg_result * GetRemoteCommandResult(MultiConnection *connection,
 												 bool raiseInterrupts);
 

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -669,3 +669,20 @@ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
         Node: host=localhost port=57637 dbname=regression
         ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem  (cost=0.28..11.83 rows=3 width=5)
               Index Cond: (l_orderkey = 5)
+-- test explain in a transaction with alter table to test we use right connections
+BEGIN;
+CREATE TABLE explain_table(id int);
+SELECT create_distributed_table('explain_table', 'id');
+
+ALTER TABLE explain_table ADD COLUMN value int;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+EXPLAIN (COSTS FALSE) SELECT value FROM explain_table WHERE id = 1;
+Custom Scan (Citus Router)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Seq Scan on explain_table_570001 explain_table
+              Filter: (id = 1)
+ROLLBACK;

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -640,3 +640,20 @@ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
         Node: host=localhost port=57637 dbname=regression
         ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem  (cost=0.28..11.83 rows=3 width=5)
               Index Cond: (l_orderkey = 5)
+-- test explain in a transaction with alter table to test we use right connections
+BEGIN;
+CREATE TABLE explain_table(id int);
+SELECT create_distributed_table('explain_table', 'id');
+
+ALTER TABLE explain_table ADD COLUMN value int;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+EXPLAIN (COSTS FALSE) SELECT value FROM explain_table WHERE id = 1;
+Custom Scan (Citus Router)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Seq Scan on explain_table_570001 explain_table
+              Filter: (id = 1)
+ROLLBACK;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -235,3 +235,15 @@ EXPLAIN (COSTS FALSE) EXECUTE real_time_executor_query;
 -- at least make sure to fail without crashing
 PREPARE router_executor_query_param(int) AS SELECT l_quantity FROM lineitem WHERE l_orderkey = $1;
 EXPLAIN EXECUTE router_executor_query_param(5);
+
+-- test explain in a transaction with alter table to test we use right connections
+BEGIN;
+
+CREATE TABLE explain_table(id int);
+SELECT create_distributed_table('explain_table', 'id');
+
+ALTER TABLE explain_table ADD COLUMN value int;
+
+EXPLAIN (COSTS FALSE) SELECT value FROM explain_table WHERE id = 1;
+
+ROLLBACK;


### PR DESCRIPTION
With this commit, we started to send explain queries within a savepoint. After
running explain query, we rollback to savepoint. This saves us from side effects
of EXPLAIN ANALYZE on DML queries.

Fixes #1344