### PR TITLE
Wait for commit/abort/prepare results asynchronously

### DIFF
--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -52,5 +52,8 @@ extern bool PutRemoteCopyData(MultiConnection *connection, const char *buffer,
 							  int nbytes);
 extern bool PutRemoteCopyEnd(MultiConnection *connection, const char *errormsg);
 
+/* waiting for multiple command results */
+extern void WaitForAllConnections(List *connectionList, bool raiseInterrupts);
+
 
 #endif /* REMOTE_COMMAND_H */


### PR DESCRIPTION
This PR introduces an API for waiting for results on multiple connections asynchronously and uses it for `COMMIT`, `ROLLBACK` and `PREPARE`. This prevents lock releases on one node from having to wait for lock releases on another node, which could form a distributed deadlock without an explicit edge in the lock graph.

A caller first creates a `MultiConnectionWaiter` for a set of connections and then repeatedly calls `AwaitResultsOnConnections`, which waits for results using a `WaitEventSet`, and returns all connections whose results are ready and connections that failed in a list. Returning a list of connections rather than a single connection (which would be simpler) minimises the number of calls to `CreateWaitEventSet` under load. Connections are returned in a list exactly once. When all connections have been returned, an empty list is returned.

To keep track of which connections were already returned, slots belonging to connections that are returned are overwritten with a connection from `currentOffset` and `currentOffset` is increased, such that the pending connections are always at the end of the connections array in `MultiConnectionWaiter` and the `currentOffset` points to the first connection that is still pending.