### PR TITLE
Add 9.5 output file for isolation test

### DIFF
--- a/src/test/regress/expected/isolation_add_node_vs_reference_table_operations_0.out
+++ b/src/test/regress/expected/isolation_add_node_vs_reference_table_operations_0.out
@@ -1,0 +1,459 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2-load-metadata-cache s1-begin s1-add-second-worker s2-copy-to-reference-table s1-commit s2-print-content
+create_reference_table
+
+               
+step s2-load-metadata-cache: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-copy-to-reference-table: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-copy-to-reference-table: <... completed>
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              10             
+57638          t              10             
+master_remove_node
+
+               
+               
+
+starting permutation: s2-load-metadata-cache s2-begin s2-copy-to-reference-table s1-add-second-worker s2-commit s2-print-content
+create_reference_table
+
+               
+step s2-load-metadata-cache: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s2-begin: 
+	BEGIN;
+
+step s2-copy-to-reference-table: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-second-worker: <... completed>
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              10             
+57638          t              10             
+master_remove_node
+
+               
+               
+
+starting permutation: s2-load-metadata-cache s1-begin s1-add-second-worker s2-insert-to-reference-table s1-commit s2-print-content
+create_reference_table
+
+               
+step s2-load-metadata-cache: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-insert-to-reference-table: 
+	INSERT INTO test_reference_table VALUES (6);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-insert-to-reference-table: <... completed>
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              6              
+57638          t              6              
+master_remove_node
+
+               
+               
+
+starting permutation: s2-load-metadata-cache s2-begin s2-insert-to-reference-table s1-add-second-worker s2-commit s2-print-content
+create_reference_table
+
+               
+step s2-load-metadata-cache: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s2-begin: 
+	BEGIN;
+
+step s2-insert-to-reference-table: 
+	INSERT INTO test_reference_table VALUES (6);
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-second-worker: <... completed>
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              6              
+57638          t              6              
+master_remove_node
+
+               
+               
+
+starting permutation: s2-load-metadata-cache s1-begin s1-add-second-worker s2-ddl-on-reference-table s1-commit s2-print-index-count
+create_reference_table
+
+               
+step s2-load-metadata-cache: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-ddl-on-reference-table: 
+	CREATE INDEX reference_index ON test_reference_table(test_id);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-ddl-on-reference-table: <... completed>
+step s2-print-index-count: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              1              
+57638          t              1              
+master_remove_node
+
+               
+               
+
+starting permutation: s2-load-metadata-cache s2-begin s2-ddl-on-reference-table s1-add-second-worker s2-commit s2-print-index-count
+create_reference_table
+
+               
+step s2-load-metadata-cache: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s2-begin: 
+	BEGIN;
+
+step s2-ddl-on-reference-table: 
+	CREATE INDEX reference_index ON test_reference_table(test_id);
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-second-worker: <... completed>
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-print-index-count: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              1              
+57638          t              1              
+master_remove_node
+
+               
+               
+
+starting permutation: s1-begin s1-add-second-worker s2-copy-to-reference-table s1-commit s2-print-content
+create_reference_table
+
+               
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-copy-to-reference-table: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-copy-to-reference-table: <... completed>
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              5              
+57638          t              5              
+master_remove_node
+
+               
+               
+
+starting permutation: s2-begin s2-copy-to-reference-table s1-add-second-worker s2-commit s2-print-content
+create_reference_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-copy-to-reference-table: 
+	COPY test_reference_table FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-second-worker: <... completed>
+error in steps s2-commit s1-add-second-worker: ERROR:  deadlock detected
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              5              
+master_remove_node
+
+               
+
+starting permutation: s1-begin s1-add-second-worker s2-insert-to-reference-table s1-commit s2-print-content
+create_reference_table
+
+               
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-insert-to-reference-table: 
+	INSERT INTO test_reference_table VALUES (6);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-insert-to-reference-table: <... completed>
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              1              
+57638          t              1              
+master_remove_node
+
+               
+               
+
+starting permutation: s2-begin s2-insert-to-reference-table s1-add-second-worker s2-commit s2-print-content
+create_reference_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-insert-to-reference-table: 
+	INSERT INTO test_reference_table VALUES (6);
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-second-worker: <... completed>
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-print-content: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from %s')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              1              
+57638          t              1              
+master_remove_node
+
+               
+               
+
+starting permutation: s1-begin s1-add-second-worker s2-ddl-on-reference-table s1-commit s2-print-index-count
+create_reference_table
+
+               
+step s1-begin: 
+    BEGIN;
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-ddl-on-reference-table: 
+	CREATE INDEX reference_index ON test_reference_table(test_id);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-ddl-on-reference-table: <... completed>
+step s2-print-index-count: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              1              
+57638          t              1              
+master_remove_node
+
+               
+               
+
+starting permutation: s2-begin s2-ddl-on-reference-table s1-add-second-worker s2-commit s2-print-index-count
+create_reference_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-ddl-on-reference-table: 
+	CREATE INDEX reference_index ON test_reference_table(test_id);
+
+step s1-add-second-worker: 
+	SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-add-second-worker: <... completed>
+nodename       nodeport       isactive       
+
+localhost      57638          t              
+step s2-print-index-count: 
+	SELECT 
+		nodeport, success, result 
+	FROM 
+		run_command_on_placements('test_reference_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
+	ORDER BY
+		nodeport;
+
+nodeport       success        result         
+
+57637          t              1              
+57638          t              1              
+master_remove_node
+
+               
+               

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -1,4 +1,4 @@
-ignore: isolation_add_node_vs_reference_table_operations
+test: isolation_add_node_vs_reference_table_operations
 
 # tests that change node metadata should precede 
 # isolation_cluster_management such that tests 


### PR DESCRIPTION
With this commit, we add one additional regression test output file which
has some output syntax differences with its 9.6 equivalence.

Note to the reviewer: The output difference is introduced to Postgres isolation tester on this [commit](https://github.com/postgres/postgres/commit/38f8bdcac4982215beb9f65a19debecaf22fd470#diff-da8e149e3cc96e8758cc82a484f81acaR547) to 9.6 release. From the changed test perspective, the outcome is the same where a deadlock is detected. But, in 9.5 the second session is not reported to be in `waiting` state whereas in 9.6 it is reported to be waiting.