### PR TITLE
Add transaction number to 2PC identifiers

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -487,3 +487,17 @@ AssignDistributedTransactionId(void)
 
 	SpinLockRelease(&MyBackendData->mutex);
 }
+
+
+/*
+ * CurrentDistributedTransactionNumber returns the transaction number of the
+ * current distributed transaction. The caller must make sure a distributed
+ * transaction is in progress.
+ */
+uint64
+CurrentDistributedTransactionNumber(void)
+{
+	Assert(MyBackendData != NULL);
+
+	return MyBackendData->transactionId.transactionNumber;
+}

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -145,7 +145,7 @@ get_current_transaction_id(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errmsg("backend is not ready for distributed transactions")));
 	}
 
-	distributedTransctionId = GetCurrentDistributedTransctionId();
+	distributedTransctionId = GetCurrentDistributedTransactionId();
 
 	memset(values, 0, sizeof(values));
 	memset(isNulls, false, sizeof(isNulls));
@@ -434,11 +434,11 @@ UnSetDistributedTransactionId(void)
 
 
 /*
- * GetCurrentDistributedTransctionId reads the backend's distributed transaction id and
+ * GetCurrentDistributedTransactionId reads the backend's distributed transaction id and
  * returns a copy of it.
  */
 DistributedTransactionId *
-GetCurrentDistributedTransctionId(void)
+GetCurrentDistributedTransactionId(void)
 {
 	DistributedTransactionId *currentDistributedTransactionId =
 		(DistributedTransactionId *) palloc(sizeof(DistributedTransactionId));

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -64,7 +64,7 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 	 * and send both in one step. The reason is purely performance, we don't want
 	 * seperate roundtrips for these two statements.
 	 */
-	distributedTransactionId = GetCurrentDistributedTransctionId();
+	distributedTransactionId = GetCurrentDistributedTransactionId();
 	appendStringInfo(beginAndSetDistributedTransactionId,
 					 "SELECT assign_distributed_transaction_id(%d, %ld, '%s')",
 					 distributedTransactionId->initiatorNodeIdentifier,

--- a/src/include/distributed/transaction_identifier.h
+++ b/src/include/distributed/transaction_identifier.h
@@ -34,6 +34,6 @@ typedef struct DistributedTransactionId
 } DistributedTransactionId;
 
 
-extern DistributedTransactionId * GetCurrentDistributedTransctionId(void);
+extern DistributedTransactionId * GetCurrentDistributedTransactionId(void);
 
 #endif /* TRANSACTION_IDENTIFIER_H */

--- a/src/include/distributed/transaction_identifier.h
+++ b/src/include/distributed/transaction_identifier.h
@@ -35,5 +35,6 @@ typedef struct DistributedTransactionId
 
 
 extern DistributedTransactionId * GetCurrentDistributedTransactionId(void);
+extern uint64 CurrentDistributedTransactionNumber(void);
 
 #endif /* TRANSACTION_IDENTIFIER_H */


### PR DESCRIPTION
As more operations are starting to use 2PC, we've been getting reports of `pg_dist_transaction` records overflowing, since the name currently consist only of process ID and a process-local counter, and the process ID can get reused rather quickly.
https://github.com/citusdata/citus_docs/issues/417

The proper fix is to periodically call `recover_prepared_transactions` from the maintenance daemon, but even then we still want to guarantee that records don't overflow between `recover_prepared_transactions` calls.

This change ensures that `pg_dist_transaction` records cannot overlap in between restarts by including the distributed transaction number in the name.