### PR TITLE
Use cached PostgreSQL build to reduce testing time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: required
 dist: trusty
 language: c
-cache: apt
+cache:
+  apt: true
+  directories:
+  - /home/travis/postgresql
 branches:
   except: [ /^open-.*$/ ]
 env:
@@ -14,7 +17,7 @@ env:
     - PGVERSION=9.5
     - PGVERSION=9.6
 before_install:
-  - git clone -b v0.6.1 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.6.2 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - curl https://install.citusdata.com/community/deb.sh | sudo bash


### PR DESCRIPTION
With this PR, we started to cache custom compiled PostgreSQL builds. If there
are no new commits to the related PostgreSQL branches, we will use already
compiled binaries to reduce testing time.

We still need to compile PostgreSQL for each PR at least once, but subsequent
tests will use cached PostgreSQL build. That is because cache of each branch and
each PR is different. Actually, Travis uses parent branch's cache if current branch's
cache is not created yet, but we do not compile PostgreSQL for branches, we only
compile it for pull requests.