### PR TITLE
Fix version checks

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1419,11 +1419,9 @@ ErrorIfUnstableCreateOrAlterExtensionStmt(Node *parsetree)
 	{
 		/*
 		 * No version was specified, so PostgreSQL will use the default_version
-		 * from the citus.control file. In case a new default is available, we
-		 * will force a compatibility check of the latest available version.
+		 * from the citus.control file.
 		 */
-		citusVersionKnownCompatible = false;
-		CheckCitusVersion(ERROR);
+		CheckAvailableVersion(ERROR);
 	}
 }
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -511,6 +511,11 @@ LookupDistTableCacheEntry(Oid relationId)
 		return NULL;
 	}
 
+	if (DistTableCacheHash == NULL)
+	{
+		InitializeDistTableCache();
+	}
+
 	/*
 	 * If the version is not known to be compatible, perform thorough check,
 	 * unless such checks are disabled.
@@ -536,11 +541,6 @@ LookupDistTableCacheEntry(Oid relationId)
 			/* incompatible, can't access cache, so return before doing so */
 			return NULL;
 		}
-	}
-
-	if (DistTableCacheHash == NULL)
-	{
-		InitializeDistTableCache();
 	}
 
 	cacheEntry = hash_search(DistTableCacheHash, hashKey, HASH_ENTER, &foundInCache);

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -106,7 +106,7 @@ static Oid workerHashFunctionId = InvalidOid;
 /* Citus extension version variables */
 bool EnableVersionChecks = true; /* version checks are enabled */
 
-bool citusVersionKnownCompatible = false;
+static bool citusVersionKnownCompatible = false;
 
 /* Hash table for informations about each partition */
 static HTAB *DistTableCacheHash = NULL;
@@ -143,7 +143,6 @@ static bool HasUniformHashDistribution(ShardInterval **shardIntervalArray,
 static bool HasUninitializedShardInterval(ShardInterval **sortedShardIntervalArray,
 										  int shardCount);
 static bool CheckInstalledVersion(int elevel);
-static bool CheckAvailableVersion(int elevel);
 static char * AvailableExtensionVersion(void);
 static char * InstalledExtensionVersion(void);
 static bool HasOverlappingShardInterval(ShardInterval **shardIntervalArray,
@@ -1181,13 +1180,15 @@ CheckCitusVersion(int elevel)
  * this function logs an error with the specified elevel and returns false,
  * otherwise it returns true.
  */
-static bool
+bool
 CheckAvailableVersion(int elevel)
 {
 	char *availableVersion = NULL;
 
-	Assert(CitusHasBeenLoaded());
-	Assert(EnableVersionChecks);
+	if (!EnableVersionChecks)
+	{
+		return true;
+	}
 
 	availableVersion = AvailableExtensionVersion();
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -18,7 +18,6 @@
 #include "utils/hsearch.h"
 
 extern bool EnableVersionChecks;
-extern bool citusVersionKnownCompatible;
 
 /*
  * Representation of a table's metadata that is frequently used for
@@ -80,6 +79,7 @@ extern void CitusInvalidateRelcacheByShardId(int64 shardId);
 
 extern bool CitusHasBeenLoaded(void);
 extern bool CheckCitusVersion(int elevel);
+extern bool CheckAvailableVersion(int elevel);
 bool MajorVersionsCompatible(char *leftVersion, char *rightVersion);
 
 /* access WorkerNodeHash */

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -169,7 +169,31 @@ SET citus.enable_version_checks TO 'true';
 DROP FUNCTION citus_table_size(regclass);
 SET citus.enable_version_checks TO 'false';
 ALTER EXTENSION citus UPDATE TO '6.2-2';
+-- Test updating to the latest version without specifying the version number
+ALTER EXTENSION citus UPDATE;
 -- re-create in newest version
 DROP EXTENSION citus;
 \c
 CREATE EXTENSION citus;
+-- test cache invalidation in workers
+\c - - - :worker_1_port
+-- this will initialize the cache
+\d
+      List of relations
+ Schema | Name | Type | Owner 
+--------+------+------+-------
+(0 rows)
+
+DROP EXTENSION citus;
+SET citus.enable_version_checks TO 'false';
+CREATE EXTENSION citus VERSION '5.2-4';
+SET citus.enable_version_checks TO 'true';
+-- during ALTER EXTENSION, we should invalidate the cache
+ALTER EXTENSION citus UPDATE;
+-- if cache is invalidated succesfull, this \d should work without any problem
+\d
+      List of relations
+ Schema | Name | Type | Owner 
+--------+------+------+-------
+(0 rows)
+

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -153,7 +153,25 @@ DROP FUNCTION citus_table_size(regclass);
 SET citus.enable_version_checks TO 'false';
 ALTER EXTENSION citus UPDATE TO '6.2-2';
 
+-- Test updating to the latest version without specifying the version number
+ALTER EXTENSION citus UPDATE;
+
 -- re-create in newest version
 DROP EXTENSION citus;
 \c
 CREATE EXTENSION citus;
+
+-- test cache invalidation in workers
+\c - - - :worker_1_port
+
+-- this will initialize the cache
+\d
+DROP EXTENSION citus;
+SET citus.enable_version_checks TO 'false';
+CREATE EXTENSION citus VERSION '5.2-4';
+SET citus.enable_version_checks TO 'true';
+-- during ALTER EXTENSION, we should invalidate the cache
+ALTER EXTENSION citus UPDATE;
+
+-- if cache is invalidated succesfull, this \d should work without any problem
+\d


### PR DESCRIPTION
While testing upgrading, we encountered two issues. This PR fixes those issues;

* During version update, we called CheckInstalledVersion, which obviously fails because during version update it is expected to have version mismatch.

* During ` citus--5.2-4--6.0-1.sql` [update](https://github.com/citusdata/citus/blob/master/src/backend/distributed/citus--5.2-4--6.0-1.sql), we alter  `pg_dist_partition` to have `regclass` instead of `Oid` for `logicalrelid` column. That operation leads to rebuild the index defined on the `logicalrelid`. In some cases, Citus reads the stale `Oid` for the index, which breaks almost all operations on the database since Citus errors out unexpectedly.  We decided to read index `Oid` from the catalog instead of cache to solve this problem only for version mismatch checks.

Both of these problems can be reproduced by upgrading 5.2 -> 6.2. To reproduce the first problem do not specify version in ALTER EXTENSION;

Instead of;
~~`ALTER EXTENSION citus UPDATE;`~~
use;
`ALTER EXTENSION citus UPDATE TO `6.2-4`;`

To reproduce the second problem, there should not be any distributed tables in the system. After successful extension upgrade, just run non-distributed command or `\d`. That problem is easily re-producible on the workers.