### PR TITLE
Replace WorkerNodeHash with WorkerNodeList

### DIFF
--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -84,8 +84,8 @@ extern bool CheckCitusVersion(int elevel);
 extern bool CheckAvailableVersion(int elevel);
 bool MajorVersionsCompatible(char *leftVersion, char *rightVersion);
 
-/* access WorkerNodeHash */
-extern HTAB * GetWorkerNodeHash(void);
+/* access WorkerNodeList */
+extern List * GetWorkerNodeList(void);
 
 /* relation oids */
 extern Oid DistColocationRelationId(void);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -34,11 +34,14 @@
 
 /*
  * In memory representation of pg_dist_node table elements. The elements are hold in
- * WorkerNodeHash table.
+ * WorkerNodeList table.
+ *
+ * InitializeWorkerNodeCache assumes that a shallow copy is sufficient to make this
+ * struct usable in a new memory context, if you add any pointers change that function!
  */
 typedef struct WorkerNode
 {
-	uint32 nodeId;                      /* node's unique id, key of the hash table */
+	uint32 nodeId;                      /* node's unique id */
 	uint32 workerPort;                  /* node's port */
 	char workerName[WORKER_LENGTH];     /* node's name */
 	uint32 groupId;                     /* node's groupId; same for the nodes that are in the same group */

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -23,8 +23,8 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes 
 --------------------------------
- (localhost,57638)
  (localhost,57637)
+ (localhost,57638)
 (2 rows)
 
 -- try to add a node that is already in the cluster
@@ -38,8 +38,8 @@ SELECT nodeid, groupid FROM master_add_node('localhost', :worker_1_port);
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes 
 --------------------------------
- (localhost,57638)
  (localhost,57637)
+ (localhost,57638)
 (2 rows)
 
 -- try to remove a node (with no placements)
@@ -115,8 +115,8 @@ ERROR:  you cannot remove the primary node of a node group which has shard place
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes 
 --------------------------------
- (localhost,57638)
  (localhost,57637)
+ (localhost,57638)
 (2 rows)
 
 -- insert a row so that master_disable_node() exercises closing connections
@@ -171,8 +171,8 @@ ERROR:  you cannot remove the primary node of a node group which has shard place
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes 
 --------------------------------
- (localhost,57638)
  (localhost,57637)
+ (localhost,57638)
 (2 rows)
 
 -- clean-up

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -52,7 +52,7 @@ Sort
                     Node: host=localhost port=57637 dbname=regression
                     ->  HashAggregate
                           Group Key: l_quantity
-                          ->  Seq Scan on lineitem_290001 lineitem
+                          ->  Seq Scan on lineitem_290000 lineitem
 -- Test JSON format
 EXPLAIN (COSTS FALSE, FORMAT JSON)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
@@ -98,7 +98,7 @@ EXPLAIN (COSTS FALSE, FORMAT JSON)
                                   "Node Type": "Seq Scan",
                                   "Parent Relationship": "Outer",
                                   "Parallel Aware": false,
-                                  "Relation Name": "lineitem_290001",
+                                  "Relation Name": "lineitem_290000",
                                   "Alias": "lineitem"
                                 }
                               ]
@@ -175,7 +175,7 @@ EXPLAIN (COSTS FALSE, FORMAT XML)
                                   <Node-Type>Seq Scan</Node-Type>
                                   <Parent-Relationship>Outer</Parent-Relationship>
                                   <Parallel-Aware>false</Parallel-Aware>
-                                  <Relation-Name>lineitem_290001</Relation-Name>
+                                  <Relation-Name>lineitem_290000</Relation-Name>
                                   <Alias>lineitem</Alias>
                                 </Plan>
                               </Plans>
@@ -240,7 +240,7 @@ EXPLAIN (COSTS FALSE, FORMAT YAML)
                             - Node Type: "Seq Scan"
                               Parent Relationship: "Outer"
                               Parallel Aware: false
