### PR TITLE
Maintenance daemon dies peacefully when it gets lost finding itself

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -212,8 +212,13 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 						   HASH_FIND, NULL);
 	if (!myDbData)
 	{
-		/* should never happen */
-		ereport(ERROR, (errmsg("got lost finding myself")));
+		/*
+		 * When the database crashes, background workers are restarted, but
+		 * the state in shared memory is lost. In that case, we exit and
+		 * wait for a session to call InitializeMaintenanceDaemonBackend
+		 * to properly add it to the hash.
+		 */
+		proc_exit(0);
 	}
 	LWLockRelease(&MaintenanceDaemonControl->lock);
 


### PR DESCRIPTION
When postgres crashes, the maintenance daemon is automatically restarted, but its state in shared memory is no longer there. In that case, it currently throws a "got lost finding myself" errors and gets in an infinite restart loop.

This PR changes the error to `proc_exit(0)` which stops the background worker and avoids further restarts. A new maintenance daemon will be started as soon as `CitusHasBeenLoaded()` is called.