### PR TITLE
Add nodecluster role (currently inoperative) to pg_dist_node

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -11,7 +11,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
 	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12 6.1-13 6.1-14 6.1-15 6.1-16 6.1-17 \
 	6.2-1 6.2-2 6.2-3 6.2-4 \
-	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5 7.0-6 7.0-7 7.0-8
+	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5 7.0-6 7.0-7 7.0-8 7.0-9
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -154,6 +154,8 @@ $(EXTENSION)--7.0-6.sql: $(EXTENSION)--7.0-5.sql $(EXTENSION)--7.0-5--7.0-6.sql
 $(EXTENSION)--7.0-7.sql: $(EXTENSION)--7.0-6.sql $(EXTENSION)--7.0-6--7.0-7.sql
 	cat $^ > $@
 $(EXTENSION)--7.0-8.sql: $(EXTENSION)--7.0-7.sql $(EXTENSION)--7.0-7--7.0-8.sql
+	cat $^ > $@
+$(EXTENSION)--7.0-9.sql: $(EXTENSION)--7.0-8.sql $(EXTENSION)--7.0-8--7.0-9.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.0-8--7.0-9.sql
+++ b/src/backend/distributed/citus--7.0-8--7.0-9.sql
@@ -1,0 +1,70 @@
+/* citus-7.0-8--7.0-9 */
+
+SET search_path = 'pg_catalog';
+
+ALTER TABLE pg_dist_node ADD COLUMN nodecluster name NOT NULL DEFAULT 'default';
+
+DROP FUNCTION master_add_node(text, integer, integer, noderole);
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                groupid integer default 0,
+                                noderole noderole default 'primary',
+                                nodecluster name default 'default',
+                                OUT nodeid integer,
+                                OUT groupid integer,
+                                OUT nodename text,
+                                OUT nodeport integer,
+                                OUT noderack text,
+                                OUT hasmetadata boolean,
+                                OUT isactive bool,
+                                OUT noderole noderole,
+                                OUT nodecluster name)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer,
+                                    groupid integer, noderole noderole, nodecluster name)
+  IS 'add node to the cluster';
+
+DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole);
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         groupid integer default 0,
+                                         noderole noderole default 'primary',
+                                         nodecluster name default 'default',
+                                         OUT nodeid integer,
+                                         OUT groupid integer,
+                                         OUT nodename text,
+                                         OUT nodeport integer,
+                                         OUT noderack text,
+                                         OUT hasmetadata boolean,
+                                         OUT isactive bool,
+                                         OUT noderole noderole,
+                                         OUT nodecluster name)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text,nodeport integer,
+                                             groupid integer, noderole noderole,
+                                             nodecluster name)
+  IS 'prepare node by adding it to pg_dist_node';
+
+DROP FUNCTION master_activate_node(text, integer);
+CREATE FUNCTION master_activate_node(nodename text,
+                                     nodeport integer,
+                                     OUT nodeid integer,
+                                     OUT groupid integer,
+                                     OUT nodename text,
+                                     OUT nodeport integer,
+                                     OUT noderack text,
+                                     OUT hasmetadata boolean,
+                                     OUT isactive bool,
+                                     OUT noderole noderole,
+                                     OUT nodecluster name)
+    RETURNS record
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME',$$master_activate_node$$;
+COMMENT ON FUNCTION master_activate_node(nodename text, nodeport integer)
+    IS 'activate a node which is in the cluster';
+
+RESET search_path;

--- a/src/backend/distributed/citus--7.0-8--7.0-9.sql
+++ b/src/backend/distributed/citus--7.0-8--7.0-9.sql
@@ -3,6 +3,9 @@
 SET search_path = 'pg_catalog';
 
 ALTER TABLE pg_dist_node ADD COLUMN nodecluster name NOT NULL DEFAULT 'default';
+ALTER TABLE pg_dist_node
+  ADD CONSTRAINT primaries_are_only_allowed_in_the_default_cluster
+  CHECK (NOT (nodecluster <> 'default' AND noderole = 'primary'));
 
 DROP FUNCTION master_add_node(text, integer, integer, noderole);
 CREATE FUNCTION master_add_node(nodename text,

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.0-8'
+default_version = '7.0-9'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -426,7 +426,7 @@ NodeListInsertCommand(List *workerNodeList)
 	/* generate the query without any values yet */
 	appendStringInfo(nodeListInsertCommand,
 					 "INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, "
-					 "noderack, hasmetadata, isactive, noderole) VALUES ");
+					 "noderack, hasmetadata, isactive, noderole, nodecluster) VALUES ");
 
 	/* iterate over the worker nodes, add the values */
 	foreach(workerNodeCell, workerNodeList)