-                              Relation Name: "lineitem_290001"
+                              Relation Name: "lineitem_290000"
                               Alias: "lineitem"
 
 -- Test Text format
@@ -258,7 +258,7 @@ Sort
                     Node: host=localhost port=57637 dbname=regression
                     ->  HashAggregate
                           Group Key: l_quantity
-                          ->  Seq Scan on lineitem_290001 lineitem
+                          ->  Seq Scan on lineitem_290000 lineitem
 -- Test verbose
 EXPLAIN (COSTS FALSE, VERBOSE TRUE)
 	SELECT sum(l_quantity) / avg(l_quantity) FROM lineitem;
@@ -272,7 +272,7 @@ Aggregate
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
                     Output: sum(l_quantity), sum(l_quantity), count(l_quantity)
-                    ->  Seq Scan on public.lineitem_290001 lineitem
+                    ->  Seq Scan on public.lineitem_290000 lineitem
                           Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
 -- Test join
 EXPLAIN (COSTS FALSE)
@@ -295,7 +295,7 @@ Limit
                                       ->  Index Scan using orders_pkey_290008 on orders_290008 orders
                                       ->  Sort
                                             Sort Key: lineitem.l_orderkey
-                                            ->  Seq Scan on lineitem_290001 lineitem
+                                            ->  Seq Scan on lineitem_290000 lineitem
                                                   Filter: (l_quantity < 5.0)
 -- Test insert
 EXPLAIN (COSTS FALSE)
@@ -304,7 +304,7 @@ Custom Scan (Citus Router)
   Task Count: 1
   Tasks Shown: All
   ->  Task
-        Node: host=localhost port=57638 dbname=regression
+        Node: host=localhost port=57637 dbname=regression
         ->  Insert on lineitem_290000
               ->  Values Scan on "*VALUES*"
 -- Test update
@@ -316,7 +316,7 @@ Custom Scan (Citus Router)
   Task Count: 1
   Tasks Shown: All
   ->  Task
-        Node: host=localhost port=57638 dbname=regression
+        Node: host=localhost port=57637 dbname=regression
         ->  Update on lineitem_290000 lineitem
               ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                     Index Cond: (l_orderkey = 1)
@@ -329,7 +329,7 @@ Custom Scan (Citus Router)
   Task Count: 1
   Tasks Shown: All
   ->  Task
-        Node: host=localhost port=57638 dbname=regression
+        Node: host=localhost port=57637 dbname=regression
         ->  Delete on lineitem_290000 lineitem
               ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                     Index Cond: (l_orderkey = 1)
@@ -374,7 +374,7 @@ Custom Scan (Citus Real-Time)
   Tasks Shown: One of 8
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Seq Scan on lineitem_290001 lineitem
+        ->  Seq Scan on lineitem_290000 lineitem
 -- Test having
 EXPLAIN (COSTS FALSE, VERBOSE TRUE)
 	SELECT sum(l_quantity) / avg(l_quantity) FROM lineitem
@@ -390,7 +390,7 @@ Aggregate
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
                     Output: sum(l_quantity), sum(l_quantity), count(l_quantity), sum(l_quantity)
-                    ->  Seq Scan on public.lineitem_290001 lineitem
+                    ->  Seq Scan on public.lineitem_290000 lineitem
                           Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
 -- Test having without aggregate
 EXPLAIN (COSTS FALSE, VERBOSE TRUE)
@@ -410,7 +410,7 @@ HashAggregate
               ->  HashAggregate
                     Output: l_quantity, l_quantity
                     Group Key: lineitem.l_quantity
-                    ->  Seq Scan on public.lineitem_290001 lineitem
+                    ->  Seq Scan on public.lineitem_290000 lineitem
                           Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
 -- Subquery pushdown tests with explain
 EXPLAIN (COSTS OFF)
