### PR TITLE
Convert create distributed table to new api with commits

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -847,9 +847,10 @@ InsertShardRow(Oid relationId, uint64 shardId, char storageType,
 /*
  * InsertShardPlacementRow opens the shard placement system catalog, and inserts
  * a new row with the given values into that system catalog. If placementId is
- * INVALID_PLACEMENT_ID, a new placement id will be assigned.
+ * INVALID_PLACEMENT_ID, a new placement id will be assigned.Then, returns the
+ * placement id of the added shard placement.
  */
-void
+uint64
 InsertShardPlacementRow(uint64 shardId, uint64 placementId,
 						char shardState, uint64 shardLength,
 						uint32 groupId)
@@ -886,6 +887,8 @@ InsertShardPlacementRow(uint64 shardId, uint64 placementId,
 
 	CommandCounterIncrement();
 	heap_close(pgDistPlacement, NoLock);
+
+	return placementId;
 }
 
 

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -496,12 +496,6 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 {
 	List *tableDDLEventList = NIL;
 	char tableType = 0;
-#if (PG_VERSION_NUM >= 100000)
-	List *sequenceIdlist = getOwnedSequences(relationId, InvalidAttrNumber);
-#else
-	List *sequenceIdlist = getOwnedSequences(relationId);
-#endif
-	ListCell *sequenceIdCell;
 	char *tableSchemaDef = NULL;
 	char *tableColumnOptionsDef = NULL;
 	char *createSchemaCommand = NULL;
@@ -537,15 +531,6 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 	if (createSchemaCommand != NULL)
 	{
 		tableDDLEventList = lappend(tableDDLEventList, createSchemaCommand);
-	}
-
-	/* create sequences if needed */
-	foreach(sequenceIdCell, sequenceIdlist)
-	{
-		Oid sequenceRelid = lfirst_oid(sequenceIdCell);
-		char *sequenceDef = pg_get_sequencedef_string(sequenceRelid);
-
-		tableDDLEventList = lappend(tableDDLEventList, sequenceDef);
 	}
 
 	/* fetch table schema and column option definitions */

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -359,6 +359,24 @@ LoadGroupShardPlacement(uint64 shardId, uint64 placementId)
 
 
 /*
+ * LoadShardPlacement returns a shard placement for the primary node.
+ */
+ShardPlacement *
+LoadShardPlacement(uint64 shardId, uint64 placementId)
+{
+	ShardCacheEntry *shardEntry = NULL;
+	GroupShardPlacement *groupPlacement = NULL;
+	ShardPlacement *nodePlacement = NULL;
+
+	shardEntry = LookupShardCacheEntry(shardId);
+	groupPlacement = LoadGroupShardPlacement(shardId, placementId);
+	nodePlacement = ResolveGroupShardPlacement(groupPlacement, shardEntry);
+
+	return nodePlacement;
+}
+
+
+/*
  * FindShardPlacementOnGroup returns the shard placement for the given shard
  * on the given group, or returns NULL of no placement for the shard exists
  * on the group.

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -126,9 +126,9 @@ extern List * GroupShardPlacementsForTableOnGroup(Oid relationId, uint32 groupId
 extern void InsertShardRow(Oid relationId, uint64 shardId, char storageType,
 						   text *shardMinValue, text *shardMaxValue);
 extern void DeleteShardRow(uint64 shardId);
-extern void InsertShardPlacementRow(uint64 shardId, uint64 placementId,
-									char shardState, uint64 shardLength,
-									uint32 groupId);
+extern uint64 InsertShardPlacementRow(uint64 shardId, uint64 placementId,
+									  char shardState, uint64 shardLength,
+									  uint32 groupId);
 extern void InsertIntoPgDistPartition(Oid relationId, char distributionMethod,
 									  Var *distributionColumn, uint32 colocationId,
 									  char replicationModel);

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -18,6 +18,7 @@
 #include "c.h"
 #include "fmgr.h"
 
+#include "distributed/connection_management.h"
 #include "distributed/shardinterval_utils.h"
 #include "nodes/pg_list.h"
 #include "distributed/master_metadata_utility.h"
@@ -106,17 +107,25 @@ extern List * GetTableIndexAndConstraintCommands(Oid relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);
 extern char ShardStorageType(Oid relationId);
 extern void CheckDistributedTable(Oid relationId);
-extern void CreateShardPlacements(Oid relationId, int64 shardId, List *ddlEventList,
-								  char *newPlacementOwner, List *workerNodeList,
-								  int workerStartIndex, int replicationFactor);
+extern void CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
+												   List *workerNodeList, int
+												   replicationFactor);
+extern void CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
+								  bool useExclusiveConnection,
+								  bool colocatedShard);
+extern List * InsertShardPlacementRows(Oid relationId, int64 shardId,
+									   List *workerNodeList, int workerStartIndex,
+									   int replicationFactor);
 extern uint64 UpdateShardStatistics(int64 shardId);
 extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
-											 int32 replicationFactor);
-extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId);
+											 int32 replicationFactor,
+											 bool useExclusiveConnections);
+extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId,
+								  bool useExclusiveConnections);
 extern void CreateReferenceTableShard(Oid distributedTableId);
-extern bool WorkerCreateShard(Oid relationId, char *nodeName, uint32 nodePort,
-							  int shardIndex, uint64 shardId, char *newShardOwner,
-							  List *ddlCommandList, List *foreignConstraintCommadList);
+extern void WorkerCreateShard(Oid relationId, int shardIndex, uint64 shardId,
+							  List *ddlCommandList, List *foreignConstraintCommandList,
+							  MultiConnection *connection);
 extern Oid ForeignConstraintGetReferencedTableId(char *queryString);
 extern void CheckHashPartitionedTable(Oid distributedTableId);
 extern void CheckTableSchemaNameForDrop(Oid relationId, char **schemaName,

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -71,6 +71,7 @@ extern List * DistributedTableList(void);
 extern ShardInterval * LoadShardInterval(uint64 shardId);
 extern ShardPlacement * FindShardPlacementOnGroup(uint32 groupId, uint64 shardId);
 extern GroupShardPlacement * LoadGroupShardPlacement(uint64 shardId, uint64 placementId);
+extern ShardPlacement * LoadShardPlacement(uint64 shardId, uint64 placementId);
 extern DistTableCacheEntry * DistributedTableCacheEntry(Oid distributedRelationId);
 extern int GetLocalGroupId(void);
 extern List * DistTableOidList(void);

--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -4,7 +4,7 @@
 -- Test checks whether constraints of distributed tables can be adjusted using
 -- the ALTER TABLE ... ADD CONSTRAINT ... command.
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1450000;
-ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1450000;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART 1450000;
 -- Check "PRIMARY KEY CONSTRAINT"
 CREATE TABLE products (
     product_no integer,
@@ -443,7 +443,7 @@ BEGIN;
 INSERT INTO products VALUES(1,'product_1', 5);
 -- DDL may error out after an INSERT because it might pick the wrong connection
 ALTER TABLE products ADD CONSTRAINT unn_pno UNIQUE(product_no);
-ERROR:  cannot establish a new connection for placement 2327, since DML has been executed on a connection that is in use
+ERROR:  cannot establish a new connection for placement 1450407, since DML has been executed on a connection that is in use
 ROLLBACK;
 BEGIN;
 -- Add constraints

--- a/src/test/regress/expected/multi_create_shards.out
+++ b/src/test/regress/expected/multi_create_shards.out
@@ -48,8 +48,7 @@ DETAIL:  Distributed relations must not specify the WITH (OIDS) option in their 
 ALTER TABLE table_to_distribute SET WITHOUT OIDS;
 -- use an index instead of table name
 SELECT master_create_distributed_table('table_to_distribute_pkey', 'id', 'hash');
-ERROR:  cannot distribute relation: table_to_distribute_pkey
-DETAIL:  Distributed relations must be regular or foreign tables.
+ERROR:  table_to_distribute_pkey is not a regular or foreign table
 -- use a bad column name
 SELECT master_create_distributed_table('table_to_distribute', 'bad_column', 'hash');
 ERROR:  column "bad_column" of relation "table_to_distribute" does not exist

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -552,3 +552,279 @@ SELECT relpersistence FROM pg_class WHERE relname LIKE 'unlogged_table_%';
  u
 (4 rows)
 
+\c - - - :master_port
+-- Test rollback of create table
+BEGIN;
+CREATE TABLE rollback_table(id int, name varchar(20));
+SELECT create_distributed_table('rollback_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ROLLBACK;
+-- Table should not exist on the worker node
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = (SELECT oid FROM pg_class WHERE relname LIKE 'rollback_table%');
+ Column | Type | Modifiers 
+--------+------+-----------
+(0 rows)
+
+\c - - - :master_port
+-- Insert 3 rows to make sure that copy after shard creation touches the same 
+-- worker node twice. 
+BEGIN;
+CREATE TABLE rollback_table(id int, name varchar(20));
+INSERT INTO rollback_table VALUES(1, 'Name_1');
+INSERT INTO rollback_table VALUES(2, 'Name_2');
+INSERT INTO rollback_table VALUES(3, 'Name_3');
+SELECT create_distributed_table('rollback_table','id');
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ROLLBACK;
+-- Table should not exist on the worker node
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = (SELECT oid FROM pg_class WHERE relname LIKE 'rollback_table%');
+ Column | Type | Modifiers 
+--------+------+-----------
+(0 rows)
+
+\c - - - :master_port
+BEGIN;
+CREATE TABLE rollback_table(id int, name varchar(20));
+SELECT create_distributed_table('rollback_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\copy rollback_table from stdin delimiter ','
+CREATE INDEX rollback_index ON rollback_table(id);
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+COMMIT;
+-- Check the table is created 
+SELECT count(*) FROM rollback_table;
+ count 
+-------
+     3
+(1 row)
+
+DROP TABLE rollback_table;
+BEGIN;
+CREATE TABLE rollback_table(id int, name varchar(20));
+SELECT create_distributed_table('rollback_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\copy rollback_table from stdin delimiter ','
+ROLLBACK;
+-- Table should not exist on the worker node
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = (SELECT oid FROM pg_class WHERE relname LIKE 'rollback_table%');
+ Column | Type | Modifiers 
+--------+------+-----------
+(0 rows)
+
+\c - - - :master_port
+BEGIN;
+CREATE TABLE tt1(id int);
+SELECT create_distributed_table('tt1','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE tt2(id int);
+SELECT create_distributed_table('tt2','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO tt1 VALUES(1);
+INSERT INTO tt2 SELECT * FROM tt1 WHERE id = 1;
+COMMIT;
+-- Table should exist on the worker node
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360430'::regclass;
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ id     | integer | 
+(1 row)
+
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt2_360462'::regclass;
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ id     | integer | 
+(1 row)
+
+\c - - - :master_port
+DROP TABLE tt1;
+DROP TABLE tt2;
+-- It is known that creating a table with master_create_empty_shard is not 
+-- transactional, so table stay remaining on the worker node after the rollback
+BEGIN;
+CREATE TABLE append_tt1(id int);
+SELECT create_distributed_table('append_tt1','id','append');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT master_create_empty_shard('append_tt1');
+ master_create_empty_shard 
+---------------------------
+                    360494
+(1 row)
+
+ROLLBACK;
+-- Table exists on the worker node.
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.append_tt1_360494'::regclass;
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ id     | integer | 
+(1 row)
+
+\c - - - :master_port
+-- There should be no table on the worker node
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = (SELECT oid from pg_class WHERE relname LIKE 'public.tt1%');
+ Column | Type | Modifiers 
+--------+------+-----------
+(0 rows)
+
+\c - - - :master_port
+-- Queries executing with router executor is allowed in the same transaction
+-- with create_distributed_table
+BEGIN;
+CREATE TABLE tt1(id int);
+INSERT INTO tt1 VALUES(1);
+SELECT create_distributed_table('tt1','id');
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO tt1 VALUES(2);
+SELECT * FROM tt1 WHERE id = 1;
+ id 
+----
+  1
+(1 row)
+
+COMMIT;
+-- Placements should be created on the worker
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360495'::regclass;
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ id     | integer | 
+(1 row)
+
+\c - - - :master_port
+DROP TABLE tt1;
+BEGIN;
+CREATE TABLE tt1(id int);
+SELECT create_distributed_table('tt1','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+DROP TABLE tt1;
+COMMIT;
+-- There should be no table on the worker node
+\c - - - :worker_1_port
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = (SELECT oid from pg_class WHERE  relname LIKE 'tt1%');
+ Column | Type | Modifiers 
+--------+------+-----------
+(0 rows)
+
+\c - - - :master_port
+-- Tests with create_distributed_table & DDL & DML commands
+-- Test should pass since GetPlacementListConnection can provide connections
+-- in this order of execution
+CREATE TABLE sample_table(id int);
+SELECT create_distributed_table('sample_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+BEGIN;
+CREATE TABLE stage_table (LIKE sample_table);
+\COPY stage_table FROM stdin; -- Note that this operation is a local copy
+SELECT create_distributed_table('stage_table', 'id');
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO sample_table SELECT * FROM stage_table;
+DROP TABLE stage_table;
+SELECT * FROM sample_table WHERE id = 3;
+ id 
+----
+  3
+(1 row)
+
+COMMIT;
+-- Show that rows of sample_table are updated 
+SELECT count(*) FROM sample_table;
+ count 
+-------
+     4
+(1 row)
+
+DROP table sample_table;
+-- Test as create_distributed_table - copy - create_distributed_table - copy
+-- This combination is used by tests written by some ORMs.
+BEGIN;
+CREATE TABLE tt1(id int);
+SELECT create_distributed_table('tt1','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY tt1 from stdin;
+CREATE TABLE tt2(like tt1);
+SELECT create_distributed_table('tt2','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY tt2 from stdin;
+INSERT INTO tt1 SELECT * FROM tt2;
+SELECT * FROM tt1 WHERE id = 3;
+ id 
+----
+  3
+(1 row)
+
+SELECT * FROM tt2 WHERE id = 6;
+ id 
+----
+  6
+(1 row)
+
+END;
+SELECT count(*) FROM tt1;
+ count 
+-------
+     6
+(1 row)
+
+DROP TABLE tt1;
+DROP TABLE tt2;

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -978,14 +978,6 @@ SELECT create_distributed_table('explain_table', 'id');
 ALTER TABLE explain_table ADD COLUMN value int;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-EXPLAIN (COSTS FALSE) SELECT value FROM explain_table WHERE id = 1;
-Custom Scan (Citus Router)
-  Task Count: 1
-  Tasks Shown: All
-  ->  Task
-        Node: host=localhost port=57637 dbname=regression
-        ->  Seq Scan on explain_table_570001 explain_table
-              Filter: (id = 1)
 ROLLBACK;
 -- test explain with local INSERT ... SELECT
 EXPLAIN (COSTS OFF)

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -978,14 +978,6 @@ SELECT create_distributed_table('explain_table', 'id');
 ALTER TABLE explain_table ADD COLUMN value int;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-EXPLAIN (COSTS FALSE) SELECT value FROM explain_table WHERE id = 1;
-Custom Scan (Citus Router)
-  Task Count: 1
-  Tasks Shown: All
-  ->  Task
-        Node: host=localhost port=57637 dbname=regression
-        ->  Seq Scan on explain_table_570001 explain_table
-              Filter: (id = 1)
 ROLLBACK;
 -- test explain with local INSERT ... SELECT
 EXPLAIN (COSTS OFF)

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2,6 +2,7 @@
 -- MULTI_INSERT_SELECT
 --
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 13300000;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART 13300000;
 -- create co-located tables
 SET citus.shard_count = 4;
 SET citus.shard_replication_factor = 2;
@@ -1645,7 +1646,7 @@ BEGIN;
 ALTER TABLE reference_table ADD COLUMN z int;
 INSERT INTO raw_events_first (user_id)
 SELECT user_id FROM raw_events_second JOIN reference_table USING (user_id);
-ERROR:  cannot establish a new connection for placement 655, since DDL has been executed on a connection that is in use
+ERROR:  cannot establish a new connection for placement 13300024, since DDL has been executed on a connection that is in use
 ROLLBACK;
 -- Insert after copy is disallowed when the INSERT INTO ... SELECT  chooses
 -- to use a connection for one shard, while the connection already modified
@@ -1653,7 +1654,7 @@ ROLLBACK;
 BEGIN;
 COPY raw_events_second (user_id, value_1) FROM STDIN DELIMITER ',';
 INSERT INTO raw_events_first SELECT * FROM raw_events_second;
-ERROR:  cannot establish a new connection for placement 636, since DML has been executed on a connection that is in use
+ERROR:  cannot establish a new connection for placement 13300005, since DML has been executed on a connection that is in use
 ROLLBACK;
 -- Insert after copy is currently allowed for single-shard operation.
 -- Both insert and copy are rolled back successfully.

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -60,7 +60,6 @@ SELECT unnest(master_metadata_snapshot());
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
- CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
  ALTER TABLE public.mx_test_table ADD CONSTRAINT mx_test_table_col_1_key UNIQUE (col_1)
  ALTER TABLE public.mx_test_table OWNER TO postgres
@@ -68,7 +67,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('public.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('public.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('public.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('public.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('public.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('public.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('public.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('public.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('public.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(13 rows)
+(12 rows)
 
 -- Show that CREATE INDEX commands are included in the metadata snapshot
 CREATE INDEX mx_index ON mx_test_table(col_2);
@@ -82,7 +81,6 @@ SELECT unnest(master_metadata_snapshot());
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
- CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
  CREATE INDEX mx_index ON public.mx_test_table USING btree (col_2) TABLESPACE pg_default
  ALTER TABLE public.mx_test_table ADD CONSTRAINT mx_test_table_col_1_key UNIQUE (col_1)
@@ -91,7 +89,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('public.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('public.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('public.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('public.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('public.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('public.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('public.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('public.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('public.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(14 rows)
+(13 rows)
 
 -- Show that schema changes are included in the metadata snapshot
 CREATE SCHEMA mx_testing_schema;
@@ -108,7 +106,6 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
- CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
  ALTER TABLE mx_testing_schema.mx_test_table ADD CONSTRAINT mx_test_table_col_1_key UNIQUE (col_1)
@@ -117,7 +114,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(16 rows)
+(15 rows)
 
 -- Show that append distributed tables are not included in the metadata snapshot
 CREATE TABLE non_mx_test_table (col_1 int, col_2 text);
@@ -138,7 +135,6 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
- CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
  ALTER TABLE mx_testing_schema.mx_test_table ADD CONSTRAINT mx_test_table_col_1_key UNIQUE (col_1)
@@ -147,7 +143,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(16 rows)
+(15 rows)
 
 -- Show that range distributed tables are not included in the metadata snapshot
 UPDATE pg_dist_partition SET partmethod='r' WHERE logicalrelid='non_mx_test_table'::regclass;
@@ -161,7 +157,6 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
- CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
  ALTER TABLE mx_testing_schema.mx_test_table ADD CONSTRAINT mx_test_table_col_1_key UNIQUE (col_1)
@@ -170,7 +165,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(16 rows)
+(15 rows)
 
 -- Test start_metadata_sync_to_node UDF
 -- Ensure that hasmetadata=false for all nodes

--- a/src/test/regress/expected/multi_mx_metadata.out
+++ b/src/test/regress/expected/multi_mx_metadata.out
@@ -224,11 +224,11 @@ SELECT count(*) FROM pg_tables WHERE tablename = 'objects_for_xacts2' and schema
      0
 (1 row)
 
--- but the shard exists since we do not create shards in a transaction
+-- shard also does not exist since we create shards in a transaction
 SELECT count(*) FROM pg_tables WHERE tablename LIKE 'objects_for_xacts2_%' and schemaname = 'citus_mx_schema_for_xacts';
  count 
 -------
-     1
+     0
 (1 row)
 
 -- make sure that master_drop_all_shards does not work from the worker nodes

--- a/src/test/regress/expected/multi_table_ddl.out
+++ b/src/test/regress/expected/multi_table_ddl.out
@@ -119,15 +119,6 @@ ERROR:  cannot associate an existing sequence with a distributed table
 HINT:  Use a sequence in a distributed table by specifying a serial column type before creating any shards.
 -- an edge case, but it's OK to change an owner to the same distributed table
 ALTER SEQUENCE testserialtable_id_seq OWNED BY testserialtable.id;
--- verify sequence was created on worker
-\c - - - :worker_1_port
-\ds
-                   List of relations
- Schema |          Name          |   Type   |  Owner   
---------+------------------------+----------+----------
- public | testserialtable_id_seq | sequence | postgres
-(1 row)
-
 -- drop distributed table
 \c - - - :master_port
 DROP TABLE testserialtable;

--- a/src/test/regress/expected/multi_transactional_drop_shards.out
+++ b/src/test/regress/expected/multi_transactional_drop_shards.out
@@ -502,11 +502,10 @@ ORDER BY
 (8 rows)
 
 \ds transactional_drop_serial_column2_seq
-                          List of relations
- Schema |                 Name                  |   Type   |  Owner   
---------+---------------------------------------+----------+----------
- public | transactional_drop_serial_column2_seq | sequence | postgres
-(1 row)
+      List of relations
+ Schema | Name | Type | Owner 
+--------+------+------+-------
+(0 rows)
 
 \c - - - :master_port
 -- test DROP TABLE(ergo master_drop_all_shards) in transaction, then COMMIT

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -440,8 +440,7 @@ SELECT master_create_distributed_table('customer_worker_copy_append_seq', 'id', 
 \c - - - 57637
 -- Test copy from the worker node
 COPY customer_worker_copy_append_seq FROM '@abs_srcdir@/data/customer.1.data' with (delimiter '|', master_host 'localhost', master_port 57636);
-ERROR:  cannot copy to table with serial column from worker
-HINT:  Connect to the master node to COPY to tables which use serial column types.
+ERROR:  relation "public.customer_worker_copy_append_seq_seq_seq" does not exist
 -- Connect back to the master node
 \c - - - 57636
 -- Create customer table for the worker copy with constraint and index

--- a/src/test/regress/sql/multi_alter_table_add_constraints.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints.sql
@@ -5,7 +5,7 @@
 -- the ALTER TABLE ... ADD CONSTRAINT ... command.
 
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1450000;
-ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1450000;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART 1450000;
 
 -- Check "PRIMARY KEY CONSTRAINT"
 CREATE TABLE products (

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -463,8 +463,6 @@ SELECT create_distributed_table('explain_table', 'id');
 
 ALTER TABLE explain_table ADD COLUMN value int;
 
-EXPLAIN (COSTS FALSE) SELECT value FROM explain_table WHERE id = 1;
-
 ROLLBACK;
 
 -- test explain with local INSERT ... SELECT

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -3,6 +3,7 @@
 --
 
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 13300000;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART 13300000;
 
 -- create co-located tables
 SET citus.shard_count = 4;

--- a/src/test/regress/sql/multi_mx_metadata.sql
+++ b/src/test/regress/sql/multi_mx_metadata.sql
@@ -128,7 +128,7 @@ SELECT count(*) FROM pg_tables WHERE tablename = 'objects_for_xacts2' and schema
 
 -- the distributed table not exists on the worker node
 SELECT count(*) FROM pg_tables WHERE tablename = 'objects_for_xacts2' and schemaname = 'citus_mx_schema_for_xacts';
--- but the shard exists since we do not create shards in a transaction
+-- shard also does not exist since we create shards in a transaction
 SELECT count(*) FROM pg_tables WHERE tablename LIKE 'objects_for_xacts2_%' and schemaname = 'citus_mx_schema_for_xacts';
 
 -- make sure that master_drop_all_shards does not work from the worker nodes

--- a/src/test/regress/sql/multi_table_ddl.sql
+++ b/src/test/regress/sql/multi_table_ddl.sql
@@ -80,10 +80,6 @@ ALTER SEQUENCE standalone_sequence OWNED BY testserialtable.group_id;
 -- an edge case, but it's OK to change an owner to the same distributed table
 ALTER SEQUENCE testserialtable_id_seq OWNED BY testserialtable.id;
 
--- verify sequence was created on worker
-\c - - - :worker_1_port
-\ds
-
 -- drop distributed table
 \c - - - :master_port
 DROP TABLE testserialtable;


### PR DESCRIPTION
Part of #1101 

Convert create_distributed_table UDF to new connection API. In order to do that, each connection is created using the new connection API. Creating sequences, schemas and append distributed tables are remained as non-transactional, because creating them transactionally causes deadlock problem.  