@@ -440,7 +440,7 @@ NodeListInsertCommand(List *workerNodeList)
 		char *nodeRoleString = DatumGetCString(nodeRoleStringDatum);
 
 		appendStringInfo(nodeListInsertCommand,
-						 "(%d, %d, %s, %d, %s, %s, %s, '%s'::noderole)",
+						 "(%d, %d, %s, %d, %s, %s, %s, '%s'::noderole, %s)",
 						 workerNode->nodeId,
 						 workerNode->groupId,
 						 quote_literal_cstr(workerNode->workerName),
@@ -448,7 +448,8 @@ NodeListInsertCommand(List *workerNodeList)
 						 quote_literal_cstr(workerNode->workerRack),
 						 hasMetadataString,
 						 isActiveString,
-						 nodeRoleString);
+						 nodeRoleString,
+						 quote_literal_cstr(workerNode->nodeCluster));
 
 		processedWorkerNodeCount++;
 		if (processedWorkerNodeCount != workerCount)

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2349,6 +2349,7 @@ InitializeWorkerNodeCache(void)
 		workerNode->hasMetadata = currentNode->hasMetadata;
 		workerNode->isActive = currentNode->isActive;
 		workerNode->nodeRole = currentNode->nodeRole;
+		strlcpy(workerNode->nodeCluster, currentNode->nodeCluster, NAMEDATALEN);
 
 		if (handleFound)
 		{

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -726,16 +726,21 @@ AddNodeMetadata(char *nodeName, int32 nodePort, int32 groupId, char *nodeRack,
 	}
 
 	/* if nodeRole hasn't been added yet there's a constraint for one-node-per-group */
-	if (nodeRole != InvalidOid)
+	if (nodeRole != InvalidOid && nodeRole == PrimaryNodeRoleId())
 	{
-		if (nodeRole == PrimaryNodeRoleId())
-		{
-			WorkerNode *existingPrimaryNode = PrimaryNodeForGroup(groupId, NULL);
+		WorkerNode *existingPrimaryNode = PrimaryNodeForGroup(groupId, NULL);
 
-			if (existingPrimaryNode != NULL)
-			{
-				ereport(ERROR, (errmsg("group %d already has a primary node", groupId)));
-			}
+		if (existingPrimaryNode != NULL)
+		{
+			ereport(ERROR, (errmsg("group %d already has a primary node", groupId)));
+		}
+	}
+
+	if (nodeRole == PrimaryNodeRoleId())
+	{
+		if (strncmp(nodeCluster, WORKER_DEFAULT_CLUSTER, WORKER_LENGTH) != 0)
+		{
+			ereport(ERROR, (errmsg("primaries must be added to the default cluster")));
 		}
 	}
 

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -12,30 +12,6 @@
 #define PG_DIST_NODE_H
 
 /* ----------------
- *		pg_dist_node definition.
- * ----------------
- */
-typedef struct FormData_pg_dist_node
-{
-	int nodeid;
-	int groupid;
-#ifdef CATALOG_VARLEN
-	text nodename;
-	int nodeport;
-	bool hasmetadata;
-	bool isactive
-	Oid noderole;
-#endif
-} FormData_pg_dist_node;
-
-/* ----------------
- *      Form_pg_dist_partitions corresponds to a pointer to a tuple with
- *      the format of pg_dist_partitions relation.
- * ----------------
- */
-typedef FormData_pg_dist_node *Form_pg_dist_node;
-
-/* ----------------
  *      compiler constants for pg_dist_node
  * ----------------
  *
@@ -44,7 +20,7 @@ typedef FormData_pg_dist_node *Form_pg_dist_node;
  *  in particular their OUT parameters) must be changed whenever the definition of
  *  pg_dist_node changes.
  */
-#define Natts_pg_dist_node 8
+#define Natts_pg_dist_node 9
 #define Anum_pg_dist_node_nodeid 1
 #define Anum_pg_dist_node_groupid 2
 #define Anum_pg_dist_node_nodename 3
@@ -53,6 +29,7 @@ typedef FormData_pg_dist_node *Form_pg_dist_node;
 #define Anum_pg_dist_node_hasmetadata 6
 #define Anum_pg_dist_node_isactive 7
 #define Anum_pg_dist_node_noderole 8
+#define Anum_pg_dist_node_nodecluster 9
 
 #define GROUPID_SEQUENCE_NAME "pg_dist_groupid_seq"
 #define NODEID_SEQUENCE_NAME "pg_dist_node_nodeid_seq"

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -30,6 +30,8 @@
 #define WORKER_RACK_TRIES 5
 #define WORKER_DEFAULT_RACK "default"
 
+#define WORKER_DEFAULT_CLUSTER "default"
+
 /*
  * In memory representation of pg_dist_node table elements. The elements are hold in
  * WorkerNodeHash table.

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -17,7 +17,7 @@
 #include "nodes/pg_list.h"
 
 
-/* Worker node name's maximum length */
+/* Worker nodeName's, nodePort's, and nodeCluster's maximum length */
 #define WORKER_LENGTH 256
 
 /* Maximum length of worker port number (represented as string) */
@@ -44,6 +44,7 @@ typedef struct WorkerNode
 	bool hasMetadata;                   /* node gets metadata changes */
 	bool isActive;                      /* node's state */
 	Oid nodeRole;                       /* the node's role in its group */
+	char nodeCluster[NAMEDATALEN];      /* the cluster the node is a part of */
 } WorkerNode;
 
 

--- a/src/test/regress/expected/multi_703_upgrade.out
+++ b/src/test/regress/expected/multi_703_upgrade.out
@@ -11,12 +11,8 @@ ALTER EXTENSION citus UPDATE TO '7.0-3';
 ERROR:  There is no node at "localhost:57637"
 CONTEXT:  PL/pgSQL function citus.find_groupid_for_node(text,integer) line 6 at RAISE
 -- if you add a matching worker the upgrade should succeed
-SELECT master_add_node('localhost', :worker_1_port);
-          master_add_node          
------------------------------------
- (1,1,localhost,57637,default,f,t)
-(1 row)
-
+INSERT INTO pg_dist_node (nodename, nodeport, groupid)
+  VALUES ('localhost', :worker_1_port, 1);
 ALTER EXTENSION citus UPDATE TO '7.0-3';
 SELECT * FROM pg_dist_placement;
  placementid | shardid | shardstate | shardlength | groupid 

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -437,6 +437,9 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
  
 (1 row)
 
+-- check that you can't add a primary to a non-default cluster
+SELECT master_add_node('localhost', 9999, nodecluster => 'olap');
+ERROR:  primaries must be added to the default cluster
 -- check that you can't add more than one primary to a group
 SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
 SELECT master_add_node('localhost', 9999, groupid => :worker_1_group, noderole => 'primary');
@@ -471,5 +474,14 @@ UPDATE pg_dist_node SET noderole = 'primary'
   WHERE groupid = :worker_1_group AND nodeport = 9998;
 ERROR:  there cannot be two primary nodes in a group
 CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 18 at RAISE
+-- check that you can't manually add a primary to a non-default cluster
+INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole, nodecluster)
+  VALUES ('localhost', 5000, 1000, 'primary', 'olap');
+ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
+DETAIL:  Failing row contains (17, 1000, localhost, 5000, default, f, t, primary, olap).
+UPDATE pg_dist_node SET nodecluster = 'olap'
+  WHERE nodeport = :worker_1_port;
+ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
+DETAIL:  Failing row contains (13, 12, localhost, 57637, default, f, t, primary, olap).
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
 -- them in any of the remaining tests

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -281,16 +281,16 @@ SELECT count(1) FROM pg_dist_node;
 SELECT
 	master_add_node('localhost', :worker_1_port),
 	master_add_node('localhost', :worker_2_port);
