### PR TITLE
Fix pg_worker_list use-after-free bug

### DIFF
--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -1065,13 +1065,13 @@ ParseWorkerNodeFileAndRename()
 		workerNodeList = lappend(workerNodeList, workerNode);
 	}
 
-	FreeFile(workerFileStream);
-	free(workerFilePath);
-
 	/* rename the file, marking that it is not used anymore */
 	appendStringInfo(renamedWorkerFilePath, "%s", workerFilePath);
 	appendStringInfo(renamedWorkerFilePath, ".obsolete");
 	rename(workerFilePath, renamedWorkerFilePath->data);
+
+	FreeFile(workerFileStream);
+	free(workerFilePath);
 
 	return workerNodeList;
 }


### PR DESCRIPTION
This change fixes a use-after-free bug while renaming obsolete
`pg_worker_list.conf` file, which causes Citus to crash during upgrade
(or even extension creation) if `pg_worker_list.conf` exists.