### PR TITLE
Add citus.cluster_name GUC

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -174,8 +174,6 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 
 	ErrorIfNotSuitableToGetSize(relationId);
 
-	LockRelationOid(DistNodeRelationId(), AccessShareLock);
-
 	workerNodeList = ActivePrimaryNodeList();
 
 	foreach(workerNodeCell, workerNodeList)

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -158,7 +158,6 @@ static uint64
 DistributedTableSize(Oid relationId, char *sizeQuery)
 {
 	Relation relation = NULL;
-	Relation pgDistNode = NULL;
 	List *workerNodeList = NULL;
 	ListCell *workerNodeCell = NULL;
 	uint64 totalRelationSize = 0;
@@ -175,7 +174,7 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 
 	ErrorIfNotSuitableToGetSize(relationId);
 
-	pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
+	LockRelationOid(DistNodeRelationId(), AccessShareLock);
 
 	workerNodeList = ActivePrimaryNodeList();
 
@@ -187,7 +186,6 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 		totalRelationSize += relationSizeOnNode;
 	}
 
-	heap_close(pgDistNode, NoLock);
 	heap_close(relation, AccessShareLock);
 
 	return totalRelationSize;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -670,6 +670,16 @@ RegisterCitusConfigVariables(void)
 		0,
 		NULL, NULL, NULL);
 