-              master_add_node              |              master_add_node              
--------------------------------------------+-------------------------------------------
- (8,7,localhost,57637,default,f,t,primary) | (9,8,localhost,57638,default,f,t,primary)
+                  master_add_node                  |                  master_add_node                  
+---------------------------------------------------+---------------------------------------------------
+ (8,7,localhost,57637,default,f,t,primary,default) | (9,8,localhost,57638,default,f,t,primary,default)
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
---------+---------+-----------+----------+----------+-------------+----------+----------
-      8 |       7 | localhost |    57637 | default  | f           | t        | primary
-      9 |       8 | localhost |    57638 | default  | f           | t        | primary
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------
+      8 |       7 | localhost |    57637 | default  | f           | t        | primary  | default
+      9 |       8 | localhost |    57638 | default  | f           | t        | primary  | default
 (2 rows)
 
 -- check that mixed add/remove node commands work fine inside transaction

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -483,5 +483,32 @@ UPDATE pg_dist_node SET nodecluster = 'olap'
   WHERE nodeport = :worker_1_port;
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
 DETAIL:  Failing row contains (13, 12, localhost, 57637, default, f, t, primary, olap).
+-- check that you /can/ add a secondary node to a non-default cluster
+SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
+SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary', nodecluster=> 'olap');
+                  master_add_node                  
+---------------------------------------------------
+ (19,12,localhost,8888,default,f,t,secondary,olap)
+(1 row)
+
+-- check that super-long cluster names are truncated
+SELECT master_add_node('localhost', 8887, groupid => :worker_1_group, noderole => 'secondary', nodecluster=>
+	'thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.'
+	'thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.'
+	'thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.'
+	'thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.'
+	'overflow'
+);
+                                               master_add_node                                                
+--------------------------------------------------------------------------------------------------------------
+ (20,12,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.)
+(1 row)
+
+SELECT * FROM pg_dist_node WHERE nodeport=8887;
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           
+--------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------
+     20 |      12 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.
+(1 row)
+
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
 -- them in any of the remaining tests

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -28,10 +28,10 @@ SELECT master_get_active_worker_nodes();
 (2 rows)
 
 -- try to add a node that is already in the cluster
-SELECT * FROM master_add_node('localhost', :worker_1_port);
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
---------+---------+-----------+----------+----------+-------------+----------+----------
-      1 |       1 | localhost |    57637 | default  | f           | t        | primary
+SELECT nodeid, groupid FROM master_add_node('localhost', :worker_1_port);
+ nodeid | groupid 
+--------+---------
+      1 |       1
 (1 row)
 
 -- get the active nodes
@@ -140,10 +140,10 @@ SELECT master_get_active_worker_nodes();
 SELECT master_disable_node('localhost.noexist', 2345);
 ERROR:  node at "localhost.noexist:2345" does not exist
 -- restore the node for next tests
-SELECT master_activate_node('localhost', :worker_2_port);
-           master_activate_node            
--------------------------------------------
- (3,3,localhost,57638,default,f,t,primary)
+SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
+ isactive 
+----------
+ t
 (1 row)
 
 -- try to remove a node with active placements and see that node removal is failed
