### PR TITLE
Remove distributed tables' dependency on distribution key columns.

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -148,7 +148,7 @@ static char * ExtractNewExtensionVersion(Node *parsetree);
 static void CreateLocalTable(RangeVar *relation, char *nodeName, int32 nodePort);
 static bool IsAlterTableRenameStmt(RenameStmt *renameStmt);
 static bool AlterInvolvesPartitionColumn(AlterTableStmt *alterTableStatement,
-												AlterTableCmd *command);
+										 AlterTableCmd *command);
 static void ExecuteDistributedDDLJob(DDLJob *ddlJob);
 static void ShowNoticeIfNotUsing2PC(void);
 static List * DDLTaskList(Oid relationId, const char *commandString);
@@ -1727,7 +1727,7 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 				if (AlterInvolvesPartitionColumn(alterTableStatement, command))
 				{
 					ereport(ERROR, (errmsg("cannot execute ALTER TABLE command "
-								   "involving partition column")));
+										   "involving partition column")));
 				}
 				break;
 			}
@@ -1828,7 +1828,7 @@ ErrorIfAlterDropsPartitionColumn(AlterTableStmt *alterTableStatement)
 			if (AlterInvolvesPartitionColumn(alterTableStatement, command))
 			{
 				ereport(ERROR, (errmsg("cannot execute ALTER TABLE command "
-								   "dropping partition column")));
+									   "dropping partition column")));
 			}
 		}
 	}
@@ -2517,7 +2517,7 @@ IsAlterTableRenameStmt(RenameStmt *renameStmt)
  */
 static bool
 AlterInvolvesPartitionColumn(AlterTableStmt *alterTableStatement,
-									AlterTableCmd *command)
+							 AlterTableCmd *command)
 {
 	bool involvesPartitionColumn = false;
 	Var *partitionColumn = NULL;

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -992,15 +992,6 @@ RecordDistributedRelationDependencies(Oid distributedRelationId, Node *distribut
 
 	/* dependency from table entry to extension */
 	recordDependencyOn(&relationAddr, &citusExtensionAddr, DEPENDENCY_NORMAL);
-
-	/* make sure the distribution key column/expression does not just go away */
-#if (PG_VERSION_NUM >= 100000)
-	recordDependencyOnSingleRelExpr(&relationAddr, distributionKey, distributedRelationId,
-									DEPENDENCY_NORMAL, DEPENDENCY_NORMAL, false);
-#else
-	recordDependencyOnSingleRelExpr(&relationAddr, distributionKey, distributedRelationId,
-									DEPENDENCY_NORMAL, DEPENDENCY_NORMAL);
-#endif
 }
 
 

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -363,7 +363,7 @@ ALTER TABLE lineitem_alter ALTER COLUMN l_orderkey SET STATISTICS 100;
 ALTER TABLE lineitem_alter DROP CONSTRAINT IF EXISTS non_existent_contraint;
 ALTER TABLE lineitem_alter SET WITHOUT OIDS;
 
--- even distribution column can be dropped however postgresql prevents this.
+-- even distribution column can be dropped.
 ALTER TABLE lineitem_alter DROP COLUMN l_orderkey;
 
 -- Even unique indexes on l_partkey (non-partition column) are allowed.

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -363,7 +363,7 @@ ALTER TABLE lineitem_alter ALTER COLUMN l_orderkey SET STATISTICS 100;
 ALTER TABLE lineitem_alter DROP CONSTRAINT IF EXISTS non_existent_contraint;
 ALTER TABLE lineitem_alter SET WITHOUT OIDS;
 
--- even distribution column can be dropped.
+-- distribution column still cannot be dropped.
 ALTER TABLE lineitem_alter DROP COLUMN l_orderkey;
 
 -- Even unique indexes on l_partkey (non-partition column) are allowed.

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -758,11 +758,8 @@ ALTER TABLE lineitem_alter ALTER COLUMN l_orderkey SET STATISTICS 100;
 ALTER TABLE lineitem_alter DROP CONSTRAINT IF EXISTS non_existent_contraint;
 NOTICE:  constraint "non_existent_contraint" of relation "lineitem_alter" does not exist, skipping
 ALTER TABLE lineitem_alter SET WITHOUT OIDS;
--- even distribution column can be dropped however postgresql prevents this.
+-- even distribution column can be dropped.
 ALTER TABLE lineitem_alter DROP COLUMN l_orderkey;
-ERROR:  cannot drop table lineitem_alter column l_orderkey because other objects depend on it
-DETAIL:  table lineitem_alter depends on table lineitem_alter column l_orderkey
-HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 -- Even unique indexes on l_partkey (non-partition column) are allowed.
 -- Citus would have prevented that.
 CREATE UNIQUE INDEX unique_lineitem_partkey on lineitem_alter(l_partkey);

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -760,7 +760,7 @@ NOTICE:  constraint "non_existent_contraint" of relation "lineitem_alter" does n
 ALTER TABLE lineitem_alter SET WITHOUT OIDS;
 -- distribution column still cannot be dropped.
 ALTER TABLE lineitem_alter DROP COLUMN l_orderkey;
-ERROR:  cannot execute ALTER TABLE command involving partition column
+ERROR:  cannot execute ALTER TABLE command dropping partition column
 -- Even unique indexes on l_partkey (non-partition column) are allowed.
 -- Citus would have prevented that.
 CREATE UNIQUE INDEX unique_lineitem_partkey on lineitem_alter(l_partkey);

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -758,8 +758,9 @@ ALTER TABLE lineitem_alter ALTER COLUMN l_orderkey SET STATISTICS 100;
 ALTER TABLE lineitem_alter DROP CONSTRAINT IF EXISTS non_existent_contraint;
 NOTICE:  constraint "non_existent_contraint" of relation "lineitem_alter" does not exist, skipping
 ALTER TABLE lineitem_alter SET WITHOUT OIDS;
--- even distribution column can be dropped.
+-- distribution column still cannot be dropped.
 ALTER TABLE lineitem_alter DROP COLUMN l_orderkey;
+ERROR:  cannot execute ALTER TABLE command involving partition column
 -- Even unique indexes on l_partkey (non-partition column) are allowed.
 -- Citus would have prevented that.
 CREATE UNIQUE INDEX unique_lineitem_partkey on lineitem_alter(l_partkey);


### PR DESCRIPTION
We already check that we cannot drop distribution key columns in ErrorIfUnsupportedAlterTableStmt() at multi_utility.c, so we don't need to have distributed table to distribution key column dependency to avoid dropping of distribution key column.

Furthermore, having this dependency causes some warnings in pg_dump --schema-only (See #866), like the following, which are not desirable:

```
  pg_dump: [sorter] WARNING: could not resolve dependency loop among these items:
  pg_dump: [sorter]   TABLE impressions  (ID 240 OID 19654)
  pg_dump: [sorter] WARNING: could not resolve dependency loop among these items:
  pg_dump: [sorter]   TABLE clicks  (ID 241 OID 19661)
```

This change also allows drop of distribution keys when `SET citus.enable_ddl_propagation to false;`, which is the expected behaviour. Regression tests are updated accordingly.

TESTING: Manual. Perl tap tests which are used to test client tools like pg_dump aren't enabled for extensions yet, so I'm postponing automated tests to after we have tap tests for extensions.