### PR TITLE
Avoid connections that accessed non-colocated placements in multi-shard commands

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -763,7 +763,7 @@ OpenCopyConnections(CopyStmt *copyStatement, ShardConnections *shardConnections,
 		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);
 		char *nodeUser = CurrentUserName();
 		MultiConnection *connection = NULL;
-		uint32 connectionFlags = FOR_DML;
+		uint32 connectionFlags = FOR_DML | CONNECTION_PER_PLACEMENT;
 		StringInfo copyCommand = NULL;
 		PGresult *result = NULL;
 

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -482,6 +482,12 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 	List *claimedConnectionList = NIL;
 	ListCell *connectionCell = NULL;
 	ListCell *shardPlacementCell = NULL;
+	int connectionFlags = FOR_DDL;
+
+	if (useExclusiveConnection)
+	{
+		connectionFlags |= CONNECTION_PER_PLACEMENT;
+	}
 
 	BeginOrContinueCoordinatedTransaction();
 
@@ -498,7 +504,7 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 			shardIndex = ShardIndex(shardInterval);
 		}
 
-		connection = GetPlacementConnection(FOR_DDL, shardPlacement,
+		connection = GetPlacementConnection(connectionFlags, shardPlacement,
 											placementOwner);
 		if (useExclusiveConnection)
 		{

--- a/src/backend/distributed/transaction/multi_shard_transaction.c
+++ b/src/backend/distributed/transaction/multi_shard_transaction.c
@@ -46,6 +46,8 @@ OpenTransactionsForAllTasks(List *taskList, int connectionFlags)
 
 	shardConnectionHash = CreateShardConnectionHash(CurrentMemoryContext);
 
+	connectionFlags |= CONNECTION_PER_PLACEMENT;
+
 	/* open connections to shards which don't have connections yet */
 	foreach(taskCell, taskList)
 	{

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -37,7 +37,10 @@ enum MultiConnectionMode
 
 	FOR_DDL = 1 << 2,
 
-	FOR_DML = 1 << 3
+	FOR_DML = 1 << 3,
+
+	/* open a connection per (co-located set of) placement(s) */
+	CONNECTION_PER_PLACEMENT = 1 << 4
 };
 
 

--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -441,9 +441,8 @@ SELECT create_distributed_table('products', 'product_no');
 
 BEGIN;
 INSERT INTO products VALUES(1,'product_1', 5);
--- DDL may error out after an INSERT because it might pick the wrong connection
+-- DDL should pick the right connections after a single INSERT
 ALTER TABLE products ADD CONSTRAINT unn_pno UNIQUE(product_no);
-ERROR:  cannot establish a new connection for placement 1450407, since DML has been executed on a connection that is in use
 ROLLBACK;
 BEGIN;
 -- Add constraints

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -1648,13 +1648,10 @@ INSERT INTO raw_events_first (user_id)
 SELECT user_id FROM raw_events_second JOIN reference_table USING (user_id);
 ERROR:  cannot establish a new connection for placement 13300024, since DDL has been executed on a connection that is in use
 ROLLBACK;
--- Insert after copy is disallowed when the INSERT INTO ... SELECT  chooses
--- to use a connection for one shard, while the connection already modified
--- another shard.
+-- Insert after copy is allowed
 BEGIN;
 COPY raw_events_second (user_id, value_1) FROM STDIN DELIMITER ',';
 INSERT INTO raw_events_first SELECT * FROM raw_events_second;
-ERROR:  cannot establish a new connection for placement 13300005, since DML has been executed on a connection that is in use
 ROLLBACK;
 -- Insert after copy is currently allowed for single-shard operation.
 -- Both insert and copy are rolled back successfully.

--- a/src/test/regress/sql/multi_alter_table_add_constraints.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints.sql
@@ -382,7 +382,7 @@ SELECT create_distributed_table('products', 'product_no');
 BEGIN;
 INSERT INTO products VALUES(1,'product_1', 5);
 
--- DDL may error out after an INSERT because it might pick the wrong connection
+-- DDL should pick the right connections after a single INSERT
 ALTER TABLE products ADD CONSTRAINT unn_pno UNIQUE(product_no);
 ROLLBACK;
 

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -1343,9 +1343,7 @@ INSERT INTO raw_events_first (user_id)
 SELECT user_id FROM raw_events_second JOIN reference_table USING (user_id);
 ROLLBACK;
 
--- Insert after copy is disallowed when the INSERT INTO ... SELECT  chooses
--- to use a connection for one shard, while the connection already modified
--- another shard.
+-- Insert after copy is allowed
 BEGIN;
 COPY raw_events_second (user_id, value_1) FROM STDIN DELIMITER ',';
 100,100


### PR DESCRIPTION
When we execute a multi-shard command we call `GetPlacementListConnection` for every shard placement. However, if a subset of placements was modified earlier in the transaction and then `GetPlacementListConnection` is called for a placement that hasn't been modified yet, then it may return a connection that already modified a placement. Since we strictly need a connection per placement for multi-shard commands, the command would then error out.

This change fixes the issue by checking whether the connection was already used for a non-co-located placement in the same table or colocation group, and opening a new connection if that was the case.