### PR TITLE
Remove fall back to select if poll is not available

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -10,9 +10,7 @@
 
 #include "postgres.h"
 
-#ifdef HAVE_POLL_H
 #include <poll.h>
-#endif
 
 #include "libpq-fe.h"
 


### PR DESCRIPTION
We used select(2) as fallback mechanism for those platforms that do not support poll().

There is no relevant systems left to have this fallback anymore. Postgres itself is also removing it.

This work removes "falling back to select when poll is not supported" logic. It was uncompiled dead code.

fixes #567 