### PR TITLE
Fix pg_dist_node locking

### DIFF
--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -162,6 +162,9 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	/* calculate the split of the hash space */
 	hashTokenIncrement = HASH_TOKEN_COUNT / shardCount;
 
+	/* don't allow concurrent node list changes that require an exclusive lock */
+	LockRelationOid(DistNodeRelationId(), RowShareLock);
+
 	/* load and sort the worker node list for deterministic placement */
 	workerNodeList = ActivePrimaryNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -44,6 +44,7 @@
 #include "distributed/transaction_management.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_protocol.h"
+#include "storage/lmgr.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/inval.h"
@@ -93,6 +94,12 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 
 	EnsureTablePermissions(relationId, ACL_INSERT);
 	CheckDistributedTable(relationId);
+
+	/* don't allow the table to be dropped */
+	LockRelationOid(relationId, AccessShareLock);
+
+	/* don't allow concurrent node list changes that require an exclusive lock */
+	LockRelationOid(DistNodeRelationId(), RowShareLock);
 
 	/*
 	 * We check whether the table is a foreign table or not. If it is, we set

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -230,6 +230,9 @@ ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 	List *workerNodeList = NULL;
 	ListCell *workerNodeCell = NULL;
 
+	/* prevent concurrent pg_dist_node changes */
+	LockRelationOid(DistNodeRelationId(), RowShareLock);
+
 	workerNodeList = ActivePrimaryNodeList();
 
 	/*

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -316,18 +316,3 @@ LockRelationShardResources(List *relationShardList, LOCKMODE lockMode)
 		}
 	}
 }
-
-
-/*
- * LockMetadataSnapshot acquires a lock needed to serialize changes to pg_dist_node
- * and all other metadata changes. Operations that modify pg_dist_node should acquire
- * AccessExclusiveLock. All other metadata changes should acquire AccessShareLock. Any locks
- * acquired using this method are released at transaction end.
- */
-void
-LockMetadataSnapshot(LOCKMODE lockMode)
-{
-	Assert(lockMode == AccessExclusiveLock || lockMode == AccessShareLock);
-
-	(void) LockRelationOid(DistNodeRelationId(), lockMode);
-}

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -80,6 +80,5 @@ extern void LockShardListMetadata(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockShardListResources(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockRelationShardResources(List *relationShardList, LOCKMODE lockMode);
 
-extern void LockMetadataSnapshot(LOCKMODE lockMode);
 
 #endif /* RESOURCE_LOCK_H */

--- a/src/test/regress/expected/isolation_add_remove_node.out
+++ b/src/test/regress/expected/isolation_add_remove_node.out
@@ -31,6 +31,41 @@ nodename       nodeport       isactive
 master_remove_node
 
 
+starting permutation: s1-begin s1-add-node-1 s2-add-node-2 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-add-node-2: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
+master_remove_node
+
+               
+               
+
 starting permutation: s1-begin s1-add-node-1 s2-add-node-1 s1-commit s1-show-nodes
 ?column?       
 
@@ -64,7 +99,40 @@ master_remove_node
 
                
 
-starting permutation: s1-begin s1-add-node-1 s2-add-node-1 s1-commit s1-show-nodes
+starting permutation: s1-begin s1-add-node-1 s2-add-node-2 s1-abort s1-show-nodes
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s1-abort: 
+	ABORT;
+
+step s2-add-node-2: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+master_remove_node
+
+               
+
+starting permutation: s1-begin s1-add-node-1 s2-add-node-1 s1-abort s1-show-nodes
 ?column?       
 
 1              
@@ -80,8 +148,8 @@ step s1-add-node-1:
 step s2-add-node-1: 
 	SELECT 1 FROM master_add_node('localhost', 57637);
  <waiting ...>
-step s1-commit: 
-	COMMIT;
+step s1-abort: 
+	ABORT;
 
 step s2-add-node-1: <... completed>
 ?column?       
@@ -472,6 +540,84 @@ step s2-disable-node-1:
  <waiting ...>
 step s1-commit: 
 	COMMIT;
+
+step s2-disable-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          f              
+master_remove_node
+
+               
+
+starting permutation: s1-add-inactive-1 s1-begin s1-activate-node-1 s2-disable-node-1 s1-abort s1-show-nodes
+?column?       
+
+1              
+step s1-add-inactive-1: 
+	SELECT 1 FROM master_add_inactive_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+ <waiting ...>
+step s1-abort: 
+	ABORT;
+
+step s2-disable-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          f              
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-1 s1-begin s1-disable-node-1 s2-disable-node-1 s1-abort s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+ <waiting ...>
+step s1-abort: 
+	ABORT;
 
 step s2-disable-node-1: <... completed>
 ?column?       

--- a/src/test/regress/expected/isolation_add_remove_node.out
+++ b/src/test/regress/expected/isolation_add_remove_node.out
@@ -1,0 +1,488 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-add-node-1 s2-remove-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-remove-node-1: 
+	SELECT * FROM master_remove_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-remove-node-1: <... completed>
+master_remove_node
+
+               
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+master_remove_node
+
+
+starting permutation: s1-begin s1-add-node-1 s2-add-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-add-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+master_remove_node
+
+               
+
+starting permutation: s1-begin s1-add-node-1 s2-add-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-add-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-1 s1-add-node-2 s1-begin s1-remove-node-1 s2-remove-node-2 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-remove-node-1: 
+	SELECT * FROM master_remove_node('localhost', 57637);
+
+master_remove_node
+
+               
+step s2-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-remove-node-2: <... completed>
+master_remove_node
+
+               
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+master_remove_node
+
+
+starting permutation: s1-add-node-1 s1-begin s1-remove-node-1 s2-remove-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-remove-node-1: 
+	SELECT * FROM master_remove_node('localhost', 57637);
+
+master_remove_node
+
+               
+step s2-remove-node-1: 
+	SELECT * FROM master_remove_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-remove-node-1: <... completed>
+error in steps s1-commit s2-remove-node-1: ERROR:  node at "localhost:57637" does not exist
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+master_remove_node
+
+
+starting permutation: s1-add-node-1 s1-begin s1-activate-node-1 s2-activate-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-activate-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-1 s1-begin s1-disable-node-1 s2-disable-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-disable-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          f              
+master_remove_node
+
+               
+
+starting permutation: s1-add-inactive-1 s1-begin s1-activate-node-1 s2-activate-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-inactive-1: 
+	SELECT 1 FROM master_add_inactive_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-activate-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+master_remove_node
+
+               
+
+starting permutation: s1-add-inactive-1 s1-begin s1-disable-node-1 s2-disable-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-inactive-1: 
+	SELECT 1 FROM master_add_inactive_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-disable-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          f              
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-1 s1-begin s1-disable-node-1 s2-activate-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-activate-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-1 s1-begin s1-activate-node-1 s2-disable-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-node-1: 
+	SELECT 1 FROM master_add_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-disable-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          f              
+master_remove_node
+
+               
+
+starting permutation: s1-add-inactive-1 s1-begin s1-disable-node-1 s2-activate-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-inactive-1: 
+	SELECT 1 FROM master_add_inactive_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-activate-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+master_remove_node
+
+               
+
+starting permutation: s1-add-inactive-1 s1-begin s1-activate-node-1 s2-disable-node-1 s1-commit s1-show-nodes
+?column?       
+
+1              
+step s1-add-inactive-1: 
+	SELECT 1 FROM master_add_inactive_node('localhost', 57637);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-activate-node-1: 
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+
+?column?       
+
+1              
+step s2-disable-node-1: 
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-disable-node-1: <... completed>
+?column?       
+
+1              
+step s1-show-nodes: 
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+
+nodename       nodeport       isactive       
+
+localhost      57637          f              
+master_remove_node
+
+               

--- a/src/test/regress/expected/isolation_create_table_vs_add_remove_node.out
+++ b/src/test/regress/expected/isolation_create_table_vs_add_remove_node.out
@@ -1,0 +1,404 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-add-node-2 s2-create-table-1 s1-commit s1-show-placements s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s2-create-table-1: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-table-1: <... completed>
+create_distributed_table
+
+               
+step s1-show-placements: 
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+
+nodename       nodeport       
+
+localhost      57637          
+localhost      57637          
+localhost      57638          
+localhost      57638          
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+               
+
+starting permutation: s1-begin s1-add-node-2 s2-create-table-1 s1-abort s1-show-placements s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-begin: 
+	BEGIN;
+
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s2-create-table-1: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+ <waiting ...>
+step s1-abort: 
+	ABORT;
+
+step s2-create-table-1: <... completed>
+create_distributed_table
+
+               
+step s1-show-placements: 
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+
+nodename       nodeport       
+
+localhost      57637          
+localhost      57637          
+localhost      57637          
+localhost      57637          
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+
+starting permutation: s2-begin s2-create-table-1 s1-add-node-2 s2-commit s1-show-placements s2-select
+node_name      node_port      
+
+localhost      57637          
+step s2-begin: 
+	BEGIN;
+
+step s2-create-table-1: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+
+create_distributed_table
+
+               
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-node-2: <... completed>
+?column?       
+
+1              
+step s1-show-placements: 
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+
+nodename       nodeport       
+
+localhost      57637          
+localhost      57637          
+localhost      57637          
+localhost      57637          
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+               
+
+starting permutation: s1-add-node-2 s1-begin s1-remove-node-2 s2-create-table-1 s1-commit s1-show-placements s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+
+master_remove_node
+
+               
+step s2-create-table-1: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-table-1: <... completed>
+create_distributed_table
+
+               
+step s1-show-placements: 
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+
+nodename       nodeport       
+
+localhost      57637          
+localhost      57637          
+localhost      57637          
+localhost      57637          
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-2 s1-begin s1-remove-node-2 s2-create-table-1 s1-abort s1-show-placements s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+
+master_remove_node
+
+               
+step s2-create-table-1: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+ <waiting ...>
+step s1-abort: 
+	ABORT;
+
+step s2-create-table-1: <... completed>
+create_distributed_table
+
+               
+step s1-show-placements: 
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+
+nodename       nodeport       
+
+localhost      57637          
+localhost      57637          
+localhost      57638          
+localhost      57638          
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+               
+
+starting permutation: s1-add-node-2 s2-begin s2-create-table-1 s1-remove-node-2 s2-commit s1-show-placements s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s2-begin: 
+	BEGIN;
+
+step s2-create-table-1: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+
+create_distributed_table
+
+               
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-remove-node-2: <... completed>
+error in steps s2-commit s1-remove-node-2: ERROR:  you cannot remove a node which has shard placements
+step s1-show-placements: 
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+
+nodename       nodeport       
+
+localhost      57637          
+localhost      57637          
+localhost      57638          
+localhost      57638          
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+               
+
+starting permutation: s1-add-node-2 s1-begin s1-remove-node-2 s2-create-table-2 s1-commit s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+
+master_remove_node
+
+               
+step s2-create-table-2: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 2;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-table-2: <... completed>
+error in steps s1-commit s2-create-table-2: ERROR:  replication_factor (2) exceeds number of worker nodes (1)
+step s2-select: 
+	SELECT * FROM dist_table;
+
+ERROR:  relation "dist_table" does not exist
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-2 s1-begin s2-create-table-2 s1-remove-node-2 s1-commit s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s2-create-table-2: 
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 2;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+
+create_distributed_table
+
+               
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+
+ERROR:  you cannot remove a node which has shard placements
+step s1-commit: 
+	COMMIT;
+
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+               

--- a/src/test/regress/expected/isolation_create_table_vs_add_remove_node.out
+++ b/src/test/regress/expected/isolation_create_table_vs_add_remove_node.out
@@ -299,7 +299,7 @@ step s2-commit:
 	COMMIT;
 
 step s1-remove-node-2: <... completed>
-error in steps s2-commit s1-remove-node-2: ERROR:  you cannot remove a node which has shard placements
+error in steps s2-commit s1-remove-node-2: ERROR:  you cannot remove the primary node of a node group which has shard placements
 step s1-show-placements: 
 	SELECT
 		nodename, nodeport
@@ -389,7 +389,7 @@ create_distributed_table
 step s1-remove-node-2: 
 	SELECT * FROM master_remove_node('localhost', 57638);
 
-ERROR:  you cannot remove a node which has shard placements
+ERROR:  you cannot remove the primary node of a node group which has shard placements
 step s1-commit: 
 	COMMIT;
 

--- a/src/test/regress/expected/isolation_create_table_vs_add_remove_node.out
+++ b/src/test/regress/expected/isolation_create_table_vs_add_remove_node.out
@@ -364,7 +364,7 @@ master_remove_node
 
                
 
-starting permutation: s1-add-node-2 s1-begin s2-create-table-2 s1-remove-node-2 s1-commit s2-select
+starting permutation: s1-add-node-2 s2-begin s2-create-table-2 s1-remove-node-2 s2-commit s2-select
 node_name      node_port      
 
 localhost      57637          
@@ -374,7 +374,7 @@ step s1-add-node-2:
 ?column?       
 
 1              
-step s1-begin: 
+step s2-begin: 
 	BEGIN;
 
 step s2-create-table-2: 
@@ -388,11 +388,12 @@ create_distributed_table
                
 step s1-remove-node-2: 
 	SELECT * FROM master_remove_node('localhost', 57638);
-
-ERROR:  you cannot remove the primary node of a node group which has shard placements
-step s1-commit: 
+ <waiting ...>
+step s2-commit: 
 	COMMIT;
 
+step s1-remove-node-2: <... completed>
+error in steps s2-commit s1-remove-node-2: ERROR:  you cannot remove the primary node of a node group which has shard placements
 step s2-select: 
 	SELECT * FROM dist_table;
 
@@ -401,4 +402,92 @@ x              y
 master_remove_node
 
                
+               
+
+starting permutation: s1-add-node-2 s1-begin s1-remove-node-2 s2-create-append-table s1-commit s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s1-begin: 
+	BEGIN;
+
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+
+master_remove_node
+
+               
+step s2-create-append-table: 
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x', 'append');
+	SELECT 1 FROM master_create_empty_shard('dist_table');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-append-table: <... completed>
+create_distributed_table
+
+               
+?column?       
+
+1              
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
+               
+
+starting permutation: s1-add-node-2 s2-begin s2-create-append-table s1-remove-node-2 s2-commit s2-select
+node_name      node_port      
+
+localhost      57637          
+step s1-add-node-2: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s2-begin: 
+	BEGIN;
+
+step s2-create-append-table: 
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x', 'append');
+	SELECT 1 FROM master_create_empty_shard('dist_table');
+
+create_distributed_table
+
+               
+?column?       
+
+1              
+step s1-remove-node-2: 
+	SELECT * FROM master_remove_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-remove-node-2: <... completed>
+master_remove_node
+
+               
+step s2-select: 
+	SELECT * FROM dist_table;
+
+x              y              
+
+master_remove_node
+
                

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -98,7 +98,7 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,189)        
+(0,279)        
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
@@ -109,4 +109,4 @@ step s2-get-first-worker-active-transactions:
 
 nodename       nodeport       success        result         
 
-localhost      57637          t              (0,189)        
+localhost      57637          t              (0,279)        

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -98,7 +98,7 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,279)        
+(0,290)        
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
@@ -109,4 +109,4 @@ step s2-get-first-worker-active-transactions:
 
 nodename       nodeport       success        result         
 