@@ -453,7 +453,7 @@ Aggregate
                                       Join Filter: ((NULL::user_composite_type) = events.composite_id)
                                       ->  Result
                                             One-Time Filter: false
-                                      ->  Seq Scan on events_1400027 events
+                                      ->  Seq Scan on events_1400026 events
                                             Filter: ((event_type)::text = ANY ('{click,submit,pay}'::text[]))
 -- Union and left join subquery pushdown
 EXPLAIN (COSTS OFF)
@@ -544,20 +544,20 @@ HashAggregate
                                                                           Join Filter: ((NULL::user_composite_type) = events.composite_id)
                                                                           ->  Result
                                                                                 One-Time Filter: false
-                                                                          ->  Seq Scan on events_1400027 events
+                                                                          ->  Seq Scan on events_1400026 events
                                                                                 Filter: ((event_type)::text = 'click'::text)
                                                                     ->  Nested Loop
                                                                           Join Filter: ((NULL::user_composite_type) = events_1.composite_id)
                                                                           ->  Result
                                                                                 One-Time Filter: false
-                                                                          ->  Seq Scan on events_1400027 events_1
+                                                                          ->  Seq Scan on events_1400026 events_1
                                                                                 Filter: ((event_type)::text = 'submit'::text)
                                                   ->  Hash
                                                         ->  Subquery Scan on subquery_2
                                                               ->  Unique
                                                                     ->  Sort
                                                                           Sort Key: ((events_2.composite_id).tenant_id), ((events_2.composite_id).user_id)
-                                                                          ->  Seq Scan on events_1400027 events_2
+                                                                          ->  Seq Scan on events_1400026 events_2
                                                                                 Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type) AND ((event_type)::text = 'pay'::text))
 -- Union, left join and having subquery pushdown
 EXPLAIN (COSTS OFF)
@@ -709,7 +709,7 @@ Limit
                                                   ->  Limit
                                                         ->  Sort
                                                               Sort Key: events.event_time DESC
-                                                              ->  Seq Scan on events_1400027 events
+                                                              ->  Seq Scan on events_1400026 events
                                                                     Filter: (composite_id = users.composite_id)
 -- Test all tasks output
 SET citus.explain_all_tasks TO on;
@@ -722,22 +722,22 @@ Aggregate
         ->  Task
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290005 lineitem
+                    ->  Seq Scan on lineitem_290004 lineitem
                           Filter: (l_orderkey > 9030)
         ->  Task
               Node: host=localhost port=57638 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290004 lineitem
+                    ->  Seq Scan on lineitem_290005 lineitem
                           Filter: (l_orderkey > 9030)
         ->  Task
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290007 lineitem
+                    ->  Seq Scan on lineitem_290006 lineitem
                           Filter: (l_orderkey > 9030)
         ->  Task
               Node: host=localhost port=57638 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290006 lineitem
+                    ->  Seq Scan on lineitem_290007 lineitem
                           Filter: (l_orderkey > 9030)
 SELECT true AS valid FROM explain_xml($$
 	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030$$);
@@ -757,7 +757,7 @@ Aggregate
         ->  Task
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290005 lineitem
+                    ->  Seq Scan on lineitem_290004 lineitem
                           Filter: (l_orderkey > 9030)
 -- Test re-partition join
 SET citus.large_table_shard_count TO 1;
@@ -938,7 +938,7 @@ Aggregate
         ->  Task
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290001 lineitem
+                    ->  Seq Scan on lineitem_290000 lineitem
 -- ensure EXPLAIN EXECUTE doesn't crash
 PREPARE task_tracker_query AS
 	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
@@ -950,7 +950,7 @@ Aggregate
         ->  Task
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290005 lineitem
+                    ->  Seq Scan on lineitem_290004 lineitem
                           Filter: (l_orderkey > 9030)
 SET citus.task_executor_type TO 'real-time';
 PREPARE router_executor_query AS SELECT l_quantity FROM lineitem WHERE l_orderkey = 5;
