### PR TITLE
Add version check to the maintenance daemon

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -266,7 +266,16 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		if (DistributedDeadlockDetectionTimeoutFactor != -1.0)
 		{
 			StartTransactionCommand();
-			foundDeadlock = CheckForDistributedDeadlocks();
+
+			/*
+			 * We don't want to run the deadlock checks if there exists
+			 * any version mistmatch.
+			 */
+			if (CheckCitusVersion(DEBUG1))
+			{
+				foundDeadlock = CheckForDistributedDeadlocks();
+			}
+
 			CommitTransactionCommand();
 
 			/*


### PR DESCRIPTION
Fixes #1557 

We should prevent running the daemon if there
is a major version change. Otherwise, the daemon
may access to obsolete metadata catalog tables.