### PR TITLE
Phase out execute remote query and command

### DIFF
--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -964,11 +964,17 @@ RemoteTableOwner(const char *nodeName, uint32 nodePort, const char *tableName)
 	List *ownerList = NIL;
 	StringInfo queryString = NULL;
 	StringInfo relationOwner;
+	MultiConnection *connection = NULL;
+	uint32 connectionFlag = FORCE_NEW_CONNECTION;
+	PGresult *result = NULL;
 
 	queryString = makeStringInfo();
 	appendStringInfo(queryString, GET_TABLE_OWNER, tableName);
+	connection = GetNodeConnection(connectionFlag, nodeName, nodePort);
 
-	ownerList = ExecuteRemoteQuery(nodeName, nodePort, NULL, queryString);
+	ExecuteOptionalRemoteCommand(connection, queryString->data, &result);
+
+	ownerList = ReadFirstColumnAsText(result);
 	if (list_length(ownerList) != 1)
 	{
 		return NULL;

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -1126,65 +1126,6 @@ ExecuteRemoteQuery(const char *nodeName, uint32 nodePort, char *runAsUser,
 
 
 /*
- * ExecuteRemoteCommand executes the given SQL command. This command could be an
- * Insert, Update, or Delete statement, or a utility command that returns
- * nothing. If query is successfuly executed, the function returns true.
- * Otherwise, it returns false.
- */
-bool
-ExecuteRemoteCommand(const char *nodeName, uint32 nodePort, StringInfo queryString)
-{
-	char *nodeDatabase = get_database_name(MyDatabaseId);
-	int32 connectionId = -1;
-	QueryStatus queryStatus = CLIENT_INVALID_QUERY;
-	bool querySent = false;
-	bool queryReady = false;
-	bool queryDone = false;
-
-	connectionId = MultiClientConnect(nodeName, nodePort, nodeDatabase, NULL);
-	if (connectionId == INVALID_CONNECTION_ID)
-	{
-		return false;
-	}
-
-	querySent = MultiClientSendQuery(connectionId, queryString->data);
-	if (!querySent)
-	{
-		MultiClientDisconnect(connectionId);
-		return false;
-	}
-
-	while (!queryReady)
-	{
-		ResultStatus resultStatus = MultiClientResultStatus(connectionId);
-		if (resultStatus == CLIENT_RESULT_READY)
-		{
-			queryReady = true;
-		}
-		else if (resultStatus == CLIENT_RESULT_BUSY)
-		{
-			long sleepIntervalPerCycle = RemoteTaskCheckInterval * 1000L;
-			pg_usleep(sleepIntervalPerCycle);
-		}
-		else
-		{
-			MultiClientDisconnect(connectionId);
-			return false;
-		}
-	}
-
-	queryStatus = MultiClientQueryStatus(connectionId);
-	if (queryStatus == CLIENT_QUERY_DONE)
-	{
-		queryDone = true;
-	}
-
-	MultiClientDisconnect(connectionId);
-	return queryDone;
-}
-
-
-/*
  * Parses the given DDL command, and returns the tree node for parsed command.
  */
 Node *

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -996,11 +996,20 @@ TableDDLCommandList(const char *nodeName, uint32 nodePort, const char *tableName
 {
 	List *ddlCommandList = NIL;
 	StringInfo queryString = NULL;
+	MultiConnection *connection = NULL;
+	PGresult *result = NULL;
+	uint32 connectionFlag = FORCE_NEW_CONNECTION;
 
 	queryString = makeStringInfo();
 	appendStringInfo(queryString, GET_TABLE_DDL_EVENTS, tableName);
+	connection = GetNodeConnection(connectionFlag, nodeName, nodePort);
 
-	ddlCommandList = ExecuteRemoteQuery(nodeName, nodePort, NULL, queryString);
+	ExecuteOptionalRemoteCommand(connection, queryString->data, &result);
+	ddlCommandList = ReadFirstColumnAsText(result);
+
+	ForgetResults(connection);
+	CloseConnection(connection);
+
 	return ddlCommandList;
 }
 

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -128,8 +128,6 @@ extern List * TableDDLCommandList(const char *nodeName, uint32 nodePort,
 extern StringInfo TaskFilename(StringInfo directoryName, uint32 taskId);
 extern List * ExecuteRemoteQuery(const char *nodeName, uint32 nodePort, char *runAsUser,
 								 StringInfo queryString);
-extern bool ExecuteRemoteCommand(const char *nodeName, uint32 nodePort,
-								 StringInfo queryString);
 extern List * ColumnDefinitionList(List *columnNameList, List *columnTypeList);
 extern CreateStmt * CreateStatement(RangeVar *relation, List *columnDefinitionList);
 extern CopyStmt * CopyStatement(RangeVar *relation, char *sourceFilename);


### PR DESCRIPTION
Part of #1101 

All of the callers of `ExecuteRemoteQuery` and `ExecuteRemoteCommand` functions are converted to the new connection API (except `WorkerCreateShard` since it is handled by #1436)