@@ -972,7 +972,7 @@ Aggregate
         ->  Task
               Node: host=localhost port=57637 dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_290005 lineitem
+                    ->  Seq Scan on lineitem_290004 lineitem
                           Filter: (l_orderkey > 9030)
 -- EXPLAIN EXECUTE of parametrized prepared statements is broken, but
 -- at least make sure to fail without crashing

--- a/src/test/regress/expected/multi_large_table_join_planning.out
+++ b/src/test/regress/expected/multi_large_table_join_planning.out
@@ -65,14 +65,14 @@ DEBUG:  generated sql query for task 21
 DETAIL:  query string: "SELECT lineitem.l_partkey, orders.o_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, orders.o_custkey FROM (lineitem_290006 lineitem JOIN orders_290009 orders ON ((lineitem.l_orderkey = orders.o_orderkey))) WHERE ((lineitem.l_partkey < 1000) AND (orders.o_totalprice > 10.0))"
 DEBUG:  generated sql query for task 24
 DETAIL:  query string: "SELECT lineitem.l_partkey, orders.o_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, orders.o_custkey FROM (lineitem_290007 lineitem JOIN orders_290009 orders ON ((lineitem.l_orderkey = orders.o_orderkey))) WHERE ((lineitem.l_partkey < 1000) AND (orders.o_totalprice > 10.0))"
-DEBUG:  assigned task 6 to node localhost:57637
-DEBUG:  assigned task 3 to node localhost:57638
-DEBUG:  assigned task 12 to node localhost:57637
-DEBUG:  assigned task 9 to node localhost:57638
-DEBUG:  assigned task 18 to node localhost:57637
-DEBUG:  assigned task 15 to node localhost:57638
-DEBUG:  assigned task 24 to node localhost:57637
-DEBUG:  assigned task 21 to node localhost:57638
+DEBUG:  assigned task 3 to node localhost:57637
+DEBUG:  assigned task 6 to node localhost:57638
+DEBUG:  assigned task 9 to node localhost:57637
+DEBUG:  assigned task 12 to node localhost:57638
+DEBUG:  assigned task 15 to node localhost:57637
+DEBUG:  assigned task 18 to node localhost:57638
+DEBUG:  assigned task 21 to node localhost:57637
+DEBUG:  assigned task 24 to node localhost:57638
 DEBUG:  join prunable for intervals [1,1000] and [6001,7000]
 DEBUG:  join prunable for intervals [6001,7000] and [1,1000]
 DEBUG:  generated sql query for task 3
@@ -83,8 +83,8 @@ DEBUG:  pruning merge fetch taskId 1
 DETAIL:  Creating dependency on merge taskId 25
 DEBUG:  pruning merge fetch taskId 4
 DETAIL:  Creating dependency on merge taskId 34
-DEBUG:  assigned task 3 to node localhost:57637
-DEBUG:  assigned task 6 to node localhost:57638
+DEBUG:  assigned task 6 to node localhost:57637
+DEBUG:  assigned task 3 to node localhost:57638
 DEBUG:  join prunable for intervals [1,1000] and [1001,2000]
 DEBUG:  join prunable for intervals [1,1000] and [6001,7000]
 DEBUG:  join prunable for intervals [1001,2000] and [1,1000]
@@ -103,8 +103,8 @@ DEBUG:  pruning merge fetch taskId 4
 DETAIL:  Creating dependency on merge taskId 10
 DEBUG:  pruning merge fetch taskId 7
 DETAIL:  Creating dependency on merge taskId 13
-DEBUG:  assigned task 6 to node localhost:57637
-DEBUG:  assigned task 9 to node localhost:57638
+DEBUG:  assigned task 9 to node localhost:57637
+DEBUG:  assigned task 6 to node localhost:57638
 DEBUG:  assigned task 3 to node localhost:57637
 DEBUG:  completed cleanup query for job 3
 DEBUG:  completed cleanup query for job 3
