### PR TITLE
Use cstore_table_size function to determine cstore table size

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -86,11 +86,16 @@ citus_total_relation_size(PG_FUNCTION_ARGS)
 {
 	Oid relationId = PG_GETARG_OID(0);
 	uint64 totalRelationSize = 0;
+	char *tableSizeFunction = PG_TOTAL_RELATION_SIZE_FUNCTION;
 
 	CheckCitusVersion(ERROR);
 
-	totalRelationSize = DistributedTableSize(relationId,
-											 PG_TOTAL_RELATION_SIZE_FUNCTION);
+	if (CStoreTable(relationId))
+	{
+		tableSizeFunction = CSTORE_TABLE_SIZE_FUNCTION;
+	}
+
+	totalRelationSize = DistributedTableSize(relationId, tableSizeFunction);
 
 	PG_RETURN_INT64(totalRelationSize);
 }
@@ -105,10 +110,16 @@ citus_table_size(PG_FUNCTION_ARGS)
 {
 	Oid relationId = PG_GETARG_OID(0);
 	uint64 tableSize = 0;
+	char *tableSizeFunction = PG_TABLE_SIZE_FUNCTION;
 
 	CheckCitusVersion(ERROR);
 
-	tableSize = DistributedTableSize(relationId, PG_TABLE_SIZE_FUNCTION);
+	if (CStoreTable(relationId))
+	{
+		tableSizeFunction = CSTORE_TABLE_SIZE_FUNCTION;
+	}
+
+	tableSize = DistributedTableSize(relationId, tableSizeFunction);
 
 	PG_RETURN_INT64(tableSize);
 }
@@ -123,10 +134,16 @@ citus_relation_size(PG_FUNCTION_ARGS)
 {
 	Oid relationId = PG_GETARG_OID(0);
 	uint64 relationSize = 0;
+	char *tableSizeFunction = PG_RELATION_SIZE_FUNCTION;
 
 	CheckCitusVersion(ERROR);
 
-	relationSize = DistributedTableSize(relationId, PG_RELATION_SIZE_FUNCTION);
+	if (CStoreTable(relationId))
+	{
+		tableSizeFunction = CSTORE_TABLE_SIZE_FUNCTION;
+	}
+
+	relationSize = DistributedTableSize(relationId, tableSizeFunction);
 
 	PG_RETURN_INT64(relationSize);
 }

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -30,6 +30,7 @@
 #define PG_TABLE_SIZE_FUNCTION "pg_table_size(%s)"
 #define PG_RELATION_SIZE_FUNCTION "pg_relation_size(%s)"
 #define PG_TOTAL_RELATION_SIZE_FUNCTION "pg_total_relation_size(%s)"
+#define CSTORE_TABLE_SIZE_FUNCTION "cstore_table_size(%s)"
 
 #if (PG_VERSION_NUM < 100000)
 static inline void


### PR DESCRIPTION
pg_table_size/pg_relation_size variants always return 0 for
cstore tables. We should be using cstore_table_size function
for cstore_tables.

fixes #1513 