### PR TITLE
Add nodeRole column to pg_dist_node

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -11,7 +11,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
 	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12 6.1-13 6.1-14 6.1-15 6.1-16 6.1-17 \
 	6.2-1 6.2-2 6.2-3 6.2-4 \
-	7.0-1 7.0-2 7.0-3 7.0-4
+	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -146,6 +146,8 @@ $(EXTENSION)--7.0-2.sql: $(EXTENSION)--7.0-1.sql $(EXTENSION)--7.0-1--7.0-2.sql
 $(EXTENSION)--7.0-3.sql: $(EXTENSION)--7.0-2.sql $(EXTENSION)--7.0-2--7.0-3.sql
 	cat $^ > $@
 $(EXTENSION)--7.0-4.sql: $(EXTENSION)--7.0-3.sql $(EXTENSION)--7.0-3--7.0-4.sql
+	cat $^ > $@
+$(EXTENSION)--7.0-5.sql: $(EXTENSION)--7.0-4.sql $(EXTENSION)--7.0-4--7.0-5.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.0-3--7.0-4.sql
+++ b/src/backend/distributed/citus--7.0-3--7.0-4.sql
@@ -22,4 +22,5 @@ CREATE OR REPLACE FUNCTION get_all_active_transactions(OUT database_id oid, OUT 
 	AS 'MODULE_PATHNAME', $$get_all_active_transactions$$;
  COMMENT ON FUNCTION get_all_active_transactions(OUT database_id oid, OUT process_id int, OUT initiator_node_identifier int4, OUT transaction_number int8, OUT transaction_stamp timestamptz)
      IS 'returns distributed transaction ids of active distributed transactions';
+
 RESET search_path;

--- a/src/backend/distributed/citus--7.0-4--7.0-5.sql
+++ b/src/backend/distributed/citus--7.0-4--7.0-5.sql
@@ -29,6 +29,7 @@ CREATE OR REPLACE VIEW pg_catalog.pg_dist_shard_placement AS
 CREATE OR REPLACE FUNCTION citus.pg_dist_node_trigger_func()
 RETURNS TRIGGER AS $$
   BEGIN
+    /* AddNodeMetadata also takes out a ShareRowExclusiveLock */
     LOCK TABLE pg_dist_node IN SHARE ROW EXCLUSIVE MODE;
     IF (TG_OP = 'INSERT') THEN
       IF NEW.noderole = 'primary'

--- a/src/backend/distributed/citus--7.0-4--7.0-5.sql
+++ b/src/backend/distributed/citus--7.0-4--7.0-5.sql
@@ -1,0 +1,97 @@
+/* citus--7.0-4--7.0-5.sql */
+
+SET search_path = 'pg_catalog';
+
+CREATE TYPE pg_catalog.noderole AS ENUM (
+  'primary',     -- node is available and accepting writes
+  'secondary',   -- node is available but only accepts reads
+  'unavailable' -- node is in recovery or otherwise not usable
+-- adding new values to a type inside of a transaction (such as during an ALTER EXTENSION
+-- citus UPDATE) isn't allowed in PG 9.6, and only allowed in PG10 if you don't use the
+-- new values inside of the same transaction. You might need to replace this type with a
+-- new one and then change the column type in pg_dist_node. There's a list of
+-- alternatives here:
+-- https://stackoverflow.com/questions/1771543/postgresql-updating-an-enum-type/41696273
+);
+
+ALTER TABLE pg_dist_node ADD COLUMN noderole noderole NOT NULL DEFAULT 'primary';
+
+-- we're now allowed to have more than one node per group
+ALTER TABLE pg_catalog.pg_dist_node DROP CONSTRAINT pg_dist_node_groupid_unique;
+
+-- so make sure pg_dist_shard_placement only returns writable placements
+CREATE OR REPLACE VIEW pg_catalog.pg_dist_shard_placement AS
+  SELECT shardid, shardstate, shardlength, nodename, nodeport, placementid
+  FROM pg_dist_placement placement INNER JOIN pg_dist_node node ON (
+    placement.groupid = node.groupid AND node.noderole = 'primary'
+  );
+
+CREATE OR REPLACE FUNCTION citus.pg_dist_node_trigger_func()
+RETURNS TRIGGER AS $$
+  BEGIN
+    LOCK TABLE pg_dist_node IN SHARE ROW EXCLUSIVE MODE;
+    IF (TG_OP = 'INSERT') THEN
+      IF NEW.noderole = 'primary'
+          AND EXISTS (SELECT 1 FROM pg_dist_node WHERE groupid = NEW.groupid AND
+                                                       noderole = 'primary' AND
+                                                       nodeid <> NEW.nodeid) THEN
+        RAISE EXCEPTION 'there cannot be two primary nodes in a group';
+      END IF;
+      RETURN NEW;
+    ELSIF (TG_OP = 'UPDATE') THEN
+      IF NEW.noderole = 'primary'
+           AND EXISTS (SELECT 1 FROM pg_dist_node WHERE groupid = NEW.groupid AND
+                                                        noderole = 'primary' AND
+                                                        nodeid <> NEW.nodeid) THEN
+         RAISE EXCEPTION 'there cannot be two primary nodes in a group';
+      END IF;
+      RETURN NEW;
+    END IF;
+  END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pg_dist_node_trigger
+  BEFORE INSERT OR UPDATE ON pg_dist_node
+  FOR EACH ROW EXECUTE PROCEDURE citus.pg_dist_node_trigger_func();
+
+DROP FUNCTION master_add_node(text, integer);
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                groupid integer default 0,
+                                noderole noderole default 'primary',
+                                OUT nodeid integer,
+                                OUT groupid integer,
+                                OUT nodename text,
+                                OUT nodeport integer,
+                                OUT noderack text,
+                                OUT hasmetadata boolean,
+                                OUT isactive bool,
+                                OUT noderole noderole)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer,
+                                    groupid integer, noderole noderole)
+  IS 'add node to the cluster';
+
+DROP FUNCTION master_add_inactive_node(text, integer);
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         groupid integer default 0,
+                                         noderole noderole default 'primary',
+                                         OUT nodeid integer,
+                                         OUT groupid integer,
+                                         OUT nodename text,
+                                         OUT nodeport integer,
+                                         OUT noderack text,
+                                         OUT hasmetadata boolean,
+                                         OUT isactive bool,
+                                         OUT noderole noderole)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text,nodeport integer,
+                                             groupid integer, noderole noderole)
+  IS 'prepare node by adding it to pg_dist_node';
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.0-4'
+default_version = '7.0-5'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -252,7 +252,7 @@ CreateReferenceTable(Oid relationId)
 	EnsureCoordinator();
 	CheckCitusVersion(ERROR);
 
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	replicationFactor = list_length(workerNodeList);
 
 	/* if there are no workers, error out */
