### PR TITLE
Improve / Fix range pruning

### DIFF
--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -1158,9 +1158,19 @@ PruneWithBoundaries(DistTableCacheEntry *cacheEntry, ClauseWalkerContext *contex
 	}
 	if (prune->greaterConsts)
 	{
-		lowerBound = prune->greaterConsts->constvalue;
-		lowerBoundInclusive = false;
-		hasLowerBound = true;
+		/*
+		 * Use the more restrictive one, if both greater and greaterEqual
+		 * constraints are specified.
+		 */
+		if (!hasLowerBound ||
+			PerformValueCompare(compareFunctionCall,
+								prune->greaterConsts->constvalue,
+								lowerBound) >= 0)
+		{
+			lowerBound = prune->greaterConsts->constvalue;
+			lowerBoundInclusive = false;
+			hasLowerBound = true;
+		}
 	}
 	if (prune->lessEqualConsts)
 	{
@@ -1170,9 +1180,19 @@ PruneWithBoundaries(DistTableCacheEntry *cacheEntry, ClauseWalkerContext *contex
 	}
 	if (prune->lessConsts)
 	{
-		upperBound = prune->lessConsts->constvalue;
-		upperBoundInclusive = false;
-		hasUpperBound = true;
+		/*
+		 * Use the more restrictive one, if both less and lessEqual
+		 * constraints are specified.
+		 */
+		if (!hasUpperBound ||
+			PerformValueCompare(compareFunctionCall,
+								prune->lessConsts->constvalue,
+								upperBound) <= 0)
+		{
+			upperBound = prune->lessConsts->constvalue;
+			upperBoundInclusive = false;
+			hasUpperBound = true;
+		}
 	}
 
 	Assert(hasLowerBound || hasUpperBound);


### PR DESCRIPTION
Previously we didn't prune aggressively enough if both equality and inequality constraints are present, or if both < and <= (> and >= respectively) are present.  The results were correct, just didn't filter enough cases, which prevents the new subquery pushdown implementation from working.

We should add more tests around this, but I'm running out of time for today.  The subquery branch exercises this quite thoroughly, and after fixing an independent bug on it, tests passed with this applied.  I think we should add a post-freeze item to improve test coverage around this a bit.

Fixes: #1364