### PR TITLE
Increase coverage of isolation tests - Part 2

### DIFF
--- a/src/test/regress/expected/isolation_append_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_append_copy_vs_all.out
@@ -38,7 +38,7 @@ create_distributed_table
 step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-real-time-select: SELECT * FROM append_copy ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM append_copy ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -61,7 +61,7 @@ step s1-begin: BEGIN;
 step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -160,7 +160,7 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM append_copy;
 ERROR:  relation "append_copy" does not exist
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -174,8 +174,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''append_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -190,8 +195,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''append_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -205,8 +215,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''append_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -220,8 +235,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''append_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -236,6 +256,31 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''append_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-rename-column: ALTER TABLE append_copy RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''append_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -349,7 +394,7 @@ create_distributed_table
                
 step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM append_copy ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM append_copy ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -372,7 +417,7 @@ step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -473,7 +518,7 @@ error in steps s1-commit s2-copy: ERROR:  relation "append_copy" does not exist
 step s1-select-count: SELECT COUNT(*) FROM append_copy;
 ERROR:  relation "append_copy" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -487,8 +532,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''append_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -503,8 +553,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''append_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -519,8 +574,13 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''append_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -535,6 +595,31 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''append_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-copy s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE append_copy RENAME data TO new_column;
+step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM append_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''append_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
 create_distributed_table