@@ -196,10 +196,10 @@ DETAIL:  there is a placement in group 3 but there are no nodes in that group
 SELECT groupid as new_group FROM master_add_node('localhost', :worker_2_port) \gset
 UPDATE pg_dist_placement SET groupid = :new_group WHERE groupid = :worker_2_group;
 -- test that you are allowed to remove secondary nodes even if there are placements
-SELECT master_add_node('localhost', 9990, groupid => :new_group, noderole => 'secondary');
-              master_add_node               
---------------------------------------------
- (5,4,localhost,9990,default,f,t,secondary)
+SELECT 1 FROM master_add_node('localhost', 9990, groupid => :new_group, noderole => 'secondary');
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT master_remove_node('localhost', :worker_2_port);
@@ -271,10 +271,11 @@ SELECT
                     | 
 (1 row)
 
-SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole 
---------+---------+----------+----------+----------+-------------+----------+----------
-(0 rows)
+SELECT count(1) FROM pg_dist_node;
+ count 
+-------
+     0
+(1 row)
 
 -- check that adding two nodes in the same transaction works
 SELECT
@@ -442,23 +443,23 @@ SELECT master_add_node('localhost', 9999, groupid => :worker_1_group, noderole =
 ERROR:  group 12 already has a primary node
 -- check that you can add secondaries and unavailable nodes to a group
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
-SELECT master_add_node('localhost', 9998, groupid => :worker_1_group, noderole => 'secondary');
-               master_add_node                
-----------------------------------------------
- (16,12,localhost,9998,default,f,t,secondary)
+SELECT 1 FROM master_add_node('localhost', 9998, groupid => :worker_1_group, noderole => 'secondary');
+ ?column? 
+----------
+        1
 (1 row)
 
-SELECT master_add_node('localhost', 9997, groupid => :worker_1_group, noderole => 'unavailable');
-                master_add_node                 
-------------------------------------------------
- (17,12,localhost,9997,default,f,t,unavailable)
+SELECT 1 FROM master_add_node('localhost', 9997, groupid => :worker_1_group, noderole => 'unavailable');
+ ?column? 
+----------
+        1
 (1 row)
 
 -- add_inactive_node also works with secondaries
-SELECT master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, noderole => 'secondary');
-           master_add_inactive_node           
-----------------------------------------------
- (18,14,localhost,9996,default,f,f,secondary)
+SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, noderole => 'secondary');
+ ?column? 
+----------
+        1
 (1 row)
 
 -- check that you can't manually add two primaries to a group

--- a/src/test/regress/expected/multi_drop_extension.out
+++ b/src/test/regress/expected/multi_drop_extension.out
@@ -19,16 +19,16 @@ DROP EXTENSION citus CASCADE;
 RESET client_min_messages;
 CREATE EXTENSION citus;
 -- re-add the nodes to the cluster
-SELECT master_add_node('localhost', :worker_1_port);
-              master_add_node              
--------------------------------------------
- (1,1,localhost,57637,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_1_port);
+ ?column? 
+----------
+        1
 (1 row)
 