@@ -720,7 +720,7 @@ CreateHashDistributedTable(Oid relationId, char *distributionColumnName,
 static void
 EnsureSchemaExistsOnAllNodes(Oid relationId)
 {
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	ListCell *workerNodeCell = NULL;
 	StringInfo applySchemaCreationDDL = makeStringInfo();
 

--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -82,7 +82,7 @@ MultiRealTimeExecute(Job *job)
 	const char *workerHashName = "Worker node hash";
 	WaitInfo *waitInfo = MultiClientCreateWaitInfo(list_length(taskList));
 
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	workerHash = WorkerHash(workerHashName, workerNodeList);
 
 	/* initialize task execution structures for remote execution */

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -71,7 +71,7 @@ JobExecutorType(MultiPlan *multiPlan)
 												 " queries on the workers.")));
 	}
 
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	workerNodeCount = list_length(workerNodeList);
 	taskCount = list_length(job->taskList);
 	tasksPerNode = taskCount / ((double) workerNodeCount);

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -190,7 +190,7 @@ MultiTaskTrackerExecute(Job *job)
 	 * assigning and checking the status of tasks. The second (temporary) hash
 	 * helps us in fetching results data from worker nodes to the master node.
 	 */
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	taskTrackerCount = (uint32) list_length(workerNodeList);
 
 	taskTrackerHash = TrackerHash(taskTrackerHashName, workerNodeList);

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -163,7 +163,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	hashTokenIncrement = HASH_TOKEN_COUNT / shardCount;
 
 	/* load and sort the worker node list for deterministic placement */
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* make sure we don't process cancel signals until all shards are created */
@@ -382,7 +382,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	}
 
 	/* load and sort the worker node list for deterministic placement */
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* get the next shard id */

--- a/src/backend/distributed/master/master_expire_table_cache.c
+++ b/src/backend/distributed/master/master_expire_table_cache.c
@@ -60,7 +60,7 @@ master_expire_table_cache(PG_FUNCTION_ARGS)
 	CheckCitusVersion(ERROR);
 
 	cacheEntry = DistributedTableCacheEntry(relationId);
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 	shardCount = cacheEntry->shardIntervalArrayLength;
 	shardIntervalArray = cacheEntry->sortedShardIntervalArray;
 

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -160,7 +160,7 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 
 	pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
 
