### PR TITLE
Switch to Postgres REL_STABLE_10 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - PGVERSION=9.6
     - PGVERSION=10
 before_install:
-  - git clone -b v0.6.3 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.6.4 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - curl https://install.citusdata.com/community/deb.sh | sudo bash


### PR DESCRIPTION
PostgreSQL master branch is now stamped with 11devel and we should
only use master branch if we want to test against PostgreSQL 11. For
PostgreSQL 9.6 tests we should use REL9_6_STABLE and for PostgreSQL 10
we should use REL_10_STABLE. v0.6.4 tag in our tools repo addresses
this problem.

Apart from that we may want to add PostgreSQL 11 to our test matrix soon.
v0.6.4 handles that too. We just need add PostgreSQL 11 to our test matrix
and stop erroring out during configure if we are compiling Citus against
PostgreSQL 11.