### PR TITLE
Allow COPY after a multi-shard command

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -734,14 +734,6 @@ OpenCopyConnections(CopyStmt *copyStatement, ShardConnections *shardConnections,
 
 	MemoryContextSwitchTo(oldContext);
 
-	if (XactModificationLevel > XACT_MODIFICATION_DATA)
-	{
-		ereport(ERROR, (errcode(ERRCODE_ACTIVE_SQL_TRANSACTION),
-						errmsg("distributed copy operations must not appear in "
-							   "transaction blocks containing other distributed "
-							   "modifications")));
-	}
-
 	foreach(placementCell, finalizedPlacementList)
 	{
 		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -1634,8 +1634,6 @@ ROLLBACK;
 BEGIN;
 INSERT INTO raw_events_first SELECT * FROM raw_events_second;
 COPY raw_events_first (user_id, value_1) FROM STDIN DELIMITER ',';
-ERROR:  distributed copy operations must not appear in transaction blocks containing other distributed modifications
-CONTEXT:  COPY raw_events_first, line 1: "102,102"
 ROLLBACK;
 BEGIN;
 INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 100;

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -202,6 +202,20 @@ BEGIN;
 INSERT INTO labs VALUES (6, 'Bell Labs');
 \copy labs from stdin delimiter ','
 COMMIT;
+-- COPY cannot be performed if multiple shards were modified over the same connection
+BEGIN;
+INSERT INTO researchers VALUES (2, 1, 'Knuth Donald');
+INSERT INTO researchers VALUES (10, 6, 'Lamport Leslie');
+\copy researchers from stdin delimiter ','
+ERROR:  cannot establish new placement connection when DML has been executed on existing placement connection
+CONTEXT:  COPY researchers, line 2: "10,6,Lesport Lampie"
+ROLLBACK;
+-- after a COPY you can modify multiple shards, since they'll use different connections
+BEGIN;
+\copy researchers from stdin delimiter ','
+INSERT INTO researchers VALUES (2, 1, 'Knuth Donald');
+INSERT INTO researchers VALUES (10, 6, 'Lamport Leslie');
+ROLLBACK;
 -- COPY can happen before single row INSERT
 BEGIN;
 \copy labs from stdin delimiter ','
@@ -369,41 +383,17 @@ ORDER BY nodeport;
  localhost |    57638 | t       | DROP FUNCTION
 (2 rows)
 
--- finally, ALTER and copy aren't compatible
+-- ALTER TABLE and COPY are compatible if ALTER TABLE precedes COPY
 BEGIN;
 ALTER TABLE labs ADD COLUMN motto text;
 \copy labs from stdin delimiter ','
-ERROR:  distributed copy operations must not appear in transaction blocks containing other distributed modifications
-CONTEXT:  COPY labs, line 1: "12,fsociety,lol"
-COMMIT;
--- but the DDL should correctly roll back
-\d labs
-     Table "public.labs"
- Column |  Type  | Modifiers 
---------+--------+-----------
- id     | bigint | not null
- name   | text   | not null
-
--- and if the copy is before the ALTER...
+ROLLBACK;
+-- but not if COPY precedes ALTER TABLE
 BEGIN;
 \copy labs from stdin delimiter ','
 ALTER TABLE labs ADD COLUMN motto text;
 ERROR:  distributed DDL commands must not appear within transaction blocks containing single-shard data modifications
-COMMIT;
--- the DDL fails, but copy persists
-\d labs
-     Table "public.labs"
- Column |  Type  | Modifiers 
---------+--------+-----------
- id     | bigint | not null
- name   | text   | not null
-
-SELECT * FROM labs WHERE id = 12;
- id |   name   
-----+----------
- 12 | fsociety
-(1 row)
-
+ROLLBACK;
 -- multi-shard operations can co-exist with DDL in a transactional way
 BEGIN;
 ALTER TABLE labs ADD COLUMN motto text;


### PR DESCRIPTION
Minor enhancement that came up in #1402.

This removes the `XactModificationLevel` check at the start of COPY that was made redundant by consistently using `GetPlacementConnection`.