### PR TITLE
Add support for router UPDATEs and DELETEs with subqueries and joins

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -412,7 +412,7 @@ CitusModifyBeginScan(CustomScanState *node, EState *estate, int eflags)
 			DeferredErrorMessage *planningError = NULL;
 
 			/* need to perform shard pruning, rebuild the task list from scratch */
-			taskList = RouterModifyTaskList(jobQuery, &planningError);
+			taskList = RouterInsertTaskList(jobQuery, &planningError);
 
 			if (planningError != NULL)
 			{

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -150,7 +150,9 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 
 	if (modifyQuery->commandType != CMD_UTILITY)
 	{
-		DeferredErrorMessage *error = ModifyQuerySupported(modifyQuery);
+		bool multiShardQuery = true;
+		DeferredErrorMessage *error = ModifyQuerySupported(modifyQuery, multiShardQuery);
+
 		if (error)
 		{
 			RaiseDeferredError(error, ERROR);

--- a/src/backend/distributed/utils/ruleutils_10.c
+++ b/src/backend/distributed/utils/ruleutils_10.c
@@ -3169,20 +3169,43 @@ get_update_query_def(Query *query, deparse_context *context)
 	 * Start the query with UPDATE relname SET
 	 */
 	rte = rt_fetch(query->resultRelation, query->rtable);
-	Assert(rte->rtekind == RTE_RELATION);
+
 	if (PRETTY_INDENT(context))
 	{
 		appendStringInfoChar(buf, ' ');
 		context->indentLevel += PRETTYINDENT_STD;
 	}
-	appendStringInfo(buf, "UPDATE %s%s",
-					 only_marker(rte),
-					 generate_relation_or_shard_name(rte->relid,
-													 context->distrelid,
-													 context->shardid, NIL));
-	if (rte->alias != NULL)
-		appendStringInfo(buf, " %s",
-						 quote_identifier(rte->alias->aliasname));
+
+	/* if it's a shard, do differently */
+	if (GetRangeTblKind(rte) == CITUS_RTE_SHARD)
+	{
+		char *fragmentSchemaName = NULL;
+		char *fragmentTableName = NULL;
+
+		ExtractRangeTblExtraData(rte, NULL, &fragmentSchemaName, &fragmentTableName, NULL);
+
+		/* use schema and table name from the remote alias */
+		appendStringInfo(buf, "UPDATE %s%s",
+						 only_marker(rte),
+						 generate_fragment_name(fragmentSchemaName, fragmentTableName));
+
+		if(rte->eref != NULL)
+			appendStringInfo(buf, " %s",
+					quote_identifier(rte->eref->aliasname));
+	}
+	else
+	{
+		appendStringInfo(buf, "UPDATE %s%s",
+						 only_marker(rte),
+						 generate_relation_or_shard_name(rte->relid,
+														 context->distrelid,
+														 context->shardid, NIL));
+
+		if (rte->alias != NULL)
+			appendStringInfo(buf, " %s",
+							 quote_identifier(rte->alias->aliasname));
+	}
+
 	appendStringInfoString(buf, " SET ");
 
 	/* Deparse targetlist */
@@ -3366,20 +3389,42 @@ get_delete_query_def(Query *query, deparse_context *context)
 	 * Start the query with DELETE FROM relname
 	 */
 	rte = rt_fetch(query->resultRelation, query->rtable);
-	Assert(rte->rtekind == RTE_RELATION);
+
 	if (PRETTY_INDENT(context))
 	{
 		appendStringInfoChar(buf, ' ');
 		context->indentLevel += PRETTYINDENT_STD;
 	}
-	appendStringInfo(buf, "DELETE FROM %s%s",
-					 only_marker(rte),
-					 generate_relation_or_shard_name(rte->relid,
-													 context->distrelid,
-													 context->shardid, NIL));
-	if (rte->alias != NULL)
-		appendStringInfo(buf, " %s",
-						 quote_identifier(rte->alias->aliasname));
+
+	/* if it's a shard, do differently */
+	if (GetRangeTblKind(rte) == CITUS_RTE_SHARD)
+	{
+		char *fragmentSchemaName = NULL;
+		char *fragmentTableName = NULL;
+
+		ExtractRangeTblExtraData(rte, NULL, &fragmentSchemaName, &fragmentTableName, NULL);
+
+		/* use schema and table name from the remote alias */
+		appendStringInfo(buf, "DELETE FROM %s%s",
+						 only_marker(rte),
+						 generate_fragment_name(fragmentSchemaName, fragmentTableName));
+
+		if(rte->eref != NULL)
+			appendStringInfo(buf, " %s",
+					quote_identifier(rte->eref->aliasname));
+	}
+	else
+	{
+		appendStringInfo(buf, "DELETE FROM %s%s",
+						 only_marker(rte),
+						 generate_relation_or_shard_name(rte->relid,
+														 context->distrelid,
+														 context->shardid, NIL));
+
+		if (rte->alias != NULL)
+			appendStringInfo(buf, " %s",
+							 quote_identifier(rte->alias->aliasname));
+	}
 
 	/* Add the USING clause if given */
 	get_from_clause(query, " USING ", context);
@@ -6857,7 +6902,7 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 
 					ExtractRangeTblExtraData(rte, NULL, &fragmentSchemaName, &fragmentTableName, NULL);
 
-					/* Use schema and table name from the remote alias */
+					/* use schema and table name from the remote alias */
 					appendStringInfoString(buf,
 										   generate_fragment_name(fragmentSchemaName,
 																  fragmentTableName));

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -31,12 +31,16 @@ extern MultiPlan * CreateRouterPlan(Query *originalQuery, Query *query,
 extern MultiPlan * CreateModifyPlan(Query *originalQuery, Query *query,
 									PlannerRestrictionContext *
 									plannerRestrictionContext);
-extern bool RouterSelectQuery(Query *originalQuery,
-							  RelationRestrictionContext *restrictionContext,
-							  List **placementList, uint64 *anchorShardId,
-							  List **relationShardList, bool replacePrunedQueryWithDummy);
+extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
+											  RelationRestrictionContext *
+											  restrictionContext,
+											  List **placementList, uint64 *anchorShardId,
+											  List **relationShardList, bool
+											  replacePrunedQueryWithDummy);
+extern List * RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError);
 extern List * IntersectPlacementList(List *lhsPlacementList, List *rhsPlacementList);
-extern DeferredErrorMessage * ModifyQuerySupported(Query *queryTree);
+extern DeferredErrorMessage * ModifyQuerySupported(Query *queryTree,
+												   bool multiShardQuery);
 extern List * ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex);
 extern RelationRestrictionContext * CopyRelationRestrictionContext(
 	RelationRestrictionContext *oldContext);
@@ -46,7 +50,6 @@ extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
-extern List * RouterModifyTaskList(Query *query, DeferredErrorMessage **planningError);
 
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -317,8 +317,8 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_290000
-              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000
+        ->  Update on lineitem_290000 lineitem
+              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
 -- Test delete
@@ -330,8 +330,8 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Delete on lineitem_290000
-              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000
+        ->  Delete on lineitem_290000 lineitem
+              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
 -- Test zero-shard update

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -317,8 +317,8 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_290000
-              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000
+        ->  Update on lineitem_290000 lineitem
+              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
 -- Test delete
@@ -330,8 +330,8 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Delete on lineitem_290000
-              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000
+        ->  Delete on lineitem_290000 lineitem
+              ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
 -- Test zero-shard update

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -657,3 +657,430 @@ INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *
 (1 row)
 
 DROP TABLE app_analytics_events;
+-- test UPDATE with subqueries
+CREATE TABLE raw_table (id bigint, value bigint);
+CREATE TABLE summary_table (
+	id bigint,
+	min_value numeric,
+	average_value numeric,
+	count int,
+	uniques int);
+SELECT create_distributed_table('raw_table', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('summary_table', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO raw_table VALUES (1, 100);
+INSERT INTO raw_table VALUES (1, 200);
+INSERT INTO raw_table VALUES (1, 200);
+INSERT INTO raw_table VALUES (1, 300);
+INSERT INTO raw_table VALUES (2, 400);
+INSERT INTO raw_table VALUES (2, 500);
+INSERT INTO summary_table VALUES (1);
+INSERT INTO summary_table VALUES (2);
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value | average_value | count | uniques 
+----+-----------+---------------+-------+---------
+  1 |           |               |       |        
+  2 |           |               |       |        
+(2 rows)
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |           | 200.0000000000000000 |       |        
+  2 |           |                      |       |        
+(2 rows)
+
+-- try different syntax
+UPDATE summary_table SET (min_value, average_value) =
+	(SELECT min(value), avg(value) FROM raw_table WHERE id = 2)
+WHERE id = 2;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |           | 200.0000000000000000 |       |        
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+UPDATE summary_table SET min_value = 100
+	WHERE id IN (SELECT id FROM raw_table WHERE id = 1 and value > 100) AND id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |       |        
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- indeed, we don't need filter on UPDATE explicitly if SELECT already prunes to one shard
+UPDATE summary_table SET uniques = 2
+	WHERE id IN (SELECT id FROM raw_table WHERE id = 1 and value IN (100, 200));
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |       |       2
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- use inner results for non-partition column
+UPDATE summary_table SET uniques = NULL
+	WHERE min_value IN (SELECT value FROM raw_table WHERE id = 1) AND id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |       |        
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- these should not update anything
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1 AND id = 4
+	) average_query
+WHERE id = 1 AND id = 4;
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1
+	) average_query
+WHERE id = 1 AND id = 4;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |       |        
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- update with NULL value
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1 AND id = 4
+	) average_query
+WHERE id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 |                      |       |        
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- unsupported multi-shard updates
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table) average_query;
+ERROR:  cannot run UPDATE command which targets multiple shards
+HINT:  Consider using an equality filter on partition column "id" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
+UPDATE summary_table SET average_value = average_value + 1 WHERE id =
+  (SELECT id FROM raw_table WHERE value > 100);
+ERROR:  cannot run UPDATE command which targets multiple shards
+HINT:  Consider using an equality filter on partition column "id" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
+-- test complex queries
+UPDATE summary_table
+SET
+       uniques = metrics.expensive_uniques,
+       count = metrics.total_count
+FROM
+		(SELECT
+			id,
+			count(DISTINCT (CASE WHEN value > 100 then value end)) AS expensive_uniques,
+			count(value) AS total_count
+        FROM raw_table
+        WHERE id = 1
+        GROUP BY id) metrics
+WHERE
+   summary_table.id = metrics.id AND
+   summary_table.id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 |                      |     4 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- test joins
+UPDATE summary_table SET count = count + 1 FROM raw_table
+	WHERE raw_table.id = summary_table.id AND summary_table.id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 |                      |     5 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- test with prepared statements
+PREPARE prepared_update_with_subquery(int, int) AS
+	UPDATE summary_table SET count = count + $1 FROM raw_table
+		WHERE raw_table.id = summary_table.id AND summary_table.id = $2;
+-- execute 6 times to trigger prepared statement usage
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 |                      |    65 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- test with reference tables
+CREATE TABLE reference_raw_table (id bigint, value bigint);
+CREATE TABLE reference_summary_table (
+	id bigint,
+	min_value numeric,
+	average_value numeric,
+	count int,
+	uniques int);
+SELECT create_reference_table('reference_raw_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_reference_table('reference_summary_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+INSERT INTO reference_raw_table VALUES (1, 100);
+INSERT INTO reference_raw_table VALUES (1, 200);
+INSERT INTO reference_raw_table VALUES (1, 200);
+INSERT INTO reference_raw_table VALUES (1, 300);
+INSERT INTO reference_raw_table VALUES (2, 400);
+INSERT INTO reference_raw_table VALUES (2, 500);
+INSERT INTO reference_summary_table VALUES (1);
+INSERT INTO reference_summary_table VALUES (2);
+SELECT * FROM reference_summary_table ORDER BY id;
+ id | min_value | average_value | count | uniques 
+----+-----------+---------------+-------+---------
+  1 |           |               |       |        
+  2 |           |               |       |        
+(2 rows)
+
+UPDATE reference_summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM reference_raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+UPDATE reference_summary_table SET (min_value, average_value) =
+	(SELECT min(value), avg(value) FROM reference_raw_table WHERE id = 2)
+WHERE id = 2;
+SELECT * FROM reference_summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |           | 200.0000000000000000 |       |        
+  2 |       400 | 450.0000000000000000 |       |        
+(2 rows)
+
+-- no need partition colum equalities on reference tables
+UPDATE reference_summary_table SET (count) =
+	(SELECT id AS inner_id FROM reference_raw_table WHERE value = 500)
+WHERE min_value = 400;
+SELECT * FROM reference_summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |           | 200.0000000000000000 |       |        
+  2 |       400 | 450.0000000000000000 |     2 |        
+(2 rows)
+
+-- can read from a reference table and update a distributed table
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM reference_raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+-- cannot read from a distributed table and update a reference table
+UPDATE reference_summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+ERROR:  cannot perform select on a distributed table and modify a reference table
+UPDATE reference_summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1 AND  id = 2
+	) average_query
+WHERE id = 1;
+ERROR:  cannot perform select on a distributed table and modify a reference table
+-- test master_modify_multiple_shards() with subqueries and expect to fail
+SELECT master_modify_multiple_shards('
+	UPDATE summary_table SET average_value = average_query.average FROM (
+		SELECT avg(value) AS average FROM raw_table WHERE id = 1
+		) average_query
+	WHERE id = 1');
+ERROR:  cannot perform distributed planning for the given modifications
+DETAIL:  Subqueries are not supported in distributed modifications.
+-- test connection API via using COPY
+-- COPY on SELECT part
+BEGIN;
+\COPY raw_table FROM STDIN WITH CSV
+INSERT INTO summary_table VALUES (3);
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 3
+	) average_query
+WHERE id = 3;
+COMMIT;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |    65 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+  3 |           | 150.0000000000000000 |       |        
+(3 rows)
+
+-- COPY on UPDATE part
+BEGIN;
+INSERT INTO raw_table VALUES (4, 100);
+INSERT INTO raw_table VALUES (4, 200);
+\COPY summary_table FROM STDIN WITH CSV
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 4
+	) average_query
+WHERE id = 4;
+COMMIT;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |    65 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+(4 rows)
+
+-- COPY on both part
+BEGIN;
+\COPY raw_table FROM STDIN WITH CSV
+\COPY summary_table FROM STDIN WITH CSV
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 5
+	) average_query
+WHERE id = 5;
+COMMIT;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |    65 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+  5 |           | 150.0000000000000000 |       |        
+(5 rows)
+
+-- COPY on reference tables
+BEGIN;
+\COPY reference_raw_table FROM STDIN WITH CSV
+\COPY summary_table FROM STDIN WITH CSV
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM reference_raw_table WHERE id = 6
+	) average_query
+WHERE id = 6;
+COMMIT;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  1 |       100 | 200.0000000000000000 |    65 |       2
+  2 |       400 | 450.0000000000000000 |       |        
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+  5 |           | 150.0000000000000000 |       |        
+  6 |           | 150.0000000000000000 |       |        
+(6 rows)
+
+-- test DELETE queries
+SELECT * FROM raw_table ORDER BY id, value;
+ id | value 
+----+-------
+  1 |   100
+  1 |   200
+  1 |   200
+  1 |   300
+  2 |   400
+  2 |   500
+  3 |   100
+  3 |   200
+  4 |   100
+  4 |   200
+  5 |   100
+  5 |   200
+(12 rows)
+
+DELETE FROM summary_table
+  WHERE min_value IN (SELECT value FROM raw_table WHERE id = 1) AND id = 1;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  2 |       400 | 450.0000000000000000 |       |        
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+  5 |           | 150.0000000000000000 |       |        
+  6 |           | 150.0000000000000000 |       |        
+(5 rows)
+
+-- test with different syntax
+DELETE FROM summary_table USING raw_table
+  WHERE summary_table.id = raw_table.id AND raw_table.id = 2;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+  5 |           | 150.0000000000000000 |       |        
+  6 |           | 150.0000000000000000 |       |        
+(4 rows)
+
+-- cannot read from a distributed table and delete from a reference table
+DELETE FROM reference_summary_table USING raw_table
+  WHERE reference_summary_table.id = raw_table.id AND raw_table.id = 3;
+ERROR:  cannot perform select on a distributed table and modify a reference table
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+  5 |           | 150.0000000000000000 |       |        
+  6 |           | 150.0000000000000000 |       |        
+(4 rows)
+
+-- test connection API via using COPY with DELETEs
+BEGIN;
+\COPY summary_table FROM STDIN WITH CSV
+DELETE FROM summary_table USING raw_table
+  WHERE summary_table.id = raw_table.id AND raw_table.id = 1;
+DELETE FROM summary_table USING reference_raw_table
+  WHERE summary_table.id = reference_raw_table.id AND reference_raw_table.id = 2;
+COMMIT;
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value |    average_value     | count | uniques 
+----+-----------+----------------------+-------+---------
+  3 |           | 150.0000000000000000 |       |        
+  4 |           | 150.0000000000000000 |       |        
+  5 |           | 150.0000000000000000 |       |        
+  6 |           | 150.0000000000000000 |       |        
+(4 rows)
+
+-- test DELETEs with prepared statements
+PREPARE prepared_delete_with_join(int) AS
+	DELETE FROM summary_table USING raw_table
+  		WHERE summary_table.id = raw_table.id AND raw_table.id = $1;
+INSERT INTO raw_table VALUES (6, 100);
+-- execute 6 times to trigger prepared statement usage
+EXECUTE prepared_delete_with_join(1);
+EXECUTE prepared_delete_with_join(2);
+EXECUTE prepared_delete_with_join(3);
+EXECUTE prepared_delete_with_join(4);
+EXECUTE prepared_delete_with_join(5);
+EXECUTE prepared_delete_with_join(6);
+SELECT * FROM summary_table ORDER BY id;
+ id | min_value | average_value | count | uniques 
+----+-----------+---------------+-------+---------
+(0 rows)
+
+DROP TABLE raw_table;
+DROP TABLE summary_table;
+DROP TABLE reference_raw_table;
+DROP TABLE reference_summary_table;

