### PR TITLE
Add weird column name test for create_distributed_table

### DIFF
--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -490,7 +490,7 @@ INSERT INTO data_load_test VALUES (243, 'world');
 DROP TABLE data_load_test;
 END;
 -- Test data loading after dropping a column
-CREATE TABLE data_load_test (col1 int, col2 text, col3 text);
+CREATE TABLE data_load_test (col1 int, col2 text, col3 text, "CoL4"")" int);
 INSERT INTO data_load_test VALUES (132, 'hello', 'world');
 INSERT INTO data_load_test VALUES (243, 'world', 'hello');
 ALTER TABLE data_load_test DROP COLUMN col2;
@@ -502,10 +502,10 @@ NOTICE:  Copying data from local table...
 (1 row)
 
 SELECT * FROM data_load_test;
- col1 | col3  
-------+-------
-  132 | world
-  243 | hello
+ col1 | col3  | CoL4") 
+------+-------+--------
+  132 | world |       
+  243 | hello |       
 (2 rows)
 
 DROP TABLE data_load_test;

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -265,7 +265,7 @@ DROP TABLE data_load_test;
 END;
 
 -- Test data loading after dropping a column
-CREATE TABLE data_load_test (col1 int, col2 text, col3 text);
+CREATE TABLE data_load_test (col1 int, col2 text, col3 text, "CoL4"")" int);
 INSERT INTO data_load_test VALUES (132, 'hello', 'world');
 INSERT INTO data_load_test VALUES (243, 'world', 'hello');
 ALTER TABLE data_load_test DROP COLUMN col2;


### PR DESCRIPTION
Fixes #1458

This was already fixed by #1402, but this PR adds a regression test specifically for `create_distributed_table`