--- a/src/test/regress/expected/isolation_ddl_vs_all.out
+++ b/src/test/regress/expected/isolation_ddl_vs_all.out
@@ -1,0 +1,787 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-ddl-create-index s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+error in steps s1-commit s2-ddl-create-index: ERROR:  duplicate key value violates unique constraint "pg_class_relname_nsp_index"
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-ddl-create-index-concurrently s1-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+error in steps s1-commit s2-ddl-create-index-concurrently: ERROR:  relation "ddl_hash_index" already exists
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-ddl-add-column s1-commit s2-commit s1-show-indexes s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-ddl-rename-column s1-commit s2-commit s1-show-indexes s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-ddl-create-index s1-commit s2-commit s1-show-columns s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-ddl-create-index-concurrently s1-commit s1-show-columns s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-ddl-add-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-ddl-rename-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-ddl-create-index s1-commit s2-commit s1-show-columns s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-ddl-create-index-concurrently s1-commit s1-show-columns s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-ddl-add-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-ddl-rename-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+error in steps s1-commit s2-ddl-rename-column: ERROR:  column "data" does not exist
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-table-size s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-table-size: SELECT citus_total_relation_size('ddl_hash');
+citus_total_relation_size
+
+57344          
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-master-modify-multiple-shards s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+5              
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-ddl-create-index s2-distribute-table s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s2-distribute-table: SELECT create_distributed_table('ddl_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,4)
+(localhost,57638,t,4)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-table-size s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-table-size: SELECT citus_total_relation_size('ddl_hash'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-table-size: <... completed>
+citus_total_relation_size
+
+57344          
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-master-modify-multiple-shards s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+5              
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-ddl-add-column s2-distribute-table s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
+step s2-distribute-table: SELECT create_distributed_table('ddl_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-table-size s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-table-size: SELECT citus_total_relation_size('ddl_hash'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-table-size: <... completed>
+citus_total_relation_size
+
+57344          
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-master-modify-multiple-shards s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+5              
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-distribute-table s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s2-distribute-table: SELECT create_distributed_table('ddl_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-ddl-create-index s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('ddl_hash');
+citus_total_relation_size
+
+57344          
+step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-ddl-create-index s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-ddl-create-index s1-commit s2-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('ddl_hash', 'id');
+create_distributed_table
+
+               
+step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,4)
+(localhost,57638,t,4)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-ddl-create-index-concurrently s1-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('ddl_hash');
+citus_total_relation_size
+
+57344          
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id);
+step s1-commit: COMMIT;
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-ddl-create-index-concurrently s1-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-ddl-create-index-concurrently s1-commit s1-show-indexes
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('ddl_hash', 'id');
+create_distributed_table
+
+               
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,4)
+(localhost,57638,t,4)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-ddl-add-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('ddl_hash');
+citus_total_relation_size
+
+57344          
+step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-ddl-add-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-ddl-add-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('ddl_hash', 'id');
+create_distributed_table
+
+               
+step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-ddl-rename-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('ddl_hash');
+citus_total_relation_size
+
+57344          
+step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-ddl-rename-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-ddl-rename-column s1-commit s2-commit s1-show-columns
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE ddl_hash;
+step s1-create-non-distributed-table: CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('ddl_hash', 'id');
+create_distributed_table
+
+               
+step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/expected/isolation_delete_vs_all.out
+++ b/src/test/regress/expected/isolation_delete_vs_all.out
@@ -1,0 +1,515 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-truncate: TRUNCATE delete_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-drop: DROP TABLE delete_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+ERROR:  relation "delete_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-ddl-create-index: CREATE INDEX delete_hash_index ON delete_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''delete_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-delete s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX delete_hash_index ON delete_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-ddl-drop-index: DROP INDEX delete_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''delete_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-delete s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY delete_hash_index ON delete_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''delete_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-ddl-add-column: ALTER TABLE delete_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-delete s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE delete_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-ddl-drop-column: ALTER TABLE delete_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-ddl-rename-column: ALTER TABLE delete_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-table-size s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-table-size: SELECT citus_total_relation_size('delete_hash');
+citus_total_relation_size
+
+57344          
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM delete_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+4              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-delete s2-distribute-table s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE delete_hash;
+step s1-create-non-distributed-table: CREATE TABLE delete_hash(id integer, data text); COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM delete_hash WHERE id = 4;
+step s2-distribute-table: SELECT create_distributed_table('delete_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+8              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE delete_hash;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE delete_hash;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+error in steps s1-commit s2-delete: ERROR:  relation "delete_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+ERROR:  relation "delete_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-delete s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX delete_hash_index ON delete_hash(id);
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''delete_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-delete s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX delete_hash_index ON delete_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX delete_hash_index;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''delete_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-delete s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE delete_hash ADD new_column int DEFAULT 0;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-delete s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE delete_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE delete_hash DROP new_column;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-delete s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE delete_hash RENAME data TO new_column;
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('delete_hash');
+citus_total_relation_size
+
+57344          
+step s2-delete: DELETE FROM delete_hash WHERE id = 4;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+4              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM delete_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE delete_hash;
+step s1-create-non-distributed-table: CREATE TABLE delete_hash(id integer, data text); COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('delete_hash', 'id');
+create_distributed_table
+
+               
+step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM delete_hash;
+count          
+
+8              
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -98,7 +98,7 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,1164)       
+(0,287)        
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
@@ -109,4 +109,4 @@ step s2-get-first-worker-active-transactions:
 
 nodename       nodeport       success        result         
 
-localhost      57637          t              (0,1164)       
+localhost      57637          t              (0,287)        

--- a/src/test/regress/expected/isolation_drop_vs_all.out
+++ b/src/test/regress/expected/isolation_drop_vs_all.out
@@ -1,0 +1,400 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+error in steps s1-commit s2-drop: ERROR:  table "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+error in steps s1-commit s2-ddl-create-index: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-drop s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-drop-index: DROP INDEX drop_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+error in steps s1-commit s2-ddl-drop-index: ERROR:  index "drop_hash_index" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-drop s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY drop_hash_index ON drop_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+error in steps s1-commit s2-ddl-create-index-concurrently: ERROR:  relation "drop_hash" does not exist
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+error in steps s1-commit s2-ddl-add-column: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-drop s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-drop-column: ALTER TABLE drop_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+error in steps s1-commit s2-ddl-drop-column: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-rename-column: ALTER TABLE drop_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+error in steps s1-commit s2-ddl-rename-column: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-table-size s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-table-size: SELECT citus_total_relation_size('drop_hash'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-table-size: <... completed>
+error in steps s1-commit s2-table-size: ERROR:  could not open relation with OID 23227
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DROP FROM drop_hash;');
+ERROR:  syntax error at or near "FROM"
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-drop s2-distribute-table s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE drop_hash;
+step s1-create-non-distributed-table: CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-distribute-table: SELECT create_distributed_table('drop_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+error in steps s1-commit s2-distribute-table: ERROR:  could not open relation with OID 23248
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX drop_hash_index;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE drop_hash DROP new_column;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE drop_hash RENAME data TO new_column;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('drop_hash');
+citus_total_relation_size
+
+57344          
+step s2-drop: DROP TABLE drop_hash;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DROP FROM drop_hash;');
+ERROR:  syntax error at or near "FROM"
+step s2-drop: DROP TABLE drop_hash;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE drop_hash;
+step s1-create-non-distributed-table: CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('drop_hash', 'id');
+create_distributed_table
+
+               
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/expected/isolation_drop_vs_all_0.out
+++ b/src/test/regress/expected/isolation_drop_vs_all_0.out
@@ -1,0 +1,400 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+error in steps s1-commit s2-drop: ERROR:  table "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+error in steps s1-commit s2-ddl-create-index: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-drop s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-drop-index: DROP INDEX drop_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+error in steps s1-commit s2-ddl-drop-index: ERROR:  index "drop_hash_index" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-drop s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY drop_hash_index ON drop_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+error in steps s1-commit s2-ddl-create-index-concurrently: ERROR:  relation "drop_hash" does not exist
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+error in steps s1-commit s2-ddl-add-column: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-drop s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-drop-column: ALTER TABLE drop_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+error in steps s1-commit s2-ddl-drop-column: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-ddl-rename-column: ALTER TABLE drop_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+error in steps s1-commit s2-ddl-rename-column: ERROR:  relation "drop_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-table-size s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-table-size: SELECT citus_total_relation_size('drop_hash'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-table-size: <... completed>
+error in steps s1-commit s2-table-size: ERROR:  could not open relation with OID 22183
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DROP FROM drop_hash;');
+ERROR:  syntax error at or near "FROM"
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-drop s2-distribute-table s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE drop_hash;
+step s1-create-non-distributed-table: CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE drop_hash;
+step s2-distribute-table: SELECT create_distributed_table('drop_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+error in steps s1-commit s2-distribute-table: ERROR:  could not open relation with OID 22204
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX drop_hash_index;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE drop_hash DROP new_column;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE drop_hash RENAME data TO new_column;
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('drop_hash');
+citus_total_relation_size
+
+57344          
+step s2-drop: DROP TABLE drop_hash;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DROP FROM drop_hash;');
+ERROR:  syntax error at or near "FROM"
+step s2-drop: DROP TABLE drop_hash;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE drop_hash;
+step s1-create-non-distributed-table: CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('drop_hash', 'id');
+create_distributed_table
+
+               
+step s2-drop: DROP TABLE drop_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-1167           1166           f              
+290            289            f              
 transactionnumberwaitingtransactionnumbers
 
-1166                          
-1167           1166           
+289                           
+290            289            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-1171           1170           f              
-1172           1170           f              
-1172           1171           t              
+294            293            f              
+295            293            f              
+295            294            t              
 transactionnumberwaitingtransactionnumbers
 
-1170                          
-1171           1170           
-1172           1170,1171      
+293                           
+294            293            
+295            293,294        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -38,7 +38,7 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-real-time-select: SELECT * FROM hash_copy ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM hash_copy ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -61,7 +61,7 @@ step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -97,12 +97,13 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-insert-select: INSERT INTO hash_copy SELECT * FROM hash_copy;
+step s2-insert-select: INSERT INTO hash_copy SELECT * FROM hash_copy; <waiting ...>
 step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
-10             
+20             
 
 starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
 create_distributed_table
@@ -160,7 +161,7 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 ERROR:  relation "hash_copy" does not exist
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -174,8 +175,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -190,8 +196,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -205,8 +216,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -220,8 +236,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -236,6 +257,31 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-rename-column: ALTER TABLE hash_copy RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -247,7 +293,7 @@ step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8,
 step s2-table-size: SELECT citus_total_relation_size('hash_copy');
 citus_total_relation_size
 
-32768          
+65536          
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
@@ -261,15 +307,16 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;');
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
 master_modify_multiple_shards
 
-5              
-step s1-commit: COMMIT;
+10             
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
-5              
+0              
 
 starting permutation: s1-initialize s1-begin s1-copy s2-master-drop-all-shards s1-commit s1-select-count
 create_distributed_table
@@ -283,7 +330,7 @@ step s1-commit: COMMIT;
 step s2-master-drop-all-shards: <... completed>
 master_drop_all_shards
 
-2              
+4              
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
@@ -332,7 +379,7 @@ create_distributed_table
                
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM hash_copy ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM hash_copy ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -355,7 +402,7 @@ step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -392,12 +439,13 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert-select: INSERT INTO hash_copy SELECT * FROM hash_copy;
-step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
 step s1-commit: COMMIT;
+step s2-copy: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
-10             
+15             
 
 starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
 create_distributed_table
@@ -456,7 +504,7 @@ error in steps s1-commit s2-copy: ERROR:  relation "hash_copy" does not exist
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 ERROR:  relation "hash_copy" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -470,8 +518,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -486,8 +539,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -502,8 +560,13 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -518,6 +581,31 @@ step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-copy s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE hash_copy RENAME data TO new_column;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM hash_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
 create_distributed_table
@@ -528,7 +616,7 @@ step s1-begin: BEGIN;
 step s1-table-size: SELECT citus_total_relation_size('hash_copy');
 citus_total_relation_size
 
-32768          
+57344          
 step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
@@ -546,8 +634,9 @@ step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DEL
 master_modify_multiple_shards
 
 5              
-step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
 step s1-commit: COMMIT;
+step s2-copy: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
@@ -562,14 +651,15 @@ step s1-begin: BEGIN;
 step s1-master-drop-all-shards: SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy');
 master_drop_all_shards
 
-1              
+4              
 step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
 step s1-commit: COMMIT;
 step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  could not find any shards into which to copy
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
-5              
+0              
 
 starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
 create_distributed_table

--- a/src/test/regress/expected/isolation_insert_select_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_select_vs_all.out
@@ -1,0 +1,1261 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-update-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-update-on-inserted: UPDATE insert_of_insert_select_hash SET data = 'l' WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-delete-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-delete-on-inserted: DELETE FROM insert_of_insert_select_hash WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-truncate-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-truncate-on-inserted: TRUNCATE insert_of_insert_select_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-drop-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-drop-on-inserted: DROP TABLE insert_of_insert_select_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-create-index-on-inserted s1-commit s1-select-count s1-show-indexes-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-create-index-on-inserted: CREATE INDEX insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-inserted: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index-on-inserted s1-begin s1-insert-select s2-ddl-drop-index-on-inserted s1-commit s1-select-count s1-show-indexes-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-create-index-on-inserted: CREATE INDEX insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id);
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-drop-index-on-inserted: DROP INDEX insert_of_insert_select_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-inserted: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-create-index-concurrently-on-inserted s1-commit s1-select-count s1-show-indexes-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-create-index-concurrently-on-inserted: CREATE INDEX CONCURRENTLY insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-inserted: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-add-column-on-inserted s1-commit s1-select-count s1-show-columns-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-add-column-on-inserted: ALTER TABLE insert_of_insert_select_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column-on-inserted s1-begin s1-insert-select s2-ddl-drop-column-on-inserted s1-commit s1-select-count s1-show-columns-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-add-column-on-inserted: ALTER TABLE insert_of_insert_select_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-drop-column-on-inserted: ALTER TABLE insert_of_insert_select_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-rename-column-on-inserted s1-commit s1-select-count s1-show-columns-inserted s1-show-columns-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-rename-column-on-inserted: ALTER TABLE insert_of_insert_select_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column-on-inserted: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-table-size-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-table-size-on-inserted: SELECT citus_total_relation_size('insert_of_insert_select_hash');
+citus_total_relation_size
+
+65536          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-master-modify-multiple-shards-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-master-modify-multiple-shards-on-inserted: SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards-on-inserted: <... completed>
+master_modify_multiple_shards
+
+15             
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-master-drop-all-shards-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-master-drop-all-shards-on-inserted: SELECT master_drop_all_shards('insert_of_insert_select_hash'::regclass, 'public', 'insert_of_insert_select_hash'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards-on-inserted: <... completed>
+master_drop_all_shards
+
+4              
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-drop-on-inserted s1-create-non-distributed-table-on-inserted s1-initialize s1-begin s1-insert-select s2-distribute-table-on-inserted s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop-on-inserted: DROP TABLE insert_of_insert_select_hash;
+step s1-create-non-distributed-table-on-inserted: CREATE TABLE insert_of_insert_select_hash(id integer, data text);
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+ERROR:  cannot plan queries which include both local and distributed relations
+step s2-distribute-table-on-inserted: SELECT create_distributed_table('insert_of_insert_select_hash', 'id');
+create_distributed_table
+
+               
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-update-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-update-on-selected: UPDATE select_of_insert_select_hash SET data = 'l' WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-delete-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-delete-on-selected: DELETE FROM select_of_insert_select_hash WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-truncate-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-truncate-on-selected: TRUNCATE select_of_insert_select_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate-on-selected: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-drop-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-drop-on-selected: DROP TABLE select_of_insert_select_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop-on-selected: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+ERROR:  relation "select_of_insert_select_hash" does not exist
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-create-index-on-selected s1-commit s1-select-count s1-show-indexes-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-create-index-on-selected: CREATE INDEX select_of_insert_select_hash_index ON select_of_insert_select_hash(id);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-selected: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index-on-selected s1-begin s1-insert-select s2-ddl-drop-index-on-selected s1-commit s1-select-count s1-show-indexes-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-create-index-on-selected: CREATE INDEX select_of_insert_select_hash_index ON select_of_insert_select_hash(id);
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-drop-index-on-selected: DROP INDEX select_of_insert_select_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index-on-selected: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-selected: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-create-index-concurrently-on-selected s1-commit s1-select-count s1-show-indexes-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-create-index-concurrently-on-selected: CREATE INDEX CONCURRENTLY select_of_insert_select_hash_index ON insert_of_insert_select_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently-on-selected: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-selected: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-add-column-on-selected s1-commit s1-select-count s1-show-columns-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-add-column-on-selected: ALTER TABLE select_of_insert_select_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column-on-selected: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-selected: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column-on-selected s1-begin s1-insert-select s2-ddl-drop-column-on-selected s1-commit s1-select-count s1-show-columns-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-add-column-on-selected: ALTER TABLE select_of_insert_select_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+ERROR:  INSERT has more expressions than target columns
+step s2-ddl-drop-column-on-selected: ALTER TABLE select_of_insert_select_hash DROP new_column;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-selected: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-ddl-rename-column-on-selected s1-commit s1-select-count s1-show-columns-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-ddl-rename-column-on-selected: ALTER TABLE select_of_insert_select_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column-on-selected: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-selected: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-table-size-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-table-size-on-selected: SELECT citus_total_relation_size('select_of_insert_select_hash');
+citus_total_relation_size
+
+65536          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-master-modify-multiple-shards-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-master-modify-multiple-shards-on-selected: SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;');
+master_modify_multiple_shards
+
+10             
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-master-drop-all-shards-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-master-drop-all-shards-on-selected: SELECT master_drop_all_shards('select_of_insert_select_hash'::regclass, 'public', 'select_of_insert_select_hash'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards-on-selected: <... completed>
+master_drop_all_shards
+
+4              
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+0              
+
+starting permutation: s1-drop-on-selected s1-create-non-distributed-table-on-selected s1-initialize s1-begin s1-insert-select s2-distribute-table-on-selected s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop-on-selected: DROP TABLE select_of_insert_select_hash;
+step s1-create-non-distributed-table-on-selected: CREATE TABLE select_of_insert_select_hash(id integer, data text);
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
+step s2-distribute-table-on-selected: SELECT create_distributed_table('select_of_insert_select_hash', 'id');
+create_distributed_table
+
+               
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-update-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-update-on-inserted: UPDATE insert_of_insert_select_hash SET data = 'l' WHERE id = 4;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-delete-on-inserted: DELETE FROM insert_of_insert_select_hash WHERE id = 4;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-truncate-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-truncate-on-inserted: TRUNCATE insert_of_insert_select_hash;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-drop-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-drop-on-inserted: DROP TABLE insert_of_insert_select_hash;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+error in steps s1-commit s2-insert-select: ERROR:  relation "insert_of_insert_select_hash" does not exist
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index-on-inserted s2-insert-select s1-commit s1-select-count s1-show-indexes-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-ddl-create-index-on-inserted: CREATE INDEX insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id);
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-inserted: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index-on-inserted s1-begin s1-ddl-drop-index-on-inserted s2-insert-select s1-commit s1-select-count s1-show-indexes-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-create-index-on-inserted: CREATE INDEX insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index-on-inserted: DROP INDEX insert_of_insert_select_hash_index;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-inserted: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column-on-inserted s2-insert-select s1-commit s1-select-count s1-show-columns-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-ddl-add-column-on-inserted: ALTER TABLE insert_of_insert_select_hash ADD new_column int DEFAULT 0;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column-on-inserted s1-begin s1-ddl-drop-column-on-inserted s2-insert-select s1-commit s1-select-count s1-show-columns-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-add-column-on-inserted: ALTER TABLE insert_of_insert_select_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column-on-inserted: ALTER TABLE insert_of_insert_select_hash DROP new_column;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column-on-inserted s2-insert-select s1-commit s1-select-count s1-show-columns-inserted
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-ddl-rename-column-on-inserted: ALTER TABLE insert_of_insert_select_hash RENAME data TO new_column;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-inserted: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-table-size-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-table-size-on-inserted: SELECT citus_total_relation_size('insert_of_insert_select_hash');
+citus_total_relation_size
+
+65536          
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards-on-inserted: SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;');
+master_modify_multiple_shards
+
+10             
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards-on-inserted: SELECT master_drop_all_shards('insert_of_insert_select_hash'::regclass, 'public', 'insert_of_insert_select_hash');
+master_drop_all_shards
+
+4              
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+error in steps s1-commit s2-insert-select: ERROR:  could not find any shards into which to copy
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-drop-on-inserted s1-create-non-distributed-table-on-inserted s1-initialize s1-begin s1-distribute-table-on-inserted s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop-on-inserted: DROP TABLE insert_of_insert_select_hash;
+step s1-create-non-distributed-table-on-inserted: CREATE TABLE insert_of_insert_select_hash(id integer, data text);
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-distribute-table-on-inserted: SELECT create_distributed_table('insert_of_insert_select_hash', 'id');
+create_distributed_table
+
+               
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-update-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-update-on-selected: UPDATE select_of_insert_select_hash SET data = 'l' WHERE id = 4;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-delete-on-selected: DELETE FROM select_of_insert_select_hash WHERE id = 4;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-truncate-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-truncate-on-selected: TRUNCATE select_of_insert_select_hash;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-drop-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-drop-on-selected: DROP TABLE select_of_insert_select_hash;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+error in steps s1-commit s2-insert-select: ERROR:  relation "select_of_insert_select_hash" does not exist
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+ERROR:  relation "select_of_insert_select_hash" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index-on-selected s2-insert-select s1-commit s1-select-count s1-show-indexes-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-ddl-create-index-on-selected: CREATE INDEX select_of_insert_select_hash_index ON select_of_insert_select_hash(id);
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-selected: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index-on-selected s1-begin s1-ddl-drop-index-on-selected s2-insert-select s1-commit s1-select-count s1-show-indexes-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-create-index-on-selected: CREATE INDEX select_of_insert_select_hash_index ON select_of_insert_select_hash(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index-on-selected: DROP INDEX select_of_insert_select_hash_index;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-indexes-selected: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_of_insert_select_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column-on-selected s2-insert-select s1-commit s1-select-count s1-show-columns-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-ddl-add-column-on-selected: ALTER TABLE select_of_insert_select_hash ADD new_column int DEFAULT 0;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+error in steps s1-commit s2-insert-select: ERROR:  INSERT has more expressions than target columns
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-selected: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column-on-selected s1-begin s1-ddl-drop-column-on-selected s2-insert-select s1-commit s1-select-count s1-show-columns-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-ddl-add-column-on-selected: ALTER TABLE select_of_insert_select_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column-on-selected: ALTER TABLE select_of_insert_select_hash DROP new_column;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-selected: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column-on-selected s2-insert-select s1-commit s1-select-count s1-show-columns-selected
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-ddl-rename-column-on-selected: ALTER TABLE select_of_insert_select_hash RENAME data TO new_column;
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+step s1-show-columns-selected: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-table-size-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-table-size-on-selected: SELECT citus_total_relation_size('select_of_insert_select_hash');
+citus_total_relation_size
+
+65536          
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards-on-selected: SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;');
+master_modify_multiple_shards
+
+10             
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards-on-selected: SELECT master_drop_all_shards('select_of_insert_select_hash'::regclass, 'public', 'select_of_insert_select_hash');
+master_drop_all_shards
+
+4              
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+0              
+
+starting permutation: s1-drop-on-selected s1-create-non-distributed-table-on-selected s1-initialize s1-begin s1-distribute-table-on-selected s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop-on-selected: DROP TABLE select_of_insert_select_hash;
+step s1-create-non-distributed-table-on-selected: CREATE TABLE select_of_insert_select_hash(id integer, data text);
+step s1-initialize: 
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+
+step s1-begin: BEGIN;
+step s1-distribute-table-on-selected: SELECT create_distributed_table('select_of_insert_select_hash', 'id');
+create_distributed_table
+
+               
+step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
+count          
+
+10             

--- a/src/test/regress/expected/isolation_insert_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_vs_all.out
@@ -14,6 +14,48 @@ count
 
 7              
 
+starting permutation: s1-initialize s1-begin s1-insert s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+9              
+
 starting permutation: s1-initialize s1-begin s1-insert s2-insert-select s1-commit s1-select-count
 create_distributed_table
 
@@ -84,7 +126,7 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 ERROR:  relation "insert_hash" does not exist
 
-starting permutation: s1-initialize s1-begin s1-insert s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -98,8 +140,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-insert s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-insert s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -114,8 +161,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-insert s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -129,8 +181,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-insert s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -144,8 +201,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-insert s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-insert s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -160,6 +222,31 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-insert s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
+step s2-ddl-rename-column: ALTER TABLE insert_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-insert s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -286,7 +373,7 @@ error in steps s1-commit s2-insert: ERROR:  relation "insert_hash" does not exis
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 ERROR:  relation "insert_hash" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-insert s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-insert s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -300,8 +387,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-insert s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-insert s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -316,8 +408,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-insert s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-insert s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -331,8 +428,13 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-insert s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-insert s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -347,6 +449,31 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 6              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-insert s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE insert_hash RENAME data TO new_column;
+step s2-insert: INSERT INTO insert_hash VALUES(7, 'k'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+6              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-insert s1-commit s1-select-count
 create_distributed_table
@@ -401,3 +528,479 @@ step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
 11             
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-insert-select: INSERT INTO insert_hash SELECT * FROM insert_hash;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+13             
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-update: UPDATE insert_hash SET data = 'l' WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-delete: DELETE FROM insert_hash WHERE id = 4;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+7              
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-truncate: TRUNCATE insert_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-drop: DROP TABLE insert_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+ERROR:  relation "insert_hash" does not exist
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-insert-multi-row s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id);
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-ddl-drop-index: DROP INDEX insert_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY insert_hash_index ON insert_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-ddl-add-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-insert-multi-row s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+WARNING:  INSERT has more target columns than expressions
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+ERROR:  could not modify any active placements
+step s2-ddl-drop-column: ALTER TABLE insert_hash DROP new_column;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-ddl-rename-column: ALTER TABLE insert_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-table-size: SELECT citus_total_relation_size('insert_hash');
+citus_total_relation_size
+
+57344          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+
+starting permutation: s1-initialize s1-begin s1-insert-multi-row s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
+master_modify_multiple_shards
+
+5              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+3              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-insert-multi-row s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE insert_hash;
+step s1-create-non-distributed-table: CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s2-distribute-table: SELECT create_distributed_table('insert_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+13             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO insert_hash SELECT * FROM insert_hash;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+13             
+
+starting permutation: s1-initialize s1-begin s1-update s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE insert_hash SET data = 'l' WHERE id = 4;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+
+starting permutation: s1-initialize s1-begin s1-delete s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM insert_hash WHERE id = 4;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+7              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE insert_hash;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+3              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE insert_hash;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+error in steps s1-commit s2-insert-multi-row: ERROR:  relation "insert_hash" does not exist
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+ERROR:  relation "insert_hash" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-insert-multi-row s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id);
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-insert-multi-row s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX insert_hash_index ON insert_hash(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX insert_hash_index;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-insert-multi-row s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+WARNING:  INSERT has more target columns than expressions
+step s2-insert-multi-row: <... completed>
+error in steps s1-commit s2-insert-multi-row: ERROR:  could not modify any active placements
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-insert-multi-row s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE insert_hash DROP new_column;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-insert-multi-row s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE insert_hash RENAME data TO new_column;
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('insert_hash');
+citus_total_relation_size
+
+57344          
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+8              
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+3              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-insert-multi-row s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE insert_hash;
+step s1-create-non-distributed-table: CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('insert_hash', 'id');
+create_distributed_table
+
+               
+step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-multi-row: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM insert_hash;
+count          
+
+13             

--- a/src/test/regress/expected/isolation_partitioned_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_partitioned_copy_vs_all.out
@@ -1,0 +1,580 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-copy s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-router-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-router-select: SELECT * FROM partitioned_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-real-time-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-real-time-select: SELECT * FROM partitioned_copy ORDER BY 1, 2;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert: INSERT INTO partitioned_copy VALUES(0, 'k', 0);
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert-select s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert-select: INSERT INTO partitioned_copy SELECT * FROM partitioned_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+20             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-update: UPDATE partitioned_copy SET data = 'l' WHERE id = 0;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-delete s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-delete: DELETE FROM partitioned_copy WHERE id = 1;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-truncate s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-truncate: TRUNCATE partitioned_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-drop s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-drop: DROP TABLE partitioned_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+ERROR:  relation "partitioned_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-add-column: ALTER TABLE partitioned_copy ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE partitioned_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-copy-additional-column: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV;
+step s2-ddl-drop-column: ALTER TABLE partitioned_copy DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-rename-column: ALTER TABLE partitioned_copy RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-table-size: SELECT citus_total_relation_size('partitioned_copy');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-modify-multiple-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+10             
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-drop-all-shards s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-drop-all-shards: SELECT master_drop_all_shards('partitioned_copy'::regclass, 'public', 'partitioned_copy'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards: <... completed>
+master_drop_all_shards
+
+4              
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE partitioned_copy;
+step s1-create-non-distributed-table: CREATE TABLE partitioned_copy(id integer, data text, int_data int); COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-distribute-table: SELECT create_distributed_table('partitioned_copy', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM partitioned_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM partitioned_copy ORDER BY 1, 2;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO partitioned_copy VALUES(0, 'k', 0);
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO partitioned_copy SELECT * FROM partitioned_copy;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE partitioned_copy SET data = 'l' WHERE id = 0;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM partitioned_copy WHERE id = 1;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE partitioned_copy;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE partitioned_copy;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  relation "partitioned_copy" does not exist
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+ERROR:  relation "partitioned_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE partitioned_copy ADD new_column int DEFAULT 0;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  missing data for column "new_column"
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE partitioned_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE partitioned_copy DROP new_column;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-copy s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE partitioned_copy RENAME data TO new_column;
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('partitioned_copy');
+citus_total_relation_size
+
+32768          
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;');
+master_modify_multiple_shards
+
+5              
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-master-drop-all-shards s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-drop-all-shards: SELECT master_drop_all_shards('partitioned_copy'::regclass, 'public', 'partitioned_copy');
+master_drop_all_shards
+
+4              
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  could not find any shards into which to copy
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE partitioned_copy;
+step s1-create-non-distributed-table: CREATE TABLE partitioned_copy(id integer, data text, int_data int); COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('partitioned_copy', 'id');
+create_distributed_table
+
+               
+step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
+count          
+
+15             

--- a/src/test/regress/expected/isolation_partitioned_copy_vs_all_0.out
+++ b/src/test/regress/expected/isolation_partitioned_copy_vs_all_0.out
@@ -1,0 +1,6 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-copy s2-copy s1-commit s1-select-count
+setup failed: ERROR:  syntax error at or near "PARTITION"
+LINE 3: ...itioned_copy(id integer, data text, int_data int) PARTITION ...
+                                                             ^

--- a/src/test/regress/expected/isolation_range_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_range_copy_vs_all.out
@@ -38,7 +38,7 @@ create_distributed_table
 step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
-step s2-real-time-select: SELECT * FROM range_copy ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM range_copy ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -61,7 +61,7 @@ step s1-begin: BEGIN;
 step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -160,7 +160,7 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM range_copy;
 ERROR:  relation "range_copy" does not exist
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -174,8 +174,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''range_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -190,8 +195,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''range_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -205,8 +215,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''range_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -220,8 +235,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -236,6 +256,31 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-rename-column: ALTER TABLE range_copy RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -349,7 +394,7 @@ create_distributed_table
                
 step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM range_copy ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM range_copy ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -372,7 +417,7 @@ step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -473,7 +518,7 @@ error in steps s1-commit s2-copy: ERROR:  relation "range_copy" does not exist
 step s1-select-count: SELECT COUNT(*) FROM range_copy;
 ERROR:  relation "range_copy" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -487,8 +532,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''range_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -503,8 +553,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''range_copy%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -519,8 +574,13 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -535,6 +595,31 @@ step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
 
 10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-copy s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE range_copy RENAME data TO new_column;
+step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM range_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
 create_distributed_table

--- a/src/test/regress/expected/isolation_reference_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_reference_copy_vs_all.out
@@ -1,0 +1,651 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s1-copy s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-router-select s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-router-select: SELECT * FROM reference_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-real-time-select s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-real-time-select: SELECT * FROM reference_copy ORDER BY 1, 2;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert: INSERT INTO reference_copy VALUES(0, 'k', 0); <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-insert-select s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-insert-select: INSERT INTO reference_copy SELECT * FROM reference_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-insert-select: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+20             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-update s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-update: UPDATE reference_copy SET data = 'l' WHERE id = 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-delete s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-delete: DELETE FROM reference_copy WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-truncate s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-truncate: TRUNCATE reference_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+0              
+
+starting permutation: s1-initialize s1-begin s1-copy s2-drop s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-drop: DROP TABLE reference_copy; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+ERROR:  relation "reference_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index: CREATE INDEX reference_copy_index ON reference_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''reference_copy%''');
+run_command_on_workers
+
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-copy s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX reference_copy_index ON reference_copy(id);
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-drop-index: DROP INDEX reference_copy_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''reference_copy%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY reference_copy_index ON reference_copy(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''reference_copy%''');
+run_command_on_workers
+
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-add-column s1-commit s1-select-count s1-show-columns
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-add-column: ALTER TABLE reference_copy ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-copy-additional-column s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE reference_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-copy-additional-column: COPY reference_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV;
+step s2-ddl-drop-column: ALTER TABLE reference_copy DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-ddl-rename-column: ALTER TABLE reference_copy RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-copy s2-table-size s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-table-size: SELECT citus_total_relation_size('reference_copy');
+citus_total_relation_size
+
+32768          
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-copy s2-master-modify-multiple-shards s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM reference_copy;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+10             
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+0              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-copy s2-distribute-table s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-drop: DROP TABLE reference_copy;
+step s1-create-non-distributed-table: CREATE TABLE reference_copy(id integer, data text, int_data int); COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s2-distribute-table: SELECT create_reference_table('reference_copy'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_reference_table
+
+               
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM reference_copy WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM reference_copy ORDER BY 1, 2;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-insert s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO reference_copy VALUES(0, 'k', 0);
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+11             
+
+starting permutation: s1-initialize s1-begin s1-insert-select s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-insert-select: INSERT INTO reference_copy SELECT * FROM reference_copy;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+15             
+
+starting permutation: s1-initialize s1-begin s1-update s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-update: UPDATE reference_copy SET data = 'l' WHERE id = 0;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-delete s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-delete: DELETE FROM reference_copy WHERE id = 1;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+9              
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE reference_copy;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+5              
+
+starting permutation: s1-initialize s1-begin s1-drop s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-drop: DROP TABLE reference_copy;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  relation "reference_copy" does not exist
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+ERROR:  relation "reference_copy" does not exist
+
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-copy s1-commit s1-select-count s1-show-indexes
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX reference_copy_index ON reference_copy(id);
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''reference_copy%''');
+run_command_on_workers
+
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-copy s1-commit s1-select-count s1-show-indexes
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX reference_copy_index ON reference_copy(id);
+step s1-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX reference_copy_index;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''reference_copy%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-copy s1-commit s1-select-count s1-show-columns
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE reference_copy ADD new_column int DEFAULT 0;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+error in steps s1-commit s2-copy: ERROR:  missing data for column "new_column"
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-copy s1-commit s1-select-count s1-show-columns
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE reference_copy ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE reference_copy DROP new_column;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-copy s1-commit s1-select-count s1-show-columns
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE reference_copy RENAME data TO new_column;
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-begin s1-table-size s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('reference_copy');
+citus_total_relation_size
+
+32768          
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV;
+step s1-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+10             
+
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM reference_copy;');
+master_modify_multiple_shards
+
+5              
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+5              
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-copy s1-commit s1-select-count
+create_reference_table
+
+               
+step s1-drop: DROP TABLE reference_copy;
+step s1-create-non-distributed-table: CREATE TABLE reference_copy(id integer, data text, int_data int); COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-distribute-table: SELECT create_reference_table('reference_copy');
+create_reference_table
+
+               
+step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; <waiting ...>
+step s1-commit: COMMIT;
+step s2-copy: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM reference_copy;
+count          
+
+15             

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-finish:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102826"
+error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102320"
 step s2-finish: 
   COMMIT;
 

--- a/src/test/regress/expected/isolation_select_vs_all.out
+++ b/src/test/regress/expected/isolation_select_vs_all.out
@@ -30,7 +30,7 @@ step s1-router-select: SELECT * FROM select_append WHERE id = 1;
 id             data           int_data       
 
 1               b             1              
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -56,7 +56,7 @@ id             data           int_data
 1               b             1              
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -77,7 +77,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -101,7 +101,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -109,7 +109,7 @@ id             data           int_data
 2               c             2              
 3               d             3              
 4               e             4              
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -129,7 +129,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -139,7 +139,7 @@ id             data           int_data
 4               e             4              
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -162,7 +162,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -189,7 +189,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -198,7 +198,7 @@ id             data           int_data       id             data           int_d
 2               c             2              2               c             2              
 3               d             3              3               d             3              
 4               e             4              4               e             4              
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -220,7 +220,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -231,7 +231,7 @@ id             data           int_data       id             data           int_d
 4               e             4              4               e             4              
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -348,7 +348,7 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 
-starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -364,8 +364,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-router-select s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-router-select s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -383,8 +388,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -400,8 +410,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -418,8 +433,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-router-select s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-router-select s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -437,6 +457,34 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-router-select s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-router-select: SELECT * FROM select_append WHERE id = 1;
+id             data           int_data       
+
+1               b             1              
+step s2-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-router-select s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -629,7 +677,7 @@ error in steps s1-commit s2-router-select: ERROR:  relation "select_append" does
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-router-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-router-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -645,8 +693,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-router-select s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-router-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -664,8 +717,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-router-select s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-router-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -682,8 +740,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-router-select s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-router-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -701,6 +764,34 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-router-select s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column;
+step s2-router-select: SELECT * FROM select_append WHERE id = 1; <waiting ...>
+step s1-commit: COMMIT;
+step s2-router-select: <... completed>
+id             new_column     int_data       
+
+1               b             1              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-router-select s1-commit s1-select-count
 create_distributed_table
@@ -800,7 +891,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -821,7 +912,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -842,7 +933,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -863,7 +954,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -884,7 +975,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -906,7 +997,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -920,13 +1011,13 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 
-starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -940,15 +1031,20 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-real-time-select s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-real-time-select s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -963,14 +1059,19 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -984,14 +1085,19 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1006,15 +1112,20 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-real-time-select s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-real-time-select s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       new_column     
 
 0               a             0              0              
@@ -1029,6 +1140,38 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
+id             data           int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s2-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-real-time-select s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -1036,7 +1179,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1060,7 +1203,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1085,7 +1228,7 @@ create_distributed_table
 step s1-drop: DROP TABLE select_append;
 step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s1-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 step s2-distribute-table: SELECT create_distributed_table('select_append', 'id', 'append');
@@ -1105,7 +1248,7 @@ create_distributed_table
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1126,7 +1269,7 @@ create_distributed_table
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert-select: INSERT INTO select_append SELECT * FROM select_append;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1147,7 +1290,7 @@ create_distributed_table
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1168,7 +1311,7 @@ create_distributed_table
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-delete: DELETE FROM select_append WHERE id = 1;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1189,7 +1332,7 @@ create_distributed_table
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-truncate: TRUNCATE select_append;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2; <waiting ...>
 step s1-commit: COMMIT;
 step s2-real-time-select: <... completed>
 id             data           int_data       
@@ -1206,21 +1349,21 @@ create_distributed_table
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-drop: DROP TABLE select_append;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2; <waiting ...>
 step s1-commit: COMMIT;
 step s2-real-time-select: <... completed>
 error in steps s1-commit s2-real-time-select: ERROR:  relation "select_append" does not exist
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-real-time-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-real-time-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1233,8 +1376,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-real-time-select s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-real-time-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -1242,7 +1390,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s1-begin: BEGIN;
 step s1-ddl-drop-index: DROP INDEX select_append_index;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2; <waiting ...>
 step s1-commit: COMMIT;
 step s2-real-time-select: <... completed>
 id             data           int_data       
@@ -1256,15 +1404,20 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-real-time-select s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-real-time-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2; <waiting ...>
 step s1-commit: COMMIT;
 step s2-real-time-select: <... completed>
 id             data           int_data       new_column     
@@ -1278,8 +1431,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-real-time-select s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-real-time-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -1287,7 +1445,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
 step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data; <waiting ...>
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2; <waiting ...>
 step s1-commit: COMMIT;
 step s2-real-time-select: <... completed>
 id             data           int_data       
@@ -1301,6 +1459,38 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-real-time-select s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2; <waiting ...>
+step s1-commit: COMMIT;
+step s2-real-time-select: <... completed>
+id             new_column     int_data       
+
+0               a             0              
+1               b             1              
+2               c             2              
+3               d             3              
+4               e             4              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-real-time-select s1-commit s1-select-count
 create_distributed_table
@@ -1312,7 +1502,7 @@ step s1-table-size: SELECT citus_total_relation_size('select_append');
 citus_total_relation_size
 
 32768          
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1336,7 +1526,7 @@ step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DEL
 master_modify_multiple_shards
 
 5              
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 0               a             0              
@@ -1361,7 +1551,7 @@ step s1-distribute-table: SELECT create_distributed_table('select_append', 'id',
 create_distributed_table
 
                
-step s2-real-time-select: SELECT * FROM select_append ORDER BY id, data;
+step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
 step s1-commit: COMMIT;
@@ -1378,7 +1568,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1402,7 +1592,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1426,7 +1616,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1450,7 +1640,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1474,7 +1664,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1499,7 +1689,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1514,7 +1704,7 @@ step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -1522,7 +1712,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1537,8 +1727,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-task-tracker-select s2-ddl-drop-index s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-task-tracker-select s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -1547,7 +1742,7 @@ step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1563,8 +1758,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index-concurrently s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -1572,7 +1772,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1587,8 +1787,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-add-column s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -1596,7 +1801,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1612,8 +1817,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-task-tracker-select s2-ddl-drop-column s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-task-tracker-select s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -1622,7 +1832,7 @@ step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       new_column     id             data           int_data       new_column     
 
@@ -1638,6 +1848,41 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+
+id             data           int_data       id             data           int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s2-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-table-size s1-commit s1-select-count
 create_distributed_table
@@ -1647,7 +1892,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1674,7 +1919,7 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2,
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1702,7 +1947,7 @@ step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, dat
 step s1-begin: BEGIN;
 step s1-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1725,7 +1970,7 @@ step s1-begin: BEGIN;
 step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1749,7 +1994,7 @@ step s1-begin: BEGIN;
 step s1-insert-select: INSERT INTO select_append SELECT * FROM select_append;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1773,7 +2018,7 @@ step s1-begin: BEGIN;
 step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1797,7 +2042,7 @@ step s1-begin: BEGIN;
 step s1-delete: DELETE FROM select_append WHERE id = 1;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1821,7 +2066,7 @@ step s1-begin: BEGIN;
 step s1-truncate: TRUNCATE select_append;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1841,7 +2086,7 @@ step s1-begin: BEGIN;
 step s1-drop: DROP TABLE select_append;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1849,7 +2094,7 @@ error in steps s1-commit s2-task-tracker-select: ERROR:  relation "select_append
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-task-tracker-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -1858,7 +2103,7 @@ step s1-begin: BEGIN;
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1872,8 +2117,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-task-tracker-select s1-commit s1-select-count
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-task-tracker-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -1883,7 +2133,7 @@ step s1-begin: BEGIN;
 step s1-ddl-drop-index: DROP INDEX select_append_index;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1898,8 +2148,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%''');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-task-tracker-select s1-commit s1-select-count
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-task-tracker-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -1908,7 +2163,7 @@ step s1-begin: BEGIN;
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1923,8 +2178,13 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-task-tracker-select s1-commit s1-select-count
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-task-tracker-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -1934,7 +2194,7 @@ step s1-begin: BEGIN;
 step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
 step s2-task-tracker-select: <... completed>
@@ -1949,6 +2209,41 @@ step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-task-tracker-select s1-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV;
+step s1-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column;
+step s2-task-tracker-select: 
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+ <waiting ...>
+step s1-commit: COMMIT;
+step s2-task-tracker-select: <... completed>
+id             new_column     int_data       id             new_column     int_data       
+
+0               a             0              0               a             0              
+1               b             1              1               b             1              
+2               c             2              2               c             2              
+3               d             3              3               d             3              
+4               e             4              4               e             4              
+step s1-select-count: SELECT COUNT(*) FROM select_append;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 
 starting permutation: s1-initialize s1-begin s1-table-size s2-task-tracker-select s1-commit s1-select-count
 create_distributed_table
@@ -1962,7 +2257,7 @@ citus_total_relation_size
 32768          
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -1989,7 +2284,7 @@ master_modify_multiple_shards
 5              
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 
@@ -2017,7 +2312,7 @@ create_distributed_table
                
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data       
 

--- a/src/test/regress/expected/isolation_truncate_vs_all.out
+++ b/src/test/regress/expected/isolation_truncate_vs_all.out
@@ -1,0 +1,606 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-drop: DROP TABLE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+ERROR:  relation "truncate_append" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-ddl-create-index: CREATE INDEX truncate_append_index ON truncate_append(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''truncate_append%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-truncate s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX truncate_append_index ON truncate_append(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-ddl-drop-index: DROP INDEX truncate_append_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''truncate_append%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-truncate s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY truncate_append_index ON truncate_append(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''truncate_append%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-ddl-add-column: ALTER TABLE truncate_append ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-truncate s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE truncate_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-ddl-drop-column: ALTER TABLE truncate_append DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-ddl-rename-column: ALTER TABLE truncate_append RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-table-size s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-table-size: SELECT citus_total_relation_size('truncate_append'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-table-size: <... completed>
+citus_total_relation_size
+
+0              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM truncate_append;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+0              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-master-apply-delete-command s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM truncate_append WHERE id <= 4;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-apply-delete-command: <... completed>
+master_apply_delete_command
+
+0              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-master-drop-all-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-master-drop-all-shards: SELECT master_drop_all_shards('truncate_append'::regclass, 'public', 'truncate_append'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-drop-all-shards: <... completed>
+master_drop_all_shards
+
+0              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s2-begin s1-truncate s2-distribute-table s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE truncate_append;
+step s1-create-non-distributed-table: CREATE TABLE truncate_append(id integer, data text);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-distribute-table: SELECT create_distributed_table('truncate_append', 'id', 'append'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE truncate_append;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE truncate_append;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+error in steps s1-commit s2-truncate: ERROR:  relation "truncate_append" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+ERROR:  relation "truncate_append" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-truncate s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX truncate_append_index ON truncate_append(id);
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''truncate_append%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-truncate s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX truncate_append_index ON truncate_append(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX truncate_append_index;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''truncate_append%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-truncate s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE truncate_append ADD new_column int DEFAULT 0;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-truncate s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE truncate_append ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE truncate_append DROP new_column;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-truncate s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE truncate_append RENAME data TO new_column;
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('truncate_append');
+citus_total_relation_size
+
+32768          
+step s2-truncate: TRUNCATE truncate_append;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM truncate_append;');
+master_modify_multiple_shards
+
+5              
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-apply-delete-command s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-apply-delete-command: SELECT master_apply_delete_command('DELETE FROM truncate_append WHERE id <= 4;');
+master_apply_delete_command
+
+1              
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-drop-all-shards s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-drop-all-shards: SELECT master_drop_all_shards('truncate_append'::regclass, 'public', 'truncate_append');
+master_drop_all_shards
+
+1              
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s2-begin s1-distribute-table s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE truncate_append;
+step s1-create-non-distributed-table: CREATE TABLE truncate_append(id integer, data text);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-distribute-table: SELECT create_distributed_table('truncate_append', 'id', 'append');
+create_distributed_table
+
+               
+step s2-truncate: TRUNCATE truncate_append; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM truncate_append;
+count          
+
+0              
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/expected/isolation_update_vs_all.out
+++ b/src/test/regress/expected/isolation_update_vs_all.out
@@ -78,7 +78,7 @@ restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-create-index s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -94,11 +94,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''update_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-update s2-ddl-drop-index s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-update s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -115,11 +120,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''update_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s1-update s2-ddl-create-index-concurrently s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-update s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -133,11 +143,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''update_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-add-column s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -153,11 +168,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''update_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-update s2-ddl-drop-column s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-update s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -169,6 +189,58 @@ step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
 step s2-ddl-drop-column: ALTER TABLE update_hash DROP new_column; <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-drop-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''update_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-ddl-rename-column: ALTER TABLE update_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''update_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-table-size s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s2-table-size: SELECT citus_total_relation_size('update_hash');
+citus_total_relation_size
+
+57344          
+step s1-commit: COMMIT;
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
@@ -285,7 +357,7 @@ restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-update s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-update s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -301,11 +373,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''update_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-update s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-update s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 
                
@@ -322,11 +399,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''update_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-update s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-update s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -342,11 +424,16 @@ step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
 
 5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''update_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
 restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-update s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-update s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 
                
@@ -358,6 +445,59 @@ step s1-ddl-drop-column: ALTER TABLE update_hash DROP new_column;
 step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
 step s1-commit: COMMIT;
 step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''update_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-update s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE update_hash RENAME data TO new_column;
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+error in steps s1-commit s2-update: ERROR:  column "data" of relation "update_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM update_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''update_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('update_hash');
+citus_total_relation_size
+
+57344          
+step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
+step s1-commit: COMMIT;
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          

--- a/src/test/regress/expected/isolation_upsert_vs_all.out
+++ b/src/test/regress/expected/isolation_upsert_vs_all.out
@@ -1,0 +1,571 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-update s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-update: UPDATE upsert_hash SET data = 'l' WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-update: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-delete s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-delete: DELETE FROM upsert_hash WHERE id = 4; <waiting ...>
+step s1-commit: COMMIT;
+step s2-delete: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+4              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-truncate s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-truncate: TRUNCATE upsert_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-truncate: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-drop s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-drop: DROP TABLE upsert_hash; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+ERROR:  relation "upsert_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-ddl-create-index: CREATE INDEX upsert_hash_index ON upsert_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''upsert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,4)
+(localhost,57638,t,4)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-upsert s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX upsert_hash_index ON upsert_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-ddl-drop-index: DROP INDEX upsert_hash_index; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-index: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''upsert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s1-upsert s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY upsert_hash_index ON upsert_hash(id); <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''upsert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,4)
+(localhost,57638,t,4)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-ddl-add-column: ALTER TABLE upsert_hash ADD new_column int DEFAULT 0; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-add-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-upsert s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE upsert_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-ddl-drop-column: ALTER TABLE upsert_hash DROP new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-ddl-rename-column: ALTER TABLE upsert_hash RENAME data TO new_column; <waiting ...>
+step s1-commit: COMMIT;
+step s2-ddl-rename-column: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-table-size s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-table-size: SELECT citus_total_relation_size('upsert_hash');
+citus_total_relation_size
+
+114688         
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-upsert s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-master-modify-multiple-shards: <... completed>
+master_modify_multiple_shards
+
+5              
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+0              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-upsert s2-distribute-table s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-drop: DROP TABLE upsert_hash;
+step s1-create-non-distributed-table: CREATE TABLE upsert_hash(id integer PRIMARY KEY, data text);
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s2-distribute-table: SELECT create_distributed_table('upsert_hash', 'id'); <waiting ...>
+step s1-commit: COMMIT;
+step s2-distribute-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-update s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-update: UPDATE upsert_hash SET data = 'l' WHERE id = 4;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-delete: DELETE FROM upsert_hash WHERE id = 4;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-truncate s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-truncate: TRUNCATE upsert_hash;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+1              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop: DROP TABLE upsert_hash;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+error in steps s1-commit s2-upsert: ERROR:  relation "upsert_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+ERROR:  relation "upsert_hash" does not exist
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-upsert s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-create-index: CREATE INDEX upsert_hash_index ON upsert_hash(id);
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''upsert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,4)
+(localhost,57638,t,4)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-upsert s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-create-index: CREATE INDEX upsert_hash_index ON upsert_hash(id);
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-index: DROP INDEX upsert_hash_index;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''upsert_hash%''');
+run_command_on_workers
+
+(localhost,57637,t,2)
+(localhost,57638,t,2)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-upsert s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-add-column: ALTER TABLE upsert_hash ADD new_column int DEFAULT 0;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-upsert s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-ddl-add-column: ALTER TABLE upsert_hash ADD new_column int DEFAULT 0;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-drop-column: ALTER TABLE upsert_hash DROP new_column;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,"")
+(localhost,57638,t,"")
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-upsert s1-commit s2-commit s1-select-count s1-show-columns
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-ddl-rename-column: ALTER TABLE upsert_hash RENAME data TO new_column;
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+error in steps s1-commit s2-upsert: ERROR:  column "data" of relation "upsert_hash" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
+run_command_on_workers
+
+(localhost,57637,t,new_column)
+(localhost,57638,t,new_column)
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-table-size: SELECT citus_total_relation_size('upsert_hash');
+citus_total_relation_size
+
+114688         
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+5              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-upsert s1-commit s2-commit s1-select-count
+create_distributed_table
+
+               
+step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;');
+master_modify_multiple_shards
+
+5              
+step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
+step s1-commit: COMMIT;
+step s2-upsert: <... completed>
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
+count          
+
+1              
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -7,13 +7,6 @@ test: isolation_create_table_vs_add_remove_node
 # that come later can be parallelized
 test: isolation_cluster_management
 
-test: isolation_hash_copy_vs_all
-test: isolation_append_copy_vs_all
-test: isolation_range_copy_vs_all
-test: isolation_select_vs_all
-test: isolation_insert_vs_all
-test: isolation_update_vs_all
-
 test: isolation_dml_vs_repair isolation_copy_placement_vs_copy_placement
 
 test: isolation_concurrent_dml isolation_data_migration
@@ -29,3 +22,18 @@ test: isolation_distributed_deadlock_detection
 # creating a restore point briefly blocks all
 # writes, run this test serially.
 test: isolation_create_restore_point
+
+test: isolation_hash_copy_vs_all
+test: isolation_append_copy_vs_all
+test: isolation_range_copy_vs_all
+test: isolation_reference_copy_vs_all
+test: isolation_partitioned_copy_vs_all
+test: isolation_select_vs_all
+test: isolation_insert_vs_all
+test: isolation_insert_select_vs_all
+test: isolation_upsert_vs_all
+test: isolation_update_vs_all
+test: isolation_delete_vs_all
+test: isolation_truncate_vs_all
+test: isolation_drop_vs_all
+test: isolation_ddl_vs_all

--- a/src/test/regress/specs/isolation_ddl_vs_all.spec
+++ b/src/test/regress/specs/isolation_ddl_vs_all.spec
@@ -1,0 +1,101 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of DDL in concurrent operations
+setup
+{
+	SELECT citus.replace_isolation_tester_func();
+	SELECT citus.refresh_isolation_tester_prepared_statement();
+
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE ddl_hash(id integer, data text);
+	SELECT create_distributed_table('ddl_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS ddl_hash CASCADE;
+
+	SELECT citus.restore_isolation_tester_func();
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-ddl-create-index" { CREATE INDEX ddl_hash_index ON ddl_hash(id); }
+step "s1-ddl-drop-index" { DROP INDEX ddl_hash_index; }
+step "s1-ddl-add-column" { ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE ddl_hash DROP new_column_2; }
+step "s1-ddl-rename-column" { ALTER TABLE ddl_hash RENAME data TO new_column; }
+step "s1-table-size" { SELECT citus_total_relation_size('ddl_hash'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); }
+step "s1-drop" { DROP TABLE ddl_hash; }
+step "s1-create-non-distributed-table" { CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('ddl_hash', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM ddl_hash; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-ddl-create-index" { CREATE INDEX ddl_hash_index ON ddl_hash(id); }
+step "s2-ddl-drop-index" { DROP INDEX ddl_hash_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); }
+step "s2-ddl-add-column" { ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE ddl_hash DROP new_column_1; }
+step "s2-ddl-rename-column" { ALTER TABLE ddl_hash RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('ddl_hash'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); }
+step "s2-create-non-distributed-table" { CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('ddl_hash', 'id'); }
+step "s2-select" { SELECT * FROM ddl_hash ORDER BY 1, 2; }
+step "s2-commit" { COMMIT; }
+
+# permutations - DDL vs DDL
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-indexes" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-show-indexes" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-show-columns" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-columns" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-show-columns" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-columns" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-show-columns"
+
+# permutations - DDL first
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-table-size" "s1-commit" "s2-commit" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-show-indexes"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-distribute-table" "s1-commit" "s2-commit" "s1-show-indexes"
+
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-table-size" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-distribute-table" "s1-commit" "s2-commit" "s1-show-columns"
+
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-table-size" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-distribute-table" "s1-commit" "s2-commit" "s1-show-columns"
+
+# permutations - DDL second
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-show-indexes"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-show-indexes"
+
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
+
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
+
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-show-columns"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-show-columns"

--- a/src/test/regress/specs/isolation_delete_vs_all.spec
+++ b/src/test/regress/specs/isolation_delete_vs_all.spec
@@ -1,0 +1,90 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of DELETE in concurrent operations
+setup
+{
+	SELECT citus.replace_isolation_tester_func();
+	SELECT citus.refresh_isolation_tester_prepared_statement();
+
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE delete_hash(id integer, data text);
+	SELECT create_distributed_table('delete_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS delete_hash CASCADE;
+
+	SELECT citus.restore_isolation_tester_func();
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-delete" { DELETE FROM delete_hash WHERE id = 4; }
+step "s1-truncate" { TRUNCATE delete_hash; }
+step "s1-drop" { DROP TABLE delete_hash; }
+step "s1-ddl-create-index" { CREATE INDEX delete_hash_index ON delete_hash(id); }
+step "s1-ddl-drop-index" { DROP INDEX delete_hash_index; }
+step "s1-ddl-add-column" { ALTER TABLE delete_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE delete_hash DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE delete_hash RENAME data TO new_column; }
+step "s1-table-size" { SELECT citus_total_relation_size('delete_hash'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM delete_hash;'); }
+step "s1-create-non-distributed-table" { CREATE TABLE delete_hash(id integer, data text); COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('delete_hash', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM delete_hash; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''delete_hash%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''delete_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-delete" { DELETE FROM delete_hash WHERE id = 4; }
+step "s2-truncate" { TRUNCATE delete_hash; }
+step "s2-drop" { DROP TABLE delete_hash; }
+step "s2-ddl-create-index" { CREATE INDEX delete_hash_index ON delete_hash(id); }
+step "s2-ddl-drop-index" { DROP INDEX delete_hash_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY delete_hash_index ON delete_hash(id); }
+step "s2-ddl-add-column" { ALTER TABLE delete_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE delete_hash DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE delete_hash RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('delete_hash'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM delete_hash;'); }
+step "s2-create-non-distributed-table" { CREATE TABLE delete_hash(id integer, data text); COPY delete_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('delete_hash', 'id'); }
+step "s2-select" { SELECT * FROM delete_hash ORDER BY 1, 2; }
+step "s2-commit" { COMMIT; }
+
+# permutations - DELETE vs DELETE
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - DELETE first
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-drop-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - DELETE second
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-ddl-drop-index" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_drop_vs_all.spec
+++ b/src/test/regress/specs/isolation_drop_vs_all.spec
@@ -1,0 +1,82 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of DROP in concurrent operations
+setup
+{
+	SELECT citus.replace_isolation_tester_func();
+	SELECT citus.refresh_isolation_tester_prepared_statement();
+
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE drop_hash(id integer, data text);
+	SELECT create_distributed_table('drop_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS drop_hash CASCADE;
+
+	SELECT citus.restore_isolation_tester_func();
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-drop" { DROP TABLE drop_hash; }
+step "s1-ddl-create-index" { CREATE INDEX drop_hash_index ON drop_hash(id); }
+step "s1-ddl-drop-index" { DROP INDEX drop_hash_index; }
+step "s1-ddl-add-column" { ALTER TABLE drop_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE drop_hash DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE drop_hash RENAME data TO new_column; }
+step "s1-table-size" { SELECT citus_total_relation_size('drop_hash'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DROP FROM drop_hash;'); }
+step "s1-create-non-distributed-table" { CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('drop_hash', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM drop_hash; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''drop_hash%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''drop_hash'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-drop" { DROP TABLE drop_hash; }
+step "s2-ddl-create-index" { CREATE INDEX drop_hash_index ON drop_hash(id); }
+step "s2-ddl-drop-index" { DROP INDEX drop_hash_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY drop_hash_index ON drop_hash(id); }
+step "s2-ddl-add-column" { ALTER TABLE drop_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE drop_hash DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE drop_hash RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('drop_hash'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DROP FROM drop_hash;'); }
+step "s2-create-non-distributed-table" { CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s2-distribute-table" { SELECT create_distributed_table('drop_hash', 'id'); }
+step "s2-select" { SELECT * FROM drop_hash ORDER BY 1, 2; }
+step "s2-commit" { COMMIT; }
+
+# permutations - DROP vs DROP
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - DROP first
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-drop-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - DROP second
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-ddl-drop-index" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_hash_copy_vs_all.spec
@@ -7,7 +7,7 @@ setup
 {
 	SET citus.shard_replication_factor TO 1;
 	CREATE TABLE hash_copy(id integer, data text, int_data int);
-	SELECT create_distributed_table('hash_copy', 'id', 'append');
+	SELECT create_distributed_table('hash_copy', 'id');
 }
 
 # drop distributed table
@@ -23,13 +23,12 @@ step "s1-begin" { BEGIN; }
 step "s1-copy" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
 step "s1-copy-additional-column" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM hash_copy WHERE id = 1; }
-step "s1-real-time-select" { SELECT * FROM hash_copy ORDER BY id, data; }
+step "s1-real-time-select" { SELECT * FROM hash_copy ORDER BY 1, 2; }
 step "s1-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
-step "s1-select-count" { SELECT COUNT(*) FROM hash_copy; }
 step "s1-insert" { INSERT INTO hash_copy VALUES(0, 'k', 0); }
 step "s1-insert-select" { INSERT INTO hash_copy SELECT * FROM hash_copy; }
 step "s1-update" { UPDATE hash_copy SET data = 'l' WHERE id = 0; }
@@ -40,13 +39,16 @@ step "s1-ddl-create-index" { CREATE INDEX hash_copy_index ON hash_copy(id); }
 step "s1-ddl-drop-index" { DROP INDEX hash_copy_index; }
 step "s1-ddl-add-column" { ALTER TABLE hash_copy ADD new_column int DEFAULT 0; }
 step "s1-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
-step "s1-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_data; }
+step "s1-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE hash_copy ADD CONSTRAINT hash_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('hash_copy'); }
 step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('hash_copy', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM hash_copy; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
 step "s1-commit" { COMMIT; }
 
 # session 2
@@ -54,11 +56,11 @@ session "s2"
 step "s2-copy" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
 step "s2-copy-additional-column" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM hash_copy WHERE id = 1; }
-step "s2-real-time-select" { SELECT * FROM hash_copy ORDER BY id, data; }
+step "s2-real-time-select" { SELECT * FROM hash_copy ORDER BY 1, 2; }
 step "s2-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
 step "s2-insert" { INSERT INTO hash_copy VALUES(0, 'k', 0); }
 step "s2-insert-select" { INSERT INTO hash_copy SELECT * FROM hash_copy; }
@@ -71,7 +73,7 @@ step "s2-ddl-drop-index" { DROP INDEX hash_copy_index; }
 step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY hash_copy_index ON hash_copy(id); }
 step "s2-ddl-add-column" { ALTER TABLE hash_copy ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
-step "s2-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_data; }
+step "s2-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('hash_copy'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
@@ -90,11 +92,12 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-sel
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
@@ -110,10 +113,11 @@ permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-sel
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_insert_select_vs_all.spec
+++ b/src/test/regress/specs/isolation_insert_select_vs_all.spec
@@ -1,0 +1,165 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of INSERT/SELECT in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE insert_of_insert_select_hash(id integer, data text);
+	SELECT create_distributed_table('insert_of_insert_select_hash', 'id');
+	CREATE TABLE select_of_insert_select_hash(id integer, data text);
+	SELECT create_distributed_table('select_of_insert_select_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS insert_of_insert_select_hash CASCADE;
+	DROP TABLE IF EXISTS select_of_insert_select_hash CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize"
+{
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
+	COPY insert_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a\\n6, b\\n7, c\\n8, d\\n9, e' WITH CSV;
+}
+step "s1-begin" { BEGIN; }
+step "s1-insert-select" { INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;; }
+step "s1-update-on-inserted" { UPDATE insert_of_insert_select_hash SET data = 'l' WHERE id = 4; }
+step "s1-delete-on-inserted" { DELETE FROM insert_of_insert_select_hash WHERE id = 4; }
+step "s1-truncate-on-inserted" { TRUNCATE insert_of_insert_select_hash; }
+step "s1-drop-on-inserted" { DROP TABLE insert_of_insert_select_hash; }
+step "s1-ddl-create-index-on-inserted" { CREATE INDEX insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id); }
+step "s1-ddl-drop-index-on-inserted" { DROP INDEX insert_of_insert_select_hash_index; }
+step "s1-ddl-add-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash DROP new_column; }
+step "s1-ddl-rename-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash RENAME data TO new_column; }
+step "s1-table-size-on-inserted" { SELECT citus_total_relation_size('insert_of_insert_select_hash'); }
+step "s1-master-modify-multiple-shards-on-inserted" { SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;'); }
+step "s1-master-drop-all-shards-on-inserted" { SELECT master_drop_all_shards('insert_of_insert_select_hash'::regclass, 'public', 'insert_of_insert_select_hash'); }
+step "s1-create-non-distributed-table-on-inserted" { CREATE TABLE insert_of_insert_select_hash(id integer, data text); }
+step "s1-distribute-table-on-inserted" { SELECT create_distributed_table('insert_of_insert_select_hash', 'id'); }
+step "s1-show-indexes-inserted" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_of_insert_select_hash%'''); }
+step "s1-show-columns-inserted" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-update-on-selected" { UPDATE select_of_insert_select_hash SET data = 'l' WHERE id = 4; }
+step "s1-delete-on-selected" { DELETE FROM select_of_insert_select_hash WHERE id = 4; }
+step "s1-truncate-on-selected" { TRUNCATE select_of_insert_select_hash; }
+step "s1-drop-on-selected" { DROP TABLE select_of_insert_select_hash; }
+step "s1-ddl-create-index-on-selected" { CREATE INDEX select_of_insert_select_hash_index ON select_of_insert_select_hash(id); }
+step "s1-ddl-drop-index-on-selected" { DROP INDEX select_of_insert_select_hash_index; }
+step "s1-ddl-add-column-on-selected" { ALTER TABLE select_of_insert_select_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column-on-selected" { ALTER TABLE select_of_insert_select_hash DROP new_column; }
+step "s1-ddl-rename-column-on-selected" { ALTER TABLE select_of_insert_select_hash RENAME data TO new_column; }
+step "s1-table-size-on-selected" { SELECT citus_total_relation_size('select_of_insert_select_hash'); }
+step "s1-master-modify-multiple-shards-on-selected" { SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;'); }
+step "s1-master-drop-all-shards-on-selected" { SELECT master_drop_all_shards('select_of_insert_select_hash'::regclass, 'public', 'select_of_insert_select_hash'); }
+step "s1-create-non-distributed-table-on-selected" { CREATE TABLE select_of_insert_select_hash(id integer, data text); }
+step "s1-distribute-table-on-selected" { SELECT create_distributed_table('select_of_insert_select_hash', 'id'); }
+step "s1-show-indexes-selected" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_of_insert_select_hash%'''); }
+step "s1-show-columns-selected" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_of_insert_select_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-select-count" { SELECT COUNT(*) FROM select_of_insert_select_hash; }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-insert-select" { INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5; }
+step "s2-update-on-inserted" { UPDATE insert_of_insert_select_hash SET data = 'l' WHERE id = 4; }
+step "s2-delete-on-inserted" { DELETE FROM insert_of_insert_select_hash WHERE id = 4; }
+step "s2-truncate-on-inserted" { TRUNCATE insert_of_insert_select_hash; }
+step "s2-drop-on-inserted" { DROP TABLE insert_of_insert_select_hash; }
+step "s2-ddl-create-index-on-inserted" { CREATE INDEX insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id); }
+step "s2-ddl-drop-index-on-inserted" { DROP INDEX insert_of_insert_select_hash_index; }
+step "s2-ddl-create-index-concurrently-on-inserted" { CREATE INDEX CONCURRENTLY insert_of_insert_select_hash_index ON insert_of_insert_select_hash(id); }
+step "s2-ddl-add-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash DROP new_column; }
+step "s2-ddl-rename-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash RENAME data TO new_column; }
+step "s2-table-size-on-inserted" { SELECT citus_total_relation_size('insert_of_insert_select_hash'); }
+step "s2-master-modify-multiple-shards-on-inserted" { SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;'); }
+step "s2-master-drop-all-shards-on-inserted" { SELECT master_drop_all_shards('insert_of_insert_select_hash'::regclass, 'public', 'insert_of_insert_select_hash'); }
+step "s2-create-non-distributed-table-on-inserted" { CREATE TABLE insert_of_insert_select_hash(id integer, data text); }
+step "s2-distribute-table-on-inserted" { SELECT create_distributed_table('insert_of_insert_select_hash', 'id'); }
+step "s2-update-on-selected" { UPDATE select_of_insert_select_hash SET data = 'l' WHERE id = 4; }
+step "s2-delete-on-selected" { DELETE FROM select_of_insert_select_hash WHERE id = 4; }
+step "s2-truncate-on-selected" { TRUNCATE select_of_insert_select_hash; }
+step "s2-drop-on-selected" { DROP TABLE select_of_insert_select_hash; }
+step "s2-ddl-create-index-on-selected" { CREATE INDEX select_of_insert_select_hash_index ON select_of_insert_select_hash(id); }
+step "s2-ddl-drop-index-on-selected" { DROP INDEX select_of_insert_select_hash_index; }
+step "s2-ddl-create-index-concurrently-on-selected" { CREATE INDEX CONCURRENTLY select_of_insert_select_hash_index ON insert_of_insert_select_hash(id); }
+step "s2-ddl-add-column-on-selected" { ALTER TABLE select_of_insert_select_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column-on-selected" { ALTER TABLE select_of_insert_select_hash DROP new_column; }
+step "s2-ddl-rename-column-on-selected" { ALTER TABLE select_of_insert_select_hash RENAME data TO new_column; }
+step "s2-table-size-on-selected" { SELECT citus_total_relation_size('select_of_insert_select_hash'); }
+step "s2-master-modify-multiple-shards-on-selected" { SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;'); }
+step "s2-master-drop-all-shards-on-selected" { SELECT master_drop_all_shards('select_of_insert_select_hash'::regclass, 'public', 'select_of_insert_select_hash'); }
+step "s2-create-non-distributed-table-on-selected" { CREATE TABLE select_of_insert_select_hash(id integer, data text); }
+step "s2-distribute-table-on-selected" { SELECT create_distributed_table('select_of_insert_select_hash', 'id'); }
+
+# permutations - INSERT/SELECT vs INSERT/SELECT
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-insert-select" "s1-commit" "s1-select-count"
+
+# permutations - INSERT/SELECT first operation on INSERT side
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-update-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-delete-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-truncate-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-drop-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-create-index-on-inserted" "s1-commit" "s1-select-count" "s1-show-indexes-inserted"
+permutation "s1-initialize" "s1-ddl-create-index-on-inserted" "s1-begin" "s1-insert-select" "s2-ddl-drop-index-on-inserted" "s1-commit" "s1-select-count" "s1-show-indexes-inserted"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-create-index-concurrently-on-inserted" "s1-commit" "s1-select-count" "s1-show-indexes-inserted"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-add-column-on-inserted" "s1-commit" "s1-select-count" "s1-show-columns-inserted"
+permutation "s1-initialize" "s1-ddl-add-column-on-inserted" "s1-begin" "s1-insert-select" "s2-ddl-drop-column-on-inserted" "s1-commit" "s1-select-count" "s1-show-columns-inserted"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-rename-column-on-inserted" "s1-commit" "s1-select-count" "s1-show-columns-inserted" "s1-show-columns-inserted"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-table-size-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-master-modify-multiple-shards-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-master-drop-all-shards-on-inserted" "s1-commit" "s1-select-count"
+permutation "s1-drop-on-inserted" "s1-create-non-distributed-table-on-inserted" "s1-initialize" "s1-begin" "s1-insert-select" "s2-distribute-table-on-inserted" "s1-commit" "s1-select-count"
+
+# permutations - INSERT/SELECT first operation on SELECT side
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-update-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-delete-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-truncate-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-drop-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-create-index-on-selected" "s1-commit" "s1-select-count" "s1-show-indexes-selected"
+permutation "s1-initialize" "s1-ddl-create-index-on-selected" "s1-begin" "s1-insert-select" "s2-ddl-drop-index-on-selected" "s1-commit" "s1-select-count" "s1-show-indexes-selected"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-create-index-concurrently-on-selected" "s1-commit" "s1-select-count" "s1-show-indexes-selected"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-add-column-on-selected" "s1-commit" "s1-select-count" "s1-show-columns-selected"
+permutation "s1-initialize" "s1-ddl-add-column-on-selected" "s1-begin" "s1-insert-select" "s2-ddl-drop-column-on-selected" "s1-commit" "s1-select-count" "s1-show-columns-selected"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-ddl-rename-column-on-selected" "s1-commit" "s1-select-count" "s1-show-columns-selected"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-table-size-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-master-modify-multiple-shards-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-master-drop-all-shards-on-selected" "s1-commit" "s1-select-count"
+permutation "s1-drop-on-selected" "s1-create-non-distributed-table-on-selected" "s1-initialize" "s1-begin" "s1-insert-select" "s2-distribute-table-on-selected" "s1-commit" "s1-select-count"
+
+# permutations - INSERT/SELECT second on INSERT side
+permutation "s1-initialize" "s1-begin" "s1-update-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-indexes-inserted"
+permutation "s1-initialize" "s1-ddl-create-index-on-inserted" "s1-begin" "s1-ddl-drop-index-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-indexes-inserted"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-columns-inserted"
+permutation "s1-initialize" "s1-ddl-add-column-on-inserted" "s1-begin" "s1-ddl-drop-column-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-columns-inserted"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-columns-inserted"
+permutation "s1-initialize" "s1-begin" "s1-table-size-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-drop-on-inserted" "s1-create-non-distributed-table-on-inserted" "s1-initialize" "s1-begin" "s1-distribute-table-on-inserted" "s2-insert-select" "s1-commit" "s1-select-count"
+
+# permutations - INSERT/SELECT second on SELECT side
+permutation "s1-initialize" "s1-begin" "s1-update-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index-on-selected" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-indexes-selected"
+permutation "s1-initialize" "s1-ddl-create-index-on-selected" "s1-begin" "s1-ddl-drop-index-on-selected" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-indexes-selected"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column-on-selected" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-columns-selected"
+permutation "s1-initialize" "s1-ddl-add-column-on-selected" "s1-begin" "s1-ddl-drop-column-on-selected" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-columns-selected"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column-on-selected" "s2-insert-select" "s1-commit" "s1-select-count" "s1-show-columns-selected"
+permutation "s1-initialize" "s1-begin" "s1-table-size-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-drop-on-selected" "s1-create-non-distributed-table-on-selected" "s1-initialize" "s1-begin" "s1-distribute-table-on-selected" "s2-insert-select" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_insert_vs_all.spec
+++ b/src/test/regress/specs/isolation_insert_vs_all.spec
@@ -21,6 +21,7 @@ session "s1"
 step "s1-initialize" { COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
 step "s1-begin" { BEGIN; }
 step "s1-insert" { INSERT INTO insert_hash VALUES(7, 'k'); }
+step "s1-insert-multi-row" { INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); }
 step "s1-insert-select" { INSERT INTO insert_hash SELECT * FROM insert_hash; }
 step "s1-update" { UPDATE insert_hash SET data = 'l' WHERE id = 4; }
 step "s1-delete" { DELETE FROM insert_hash WHERE id = 4; }
@@ -30,17 +31,20 @@ step "s1-ddl-create-index" { CREATE INDEX insert_hash_index ON insert_hash(id); 
 step "s1-ddl-drop-index" { DROP INDEX insert_hash_index; }
 step "s1-ddl-add-column" { ALTER TABLE insert_hash ADD new_column int DEFAULT 0; }
 step "s1-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
-step "s1-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_data; }
+step "s1-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('insert_hash'); }
 step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
 step "s1-create-non-distributed-table" { CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
 step "s1-select-count" { SELECT COUNT(*) FROM insert_hash; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''insert_hash%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
 step "s1-commit" { COMMIT; }
 
 # session 2
 session "s2"
 step "s2-insert" { INSERT INTO insert_hash VALUES(7, 'k'); }
+step "s2-insert-multi-row" { INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); }
 step "s2-insert-select" { INSERT INTO insert_hash SELECT * FROM insert_hash; }
 step "s2-update" { UPDATE insert_hash SET data = 'l' WHERE id = 4; }
 step "s2-delete" { DELETE FROM insert_hash WHERE id = 4; }
@@ -51,13 +55,16 @@ step "s2-ddl-drop-index" { DROP INDEX insert_hash_index; }
 step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY insert_hash_index ON insert_hash(id); }
 step "s2-ddl-add-column" { ALTER TABLE insert_hash ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
-step "s2-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_data; }
+step "s2-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('insert_hash'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
 step "s2-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
 
 # permutations - INSERT vs INSERT
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-insert" "s1-commit" "s1-select-count"
 
 # permutations - INSERT first
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-insert-select" "s1-commit" "s1-select-count"
@@ -65,11 +72,12 @@ permutation "s1-initialize" "s1-begin" "s1-insert" "s2-update" "s1-commit" "s1-s
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-truncate" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-create-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-insert" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-add-column" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-insert" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-insert" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-insert" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-insert" "s2-distribute-table" "s1-commit" "s1-select-count"
@@ -80,10 +88,42 @@ permutation "s1-initialize" "s1-begin" "s1-update" "s2-insert" "s1-commit" "s1-s
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-drop" "s2-insert" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-insert" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-insert" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-insert" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-insert" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-insert" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-insert" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-insert" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-insert" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-insert" "s1-commit" "s1-select-count"
+
+# permutations - multi row INSERT first
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-insert-multi-row" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-insert-multi-row" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-insert-multi-row" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - multi row INSERT second
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-insert-multi-row" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-insert-multi-row" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-insert-multi-row" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-insert-multi-row" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-insert-multi-row" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-insert-multi-row" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-insert-multi-row" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_partitioned_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_partitioned_copy_vs_all.spec
@@ -1,0 +1,122 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create append distributed table to test behavior of COPY in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE partitioned_copy(id integer, data text, int_data int) PARTITION BY RANGE (int_data);
+    CREATE TABLE partitioned_copy_0_3 PARTITION OF partitioned_copy FOR VALUES FROM (0) TO (3);
+    CREATE TABLE partitioned_copy_3_6 PARTITION OF partitioned_copy FOR VALUES FROM (3) TO (6);
+    CREATE TABLE partitioned_copy_6_10 PARTITION OF partitioned_copy FOR VALUES FROM (6) TO (10);
+	SELECT create_distributed_table('partitioned_copy', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS partitioned_copy CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-copy" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s1-copy-additional-column" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s1-router-select" { SELECT * FROM partitioned_copy WHERE id = 1; }
+step "s1-real-time-select" { SELECT * FROM partitioned_copy ORDER BY 1, 2; }
+step "s1-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+}
+step "s1-insert" { INSERT INTO partitioned_copy VALUES(0, 'k', 0); }
+step "s1-insert-select" { INSERT INTO partitioned_copy SELECT * FROM partitioned_copy; }
+step "s1-update" { UPDATE partitioned_copy SET data = 'l' WHERE id = 0; }
+step "s1-delete" { DELETE FROM partitioned_copy WHERE id = 1; }
+step "s1-truncate" { TRUNCATE partitioned_copy; }
+step "s1-drop" { DROP TABLE partitioned_copy; }
+step "s1-ddl-create-index" { CREATE INDEX partitioned_copy_index ON partitioned_copy(id); }
+step "s1-ddl-drop-index" { DROP INDEX partitioned_copy_index; }
+step "s1-ddl-add-column" { ALTER TABLE partitioned_copy ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE partitioned_copy DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE partitioned_copy RENAME data TO new_column; }
+step "s1-ddl-unique-constraint" { ALTER TABLE partitioned_copy ADD CONSTRAINT partitioned_copy_unique UNIQUE(id); }
+step "s1-table-size" { SELECT citus_total_relation_size('partitioned_copy'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;'); }
+step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('partitioned_copy'::regclass, 'public', 'partitioned_copy'); }
+step "s1-create-non-distributed-table" { CREATE TABLE partitioned_copy(id integer, data text, int_data int); COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-distribute-table" { SELECT create_distributed_table('partitioned_copy', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM partitioned_copy; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''partitioned_copy%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''partitioned_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-copy" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s2-copy-additional-column" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s2-router-select" { SELECT * FROM partitioned_copy WHERE id = 1; }
+step "s2-real-time-select" { SELECT * FROM partitioned_copy ORDER BY 1, 2; }
+step "s2-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+}
+step "s2-insert" { INSERT INTO partitioned_copy VALUES(0, 'k', 0); }
+step "s2-insert-select" { INSERT INTO partitioned_copy SELECT * FROM partitioned_copy; }
+step "s2-update" { UPDATE partitioned_copy SET data = 'l' WHERE id = 0; }
+step "s2-delete" { DELETE FROM partitioned_copy WHERE id = 1; }
+step "s2-truncate" { TRUNCATE partitioned_copy; }
+step "s2-drop" { DROP TABLE partitioned_copy; }
+step "s2-ddl-create-index" { CREATE INDEX partitioned_copy_index ON partitioned_copy(id); }
+step "s2-ddl-drop-index" { DROP INDEX partitioned_copy_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY partitioned_copy_index ON partitioned_copy(id); }
+step "s2-ddl-add-column" { ALTER TABLE partitioned_copy ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE partitioned_copy DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE partitioned_copy RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('partitioned_copy'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('partitioned_copy'::regclass, 'public', 'partitioned_copy'); }
+step "s2-distribute-table" { SELECT create_distributed_table('partitioned_copy', 'id'); }
+
+# permutations - COPY vs COPY
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-select-count"
+
+# permutations - COPY first
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - COPY second
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_range_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_range_copy_vs_all.spec
@@ -23,13 +23,12 @@ step "s1-begin" { BEGIN; }
 step "s1-copy" { COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
 step "s1-copy-additional-column" { COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM range_copy WHERE id = 1; }
-step "s1-real-time-select" { SELECT * FROM range_copy ORDER BY id, data; }
+step "s1-real-time-select" { SELECT * FROM range_copy ORDER BY 1, 2; }
 step "s1-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
-step "s1-select-count" { SELECT COUNT(*) FROM range_copy; }
 step "s1-insert" { INSERT INTO range_copy VALUES(0, 'k', 0); }
 step "s1-insert-select" { INSERT INTO range_copy SELECT * FROM range_copy; }
 step "s1-update" { UPDATE range_copy SET data = 'l' WHERE id = 0; }
@@ -40,7 +39,7 @@ step "s1-ddl-create-index" { CREATE INDEX range_copy_index ON range_copy(id); }
 step "s1-ddl-drop-index" { DROP INDEX range_copy_index; }
 step "s1-ddl-add-column" { ALTER TABLE range_copy ADD new_column int DEFAULT 0; }
 step "s1-ddl-drop-column" { ALTER TABLE range_copy DROP new_column; }
-step "s1-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_data; }
+step "s1-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE range_copy ADD CONSTRAINT range_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('range_copy'); }
 step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
@@ -48,6 +47,10 @@ step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELE
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); }
 step "s1-distribute-table" { SELECT create_distributed_table('range_copy', 'id', 'range'); }
+step "s1-select-count" { SELECT COUNT(*) FROM range_copy; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''range_copy%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''range_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+
 step "s1-commit" { COMMIT; }
 
 # session 2
@@ -55,11 +58,11 @@ session "s2"
 step "s2-copy" { COPY range_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
 step "s2-copy-additional-column" { COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM range_copy WHERE id = 1; }
-step "s2-real-time-select" { SELECT * FROM range_copy ORDER BY id, data; }
+step "s2-real-time-select" { SELECT * FROM range_copy ORDER BY 1, 2; }
 step "s2-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
 step "s2-insert" { INSERT INTO range_copy VALUES(0, 'k', 0); }
 step "s2-insert-select" { INSERT INTO range_copy SELECT * FROM range_copy; }
@@ -72,7 +75,7 @@ step "s2-ddl-drop-index" { DROP INDEX range_copy_index; }
 step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY range_copy_index ON range_copy(id); }
 step "s2-ddl-add-column" { ALTER TABLE range_copy ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE range_copy DROP new_column; }
-step "s2-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_data; }
+step "s2-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('range_copy'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
@@ -92,11 +95,12 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-sel
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
@@ -113,10 +117,11 @@ permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-sel
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_reference_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_reference_copy_vs_all.spec
@@ -1,0 +1,124 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create append distributed table to test behavior of COPY in concurrent operations
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE reference_copy(id integer, data text, int_data int);
+	SELECT create_reference_table('reference_copy');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS reference_copy CASCADE;
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-copy" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s1-copy-additional-column" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s1-router-select" { SELECT * FROM reference_copy WHERE id = 1; }
+step "s1-real-time-select" { SELECT * FROM reference_copy ORDER BY 1, 2; }
+step "s1-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+}
+step "s1-insert" { INSERT INTO reference_copy VALUES(0, 'k', 0); }
+step "s1-insert-select" { INSERT INTO reference_copy SELECT * FROM reference_copy; }
+step "s1-update" { UPDATE reference_copy SET data = 'l' WHERE id = 0; }
+step "s1-delete" { DELETE FROM reference_copy WHERE id = 1; }
+step "s1-truncate" { TRUNCATE reference_copy; }
+step "s1-drop" { DROP TABLE reference_copy; }
+step "s1-ddl-create-index" { CREATE INDEX reference_copy_index ON reference_copy(id); }
+step "s1-ddl-drop-index" { DROP INDEX reference_copy_index; }
+step "s1-ddl-add-column" { ALTER TABLE reference_copy ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE reference_copy DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE reference_copy RENAME data TO new_column; }
+step "s1-ddl-unique-constraint" { ALTER TABLE reference_copy ADD CONSTRAINT reference_copy_unique UNIQUE(id); }
+step "s1-table-size" { SELECT citus_total_relation_size('reference_copy'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM reference_copy;'); }
+step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM reference_copy WHERE id <= 4;'); }
+step "s1-create-non-distributed-table" { CREATE TABLE reference_copy(id integer, data text, int_data int); COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s1-distribute-table" { SELECT create_reference_table('reference_copy'); }
+step "s1-select-count" { SELECT COUNT(*) FROM reference_copy; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''reference_copy%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''reference_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-copy" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5\\n6, g, 6\\n7, h, 7\\n8, i, 8\\n9, j, 9' WITH CSV; }
+step "s2-copy-additional-column" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5, 5\\n6, g, 6, 6\\n7, h, 7, 7\\n8, i, 8, 8\\n9, j, 9, 9' WITH CSV; }
+step "s2-router-select" { SELECT * FROM reference_copy WHERE id = 1; }
+step "s2-real-time-select" { SELECT * FROM reference_copy ORDER BY 1, 2; }
+step "s2-task-tracker-select"
+{
+	SET citus.task_executor_type TO "task-tracker";
+	SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+}
+step "s2-insert" { INSERT INTO reference_copy VALUES(0, 'k', 0); }
+step "s2-insert-select" { INSERT INTO reference_copy SELECT * FROM reference_copy; }
+step "s2-update" { UPDATE reference_copy SET data = 'l' WHERE id = 0; }
+step "s2-delete" { DELETE FROM reference_copy WHERE id = 1; }
+step "s2-truncate" { TRUNCATE reference_copy; }
+step "s2-drop" { DROP TABLE reference_copy; }
+step "s2-ddl-create-index" { CREATE INDEX reference_copy_index ON reference_copy(id); }
+step "s2-ddl-drop-index" { DROP INDEX reference_copy_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY reference_copy_index ON reference_copy(id); }
+step "s2-ddl-add-column" { ALTER TABLE reference_copy ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE reference_copy DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE reference_copy RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('reference_copy'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM reference_copy;'); }
+step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM reference_copy WHERE id <= 4;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('reference_copy'::regclass, 'public', 'reference_copy'); }
+step "s2-create-non-distributed-table" { CREATE TABLE reference_copy(id integer, data text, int_data int); COPY reference_copy FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
+step "s2-distribute-table" { SELECT create_reference_table('reference_copy'); }
+
+# permutations - COPY vs COPY
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-select-count"
+
+# permutations - COPY first
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
+
+# permutations - COPY second
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-copy" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-copy" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_select_vs_all.spec
+++ b/src/test/regress/specs/isolation_select_vs_all.spec
@@ -21,13 +21,12 @@ session "s1"
 step "s1-initialize" { COPY select_append FROM PROGRAM 'echo 0, a, 0\\n1, b, 1\\n2, c, 2\\n3, d, 3\\n4, e, 4' WITH CSV; }
 step "s1-begin" { BEGIN; }
 step "s1-router-select" { SELECT * FROM select_append WHERE id = 1; }
-step "s1-real-time-select" { SELECT * FROM select_append ORDER BY id, data; }
+step "s1-real-time-select" { SELECT * FROM select_append ORDER BY 1, 2; }
 step "s1-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
-step "s1-select-count" { SELECT COUNT(*) FROM select_append; }
 step "s1-insert" { INSERT INTO select_append VALUES(0, 'k', 0); }
 step "s1-insert-select" { INSERT INTO select_append SELECT * FROM select_append; }
 step "s1-update" { UPDATE select_append SET data = 'l' WHERE id = 0; }
@@ -38,23 +37,26 @@ step "s1-ddl-create-index" { CREATE INDEX select_append_index ON select_append(i
 step "s1-ddl-drop-index" { DROP INDEX select_append_index; }
 step "s1-ddl-add-column" { ALTER TABLE select_append ADD new_column int DEFAULT 0; }
 step "s1-ddl-drop-column" { ALTER TABLE select_append DROP new_column; }
-step "s1-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_data; }
+step "s1-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('select_append'); }
 step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); }
 step "s1-distribute-table" { SELECT create_distributed_table('select_append', 'id', 'append'); }
+step "s1-select-count" { SELECT COUNT(*) FROM select_append; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''select_append%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''select_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
 step "s1-commit" { COMMIT; }
 
 # session 2
 session "s2"
 step "s2-router-select" { SELECT * FROM select_append WHERE id = 1; }
-step "s2-real-time-select" { SELECT * FROM select_append ORDER BY id, data; }
+step "s2-real-time-select" { SELECT * FROM select_append ORDER BY 1, 2; }
 step "s2-task-tracker-select"
 {
 	SET citus.task_executor_type TO "task-tracker";
-	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY t1.id, t1.data, t2.id;
+	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
 step "s2-insert" { INSERT INTO select_append VALUES(0, 'k', 0); }
 step "s2-insert-select" { INSERT INTO select_append SELECT * FROM select_append; }
@@ -67,7 +69,7 @@ step "s2-ddl-drop-index" { DROP INDEX select_append_index; }
 step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY select_append_index ON select_append(id); }
 step "s2-ddl-add-column" { ALTER TABLE select_append ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE select_append DROP new_column; }
-step "s2-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_data; }
+step "s2-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('select_append'); }
 step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
@@ -92,11 +94,12 @@ permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-update" "s1-commit
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-truncate" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-create-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-router-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-add-column" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-router-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-router-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-router-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
@@ -110,10 +113,11 @@ permutation "s1-initialize" "s1-begin" "s1-update" "s2-router-select" "s1-commit
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-drop" "s2-router-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-router-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-router-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-router-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-router-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-router-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-router-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-router-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-router-select" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s1-commit" "s1-select-count"
@@ -127,11 +131,12 @@ permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-update" "s1-com
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-truncate" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-create-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-real-time-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-add-column" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-real-time-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-real-time-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-real-time-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-real-time-select" "s2-distribute-table" "s1-commit" "s1-select-count"
@@ -143,10 +148,11 @@ permutation "s1-initialize" "s1-begin" "s1-update" "s2-real-time-select" "s1-com
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-drop" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-real-time-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-real-time-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-real-time-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-real-time-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-real-time-select" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-real-time-select" "s1-commit" "s1-select-count"
@@ -158,11 +164,12 @@ permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-update" "s1-
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-delete" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-truncate" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-add-column" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-table-size" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-task-tracker-select" "s2-distribute-table" "s1-commit" "s1-select-count"
@@ -174,10 +181,11 @@ permutation "s1-initialize" "s1-begin" "s1-update" "s2-task-tracker-select" "s1-
 permutation "s1-initialize" "s1-begin" "s1-delete" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-drop" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-task-tracker-select" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-task-tracker-select" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_truncate_vs_all.spec
+++ b/src/test/regress/specs/isolation_truncate_vs_all.spec
@@ -1,0 +1,96 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of TRUNCATE in concurrent operations
+setup
+{
+	SELECT citus.replace_isolation_tester_func();
+	SELECT citus.refresh_isolation_tester_prepared_statement();
+
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE truncate_append(id integer, data text);
+	SELECT create_distributed_table('truncate_append', 'id', 'append');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS truncate_append CASCADE;
+
+	SELECT citus.restore_isolation_tester_func();
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY truncate_append FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-truncate" { TRUNCATE truncate_append; }
+step "s1-drop" { DROP TABLE truncate_append; }
+step "s1-ddl-create-index" { CREATE INDEX truncate_append_index ON truncate_append(id); }
+step "s1-ddl-drop-index" { DROP INDEX truncate_append_index; }
+step "s1-ddl-add-column" { ALTER TABLE truncate_append ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE truncate_append DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE truncate_append RENAME data TO new_column; }
+step "s1-table-size" { SELECT citus_total_relation_size('truncate_append'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM truncate_append;'); }
+step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM truncate_append WHERE id <= 4;'); }
+step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('truncate_append'::regclass, 'public', 'truncate_append'); }
+step "s1-create-non-distributed-table" { CREATE TABLE truncate_append(id integer, data text); }
+step "s1-distribute-table" { SELECT create_distributed_table('truncate_append', 'id', 'append'); }
+step "s1-select-count" { SELECT COUNT(*) FROM truncate_append; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''truncate_append%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''truncate_append%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-truncate" { TRUNCATE truncate_append; }
+step "s2-drop" { DROP TABLE truncate_append; }
+step "s2-ddl-create-index" { CREATE INDEX truncate_append_index ON truncate_append(id); }
+step "s2-ddl-drop-index" { DROP INDEX truncate_append_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY truncate_append_index ON truncate_append(id); }
+step "s2-ddl-add-column" { ALTER TABLE truncate_append ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE truncate_append DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE truncate_append RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('truncate_append'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM truncate_append;'); }
+step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM truncate_append WHERE id <= 4;'); }
+step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('truncate_append'::regclass, 'public', 'truncate_append'); }
+step "s2-create-non-distributed-table" { CREATE TABLE truncate_append(id integer, data text); }
+step "s2-distribute-table" { SELECT create_distributed_table('truncate_append', 'id', 'append'); }
+step "s2-select" { SELECT * FROM truncate_append ORDER BY 1, 2; }
+step "s2-commit" { COMMIT; }
+
+# permutations - TRUNCATE vs TRUNCATE
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - TRUNCATE first
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-truncate" "s2-ddl-drop-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-truncate" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-master-apply-delete-command" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-master-drop-all-shards" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s2-begin" "s1-truncate" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - TRUNCATE second
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-ddl-drop-index" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-apply-delete-command" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-drop-all-shards" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s2-begin" "s1-distribute-table" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_upsert_vs_all.spec
+++ b/src/test/regress/specs/isolation_upsert_vs_all.spec
@@ -1,0 +1,95 @@
+#
+# How we organize this isolation test spec, is explained at README.md file in this directory.
+#
+
+# create range distributed table to test behavior of UPSERT in concurrent operations
+setup
+{
+	SELECT citus.replace_isolation_tester_func();
+	SELECT citus.refresh_isolation_tester_prepared_statement();
+
+	SET citus.shard_replication_factor TO 1;
+	CREATE TABLE upsert_hash(id integer PRIMARY KEY, data text);
+	SELECT create_distributed_table('upsert_hash', 'id');
+}
+
+# drop distributed table
+teardown
+{
+	DROP TABLE IF EXISTS upsert_hash CASCADE;
+
+	SELECT citus.restore_isolation_tester_func();
+}
+
+# session 1
+session "s1"
+step "s1-initialize" { COPY upsert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV; }
+step "s1-begin" { BEGIN; }
+step "s1-upsert" { INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; }
+step "s1-update" { UPDATE upsert_hash SET data = 'l' WHERE id = 4; }
+step "s1-delete" { DELETE FROM upsert_hash WHERE id = 4; }
+step "s1-truncate" { TRUNCATE upsert_hash; }
+step "s1-drop" { DROP TABLE upsert_hash; }
+step "s1-ddl-create-index" { CREATE INDEX upsert_hash_index ON upsert_hash(id); }
+step "s1-ddl-drop-index" { DROP INDEX upsert_hash_index; }
+step "s1-ddl-add-column" { ALTER TABLE upsert_hash ADD new_column int DEFAULT 0; }
+step "s1-ddl-drop-column" { ALTER TABLE upsert_hash DROP new_column; }
+step "s1-ddl-rename-column" { ALTER TABLE upsert_hash RENAME data TO new_column; }
+step "s1-table-size" { SELECT citus_total_relation_size('upsert_hash'); }
+step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;'); }
+step "s1-create-non-distributed-table" { CREATE TABLE upsert_hash(id integer PRIMARY KEY, data text); }
+step "s1-distribute-table" { SELECT create_distributed_table('upsert_hash', 'id'); }
+step "s1-select-count" { SELECT COUNT(*) FROM upsert_hash; }
+step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''upsert_hash%'''); }
+step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''upsert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-commit" { COMMIT; }
+
+# session 2
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-upsert" { INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; }
+step "s2-update" { UPDATE upsert_hash SET data = 'l' WHERE id = 4; }
+step "s2-delete" { DELETE FROM upsert_hash WHERE id = 4; }
+step "s2-truncate" { TRUNCATE upsert_hash; }
+step "s2-drop" { DROP TABLE upsert_hash; }
+step "s2-ddl-create-index" { CREATE INDEX upsert_hash_index ON upsert_hash(id); }
+step "s2-ddl-drop-index" { DROP INDEX upsert_hash_index; }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY upsert_hash_index ON upsert_hash(id); }
+step "s2-ddl-add-column" { ALTER TABLE upsert_hash ADD new_column int DEFAULT 0; }
+step "s2-ddl-drop-column" { ALTER TABLE upsert_hash DROP new_column; }
+step "s2-ddl-rename-column" { ALTER TABLE upsert_hash RENAME data TO new_column; }
+step "s2-table-size" { SELECT citus_total_relation_size('upsert_hash'); }
+step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;'); }
+step "s2-distribute-table" { SELECT create_distributed_table('upsert_hash', 'id'); }
+step "s2-commit" { COMMIT; }
+
+# permutations - UPSERT vs UPSERT
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - UPSERT first
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-update" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-truncate" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-ddl-create-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-upsert" "s2-ddl-drop-index" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-upsert" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-upsert" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-upsert" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
+
+# permutations - UPSERT second
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-update" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-truncate" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-create-index" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s2-begin" "s1-ddl-drop-index" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-upsert" "s1-commit" "s2-commit" "s1-select-count"


### PR DESCRIPTION
With this PR we add isolation tests for

- COPY to reference table vs. other operations
- COPY to partitioned table vs. other operations
- Multi row INSERTs vs other operations
- INSERT/SELECT vs. other operations
- UPSERT vs. other operations
- DELETE vs. other operations
- TRUNCATE vs. other operations
- DROP vs. other operations
- DDL vs. other operations

other operations consist of basic SQL operations (like SELECT,
INSERT, DELETE, UPSERT, COPY TRUNCATE, CREATE INDEX) as well
as some Citus functionalities (like master_modify_multiple_shards,
master_apply_delete_command, citus_total_relation_size etc.)