@@ -172,20 +172,20 @@ DEBUG:  generated sql query for task 14
 DETAIL:  query string: "SELECT l_partkey, l_suppkey FROM lineitem_290006 lineitem WHERE (l_quantity < 5.0)"
 DEBUG:  generated sql query for task 16
 DETAIL:  query string: "SELECT l_partkey, l_suppkey FROM lineitem_290007 lineitem WHERE (l_quantity < 5.0)"
-DEBUG:  assigned task 4 to node localhost:57637
-DEBUG:  assigned task 2 to node localhost:57638
-DEBUG:  assigned task 8 to node localhost:57637
-DEBUG:  assigned task 6 to node localhost:57638
-DEBUG:  assigned task 12 to node localhost:57637
-DEBUG:  assigned task 10 to node localhost:57638
-DEBUG:  assigned task 16 to node localhost:57637
-DEBUG:  assigned task 14 to node localhost:57638
+DEBUG:  assigned task 2 to node localhost:57637
+DEBUG:  assigned task 4 to node localhost:57638
+DEBUG:  assigned task 6 to node localhost:57637
+DEBUG:  assigned task 8 to node localhost:57638
+DEBUG:  assigned task 10 to node localhost:57637
+DEBUG:  assigned task 12 to node localhost:57638
+DEBUG:  assigned task 14 to node localhost:57637
+DEBUG:  assigned task 16 to node localhost:57638
 DEBUG:  generated sql query for task 2
 DETAIL:  query string: "SELECT o_orderkey, o_shippriority FROM orders_290008 orders WHERE (o_totalprice <> 4.0)"
 DEBUG:  generated sql query for task 4
 DETAIL:  query string: "SELECT o_orderkey, o_shippriority FROM orders_290009 orders WHERE (o_totalprice <> 4.0)"
-DEBUG:  assigned task 4 to node localhost:57637
-DEBUG:  assigned task 2 to node localhost:57638
+DEBUG:  assigned task 2 to node localhost:57637
+DEBUG:  assigned task 4 to node localhost:57638
 DEBUG:  join prunable for task partitionId 0 and 1
 DEBUG:  join prunable for task partitionId 0 and 2
 DEBUG:  join prunable for task partitionId 0 and 3

--- a/src/test/regress/expected/multi_large_table_task_assignment.out
+++ b/src/test/regress/expected/multi_large_table_task_assignment.out
@@ -26,8 +26,8 @@ FROM
 	orders, customer
 WHERE
 	o_custkey = c_custkey;
-DEBUG:  assigned task 4 to node localhost:57637
-DEBUG:  assigned task 2 to node localhost:57638
+DEBUG:  assigned task 2 to node localhost:57637
+DEBUG:  assigned task 4 to node localhost:57638
 DEBUG:  join prunable for intervals [1,1000] and [1001,2000]
 DEBUG:  join prunable for intervals [1,1000] and [6001,7000]
 DEBUG:  join prunable for intervals [1001,2000] and [1,1000]
@@ -40,8 +40,8 @@ DEBUG:  pruning merge fetch taskId 4
 DETAIL:  Creating dependency on merge taskId 8
 DEBUG:  pruning merge fetch taskId 7
 DETAIL:  Creating dependency on merge taskId 11
-DEBUG:  assigned task 6 to node localhost:57637
-DEBUG:  assigned task 9 to node localhost:57638
+DEBUG:  assigned task 9 to node localhost:57637
+DEBUG:  assigned task 6 to node localhost:57638
 DEBUG:  assigned task 3 to node localhost:57637
  count 
 -------
@@ -60,10 +60,10 @@ FROM
 WHERE
 	o_custkey = c_custkey AND
 	o_orderkey = l_orderkey;