-localhost      57637          t              (0,279)        
+localhost      57637          t              (0,290)        

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-192            191            f              
+293            292            f              
 transactionnumberwaitingtransactionnumbers
 
-191                           
-192            191            
+292                           
+293            292            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-196            195            f              
-197            195            f              
-197            196            t              
+297            296            f              
+298            296            f              
+298            297            t              
 transactionnumberwaitingtransactionnumbers
 
-195                           
-196            195            
-197            195,196        
+296                           
+297            296            
+298            296,297        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-finish:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102751"
+error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102781"
 step s2-finish: 
   COMMIT;
 

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -1,3 +1,4 @@
+test: isolation_add_remove_node
 test: isolation_add_node_vs_reference_table_operations
 
 # tests that change node metadata should precede

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -1,5 +1,6 @@
 test: isolation_add_remove_node
 test: isolation_add_node_vs_reference_table_operations
+test: isolation_create_table_vs_add_remove_node
 
 # tests that change node metadata should precede
 # isolation_cluster_management such that tests

--- a/src/test/regress/specs/isolation_add_remove_node.spec
+++ b/src/test/regress/specs/isolation_add_remove_node.spec
@@ -1,0 +1,134 @@
+setup
+{
+	SELECT 1;
+}
+
+teardown
+{
+	SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+	BEGIN;
+}
+
+step "s1-add-node-1"
+{
+	SELECT 1 FROM master_add_node('localhost', 57637);
+}
+
+step "s1-add-node-2"
+{
+	SELECT 1 FROM master_add_node('localhost', 57638);
+}
+
+step "s1-add-inactive-1"
+{
+	SELECT 1 FROM master_add_inactive_node('localhost', 57637);
+}
+
+step "s1-activate-node-1"
+{
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+}
+
+step "s1-disable-node-1"
+{
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+}
+
+step "s1-remove-node-1"
+{
+	SELECT * FROM master_remove_node('localhost', 57637);
+}
+
+step "s1-remove-node-2"
+{
+	SELECT * FROM master_remove_node('localhost', 57638);
+}
+
+step "s1-commit"
+{
+	COMMIT;
+}
+
+step "s1-show-nodes"
+{
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+	BEGIN;
+}
+
+step "s2-add-node-1"
+{
+	SELECT 1 FROM master_add_node('localhost', 57637);
+}
+
+step "s2-add-node-2"
+{
+	SELECT 1 FROM master_add_node('localhost', 57638);
+}
+
+step "s2-activate-node-1"
+{
+	SELECT 1 FROM master_activate_node('localhost', 57637);
+}
+
+step "s2-disable-node-1"
+{
+	SELECT 1 FROM master_disable_node('localhost', 57637);
+}
+
+step "s2-remove-node-1"
+{
+	SELECT * FROM master_remove_node('localhost', 57637);
+}
+
+step "s2-remove-node-2"
+{
+	SELECT * FROM master_remove_node('localhost', 57638);
+}
+
+step "s2-commit"
+{
+	COMMIT;
+}
+
+# session 1 adds a node, session 2 removes it, should be ok
+permutation "s1-begin" "s1-add-node-1" "s2-remove-node-1" "s1-commit" "s1-show-nodes"
+# add a different node from 2 sessions, should be ok
+permutation "s1-begin" "s1-add-node-1" "s2-add-node-1" "s1-commit" "s1-show-nodes"
+# add the same node from 2 sessions, should be ok (idempotent)
+permutation "s1-begin" "s1-add-node-1" "s2-add-node-1" "s1-commit" "s1-show-nodes"
+# remove a different node from 2 transactions, should be ok
+permutation "s1-add-node-1" "s1-add-node-2" "s1-begin" "s1-remove-node-1" "s2-remove-node-2" "s1-commit" "s1-show-nodes"
+# remove the same node from 2 transactions, should be ok (idempotent)
+permutation "s1-add-node-1" "s1-begin" "s1-remove-node-1" "s2-remove-node-1" "s1-commit" "s1-show-nodes"
+
+# activate an active node from 2 transactions, should be ok
+permutation "s1-add-node-1" "s1-begin" "s1-activate-node-1" "s2-activate-node-1" "s1-commit" "s1-show-nodes"
+# disable an active node from 2 transactions, should be ok
+permutation "s1-add-node-1" "s1-begin" "s1-disable-node-1" "s2-disable-node-1" "s1-commit" "s1-show-nodes"
+
+# activate an inactive node from 2 transactions, should be ok
+permutation "s1-add-inactive-1" "s1-begin" "s1-activate-node-1" "s2-activate-node-1" "s1-commit" "s1-show-nodes"
+# disable an inactive node from 2 transactions, should be ok
+permutation "s1-add-inactive-1" "s1-begin" "s1-disable-node-1" "s2-disable-node-1" "s1-commit" "s1-show-nodes"
+
+# disable and activate an active node from 2 transactions, should be ok
+permutation "s1-add-node-1" "s1-begin" "s1-disable-node-1" "s2-activate-node-1" "s1-commit" "s1-show-nodes"
+# activate and disable an active node node from 2 transactions, should be ok
+permutation "s1-add-node-1" "s1-begin" "s1-activate-node-1" "s2-disable-node-1" "s1-commit" "s1-show-nodes"
+
+# disable and activate an inactive node from 2 transactions, should be ok
+permutation "s1-add-inactive-1" "s1-begin" "s1-disable-node-1" "s2-activate-node-1" "s1-commit" "s1-show-nodes"
+# activate and disable an inactive node node from 2 transactions, should be ok
+permutation "s1-add-inactive-1" "s1-begin" "s1-activate-node-1" "s2-disable-node-1" "s1-commit" "s1-show-nodes"