--- a/src/test/regress/expected/multi_mx_explain.out
+++ b/src/test/regress/expected/multi_mx_explain.out
@@ -335,8 +335,8 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_mx_1220052
-              ->  Index Scan using lineitem_mx_pkey_1220052 on lineitem_mx_1220052
+        ->  Update on lineitem_mx_1220052 lineitem_mx
+              ->  Index Scan using lineitem_mx_pkey_1220052 on lineitem_mx_1220052 lineitem_mx
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
 -- Test delete
@@ -348,8 +348,8 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Delete on lineitem_mx_1220052
-              ->  Index Scan using lineitem_mx_pkey_1220052 on lineitem_mx_1220052
+        ->  Delete on lineitem_mx_1220052 lineitem_mx
+              ->  Index Scan using lineitem_mx_pkey_1220052 on lineitem_mx_1220052 lineitem_mx
                     Index Cond: (l_orderkey = 1)
                     Filter: (l_partkey = 0)
 -- Test single-shard SELECT

--- a/src/test/regress/expected/multi_upsert.out
+++ b/src/test/regress/expected/multi_upsert.out
@@ -236,7 +236,8 @@ INSERT INTO dropcol_distributed AS dropcol (key, keep1) VALUES (1, '5') ON CONFL
 -- subquery in the SET clause
 INSERT INTO upsert_test (part_key, other_col) VALUES (1, 1) ON CONFLICT (part_key) DO
 	UPDATE SET other_col = (SELECT count(*) from upsert_test);
