### PR TITLE
Improve locking semantics for the backend management

### DIFF
--- a/src/backend/distributed/transaction/lock_graph.c
+++ b/src/backend/distributed/transaction/lock_graph.c
@@ -503,11 +503,16 @@ BuildWaitGraphForSourceNode(int sourceNodeId)
 /*
  * LockLockData takes locks the shared lock data structure, which prevents
  * concurrent lock acquisitions/releases.
+ *
+ * The function also acquires lock on the backend shared memory to prevent
+ * new backends to start.
  */
 static void
 LockLockData(void)
 {
 	int partitionNum = 0;
+
+	LockBackendSharedMemory(LW_SHARED);
 
 	for (partitionNum = 0; partitionNum < NUM_LOCK_PARTITIONS; partitionNum++)
 	{
@@ -520,6 +525,9 @@ LockLockData(void)
  * UnlockLockData unlocks the locks on the shared lock data structure in reverse
  * order since LWLockRelease searches the given lock from the end of the
  * held_lwlocks array.
+ *
+ * The function also releases the shared memory lock to allow new backends to
+ * start.
  */
 static void
 UnlockLockData(void)
@@ -530,6 +538,8 @@ UnlockLockData(void)
 	{
 		LWLockRelease(LockHashPartitionLockByIndex(partitionNum));
 	}
+
+	UnlockBackendSharedMemory();
 }
 
 

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -35,6 +35,8 @@ typedef struct BackendData
 
 extern void InitializeBackendManagement(void);
 extern void InitializeBackendData(void);
+extern void LockBackendSharedMemory(LWLockMode lockMode);
+extern void UnlockBackendSharedMemory(void);
 extern void UnSetDistributedTransactionId(void);
 extern void AssignDistributedTransactionId(void);
 extern void GetBackendDataForProc(PGPROC *proc, BackendData *result);


### PR DESCRIPTION
We use the backend shared memory lock for preventing
new backends to be part of a new distributed transaction
or an existing backend to leave a distributed transaction
while we're reading the all backends' data.

The primary goal is to provide consistent view of the
current distributed transactions while doing the
deadlock detection.

**Important Note:** I considered using the the lock on backend initialization as proposed in #1447. However, I think it makes more sense to use the locks only when a backend enters/leaves a distributed transaction instead of doing it on the backend initialization. This seems (i) more convenient to achieve the goal (i.e., consistent reads of txs) (ii) plays better with cached connections). Any comments?