-SELECT master_add_node('localhost', :worker_2_port);
-              master_add_node              
--------------------------------------------
- (2,2,localhost,57638,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- verify that a table can be created after the extension has been dropped and recreated

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -118,6 +118,7 @@ ALTER EXTENSION citus UPDATE TO '7.0-5';
 ALTER EXTENSION citus UPDATE TO '7.0-6';
 ALTER EXTENSION citus UPDATE TO '7.0-7';
 ALTER EXTENSION citus UPDATE TO '7.0-8';
+ALTER EXTENSION citus UPDATE TO '7.0-9';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -27,11 +27,11 @@ SELECT * FROM pg_dist_partition WHERE partmethod='h' AND repmodel='s';
 -- Show that, with no MX tables, metadata snapshot contains only the delete commands,
 -- pg_dist_node entries and reference tables
 SELECT unnest(master_metadata_snapshot());
-                                                                                                                              unnest                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                               unnest                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
 (3 rows)
 
 -- Create a test table with constraints and SERIAL
@@ -57,7 +57,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
@@ -78,7 +78,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
@@ -101,7 +101,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -130,7 +130,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -152,7 +152,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -178,9 +178,9 @@ SELECT count(*) FROM pg_dist_node WHERE hasmetadata=true;
 -- Ensure it works when run on a secondary node
 SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
 SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary');
-              master_add_node               
---------------------------------------------
- (4,1,localhost,8888,default,f,t,secondary)
+                  master_add_node                   
+----------------------------------------------------
+ (4,1,localhost,8888,default,f,t,secondary,default)
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', 8888);
@@ -229,10 +229,10 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
---------+---------+-----------+----------+----------+-------------+----------+----------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary  | default
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default
 (2 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -366,10 +366,10 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
---------+---------+-----------+----------+----------+-------------+----------+----------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary  | default
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default
 (2 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -1161,9 +1161,9 @@ SELECT create_distributed_table('mx_table', 'a');
 
 \c - postgres - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
-              master_add_node              
--------------------------------------------
- (5,4,localhost,57638,default,f,t,primary)
+                  master_add_node                  
+---------------------------------------------------
+ (5,4,localhost,57638,default,f,t,primary,default)
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
@@ -1374,9 +1374,9 @@ WHERE logicalrelid='mx_ref'::regclass;
 \c - - - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "mx_ref" to the node localhost:57638
-              master_add_node              
--------------------------------------------
- (6,5,localhost,57638,default,f,t,primary)
+                  master_add_node                  
+---------------------------------------------------
+ (6,5,localhost,57638,default,f,t,primary,default)
 (1 row)
 
 SELECT shardid, nodename, nodeport 

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -90,10 +90,10 @@ SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
 (1 row)
 
 -- make sure when we activate a secondary we don't add any placements
-SELECT master_activate_node('localhost', 9001);
-                  master_activate_node                  
---------------------------------------------------------
- (1380002,1380000,localhost,9001,default,f,t,secondary)
+SELECT 1 FROM master_activate_node('localhost', 9001);
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
@@ -222,11 +222,11 @@ WHERE
 SELECT master_remove_node('localhost', :worker_2_port);
 ERROR:  node at "localhost:57638" does not exist
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1380003,1380001,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- try to disable the node before removing it (this used to crash)
@@ -243,11 +243,11 @@ SELECT master_remove_node('localhost', :worker_2_port);
 (1 row)
 
 -- re-add the node for the next test
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1380004,1380002,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- remove node in a transaction and ROLLBACK
@@ -466,11 +466,11 @@ WHERE
     
 \c - - - :master_port
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1380005,1380003,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- test inserting a value then removing a node in a transaction
@@ -595,11 +595,11 @@ SELECT * FROM remove_node_reference_table;
     
 \c - - - :master_port
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1380006,1380004,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- test executing DDL command then removing a node in a transaction
@@ -720,11 +720,11 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.remove_
 (2 rows)
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1380007,1380005,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- test DROP table after removing a node in a transaction
@@ -789,10 +789,10 @@ SELECT * FROM pg_dist_colocation WHERE colocationid = 1380000;
 (0 rows)
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
-                    master_add_node                    
--------------------------------------------------------
- (1380008,1380006,localhost,57638,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- re-create remove_node_reference_table
@@ -922,12 +922,12 @@ WHERE
 \c - - - :master_port     
      
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
 NOTICE:  Replicating reference table "table1" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1380009,1380007,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- test with master_disable_node
@@ -1040,12 +1040,12 @@ WHERE
     
 \c - - - :master_port
 -- re-add the node for next tests
-SELECT master_activate_node('localhost', :worker_2_port);
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "remove_node_reference_table" to the node localhost:57638
 NOTICE:  Replicating reference table "table1" to the node localhost:57638
-                 master_activate_node                  
--------------------------------------------------------
- (1380009,1380007,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- DROP tables to clean workspace

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -23,10 +23,10 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
      0
 (1 row)
 
-SELECT master_add_node('localhost', :worker_2_port);
-                    master_add_node                    
--------------------------------------------------------
- (1370000,1370000,localhost,57638,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- verify node is added
@@ -69,7 +69,7 @@ SELECT create_reference_table('replicate_reference_table_unhealthy');
 (1 row)
 
 UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1370000;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ERROR:  could not find any healthy placement for shard 1370000
 -- verify node is not added
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
@@ -120,11 +120,11 @@ WHERE colocationid IN
       1370001 |          1 |                 1 |                      0
 (1 row)
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_valid" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1370002,1370002,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- status after master_add_node
@@ -174,10 +174,10 @@ WHERE colocationid IN
       1370001 |          1 |                 2 |                      0
 (1 row)
 
-SELECT master_add_node('localhost', :worker_2_port);
-                    master_add_node                    
--------------------------------------------------------
- (1370002,1370002,localhost,57638,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- status after master_add_node
@@ -241,11 +241,11 @@ WHERE colocationid IN
 (1 row)
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_rollback" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1370003,1370003,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 ROLLBACK;
@@ -303,11 +303,11 @@ WHERE colocationid IN
 (1 row)
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_commit" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1370004,1370004,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 COMMIT;
@@ -398,11 +398,11 @@ ORDER BY logicalrelid;
 (2 rows)
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_reference_one" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1370005,1370005,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT upgrade_to_reference_table('replicate_reference_table_hash');
@@ -480,7 +480,7 @@ SELECT create_reference_table('replicate_reference_table_insert');
 
 BEGIN;
 INSERT INTO replicate_reference_table_insert VALUES(1);
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_insert" to the node localhost:57638
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
@@ -495,7 +495,7 @@ SELECT create_reference_table('replicate_reference_table_copy');
 
 BEGIN;
 COPY replicate_reference_table_copy FROM STDIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_copy" to the node localhost:57638
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
@@ -512,7 +512,7 @@ BEGIN;
 ALTER TABLE replicate_reference_table_ddl ADD column2 int;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_ddl" to the node localhost:57638
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
@@ -548,11 +548,11 @@ WHERE colocationid IN
 (1 row)
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "replicate_reference_table_drop" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1370009,1370009,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 DROP TABLE replicate_reference_table_drop;
@@ -610,11 +610,11 @@ WHERE colocationid IN
       1370010 |          1 |                 1 |                      0
 (1 row)
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "table1" to the node localhost:57638
-                    master_add_node                    
--------------------------------------------------------
- (1370010,1370010,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 -- status after master_add_node
@@ -656,10 +656,10 @@ SELECT create_reference_table('initially_not_replicated_reference_table');
  
 (1 row)
 
-SELECT master_add_inactive_node('localhost', :worker_2_port);
-               master_add_inactive_node                
--------------------------------------------------------
- (1370011,1370011,localhost,57638,default,f,f,primary)
+SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- we should see only one shard placements
@@ -681,11 +681,11 @@ ORDER BY 1,4,5;
 (1 row)
 
 -- we should see the two shard placements after activation
-SELECT master_activate_node('localhost', :worker_2_port);
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "initially_not_replicated_reference_table" to the node localhost:57638
-                 master_activate_node                  
--------------------------------------------------------
- (1370011,1370011,localhost,57638,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT
@@ -707,10 +707,10 @@ ORDER BY 1,4,5;
 (2 rows)
 
 -- this should have no effect
-SELECT master_add_node('localhost', :worker_2_port);
-                    master_add_node                    
--------------------------------------------------------
- (1370011,1370011,localhost,57638,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- drop unnecassary tables

--- a/src/test/regress/expected/multi_table_ddl.out
+++ b/src/test/regress/expected/multi_table_ddl.out
@@ -76,16 +76,16 @@ SELECT * FROM pg_dist_shard_placement;
 DROP EXTENSION citus;
 CREATE EXTENSION citus;
 -- re-add the nodes to the cluster
-SELECT master_add_node('localhost', :worker_1_port);
-              master_add_node              
--------------------------------------------
- (1,1,localhost,57637,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_1_port);
+ ?column? 
+----------
+        1
 (1 row)
 
-SELECT master_add_node('localhost', :worker_2_port);
-              master_add_node              
--------------------------------------------
- (2,2,localhost,57638,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 -- create a table with a SERIAL column

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -216,7 +216,7 @@ SELECT count(*) FROM mx_table;
 (1 row)
 
 -- master_add_node
-SELECT master_add_node('localhost', 5432);
+SELECT 1 FROM master_add_node('localhost', 5432);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
 SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
@@ -230,20 +230,20 @@ SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 DROP INDEX mx_test_uniq_index;
 NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
-SELECT master_add_node('localhost', 5432);
-                   master_add_node                    
-------------------------------------------------------
- (1370000,1370000,localhost,5432,default,f,t,primary)
+SELECT 1 FROM master_add_node('localhost', 5432);
+ ?column? 
+----------
+        1
 (1 row)
 
 \c - - - :worker_1_port
 SELECT master_remove_node('localhost', 5432);
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
-SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
- nodeid  | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole 
----------+---------+-----------+----------+----------+-------------+----------+----------
- 1370000 | 1370000 | localhost |     5432 | default  | f           | t        | primary
+SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
+ count 
+-------
+     1
 (1 row)
 
 \c - - - :master_port

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -585,7 +585,7 @@ SELECT shardid, nodename, nodeport
 	WHERE logicalrelid = 'numbers_append'::regclass order by placementid;
 
 -- add the node back
-SELECT master_activate_node('localhost', :worker_1_port);
+SELECT 1 FROM master_activate_node('localhost', :worker_1_port);
 RESET citus.shard_replication_factor;
 -- add two new shards and verify they are created at both workers
 COPY numbers_append FROM STDIN WITH (FORMAT 'csv');

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -764,12 +764,12 @@ SELECT shardid, nodename, nodeport
 (6 rows)
 
 -- add the node back
-SELECT master_activate_node('localhost', :worker_1_port);
+SELECT 1 FROM master_activate_node('localhost', :worker_1_port);
 NOTICE:  Replicating reference table "nation" to the node localhost:57637
 NOTICE:  Replicating reference table "supplier" to the node localhost:57637
-           master_activate_node            
--------------------------------------------
- (1,1,localhost,57637,default,f,t,primary)
+ ?column? 
+----------
+        1
 (1 row)
 
 RESET citus.shard_replication_factor;

--- a/src/test/regress/sql/multi_703_upgrade.sql
+++ b/src/test/regress/sql/multi_703_upgrade.sql
@@ -15,7 +15,8 @@ INSERT INTO pg_dist_shard_placement
 ALTER EXTENSION citus UPDATE TO '7.0-3';
 
 -- if you add a matching worker the upgrade should succeed
-SELECT master_add_node('localhost', :worker_1_port);
+INSERT INTO pg_dist_node (nodename, nodeport, groupid)
+  VALUES ('localhost', :worker_1_port, 1);
 ALTER EXTENSION citus UPDATE TO '7.0-3';
 
 SELECT * FROM pg_dist_placement;

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -184,6 +184,9 @@ DELETE FROM pg_dist_node;
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
 
+-- check that you can't add a primary to a non-default cluster
+SELECT master_add_node('localhost', 9999, nodecluster => 'olap');
+
 -- check that you can't add more than one primary to a group
 SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
 SELECT master_add_node('localhost', 9999, groupid => :worker_1_group, noderole => 'primary');
@@ -200,6 +203,12 @@ INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole)
   VALUES ('localhost', 5000, :worker_1_group, 'primary');
 UPDATE pg_dist_node SET noderole = 'primary'
   WHERE groupid = :worker_1_group AND nodeport = 9998;
+
+-- check that you can't manually add a primary to a non-default cluster
+INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole, nodecluster)
+  VALUES ('localhost', 5000, 1000, 'primary', 'olap');
+UPDATE pg_dist_node SET nodecluster = 'olap'
+  WHERE nodeport = :worker_1_port;
 
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
 -- them in any of the remaining tests

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -15,7 +15,7 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT master_get_active_worker_nodes();
 
 -- try to add a node that is already in the cluster
-SELECT * FROM master_add_node('localhost', :worker_1_port);
+SELECT nodeid, groupid FROM master_add_node('localhost', :worker_1_port);
 
 -- get the active nodes
 SELECT master_get_active_worker_nodes();
@@ -56,7 +56,7 @@ SELECT master_get_active_worker_nodes();
 SELECT master_disable_node('localhost.noexist', 2345);
 
 -- restore the node for next tests
-SELECT master_activate_node('localhost', :worker_2_port);
+SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
 
 -- try to remove a node with active placements and see that node removal is failed
 SELECT master_remove_node('localhost', :worker_2_port); 
@@ -87,7 +87,7 @@ SELECT groupid as new_group FROM master_add_node('localhost', :worker_2_port) \g
 UPDATE pg_dist_placement SET groupid = :new_group WHERE groupid = :worker_2_group;
 
 -- test that you are allowed to remove secondary nodes even if there are placements
-SELECT master_add_node('localhost', 9990, groupid => :new_group, noderole => 'secondary');
+SELECT 1 FROM master_add_node('localhost', 9990, groupid => :new_group, noderole => 'secondary');
 SELECT master_remove_node('localhost', :worker_2_port);
 SELECT master_remove_node('localhost', 9990);
 
@@ -117,7 +117,7 @@ SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodep
 SELECT 
 	master_remove_node('localhost', :worker_1_port), 
 	master_remove_node('localhost', :worker_2_port);
-SELECT * FROM pg_dist_node ORDER BY nodeid;
+SELECT count(1) FROM pg_dist_node;
 
 -- check that adding two nodes in the same transaction works
 SELECT
@@ -190,10 +190,10 @@ SELECT master_add_node('localhost', 9999, groupid => :worker_1_group, noderole =
 
 -- check that you can add secondaries and unavailable nodes to a group
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
-SELECT master_add_node('localhost', 9998, groupid => :worker_1_group, noderole => 'secondary');
-SELECT master_add_node('localhost', 9997, groupid => :worker_1_group, noderole => 'unavailable');
+SELECT 1 FROM master_add_node('localhost', 9998, groupid => :worker_1_group, noderole => 'secondary');
+SELECT 1 FROM master_add_node('localhost', 9997, groupid => :worker_1_group, noderole => 'unavailable');
 -- add_inactive_node also works with secondaries
-SELECT master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, noderole => 'secondary');
+SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, noderole => 'secondary');
 
 -- check that you can't manually add two primaries to a group
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole)

--- a/src/test/regress/sql/multi_drop_extension.sql
+++ b/src/test/regress/sql/multi_drop_extension.sql
@@ -21,8 +21,8 @@ RESET client_min_messages;
 CREATE EXTENSION citus;
 
 -- re-add the nodes to the cluster
-SELECT master_add_node('localhost', :worker_1_port);
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_1_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- verify that a table can be created after the extension has been dropped and recreated
 CREATE TABLE testtableddl(somecol int, distributecol text NOT NULL);

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -118,6 +118,7 @@ ALTER EXTENSION citus UPDATE TO '7.0-5';
 ALTER EXTENSION citus UPDATE TO '7.0-6';
 ALTER EXTENSION citus UPDATE TO '7.0-7';
 ALTER EXTENSION citus UPDATE TO '7.0-8';
+ALTER EXTENSION citus UPDATE TO '7.0-9';
 
 -- show running version
 SHOW citus.version;

--- a/src/test/regress/sql/multi_remove_node_reference_table.sql
+++ b/src/test/regress/sql/multi_remove_node_reference_table.sql
@@ -47,7 +47,7 @@ SELECT master_disable_node('localhost', 9001);
 SELECT isactive FROM pg_dist_node WHERE nodeport = 9001;
 SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
 -- make sure when we activate a secondary we don't add any placements
-SELECT master_activate_node('localhost', 9001);
+SELECT 1 FROM master_activate_node('localhost', 9001);
 SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
 -- make sure when we remove a secondary we don't remove any placements
 SELECT master_remove_node('localhost', 9001);
@@ -119,14 +119,14 @@ WHERE
 SELECT master_remove_node('localhost', :worker_2_port);
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- try to disable the node before removing it (this used to crash)
 SELECT master_disable_node('localhost', :worker_2_port);
 SELECT master_remove_node('localhost', :worker_2_port);
 
 -- re-add the node for the next test
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- remove node in a transaction and ROLLBACK
 
@@ -261,7 +261,7 @@ WHERE
 \c - - - :master_port
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- test inserting a value then removing a node in a transaction
 
@@ -336,7 +336,7 @@ SELECT * FROM remove_node_reference_table;
 \c - - - :master_port
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 
 -- test executing DDL command then removing a node in a transaction
@@ -410,7 +410,7 @@ WHERE
 SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.remove_node_reference_table'::regclass;
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 
 -- test DROP table after removing a node in a transaction
@@ -450,7 +450,7 @@ WHERE
 SELECT * FROM pg_dist_colocation WHERE colocationid = 1380000;
 
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- re-create remove_node_reference_table
 CREATE TABLE remove_node_reference_table(column1 int);
@@ -527,7 +527,7 @@ WHERE
 \c - - - :master_port     
      
 -- re-add the node for next tests
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 
 -- test with master_disable_node
@@ -598,7 +598,7 @@ WHERE
 \c - - - :master_port
 
 -- re-add the node for next tests
-SELECT master_activate_node('localhost', :worker_2_port);
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
 
 
 -- DROP tables to clean workspace

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -21,7 +21,7 @@ SELECT master_remove_node('localhost', :worker_2_port);
 -- verify there is no node with nodeport = :worker_2_port before adding the node
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- verify node is added
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
@@ -45,7 +45,7 @@ CREATE TABLE replicate_reference_table_unhealthy(column1 int);
 SELECT create_reference_table('replicate_reference_table_unhealthy');
 UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1370000;
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- verify node is not added
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
@@ -80,7 +80,7 @@ WHERE colocationid IN
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- status after master_add_node
 SELECT
@@ -115,7 +115,7 @@ WHERE colocationid IN
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- status after master_add_node
 SELECT
@@ -157,7 +157,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ROLLBACK;
 
 -- status after master_add_node
@@ -198,7 +198,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 COMMIT;
 
 -- status after master_add_node
@@ -260,7 +260,7 @@ WHERE
 ORDER BY logicalrelid;
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT upgrade_to_reference_table('replicate_reference_table_hash');
 SELECT create_reference_table('replicate_reference_table_reference_two');
 COMMIT;
@@ -304,7 +304,7 @@ SELECT create_reference_table('replicate_reference_table_insert');
 
 BEGIN;
 INSERT INTO replicate_reference_table_insert VALUES(1);
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ROLLBACK;
 
 DROP TABLE replicate_reference_table_insert;
@@ -322,7 +322,7 @@ COPY replicate_reference_table_copy FROM STDIN;
 4
 5
 \.
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ROLLBACK;
 
 DROP TABLE replicate_reference_table_copy;
@@ -334,7 +334,7 @@ SELECT create_reference_table('replicate_reference_table_ddl');
 
 BEGIN;
 ALTER TABLE replicate_reference_table_ddl ADD column2 int;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ROLLBACK;
 
 DROP TABLE replicate_reference_table_ddl;
@@ -360,7 +360,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_drop'::regclass);
 
 BEGIN;
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 DROP TABLE replicate_reference_table_drop;
 COMMIT;
 
@@ -396,7 +396,7 @@ WHERE colocationid IN
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
 
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- status after master_add_node
 SELECT
@@ -422,7 +422,7 @@ SELECT master_remove_node('localhost', :worker_2_port);
 CREATE TABLE initially_not_replicated_reference_table (key int);
 SELECT create_reference_table('initially_not_replicated_reference_table');
 
-SELECT master_add_inactive_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
 
 -- we should see only one shard placements
 SELECT
@@ -439,7 +439,7 @@ WHERE
 ORDER BY 1,4,5;
 
 -- we should see the two shard placements after activation
-SELECT master_activate_node('localhost', :worker_2_port);
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
 
 SELECT
     shardid, shardstate, shardlength, nodename, nodeport
@@ -455,7 +455,7 @@ WHERE
 ORDER BY 1,4,5;
 
 -- this should have no effect
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- drop unnecassary tables
 DROP TABLE initially_not_replicated_reference_table;

--- a/src/test/regress/sql/multi_table_ddl.sql
+++ b/src/test/regress/sql/multi_table_ddl.sql
@@ -56,8 +56,8 @@ DROP EXTENSION citus;
 CREATE EXTENSION citus;
 
 -- re-add the nodes to the cluster
-SELECT master_add_node('localhost', :worker_1_port);
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_1_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- create a table with a SERIAL column
 CREATE TABLE testserialtable(id serial, group_id integer);

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -118,17 +118,17 @@ SELECT count(*) FROM mx_table;
 
 -- master_add_node
 
-SELECT master_add_node('localhost', 5432);
+SELECT 1 FROM master_add_node('localhost', 5432);
 SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 -- master_remove_node
 \c - - - :master_port
 DROP INDEX mx_test_uniq_index;
-SELECT master_add_node('localhost', 5432);
+SELECT 1 FROM master_add_node('localhost', 5432);
 
 \c - - - :worker_1_port
 SELECT master_remove_node('localhost', 5432);
-SELECT * FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
+SELECT count(1) FROM pg_dist_node WHERE nodename='localhost' AND nodeport=5432;
 
 \c - - - :master_port
 SELECT master_remove_node('localhost', 5432);


### PR DESCRIPTION
In the interest of making this easier review I decided to create a master ticket for follower clusters, #1528, and submit three different PRs. This one only adds the `nodecluster` column, it doesn't add any functionality.

Currently `nodecluster` is `text` as that matches `workername` and `noderack`. I think, however, that a better type would be `varchar(256)`, as that's how it's handled internally, and currently names above that length are silently clipped (I believe).