### PR TITLE
Add comment to subquery regression test file

### DIFF
--- a/src/test/regress/expected/multi_subquery_behavioral_analytics.out
+++ b/src/test/regress/expected/multi_subquery_behavioral_analytics.out
@@ -3,9 +3,11 @@
 -- regression tests to cover more cases
 -- the tables that are used depends to multi_insert_select_behavioral_analytics_create_table.sql
 --
--- We don't need shard id sequence here, so commented out to prevent conflicts with concurrent tests
--- ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1430000;
--- ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1430000;
+--- We don't need shard id sequence here given that we're not creating any shards, so not writing it at all
+-- The following line is intended to force Citus to NOT use router planner for the tests in this
+-- file. The motivation for doing this is to make sure that single-task queries can be planned
+-- by non-router code-paths. Thus, this flag should NOT be used in production. Otherwise, the actual
+-- router queries would fail.
 SET citus.enable_router_execution TO FALSE;
 ------------------------------------
 -- Vanilla funnel query

--- a/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
+++ b/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
@@ -4,10 +4,12 @@
 -- the tables that are used depends to multi_insert_select_behavioral_analytics_create_table.sql
 --
 
--- We don't need shard id sequence here, so commented out to prevent conflicts with concurrent tests
--- ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1430000;
--- ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1430000;
+--- We don't need shard id sequence here given that we're not creating any shards, so not writing it at all
 
+-- The following line is intended to force Citus to NOT use router planner for the tests in this
+-- file. The motivation for doing this is to make sure that single-task queries can be planned
+-- by non-router code-paths. Thus, this flag should NOT be used in production. Otherwise, the actual
+-- router queries would fail.
 SET citus.enable_router_execution TO FALSE;
 
 ------------------------------------


### PR DESCRIPTION
Add a comment to the subquery regression test file to prevent any misunderstandings about the usage of `enable_router_execution` GUC variable.