### PR TITLE
Function evaluation descends into expression trees

### DIFF
--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -100,12 +100,10 @@ RequiresMasterEvaluation(Query *query)
 void
 ExecuteMasterEvaluableFunctions(Query *query, PlanState *planState)
 {
-	CmdType commandType = query->commandType;
 	ListCell *targetEntryCell = NULL;
 	ListCell *rteCell = NULL;
 	ListCell *cteCell = NULL;
 	Node *modifiedNode = NULL;
-	bool insertSelectQuery = InsertSelectIntoDistributedTable(query);
 
 	if (query->jointree && query->jointree->quals)
 	{
@@ -123,16 +121,8 @@ ExecuteMasterEvaluableFunctions(Query *query, PlanState *planState)
 			continue;
 		}
 
-		if (commandType == CMD_INSERT && !insertSelectQuery)
-		{
-			modifiedNode = EvaluateNodeIfReferencesFunction((Node *) targetEntry->expr,
-															planState);
-		}
-		else
-		{
-			modifiedNode = PartiallyEvaluateExpression((Node *) targetEntry->expr,
-													   planState);
-		}
+		modifiedNode = PartiallyEvaluateExpression((Node *) targetEntry->expr,
+												   planState);
 
 		targetEntry->expr = (Expr *) modifiedNode;
 	}

--- a/src/test/regress/expected/multi_function_evaluation.out
+++ b/src/test/regress/expected/multi_function_evaluation.out
@@ -115,4 +115,26 @@ SELECT * FROM example WHERE key = 3;
 -----+-------
 (0 rows)
 
+-- test that function evaluation descends into expressions
+CREATE OR REPLACE FUNCTION stable_fn()
+RETURNS timestamptz STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+	RAISE NOTICE 'stable_fn called';
+	RETURN timestamp '10-10-2000 00:00';
+END;
+$function$;
+INSERT INTO example VALUES (44, (ARRAY[stable_fn(),stable_fn()])[1]);
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function stable_fn() line 3 at RAISE
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function stable_fn() line 3 at RAISE
+SELECT * FROM example WHERE key = 44;
+ key |            value             
+-----+------------------------------
+  44 | Tue Oct 10 00:00:00 2000 PDT
+(1 row)
+
+DROP FUNCTION stable_fn();
 DROP TABLE example;

--- a/src/test/regress/sql/multi_function_evaluation.sql
+++ b/src/test/regress/sql/multi_function_evaluation.sql
@@ -110,4 +110,20 @@ SELECT * FROM example WHERE key = 3;
 DELETE FROM example WHERE key = 3 AND value < now() - interval '1 hour';
 SELECT * FROM example WHERE key = 3;
 
+-- test that function evaluation descends into expressions
+CREATE OR REPLACE FUNCTION stable_fn()
+RETURNS timestamptz STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+	RAISE NOTICE 'stable_fn called';
+	RETURN timestamp '10-10-2000 00:00';
+END;
+$function$;
+
+INSERT INTO example VALUES (44, (ARRAY[stable_fn(),stable_fn()])[1]);
+SELECT * FROM example WHERE key = 44;
+
+DROP FUNCTION stable_fn();
+
 DROP TABLE example;


### PR DESCRIPTION
While working on #1487 I found that we don't descend into expressions when evaluating functions in DML commands, which means we skip evaluation for certain expressions.