### PR TITLE
Fix locking in master_drop_all_shards / master_apply_delete_command

### DIFF
--- a/src/test/regress/expected/isolation_drop_shards.out
+++ b/src/test/regress/expected/isolation_drop_shards.out
@@ -160,3 +160,83 @@ step s2-drop-all-shards: <... completed>
 master_drop_all_shards
 
 0              
+
+starting permutation: s1-begin s1-truncate s2-truncate s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-truncate: 
+	TRUNCATE append_table;
+
+step s2-truncate: 
+	TRUNCATE append_table;
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-truncate: <... completed>
+
+starting permutation: s1-begin s1-truncate s2-apply-delete-command s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-truncate: 
+	TRUNCATE append_table;
+
+step s2-apply-delete-command: 
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-apply-delete-command: <... completed>
+master_apply_delete_command
+
+0              
+
+starting permutation: s1-begin s1-truncate s2-drop-all-shards s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-truncate: 
+	TRUNCATE append_table;
+
+step s2-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-drop-all-shards: <... completed>
+master_drop_all_shards
+
+0              
+
+starting permutation: s1-begin s1-truncate s2-select s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-truncate: 
+	TRUNCATE append_table;
+
+step s2-select: 
+	SELECT * FROM append_table;
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-select: <... completed>
+test_id        data           
+

--- a/src/test/regress/expected/isolation_drop_shards.out
+++ b/src/test/regress/expected/isolation_drop_shards.out
@@ -1,0 +1,162 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-drop-all-shards s2-truncate s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+
+master_drop_all_shards
+
+16             
+step s2-truncate: 
+	TRUNCATE append_table;
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-truncate: <... completed>
+
+starting permutation: s1-begin s1-drop-all-shards s2-apply-delete-command s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+
+master_drop_all_shards
+
+16             
+step s2-apply-delete-command: 
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-apply-delete-command: <... completed>
+master_apply_delete_command
+
+0              
+
+starting permutation: s1-begin s1-drop-all-shards s2-drop-all-shards s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+
+master_drop_all_shards
+
+16             
+step s2-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-drop-all-shards: <... completed>
+master_drop_all_shards
+
+0              
+
+starting permutation: s1-begin s1-drop-all-shards s2-select s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+
+master_drop_all_shards
+
+16             
+step s2-select: 
+	SELECT * FROM append_table;
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-select: <... completed>
+test_id        data           
+
+
+starting permutation: s1-begin s1-apply-delete-command s2-truncate s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-apply-delete-command: 
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+
+master_apply_delete_command
+
+16             
+step s2-truncate: 
+	TRUNCATE append_table;
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-truncate: <... completed>
+
+starting permutation: s1-begin s1-apply-delete-command s2-apply-delete-command s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-apply-delete-command: 
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+
+master_apply_delete_command
+
+16             
+step s2-apply-delete-command: 
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-apply-delete-command: <... completed>
+master_apply_delete_command
+
+0              
+
+starting permutation: s1-begin s1-apply-delete-command s2-drop-all-shards s1-commit
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-apply-delete-command: 
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+
+master_apply_delete_command
+
+16             
+step s2-drop-all-shards: 
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-drop-all-shards: <... completed>
+master_drop_all_shards
+
+0              

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -1,3 +1,4 @@
 test: isolation_cluster_management
 test: isolation_dml_vs_repair
 test: isolation_concurrent_dml
+test: isolation_drop_shards

