### PR TITLE
Fix bug on error check for assigning distributed transaction id

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -92,7 +92,7 @@ assign_distributed_transaction_id(PG_FUNCTION_ARGS)
 	SpinLockAcquire(&MyBackendData->mutex);
 
 	/* if an id is already assigned, release the lock and error */
-	if (MyBackendData->transactionId.initiatorNodeIdentifier != 0)
+	if (MyBackendData->transactionId.transactionNumber != 0)
 	{
 		SpinLockRelease(&MyBackendData->mutex);
 


### PR DESCRIPTION
The bug introduced with #1489.

Fix bug on error check for assigning distributed transaction id to a backend that has already been assigned a transaction.

There is already a regression test that triggers that. It passes the tests just because the nodeId is not equal to `0`. See the test in the regression tests:

```SQL

BEGIN;
	
	-- we should still see the uninitialized values
	SELECT initiator_node_identifier, transaction_number, transaction_stamp, (process_id = pg_backend_pid()) FROM get_current_transaction_id();

	-- now assign a value
    SELECT assign_distributed_transaction_id(50, 50, '2016-01-01 00:00:00+0');

    -- see the assigned value
	SELECT initiator_node_identifier, transaction_number, transaction_stamp, (process_id = pg_backend_pid()) FROM get_current_transaction_id();

	-- a backend cannot be assigned another tx id if already assigned
    SELECT assign_distributed_transaction_id(51, 51, '2017-01-01 00:00:00+0');

ROLLBACK;
```