### PR TITLE
Lock transaction metadata before issue PREPARE TRANSACTION

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -23,6 +23,7 @@
 #include "distributed/transaction_management.h"
 #include "distributed/transaction_recovery.h"
 #include "distributed/worker_manager.h"
+#include "storage/lmgr.h"
 #include "utils/hsearch.h"
 
 
@@ -660,6 +661,12 @@ void
 CoordinatedRemoteTransactionsPrepare(void)
 {
 	dlist_iter iter;
+
+	/*
+	 * Lock transaction metadata here to prevent transaction recovery from
+	 * getting inconsistent pending transactions list.
+	 */
+	LockRelationOid(DistTransactionRelationId(), RowExclusiveLock);
 
 	/* issue PREPARE TRANSACTION; to all relevant remote nodes */
 


### PR DESCRIPTION
Lock transaction metadata before issue `PREPARE TRANSACTION` to all relevant remote nodes to prevent transaction recovery(`SELECT recover_prepared_transactions()`) from getting inconsistent pending transactions list, and could cause data loss.

Please see #1030 for detail.


