### PR TITLE
Terminate bg worker on drop database

### DIFF
--- a/src/include/distributed/maintenanced.h
+++ b/src/include/distributed/maintenanced.h
@@ -15,6 +15,7 @@
 /* config variable for */
 extern double DistributedDeadlockDetectionTimeoutFactor;
 
+extern void StopMaintenanceDaemon(Oid databaseId);
 extern void InitializeMaintenanceDaemon(void);
 extern void InitializeMaintenanceDaemonBackend(void);
 

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -278,6 +278,7 @@ BEGIN
     END LOOP;
 END;
 $$;
+-- see that the deamon started
 SELECT datname,
     datname = current_database(),
     usename = (SELECT extowner::regrole::text FROM pg_extension WHERE extname = 'citus')
@@ -287,15 +288,43 @@ FROM test.maintenance_worker();
  another | t        | t
 (1 row)
 
--- Test that database with active worker can be dropped. That'll
--- require killing the maintenance worker.
+-- Test that database with active worker can be dropped.
 \c regression
-SELECT datname,
-    pg_terminate_backend(pid)
-FROM test.maintenance_worker('another');
- datname | pg_terminate_backend 
----------+----------------------
- another | t
+CREATE SCHEMA test_deamon;
+-- we create a similar function on the regression database
+-- note that this function checks for the existence of the daemon
+-- when not found, returns true else tries for 5 times and 
+-- returns false
+CREATE OR REPLACE FUNCTION test_deamon.maintenance_deamon_died(p_dbname text)
+    RETURNS boolean
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+   activity record;
+BEGIN
+    PERFORM pg_stat_clear_snapshot();
+    LOOP
+        SELECT * INTO activity FROM pg_stat_activity
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        IF activity.pid IS NULL THEN
+            RETURN true;
+        ELSE
+            RETURN false;
+        END IF;
+    END LOOP;
+END;
+$$;
+-- drop the database and see that the deamon is dead
+DROP DATABASE another;
+SELECT 
+    *
+FROM 
+    test_deamon.maintenance_deamon_died('another');
+ maintenance_deamon_died 
+-------------------------
+ t
 (1 row)
 
-DROP DATABASE another;
+-- we don't need the schema and the function anymore
+DROP SCHEMA test_deamon CASCADE;
+NOTICE:  drop cascades to function test_deamon.maintenance_deamon_died(text)


### PR DESCRIPTION
I'm working on #1579.

My goal is the following:

* On `DROP DATABASE`, remove the db from the hash and terminate the bg worker before the standard utility kicks in
   * If standard utility succeeds we're done.
   * If fails, we'll re-start the bg worker since we've already removed that.

However, this doesn't work as expected. I couldn't make `TerminateBackgroundWorker () && WaitForBackgroundWorkerShutdown()` actually terminates the worker. This ends up not terminating the session to the database being dropped and getting the same error
```
ERROR:  database "test" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```

Also,  `WaitForBackgroundWorkerShutdown()` really long time. Debugging shows that it actually returns `BGWH_STOPPED`, but on `ps` I can see that worker is not terminated.

Any comments on the approach or the problems I face? What am I missing here?

