### PR TITLE
Explicit switch/case fall-throughs to avoid compiler warnings.

### DIFF
--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -164,6 +164,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 			 * performed on CreateStmt should be done here too, we simply *fall
 			 * through* to avoid code repetition.
 			 */
+			__attribute__((fallthrough));
 		}
 
 		case T_CreateStmt:

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -164,9 +164,8 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 			 * performed on CreateStmt should be done here too, we simply *fall
 			 * through* to avoid code repetition.
 			 */
-			__attribute__((fallthrough));
 		}
-
+		/* fallthrough */
 		case T_CreateStmt:
 		{
 			CreateStmt *createStmt = (CreateStmt *) parseTree;

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -165,6 +165,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 			 * through* to avoid code repetition.
 			 */
 		}
+
 		/* fallthrough */
 		case T_CreateStmt:
 		{

--- a/src/backend/distributed/utils/ruleutils_96.c
+++ b/src/backend/distributed/utils/ruleutils_96.c
@@ -4448,10 +4448,8 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 					return false;
 				}
 				/* else do the same stuff as for T_SubLink et al. */
-				/* FALL THROUGH */
-				__attribute__((fallthrough));
 			}
-
+		/* fallthrough */
 		case T_SubLink:
 		case T_NullTest:
 		case T_BooleanTest:

--- a/src/backend/distributed/utils/ruleutils_96.c
+++ b/src/backend/distributed/utils/ruleutils_96.c
@@ -4449,6 +4449,7 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 				}
 				/* else do the same stuff as for T_SubLink et al. */
 				/* FALL THROUGH */
+				__attribute__((fallthrough));
 			}
 
 		case T_SubLink:

--- a/src/backend/distributed/utils/ruleutils_96.c
+++ b/src/backend/distributed/utils/ruleutils_96.c
@@ -4449,6 +4449,7 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 				}
 				/* else do the same stuff as for T_SubLink et al. */
 			}
+
 		/* fallthrough */
 		case T_SubLink:
 		case T_NullTest:


### PR DESCRIPTION
Currently when compiling Citus we get couple of warnings related to implicit switch/case fall-throughs. To avoid having to go to the code on every compile and making sure that the fall-through was intentional, this change marks them as intentional in the code so compiler doesn't warn about them.