-DEBUG:  assigned task 9 to node localhost:57637
-DEBUG:  assigned task 15 to node localhost:57638
-DEBUG:  assigned task 12 to node localhost:57637
-DEBUG:  assigned task 18 to node localhost:57638
+DEBUG:  assigned task 15 to node localhost:57637
+DEBUG:  assigned task 9 to node localhost:57638
+DEBUG:  assigned task 18 to node localhost:57637
+DEBUG:  assigned task 12 to node localhost:57638
 DEBUG:  assigned task 3 to node localhost:57637
 DEBUG:  assigned task 6 to node localhost:57638
 DEBUG:  join prunable for intervals [1,1509] and [2951,4455]
@@ -150,12 +150,12 @@ DEBUG:  pruning merge fetch taskId 55
 DETAIL:  Creating dependency on merge taskId 68
 DEBUG:  pruning merge fetch taskId 58
 DETAIL:  Creating dependency on merge taskId 68
-DEBUG:  assigned task 21 to node localhost:57637
-DEBUG:  assigned task 3 to node localhost:57638
-DEBUG:  assigned task 27 to node localhost:57637
-DEBUG:  assigned task 9 to node localhost:57638
-DEBUG:  assigned task 48 to node localhost:57637
-DEBUG:  assigned task 33 to node localhost:57638
+DEBUG:  assigned task 3 to node localhost:57637
+DEBUG:  assigned task 21 to node localhost:57638
+DEBUG:  assigned task 9 to node localhost:57637
+DEBUG:  assigned task 27 to node localhost:57638
+DEBUG:  assigned task 33 to node localhost:57637
+DEBUG:  assigned task 48 to node localhost:57638
 DEBUG:  assigned task 39 to node localhost:57637
 DEBUG:  assigned task 57 to node localhost:57638
 DEBUG:  propagating assignment from merge task 19 to constrained sql task 6
@@ -184,16 +184,16 @@ FROM
 	lineitem, customer
 WHERE
 	l_partkey = c_nationkey;
-DEBUG:  assigned task 4 to node localhost:57637
-DEBUG:  assigned task 2 to node localhost:57638
-DEBUG:  assigned task 8 to node localhost:57637
-DEBUG:  assigned task 6 to node localhost:57638
-DEBUG:  assigned task 12 to node localhost:57637
-DEBUG:  assigned task 10 to node localhost:57638
-DEBUG:  assigned task 16 to node localhost:57637
-DEBUG:  assigned task 14 to node localhost:57638
-DEBUG:  assigned task 4 to node localhost:57637
-DEBUG:  assigned task 6 to node localhost:57638
+DEBUG:  assigned task 2 to node localhost:57637
+DEBUG:  assigned task 4 to node localhost:57638
+DEBUG:  assigned task 6 to node localhost:57637
+DEBUG:  assigned task 8 to node localhost:57638
+DEBUG:  assigned task 10 to node localhost:57637
+DEBUG:  assigned task 12 to node localhost:57638
+DEBUG:  assigned task 14 to node localhost:57637
+DEBUG:  assigned task 16 to node localhost:57638
+DEBUG:  assigned task 6 to node localhost:57637
+DEBUG:  assigned task 4 to node localhost:57638
 DEBUG:  assigned task 2 to node localhost:57637
 DEBUG:  join prunable for task partitionId 0 and 1
 DEBUG:  join prunable for task partitionId 0 and 2

--- a/src/test/regress/expected/multi_master_protocol.out
+++ b/src/test/regress/expected/multi_master_protocol.out
@@ -27,7 +27,7 @@ SELECT * FROM master_get_new_shardid();
 SELECT * FROM master_get_active_worker_nodes();
  node_name | node_port 
 -----------+-----------
- localhost |     57638
  localhost |     57637
+ localhost |     57638
 (2 rows)
 

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -31,7 +31,7 @@ SELECT unnest(master_metadata_snapshot());
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
 (3 rows)
 
 -- Create a test table with constraints and SERIAL
