### PR TITLE
Return readable nodes in master_get_active_worker_nodes

### DIFF
--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -399,7 +399,7 @@ master_get_active_worker_nodes(PG_FUNCTION_ARGS)
 		/* switch to memory context appropriate for multiple function calls */
 		oldContext = MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
 
-		workerNodeList = ActivePrimaryNodeList();
+		workerNodeList = ActiveReadableNodeList();
 		workerNodeCount = (uint32) list_length(workerNodeList);
 
 		functionContext->user_fctx = workerNodeList;

--- a/src/test/regress/expected/multi_follower_select_statements.out
+++ b/src/test/regress/expected/multi_follower_select_statements.out
@@ -64,6 +64,18 @@ SELECT * FROM the_table;
  1 | 2
 (2 rows)
 
+SELECT
+  node_name, node_port
+FROM
+  master_get_active_worker_nodes()
+ORDER BY
+  node_name, node_port;
+ node_name | node_port 
+-----------+-----------
+ localhost |      9071
+ localhost |      9072
+(2 rows)
+
 -- okay, now let's play with nodecluster. If we change the cluster of our follower node
 -- queries should stat failing again, since there are no worker nodes in the new cluster
 \c "port=9070 dbname=regression options='-c\ citus.use_secondary_nodes=always\ -c\ citus.cluster_name=second-cluster'"

--- a/src/test/regress/sql/multi_follower_select_statements.sql
+++ b/src/test/regress/sql/multi_follower_select_statements.sql
@@ -42,6 +42,13 @@ SELECT 1 FROM master_add_node('localhost', :follower_worker_2_port,
 -- now that we've added secondaries this should work
 SELECT * FROM the_table;
 
+SELECT
+  node_name, node_port
+FROM
+  master_get_active_worker_nodes()
+ORDER BY
+  node_name, node_port;
+
 -- okay, now let's play with nodecluster. If we change the cluster of our follower node
 -- queries should stat failing again, since there are no worker nodes in the new cluster
 


### PR DESCRIPTION
`master_get_active_worker_nodes` currently returns primary nodes only, which is not possible in a follower cluster. Make it return readable nodes (meaning primary or secondary in the same nodecluster) instead.

Fixes #1576