### PR TITLE
Lock on pg_dist_node while dropping extension

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -617,12 +617,26 @@ IsCitusDropExtensionStmt(DropStmt *dropStatement)
 	{
 		foreach(objectListCell, objectList)
 		{
-			List *objectNames = (List *) lfirst(objectListCell);
-			ListCell *objectName = NULL;
+			Node *objectNode = (Node *) lfirst(objectListCell);
 
-			foreach(objectName, objectNames)
+			if (IsA(objectNode, List))
 			{
-				Value *extensionName = (Value *) lfirst(objectName);
+				List *objectNames = (List *) objectNode;
+				ListCell *objectName = NULL;
+
+				foreach(objectName, objectNames)
+				{
+					Value *extensionName = (Value *) lfirst(objectName);
+
+					if (strcmp(strVal(extensionName), "citus") == 0)
+					{
+						return true;
+					}
+				}
+			}
+			else
+			{
+				Value *extensionName = (Value *) objectNode;
 
 				if (strcmp(strVal(extensionName), "citus") == 0)
 				{

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -336,6 +336,17 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		ErrorIfUnsupportedTruncateStmt((TruncateStmt *) parsetree);
 	}
 
+	/* prevent any operation on pg_dist_node while dropping the extension */
+	if (IsA(parsetree, DropStmt))
+	{
+		DropStmt *dropStatement = (DropStmt *) parsetree;
+
+		if (dropStatement->removeType == OBJECT_EXTENSION)
+		{
+			LockRelationOid(DistNodeRelationId(), AccessExclusiveLock);
+		}
+	}
+
 	/* only generate worker DDLJobs if propagation is enabled */
 	if (EnableDDLPropagation)
 	{

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2348,15 +2348,9 @@ GetWorkerNodeHash(void)
 
 	/*
 	 * Simulate a SELECT from pg_dist_node, ensure pg_dist_node doesn't change while our
-	 * caller is using GetWorkerNodeHash.
+	 * caller is using WorkerNodeHash.
 	 */
 	LockRelationOid(DistNodeRelationId(), AccessShareLock);
-
-	/* make sure that citus extension still exists */
-	if (!CitusHasBeenLoaded())
-	{
-		ereport(ERROR, (errmsg("citus extension has been dropped")));
-	}
 
 	/*
 	 * We might have some concurrent metadata changes. In order to get the changes,

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2348,9 +2348,15 @@ GetWorkerNodeHash(void)
 
 	/*
 	 * Simulate a SELECT from pg_dist_node, ensure pg_dist_node doesn't change while our
-	 * caller is using WorkerNodeHash.
+	 * caller is using GetWorkerNodeHash.
 	 */
 	LockRelationOid(DistNodeRelationId(), AccessShareLock);
+
+	/* make sure that citus extension still exists */
+	if (!CitusHasBeenLoaded())
+	{
+		ereport(ERROR, (errmsg("citus extension has been dropped")));
+	}
 
 	/*
 	 * We might have some concurrent metadata changes. In order to get the changes,


### PR DESCRIPTION
Fixes #1558 

This PR fixes the deadlock between maintenance daemon and drop extension by getting a lock on pg_dist_node.  