-ERROR:  subqueries are not supported in distributed modifications
+ERROR:  cannot perform distributed planning for the given modifications
+DETAIL:  Subqueries are not supported in distributed modifications.
 -- non mutable function call in the SET
 INSERT INTO upsert_test (part_key, other_col) VALUES (1, 1) ON CONFLICT (part_key) DO
 	UPDATE SET other_col = random()::int;

--- a/src/test/regress/output/multi_master_delete_protocol.source
+++ b/src/test/regress/output/multi_master_delete_protocol.source
@@ -30,7 +30,7 @@ DETAIL:  Where clause includes a column other than partition column
 -- Check that free-form deletes are not supported.
 DELETE FROM customer_delete_protocol WHERE c_custkey > 100;
 ERROR:  cannot run DELETE command which targets multiple shards
-HINT:  Consider using an equality filter on partition column "c_custkey" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards(). You can also use master_apply_delete_command() to drop all shards satisfying delete criteria.
+HINT:  Consider using an equality filter on partition column "c_custkey" to target a single shard. If you'd like to run a multi-shard operation, use master_modify_multiple_shards().
 -- Check that we delete a shard if and only if all rows in the shard satisfy the condition.
 SELECT master_apply_delete_command('DELETE FROM customer_delete_protocol 
                                            WHERE c_custkey > 6500');

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -429,3 +429,335 @@ INSERT INTO app_analytics_events (app_id, name) VALUES (102, 'Wayz') RETURNING i
 INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *;
 
 DROP TABLE app_analytics_events;
+
+-- test UPDATE with subqueries
+CREATE TABLE raw_table (id bigint, value bigint);
+CREATE TABLE summary_table (
+	id bigint,
+	min_value numeric,
+	average_value numeric,
+	count int,
+	uniques int);
+
+SELECT create_distributed_table('raw_table', 'id');
+SELECT create_distributed_table('summary_table', 'id');
+
+INSERT INTO raw_table VALUES (1, 100);
+INSERT INTO raw_table VALUES (1, 200);
+INSERT INTO raw_table VALUES (1, 200);
+INSERT INTO raw_table VALUES (1, 300);
+INSERT INTO raw_table VALUES (2, 400);
+INSERT INTO raw_table VALUES (2, 500);
+
+INSERT INTO summary_table VALUES (1);
+INSERT INTO summary_table VALUES (2);
+
+SELECT * FROM summary_table ORDER BY id;
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- try different syntax
+UPDATE summary_table SET (min_value, average_value) =
+	(SELECT min(value), avg(value) FROM raw_table WHERE id = 2)
+WHERE id = 2;
+
+SELECT * FROM summary_table ORDER BY id;
+
+UPDATE summary_table SET min_value = 100
+	WHERE id IN (SELECT id FROM raw_table WHERE id = 1 and value > 100) AND id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- indeed, we don't need filter on UPDATE explicitly if SELECT already prunes to one shard
+UPDATE summary_table SET uniques = 2
+	WHERE id IN (SELECT id FROM raw_table WHERE id = 1 and value IN (100, 200));
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- use inner results for non-partition column
+UPDATE summary_table SET uniques = NULL
+	WHERE min_value IN (SELECT value FROM raw_table WHERE id = 1) AND id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- these should not update anything
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1 AND id = 4
+	) average_query
+WHERE id = 1 AND id = 4;
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1
+	) average_query
+WHERE id = 1 AND id = 4;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- update with NULL value
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1 AND id = 4
+	) average_query
+WHERE id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- unsupported multi-shard updates
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table) average_query;
+
+UPDATE summary_table SET average_value = average_value + 1 WHERE id =
+  (SELECT id FROM raw_table WHERE value > 100);
+
+-- test complex queries
+UPDATE summary_table
+SET
+       uniques = metrics.expensive_uniques,
+       count = metrics.total_count
+FROM
+		(SELECT
+			id,
+			count(DISTINCT (CASE WHEN value > 100 then value end)) AS expensive_uniques,
+			count(value) AS total_count
+        FROM raw_table
+        WHERE id = 1
+        GROUP BY id) metrics
+WHERE
+   summary_table.id = metrics.id AND
+   summary_table.id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test joins
+UPDATE summary_table SET count = count + 1 FROM raw_table
+	WHERE raw_table.id = summary_table.id AND summary_table.id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test with prepared statements
+PREPARE prepared_update_with_subquery(int, int) AS
+	UPDATE summary_table SET count = count + $1 FROM raw_table
+		WHERE raw_table.id = summary_table.id AND summary_table.id = $2;
+
+-- execute 6 times to trigger prepared statement usage
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+EXECUTE prepared_update_with_subquery(10, 1);
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test with reference tables
+
+CREATE TABLE reference_raw_table (id bigint, value bigint);
+CREATE TABLE reference_summary_table (
+	id bigint,
+	min_value numeric,
+	average_value numeric,
+	count int,
+	uniques int);
+
+SELECT create_reference_table('reference_raw_table');
+SELECT create_reference_table('reference_summary_table');
+
+INSERT INTO reference_raw_table VALUES (1, 100);
+INSERT INTO reference_raw_table VALUES (1, 200);
+INSERT INTO reference_raw_table VALUES (1, 200);
+INSERT INTO reference_raw_table VALUES (1, 300);
+INSERT INTO reference_raw_table VALUES (2, 400);
+INSERT INTO reference_raw_table VALUES (2, 500);
+
+INSERT INTO reference_summary_table VALUES (1);
+INSERT INTO reference_summary_table VALUES (2);
+
+SELECT * FROM reference_summary_table ORDER BY id;
+
+UPDATE reference_summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM reference_raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+
+UPDATE reference_summary_table SET (min_value, average_value) =
+	(SELECT min(value), avg(value) FROM reference_raw_table WHERE id = 2)
+WHERE id = 2;
+
+SELECT * FROM reference_summary_table ORDER BY id;
+
+-- no need partition colum equalities on reference tables
+UPDATE reference_summary_table SET (count) =
+	(SELECT id AS inner_id FROM reference_raw_table WHERE value = 500)
+WHERE min_value = 400;
+
+SELECT * FROM reference_summary_table ORDER BY id;
+
+-- can read from a reference table and update a distributed table
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM reference_raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+
+-- cannot read from a distributed table and update a reference table
+UPDATE reference_summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1
+	) average_query
+WHERE id = 1;
+
+UPDATE reference_summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 1 AND  id = 2
+	) average_query
+WHERE id = 1;
+
+-- test master_modify_multiple_shards() with subqueries and expect to fail
+SELECT master_modify_multiple_shards('
+	UPDATE summary_table SET average_value = average_query.average FROM (
+		SELECT avg(value) AS average FROM raw_table WHERE id = 1
+		) average_query
+	WHERE id = 1');
+
+-- test connection API via using COPY
+
+-- COPY on SELECT part
+BEGIN;
+
+\COPY raw_table FROM STDIN WITH CSV
+3, 100
+3, 200
+\.
+
+INSERT INTO summary_table VALUES (3);
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 3
+	) average_query
+WHERE id = 3;
+
+COMMIT;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- COPY on UPDATE part
+BEGIN;
+
+INSERT INTO raw_table VALUES (4, 100);
+INSERT INTO raw_table VALUES (4, 200);
+
+\COPY summary_table FROM STDIN WITH CSV
+4,,,,
+\.
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 4
+	) average_query
+WHERE id = 4;
+
+COMMIT;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- COPY on both part
+BEGIN;
+
+\COPY raw_table FROM STDIN WITH CSV
+5, 100
+5, 200
+\.
+
+\COPY summary_table FROM STDIN WITH CSV
+5,,,,
+\.
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM raw_table WHERE id = 5
+	) average_query
+WHERE id = 5;
+
+COMMIT;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- COPY on reference tables
+BEGIN;
+
+\COPY reference_raw_table FROM STDIN WITH CSV
+6, 100
+6, 200
+\.
+
+\COPY summary_table FROM STDIN WITH CSV
+6,,,,
+\.
+
+UPDATE summary_table SET average_value = average_query.average FROM (
+	SELECT avg(value) AS average FROM reference_raw_table WHERE id = 6
+	) average_query
+WHERE id = 6;
+
+COMMIT;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test DELETE queries
+SELECT * FROM raw_table ORDER BY id, value;
+
+DELETE FROM summary_table
+  WHERE min_value IN (SELECT value FROM raw_table WHERE id = 1) AND id = 1;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test with different syntax
+DELETE FROM summary_table USING raw_table
+  WHERE summary_table.id = raw_table.id AND raw_table.id = 2;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- cannot read from a distributed table and delete from a reference table
+DELETE FROM reference_summary_table USING raw_table
+  WHERE reference_summary_table.id = raw_table.id AND raw_table.id = 3;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test connection API via using COPY with DELETEs
+BEGIN;
+
+\COPY summary_table FROM STDIN WITH CSV
+1,,,,
+2,,,,
+\.
+
+DELETE FROM summary_table USING raw_table
+  WHERE summary_table.id = raw_table.id AND raw_table.id = 1;
+
+DELETE FROM summary_table USING reference_raw_table
+  WHERE summary_table.id = reference_raw_table.id AND reference_raw_table.id = 2;
+
+COMMIT;
+
+SELECT * FROM summary_table ORDER BY id;
+
+-- test DELETEs with prepared statements
+PREPARE prepared_delete_with_join(int) AS
+	DELETE FROM summary_table USING raw_table
+  		WHERE summary_table.id = raw_table.id AND raw_table.id = $1;
+
+INSERT INTO raw_table VALUES (6, 100);
+
+-- execute 6 times to trigger prepared statement usage
+EXECUTE prepared_delete_with_join(1);
+EXECUTE prepared_delete_with_join(2);
+EXECUTE prepared_delete_with_join(3);
+EXECUTE prepared_delete_with_join(4);
+EXECUTE prepared_delete_with_join(5);
+EXECUTE prepared_delete_with_join(6);
+
+SELECT * FROM summary_table ORDER BY id;
+
+DROP TABLE raw_table;
+DROP TABLE summary_table;
+DROP TABLE reference_raw_table;
+DROP TABLE reference_summary_table;


### PR DESCRIPTION
Add support for router UPDATEs and DELETEs with subqueries and joins

Fixes #1127

TODO List:

- [x] Changing error messages: Need to modify RouterSelectJob() to return also deferred messages.
- [x] Support for zero shard cases: Need to refactor RouterSelectJob()
- [x] Make function evaluation more robust: https://github.com/citusdata/citus/pull/1483/commits/a396c0127ad3301633b0ce1546f9a0174c7bbcbd
- [x] Make setting replication model more robust: https://github.com/citusdata/citus/pull/1483/commits/92e2743939f341d17e9d58aded0cfba16810d21a
- [x] PostgreSQL 10 support: changing ruleutils should be fine
- [x] Add regression tests without SELECT but with JOINS (?)
- [x] Fix modify_multiple_shards() problem: Regressions are a bit changed.
- [x] Replication model checks (reference + distributed) + regression tests
- [x] Rename *Select functions and refactor code
- [x] Also support DELETE with the same code path
- [x] Performance tests for UPDATE and DELETE 
- [x] Minor refactoring: style, naming, writing subfunctions