### PR TITLE
Don't take a table lock in ForeignConstraintGetReferencedTableId

### DIFF
--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -763,9 +763,8 @@ ForeignConstraintGetReferencedTableId(char *queryString)
 		if (constraint->contype == CONSTR_FOREIGN)
 		{
 			RangeVar *referencedTable = constraint->pktable;
-			LOCKMODE lockmode = AlterTableGetLockLevel(foreignConstraintStmt->cmds);
 
-			return RangeVarGetRelid(referencedTable, lockmode,
+			return RangeVarGetRelid(referencedTable, NoLock,
 									foreignConstraintStmt->missing_ok);
 		}
 	}


### PR DESCRIPTION
We should add some isolation tests, but those can only be added in enterprise.

See #1437 