### PR TITLE
Fix crash during local CREATE INDEX CONCURRENTLY

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -395,7 +395,11 @@ multi_ProcessUtility(Node *parsetree,
 	standard_ProcessUtility(parsetree, queryString, context,
 							params, dest, completionTag);
 
-	PostProcessUtility(parsetree);
+	/* don't run post-process code for local commands */
+	if (ddlJobs != NIL)
+	{
+		PostProcessUtility(parsetree);
+	}
 
 	if (commandMustRunAsOwner)
 	{

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -92,6 +92,10 @@ CREATE INDEX IF NOT EXISTS lineitem_orderkey_index on index_test_hash(a);
 NOTICE:  relation "lineitem_orderkey_index" already exists, skipping
 -- Verify that we can create indexes concurrently
 CREATE INDEX CONCURRENTLY lineitem_concurrently_index ON lineitem (l_orderkey);
+-- Verify that no-name local CREATE INDEX CONCURRENTLY works
+CREATE TABLE local_table (id integer, name text);
+CREATE INDEX CONCURRENTLY ON local_table(id);
+DROP TABLE local_table;
 -- Verify that all indexes got created on the master node and one of the workers
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
  schemaname |    tablename     |             indexname              | tablespace |                                                      indexdef                                                       

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -66,6 +66,11 @@ CREATE INDEX IF NOT EXISTS lineitem_orderkey_index on index_test_hash(a);
 -- Verify that we can create indexes concurrently
 CREATE INDEX CONCURRENTLY lineitem_concurrently_index ON lineitem (l_orderkey);
 
+-- Verify that no-name local CREATE INDEX CONCURRENTLY works
+CREATE TABLE local_table (id integer, name text);
+CREATE INDEX CONCURRENTLY ON local_table(id);
+DROP TABLE local_table;
+
 -- Verify that all indexes got created on the master node and one of the workers
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
 \c - - - :worker_1_port


### PR DESCRIPTION
Fixes #1456

`PostProcessUtility` does not correctly handle `CREATE INDEX` commands which lack an explicit index name. It was designed to be called to aid in the more complex processing needed for the never-transactional nature of `CREATE INDEX CONCURRENTLY` in a distributed context where transactions might otherwise be very useful.

Unfortunately, it was being called for _all_ DDL commands, not just distributed ones. Distributed `CREATE INDEX` calls go through our feature checks and those lacking an explicit index name error out earlier, but _local_ `CREATE INDEX` commands do not hit this check.

For that reason, if a `CREATE INDEX` command is local, lacks an explicit name, and has the `CONCURRENTLY` flag, we'd reach `PostProcessUtility`, which crashes when called with a `CREATE INDEX` command lacking an explicit name.

Ensuring that the original intent of that method is respected (i.e. that it is only called for distributed DDL commands) avoids the problem altogether.

This is present in `6.2`, so we should consider backporting it (the change is minimal).