-	workerNodeList = ActiveWorkerNodeList();
+	workerNodeList = ActivePrimaryNodeList();
 
 	foreach(workerNodeCell, workerNodeList)
 	{
@@ -606,11 +606,10 @@ ShardLength(uint64 shardId)
 
 
 /*
- * NodeHasShardPlacements returns whether any active shards are placed on the group
- * this node is a part of.
+ * NodeGroupHasShardPlacements returns whether any active shards are placed on the group
  */
 bool
-NodeHasShardPlacements(char *nodeName, int32 nodePort, bool onlyConsiderActivePlacements)
+NodeGroupHasShardPlacements(uint32 groupId, bool onlyConsiderActivePlacements)
 {
 	const int scanKeyCount = (onlyConsiderActivePlacements ? 2 : 1);
 	const bool indexOK = false;
@@ -620,8 +619,6 @@ NodeHasShardPlacements(char *nodeName, int32 nodePort, bool onlyConsiderActivePl
 	HeapTuple heapTuple = NULL;
 	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[scanKeyCount];
-
-	uint32 groupId = GroupForNode(nodeName, nodePort);
 
 	Relation pgPlacement = heap_open(DistPlacementRelationId(),
 									 AccessShareLock);

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -399,7 +399,7 @@ master_get_active_worker_nodes(PG_FUNCTION_ARGS)
 		/* switch to memory context appropriate for multiple function calls */
 		oldContext = MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
 
-		workerNodeList = ActiveWorkerNodeList();
+		workerNodeList = ActivePrimaryNodeList();
 		workerNodeCount = (uint32) list_length(workerNodeList);
 
 		functionContext->user_fctx = workerNodeList;

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -70,7 +70,6 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 {
 	text *relationNameText = PG_GETARG_TEXT_P(0);
 	char *relationName = text_to_cstring(relationNameText);
-	List *workerNodeList = NIL;
 	uint64 shardId = INVALID_SHARD_ID;
 	uint32 attemptableNodeCount = 0;
 	uint32 liveNodeCount = 0;
@@ -87,8 +86,6 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	char replicationModel = REPLICATION_MODEL_INVALID;
 
 	CheckCitusVersion(ERROR);
-
-	workerNodeList = ActiveWorkerNodeList();
 
 	EnsureTablePermissions(relationId, ACL_INSERT);
 	CheckDistributedTable(relationId);
@@ -155,6 +152,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 		}
 		else if (ShardPlacementPolicy == SHARD_PLACEMENT_ROUND_ROBIN)
 		{
+			List *workerNodeList = ActiveWorkerNodeList();
 			candidateNode = WorkerGetRoundRobinCandidateNode(workerNodeList, shardId,
 															 candidateNodeIndex);
 		}

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -40,6 +40,7 @@ int MaxWorkerNodesTracked = 2048;    /* determines worker node hash table size *
 
 
 /* Local functions forward declarations */
+static WorkerNode * WorkerGetNodeWithName(const char *hostname);
 static char * ClientHostAddress(StringInfo remoteHostStringInfo);
 static WorkerNode * FindRandomNodeNotInList(HTAB *WorkerNodesHash,
 											List *currentNodeList);
@@ -276,7 +277,7 @@ ClientHostAddress(StringInfo clientHostStringInfo)
  * WorkerGetNodeWithName finds and returns a node from the membership list that
  * has the given hostname. The function returns null if no such node exists.
  */
-WorkerNode *
+static WorkerNode *
 WorkerGetNodeWithName(const char *hostname)
 {
 	WorkerNode *workerNode = NULL;

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -1863,10 +1863,10 @@ BuildMapMergeJob(Query *jobQuery, List *dependedJobList, Var *partitionKey,
 static uint32
 HashPartitionCount(void)
 {
-	uint32 nodeCount = WorkerGetLiveNodeCount();
+	uint32 groupCount = ActivePrimaryNodeCount();
 	double maxReduceTasksPerNode = MaxRunningTasksPerNode / 2.0;
 
-	uint32 partitionCount = (uint32) rint(nodeCount * maxReduceTasksPerNode);
+	uint32 partitionCount = (uint32) rint(groupCount * maxReduceTasksPerNode);
 	return partitionCount;
 }
 
@@ -4791,7 +4791,7 @@ GreedyAssignTaskList(List *taskList)
 	uint32 taskCount = list_length(taskList);
 
 	/* get the worker node list and sort the list */
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/*
@@ -5223,7 +5223,7 @@ AssignDualHashTaskList(List *taskList)
 	 * if subsequent jobs have a small number of tasks, we won't allocate the
 	 * tasks to the same worker repeatedly.
 	 */
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	uint32 workerNodeCount = (uint32) list_length(workerNodeList);
 	uint32 beginningNodeIndex = jobId % workerNodeCount;
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1535,7 +1535,7 @@ RouterSelectQuery(Query *originalQuery, RelationRestrictionContext *restrictionC
 	}
 	else if (replacePrunedQueryWithDummy)
 	{
-		List *workerNodeList = ActiveWorkerNodeList();
+		List *workerNodeList = ActivePrimaryNodeList();
 		if (workerNodeList != NIL)
 		{
 			WorkerNode *workerNode = (WorkerNode *) linitial(workerNodeList);

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -127,7 +127,7 @@ RecoverPreparedTransactions(void)
 	 */
 	LockRelationOid(DistTransactionRelationId(), ExclusiveLock);
 
-	workerList = ActiveWorkerNodeList();
+	workerList = ActivePrimaryNodeList();
 
 	foreach(workerNodeCell, workerList)
 	{

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -78,7 +78,7 @@ SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command)
 void
 SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
 {
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	ListCell *workerNodeCell = NULL;
 	char *nodeUser = CitusExtensionOwnerName();
 	ListCell *commandCell = NULL;
@@ -128,7 +128,7 @@ SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
 {
 	List *connectionList = NIL;
 	ListCell *connectionCell = NULL;
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	ListCell *workerNodeCell = NULL;
 	char *nodeUser = CitusExtensionOwnerName();
 

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -127,7 +127,7 @@ ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort)
 {
 	List *referenceTableList = ReferenceTableOidList();
 	ListCell *referenceTableCell = NULL;
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	uint32 workerCount = 0;
 	Oid firstReferenceTableId = InvalidOid;
 	uint32 referenceTableColocationId = INVALID_COLOCATION_ID;
@@ -228,7 +228,7 @@ ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 {
 	/* we do not use pgDistNode, we only obtain a lock on it to prevent modifications */
 	Relation pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	ListCell *workerNodeCell = NULL;
 
 	/*
@@ -364,7 +364,7 @@ uint32
 CreateReferenceTableColocationId()
 {
 	uint32 colocationId = INVALID_COLOCATION_ID;
-	List *workerNodeList = ActiveWorkerNodeList();
+	List *workerNodeList = ActivePrimaryNodeList();
 	int shardCount = 1;
 	int replicationFactor = list_length(workerNodeList);
 	Oid distributionColumnType = InvalidOid;
@@ -382,13 +382,13 @@ CreateReferenceTableColocationId()
 
 
 /*
- * DeleteAllReferenceTablePlacementsFromNode function iterates over list of reference
+ * DeleteAllReferenceTablePlacementsFromNodeGroup function iterates over list of reference
  * tables and deletes all reference table placements from pg_dist_placement table
- * for given worker node. However, it does not modify replication factor of the colocation
+ * for given group. However, it does not modify replication factor of the colocation
  * group of reference tables. It is caller's responsibility to do that if it is necessary.
  */
 void
-DeleteAllReferenceTablePlacementsFromNode(char *workerName, uint32 workerPort)
+DeleteAllReferenceTablePlacementsFromNodeGroup(uint32 groupId)
 {
 	List *referenceTableList = ReferenceTableOidList();
 	ListCell *referenceTableCell = NULL;
@@ -401,7 +401,7 @@ DeleteAllReferenceTablePlacementsFromNode(char *workerName, uint32 workerPort)
 
 	/*
 	 * We sort the reference table list to prevent deadlocks in concurrent
-	 * DeleteAllReferenceTablePlacementsFromNode calls.
+	 * DeleteAllReferenceTablePlacementsFromNodeGroup calls.
 	 */
 	referenceTableList = SortList(referenceTableList, CompareOids);
 	foreach(referenceTableCell, referenceTableList)
@@ -409,11 +409,9 @@ DeleteAllReferenceTablePlacementsFromNode(char *workerName, uint32 workerPort)
 		GroupShardPlacement *placement = NULL;
 		StringInfo deletePlacementCommand = makeStringInfo();
 
-		uint32 workerGroup = GroupForNode(workerName, workerPort);
-
 		Oid referenceTableId = lfirst_oid(referenceTableCell);
 		List *placements = GroupShardPlacementsForTableOnGroup(referenceTableId,
-															   workerGroup);
+															   groupId);
 		if (list_length(placements) == 0)
 		{
 			/* this happens if the node was previously disabled */

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -115,8 +115,8 @@ extern void CopyShardInterval(ShardInterval *srcInterval, ShardInterval *destInt
 extern void CopyShardPlacement(ShardPlacement *srcPlacement,
 							   ShardPlacement *destPlacement);
 extern uint64 ShardLength(uint64 shardId);
-extern bool NodeHasShardPlacements(char *nodeName, int32 nodePort,
-								   bool onlyLookForActivePlacements);
+extern bool NodeGroupHasShardPlacements(uint32 groupId,
+										bool onlyConsiderActivePlacements);
 extern List * FinalizedShardPlacementList(uint64 shardId);
 extern ShardPlacement * FinalizedShardPlacement(uint64 shardId, bool missingOk);
 extern List * BuildShardPlacementList(ShardInterval *shardInterval);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -112,6 +112,11 @@ extern Oid DistPlacementGroupidIndexId(void);
 extern Oid CitusExtraDataContainerFuncId(void);
 extern Oid CitusWorkerHashFunctionId(void);
 
+/* nodeRole enum oids */
+extern Oid PrimaryNodeRoleId(void);
+extern Oid SecondaryNodeRoleId(void);
+extern Oid UnavailableNodeRoleId(void);
+
 /* user related functions */
 extern Oid CitusExtensionOwner(void);
 extern char * CitusExtensionOwnerName(void);

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -24,6 +24,7 @@ typedef struct FormData_pg_dist_node
 	int nodeport;
 	bool hasmetadata;
 	bool isactive
+	Oid noderole;
 #endif
 } FormData_pg_dist_node;
 
@@ -38,7 +39,7 @@ typedef FormData_pg_dist_node *Form_pg_dist_node;
  *      compiler constants for pg_dist_node
  * ----------------
  */
-#define Natts_pg_dist_node 7
+#define Natts_pg_dist_node 8
 #define Anum_pg_dist_node_nodeid 1
 #define Anum_pg_dist_node_groupid 2
 #define Anum_pg_dist_node_nodename 3
@@ -46,6 +47,7 @@ typedef FormData_pg_dist_node *Form_pg_dist_node;
 #define Anum_pg_dist_node_noderack 5
 #define Anum_pg_dist_node_hasmetadata 6
 #define Anum_pg_dist_node_isactive 7
+#define Anum_pg_dist_node_noderole 8
 
 #define GROUPID_SEQUENCE_NAME "pg_dist_groupid_seq"
 #define NODEID_SEQUENCE_NAME "pg_dist_node_nodeid_seq"

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -14,8 +14,7 @@
 
 extern uint32 CreateReferenceTableColocationId(void);
 extern void ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort);
-extern void DeleteAllReferenceTablePlacementsFromNode(char *workerName,
-													  uint32 workerPort);
+extern void DeleteAllReferenceTablePlacementsFromNodeGroup(uint32 groupId);
 extern List * ReferenceTableOidList(void);
 extern int CompareOids(const void *leftElement, const void *rightElement);
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -57,7 +57,6 @@ extern WorkerNode * WorkerGetRoundRobinCandidateNode(List *workerNodeList,
 													 uint64 shardId,
 													 uint32 placementIndex);
 extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
-extern WorkerNode * WorkerGetNodeWithName(const char *hostname);
 extern uint32 WorkerGetLiveNodeCount(void);
 extern List * ActiveWorkerNodeList(void);
 extern WorkerNode * FindWorkerNode(char *nodeName, int32 nodePort);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -43,6 +43,7 @@ typedef struct WorkerNode
 	char workerRack[WORKER_LENGTH];     /* node's network location */
 	bool hasMetadata;                   /* node gets metadata changes */
 	bool isActive;                      /* node's state */
+	Oid nodeRole;                       /* the node's role in its group */
 } WorkerNode;
 
 
@@ -57,13 +58,14 @@ extern WorkerNode * WorkerGetRoundRobinCandidateNode(List *workerNodeList,
 													 uint64 shardId,
 													 uint32 placementIndex);
 extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
-extern uint32 WorkerGetLiveNodeCount(void);
-extern List * ActiveWorkerNodeList(void);
+extern uint32 ActivePrimaryNodeCount(void);
+extern List * ActivePrimaryNodeList(void);
 extern WorkerNode * FindWorkerNode(char *nodeName, int32 nodePort);
 extern List * ReadWorkerNodes(void);
 extern void EnsureCoordinator(void);
 extern uint32 GroupForNode(char *nodeName, int32 nodePorT);
-extern WorkerNode * NodeForGroup(uint32 groupId);
+extern WorkerNode * PrimaryNodeForGroup(uint32 groupId, bool *groupContainsNodes);
+extern bool WorkerNodeIsPrimary(WorkerNode *worker);
 
 /* Function declarations for worker node utilities */
 extern int CompareWorkerNodes(const void *leftElement, const void *rightElement);

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -462,10 +462,10 @@ SELECT master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, n
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole)
   VALUES ('localhost', 5000, :worker_1_group, 'primary');
 ERROR:  there cannot be two primary nodes in a group
-CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 9 at RAISE
+CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 10 at RAISE
 UPDATE pg_dist_node SET noderole = 'primary'
   WHERE groupid = :worker_1_group AND nodeport = 9998;
 ERROR:  there cannot be two primary nodes in a group
-CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 17 at RAISE
+CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 18 at RAISE
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
 -- them in any of the remaining tests

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -29,9 +29,9 @@ SELECT master_get_active_worker_nodes();
 
 -- try to add a node that is already in the cluster
 SELECT * FROM master_add_node('localhost', :worker_1_port);
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
---------+---------+-----------+----------+----------+-------------+----------
-      1 |       1 | localhost |    57637 | default  | f           | t
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
+--------+---------+-----------+----------+----------+-------------+----------+----------
+      1 |       1 | localhost |    57637 | default  | f           | t        | primary
 (1 row)
 
 -- get the active nodes
@@ -77,9 +77,9 @@ SELECT master_get_active_worker_nodes();
 
 -- add some shard placements to the cluster
 SELECT master_activate_node('localhost', :worker_2_port);
-       master_activate_node        
------------------------------------
- (3,3,localhost,57638,default,f,t)
+           master_activate_node            
+-------------------------------------------
+ (3,3,localhost,57638,default,f,t,primary)
 (1 row)
 
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
@@ -111,7 +111,7 @@ SELECT shardid, shardstate, nodename, nodeport FROM pg_dist_shard_placement WHER
 
 -- try to remove a node with active placements and see that node removal is failed
 SELECT master_remove_node('localhost', :worker_2_port); 
-ERROR:  you cannot remove a node which has shard placements
+ERROR:  you cannot remove the primary node of a node group which has shard placements
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes 
 --------------------------------
@@ -138,14 +138,14 @@ SELECT master_get_active_worker_nodes();
 
 -- restore the node for next tests
 SELECT master_activate_node('localhost', :worker_2_port);
-       master_activate_node        
------------------------------------
- (3,3,localhost,57638,default,f,t)
+           master_activate_node            
+-------------------------------------------
+ (3,3,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- try to remove a node with active placements and see that node removal is failed
 SELECT master_remove_node('localhost', :worker_2_port); 
-ERROR:  you cannot remove a node which has shard placements
+ERROR:  you cannot remove the primary node of a node group which has shard placements
 -- mark all placements in the candidate node as inactive
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport=:worker_2_port \gset
 UPDATE pg_dist_placement SET shardstate=3 WHERE groupid=:worker_2_group;
@@ -164,7 +164,7 @@ SELECT shardid, shardstate, nodename, nodeport FROM pg_dist_shard_placement WHER
 
 -- try to remove a node with only inactive placements and see that removal still fails
 SELECT master_remove_node('localhost', :worker_2_port); 
-ERROR:  you cannot remove a node which has shard placements
+ERROR:  you cannot remove the primary node of a node group which has shard placements
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes 
 --------------------------------
@@ -180,6 +180,34 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 (1 row)
 
 UPDATE pg_dist_placement SET shardstate=1 WHERE groupid=:worker_2_group;
+-- when there is no primary we should get a pretty error
+UPDATE pg_dist_node SET noderole = 'secondary' WHERE nodeport=:worker_2_port;
+SELECT * FROM cluster_management_test;
+ERROR:  node group 3 does not have a primary node
+-- when there is no node at all in the group we should get a different error
+DELETE FROM pg_dist_node WHERE nodeport=:worker_2_port;
+SELECT * FROM cluster_management_test;
+ERROR:  the metadata is inconsistent
+DETAIL:  there is a placement in group 3 but there are no nodes in that group
+-- clean-up
+SELECT groupid as new_group FROM master_add_node('localhost', :worker_2_port) \gset
+UPDATE pg_dist_placement SET groupid = :new_group WHERE groupid = :worker_2_group;
+-- test that you are allowed to remove secondary nodes even if there are placements
+SELECT master_add_node('localhost', 9990, groupid => :new_group, noderole => 'secondary');
+              master_add_node               
+--------------------------------------------
+ (5,4,localhost,9990,default,f,t,secondary)
+(1 row)
+
+SELECT master_remove_node('localhost', :worker_2_port);
+ERROR:  you cannot remove the primary node of a node group which has shard placements
+SELECT master_remove_node('localhost', 9990);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+-- clean-up
 DROP TABLE cluster_management_test;
 -- check that adding/removing nodes are propagated to nodes with hasmetadata=true
 SELECT master_remove_node('localhost', :worker_2_port);
@@ -241,24 +269,24 @@ SELECT
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive 
---------+---------+----------+----------+----------+-------------+----------
+ nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole 
+--------+---------+----------+----------+----------+-------------+----------+----------
 (0 rows)
 
 -- check that adding two nodes in the same transaction works
 SELECT
 	master_add_node('localhost', :worker_1_port),
 	master_add_node('localhost', :worker_2_port);
-          master_add_node          |          master_add_node          
------------------------------------+-----------------------------------
- (6,6,localhost,57637,default,f,t) | (7,7,localhost,57638,default,f,t)
+              master_add_node              |              master_add_node              
+-------------------------------------------+-------------------------------------------
+ (8,7,localhost,57637,default,f,t,primary) | (9,8,localhost,57638,default,f,t,primary)
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
---------+---------+-----------+----------+----------+-------------+----------
-      6 |       6 | localhost |    57637 | default  | f           | t
-      7 |       7 | localhost |    57638 | default  | f           | t
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
+--------+---------+-----------+----------+----------+-------------+----------+----------
+      8 |       7 | localhost |    57637 | default  | f           | t        | primary
+      9 |       8 | localhost |    57638 | default  | f           | t        | primary
 (2 rows)
 
 -- check that mixed add/remove node commands work fine inside transaction
@@ -405,3 +433,39 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
  
 (1 row)
 
+-- check that you can't add more than one primary to a group
+SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
+SELECT master_add_node('localhost', 9999, groupid => :worker_1_group, noderole => 'primary');
+ERROR:  group 12 already has a primary node
+-- check that you can add secondaries and unavailable nodes to a group
+SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
+SELECT master_add_node('localhost', 9998, groupid => :worker_1_group, noderole => 'secondary');
+               master_add_node                
+----------------------------------------------
+ (16,12,localhost,9998,default,f,t,secondary)
+(1 row)
+
+SELECT master_add_node('localhost', 9997, groupid => :worker_1_group, noderole => 'unavailable');
+                master_add_node                 
+------------------------------------------------
+ (17,12,localhost,9997,default,f,t,unavailable)
+(1 row)
+
+-- add_inactive_node also works with secondaries
+SELECT master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, noderole => 'secondary');
+           master_add_inactive_node           
+----------------------------------------------
+ (18,14,localhost,9996,default,f,f,secondary)
+(1 row)
+
+-- check that you can't manually add two primaries to a group
+INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole)
+  VALUES ('localhost', 5000, :worker_1_group, 'primary');
+ERROR:  there cannot be two primary nodes in a group
+CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 9 at RAISE
+UPDATE pg_dist_node SET noderole = 'primary'
+  WHERE groupid = :worker_1_group AND nodeport = 9998;
+ERROR:  there cannot be two primary nodes in a group
+CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 17 at RAISE
+-- don't remove the secondary and unavailable nodes, check that no commands are sent to
+-- them in any of the remaining tests

--- a/src/test/regress/expected/multi_drop_extension.out
+++ b/src/test/regress/expected/multi_drop_extension.out
@@ -20,15 +20,15 @@ RESET client_min_messages;
 CREATE EXTENSION citus;
 -- re-add the nodes to the cluster
 SELECT master_add_node('localhost', :worker_1_port);
-          master_add_node          
------------------------------------
- (1,1,localhost,57637,default,f,t)
+              master_add_node              
+-------------------------------------------
+ (1,1,localhost,57637,default,f,t,primary)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (2,2,localhost,57638,default,f,t)
+              master_add_node              
+-------------------------------------------
+ (2,2,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- verify that a table can be created after the extension has been dropped and recreated

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -27,11 +27,11 @@ SELECT * FROM pg_dist_partition WHERE partmethod='h' AND repmodel='s';
 -- Show that, with no MX tables, metadata snapshot contains only the delete commands,
 -- pg_dist_node entries and reference tables
 SELECT unnest(master_metadata_snapshot());
-                                                                                                    unnest                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                              unnest                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
 (3 rows)
 
 -- Create a test table with constraints and SERIAL
@@ -57,7 +57,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
@@ -78,7 +78,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
@@ -101,7 +101,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -130,7 +130,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -152,7 +152,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -197,10 +197,10 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
---------+---------+-----------+----------+----------+-------------+----------
-      1 |       1 | localhost |    57637 | default  | t           | t
-      2 |       2 | localhost |    57638 | default  | f           | t
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
+--------+---------+-----------+----------+----------+-------------+----------+----------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary
 (2 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -334,10 +334,10 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
---------+---------+-----------+----------+----------+-------------+----------
-      1 |       1 | localhost |    57637 | default  | t           | t
-      2 |       2 | localhost |    57638 | default  | f           | t
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
+--------+---------+-----------+----------+----------+-------------+----------+----------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary
 (2 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -1129,9 +1129,9 @@ SELECT create_distributed_table('mx_table', 'a');
 
 \c - postgres - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (4,4,localhost,57638,default,f,t)
+              master_add_node              
+-------------------------------------------
+ (4,4,localhost,57638,default,f,t,primary)
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
@@ -1342,9 +1342,9 @@ WHERE logicalrelid='mx_ref'::regclass;
 \c - - - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "mx_ref" to the node localhost:57638
-          master_add_node          
------------------------------------
- (5,5,localhost,57638,default,f,t)
+              master_add_node              
+-------------------------------------------
+ (5,5,localhost,57638,default,f,t,primary)
 (1 row)
 
 SELECT shardid, nodename, nodeport 

--- a/src/test/regress/expected/multi_mx_modifications.out
+++ b/src/test/regress/expected/multi_mx_modifications.out
@@ -481,7 +481,7 @@ INSERT INTO app_analytics_events_mx (app_id, name) VALUES (103, 'Mynt') RETURNIN
 SELECT setval('app_analytics_events_mx_id_seq'::regclass, :last_value);
       setval      
 ------------------
- 3659174697238529
+ 3940649673949185
 (1 row)
 
 ALTER SEQUENCE app_analytics_events_mx_id_seq

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -41,10 +41,12 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 (1 row)
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
-                master_add_node                
------------------------------------------------
- (1380000,1380000,localhost,57638,default,f,t)
+SELECT groupid AS worker_2_group FROM master_add_node('localhost', :worker_2_port) \gset
+-- add a secondary to check we don't attempt to replicate the table to it
+SELECT isactive FROM master_add_node('localhost', 9000, groupid=>:worker_2_group, noderole=>'secondary');
+ isactive 
+----------
+ t
 (1 row)
 
 -- remove a node with reference table
@@ -53,6 +55,64 @@ SELECT create_reference_table('remove_node_reference_table');
  create_reference_table 
 ------------------------
  
+(1 row)
+
+-- make sure when we add a secondary we don't attempt to add placements to it
+SELECT isactive FROM master_add_node('localhost', 9001, groupid=>:worker_2_group, noderole=>'secondary');
+ isactive 
+----------
+ t
+(1 row)
+
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+ count 
+-------
+     1
+(1 row)
+
+-- make sure when we disable a secondary we don't remove any placements
+SELECT master_disable_node('localhost', 9001);
+ master_disable_node 
+---------------------
+ 
+(1 row)
+
+SELECT isactive FROM pg_dist_node WHERE nodeport = 9001;
+ isactive 
+----------
+ f
+(1 row)
+
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+ count 
+-------
+     1
+(1 row)
+
+-- make sure when we activate a secondary we don't add any placements
+SELECT master_activate_node('localhost', 9001);
+                  master_activate_node                  
+--------------------------------------------------------
+ (1380002,1380000,localhost,9001,default,f,t,secondary)
+(1 row)
+
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+ count 
+-------
+     1
+(1 row)
+
+-- make sure when we remove a secondary we don't remove any placements
+SELECT master_remove_node('localhost', 9001);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+ count 
+-------
+     1
 (1 row)
 
 -- status before master_remove_node
@@ -164,9 +224,9 @@ ERROR:  node at "localhost:57638" does not exist
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1380001,1380001,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380003,1380001,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- try to disable the node before removing it (this used to crash)
@@ -185,9 +245,9 @@ SELECT master_remove_node('localhost', :worker_2_port);
 -- re-add the node for the next test
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1380002,1380002,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380004,1380002,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- remove node in a transaction and ROLLBACK
@@ -408,9 +468,9 @@ WHERE
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1380003,1380003,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380005,1380003,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- test inserting a value then removing a node in a transaction
@@ -537,9 +597,9 @@ SELECT * FROM remove_node_reference_table;
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1380004,1380004,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380006,1380004,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- test executing DDL command then removing a node in a transaction
@@ -662,9 +722,9 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.remove_
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1380005,1380005,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380007,1380005,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- test DROP table after removing a node in a transaction
@@ -730,9 +790,9 @@ SELECT * FROM pg_dist_colocation WHERE colocationid = 1380000;
 
 -- re-add the node for next tests
 SELECT master_add_node('localhost', :worker_2_port);
-                master_add_node                
------------------------------------------------
- (1380006,1380006,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380008,1380006,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- re-create remove_node_reference_table
@@ -865,9 +925,9 @@ WHERE
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
 NOTICE:  Replicating reference table "table1" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1380007,1380007,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1380009,1380007,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- test with master_disable_node
@@ -915,7 +975,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid ASC;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1380001 |          1 |           0 | localhost |    57638
@@ -982,9 +1043,9 @@ WHERE
 SELECT master_activate_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
 NOTICE:  Replicating reference table "table1" to the node localhost:57638
-             master_activate_node              
------------------------------------------------
- (1380007,1380007,localhost,57638,default,f,t)
+                 master_activate_node                  
+-------------------------------------------------------
+ (1380009,1380007,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- DROP tables to clean workspace

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -24,9 +24,9 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-                master_add_node                
------------------------------------------------
- (1370000,1370000,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370000,1370000,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- verify node is added
@@ -122,9 +122,9 @@ WHERE colocationid IN
 
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_valid" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1370002,1370002,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370002,1370002,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- status after master_add_node
@@ -175,9 +175,9 @@ WHERE colocationid IN
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-                master_add_node                
------------------------------------------------
- (1370002,1370002,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370002,1370002,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- status after master_add_node
@@ -243,9 +243,9 @@ WHERE colocationid IN
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_rollback" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1370003,1370003,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370003,1370003,localhost,57638,default,f,t,primary)
 (1 row)
 
 ROLLBACK;
@@ -305,9 +305,9 @@ WHERE colocationid IN
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_commit" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1370004,1370004,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370004,1370004,localhost,57638,default,f,t,primary)
 (1 row)
 
 COMMIT;
@@ -400,9 +400,9 @@ ORDER BY logicalrelid;
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_reference_one" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1370005,1370005,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370005,1370005,localhost,57638,default,f,t,primary)
 (1 row)
 
 SELECT upgrade_to_reference_table('replicate_reference_table_hash');
@@ -550,9 +550,9 @@ WHERE colocationid IN
 BEGIN;
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_drop" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1370009,1370009,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370009,1370009,localhost,57638,default,f,t,primary)
 (1 row)
 
 DROP TABLE replicate_reference_table_drop;
@@ -612,9 +612,9 @@ WHERE colocationid IN
 
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "table1" to the node localhost:57638
-                master_add_node                
------------------------------------------------
- (1370010,1370010,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370010,1370010,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- status after master_add_node
@@ -657,9 +657,9 @@ SELECT create_reference_table('initially_not_replicated_reference_table');
 (1 row)
 
 SELECT master_add_inactive_node('localhost', :worker_2_port);
-           master_add_inactive_node            
------------------------------------------------
- (1370011,1370011,localhost,57638,default,f,f)
+               master_add_inactive_node                
+-------------------------------------------------------
+ (1370011,1370011,localhost,57638,default,f,f,primary)
 (1 row)
 
 -- we should see only one shard placements
@@ -683,9 +683,9 @@ ORDER BY 1,4,5;
 -- we should see the two shard placements after activation
 SELECT master_activate_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "initially_not_replicated_reference_table" to the node localhost:57638
-             master_activate_node              
------------------------------------------------
- (1370011,1370011,localhost,57638,default,f,t)
+                 master_activate_node                  
+-------------------------------------------------------
+ (1370011,1370011,localhost,57638,default,f,t,primary)
 (1 row)
 
 SELECT
@@ -708,9 +708,9 @@ ORDER BY 1,4,5;
 
 -- this should have no effect
 SELECT master_add_node('localhost', :worker_2_port);
-                master_add_node                
------------------------------------------------
- (1370011,1370011,localhost,57638,default,f,t)
+                    master_add_node                    
+-------------------------------------------------------
+ (1370011,1370011,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- drop unnecassary tables

--- a/src/test/regress/expected/multi_table_ddl.out
+++ b/src/test/regress/expected/multi_table_ddl.out
@@ -77,15 +77,15 @@ DROP EXTENSION citus;
 CREATE EXTENSION citus;
 -- re-add the nodes to the cluster
 SELECT master_add_node('localhost', :worker_1_port);
-          master_add_node          
------------------------------------
- (1,1,localhost,57637,default,f,t)
+              master_add_node              
+-------------------------------------------
+ (1,1,localhost,57637,default,f,t,primary)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port);
-          master_add_node          
------------------------------------
- (2,2,localhost,57638,default,f,t)
+              master_add_node              
+-------------------------------------------
+ (2,2,localhost,57638,default,f,t,primary)
 (1 row)
 
 -- create a table with a SERIAL column

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -219,10 +219,11 @@ SELECT count(*) FROM mx_table;
 SELECT master_add_node('localhost', 5432);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
-SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive 
---------+---------+----------+----------+----------+-------------+----------
-(0 rows)
+SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
+ count 
+-------
+     0
+(1 row)
 
 -- master_remove_node
 \c - - - :master_port
@@ -230,9 +231,9 @@ DROP INDEX mx_test_uniq_index;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 SELECT master_add_node('localhost', 5432);
-               master_add_node                
-----------------------------------------------
- (1370000,1370000,localhost,5432,default,f,t)
+                   master_add_node                    
+------------------------------------------------------
+ (1370000,1370000,localhost,5432,default,f,t,primary)
 (1 row)
 
 \c - - - :worker_1_port
@@ -240,9 +241,9 @@ SELECT master_remove_node('localhost', 5432);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
 SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
- nodeid  | groupid | nodename  | nodeport | noderack | hasmetadata | isactive 
----------+---------+-----------+----------+----------+-------------+----------
- 1370000 | 1370000 | localhost |     5432 | default  | f           | t
+ nodeid  | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
+---------+---------+-----------+----------+----------+-------------+----------+----------
+ 1370000 | 1370000 | localhost |     5432 | default  | f           | t        | primary
 (1 row)
 
 \c - - - :master_port

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -767,9 +767,9 @@ SELECT shardid, nodename, nodeport
 SELECT master_activate_node('localhost', :worker_1_port);
 NOTICE:  Replicating reference table "nation" to the node localhost:57637
 NOTICE:  Replicating reference table "supplier" to the node localhost:57637
-       master_activate_node        
------------------------------------
- (1,1,localhost,57637,default,f,t)
+           master_activate_node            
+-------------------------------------------
+ (1,1,localhost,57637,default,f,t,primary)
 (1 row)
 
 RESET citus.shard_replication_factor;

--- a/src/test/regress/sql/multi_remove_node_reference_table.sql
+++ b/src/test/regress/sql/multi_remove_node_reference_table.sql
@@ -31,11 +31,27 @@ SELECT master_remove_node('localhost', :worker_2_port);
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT groupid AS worker_2_group FROM master_add_node('localhost', :worker_2_port) \gset
+-- add a secondary to check we don't attempt to replicate the table to it
+SELECT isactive FROM master_add_node('localhost', 9000, groupid=>:worker_2_group, noderole=>'secondary');
 
 -- remove a node with reference table
 CREATE TABLE remove_node_reference_table(column1 int);
 SELECT create_reference_table('remove_node_reference_table');
+
+-- make sure when we add a secondary we don't attempt to add placements to it
+SELECT isactive FROM master_add_node('localhost', 9001, groupid=>:worker_2_group, noderole=>'secondary');
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+-- make sure when we disable a secondary we don't remove any placements
+SELECT master_disable_node('localhost', 9001);
+SELECT isactive FROM pg_dist_node WHERE nodeport = 9001;
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+-- make sure when we activate a secondary we don't add any placements
+SELECT master_activate_node('localhost', 9001);
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
+-- make sure when we remove a secondary we don't remove any placements
+SELECT master_remove_node('localhost', 9001);
+SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
 
 -- status before master_remove_node
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
@@ -544,7 +560,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid ASC;
     
 \c - - - :master_port     
      

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -119,7 +119,7 @@ SELECT count(*) FROM mx_table;
 -- master_add_node
 
 SELECT master_add_node('localhost', 5432);
-SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
+SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 -- master_remove_node
 \c - - - :master_port


### PR DESCRIPTION
Rebasing #1235 was going to be a lot of work so I'm going through and re-implementing it

Current behavior:
- `master_add_node` and `master_add_inactive_node` now accept a `noderole` parameter, which defaults to `primary`.
- If the specified group already has a `primary` node then the call errors out
- When resolving `GroupShardPlacement`s into `ShardPlacement`s only `primary` nodes are considered

Remaining work:
- Add tests:
  - [x] It's not possible to add more than one primary to a group
  - [x] You get a useful error message when running a query and there's no primary in the requested group
  - [x] It's possible to add secondaries to a group
  - [x] It's possible to add multiple secondaries to a group
  - [x] secondaries are never picked when doing things like creating shards on workers
- Copy commits over from previous PR which exclude secondary nodes from some functions:
  - [x] [WorkerGetLiveNodeCount](https://github.com/citusdata/citus/pull/1235/commits/8f94bd3d14e112f84b0ad581a33b4c82b7669a6a)
  - [x] [WorkerGetRandomCandidateNode](https://github.com/citusdata/citus/pull/1235/commits/8260fcddbdce084798c09cc487eb0c3c01fe439c)
  - [x] [WorkerGetFirstLocalCandidateNode](https://github.com/citusdata/citus/pull/1235/commits/e39ac1821f7bfc081dc08b8d5226c3b5d8862623)
  - [x] [WorkerNodeList](https://github.com/citusdata/citus/pull/1235/commits/b081fb0efa650da7f75a876c52f4c489a0b34cee)
- [x] Once again look into making a unique constraint for one-primary-per-group. Where else can we try to enforce it? An insert/update trigger?
- [x] Check that you're allowed to remove nodes as long as they're not the last node in the group
- [x] Is it okay that `TupleToWorkerNode` doesn't check that `nodeRole` exists like [here](https://github.com/citusdata/citus/pull/1235/commits/f79d7a1f4d40cafabb8b51ef83fb56699693c286#diff-951979618a176dba2130cdf086a564abR916)?
- [ ] Add a trigger to enforce that you can't remove nodes which still have placements?
- [x] What about `CreateReferenceTable`?
- [x] Does `WorkerGetRandomCandidateNode` still do the right thing?