### PR TITLE
master_activate_node UDF also returns noderole

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -11,7 +11,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	6.0-1 6.0-2 6.0-3 6.0-4 6.0-5 6.0-6 6.0-7 6.0-8 6.0-9 6.0-10 6.0-11 6.0-12 6.0-13 6.0-14 6.0-15 6.0-16 6.0-17 6.0-18 \
 	6.1-1 6.1-2 6.1-3 6.1-4 6.1-5 6.1-6 6.1-7 6.1-8 6.1-9 6.1-10 6.1-11 6.1-12 6.1-13 6.1-14 6.1-15 6.1-16 6.1-17 \
 	6.2-1 6.2-2 6.2-3 6.2-4 \
-	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5 7.0-6 7.0-7
+	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5 7.0-6 7.0-7 7.0-8
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -152,6 +152,8 @@ $(EXTENSION)--7.0-5.sql: $(EXTENSION)--7.0-4.sql $(EXTENSION)--7.0-4--7.0-5.sql
 $(EXTENSION)--7.0-6.sql: $(EXTENSION)--7.0-5.sql $(EXTENSION)--7.0-5--7.0-6.sql
 	cat $^ > $@
 $(EXTENSION)--7.0-7.sql: $(EXTENSION)--7.0-6.sql $(EXTENSION)--7.0-6--7.0-7.sql
+	cat $^ > $@
+$(EXTENSION)--7.0-8.sql: $(EXTENSION)--7.0-7.sql $(EXTENSION)--7.0-7--7.0-8.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.0-7--7.0-8.sql
+++ b/src/backend/distributed/citus--7.0-7--7.0-8.sql
@@ -1,0 +1,22 @@
+/* citus--7.0-7--7.0-8.sql */
+
+SET search_path = 'pg_catalog';
+
+DROP FUNCTION master_activate_node(text, integer);
+CREATE FUNCTION master_activate_node(nodename text,
+                                     nodeport integer,
+                                     OUT nodeid integer,
+                                     OUT groupid integer,
+                                     OUT nodename text,
+                                     OUT nodeport integer,
+                                     OUT noderack text,
+                                     OUT hasmetadata boolean,
+                                     OUT isactive bool,
+                                     OUT noderole noderole)
+    RETURNS record
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME',$$master_activate_node$$;
+COMMENT ON FUNCTION master_activate_node(nodename text, nodeport integer)
+    IS 'activate a node which is in the cluster';
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.0-7'
+default_version = '7.0-8'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -122,7 +122,7 @@ master_add_node(PG_FUNCTION_ARGS)
 		nodeRecord = ActivateNode(nodeNameString, nodePort);
 	}
 
-	PG_RETURN_CSTRING(nodeRecord);
+	PG_RETURN_DATUM(nodeRecord);
 }
 
 
@@ -150,7 +150,7 @@ master_add_inactive_node(PG_FUNCTION_ARGS)
 	nodeRecord = AddNodeMetadata(nodeNameString, nodePort, groupId, nodeRack,
 								 hasMetadata, isActive, nodeRole, &nodeAlreadyExists);
 
-	PG_RETURN_CSTRING(nodeRecord);
+	PG_RETURN_DATUM(nodeRecord);
 }
 
 
@@ -244,7 +244,7 @@ master_activate_node(PG_FUNCTION_ARGS)
 
 	nodeRecord = ActivateNode(nodeNameString, nodePort);
 
-	PG_RETURN_CSTRING(nodeRecord);
+	PG_RETURN_DATUM(nodeRecord);
 }
 
 

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -38,6 +38,11 @@ typedef FormData_pg_dist_node *Form_pg_dist_node;
 /* ----------------
  *      compiler constants for pg_dist_node
  * ----------------
+ *
+ *  n.b. master_add_node, master_add_inactive_node, and master_activate_node all
+ *  directly return pg_dist_node tuples. This means their definitions (and
+ *  in particular their OUT parameters) must be changed whenever the definition of
+ *  pg_dist_node changes.
  */
 #define Natts_pg_dist_node 8
 #define Anum_pg_dist_node_nodeid 1

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -76,10 +76,10 @@ SELECT master_get_active_worker_nodes();
 (1 row)
 
 -- add some shard placements to the cluster
-SELECT master_activate_node('localhost', :worker_2_port);
-           master_activate_node            
--------------------------------------------
- (3,3,localhost,57638,default,f,t,primary)
+SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
+ isactive 
+----------
+ t
 (1 row)
 
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -117,6 +117,7 @@ ALTER EXTENSION citus UPDATE TO '7.0-4';
 ALTER EXTENSION citus UPDATE TO '7.0-5';
 ALTER EXTENSION citus UPDATE TO '7.0-6';
 ALTER EXTENSION citus UPDATE TO '7.0-7';
+ALTER EXTENSION citus UPDATE TO '7.0-8';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -64,7 +64,8 @@ test: multi_task_assignment_policy multi_cross_shard
 test: multi_utility_statements
 test: multi_dropped_column_aliases
 test: multi_binary_master_copy_format
-test: multi_prepare_sql multi_prepare_plsql
+test: multi_prepare_sql
+test: multi_prepare_plsql
 test: multi_sql_function
 test: multi_view
 

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -32,7 +32,7 @@ SELECT master_disable_node('localhost', :worker_2_port);
 SELECT master_get_active_worker_nodes();
 
 -- add some shard placements to the cluster
-SELECT master_activate_node('localhost', :worker_2_port);
+SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
 SELECT master_create_distributed_table('cluster_management_test', 'col_1', 'hash');
 SELECT master_create_worker_shards('cluster_management_test', 16, 1);

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -117,6 +117,7 @@ ALTER EXTENSION citus UPDATE TO '7.0-4';
 ALTER EXTENSION citus UPDATE TO '7.0-5';
 ALTER EXTENSION citus UPDATE TO '7.0-6';
 ALTER EXTENSION citus UPDATE TO '7.0-7';
+ALTER EXTENSION citus UPDATE TO '7.0-8';
 
 -- show running version
 SHOW citus.version;


### PR DESCRIPTION
Fix bug introduced by https://github.com/citusdata/citus/pull/1476

Before this PR master_activate_node fails when used as a range table:

```
-SELECT master_activate_node('localhost', :worker_2_port);
-           master_activate_node            
--------------------------------------------
- (3,3,localhost,57638,default,f,t,primary)
-(1 row)
-
+SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
+ERROR:  function return row and query-specified return row do not match
+DETAIL:  Returned row contains 8 attributes, but query expects 7.
```