@@ -57,7 +57,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
@@ -78,7 +78,7 @@ SELECT unnest(master_metadata_snapshot());
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE public.mx_test_table_col_3_seq OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
@@ -101,7 +101,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -130,7 +130,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
@@ -152,7 +152,7 @@ SELECT unnest(master_metadata_snapshot());
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SELECT worker_drop_distributed_table(logicalrelid) FROM pg_dist_partition
  TRUNCATE pg_dist_node
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
  CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres

--- a/src/test/regress/expected/multi_null_minmax_value_pruning.out
+++ b/src/test/regress/expected/multi_null_minmax_value_pruning.out
@@ -82,56 +82,56 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
-                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
-         ->  Task
-               Node: host=localhost port=57638 dbname=regression
-               ->  Aggregate
-                     ->  Merge Join
-                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57637 dbname=regression
+               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57638 dbname=regression
+               Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57637 dbname=regression
+               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
-                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57638 dbname=regression
+               Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+         ->  Task
                Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
 (60 rows)
 
@@ -176,56 +176,56 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
                Node: host=localhost port=57637 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+         ->  Task
+               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57638 dbname=regression
-               ->  Aggregate
-                     ->  Merge Join
-                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
-                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
-         ->  Task
                Node: host=localhost port=57637 dbname=regression
-               ->  Aggregate
-                     ->  Merge Join
-                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
-                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
-         ->  Task
-               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+         ->  Task
                Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57637 dbname=regression
@@ -248,11 +248,11 @@ SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 903
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57637 dbname=regression
-         ->  Index Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                Index Cond: (l_orderkey = 9030)
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Index Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+         ->  Index Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                Index Cond: (l_orderkey = 9030)
    ->  Task
          Node: host=localhost port=57637 dbname=regression
@@ -280,70 +280,70 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
-                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
-         ->  Task
-               Node: host=localhost port=57638 dbname=regression
-               ->  Aggregate
-                     ->  Merge Join
-                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
-                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
-         ->  Task
-               Node: host=localhost port=57637 dbname=regression
-               ->  Aggregate
-                     ->  Merge Join
-                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
-                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57637 dbname=regression
+               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
-                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57638 dbname=regression
+               Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
+         ->  Task
                Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290007 on lineitem_290007 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
 (74 rows)
 
@@ -359,11 +359,11 @@ SELECT l_orderkey, l_linenumber, l_shipdate FROM lineitem WHERE l_orderkey = 903
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57637 dbname=regression
-         ->  Index Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
+         ->  Index Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
                Index Cond: (l_orderkey = 9030)
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Index Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
+         ->  Index Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                Index Cond: (l_orderkey = 9030)
 (11 rows)
 
@@ -388,56 +388,56 @@ DEBUG:  join prunable for intervals [13473,14947] and [1,5986]
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
-                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
-         ->  Task
-               Node: host=localhost port=57638 dbname=regression
-               ->  Aggregate
-                     ->  Merge Join
-                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290000 on lineitem_290000 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57637 dbname=regression
+               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
-                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+                           ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
-               Node: host=localhost port=57638 dbname=regression
+               Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290002 on lineitem_290002 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57637 dbname=regression
+               Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290001 on lineitem_290001 lineitem
                            ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
          ->  Task
-               Node: host=localhost port=57638 dbname=regression
+               Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
                            ->  Index Only Scan using lineitem_pkey_290004 on lineitem_290004 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
+               Node: host=localhost port=57638 dbname=regression
+               ->  Aggregate
+                     ->  Merge Join
+                           Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
+                           ->  Index Only Scan using lineitem_pkey_290003 on lineitem_290003 lineitem
+                           ->  Index Only Scan using orders_pkey_290008 on orders_290008 orders
+         ->  Task
                Node: host=localhost port=57637 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57638 dbname=regression
                ->  Aggregate
                      ->  Merge Join
                            Merge Cond: (lineitem.l_orderkey = orders.o_orderkey)
