### PR TITLE
Accept invalidations during COPY command

### DIFF
--- a/src/test/regress/expected/isolation_add_node_vs_copy.out
+++ b/src/test/regress/expected/isolation_add_node_vs_copy.out
@@ -8,11 +8,11 @@ step s1-begin:
     BEGIN;
 
 step s1-add-second-worker: 
-   	SELECT master_add_node('localhost', 57638);
+   	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
-master_add_node
+nodename       nodeport       isactive       
 
-(4,4,localhost,57638,default,f,t)
+localhost      57638          t              
 step s2-begin: 
     BEGIN;
 
@@ -27,12 +27,17 @@ step s2-commit:
     COMMIT;
 
 step s2-print-content: 
-	SELECT run_command_on_placements('test_reference_table', 'select count(*) from %s');
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
 
-run_command_on_placements
+nodeport       success        result         
 
-(localhost,57637,102197,t,5)
-(localhost,57638,102197,t,5)
+57637          t              5              
+57638          t              5              
 step s1-remove-second-worker: 
    	SELECT master_remove_node('localhost', 57638);
 
@@ -43,11 +48,11 @@ step s1-begin:
     BEGIN;
 
 step s1-add-second-worker: 
-   	SELECT master_add_node('localhost', 57638);
+   	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
-master_add_node
+nodename       nodeport       isactive       
 
-(5,5,localhost,57638,default,f,t)
+localhost      57638          t              
 step s2-begin: 
     BEGIN;
 
@@ -62,12 +67,17 @@ step s2-commit:
     COMMIT;
 
 step s2-print-content: 
-	SELECT run_command_on_placements('test_reference_table', 'select count(*) from %s');
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
 
-run_command_on_placements
+nodeport       success        result         
 
-(localhost,57637,102197,t,10)
-(localhost,57638,102197,t,10)
-master_add_node
+57637          t              10             
+57638          t              10             
+nodename       nodeport       isactive       
 
-(5,5,localhost,57638,default,f,t)
+localhost      57638          t              

--- a/src/test/regress/expected/isolation_add_node_vs_copy.out
+++ b/src/test/regress/expected/isolation_add_node_vs_copy.out
@@ -1,0 +1,73 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-add-second-worker s2-begin s2-copy-to-reference-table s1-commit s2-commit s2-print-content s1-remove-second-worker s1-begin s1-add-second-worker s2-begin s2-copy-to-reference-table s1-commit s2-commit s2-print-content
+create_reference_table
+
+               
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+   	SELECT master_add_node('localhost', 57638);
+
+master_add_node
+
+(4,4,localhost,57638,default,f,t)
+step s2-begin: 
+    BEGIN;
+
+step s2-copy-to-reference-table: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-copy-to-reference-table: <... completed>
+step s2-commit: 
+    COMMIT;
+
+step s2-print-content: 
+	SELECT run_command_on_placements('test_reference_table', 'select count(*) from %s');
+
+run_command_on_placements
+
+(localhost,57637,102197,t,5)
+(localhost,57638,102197,t,5)
+step s1-remove-second-worker: 
+   	SELECT master_remove_node('localhost', 57638);
+
+master_remove_node
+
+               
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+   	SELECT master_add_node('localhost', 57638);
+
+master_add_node
+
+(5,5,localhost,57638,default,f,t)
+step s2-begin: 
+    BEGIN;
+
+step s2-copy-to-reference-table: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-copy-to-reference-table: <... completed>
+step s2-commit: 
+    COMMIT;
+
+step s2-print-content: 
+	SELECT run_command_on_placements('test_reference_table', 'select count(*) from %s');
+
+run_command_on_placements
+
+(localhost,57637,102197,t,10)
+(localhost,57638,102197,t,10)
+master_add_node
+
+(5,5,localhost,57638,default,f,t)

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -2,3 +2,4 @@ test: isolation_cluster_management
 test: isolation_dml_vs_repair
 test: isolation_concurrent_dml
 test: isolation_drop_shards
+test: isolation_add_node_vs_copy

--- a/src/test/regress/specs/isolation_add_node_vs_copy.spec
+++ b/src/test/regress/specs/isolation_add_node_vs_copy.spec
@@ -1,0 +1,71 @@
+setup
+{
+	truncate pg_dist_shard_placement;
+	truncate pg_dist_shard;
+	truncate pg_dist_partition;
+	truncate pg_dist_colocation;
+	truncate pg_dist_node;
+	
+	SELECT master_add_node('localhost', 57637);
+	
+    CREATE TABLE test_reference_table (test_id integer);
+    SELECT create_reference_table('test_reference_table');
+}
+
+teardown
+{
+    DROP TABLE IF EXISTS test_reference_table CASCADE;
+
+	SELECT master_add_node('localhost', 57637);
+	SELECT master_add_node('localhost', 57638);
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-add-second-worker"
+{
+   	SELECT master_add_node('localhost', 57638);
+}
+
+step "s1-remove-second-worker"
+{
+   	SELECT master_remove_node('localhost', 57638);
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+    BEGIN;
+}
+
+step "s2-copy-to-reference-table" 
+{
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+}
+
+step "s2-commit"
+{
+    COMMIT;
+}
+
+step "s2-print-content"
+{
+	SELECT run_command_on_placements('test_reference_table', 'select count(*) from %s');
+}
+
+# verify that copy gets the invalidation and re-builts its metadata cache
+# note that we need to run the same test twice to ensure that metadata is cached
+# otherwise the test would be useless since the cache would be empty and the 
+# metadata data is gathered from the tables directly
+permutation "s1-begin" "s1-add-second-worker" "s2-begin" "s2-copy-to-reference-table" "s1-commit" "s2-commit" "s2-print-content" "s1-remove-second-worker" "s1-begin" "s1-add-second-worker" "s2-begin" "s2-copy-to-reference-table" "s1-commit" "s2-commit" "s2-print-content"


### PR DESCRIPTION
Fixes #1392 . 

    Accept invalidations during COPY command to prevent inconsistent data among placements
    
    COPY command is blocked on the shard metadata lock and once it acquires the lock it doesn't check the cache invalidations. In some
    cases this could lead to data inconsistency among the shard replicas
    if there exists concurrent shard placement addition.
