### PR TITLE
Increase coverage of isolation tests - Part 1

### DIFF
--- a/src/test/regress/expected/isolation_append_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_append_copy_vs_all.out
@@ -1,0 +1,602 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-copy s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-router-select: SELECT * FROM append_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-real-time-select: SELECT * FROM append_copy ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert: INSERT INTO append_copy VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-update: UPDATE append_copy SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-delete: DELETE FROM append_copy WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-truncate: TRUNCATE append_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-drop: DROP TABLE append_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+ERROR:  relation "append_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index: CREATE INDEX append_copy_index ON append_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX append_copy_index ON append_copy(id);
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-drop-index: DROP INDEX append_copy_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY append_copy_index ON append_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-add-column: ALTER TABLE append_copy ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE append_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-copy-additional-column: COPY append_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV;
+step s2-ddl-drop-column: ALTER TABLE append_copy DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-table-size: SELECT citus_total_relation_size('append_copy');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM append_copy;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-apply-delete-command s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM append_copy WHERE id <= 4;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-apply-delete-command: <... completed>
+master_apply_delete_command
+
+1              
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-drop-all-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-drop-all-shards: SELECT master_drop_all_shards('append_copy'::regclass, 'public', 'append_copy'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards: <... completed>
+master_drop_all_shards
+
+2              
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE append_copy;
+step s1-create-non-distributed-table: CREATE TABLE append_copy(id integer, data text, int_data int); COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-distribute-table: SELECT create_distributed_table('append_copy', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM append_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM append_copy ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO append_copy VALUES(0, 'k', 0);
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE append_copy SET data = 'l' WHERE id = 0;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM append_copy WHERE id = 1;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE append_copy;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE append_copy;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  relation "append_copy" does not exist
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+ERROR:  relation "append_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX append_copy_index ON append_copy(id);
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX append_copy_index ON append_copy(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX append_copy_index;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE append_copy ADD new_column int DEFAULT 0;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  missing data for column "new_column"
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE append_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE append_copy DROP new_column;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('append_copy');
+citus_total_relation_size
+
+32768          
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM append_copy;');
+master_modify_multiple_shards
+
+5              
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-apply-delete-command s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM append_copy WHERE id <= 4;');
+master_apply_delete_command
+
+1              
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards: SELECT master_drop_all_shards('append_copy'::regclass, 'public', 'append_copy');
+master_drop_all_shards
+
+1              
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+5              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE append_copy;
+step s1-create-non-distributed-table: CREATE TABLE append_copy(id integer, data text, int_data int); COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('append_copy', 'id');
+create_distributed_table
+
+               
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+15             

--- a/src/test/regress/expected/isolation_append_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_append_copy_vs_all.out
@@ -62,7 +62,6 @@ step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -90,6 +89,20 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert-select: INSERT INTO append_copy SELECT * FROM append_copy;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
 
 starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
 create_distributed_table
@@ -294,16 +307,15 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE append_copy;
-step s1-create-non-distributed-table: CREATE TABLE append_copy(id integer, data text, int_data int); COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE append_copy(id integer, data text, int_data int);
 step s1-begin: BEGIN;
 step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-distribute-table: SELECT create_distributed_table('append_copy', 'id'); <waiting ...>
+step s2-distribute-table: SELECT create_distributed_table('append_copy', 'id', 'append'); <waiting ...>
 step s1-commit: COMMIT;
 step s2-distribute-table: <... completed>
 create_distributed_table
@@ -312,7 +324,7 @@ create_distributed_table
 step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
-15             
+0              
 
 starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
 create_distributed_table
@@ -361,7 +373,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -390,6 +401,20 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO append_copy SELECT * FROM append_copy;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
 
 starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
 create_distributed_table
@@ -581,15 +606,14 @@ count
 
 5              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE append_copy;
-step s1-create-non-distributed-table: CREATE TABLE append_copy(id integer, data text, int_data int); COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE append_copy(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-distribute-table: SELECT create_distributed_table('append_copy', 'id');
+step s1-distribute-table: SELECT create_distributed_table('append_copy', 'id', 'append');
 create_distributed_table
 
                
@@ -599,4 +623,4 @@ step s2-copy: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
-15             
+5              

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -98,7 +98,7 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,1129)       
+(0,1164)       
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
@@ -109,4 +109,4 @@ step s2-get-first-worker-active-transactions:
 
 nodename       nodeport       success        result         
 
-localhost      57637          t              (0,1129)       
+localhost      57637          t              (0,1164)       

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -98,7 +98,7 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,301)        
+(0,1129)       
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
@@ -109,4 +109,4 @@ step s2-get-first-worker-active-transactions:
 
 nodename       nodeport       success        result         
 
-localhost      57637          t              (0,301)        
+localhost      57637          t              (0,1129)       

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-1132           1131           f              
+1167           1166           f              
 transactionnumberwaitingtransactionnumbers
 
-1131                          
-1132           1131           
+1166                          
+1167           1166           
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-1136           1135           f              
-1137           1135           f              
-1137           1136           t              
+1171           1170           f              
+1172           1170           f              
+1172           1171           t              
 transactionnumberwaitingtransactionnumbers
 
-1135                          
-1136           1135           
-1137           1135,1136      
+1170                          
+1171           1170           
+1172           1170,1171      
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-304            303            f              
+1132           1131           f              
 transactionnumberwaitingtransactionnumbers
 
-303                           
-304            303            
+1131                          
+1132           1131           
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-308            307            f              
-309            307            f              
-309            308            t              
+1136           1135           f              
+1137           1135           f              
+1137           1136           t              
 transactionnumberwaitingtransactionnumbers
 
-307                           
-308            307            
-309            307,308        
+1135                          
+1136           1135           
+1137           1135,1136      
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -1,0 +1,566 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-copy s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-router-select: SELECT * FROM hash_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-real-time-select: SELECT * FROM hash_copy ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert: INSERT INTO hash_copy VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-update: UPDATE hash_copy SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-delete: DELETE FROM hash_copy WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-truncate: TRUNCATE hash_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-drop: DROP TABLE hash_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+ERROR:  relation "hash_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index: CREATE INDEX hash_copy_index ON hash_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX hash_copy_index ON hash_copy(id);
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-drop-index: DROP INDEX hash_copy_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY hash_copy_index ON hash_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-add-column: ALTER TABLE hash_copy ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE hash_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-copy-additional-column: COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV;
+step s2-ddl-drop-column: ALTER TABLE hash_copy DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-table-size: SELECT citus_total_relation_size('hash_copy');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-drop-all-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-drop-all-shards: SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards: <... completed>
+master_drop_all_shards
+
+2              
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE hash_copy;
+step s1-create-non-distributed-table: CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-distribute-table: SELECT create_distributed_table('hash_copy', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM hash_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM hash_copy ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO hash_copy VALUES(0, 'k', 0);
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE hash_copy SET data = 'l' WHERE id = 0;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM hash_copy WHERE id = 1;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE hash_copy;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE hash_copy;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  relation "hash_copy" does not exist
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+ERROR:  relation "hash_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX hash_copy_index ON hash_copy(id);
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX hash_copy_index ON hash_copy(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX hash_copy_index;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE hash_copy ADD new_column int DEFAULT 0;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  missing data for column "new_column"
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE hash_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE hash_copy DROP new_column;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('hash_copy');
+citus_total_relation_size
+
+32768          
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;');
+master_modify_multiple_shards
+
+5              
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards: SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy');
+master_drop_all_shards
+
+1              
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+5              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE hash_copy;
+step s1-create-non-distributed-table: CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('hash_copy', 'id');
+create_distributed_table
+
+               
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+15             

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -62,7 +62,6 @@ step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8,
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -90,6 +89,20 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert-select: INSERT INTO hash_copy SELECT * FROM hash_copy;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
 
 starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
 create_distributed_table
@@ -343,7 +356,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -372,6 +384,20 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO hash_copy SELECT * FROM hash_copy;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
 
 starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
 create_distributed_table

--- a/src/test/regress/expected/isolation_insert_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_vs_all.out
@@ -14,6 +14,20 @@ count
 
 7              
 
+starting permutation: s1-initialize s1-begin s1-insert s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-insert-select: INSERT INTO insert_hash SELECT * FROM insert_hash;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+11             
+
 starting permutation: s1-initialize s1-begin s1-insert s2-update s1-commit s1-select-count
 create_distributed_table
 
@@ -196,6 +210,20 @@ step s2-distribute-table: <... completed>
 create_distributed_table
 
                
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_hash SELECT * FROM insert_hash;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 

--- a/src/test/regress/expected/isolation_insert_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_vs_all.out
@@ -1,0 +1,375 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-insert s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+7              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-update: UPDATE insert_hash SET data = 'l' WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-delete: DELETE FROM insert_hash WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-truncate: TRUNCATE insert_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-drop: DROP TABLE insert_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+ERROR:  relation "insert_hash" does not exist
+
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-insert s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id);
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-ddl-drop-index: DROP INDEX insert_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY insert_hash_index ON insert_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-insert s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-ddl-drop-column: ALTER TABLE insert_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-table-size: SELECT citus_total_relation_size('insert_hash');
+citus_total_relation_size
+
+57344          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-insert s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+1              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-insert s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE insert_hash;
+step s1-create-non-distributed-table: CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-distribute-table: SELECT create_distributed_table('insert_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-update s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE insert_hash SET data = 'l' WHERE id = 4;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-delete s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM insert_hash WHERE id = 4;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE insert_hash;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+1              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE insert_hash;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+error in steps s1-commit s2-insert: ERROR:  relation "insert_hash" does not exist
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+ERROR:  relation "insert_hash" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id);
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX insert_hash_index;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE insert_hash DROP new_column;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('insert_hash');
+citus_total_relation_size
+
+57344          
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+1              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE insert_hash;
+step s1-create-non-distributed-table: CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('insert_hash', 'id');
+create_distributed_table
+
+               
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+11             

--- a/src/test/regress/expected/isolation_range_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_range_copy_vs_all.out
@@ -1,0 +1,602 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-copy s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-router-select: SELECT * FROM range_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-real-time-select: SELECT * FROM range_copy ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert: INSERT INTO range_copy VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-update: UPDATE range_copy SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-delete: DELETE FROM range_copy WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-truncate: TRUNCATE range_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-drop: DROP TABLE range_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+ERROR:  relation "range_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index: CREATE INDEX range_copy_index ON range_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX range_copy_index ON range_copy(id);
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-drop-index: DROP INDEX range_copy_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY range_copy_index ON range_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-add-column: ALTER TABLE range_copy ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE range_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-copy-additional-column: COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV;
+step s2-ddl-drop-column: ALTER TABLE range_copy DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-table-size: SELECT citus_total_relation_size('range_copy');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM range_copy;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-apply-delete-command s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-apply-delete-command: <... completed>
+master_apply_delete_command
+
+1              
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-drop-all-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-drop-all-shards: SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards: <... completed>
+master_drop_all_shards
+
+2              
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE range_copy;
+step s1-create-non-distributed-table: CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-distribute-table: SELECT create_distributed_table('range_copy', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM range_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM range_copy ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO range_copy VALUES(0, 'k', 0);
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE range_copy SET data = 'l' WHERE id = 0;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM range_copy WHERE id = 1;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE range_copy;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE range_copy;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  relation "range_copy" does not exist
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+ERROR:  relation "range_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX range_copy_index ON range_copy(id);
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX range_copy_index ON range_copy(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX range_copy_index;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE range_copy ADD new_column int DEFAULT 0;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  missing data for column "new_column"
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE range_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE range_copy DROP new_column;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('range_copy');
+citus_total_relation_size
+
+32768          
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM range_copy;');
+master_modify_multiple_shards
+
+5              
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-apply-delete-command s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;');
+master_apply_delete_command
+
+1              
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards: SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy');
+master_drop_all_shards
+
+1              
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+5              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE range_copy;
+step s1-create-non-distributed-table: CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('range_copy', 'id');
+create_distributed_table
+
+               
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+15             

--- a/src/test/regress/expected/isolation_range_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_range_copy_vs_all.out
@@ -61,8 +61,7 @@ step s1-begin: BEGIN;
 step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
 
 id             data           int_data       id             data           int_data       
 
@@ -90,6 +89,20 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert-select: INSERT INTO range_copy SELECT * FROM range_copy;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
 
 starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
 create_distributed_table
@@ -294,16 +307,15 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE range_copy;
-step s1-create-non-distributed-table: CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE range_copy(id integer, data text, int_data int);
 step s1-begin: BEGIN;
 step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-distribute-table: SELECT create_distributed_table('range_copy', 'id'); <waiting ...>
+step s2-distribute-table: SELECT create_distributed_table('range_copy', 'id', 'range'); <waiting ...>
 step s1-commit: COMMIT;
 step s2-distribute-table: <... completed>
 create_distributed_table
@@ -312,7 +324,7 @@ create_distributed_table
 step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
-15             
+0              
 
 starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
 create_distributed_table
@@ -361,7 +373,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -390,6 +401,20 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO range_copy SELECT * FROM range_copy;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
 
 starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
 create_distributed_table
@@ -581,22 +606,22 @@ count
 
 5              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE range_copy;
-step s1-create-non-distributed-table: CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE range_copy(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-distribute-table: SELECT create_distributed_table('range_copy', 'id');
+step s1-distribute-table: SELECT create_distributed_table('range_copy', 'id', 'range');
 create_distributed_table
 
                
 step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
 step s1-commit: COMMIT;
 step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  could not find any shards into which to copy
 step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
-15             
+0              

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-finish:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102839"
+error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102826"
 step s2-finish: 
   COMMIT;
 

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-finish:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102793"
+error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102839"
 step s2-finish: 
   COMMIT;
 

--- a/src/test/regress/expected/isolation_select_vs_all.out
+++ b/src/test/regress/expected/isolation_select_vs_all.out
@@ -1,0 +1,2005 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-insert: INSERT INTO select_append VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-update: UPDATE select_append SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-delete: DELETE FROM select_append WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+4              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-truncate: TRUNCATE select_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-drop: DROP TABLE select_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+ERROR:  relation "select_append" does not exist
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-router-select s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-ddl-drop-index: DROP INDEX select_append_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY select_append_index ON select_append(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-router-select s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       new_column     
+
+1               b             1              0              
+step s2-ddl-drop-column: ALTER TABLE select_append DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-table-size: SELECT citus_total_relation_size('select_append');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s2-master-apply-delete-command s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s2-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;');
+master_apply_delete_command
+
+1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s2-master-drop-all-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s2-master-drop-all-shards: SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy');
+master_drop_all_shards
+
+1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-router-select s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE select_append;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+1               b             1              
+step s2-distribute-table: SELECT create_distributed_table('select_append', 'id');
+create_distributed_table
+
+               
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-update s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-delete s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM select_append WHERE id = 1;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+4              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE select_append;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-router-select: <... completed>
+id             data           int_data       
+
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE select_append;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-router-select: <... completed>
+error in steps s1-commit s2-router-select: ERROR:  relation "select_append" does not exist
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+ERROR:  relation "select_append" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX select_append_index;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-router-select: <... completed>
+id             data           int_data       
+
+1               b             1              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-router-select: <... completed>
+id             data           int_data       new_column     
+
+1               b             1              0              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-router-select: <... completed>
+id             data           int_data       
+
+1               b             1              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('select_append');
+citus_total_relation_size
+
+32768          
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
+master_modify_multiple_shards
+
+5              
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-master-apply-delete-command s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;');
+master_apply_delete_command
+
+1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards: SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy');
+master_drop_all_shards
+
+1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE select_append;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('select_append', 'id');
+create_distributed_table
+
+               
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-insert: INSERT INTO select_append VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-update: UPDATE select_append SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-delete: DELETE FROM select_append WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+4              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-truncate: TRUNCATE select_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-drop: DROP TABLE select_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+ERROR:  relation "select_append" does not exist
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-real-time-select s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-ddl-drop-index: DROP INDEX select_append_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY select_append_index ON select_append(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-real-time-select s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       new_column     
+
+0               a             0              0              
+1               b             1              0              
+2               c             2              0              
+3               d             3              0              
+4               e             4              0              
+step s2-ddl-drop-column: ALTER TABLE select_append DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-table-size: SELECT citus_total_relation_size('select_append');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-real-time-select s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE select_append;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+0               a             0              
+1               b             1              
+1               b             1              
+2               c             2              
+2               c             2              
+3               d             3              
+3               d             3              
+4               e             4              
+4               e             4              
+step s2-distribute-table: SELECT create_distributed_table('select_append', 'id');
+create_distributed_table
+
+               
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-update s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-delete s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM select_append WHERE id = 1;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+4              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE select_append;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s1-commit: COMMIT;
+step s2-real-time-select: <... completed>
+id             data           int_data       
+
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE select_append;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s1-commit: COMMIT;
+step s2-real-time-select: <... completed>
+error in steps s1-commit s2-real-time-select: ERROR:  relation "select_append" does not exist
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+ERROR:  relation "select_append" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX select_append_index;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s1-commit: COMMIT;
+step s2-real-time-select: <... completed>
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s1-commit: COMMIT;
+step s2-real-time-select: <... completed>
+id             data           int_data       new_column     
+
+0               a             0              0              
+1               b             1              0              
+2               c             2              0              
+3               d             3              0              
+4               e             4              0              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s1-commit: COMMIT;
+step s2-real-time-select: <... completed>
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('select_append');
+citus_total_relation_size
+
+32768          
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
+master_modify_multiple_shards
+
+5              
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE select_append;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('select_append', 'id');
+create_distributed_table
+
+               
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+0               a             0              
+1               b             1              
+1               b             1              
+2               c             2              
+2               c             2              
+3               d             3              
+3               d             3              
+4               e             4              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-insert: INSERT INTO select_append VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-update: UPDATE select_append SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-delete: DELETE FROM select_append WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+4              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-truncate: TRUNCATE select_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-drop: DROP TABLE select_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+ERROR:  relation "select_append" does not exist
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-task-tracker-select s2-ddl-drop-index s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-ddl-drop-index: DROP INDEX select_append_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY select_append_index ON select_append(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-add-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-task-tracker-select s2-ddl-drop-column s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       new_column     id             data           int_data       new_column     
+
+0               a             0              0              0               a             0              0              
+1               b             1              0              1               b             1              0              
+2               c             2              0              2               c             2              0              
+3               d             3              0              3               d             3              0              
+4               e             4              0              4               e             4              0              
+step s2-ddl-drop-column: ALTER TABLE select_append DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-table-size: SELECT citus_total_relation_size('select_append');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-task-tracker-select s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE select_append;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+0               a             0              0               a             0              
+0               a             0              0               a             0              
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+1               b             1              1               b             1              
+1               b             1              1               b             1              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+2               c             2              2               c             2              
+2               c             2              2               c             2              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+3               d             3              3               d             3              
+3               d             3              3               d             3              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+4               e             4              4               e             4              
+4               e             4              4               e             4              
+4               e             4              4               e             4              
+step s2-distribute-table: SELECT create_distributed_table('select_append', 'id');
+create_distributed_table
+
+               
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+6              
+
+starting permutation: s1-initialize s1-begin s1-update s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-delete s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM select_append WHERE id = 1;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+4              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE select_append;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+ <waiting ...>
+step s1-commit: COMMIT;
+step s2-task-tracker-select: <... completed>
+id             data           int_data       id             data           int_data       
+
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE select_append;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+ <waiting ...>
+step s1-commit: COMMIT;
+step s2-task-tracker-select: <... completed>
+error in steps s1-commit s2-task-tracker-select: ERROR:  relation "select_append" does not exist
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+ERROR:  relation "select_append" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX select_append_index;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+ <waiting ...>
+step s1-commit: COMMIT;
+step s2-task-tracker-select: <... completed>
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+ <waiting ...>
+step s1-commit: COMMIT;
+step s2-task-tracker-select: <... completed>
+id             data           int_data       new_column     id             data           int_data       new_column     
+
+0               a             0              0              0               a             0              0              
+1               b             1              0              1               b             1              0              
+2               c             2              0              2               c             2              0              
+3               d             3              0              3               d             3              0              
+4               e             4              0              4               e             4              0              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+ <waiting ...>
+step s1-commit: COMMIT;
+step s2-task-tracker-select: <... completed>
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('select_append');
+citus_total_relation_size
+
+32768          
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
+master_modify_multiple_shards
+
+5              
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE select_append;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('select_append', 'id');
+create_distributed_table
+
+               
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+0               a             0              0               a             0              
+0               a             0              0               a             0              
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+1               b             1              1               b             1              
+1               b             1              1               b             1              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+2               c             2              2               c             2              
+2               c             2              2               c             2              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+3               d             3              3               d             3              
+3               d             3              3               d             3              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+4               e             4              4               e             4              
+4               e             4              4               e             4              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+10             

--- a/src/test/regress/expected/isolation_select_vs_all.out
+++ b/src/test/regress/expected/isolation_select_vs_all.out
@@ -57,7 +57,6 @@ id             data           int_data
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -141,7 +140,6 @@ id             data           int_data
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -165,7 +163,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -193,7 +190,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -225,7 +221,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -237,7 +232,6 @@ id             data           int_data       id             data           int_d
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -268,6 +262,23 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 6              
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-insert-select: INSERT INTO select_append SELECT * FROM select_append;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
 
 starting permutation: s1-initialize s1-begin s1-router-select s2-update s1-commit s1-select-count
 create_distributed_table
@@ -499,20 +510,17 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-router-select s2-distribute-table s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-router-select s2-distribute-table s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE select_append;
-step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
 step s1-router-select: SELECT * FROM select_append WHERE id = 1;
 id             data           int_data       
 
-1               b             1              
-1               b             1              
-step s2-distribute-table: SELECT create_distributed_table('select_append', 'id');
+step s2-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
 create_distributed_table
 
                
@@ -520,7 +528,7 @@ step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
-10             
+0              
 
 starting permutation: s1-initialize s1-begin s1-insert s2-router-select s1-commit s1-select-count
 create_distributed_table
@@ -538,6 +546,23 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 6              
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO select_append SELECT * FROM select_append;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
 
 starting permutation: s1-initialize s1-begin s1-update s2-router-select s1-commit s1-select-count
 create_distributed_table
@@ -749,28 +774,25 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-router-select s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-router-select s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE select_append;
-step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-distribute-table: SELECT create_distributed_table('select_append', 'id');
+step s1-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
 create_distributed_table
 
                
 step s2-router-select: SELECT * FROM select_append WHERE id = 1;
 id             data           int_data       
 
-1               b             1              
-1               b             1              
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
-10             
+0              
 
 starting permutation: s1-initialize s1-begin s1-real-time-select s2-insert s1-commit s1-select-count
 create_distributed_table
@@ -792,6 +814,27 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 6              
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-insert-select: INSERT INTO select_append SELECT * FROM select_append;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
 
 starting permutation: s1-initialize s1-begin s1-real-time-select s2-update s1-commit s1-select-count
 create_distributed_table
@@ -1035,28 +1078,17 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-real-time-select s2-distribute-table s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-real-time-select s2-distribute-table s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE select_append;
-step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
 step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
 id             data           int_data       
 
-0               a             0              
-0               a             0              
-1               b             1              
-1               b             1              
-2               c             2              
-2               c             2              
-3               d             3              
-3               d             3              
-4               e             4              
-4               e             4              
-step s2-distribute-table: SELECT create_distributed_table('select_append', 'id');
+step s2-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
 create_distributed_table
 
                
@@ -1064,7 +1096,7 @@ step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
-10             
+0              
 
 starting permutation: s1-initialize s1-begin s1-insert s2-real-time-select s1-commit s1-select-count
 create_distributed_table
@@ -1086,6 +1118,27 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 6              
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO select_append SELECT * FROM select_append;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
 
 starting permutation: s1-initialize s1-begin s1-update s2-real-time-select s1-commit s1-select-count
 create_distributed_table
@@ -1297,36 +1350,25 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-real-time-select s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-real-time-select s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE select_append;
-step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-distribute-table: SELECT create_distributed_table('select_append', 'id');
+step s1-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
 create_distributed_table
 
                
 step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
 id             data           int_data       
 
-0               a             0              
-0               a             0              
-1               b             1              
-1               b             1              
-2               c             2              
-2               c             2              
-3               d             3              
-3               d             3              
-4               e             4              
-4               e             4              
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
-10             
+0              
 
 starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-insert s1-commit s1-select-count
 create_distributed_table
@@ -1337,7 +1379,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1353,6 +1394,30 @@ count
 
 6              
 
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-insert-select: INSERT INTO select_append SELECT * FROM select_append;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
 starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-update s1-commit s1-select-count
 create_distributed_table
 
@@ -1362,7 +1427,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1387,7 +1451,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1412,7 +1475,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1438,7 +1500,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1462,7 +1523,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1488,7 +1548,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1514,7 +1573,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1539,7 +1597,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1566,7 +1623,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       new_column     id             data           int_data       new_column     
 
@@ -1592,7 +1648,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1620,7 +1675,6 @@ step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1639,42 +1693,20 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-task-tracker-select s2-distribute-table s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-task-tracker-select s2-distribute-table s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE select_append;
-step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
-0               a             0              0               a             0              
-0               a             0              0               a             0              
-0               a             0              0               a             0              
-0               a             0              0               a             0              
-1               b             1              1               b             1              
-1               b             1              1               b             1              
-1               b             1              1               b             1              
-1               b             1              1               b             1              
-2               c             2              2               c             2              
-2               c             2              2               c             2              
-2               c             2              2               c             2              
-2               c             2              2               c             2              
-3               d             3              3               d             3              
-3               d             3              3               d             3              
-3               d             3              3               d             3              
-3               d             3              3               d             3              
-4               e             4              4               e             4              
-4               e             4              4               e             4              
-4               e             4              4               e             4              
-4               e             4              4               e             4              
-step s2-distribute-table: SELECT create_distributed_table('select_append', 'id');
+step s2-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
 create_distributed_table
 
                
@@ -1682,7 +1714,7 @@ step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
-10             
+0              
 
 starting permutation: s1-initialize s1-begin s1-insert s2-task-tracker-select s1-commit s1-select-count
 create_distributed_table
@@ -1694,7 +1726,6 @@ step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1709,6 +1740,30 @@ count
 
 6              
 
+starting permutation: s1-initialize s1-begin s1-insert-select s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO select_append SELECT * FROM select_append;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+
 starting permutation: s1-initialize s1-begin s1-update s2-task-tracker-select s1-commit s1-select-count
 create_distributed_table
 
@@ -1719,7 +1774,6 @@ step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1744,7 +1798,6 @@ step s1-delete: DELETE FROM select_append WHERE id = 1;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1769,7 +1822,6 @@ step s1-truncate: TRUNCATE select_append;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1790,7 +1842,6 @@ step s1-drop: DROP TABLE select_append;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1808,7 +1859,6 @@ step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1834,7 +1884,6 @@ step s1-ddl-drop-index: DROP INDEX select_append_index;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1860,7 +1909,6 @@ step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1887,7 +1935,6 @@ step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1916,7 +1963,6 @@ citus_total_relation_size
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1944,7 +1990,6 @@ master_modify_multiple_shards
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
@@ -1959,47 +2004,25 @@ count
 
 0              
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-task-tracker-select s1-commit s1-select-count
 create_distributed_table
 
                
 step s1-drop: DROP TABLE select_append;
-step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
-step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-distribute-table: SELECT create_distributed_table('select_append', 'id');
+step s1-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
 create_distributed_table
 
                
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 
 id             data           int_data       id             data           int_data       
 
-0               a             0              0               a             0              
-0               a             0              0               a             0              
-0               a             0              0               a             0              
-0               a             0              0               a             0              
-1               b             1              1               b             1              
-1               b             1              1               b             1              
-1               b             1              1               b             1              
-1               b             1              1               b             1              
-2               c             2              2               c             2              
-2               c             2              2               c             2              
-2               c             2              2               c             2              
-2               c             2              2               c             2              
-3               d             3              3               d             3              
-3               d             3              3               d             3              
-3               d             3              3               d             3              
-3               d             3              3               d             3              
-4               e             4              4               e             4              
-4               e             4              4               e             4              
-4               e             4              4               e             4              
-4               e             4              4               e             4              
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
-10             
+0              

--- a/src/test/regress/expected/isolation_update_vs_all.out
+++ b/src/test/regress/expected/isolation_update_vs_all.out
@@ -1,0 +1,416 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-delete: DELETE FROM update_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+4              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-truncate: TRUNCATE update_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-drop: DROP TABLE update_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+ERROR:  relation "update_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-create-index s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-ddl-create-index: CREATE INDEX update_hash_index ON update_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-update s2-ddl-drop-index s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX update_hash_index ON update_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-ddl-drop-index: DROP INDEX update_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-update s2-ddl-create-index-concurrently s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY update_hash_index ON update_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-add-column s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-ddl-add-column: ALTER TABLE update_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-update s2-ddl-drop-column s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE update_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-ddl-drop-column: ALTER TABLE update_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+5              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-update s2-distribute-table s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE update_hash;
+step s1-create-non-distributed-table: CREATE TABLE update_hash(id integer, data text); COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-distribute-table: SELECT create_distributed_table('update_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+10             
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM update_hash WHERE id = 4;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+4              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE update_hash;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE update_hash;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+error in steps s1-commit s2-update: ERROR:  relation "update_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+ERROR:  relation "update_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX update_hash_index ON update_hash(id);
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX update_hash_index ON update_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX update_hash_index;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE update_hash ADD new_column int DEFAULT 0;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE update_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE update_hash DROP new_column;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM update_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE update_hash;
+step s1-create-non-distributed-table: CREATE TABLE update_hash(id integer, data text); COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('update_hash', 'id');
+create_distributed_table
+
+               
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+10             
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -7,8 +7,15 @@ test: isolation_create_table_vs_add_remove_node
 # that come later can be parallelized
 test: isolation_cluster_management
 
-test: isolation_dml_vs_repair
-test: isolation_copy_placement_vs_copy_placement isolation_cancellation
+test: isolation_hash_copy_vs_all
+test: isolation_append_copy_vs_all
+test: isolation_range_copy_vs_all
+test: isolation_select_vs_all
+test: isolation_insert_vs_all
+test: isolation_update_vs_all
+
+test: isolation_dml_vs_repair isolation_copy_placement_vs_copy_placement
+
 test: isolation_concurrent_dml isolation_data_migration
 test: isolation_drop_shards isolation_copy_placement_vs_modification
 test: isolation_insert_vs_vacuum isolation_transaction_recovery

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -257,11 +257,14 @@ if ($followercluster)
 # to make sure that we always get consistent test outputs. If we don't  manually
 # (i.e., calling a UDF) detect the deadlocks, some sessions that do not participate
 # in the deadlock may interleave with the deadlock detection, which results in non-
-# consistent test outputs. 
+# consistent test outputs.
+# since we have CREATE/DROP distributed tables very frequently, we also set
+# shard_count to 4 to speed up the tests.
 if($isolationtester)
 {
    push(@pgOptions, '-c', "citus.log_distributed_deadlock_detection=on");
    push(@pgOptions, '-c', "citus.distributed_deadlock_detection_factor=-1");
+   push(@pgOptions, '-c', "citus.shard_count=4");
 }
 
 # Add externally added options last, so they overwrite the default ones above

--- a/src/test/regress/specs/README.md
+++ b/src/test/regress/specs/README.md
@@ -1,0 +1,9 @@
+In this folder, all tests which in the format of '*_add.spec' organized
+according to specific format.
+
+For isolation tests, we selected 'n' representative operations and we aimed to
+perform all possible pairs of 'n' operations together. So first test just runs
+first of these 'n' operation with remaining 'n - 1' operation. Similary, second
+test just runs second operation with remaining 'n - 2' operation. With this
+logic, we eventually run every selected operation with every other selected
+operation.

--- a/src/test/regress/specs/isolation_append_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_append_copy_vs_all.spec
@@ -1,0 +1,123 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create append distributed table to test behavior of COPY in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE append_copy(id integer, data text, int_data int);
+	SELECT create_distributed_table('append_copy', 'id', 'append');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS append_copy CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-copy" { COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s1-copy-additional-column" { COPY append_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s1-router-select" { SELECT * FROM append_copy WHERE id = 1; }
+step "s1-real-time-select" { SELECT * FROM append_copy ORDER BY id, data; }
+step "s1-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s1-select-count" { SELECT COUNT(*) FROM append_copy; }
+step "s1-insert" { INSERT INTO append_copy VALUES(0, 'k', 0); }
+step "s1-update" { UPDATE append_copy SET data = 'l' WHERE id = 0; }
+step "s1-delete" { DELETE FROM append_copy WHERE id = 1; }
+step "s1-truncate" { TRUNCATE append_copy; }
+step "s1-drop" { DROP TABLE append_copy; }
+step "s1-ddl-create-index" { CREATE INDEX append_copy_index ON append_copy(id); }
+step "s1-ddl-drop-index" { DROP INDEX append_copy_index; }
+step "s1-ddl-add-column" { ALTER TABLE append_copy ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE append_copy DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE append_copy RENAME data TO new_data; }
+step "s1-ddl-unique-constraint" { ALTER TABLE append_copy ADD CONSTRAINT append_copy_unique UNIQUE(id); }
+step "s1-table-size" { SELECT citus_total_relation_size('append_copy'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM append_copy;'); }
+step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM append_copy WHERE id <= 4;'); }
+step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('append_copy'::regclass, 'public', 'append_copy'); }
+step "s1-create-non-distributed-table" { CREATE TABLE append_copy(id integer, data text, int_data int); COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('append_copy', 'id'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-copy" { COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s2-copy-additional-column" { COPY append_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s2-router-select" { SELECT * FROM append_copy WHERE id = 1; }
+step "s2-real-time-select" { SELECT * FROM append_copy ORDER BY id, data; }
+step "s2-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s2-insert" { INSERT INTO append_copy VALUES(0, 'k', 0); }
+step "s2-update" { UPDATE append_copy SET data = 'l' WHERE id = 0; }
+step "s2-delete" { DELETE FROM append_copy WHERE id = 1; }
+step "s2-truncate" { TRUNCATE append_copy; }
+step "s2-drop" { DROP TABLE append_copy; }
+step "s2-ddl-create-index" { CREATE INDEX append_copy_index ON append_copy(id); }
+step "s2-ddl-drop-index" { DROP INDEX append_copy_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY append_copy_index ON append_copy(id); }
+step "s2-ddl-add-column" { ALTER TABLE append_copy ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE append_copy DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE append_copy RENAME data TO new_data; }
+step "s2-table-size" { SELECT citus_total_relation_size('append_copy'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM append_copy;'); }
+step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM append_copy WHERE id <= 4;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('append_copy'::regclass, 'public', 'append_copy'); }
+step "s2-create-non-distributed-table" { CREATE TABLE append_copy(id integer, data text, int_data int); COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('append_copy', 'id'); }
+
+# permutations - COPY vs COPY
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-select-count"
+
+# permutations - COPY first
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - COPY second
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_hash_copy_vs_all.spec
@@ -28,10 +28,10 @@ step "s1-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 }
 step "s1-select-count" { SELECT COUNT(*) FROM hash_copy; }
 step "s1-insert" { INSERT INTO hash_copy VALUES(0, 'k', 0); }
+step "s1-insert-select" { INSERT INTO hash_copy SELECT * FROM hash_copy; }
 step "s1-update" { UPDATE hash_copy SET data = 'l' WHERE id = 0; }
 step "s1-delete" { DELETE FROM hash_copy WHERE id = 1; }
 step "s1-truncate" { TRUNCATE hash_copy; }
@@ -59,9 +59,9 @@ step "s2-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 }
 step "s2-insert" { INSERT INTO hash_copy VALUES(0, 'k', 0); }
+step "s2-insert-select" { INSERT INTO hash_copy SELECT * FROM hash_copy; }
 step "s2-update" { UPDATE hash_copy SET data = 'l' WHERE id = 0; }
 step "s2-delete" { DELETE FROM hash_copy WHERE id = 1; }
 step "s2-truncate" { TRUNCATE hash_copy; }
@@ -75,7 +75,6 @@ step "s2-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_data; }
 step "s2-table-size" { SELECT citus_total_relation_size('hash_copy'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
-step "s2-create-non-distributed-table" { CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
 step "s2-distribute-table" { SELECT create_distributed_table('hash_copy', 'id'); }
 
 # permutations - COPY vs COPY
@@ -86,6 +85,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" 
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
@@ -105,6 +105,7 @@ permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" 
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_hash_copy_vs_all.spec
@@ -1,0 +1,119 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create append distributed table to test behavior of COPY in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE hash_copy(id integer, data text, int_data int);
+	SELECT create_distributed_table('hash_copy', 'id', 'append');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS hash_copy CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-copy" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s1-copy-additional-column" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s1-router-select" { SELECT * FROM hash_copy WHERE id = 1; }
+step "s1-real-time-select" { SELECT * FROM hash_copy ORDER BY id, data; }
+step "s1-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s1-select-count" { SELECT COUNT(*) FROM hash_copy; }
+step "s1-insert" { INSERT INTO hash_copy VALUES(0, 'k', 0); }
+step "s1-update" { UPDATE hash_copy SET data = 'l' WHERE id = 0; }
+step "s1-delete" { DELETE FROM hash_copy WHERE id = 1; }
+step "s1-truncate" { TRUNCATE hash_copy; }
+step "s1-drop" { DROP TABLE hash_copy; }
+step "s1-ddl-create-index" { CREATE INDEX hash_copy_index ON hash_copy(id); }
+step "s1-ddl-drop-index" { DROP INDEX hash_copy_index; }
+step "s1-ddl-add-column" { ALTER TABLE hash_copy ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_data; }
+step "s1-ddl-unique-constraint" { ALTER TABLE hash_copy ADD CONSTRAINT hash_copy_unique UNIQUE(id); }
+step "s1-table-size" { SELECT citus_total_relation_size('hash_copy'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
+step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
+step "s1-create-non-distributed-table" { CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('hash_copy', 'id'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-copy" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s2-copy-additional-column" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s2-router-select" { SELECT * FROM hash_copy WHERE id = 1; }
+step "s2-real-time-select" { SELECT * FROM hash_copy ORDER BY id, data; }
+step "s2-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s2-insert" { INSERT INTO hash_copy VALUES(0, 'k', 0); }
+step "s2-update" { UPDATE hash_copy SET data = 'l' WHERE id = 0; }
+step "s2-delete" { DELETE FROM hash_copy WHERE id = 1; }
+step "s2-truncate" { TRUNCATE hash_copy; }
+step "s2-drop" { DROP TABLE hash_copy; }
+step "s2-ddl-create-index" { CREATE INDEX hash_copy_index ON hash_copy(id); }
+step "s2-ddl-drop-index" { DROP INDEX hash_copy_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY hash_copy_index ON hash_copy(id); }
+step "s2-ddl-add-column" { ALTER TABLE hash_copy ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_data; }
+step "s2-table-size" { SELECT citus_total_relation_size('hash_copy'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
+step "s2-create-non-distributed-table" { CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('hash_copy', 'id'); }
+
+# permutations - COPY vs COPY
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-select-count"
+
+# permutations - COPY first
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - COPY second
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_insert_vs_all.spec
+++ b/src/test/regress/specs/isolation_insert_vs_all.spec
@@ -21,6 +21,7 @@ session "s1"
 step "s1-initialize" { COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
 step "s1-begin" { BEGIN; }
 step "s1-insert" { INSERT INTO insert_hash VALUES(7, 'k'); }
+step "s1-insert-select" { INSERT INTO insert_hash SELECT * FROM insert_hash; }
 step "s1-update" { UPDATE insert_hash SET data = 'l' WHERE id = 4; }
 step "s1-delete" { DELETE FROM insert_hash WHERE id = 4; }
 step "s1-truncate" { TRUNCATE insert_hash; }
@@ -40,6 +41,7 @@ step "s1-commit" { COMMIT; }
 # session 2
 session "s2"
 step "s2-insert" { INSERT INTO insert_hash VALUES(7, 'k'); }
+step "s2-insert-select" { INSERT INTO insert_hash SELECT * FROM insert_hash; }
 step "s2-update" { UPDATE insert_hash SET data = 'l' WHERE id = 4; }
 step "s2-delete" { DELETE FROM insert_hash WHERE id = 4; }
 step "s2-truncate" { TRUNCATE insert_hash; }
@@ -52,14 +54,13 @@ step "s2-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_data; }
 step "s2-table-size" { SELECT citus_total_relation_size('insert_hash'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
-step "s2-create-non-distributed-table" { CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
 step "s2-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
-step "s2-select" { SELECT * FROM insert_hash ORDER BY id, data; }
 
 # permutations - INSERT vs INSERT
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-insert" "s1-commit" "s1-select-count"
 
 # permutations - INSERT first
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-update" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-truncate" "s1-commit" "s1-select-count"
@@ -74,6 +75,7 @@ permutation "s1-initialize" "s1-begin" "s1-insert" "s2-master-modify-multiple-sh
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-insert" "s2-distribute-table" "s1-commit" "s1-select-count"
 
 # permutations - INSERT second
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-insert" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_insert_vs_all.spec
+++ b/src/test/regress/specs/isolation_insert_vs_all.spec
@@ -1,0 +1,87 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of INSERT in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE insert_hash(id integer, data text);
+	SELECT create_distributed_table('insert_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS insert_hash CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-insert" { INSERT INTO insert_hash VALUES(7, 'k'); }
+step "s1-update" { UPDATE insert_hash SET data = 'l' WHERE id = 4; }
+step "s1-delete" { DELETE FROM insert_hash WHERE id = 4; }
+step "s1-truncate" { TRUNCATE insert_hash; }
+step "s1-drop" { DROP TABLE insert_hash; }
+step "s1-ddl-create-index" { CREATE INDEX insert_hash_index ON insert_hash(id); }
+step "s1-ddl-drop-index" { DROP INDEX insert_hash_index; }
+step "s1-ddl-add-column" { ALTER TABLE insert_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_data; }
+step "s1-table-size" { SELECT citus_total_relation_size('insert_hash'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
+step "s1-create-non-distributed-table" { CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM insert_hash; }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-insert" { INSERT INTO insert_hash VALUES(7, 'k'); }
+step "s2-update" { UPDATE insert_hash SET data = 'l' WHERE id = 4; }
+step "s2-delete" { DELETE FROM insert_hash WHERE id = 4; }
+step "s2-truncate" { TRUNCATE insert_hash; }
+step "s2-drop" { DROP TABLE insert_hash; }
+step "s2-ddl-create-index" { CREATE INDEX insert_hash_index ON insert_hash(id); }
+step "s2-ddl-drop-index" { DROP INDEX insert_hash_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY insert_hash_index ON insert_hash(id); }
+step "s2-ddl-add-column" { ALTER TABLE insert_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_data; }
+step "s2-table-size" { SELECT citus_total_relation_size('insert_hash'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
+step "s2-create-non-distributed-table" { CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
+step "s2-select" { SELECT * FROM insert_hash ORDER BY id, data; }
+
+# permutations - INSERT vs INSERT
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-insert" "s1-commit" "s1-select-count"
+
+# permutations - INSERT first
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-insert" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-insert" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-insert" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - INSERT second
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-insert" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_range_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_range_copy_vs_all.spec
@@ -1,0 +1,123 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create append distributed table to test behavior of COPY in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE range_copy(id integer, data text, int_data int);
+	SELECT create_distributed_table('range_copy', 'id', 'append');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS range_copy CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-copy" { COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s1-copy-additional-column" { COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s1-router-select" { SELECT * FROM range_copy WHERE id = 1; }
+step "s1-real-time-select" { SELECT * FROM range_copy ORDER BY id, data; }
+step "s1-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s1-select-count" { SELECT COUNT(*) FROM range_copy; }
+step "s1-insert" { INSERT INTO range_copy VALUES(0, 'k', 0); }
+step "s1-update" { UPDATE range_copy SET data = 'l' WHERE id = 0; }
+step "s1-delete" { DELETE FROM range_copy WHERE id = 1; }
+step "s1-truncate" { TRUNCATE range_copy; }
+step "s1-drop" { DROP TABLE range_copy; }
+step "s1-ddl-create-index" { CREATE INDEX range_copy_index ON range_copy(id); }
+step "s1-ddl-drop-index" { DROP INDEX range_copy_index; }
+step "s1-ddl-add-column" { ALTER TABLE range_copy ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE range_copy DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_data; }
+step "s1-ddl-unique-constraint" { ALTER TABLE range_copy ADD CONSTRAINT range_copy_unique UNIQUE(id); }
+step "s1-table-size" { SELECT citus_total_relation_size('range_copy'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
+step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
+step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
+step "s1-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('range_copy', 'id'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-copy" { COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s2-copy-additional-column" { COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s2-router-select" { SELECT * FROM range_copy WHERE id = 1; }
+step "s2-real-time-select" { SELECT * FROM range_copy ORDER BY id, data; }
+step "s2-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s2-insert" { INSERT INTO range_copy VALUES(0, 'k', 0); }
+step "s2-update" { UPDATE range_copy SET data = 'l' WHERE id = 0; }
+step "s2-delete" { DELETE FROM range_copy WHERE id = 1; }
+step "s2-truncate" { TRUNCATE range_copy; }
+step "s2-drop" { DROP TABLE range_copy; }
+step "s2-ddl-create-index" { CREATE INDEX range_copy_index ON range_copy(id); }
+step "s2-ddl-drop-index" { DROP INDEX range_copy_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY range_copy_index ON range_copy(id); }
+step "s2-ddl-add-column" { ALTER TABLE range_copy ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE range_copy DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_data; }
+step "s2-table-size" { SELECT citus_total_relation_size('range_copy'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
+step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
+step "s2-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('range_copy', 'id'); }
+
+# permutations - COPY vs COPY
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-select-count"
+
+# permutations - COPY first
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - COPY second
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_range_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_range_copy_vs_all.spec
@@ -28,10 +28,10 @@ step "s1-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 }
 step "s1-select-count" { SELECT COUNT(*) FROM range_copy; }
 step "s1-insert" { INSERT INTO range_copy VALUES(0, 'k', 0); }
+step "s1-insert-select" { INSERT INTO range_copy SELECT * FROM range_copy; }
 step "s1-update" { UPDATE range_copy SET data = 'l' WHERE id = 0; }
 step "s1-delete" { DELETE FROM range_copy WHERE id = 1; }
 step "s1-truncate" { TRUNCATE range_copy; }
@@ -46,8 +46,8 @@ step "s1-table-size" { SELECT citus_total_relation_size('range_copy'); }
 step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
-step "s1-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
-step "s1-distribute-table" { SELECT create_distributed_table('range_copy', 'id'); }
+step "s1-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); }
+step "s1-distribute-table" { SELECT create_distributed_table('range_copy', 'id', 'range'); }
 step "s1-commit" { COMMIT; }
 
 # session 2
@@ -59,10 +59,10 @@ step "s2-real-time-select" { SELECT * FROM range_copy ORDER BY id, data; }
 step "s2-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
 }
 step "s2-insert" { INSERT INTO range_copy VALUES(0, 'k', 0); }
+step "s2-insert-select" { INSERT INTO range_copy SELECT * FROM range_copy; }
 step "s2-update" { UPDATE range_copy SET data = 'l' WHERE id = 0; }
 step "s2-delete" { DELETE FROM range_copy WHERE id = 1; }
 step "s2-truncate" { TRUNCATE range_copy; }
@@ -77,8 +77,7 @@ step "s2-table-size" { SELECT citus_total_relation_size('range_copy'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
-step "s2-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
-step "s2-distribute-table" { SELECT create_distributed_table('range_copy', 'id'); }
+step "s2-distribute-table" { SELECT create_distributed_table('range_copy', 'id', 'range'); }
 
 # permutations - COPY vs COPY
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-select-count"
@@ -88,6 +87,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" 
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
@@ -101,13 +101,14 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
 
 # permutations - COPY second
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
@@ -120,4 +121,4 @@ permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_select_vs_all.spec
+++ b/src/test/regress/specs/isolation_select_vs_all.spec
@@ -26,10 +26,10 @@ step "s1-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 }
 step "s1-select-count" { SELECT COUNT(*) FROM select_append; }
 step "s1-insert" { INSERT INTO select_append VALUES(0, 'k', 0); }
+step "s1-insert-select" { INSERT INTO select_append SELECT * FROM select_append; }
 step "s1-update" { UPDATE select_append SET data = 'l' WHERE id = 0; }
 step "s1-delete" { DELETE FROM select_append WHERE id = 1; }
 step "s1-truncate" { TRUNCATE select_append; }
@@ -43,8 +43,8 @@ step "s1-table-size" { SELECT citus_total_relation_size('select_append'); }
 step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
-step "s1-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
-step "s1-distribute-table" { SELECT create_distributed_table('select_append', 'id'); }
+step "s1-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); }
+step "s1-distribute-table" { SELECT create_distributed_table('select_append', 'id', 'append'); }
 step "s1-commit" { COMMIT; }
 
 # session 2
@@ -55,9 +55,9 @@ step "s2-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
-	SET citus.task_executor_type TO "real-time";
 }
 step "s2-insert" { INSERT INTO select_append VALUES(0, 'k', 0); }
+step "s2-insert-select" { INSERT INTO select_append SELECT * FROM select_append; }
 step "s2-update" { UPDATE select_append SET data = 'l' WHERE id = 0; }
 step "s2-delete" { DELETE FROM select_append WHERE id = 1; }
 step "s2-truncate" { TRUNCATE select_append; }
@@ -72,8 +72,7 @@ step "s2-table-size" { SELECT citus_total_relation_size('select_append'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
-step "s2-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
-step "s2-distribute-table" { SELECT create_distributed_table('select_append', 'id'); }
+step "s2-distribute-table" { SELECT create_distributed_table('select_append', 'id', 'append'); }
 
 # permutations - SELECT vs SELECT
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-router-select" "s1-commit" "s1-select-count"
@@ -88,6 +87,7 @@ permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-task-tracker
 
 # permutations - router SELECT first
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-update" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-truncate" "s1-commit" "s1-select-count"
@@ -101,10 +101,11 @@ permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-table-size" "s1-co
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-router-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-router-select" "s2-distribute-table" "s1-commit" "s1-select-count"
 
 # permutations - router SELECT second
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-router-select" "s1-commit" "s1-select-count"
@@ -117,10 +118,11 @@ permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-router-select" "s1-co
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-router-select" "s1-commit" "s1-select-count"
 
 # permutations - real-time SELECT first
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-update" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-truncate" "s1-commit" "s1-select-count"
@@ -132,10 +134,11 @@ permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-add-column"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-real-time-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-real-time-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-real-time-select" "s2-distribute-table" "s1-commit" "s1-select-count"
 
 # permutations - real-time SELECT second
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-real-time-select" "s1-commit" "s1-select-count"
@@ -146,10 +149,11 @@ permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-real-time-select"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-real-time-select" "s1-commit" "s1-select-count"
 
 # permutations - task-tracker SELECT first
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-update" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-truncate" "s1-commit" "s1-select-count"
@@ -161,10 +165,11 @@ permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-add-colu
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-task-tracker-select" "s2-distribute-table" "s1-commit" "s1-select-count"
 
 # permutations - task-tracker SELECT second
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-task-tracker-select" "s1-commit" "s1-select-count"
@@ -175,4 +180,4 @@ permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-task-tracker-sele
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-task-tracker-select" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_select_vs_all.spec
+++ b/src/test/regress/specs/isolation_select_vs_all.spec
@@ -1,0 +1,178 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of SELECT in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE select_append(id integer, data text, int_data int);
+	SELECT create_distributed_table('select_append', 'id', 'append');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS select_append CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-router-select" { SELECT * FROM select_append WHERE id = 1; }
+step "s1-real-time-select" { SELECT * FROM select_append ORDER BY id, data; }
+step "s1-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s1-select-count" { SELECT COUNT(*) FROM select_append; }
+step "s1-insert" { INSERT INTO select_append VALUES(0, 'k', 0); }
+step "s1-update" { UPDATE select_append SET data = 'l' WHERE id = 0; }
+step "s1-delete" { DELETE FROM select_append WHERE id = 1; }
+step "s1-truncate" { TRUNCATE select_append; }
+step "s1-drop" { DROP TABLE select_append; }
+step "s1-ddl-create-index" { CREATE INDEX select_append_index ON select_append(id); }
+step "s1-ddl-drop-index" { DROP INDEX select_append_index; }
+step "s1-ddl-add-column" { ALTER TABLE select_append ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE select_append DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_data; }
+step "s1-table-size" { SELECT citus_total_relation_size('select_append'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
+step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
+step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
+step "s1-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('select_append', 'id'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-router-select" { SELECT * FROM select_append WHERE id = 1; }
+step "s2-real-time-select" { SELECT * FROM select_append ORDER BY id, data; }
+step "s2-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SET citus.task_executor_type TO "real-time";
+}
+step "s2-insert" { INSERT INTO select_append VALUES(0, 'k', 0); }
+step "s2-update" { UPDATE select_append SET data = 'l' WHERE id = 0; }
+step "s2-delete" { DELETE FROM select_append WHERE id = 1; }
+step "s2-truncate" { TRUNCATE select_append; }
+step "s2-drop" { DROP TABLE select_append; }
+step "s2-ddl-create-index" { CREATE INDEX select_append_index ON select_append(id); }
+step "s2-ddl-drop-index" { DROP INDEX select_append_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY select_append_index ON select_append(id); }
+step "s2-ddl-add-column" { ALTER TABLE select_append ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE select_append DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_data; }
+step "s2-table-size" { SELECT citus_total_relation_size('select_append'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
+step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
+step "s2-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('select_append', 'id'); }
+
+# permutations - SELECT vs SELECT
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+
+# permutations - router SELECT first
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-router-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-router-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-router-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - router SELECT second
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-router-select" "s1-commit" "s1-select-count"
+
+# permutations - real-time SELECT first
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-real-time-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-real-time-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-real-time-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - real-time SELECT second
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-real-time-select" "s1-commit" "s1-select-count"
+
+# permutations - task-tracker SELECT first
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-add-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - task-tracker SELECT second
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-task-tracker-select" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_update_vs_all.spec
+++ b/src/test/regress/specs/isolation_update_vs_all.spec
@@ -56,9 +56,7 @@ step "s2-ddl-drop-column" { ALTER TABLE update_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE update_hash RENAME data TO new_data; }
 step "s2-table-size" { SELECT citus_total_relation_size('update_hash'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); }
-step "s2-create-non-distributed-table" { CREATE TABLE update_hash(id integer, data text); COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
 step "s2-distribute-table" { SELECT create_distributed_table('update_hash', 'id'); }
-step "s2-select" { SELECT * FROM update_hash ORDER BY id, data; }
 step "s2-commit" { COMMIT; }
 
 # permutations - UPDATE vs UPDATE

--- a/src/test/regress/specs/isolation_update_vs_all.spec
+++ b/src/test/regress/specs/isolation_update_vs_all.spec
@@ -1,0 +1,90 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of UPDATE in concurrent operations
+setup
+{
+	SELECT citus.replace_isolation_tester_func();
+	SELECT citus.refresh_isolation_tester_prepared_statement();
+
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE update_hash(id integer, data text);
+	SELECT create_distributed_table('update_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS update_hash CASCADE;
+
+	SELECT citus.restore_isolation_tester_func();
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-update" { UPDATE update_hash SET data = 'l' WHERE id = 4; }
+step "s1-delete" { DELETE FROM update_hash WHERE id = 4; }
+step "s1-truncate" { TRUNCATE update_hash; }
+step "s1-drop" { DROP TABLE update_hash; }
+step "s1-ddl-create-index" { CREATE INDEX update_hash_index ON update_hash(id); }
+step "s1-ddl-drop-index" { DROP INDEX update_hash_index; }
+step "s1-ddl-add-column" { ALTER TABLE update_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE update_hash DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE update_hash RENAME data TO new_data; }
+step "s1-table-size" { SELECT citus_total_relation_size('update_hash'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); }
+step "s1-create-non-distributed-table" { CREATE TABLE update_hash(id integer, data text); COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('update_hash', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM update_hash; }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-update" { UPDATE update_hash SET data = 'l' WHERE id = 4; }
+step "s2-delete" { DELETE FROM update_hash WHERE id = 4; }
+step "s2-truncate" { TRUNCATE update_hash; }
+step "s2-drop" { DROP TABLE update_hash; }
+step "s2-ddl-create-index" { CREATE INDEX update_hash_index ON update_hash(id); }
+step "s2-ddl-drop-index" { DROP INDEX update_hash_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY update_hash_index ON update_hash(id); }
+step "s2-ddl-add-column" { ALTER TABLE update_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE update_hash DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE update_hash RENAME data TO new_data; }
+step "s2-table-size" { SELECT citus_total_relation_size('update_hash'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); }
+step "s2-create-non-distributed-table" { CREATE TABLE update_hash(id integer, data text); COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('update_hash', 'id'); }
+step "s2-select" { SELECT * FROM update_hash ORDER BY id, data; }
+step "s2-commit" { COMMIT; }
+
+# permutations - UPDATE vs UPDATE
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - UPDATE first
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-update" "s2-ddl-drop-index" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-update" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count"
+#permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - UPDATE second
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-ddl-drop-index" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+#permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-update" "s1-commit" "s2-commit" "s1-select-count"


### PR DESCRIPTION
With this PR we add isolation tests for

COPY to hash distributed table vs. other operations
COPY to append distributed table vs. other operations
COPY to range distributed table vs. other operations
SELECT vs. other operations
INSERT vs. other operations
UPDATE vs. other operations

other operations consist of basic SQL operations (like SELECT, INSERT, DELETE, UPSERT, COPY TRUNCATE, CREATE INDEX) as well as some Citus functionalities (like master_modify_multiple_shards, master_apply_delete_command, citus_total_relation_size etc.)