### PR TITLE
Execute UPDATE/DELETE statements with 0 shards

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -158,8 +158,8 @@ RouterCreateScan(CustomScan *scan)
 
 	isModificationQuery = IsModifyMultiPlan(multiPlan);
 
-	/* check if this is a single shard query */
-	if (list_length(taskList) == 1)
+	/* check whether query has at most one shard */
+	if (list_length(taskList) <= 1)
 	{
 		if (isModificationQuery)
 		{

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -46,8 +46,7 @@ extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
-extern ShardInterval * FindShardForInsert(Query *query,
-										  DeferredErrorMessage **planningError);
+extern List * RouterModifyTaskList(Query *query, DeferredErrorMessage **planningError);
 
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/test/regress/expected/isolation_dml_vs_repair.out
+++ b/src/test/regress/expected/isolation_dml_vs_repair.out
@@ -78,7 +78,7 @@ step s2-invalidate-57638:
     UPDATE pg_dist_shard_placement SET shardstate = '3' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57638;
 
 step s1-display: 
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 
 test_id        data           
 
@@ -90,7 +90,7 @@ step s2-revalidate-57638:
     UPDATE pg_dist_shard_placement SET shardstate = '1' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57638;
 
 step s1-display: 
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 
 test_id        data           
 
@@ -122,15 +122,15 @@ step s2-commit:
     COMMIT;
 
 step s1-prepared-insertone: <... completed>
-error in steps s2-commit s1-prepared-insertone: ERROR:  prepared modifications cannot be executed on a shard while it is being copied
 step s2-invalidate-57638: 
     UPDATE pg_dist_shard_placement SET shardstate = '3' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57638;
 
 step s1-display: 
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 
 test_id        data           
 
+1              1              
 1              1              
 step s2-invalidate-57637: 
     UPDATE pg_dist_shard_placement SET shardstate = '3' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57637;
@@ -139,10 +139,11 @@ step s2-revalidate-57638:
     UPDATE pg_dist_shard_placement SET shardstate = '1' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57638;
 
 step s1-display: 
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 
 test_id        data           
 
+1              1              
 1              1              
 
 starting permutation: s2-invalidate-57637 s1-insertone s1-prepared-insertall s2-begin s2-repair s1-prepared-insertall s2-commit s2-invalidate-57638 s1-display s2-invalidate-57637 s2-revalidate-57638 s1-display
@@ -174,17 +175,18 @@ step s2-commit:
     COMMIT;
 
 step s1-prepared-insertall: <... completed>
-error in steps s2-commit s1-prepared-insertall: ERROR:  prepared modifications cannot be executed on a shard while it is being copied
 step s2-invalidate-57638: 
     UPDATE pg_dist_shard_placement SET shardstate = '3' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57638;
 
 step s1-display: 
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 
 test_id        data           
 
 1              1              
 1              2              
+1              2              
+1              3              
 step s2-invalidate-57637: 
     UPDATE pg_dist_shard_placement SET shardstate = '3' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57637;
 
@@ -192,9 +194,11 @@ step s2-revalidate-57638:
     UPDATE pg_dist_shard_placement SET shardstate = '1' WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'test_dml_vs_repair'::regclass) AND nodeport = 57638;
 
 step s1-display: 
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 
 test_id        data           
 
 1              1              
 1              2              
+1              2              
+1              3              

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -334,6 +334,21 @@ Custom Scan (Citus Router)
               ->  Index Scan using lineitem_pkey_290000 on lineitem_290000
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
+-- Test zero-shard update
+EXPLAIN (COSTS FALSE)
+	UPDATE lineitem
+	SET l_suppkey = 12
+	WHERE l_orderkey = 1 AND l_orderkey = 0;
+Custom Scan (Citus Router)
+  Task Count: 0
+  Tasks Shown: All
+-- Test zero-shard delete
+EXPLAIN (COSTS FALSE)
+	DELETE FROM lineitem
+	WHERE l_orderkey = 1 AND l_orderkey = 0;
+Custom Scan (Citus Router)
+  Task Count: 0
+  Tasks Shown: All
 -- Test single-shard SELECT
 EXPLAIN (COSTS FALSE)
 	SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -334,6 +334,21 @@ Custom Scan (Citus Router)
               ->  Index Scan using lineitem_pkey_290000 on lineitem_290000
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
+-- Test zero-shard update
+EXPLAIN (COSTS FALSE)
+	UPDATE lineitem
+	SET l_suppkey = 12
+	WHERE l_orderkey = 1 AND l_orderkey = 0;
+Custom Scan (Citus Router)
+  Task Count: 0
+  Tasks Shown: All
+-- Test zero-shard delete
+EXPLAIN (COSTS FALSE)
+	DELETE FROM lineitem
+	WHERE l_orderkey = 1 AND l_orderkey = 0;
+Custom Scan (Citus Router)
+  Task Count: 0
+  Tasks Shown: All
 -- Test single-shard SELECT
 EXPLAIN (COSTS FALSE)
 	SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -89,13 +89,10 @@ INSERT INTO articles VALUES (49,  9, 'anyone', 2681);
 INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
 -- insert a single row for the test
 INSERT INTO articles_single_shard VALUES (50, 10, 'anjanette', 19519);
--- zero-shard modifications should fail
+-- zero-shard modifications should succeed
 UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
-ERROR:  cannot run UPDATE command which targets no shards
-HINT:  Consider using an equality filter on partition column "author_id" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
+UPDATE articles SET title = '' WHERE 0 = 1;
 DELETE FROM articles WHERE author_id = 1 AND author_id = 2;
-ERROR:  cannot run DELETE command which targets no shards
-HINT:  Consider using an equality filter on partition column "author_id" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles WHERE author_id = 10 AND id = 50;

--- a/src/test/regress/specs/isolation_dml_vs_repair.spec
+++ b/src/test/regress/specs/isolation_dml_vs_repair.spec
@@ -47,7 +47,7 @@ step "s1-prepared-insertall"
 
 step "s1-display"
 {
-    SELECT * FROM test_dml_vs_repair WHERE test_id = 1;
+    SELECT * FROM test_dml_vs_repair WHERE test_id = 1 ORDER BY test_id;
 }
 
 step "s1-commit"
@@ -102,8 +102,8 @@ permutation "s1-insertone" "s2-invalidate-57637" "s1-begin" "s1-insertall" "s2-r
 # verify that modifications wait for shard repair
 permutation "s2-invalidate-57637" "s2-begin" "s2-repair" "s1-insertone" "s2-commit" "s2-invalidate-57638" "s1-display" "s2-invalidate-57637" "s2-revalidate-57638" "s1-display"
 
-# verify that prepared plain modifications wait for shard repair (and then fail to avoid race)
+# verify that prepared plain modifications wait for shard repair
 permutation "s2-invalidate-57637" "s1-prepared-insertone" "s2-begin" "s2-repair" "s1-prepared-insertone" "s2-commit" "s2-invalidate-57638" "s1-display" "s2-invalidate-57637" "s2-revalidate-57638" "s1-display"
 
-# verify that prepared INSERT ... SELECT waits for shard repair  (and then fail to avoid race)
+# verify that prepared INSERT ... SELECT waits for shard repair
 permutation "s2-invalidate-57637" "s1-insertone" "s1-prepared-insertall" "s2-begin" "s2-repair" "s1-prepared-insertall" "s2-commit" "s2-invalidate-57638" "s1-display" "s2-invalidate-57637" "s2-revalidate-57638" "s1-display"

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -100,6 +100,17 @@ EXPLAIN (COSTS FALSE)
 	DELETE FROM lineitem
 	WHERE l_orderkey = 1 AND l_partkey = 0;
 
+-- Test zero-shard update
+EXPLAIN (COSTS FALSE)
+	UPDATE lineitem
+	SET l_suppkey = 12
+	WHERE l_orderkey = 1 AND l_orderkey = 0;
+
+-- Test zero-shard delete
+EXPLAIN (COSTS FALSE)
+	DELETE FROM lineitem
+	WHERE l_orderkey = 1 AND l_orderkey = 0;
+
 -- Test single-shard SELECT
 EXPLAIN (COSTS FALSE)
 	SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;

--- a/src/test/regress/sql/multi_simple_queries.sql
+++ b/src/test/regress/sql/multi_simple_queries.sql
@@ -80,8 +80,9 @@ INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
 -- insert a single row for the test
 INSERT INTO articles_single_shard VALUES (50, 10, 'anjanette', 19519);
 
--- zero-shard modifications should fail
+-- zero-shard modifications should succeed
 UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
+UPDATE articles SET title = '' WHERE 0 = 1;
 DELETE FROM articles WHERE author_id = 1 AND author_id = 2;
 
 -- single-shard tests


### PR DESCRIPTION
This PR adds execution logic for `UPDATE` and `DELETE` commands that prune down to 0 shard, which currently error out.

The router planner currently makes a lot of assumptions about a job containing exactly 1 task. This PR does considerable refactoring to be able to generate a list of tasks for a job in either the planner or the executor (depending on whether the partition column value is known at planning time), which also paves the way for supporting multi-row INSERT and multi-shard UPDATE/DELETE.

There are 2 subtle behavioural changes that resolve some outstanding issues:
- Placement lists are now always loaded in the executor, after acquiring metadata locks. This resolves a race condition where a prepared statement could be executed with a stale placement list. It also prevents prepared DML statements that run during a shard copy from throwing an error.
- Parameters in modifications are now always evaluated on the master. This simplifies handling of parameters and functions, which was strangely inconsistent and prone to bugs (e.g. previously parameters were evaluated on the master if the query contained a stable function, but pushed down otherwise).

Note: I wrote this a few weeks back and got a little stuck with 0-task SELECT queries and didn't want to spend more time on it (plus it seemed invasive). However, it seems like it might be useful for #1465 and other ongoing work.

Fixes #1230
Fixes #127