--- a/src/test/regress/specs/isolation_drop_shards.spec
+++ b/src/test/regress/specs/isolation_drop_shards.spec
@@ -1,0 +1,71 @@
+setup
+{
+	CREATE TABLE append_table (test_id integer NOT NULL, data text);
+	SELECT create_distributed_table('append_table', 'test_id', 'append');
+
+	SELECT 1 FROM (
+		SELECT min(master_create_empty_shard('append_table')) FROM generate_series(1,16)
+	) a;
+}
+
+teardown
+{
+	DROP TABLE append_table;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+	BEGIN;
+}
+
+step "s1-apply-delete-command"
+{
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+}
+
+step "s1-drop-all-shards"
+{
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+}
+
+step "s1-commit"
+{
+	COMMIT;
+}
+
+session "s2"
+
+step "s2-truncate"
+{
+	TRUNCATE append_table;
+}
+
+step "s2-apply-delete-command"
+{
+	SELECT master_apply_delete_command('DELETE FROM append_table');
+}
+
+step "s2-drop-all-shards"
+{
+	SELECT master_drop_all_shards('append_table', 'public', 'append_table');
+}
+
+step "s2-select"
+{
+	SELECT * FROM append_table;
+}
+
+permutation "s1-begin" "s1-drop-all-shards" "s2-truncate" "s1-commit"
+permutation "s1-begin" "s1-drop-all-shards" "s2-apply-delete-command" "s1-commit"
+permutation "s1-begin" "s1-drop-all-shards" "s2-drop-all-shards" "s1-commit"
+permutation "s1-begin" "s1-drop-all-shards" "s2-select" "s1-commit"
+
+permutation "s1-begin" "s1-apply-delete-command" "s2-truncate" "s1-commit"
+permutation "s1-begin" "s1-apply-delete-command" "s2-apply-delete-command" "s1-commit"
+permutation "s1-begin" "s1-apply-delete-command" "s2-drop-all-shards" "s1-commit"
+
+# We can't verify master_apply_delete_command + SELECT since it blocks on the
+# the workers, but this is not visible on the master, meaning the isolation
+# test cannot proceed.

--- a/src/test/regress/specs/isolation_drop_shards.spec
+++ b/src/test/regress/specs/isolation_drop_shards.spec
@@ -20,6 +20,11 @@ step "s1-begin"
 	BEGIN;
 }
 
+step "s1-truncate"
+{
+	TRUNCATE append_table;
+}
+
 step "s1-apply-delete-command"
 {
 	SELECT master_apply_delete_command('DELETE FROM append_table');
@@ -62,10 +67,14 @@ permutation "s1-begin" "s1-drop-all-shards" "s2-apply-delete-command" "s1-commit
 permutation "s1-begin" "s1-drop-all-shards" "s2-drop-all-shards" "s1-commit"
 permutation "s1-begin" "s1-drop-all-shards" "s2-select" "s1-commit"
 
+# We can't verify master_apply_delete_command + SELECT since it blocks on the
+# the workers, but this is not visible on the master, meaning the isolation
+# test cannot proceed.
 permutation "s1-begin" "s1-apply-delete-command" "s2-truncate" "s1-commit"
 permutation "s1-begin" "s1-apply-delete-command" "s2-apply-delete-command" "s1-commit"
 permutation "s1-begin" "s1-apply-delete-command" "s2-drop-all-shards" "s1-commit"
 
-# We can't verify master_apply_delete_command + SELECT since it blocks on the
-# the workers, but this is not visible on the master, meaning the isolation
-# test cannot proceed.
+permutation "s1-begin" "s1-truncate" "s2-truncate" "s1-commit"
+permutation "s1-begin" "s1-truncate" "s2-apply-delete-command" "s1-commit"
+permutation "s1-begin" "s1-truncate" "s2-drop-all-shards" "s1-commit"
+permutation "s1-begin" "s1-truncate" "s2-select" "s1-commit"


### PR DESCRIPTION
This PR adds the appropriate table locks to `master_drop_all_shards` and `master_apply_delete_command` and ensures that they can safely be executed concurrently through isolation tests.

It does not prevent `master_apply_delete_command` from running concurrently with `SELECT` since users might rely on the current behaviour. The long-term solution there is to take shard metadata locks on `SELECT`.

Fixes #1381 
Fixes #727
Fixes #761