### PR TITLE
Fix pg_worker_list use-after-free bug

### DIFF
--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -1424,7 +1424,17 @@ TupleToWorkerNode(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	{
 		Name nodeClusterName = DatumGetName(nodeCluster);
 		char *nodeClusterString = NameStr(*nodeClusterName);
-		strlcpy(workerNode->nodeCluster, nodeClusterString, NAMEDATALEN);
+
+		/*
+		 * nodeClusterString can be null if nodecluster column is not present.
+		 * In the case of extension creation/upgrade, master_initialize_node_metadata
+		 * function is called before the nodecluster column is added to pg_dist_node
+		 * table.
+		 */
+		if (nodeClusterString != NULL)
+		{
+			strlcpy(workerNode->nodeCluster, nodeClusterString, NAMEDATALEN);
+		}
 	}
 
 	return workerNode;

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -1367,13 +1367,13 @@ ParseWorkerNodeFileAndRename()
 		workerNodeList = lappend(workerNodeList, workerNode);
 	}
 
-	FreeFile(workerFileStream);
-	free(workerFilePath);
-
 	/* rename the file, marking that it is not used anymore */
 	appendStringInfo(renamedWorkerFilePath, "%s", workerFilePath);
 	appendStringInfo(renamedWorkerFilePath, ".obsolete");
 	rename(workerFilePath, renamedWorkerFilePath->data);
+
+	FreeFile(workerFileStream);
+	free(workerFilePath);
 
 	return workerNodeList;
 }


### PR DESCRIPTION
This change fixes a use-after-free bug while renaming obsolete
`pg_worker_list.conf` file, which causes Citus to crash during upgrade
(or even extension creation) if `pg_worker_list.conf` exists. This made shard rebalancer Travis CI tests fail with nightlies, since we still use `pg_worker_list.conf` in Travis scripts.

Steps to reproduce the crash :
```
mkdir bugtest
cd bugtest

initdb data
initdb data.9700
initdb data.9701

echo "shared_preload_libraries = 'citus'" >> data/postgresql.conf
echo "shared_preload_libraries = 'citus'" >> data.9700/postgresql.conf
echo "shared_preload_libraries = 'citus'" >> data.9701/postgresql.conf

echo "localhost 9700" >> data/pg_worker_list.conf
echo "localhost 9701" >> data/pg_worker_list.conf

pg_ctl start -w -D data -l logfile
pg_ctl start -w -D data.9700 -o "-p 9700" -l logfile.9700
pg_ctl start -w -D data.9701 -o "-p 9701" -l logfile.9701

createdb testdb -h localhost -p 9700
createdb testdb -h localhost -p 9701

psql -h localhost -p 9700 -d testdb -c "CREATE EXTENSION citus"
psql -h localhost -p 9701 -d testdb -c "CREATE EXTENSION citus"

createdb testdb -h localhost -p 5432
psql -h localhost -p 5432 -d testdb -c "CREATE EXTENSION citus" # Server crashes at this step

# Cleanup
pg_ctl stop -D data
pg_ctl stop -D data.9700
pg_ctl stop -D data.9701
cd ..
rm -rf bugtest
```