### PR TITLE
Creating distributed partitioned tables [WIP]

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -78,9 +78,6 @@ static char LookupDistributionMethod(Oid distributionMethodOid);
 static Oid SupportFunctionForColumn(Var *partitionColumn, Oid accessMethodId,
 									int16 supportFunctionNumber);
 static bool LocalTableEmpty(Oid tableId);
-static void CreateHashDistributedTable(Oid relationId, char *distributionColumnName,
-									   char *colocateWithTableName,
-									   int shardCount, int replicationFactor);
 static Oid ColumnType(Oid relationId, char *columnName);
 static void CopyLocalDataIntoShards(Oid destinationDistributedRelationId, List *
 									sourceLocalRelationList);
@@ -618,7 +615,7 @@ CreateTruncateTrigger(Oid relationId)
 /*
  * CreateHashDistributedTable creates a hash distributed table.
  */
-static void
+void
 CreateHashDistributedTable(Oid relationId, char *distributionColumnName,
 						   char *colocateWithTableName, int shardCount,
 						   int replicationFactor)

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1880,14 +1880,14 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 #if (PG_VERSION_NUM >= 100000)
 			case AT_AttachPartition:
 #endif
-			{
-				/*
-				 * We will not perform any special check for ALTER TABLE DROP CONSTRAINT
-				 * , ALTER TABLE .. ALTER COLUMN .. SET NOT NULL and ALTER TABLE ENABLE/
-				 * DISABLE TRIGGER ALL
-				 */
-				break;
-			}
+				{
+					/*
+					 * We will not perform any special check for ALTER TABLE DROP CONSTRAINT
+					 * , ALTER TABLE .. ALTER COLUMN .. SET NOT NULL and ALTER TABLE ENABLE/
+					 * DISABLE TRIGGER ALL
+					 */
+					break;
+				}
 
 			default:
 			{

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -736,7 +736,11 @@ ShardStorageType(Oid relationId)
 	char shardStorageType = 0;
 
 	char relationType = get_rel_relkind(relationId);
+#if (PG_VERSION_NUM >= 100000)
+	if (relationType == RELKIND_RELATION || relationType == RELKIND_PARTITIONED_TABLE)
+#else
 	if (relationType == RELKIND_RELATION)
+#endif
 	{
 		shardStorageType = SHARD_STORAGE_TABLE;
 	}

--- a/src/backend/distributed/utils/citus_ruleutils.c
+++ b/src/backend/distributed/utils/citus_ruleutils.c
@@ -59,7 +59,6 @@
 
 
 static void AppendOptionListToString(StringInfo stringData, List *options);
-static bool SupportedRelationKind(Relation relation);
 static const char * convert_aclright_to_string(int aclright);
 
 
@@ -494,7 +493,7 @@ pg_get_tableschemadef_string(Oid tableRelationId, bool includeSequenceDefaults)
  * SupportedRelationKind returns true if the given relation is supported as a
  * distributed relation.
  */
-static bool
+bool
 SupportedRelationKind(Relation relation)
 {
 	char relationKind = relation->rd_rel->relkind;

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -198,6 +198,26 @@ PartitionList(Oid parentRelationId)
 
 
 /*
+ * Wrapper around get_partition_parent
+ *  *
+ * Note: Because this function assumes that the relation whose OID is passed
+ * as an argument will have precisely one parent, it should only be called
+ * when it is known that the relation is a partition.
+ */
+Oid
+PartitionParentOid(Oid partitionOid)
+{
+	Oid partitionParentOid = InvalidOid;
+
+#if (PG_VERSION_NUM >= 100000)
+	partitionParentOid = get_partition_parent(partitionOid);
+#endif
+
+	return partitionParentOid;
+}
+
+
+/*
  * GenerateDetachPartitionCommand gets a partition table and returns
  * "ALTER TABLE parent_table DETACH PARTITION partitionName" command.
  */

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -34,6 +34,7 @@ extern char * pg_get_serverdef_string(Oid tableRelationId);
 extern char * pg_get_sequencedef_string(Oid sequenceRelid);
 extern Form_pg_sequence pg_get_sequencedef(Oid sequenceRelationId);
 extern char * pg_get_tableschemadef_string(Oid tableRelationId, bool forShardCreation);
+extern bool SupportedRelationKind(Relation relation);
 extern char * pg_get_tablecolumnoptionsdef_string(Oid tableRelationId);
 extern void deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid,
 										  int64 shardid, StringInfo buffer);

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -49,5 +49,9 @@ extern void deparse_shard_query(Query *query, Oid distrelid, int64 shardid,
 extern char * generate_relation_name(Oid relid, List *namespaces);
 extern char * generate_qualified_relation_name(Oid relid);
 
+/* TODO: THIS SHOULD NOT BE HERE */
+extern void CreateHashDistributedTable(Oid relationId, char *distributionColumnName,
+									   char *colocateWithTableName,
+									   int shardCount, int replicationFactor);
 
 #endif /* CITUS_RULEUTILS_H */

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -116,7 +116,8 @@ extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId);
 extern void CreateReferenceTableShard(Oid distributedTableId);
 extern bool WorkerCreateShard(Oid relationId, char *nodeName, uint32 nodePort,
 							  int shardIndex, uint64 shardId, char *newShardOwner,
-							  List *ddlCommandList, List *foreignConstraintCommadList);
+							  List *ddlCommandList, List *foreignConstraintCommadList,
+							  char *alterTableAttachPartitionCommand);
 extern Oid ForeignConstraintGetReferencedTableId(char *queryString);
 extern void CheckHashPartitionedTable(Oid distributedTableId);
 extern void CheckTableSchemaNameForDrop(Oid relationId, char **schemaName,

--- a/src/include/distributed/multi_partitioning_utils.h
+++ b/src/include/distributed/multi_partitioning_utils.h
@@ -16,6 +16,7 @@ extern bool PartitionTable(Oid relationId);
 extern bool IsChildTable(Oid relationId);
 extern bool IsParentTable(Oid relationId);
 extern List * PartitionList(Oid parentRelationId);
+extern Oid PartitionParentOid(Oid partitionOid);
 extern char * GenerateDetachPartitionCommand(Oid partitionTableId);
 extern char * GenerateAlterTableAttachPartitionCommand(Oid partitionTableId);
 extern char * GeneratePartitioningInformation(Oid tableId);

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1,0 +1,86 @@
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1660000;
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+ 
+-- create its partitions
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+-- this should error out given that parent of the partition is not distributed
+SELECT create_distributed_table('partitioning_test_2010', 'id');
+ERROR:  cannot distributed relation "partitioning_test_2010" which is partition of "partitioning_test"
+DETAIL:  Citus does not support partitioning among local tables and distributed tables
+HINT:  First distribute the partitioned table  "partitioning_test"
+-- this should suceed
+SELECT create_distributed_table('partitioning_test', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- check the data
+SELECT * FROM partitioning_test ORDER BY 1;
+ id |    time    
+----+------------
+  1 | 06-06-2009
+  2 | 07-07-2010
+  3 | 09-09-2009
+  4 | 03-03-2010
+(4 rows)
+
+-- check the metadata
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010')
+ORDER BY 1;
+      logicalrelid      | partmethod |                                                        partkey                                                         | colocationid | repmodel 
+------------------------+------------+------------------------------------------------------------------------------------------------------------------------+--------------+----------
+ partitioning_test      | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2009 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2010 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+(3 rows)
+
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+      logicalrelid      | count 
+------------------------+-------
+ partitioning_test      |     4
+ partitioning_test_2009 |     4
+ partitioning_test_2010 |     4
+(3 rows)
+
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+ nodename  | nodeport | count 
+-----------+----------+-------
+ localhost |    57637 |     6
+ localhost |    57638 |     6
+(2 rows)
+
+-- dropping the parent should CASCADE to the children as well
+DROP TABLE partitioning_test;
+\d+ partitioning_test*

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -81,6 +81,55 @@ ORDER BY
  localhost |    57638 |     6
 (2 rows)
 
+-- now create a partition and see that it also becomes a distributed table
+CREATE TABLE partitioning_test_2011 PARTITION OF partitioning_test FOR VALUES FROM ('2011-01-01') TO ('2012-01-01');
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011')
+ORDER BY 1;
+      logicalrelid      | partmethod |                                                        partkey                                                         | colocationid | repmodel 
+------------------------+------------+------------------------------------------------------------------------------------------------------------------------+--------------+----------
+ partitioning_test      | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2009 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2010 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2011 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+(4 rows)
+
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+      logicalrelid      | count 
+------------------------+-------
+ partitioning_test      |     4
+ partitioning_test_2009 |     4
+ partitioning_test_2010 |     4
+ partitioning_test_2011 |     4
+(4 rows)
+
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+ nodename  | nodeport | count 
+-----------+----------+-------
+ localhost |    57637 |     8
+ localhost |    57638 |     8
+(2 rows)
+
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 \d+ partitioning_test*

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -130,6 +130,59 @@ ORDER BY
  localhost |    57638 |     8
 (2 rows)
 
+-- citus can also support ALTER TABLE .. ATTACH PARTITION 
+-- even if the partition is not distributed
+CREATE TABLE partitioning_test_2012(id int, time date);
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2012 FOR VALUES FROM ('2012-01-01') TO ('2013-01-01');
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012')
+ORDER BY 1;
+      logicalrelid      | partmethod |                                                        partkey                                                         | colocationid | repmodel 
+------------------------+------------+------------------------------------------------------------------------------------------------------------------------+--------------+----------
+ partitioning_test      | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2009 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2010 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2011 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+ partitioning_test_2012 | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            2 | c
+(5 rows)
+
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+      logicalrelid      | count 
+------------------------+-------
+ partitioning_test      |     4
+ partitioning_test_2009 |     4
+ partitioning_test_2010 |     4
+ partitioning_test_2011 |     4
+ partitioning_test_2012 |     4
+(5 rows)
+
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+ nodename  | nodeport | count 
+-----------+----------+-------
+ localhost |    57637 |    10
+ localhost |    57638 |    10
+(2 rows)
+
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 \d+ partitioning_test*

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -186,3 +186,6 @@ ORDER BY
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 \d+ partitioning_test*
+-- set the colocationid sequence back to 1 to make sure
+-- that this file does not break other tests
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1;

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -82,6 +82,45 @@ ORDER BY
 ERROR:  relation "partitioning_test" does not exist
 LINE 6: ...shardid FROM pg_dist_shard WHERE logicalrelid IN ('partition...
                                                              ^
+-- now create a partition and see that it also becomes a distributed table
+CREATE TABLE partitioning_test_2011 PARTITION OF partitioning_test FOR VALUES FROM ('2011-01-01') TO ('2012-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test_2011 PARTITION OF partitionin...
+                                            ^
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011')
+ORDER BY 1;
+ERROR:  relation "partitioning_test" does not exist
+LINE 6:  logicalrelid IN ('partitioning_test', 'partitioning_test_20...
+                          ^
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+ERROR:  relation "partitioning_test" does not exist
+LINE 4:  WHERE logicalrelid IN ('partitioning_test', 'partitioning_t...
+                                ^
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+ERROR:  relation "partitioning_test" does not exist
+LINE 6: ...shardid FROM pg_dist_shard WHERE logicalrelid IN ('partition...
+                                                             ^
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 ERROR:  table "partitioning_test" does not exist

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -1,0 +1,88 @@
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1660000;
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test(id int, time date) PARTITION ...
+                                                          ^
+ 
+-- create its partitions
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test_2009 PARTITION OF partitionin...
+                                            ^
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test_2010 PARTITION OF partitionin...
+                                            ^
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+                    ^
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+                    ^
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+ERROR:  relation "partitioning_test_2009" does not exist
+LINE 1: INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+                    ^
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+ERROR:  relation "partitioning_test_2010" does not exist
+LINE 1: INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+                    ^
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+-- this should error out given that parent of the partition is not distributed
+SELECT create_distributed_table('partitioning_test_2010', 'id');
+ERROR:  relation "partitioning_test_2010" does not exist
+LINE 1: SELECT create_distributed_table('partitioning_test_2010', 'i...
+                                        ^
+-- this should suceed
+SELECT create_distributed_table('partitioning_test', 'id');
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: SELECT create_distributed_table('partitioning_test', 'id');
+                                        ^
+-- check the data
+SELECT * FROM partitioning_test ORDER BY 1;
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: SELECT * FROM partitioning_test ORDER BY 1;
+                      ^
+-- check the metadata
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010')
+ORDER BY 1;
+ERROR:  relation "partitioning_test" does not exist
+LINE 6:  logicalrelid IN ('partitioning_test', 'partitioning_test_20...
+                          ^
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+ERROR:  relation "partitioning_test" does not exist
+LINE 4:  WHERE logicalrelid IN ('partitioning_test', 'partitioning_t...
+                                ^
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+ERROR:  relation "partitioning_test" does not exist
+LINE 6: ...shardid FROM pg_dist_shard WHERE logicalrelid IN ('partition...
+                                                             ^
+-- dropping the parent should CASCADE to the children as well
+DROP TABLE partitioning_test;
+ERROR:  table "partitioning_test" does not exist
+\d+ partitioning_test*

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -121,7 +121,54 @@ ORDER BY
 ERROR:  relation "partitioning_test" does not exist
 LINE 6: ...shardid FROM pg_dist_shard WHERE logicalrelid IN ('partition...
                                                              ^
+-- citus can also support ALTER TABLE .. ATTACH PARTITION 
+-- even if the partition is not distributed
+CREATE TABLE partitioning_test_2012(id int, time date);
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2012 FOR VALUES FROM ('2012-01-01') TO ('2013-01-01');
+ERROR:  syntax error at or near "ATTACH"
+LINE 1: ALTER TABLE partitioning_test ATTACH PARTITION partitioning_...
+                                      ^
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012')
+ORDER BY 1;
+ERROR:  relation "partitioning_test" does not exist
+LINE 6:  logicalrelid IN ('partitioning_test', 'partitioning_test_20...
+                          ^
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+ERROR:  relation "partitioning_test" does not exist
+LINE 4:  WHERE logicalrelid IN ('partitioning_test', 'partitioning_t...
+                                ^
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+ERROR:  relation "partitioning_test" does not exist
+LINE 6: ...shardid FROM pg_dist_shard WHERE logicalrelid IN ('partition...
+                                                             ^
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 ERROR:  table "partitioning_test" does not exist
 \d+ partitioning_test*
+                Table "public.partitioning_test_2012"
+ Column |  Type   | Modifiers | Storage | Stats target | Description 
+--------+---------+-----------+---------+--------------+-------------
+ id     | integer |           | plain   |              | 
+ time   | date    |           | plain   |              | 
+

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -172,3 +172,6 @@ ERROR:  table "partitioning_test" does not exist
  id     | integer |           | plain   |              | 
  time   | date    |           | plain   |              | 
 
+-- set the colocationid sequence back to 1 to make sure
+-- that this file does not break other tests
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1;

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -19,7 +19,7 @@ WHERE
 	logicalrelid = 'reference_table_test'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |            1 | t
+ n          | t             |            3 | t
 (1 row)
 
 -- now see that shard min/max values are NULL

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -19,7 +19,7 @@ WHERE
 	logicalrelid = 'reference_table_test'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |            3 | t
+ n          | t             |            1 | t
 (1 row)
 
 -- now see that shard min/max values are NULL

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -25,7 +25,7 @@ test: multi_metadata_access
 # ---
 # Tests for partitioning support
 # ---
-test: multi_partitioning_utils
+test: multi_partitioning_utils multi_partitioning
 
 # ----------
 # The following distributed tests depend on creating a partitioned table and

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -85,6 +85,41 @@ GROUP BY
 ORDER BY
 	1,2,3;
 
+
+-- citus can also support ALTER TABLE .. ATTACH PARTITION 
+-- even if the partition is not distributed
+CREATE TABLE partitioning_test_2012(id int, time date);
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2012 FOR VALUES FROM ('2012-01-01') TO ('2013-01-01');
+
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012')
+ORDER BY 1;
+
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011', 'partitioning_test_2012') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+
+
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -54,6 +54,37 @@ GROUP BY
 ORDER BY
 	1,2,3;
 
+-- now create a partition and see that it also becomes a distributed table
+CREATE TABLE partitioning_test_2011 PARTITION OF partitioning_test FOR VALUES FROM ('2011-01-01') TO ('2012-01-01');
+
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011')
+ORDER BY 1;
+
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010', 'partitioning_test_2011') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+
 -- dropping the parent should CASCADE to the children as well
 DROP TABLE partitioning_test;
 

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -1,0 +1,60 @@
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1660000;
+
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+ 
+-- create its partitions
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+
+-- this should error out given that parent of the partition is not distributed
+SELECT create_distributed_table('partitioning_test_2010', 'id');
+
+-- this should suceed
+SELECT create_distributed_table('partitioning_test', 'id');
+
+-- check the data
+SELECT * FROM partitioning_test ORDER BY 1;
+
+-- check the metadata
+SELECT 
+	* 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010')
+ORDER BY 1;
+
+SELECT 
+	logicalrelid, count(*) 
+FROM pg_dist_shard 
+	WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010')
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+
+SELECT 
+	nodename, nodeport, count(*)	
+FROM
+	pg_dist_shard_placement
+WHERE
+	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid IN ('partitioning_test', 'partitioning_test_2009', 'partitioning_test_2010') )
+GROUP BY
+	nodename, nodeport
+ORDER BY
+	1,2,3;
+
+-- dropping the parent should CASCADE to the children as well
+DROP TABLE partitioning_test;
+
+\d+ partitioning_test*

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -124,3 +124,7 @@ ORDER BY
 DROP TABLE partitioning_test;
 
 \d+ partitioning_test*
+
+-- set the colocationid sequence back to 1 to make sure
+-- that this file does not break other tests
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1;


### PR DESCRIPTION
Currently only the following is supported:
```SQL
CREATE TABLE prange1(id int, time date) PARTITION BY RANGE (time);
 
-- create its partitions
CREATE TABLE prange1_2006 PARTITION OF prange1 FOR VALUES FROM ('2006-01-01') TO ('2007-01-01');
CREATE TABLE prange1_2007 PARTITION OF prange1 FOR VALUES FROM ('2007-01-01') TO ('2008-01-01');

SELECT create_distributed_table('prange1', 'id');

-- partitions can be created later on as well
CREATE TABLE prange1_2008 PARTITION OF prange1 FOR VALUES FROM ('2008-01-01') TO ('2009-01-01');

-- also regular tables can be attached to parent tables
CREATE TABLE prange1_2009(id int, time date);
ALTER TABLE prange1 ATTACH PARTITION prange1_2009 FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');


```

Other ways of creating distributed tables mentioned on #1459 will be added to this PR.