+	DefineCustomStringVariable(
+		"citus.cluster_name",
+		gettext_noop("Which cluster this node is a part of"),
+		NULL,
+		&CurrentCluster,
+		"default",
+		PGC_SU_BACKEND,
+		0,
+		NULL, NULL, NULL);
+
 	DefineCustomBoolVariable(
 		"citus.enable_version_checks",
 		gettext_noop("Enables version checks during CREATE/ALTER EXTENSION commands"),

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -43,6 +43,7 @@
 #include "nodes/makefuncs.h"
 #include "parser/parse_func.h"
 #include "parser/parse_type.h"
+#include "storage/lmgr.h"
 #include "utils/builtins.h"
 #include "utils/catcache.h"
 #include "utils/datum.h"
@@ -2271,6 +2272,12 @@ HTAB *
 GetWorkerNodeHash(void)
 {
 	InitializeCaches(); /* ensure relevant callbacks are registered */
+
+	/*
+	 * Simulate a SELECT from pg_dist_node, ensure pg_dist_node doesn't change while our
+	 * caller is using WorkerNodeHash.
+	 */
+	LockRelationOid(DistNodeRelationId(), AccessShareLock);
 
 	/*
 	 * We might have some concurrent metadata changes. In order to get the changes,

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -772,7 +772,7 @@ AddNodeMetadata(char *nodeName, int32 nodePort, int32 groupId, char *nodeRack,
 
 /*
  * SetNodeState function sets the isactive column of the specified worker in
- * pg_dist_node to true.
+ * pg_dist_node to isActive.
  */
 static void
 SetNodeState(char *nodeName, int32 nodePort, bool isActive)

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -230,7 +230,6 @@ ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 	List *workerNodeList = NULL;
 	ListCell *workerNodeCell = NULL;
 
-	LockRelationOid(DistNodeRelationId(), AccessShareLock);
 	workerNodeList = ActivePrimaryNodeList();
 
 	/*

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -28,6 +28,7 @@
 #include "distributed/transaction_management.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
+#include "storage/lmgr.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -226,10 +227,11 @@ ReplicateSingleShardTableToAllWorkers(Oid relationId)
 static void
 ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 {
-	/* we do not use pgDistNode, we only obtain a lock on it to prevent modifications */
-	Relation pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = NULL;
 	ListCell *workerNodeCell = NULL;
+
+	LockRelationOid(DistNodeRelationId(), AccessShareLock);
+	workerNodeList = ActivePrimaryNodeList();
 
 	/*
 	 * We will iterate over all worker nodes and if healthy placement is not exist at
@@ -245,8 +247,6 @@ ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 
 		ReplicateShardToNode(shardInterval, nodeName, nodePort);
 	}
-
-	heap_close(pgDistNode, NoLock);
 }
 
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -65,6 +65,7 @@ extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern uint32 ActivePrimaryNodeCount(void);
 extern List * ActivePrimaryNodeList(void);
 extern WorkerNode * FindWorkerNode(char *nodeName, int32 nodePort);
+extern WorkerNode * FindWorkerNodeAnyCluster(char *nodeName, int32 nodePort);
 extern List * ReadWorkerNodes(void);
 extern void EnsureCoordinator(void);
 extern uint32 GroupForNode(char *nodeName, int32 nodePorT);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -53,6 +53,7 @@ typedef struct WorkerNode
 /* Config variables managed via guc.c */
 extern int MaxWorkerNodesTracked;
 extern char *WorkerListFileName;
+extern char *CurrentCluster;
 
 
 /* Function declarations for finding worker nodes to place shards on */

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -465,6 +465,31 @@ SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_g
         1
 (1 row)
 
+-- check that you can add a seconary to a non-default cluster, and activate it, and remove it
+SELECT master_add_inactive_node('localhost', 9999, groupid => :worker_2_group, nodecluster => 'olap', noderole => 'secondary');
+             master_add_inactive_node              
+---------------------------------------------------
+ (19,14,localhost,9999,default,f,f,secondary,olap)
+(1 row)
+
+SELECT master_activate_node('localhost', 9999);
+               master_activate_node                
+---------------------------------------------------
+ (19,14,localhost,9999,default,f,t,secondary,olap)
+(1 row)
+
+SELECT master_disable_node('localhost', 9999);
+ master_disable_node 
+---------------------
+ 
+(1 row)
+
+SELECT master_remove_node('localhost', 9999);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
 -- check that you can't manually add two primaries to a group
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole)
   VALUES ('localhost', 5000, :worker_1_group, 'primary');
@@ -488,7 +513,7 @@ SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_po
 SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary', nodecluster=> 'olap');
                   master_add_node                  
 ---------------------------------------------------
- (19,12,localhost,8888,default,f,t,secondary,olap)
+ (20,12,localhost,8888,default,f,t,secondary,olap)
 (1 row)
 
 -- check that super-long cluster names are truncated
@@ -501,13 +526,13 @@ SELECT master_add_node('localhost', 8887, groupid => :worker_1_group, noderole =
 );
                                                master_add_node                                                
 --------------------------------------------------------------------------------------------------------------
- (20,12,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.)
+ (21,12,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.)
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeport=8887;
  nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           
 --------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------
-     20 |      12 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.
+     21 |      12 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.
 (1 row)
 
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -198,6 +198,12 @@ SELECT 1 FROM master_add_node('localhost', 9997, groupid => :worker_1_group, nod
 -- add_inactive_node also works with secondaries
 SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_group, noderole => 'secondary');
 
+-- check that you can add a seconary to a non-default cluster, and activate it, and remove it
+SELECT master_add_inactive_node('localhost', 9999, groupid => :worker_2_group, nodecluster => 'olap', noderole => 'secondary');
+SELECT master_activate_node('localhost', 9999);
+SELECT master_disable_node('localhost', 9999);
+SELECT master_remove_node('localhost', 9999);
+
 -- check that you can't manually add two primaries to a group
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole)
   VALUES ('localhost', 5000, :worker_1_group, 'primary');


### PR DESCRIPTION
No part of Citus sees any node which is not in the current cluster.

(A subcomponent of #1528, depends on #1518)

- [x] I think `AddNodeMetadata` will allow you to add duplicate nodes, because `FindWorkerNode` uses the worker node hash
- [x] Add test that primaries in other clusters aren't used when running queries
- [x] Add test that you can remove nodes in other clusters
- [x] Add test that you cannot add primary nodes to the non-default cluster

After this PR:
- I'm not sure if it makes sense to be able to toggle `isActive` on nodes in other clusters but this PR preserves that ability.