### PR TITLE
Allow reads from secondaries

### DIFF
--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -82,7 +82,7 @@ MultiRealTimeExecute(Job *job)
 	const char *workerHashName = "Worker node hash";
 	WaitInfo *waitInfo = MultiClientCreateWaitInfo(list_length(taskList));
 
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActiveReadableNodeList();
 	workerHash = WorkerHash(workerHashName, workerNodeList);
 
 	/* initialize task execution structures for remote execution */

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -71,7 +71,9 @@ JobExecutorType(MultiPlan *multiPlan)
 												 " queries on the workers.")));
 	}
 
-	workerNodeList = ActivePrimaryNodeList();
+	Assert(multiPlan->operation == CMD_SELECT);
+
+	workerNodeList = ActiveReadableNodeList();
 	workerNodeCount = list_length(workerNodeList);
 	taskCount = list_length(job->taskList);
 	tasksPerNode = taskCount / ((double) workerNodeCount);

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -190,7 +190,7 @@ MultiTaskTrackerExecute(Job *job)
 	 * assigning and checking the status of tasks. The second (temporary) hash
 	 * helps us in fetching results data from worker nodes to the master node.
 	 */
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActiveReadableNodeList();
 	taskTrackerCount = (uint32) list_length(workerNodeList);
 
 	taskTrackerHash = TrackerHash(taskTrackerHashName, workerNodeList);

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -174,7 +174,7 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 
 	ErrorIfNotSuitableToGetSize(relationId);
 
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActiveReadableNodeList();
 
 	foreach(workerNodeCell, workerNodeList)
 	{

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -87,6 +87,7 @@ start_metadata_sync_to_node(PG_FUNCTION_ARGS)
 
 	EnsureCoordinator();
 	EnsureSuperUser();
+	EnsureModificationsCanRun();
 	CheckCitusVersion(ERROR);
 
 	PreventTransactionChain(true, "start_metadata_sync_to_node");

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -1863,7 +1863,7 @@ BuildMapMergeJob(Query *jobQuery, List *dependedJobList, Var *partitionKey,
 static uint32
 HashPartitionCount(void)
 {
-	uint32 groupCount = ActivePrimaryNodeCount();
+	uint32 groupCount = ActiveReadableNodeCount();
 	double maxReduceTasksPerNode = MaxRunningTasksPerNode / 2.0;
 
 	uint32 partitionCount = (uint32) rint(groupCount * maxReduceTasksPerNode);
@@ -4791,7 +4791,7 @@ GreedyAssignTaskList(List *taskList)
 	uint32 taskCount = list_length(taskList);
 
 	/* get the worker node list and sort the list */
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = ActiveReadableNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/*
@@ -5223,7 +5223,7 @@ AssignDualHashTaskList(List *taskList)
 	 * if subsequent jobs have a small number of tasks, we won't allocate the
 	 * tasks to the same worker repeatedly.
 	 */
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = ActiveReadableNodeList();
 	uint32 workerNodeCount = (uint32) list_length(workerNodeList);
 	uint32 beginningNodeIndex = jobId % workerNodeCount;
 

--- a/src/backend/distributed/planner/multi_planner.c
+++ b/src/backend/distributed/planner/multi_planner.c
@@ -322,6 +322,8 @@ CreateDistributedPlan(PlannedStmt *localPlan, Query *originalQuery, Query *query
 
 	if (IsModifyCommand(query))
 	{
+		EnsureModificationsCanRun();
+
 		if (InsertSelectIntoDistributedTable(originalQuery))
 		{
 			distributedPlan =

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1617,7 +1617,7 @@ PlanRouterQuery(Query *originalQuery, RelationRestrictionContext *restrictionCon
 	}
 	else if (replacePrunedQueryWithDummy)
 	{
-		List *workerNodeList = ActivePrimaryNodeList();
+		List *workerNodeList = ActiveReadableNodeList();
 		if (workerNodeList != NIL)
 		{
 			WorkerNode *workerNode = (WorkerNode *) linitial(workerNodeList);

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -26,6 +26,7 @@
 #include "distributed/maintenanced.h"
 #include "distributed/master_metadata_utility.h"
 #include "distributed/master_protocol.h"
+#include "distributed/metadata_cache.h"
 #include "distributed/multi_copy.h"
 #include "distributed/multi_explain.h"
 #include "distributed/multi_join_order.h"
@@ -86,6 +87,12 @@ static const struct config_enum_entry shard_placement_policy_options[] = {
 	{ "local-node-first", SHARD_PLACEMENT_LOCAL_NODE_FIRST, false },
 	{ "round-robin", SHARD_PLACEMENT_ROUND_ROBIN, false },
 	{ "random", SHARD_PLACEMENT_RANDOM, false },
+	{ NULL, 0, false }
+};
+
+static const struct config_enum_entry use_secondary_nodes_options[] = {
+	{ "never", USE_SECONDARY_NODES_NEVER, false },
+	{ "always", USE_SECONDARY_NODES_ALWAYS, false },
 	{ NULL, 0, false }
 };
 
@@ -647,6 +654,16 @@ RegisterCitusConfigVariables(void)
 		&ShardPlacementPolicy,
 		SHARD_PLACEMENT_ROUND_ROBIN, shard_placement_policy_options,
 		PGC_USERSET,
+		0,
+		NULL, NULL, NULL);
+
+	DefineCustomEnumVariable(
+		"citus.use_secondary_nodes",
+		gettext_noop("Sets the policy to use when choosing nodes for SELECT queries."),
+		NULL,
+		&ReadFromSecondaries,
+		USE_SECONDARY_NODES_NEVER, use_secondary_nodes_options,
+		PGC_SU_BACKEND,
 		0,
 		NULL, NULL, NULL);
 

--- a/src/backend/distributed/transaction/lock_graph.c
+++ b/src/backend/distributed/transaction/lock_graph.c
@@ -91,7 +91,7 @@ dump_global_wait_edges(PG_FUNCTION_ARGS)
 WaitGraph *
 BuildGlobalWaitGraph(void)
 {
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = ActiveReadableNodeList();
 	ListCell *workerNodeCell = NULL;
 	char *nodeUser = CitusExtensionOwnerName();
 	List *connectionList = NIL;

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -344,6 +344,47 @@ WorkerNodeIsPrimary(WorkerNode *worker)
 
 
 /*
+ * WorkerNodeIsSecondary returns whether the argument represents a secondary node.
+ */
+bool
+WorkerNodeIsSecondary(WorkerNode *worker)
+{
+	Oid secondaryRole = SecondaryNodeRoleId();
+
+	/* if nodeRole does not yet exist, all nodes are primary nodes */
+	if (secondaryRole == InvalidOid)
+	{
+		return false;
+	}
+
+	return worker->nodeRole == secondaryRole;
+}
+
+
+/*
+ * WorkerNodeIsReadable returns whether we're allowed to send SELECT queries to this
+ * node.
+ */
+bool
+WorkerNodeIsReadable(WorkerNode *workerNode)
+{
+	if (ReadFromSecondaries == USE_SECONDARY_NODES_NEVER &&
+		WorkerNodeIsPrimary(workerNode))
+	{
+		return true;
+	}
+
+	if (ReadFromSecondaries == USE_SECONDARY_NODES_ALWAYS &&
+		WorkerNodeIsSecondary(workerNode))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+
+/*
  * PrimaryNodeForGroup returns the (unique) primary in the specified group.
  *
  * If there are any nodes in the requested group and groupContainsNodes is not NULL

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -19,6 +19,14 @@
 
 extern bool EnableVersionChecks;
 
+/* managed via guc.c */
+typedef enum
+{
+	USE_SECONDARY_NODES_NEVER = 0,
+	USE_SECONDARY_NODES_ALWAYS = 1
+} ReadFromSecondariesType;
+extern int ReadFromSecondaries;
+
 /*
  * Representation of a table's metadata that is frequently used for
  * distributed execution. Cached.
@@ -83,6 +91,8 @@ extern bool CitusHasBeenLoaded(void);
 extern bool CheckCitusVersion(int elevel);
 extern bool CheckAvailableVersion(int elevel);
 bool MajorVersionsCompatible(char *leftVersion, char *rightVersion);
+
+extern void EnsureModificationsCanRun(void);
 
 /* access WorkerNodeHash */
 extern HTAB * GetWorkerNodeHash(void);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -64,6 +64,8 @@ extern WorkerNode * WorkerGetRoundRobinCandidateNode(List *workerNodeList,
 extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern uint32 ActivePrimaryNodeCount(void);
 extern List * ActivePrimaryNodeList(void);
+extern uint32 ActiveReadableNodeCount(void);
+extern List * ActiveReadableNodeList(void);
 extern WorkerNode * FindWorkerNode(char *nodeName, int32 nodePort);
 extern WorkerNode * FindWorkerNodeAnyCluster(char *nodeName, int32 nodePort);
 extern List * ReadWorkerNodes(bool includeNodesFromOtherClusters);
@@ -71,6 +73,8 @@ extern void EnsureCoordinator(void);
 extern uint32 GroupForNode(char *nodeName, int32 nodePorT);
 extern WorkerNode * PrimaryNodeForGroup(uint32 groupId, bool *groupContainsNodes);
 extern bool WorkerNodeIsPrimary(WorkerNode *worker);
+extern bool WorkerNodeIsSecondary(WorkerNode *worker);
+extern bool WorkerNodeIsReadable(WorkerNode *worker);
 
 /* Function declarations for worker node utilities */
 extern int CompareWorkerNodes(const void *leftElement, const void *rightElement);

--- a/src/test/regress/expected/multi_read_from_secondaries.out
+++ b/src/test/regress/expected/multi_read_from_secondaries.out
@@ -1,0 +1,61 @@
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1600000;
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"
+CREATE TABLE dest_table (a int, b int);
+CREATE TABLE source_table (a int, b int);
+-- attempts to change metadata should fail while reading from secondaries
+SELECT create_distributed_table('dest_table', 'a');
+ERROR:  writing to worker nodes is not currently allowed
+DETAIL:  citus.use_secondary_nodes is set to 'always'
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=never'"
+SELECT create_distributed_table('dest_table', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('source_table', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO dest_table (a, b) VALUES (1, 1);
+INSERT INTO dest_table (a, b) VALUES (2, 1);
+INSERT INTO source_table (a, b) VALUES (10, 10);
+-- simluate actually having secondary nodes
+SELECT * FROM pg_dist_node;
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------
+      1 |       1 | localhost |    57637 | default  | f           | t        | primary  | default
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default
+(2 rows)
+
+UPDATE pg_dist_node SET noderole = 'secondary';
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"
+-- inserts are disallowed
+INSERT INTO dest_table (a, b) VALUES (1, 2);
+ERROR:  writing to worker nodes is not currently allowed
+DETAIL:  citus.use_secondary_nodes is set to 'always'
+-- router selects are allowed
+SELECT a FROM dest_table WHERE a = 1;
+ a 
+---
+ 1
+(1 row)
+
+-- real-time selects are also allowed
+SELECT a FROM dest_table;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+-- insert into is definitely not allowed
+INSERT INTO dest_table (a, b)
+  SELECT a, b FROM source_table;
+ERROR:  writing to worker nodes is not currently allowed
+DETAIL:  citus.use_secondary_nodes is set to 'always'
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=never'"
+UPDATE pg_dist_node SET noderole = 'primary';
+DROP TABLE dest_table;

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -12,14 +12,14 @@ NOTICE:  Copying data from local table...
 
 -- see that partkey is NULL
 SELECT
-	partmethod, (partkey IS NULL) as partkeyisnull, colocationid, repmodel
+	partmethod, (partkey IS NULL) as partkeyisnull, repmodel
 FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'reference_table_test'::regclass;
- partmethod | partkeyisnull | colocationid | repmodel 
-------------+---------------+--------------+----------
- n          | t             |            1 | t
+ partmethod | partkeyisnull | repmodel 
+------------+---------------+----------
+ n          | t             | t
 (1 row)
 
 -- now see that shard min/max values are NULL

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -23,6 +23,8 @@ test: multi_table_ddl
 test: multi_name_lengths
 test: multi_metadata_access
 
+test: multi_read_from_secondaries
+
 # ----------
 # The following distributed tests depend on creating a partitioned table and
 # uploading data to it.

--- a/src/test/regress/sql/multi_read_from_secondaries.sql
+++ b/src/test/regress/sql/multi_read_from_secondaries.sql
@@ -1,0 +1,42 @@
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1600000;
+
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"
+
+CREATE TABLE dest_table (a int, b int);
+CREATE TABLE source_table (a int, b int);
+
+-- attempts to change metadata should fail while reading from secondaries
+SELECT create_distributed_table('dest_table', 'a');
+
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=never'"
+
+SELECT create_distributed_table('dest_table', 'a');
+SELECT create_distributed_table('source_table', 'a');
+
+INSERT INTO dest_table (a, b) VALUES (1, 1);
+INSERT INTO dest_table (a, b) VALUES (2, 1);
+
+INSERT INTO source_table (a, b) VALUES (10, 10);
+
+-- simluate actually having secondary nodes
+SELECT * FROM pg_dist_node;
+UPDATE pg_dist_node SET noderole = 'secondary';
+
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"
+
+-- inserts are disallowed
+INSERT INTO dest_table (a, b) VALUES (1, 2);
+
+-- router selects are allowed
+SELECT a FROM dest_table WHERE a = 1;
+
+-- real-time selects are also allowed
+SELECT a FROM dest_table;
+
+-- insert into is definitely not allowed
+INSERT INTO dest_table (a, b)
+  SELECT a, b FROM source_table;
+
+\c "dbname=regression options='-c\ citus.use_secondary_nodes=never'"
+UPDATE pg_dist_node SET noderole = 'primary';
+DROP TABLE dest_table;

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -10,7 +10,7 @@ SELECT create_reference_table('reference_table_test');
 
 -- see that partkey is NULL
 SELECT
-	partmethod, (partkey IS NULL) as partkeyisnull, colocationid, repmodel
+	partmethod, (partkey IS NULL) as partkeyisnull, repmodel
 FROM
 	pg_dist_partition
 WHERE


### PR DESCRIPTION
An item in #1528

Behavior:
- When `citus.use_secondary_nodes = 'never'` behavior is identical.
- When `citus.use_secondary_nodes = 'always'` all modification DML are disallowed.
- When `citus.use_secondary_nodes = 'always'` the planner and executor only see secondary nodes., and use them to handle `SELECT` queries.
- When `citus.use_secondary_nodes = 'always'` all utility commands which call `ActivePrimaryNodeList` error out.