### PR TITLE
Remove shared memory locks for managing backends

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -227,9 +227,6 @@ get_all_active_transactions(PG_FUNCTION_ARGS)
 	memset(values, 0, sizeof(values));
 	memset(isNulls, false, sizeof(isNulls));
 
-	/* we're reading all the backend data, take a lock to prevent concurrent additions */
-	LWLockAcquire(AddinShmemInitLock, LW_SHARED);
-
 	for (backendIndex = 0; backendIndex < MaxBackends; ++backendIndex)
 	{
 		BackendData *currentBackend =
@@ -262,8 +259,6 @@ get_all_active_transactions(PG_FUNCTION_ARGS)
 		memset(values, 0, sizeof(values));
 		memset(isNulls, false, sizeof(isNulls));
 	}
-
-	LWLockRelease(AddinShmemInitLock);
 
 	/* clean up and return the tuplestore */
 	tuplestore_donestoring(tupleStore);


### PR DESCRIPTION
As we realize, the locking around shared memory segment isn't 
strictly necessary. 

Per-backend spinlocks already protect each backend's data.
Those locks don't provide a global consistent result while 
reading all backends' data (i.e., after a backend's data is 
read, it could be updated).

However the above is not a problem for deadlock detection. In the
worst case, we'd end-up with edges that do not exist anymore. The 
deadlock detection should already be ready for such cases.