--- a/src/test/regress/specs/isolation_add_remove_node.spec
+++ b/src/test/regress/specs/isolation_add_remove_node.spec
@@ -50,6 +50,11 @@ step "s1-remove-node-2"
 	SELECT * FROM master_remove_node('localhost', 57638);
 }
 
+step "s1-abort"
+{
+	ABORT;
+}
+
 step "s1-commit"
 {
 	COMMIT;
@@ -105,9 +110,14 @@ step "s2-commit"
 # session 1 adds a node, session 2 removes it, should be ok
 permutation "s1-begin" "s1-add-node-1" "s2-remove-node-1" "s1-commit" "s1-show-nodes"
 # add a different node from 2 sessions, should be ok
-permutation "s1-begin" "s1-add-node-1" "s2-add-node-1" "s1-commit" "s1-show-nodes"
+permutation "s1-begin" "s1-add-node-1" "s2-add-node-2" "s1-commit" "s1-show-nodes"
 # add the same node from 2 sessions, should be ok (idempotent)
 permutation "s1-begin" "s1-add-node-1" "s2-add-node-1" "s1-commit" "s1-show-nodes"
+# add a different node from 2 sessions, one aborts
+permutation "s1-begin" "s1-add-node-1" "s2-add-node-2" "s1-abort" "s1-show-nodes"
+# add the same node from 2 sessions, one aborts
+permutation "s1-begin" "s1-add-node-1" "s2-add-node-1" "s1-abort" "s1-show-nodes"
+
 # remove a different node from 2 transactions, should be ok
 permutation "s1-add-node-1" "s1-add-node-2" "s1-begin" "s1-remove-node-1" "s2-remove-node-2" "s1-commit" "s1-show-nodes"
 # remove the same node from 2 transactions, should be ok (idempotent)
@@ -132,3 +142,8 @@ permutation "s1-add-node-1" "s1-begin" "s1-activate-node-1" "s2-disable-node-1" 
 permutation "s1-add-inactive-1" "s1-begin" "s1-disable-node-1" "s2-activate-node-1" "s1-commit" "s1-show-nodes"
 # activate and disable an inactive node node from 2 transactions, should be ok
 permutation "s1-add-inactive-1" "s1-begin" "s1-activate-node-1" "s2-disable-node-1" "s1-commit" "s1-show-nodes"
+
+# activate and disable an inactive node from 2 transactions, one aborts
+permutation "s1-add-inactive-1" "s1-begin" "s1-activate-node-1" "s2-disable-node-1" "s1-abort" "s1-show-nodes"
+# disable an active node from 2 transactions, one aborts
+permutation "s1-add-node-1" "s1-begin" "s1-disable-node-1" "s2-disable-node-1" "s1-abort" "s1-show-nodes"

--- a/src/test/regress/specs/isolation_create_table_vs_add_remove_node.spec
+++ b/src/test/regress/specs/isolation_create_table_vs_add_remove_node.spec
@@ -1,0 +1,108 @@
+setup
+{
+	SELECT 1 FROM master_add_node('localhost', 57637);
+	SELECT * FROM master_get_active_worker_nodes() ORDER BY node_name, node_port;
+}
+
+teardown
+{
+	DROP TABLE IF EXISTS dist_table;
+
+	SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+	BEGIN;
+}
+
+step "s1-add-node-2"
+{
+	SELECT 1 FROM master_add_node('localhost', 57638);
+}
+
+step "s1-remove-node-2"
+{
+	SELECT * FROM master_remove_node('localhost', 57638);
+}
+
+step "s1-abort"
+{
+	ABORT;
+}
+
+step "s1-commit"
+{
+	COMMIT;
+}
+
+step "s1-query-table"
+{
+	SELECT * FROM dist_table;
+}
+
+step "s1-show-nodes"
+{
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodename, nodeport;
+}
+
+step "s1-show-placements"
+{
+	SELECT
+		nodename, nodeport
+	FROM
+		pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
+	WHERE
+		logicalrelid = 'dist_table'::regclass
+	ORDER BY
+		nodename, nodeport;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+	BEGIN;
+}
+
+step "s2-create-table-1"
+{
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+}
+
+step "s2-create-table-2"
+{
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 2;
+	CREATE TABLE dist_table (x int, y int);
+	SELECT create_distributed_table('dist_table', 'x');
+}
+
+step "s2-select"
+{
+	SELECT * FROM dist_table;
+}
+
+step "s2-commit"
+{
+	COMMIT;
+}
+
+# session 1 adds a node, session 2 creates a distributed table
+permutation "s1-begin" "s1-add-node-2" "s2-create-table-1" "s1-commit" "s1-show-placements" "s2-select"
+permutation "s1-begin" "s1-add-node-2" "s2-create-table-1" "s1-abort" "s1-show-placements" "s2-select"
+permutation "s2-begin" "s2-create-table-1" "s1-add-node-2" "s2-commit" "s1-show-placements" "s2-select"
+
+# session 1 removes a node, session 2 creates a distributed table
+permutation "s1-add-node-2" "s1-begin" "s1-remove-node-2" "s2-create-table-1" "s1-commit" "s1-show-placements" "s2-select"
+permutation "s1-add-node-2" "s1-begin" "s1-remove-node-2" "s2-create-table-1" "s1-abort" "s1-show-placements" "s2-select"
+permutation "s1-add-node-2" "s2-begin" "s2-create-table-1" "s1-remove-node-2" "s2-commit" "s1-show-placements" "s2-select"
+
+# session 1 removes a node, session 2 creates a distributed table with replication factor 2, should throw a sane error
+permutation "s1-add-node-2" "s1-begin" "s1-remove-node-2" "s2-create-table-2" "s1-commit" "s2-select"
+permutation "s1-add-node-2" "s1-begin" "s2-create-table-2" "s1-remove-node-2" "s1-commit" "s2-select"


### PR DESCRIPTION
This PR adds slightly saner locking to node metadata changes by taking an exclusive lock on `pg_dist_node` changes, and a row share lock on `create_distributed_table` and `create_reference_table`, which cannot tolerate concurrent `pg_dist_node` changes, and an access share lock for normal reads. Recommendations for better lock combinations welcome.

It also adds isolation tests to test concurrent usage of pg_dist_node-changing functions, as well as pg_dist_node changes that run concurrently with `create_distributed_table`, `create_reference_table`, or insert into a reference table.

It's not meant to be a comprehensive solution for all pg_dist_node accesses, just to make it somewhat sane.

Fixes #1397 
Fixes #1400
Fixes #1401