-                           ->  Index Only Scan using lineitem_pkey_290006 on lineitem_290006 lineitem
+                           ->  Index Only Scan using lineitem_pkey_290005 on lineitem_290005 lineitem
                            ->  Index Only Scan using orders_pkey_290009 on orders_290009 orders
          ->  Task
                Node: host=localhost port=57637 dbname=regression

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -378,7 +378,7 @@ LINE 1: ALTER TABLE lineitem_alter ADD COLUMN new_column non_existen...
                                                          ^
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
 ERROR:  column "null_column" contains null values
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 ERROR:  invalid input syntax for integer: "a"
 -- Verify that we error out on non-column RENAME statements

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -421,11 +421,11 @@ LIMIT
         5;
  shardid | nodeport 
 ---------+----------
-  560141 |    57637
-  560140 |    57638
-  560139 |    57637
-  560138 |    57638
-  560137 |    57637
+  560141 |    57638
+  560140 |    57637
+  560139 |    57638
+  560138 |    57637
+  560137 |    57638
 (5 rows)
 
 -- Ensure that copy from worker node of table with serial column fails
@@ -699,13 +699,13 @@ SELECT master_create_distributed_table('composite_partition_column_table', 'comp
 \COPY composite_partition_column_table FROM STDIN WITH (FORMAT 'csv');
 WARNING:  function min(number_pack) does not exist
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 WARNING:  function min(number_pack) does not exist
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 WARNING:  could not get statistics for shard public.composite_partition_column_table_560164
 DETAIL:  Setting shard statistics to NULL
-ERROR:  failure on connection marked as essential: localhost:57637
+ERROR:  failure on connection marked as essential: localhost:57638
 -- Test copy on append distributed tables do not create shards on removed workers
 CREATE TABLE numbers_append (a int, b int);
 SELECT master_create_distributed_table('numbers_append', 'a', 'append');
@@ -730,10 +730,10 @@ SELECT shardid, nodename, nodeport
 	WHERE logicalrelid = 'numbers_append'::regclass order by placementid;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
-  560165 | localhost |    57637
   560165 | localhost |    57638
-  560166 | localhost |    57638
+  560165 | localhost |    57637
   560166 | localhost |    57637
+  560166 | localhost |    57638
 (4 rows)
 
 -- disable the first node
@@ -755,10 +755,10 @@ SELECT shardid, nodename, nodeport
 	WHERE logicalrelid = 'numbers_append'::regclass order by placementid;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
-  560165 | localhost |    57637
   560165 | localhost |    57638
-  560166 | localhost |    57638
+  560165 | localhost |    57637
   560166 | localhost |    57637
+  560166 | localhost |    57638
   560167 | localhost |    57638
   560168 | localhost |    57638
 (6 rows)
@@ -781,10 +781,10 @@ SELECT shardid, nodename, nodeport
 	WHERE logicalrelid = 'numbers_append'::regclass order by placementid;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
-  560165 | localhost |    57637
   560165 | localhost |    57638
-  560166 | localhost |    57638
+  560165 | localhost |    57637
   560166 | localhost |    57637
+  560166 | localhost |    57638
   560167 | localhost |    57638
   560168 | localhost |    57638
   560169 | localhost |    57637


### PR DESCRIPTION
Here's a PR which replaces the hash with a list, which should be a fair bit faster to iterate over.

This slows down `FindWorkerNode`, which was previously able to search the hash by key, but speeds up literally every other access to the cached worker node set.

The most notable caller of `FindWorkerNode` is `ActivePlacementList` (called by `GreedyAssignTaskList`) which will now iterate over the entire list of `WorkerNode`s for every shard placement.

I'm not sure what the best answer is for all these tests which have changed. Probably some of them can have `ORDER BY` added to them but that won't make this PR any smaller, just future ones, and I'm not sure how many times we'll mess with something this deep.