### PR TITLE
Fix PG 10 build, UNBOUNDED partitions now have different syntax

### DIFF
--- a/src/backend/distributed/utils/ruleutils_10.c
+++ b/src/backend/distributed/utils/ruleutils_10.c
@@ -5796,8 +5796,10 @@ get_rule_expr(Node *node, deparse_context *context,
 							Const	   *val;
 
 							appendStringInfoString(buf, sep);
-							if (datum->infinite)
-								appendStringInfoString(buf, "UNBOUNDED");
+							if (datum->kind == PARTITION_RANGE_DATUM_MINVALUE)
+								appendStringInfoString(buf, "MINVALUE");
+							else if (datum->kind == PARTITION_RANGE_DATUM_MAXVALUE)
+								appendStringInfoString(buf, "MAXVALUE");
 							else
 							{
 								val = (Const *) datum->value;
@@ -5816,8 +5818,10 @@ get_rule_expr(Node *node, deparse_context *context,
 							Const	   *val;
 
 							appendStringInfoString(buf, sep);
-							if (datum->infinite)
-								appendStringInfoString(buf, "UNBOUNDED");
+							if (datum->kind == PARTITION_RANGE_DATUM_MINVALUE)
+								appendStringInfoString(buf, "MINVALUE");
+							else if (datum->kind == PARTITION_RANGE_DATUM_MAXVALUE)
+								appendStringInfoString(buf, "MAXVALUE");
 							else
 							{
 								val = (Const *) datum->value;

--- a/src/test/regress/expected/multi_partitioning_utils.out
+++ b/src/test/regress/expected/multi_partitioning_utils.out
@@ -334,11 +334,11 @@ SELECT generate_alter_table_attach_partition_command('multi_column_partition_1')
  ALTER TABLE public.multi_column_partitioned ATTACH PARTITION public.multi_column_partition_1 FOR VALUES FROM (1, 10, 250) TO (1, 20, 250);
 (1 row)
 
-ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_2 FOR VALUES FROM (10, 1000, '2500') TO (UNBOUNDED, UNBOUNDED, UNBOUNDED);
+ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_2 FOR VALUES FROM (10, 1000, '2500') TO (MAXVALUE, MAXVALUE, MAXVALUE);
 SELECT generate_alter_table_attach_partition_command('multi_column_partition_2');
-                                                            generate_alter_table_attach_partition_command                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- ALTER TABLE public.multi_column_partitioned ATTACH PARTITION public.multi_column_partition_2 FOR VALUES FROM (10, 1000, 2500) TO (UNBOUNDED, UNBOUNDED, UNBOUNDED);
+                                                          generate_alter_table_attach_partition_command                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ ALTER TABLE public.multi_column_partitioned ATTACH PARTITION public.multi_column_partition_2 FOR VALUES FROM (10, 1000, 2500) TO (MAXVALUE, MAXVALUE, MAXVALUE);
 (1 row)
 
 SELECT generate_alter_table_detach_partition_command('multi_column_partition_2');

--- a/src/test/regress/expected/multi_partitioning_utils_0.out
+++ b/src/test/regress/expected/multi_partitioning_utils_0.out
@@ -279,7 +279,7 @@ SELECT generate_alter_table_attach_partition_command('multi_column_partition_1')
  
 (1 row)
 
-ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_2 FOR VALUES FROM (10, 1000, '2500') TO (UNBOUNDED, UNBOUNDED, UNBOUNDED);
+ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_2 FOR VALUES FROM (10, 1000, '2500') TO (MAXVALUE, MAXVALUE, MAXVALUE);
 ERROR:  syntax error at or near "ATTACH"
 LINE 1: ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_...
                                              ^

--- a/src/test/regress/sql/multi_partitioning_utils.sql
+++ b/src/test/regress/sql/multi_partitioning_utils.sql
@@ -223,7 +223,7 @@ SELECT drop_and_recreate_partitioned_table('multi_column_partitioned');
 -- partitions and their ranges
 ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_1 FOR VALUES FROM (1, 10, '250') TO (1, 20, '250');
 SELECT generate_alter_table_attach_partition_command('multi_column_partition_1');
-ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_2 FOR VALUES FROM (10, 1000, '2500') TO (UNBOUNDED, UNBOUNDED, UNBOUNDED);
+ALTER TABLE multi_column_partitioned ATTACH PARTITION multi_column_partition_2 FOR VALUES FROM (10, 1000, '2500') TO (MAXVALUE, MAXVALUE, MAXVALUE);
 SELECT generate_alter_table_attach_partition_command('multi_column_partition_2');
 SELECT generate_alter_table_detach_partition_command('multi_column_partition_2');
 


### PR DESCRIPTION
Update code and tests to match the changes made in pg's d363d42