### PR TITLE
Consider dropped columns that precede the partition column in COPY

### DIFF
--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -99,6 +99,8 @@ ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
 	List *columnNameList = NIL;
 	bool stopOnFailure = false;
 	char partitionMethod = 0;
+	Var *partitionColumn = NULL;
+	int partitionColumnIndex = -1;
 
 	CitusCopyDestReceiver *copyDest = NULL;
 
@@ -108,17 +110,32 @@ ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
 		stopOnFailure = true;
 	}
 
+	partitionColumn = PartitionColumn(targetRelationId, 0);
+
 	/* build the list of column names for the COPY statement */
 	foreach(insertTargetCell, insertTargetList)
 	{
 		TargetEntry *insertTargetEntry = (TargetEntry *) lfirst(insertTargetCell);
+		char *columnName = insertTargetEntry->resname;
+
+		/* load the column information from pg_attribute */
+		AttrNumber attrNumber = get_attnum(targetRelationId, columnName);
+
+		/* check whether this is the partition column */
+		if (partitionColumn != NULL && attrNumber == partitionColumn->varattno)
+		{
+			Assert(partitionColumnIndex == -1);
+
+			partitionColumnIndex = list_length(columnNameList);
+		}
 
 		columnNameList = lappend(columnNameList, insertTargetEntry->resname);
 	}
 
 	/* set up a DestReceiver that copies into the distributed table */
 	copyDest = CreateCitusCopyDestReceiver(targetRelationId, columnNameList,
-										   executorState, stopOnFailure);
+										   partitionColumnIndex, executorState,
+										   stopOnFailure);
 
 	ExecuteIntoDestReceiver(selectQuery, paramListInfo, (DestReceiver *) copyDest);
 

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -20,6 +20,9 @@
 #include "tcop/dest.h"
 
 
+#define INVALID_PARTITION_COLUMN_INDEX -1
+
+
 /*
  * A smaller version of copy.c's CopyStateData, trimmed to the elements
  * necessary to copy out results. While it'd be a bit nicer to share code,
@@ -93,6 +96,7 @@ typedef struct CitusCopyDestReceiver
 /* function declarations for copying into a distributed table */
 extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   List *columnNameList,
+														   int partitionColumnIndex,
 														   EState *executorState,
 														   bool stopOnFailure);
 extern FmgrInfo * ColumnOutputFunctions(TupleDesc rowDescriptor, bool binaryFormat);

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -533,20 +533,27 @@ END;
 CREATE TABLE data_load_test (col1 int, col2 text, col3 text, "CoL4"")" int);
 INSERT INTO data_load_test VALUES (132, 'hello', 'world');
 INSERT INTO data_load_test VALUES (243, 'world', 'hello');
-ALTER TABLE data_load_test DROP COLUMN col2;
-SELECT create_distributed_table('data_load_test', 'col1');
+ALTER TABLE data_load_test DROP COLUMN col1;
+SELECT create_distributed_table('data_load_test', 'col3');
 NOTICE:  Copying data from local table...
  create_distributed_table 
 --------------------------
  
 (1 row)
 
-SELECT * FROM data_load_test;
- col1 | col3  | CoL4") 
-------+-------+--------
-  132 | world |       
-  243 | hello |       
+SELECT * FROM data_load_test ORDER BY col2;
+ col2  | col3  | CoL4") 
+-------+-------+--------
+ hello | world |       
+ world | hello |       
 (2 rows)
+
+-- make sure the tuple went to the right shard
+SELECT * FROM data_load_test WHERE col3 = 'world';
+ col2  | col3  | CoL4") 
+-------+-------+--------
+ hello | world |       
+(1 row)
 
 DROP TABLE data_load_test;
 SET citus.shard_replication_factor TO default;

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2401,21 +2401,35 @@ SELECT user_id, value_4 FROM test_view ORDER BY user_id, value_4;
 -- Drop the view now, because the column we are about to drop depends on it
 DROP VIEW test_view;
 -- Make sure we handle dropped columns correctly
-TRUNCATE raw_events_first;
-ALTER TABLE raw_events_first DROP COLUMN value_1;
-INSERT INTO raw_events_first (user_id, value_4)
+CREATE TABLE drop_col_table (col1 text, col2 text, col3 text);
+SELECT create_distributed_table('drop_col_table', 'col2');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE drop_col_table DROP COLUMN col1;
+INSERT INTO drop_col_table (col3, col2)
 SELECT value_4, user_id FROM raw_events_second LIMIT 5;
-SELECT user_id, value_4 FROM raw_events_first ORDER BY user_id;
- user_id | value_4 
----------+---------
-       3 |       1
-       6 |       2
-       9 |       3
-      12 |       4
-      15 |       5
+SELECT * FROM drop_col_table ORDER BY col2, col3;
+ col2 | col3 
+------+------
+ 1    | 3
+ 2    | 6
+ 3    | 9
+ 4    | 12
+ 5    | 15
 (5 rows)
 
+-- make sure the tuple went to the right shard
+SELECT * FROM drop_col_table WHERE col2 = '1';
+ col2 | col3 
+------+------
+ 1    | 3
+(1 row)
+
 RESET client_min_messages;
+DROP TABLE drop_col_table;
 DROP TABLE raw_table;
 DROP TABLE summary_table;
 DROP TABLE raw_events_first CASCADE;

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -781,6 +781,26 @@ SELECT create_distributed_table('tt1','id');
 DROP TABLE tt1;
 END;
 
+-- Test dropping a column in front of the partition column
+CREATE TABLE drop_copy_test_table (col1 int, col2 int, col3 int, col4 int);
+SELECT create_distributed_table('drop_copy_test_table','col3');
+
+ALTER TABLE drop_copy_test_table drop column col1;
+COPY drop_copy_test_table (col2,col3,col4) from STDIN with CSV;
+,1,
+,2,
+\.
+SELECT * FROM drop_copy_test_table WHERE col3 = 1;
+
+ALTER TABLE drop_copy_test_table drop column col4;
+COPY drop_copy_test_table (col2,col3) from STDIN with CSV;
+,1
+,2
+\.
+SELECT * FROM drop_copy_test_table WHERE col3 = 1;
+
+DROP TABLE drop_copy_test_table;
+
 -- There should be no "tt1" shard on the worker nodes
 \c - - - :worker_1_port
 SELECT relname FROM pg_class WHERE relname LIKE 'tt1%';

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -1050,6 +1050,34 @@ SELECT create_distributed_table('tt1','id');
 \copy tt1 from STDIN;
 DROP TABLE tt1;
 END;
+-- Test dropping a column in front of the partition column
+CREATE TABLE drop_copy_test_table (col1 int, col2 int, col3 int, col4 int);
+SELECT create_distributed_table('drop_copy_test_table','col3');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE drop_copy_test_table drop column col1;
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+COPY drop_copy_test_table (col2,col3,col4) from STDIN with CSV;
+SELECT * FROM drop_copy_test_table WHERE col3 = 1;
+ col2 | col3 | col4 
+------+------+------
+      |    1 |     
+(1 row)
+
+ALTER TABLE drop_copy_test_table drop column col4;
+COPY drop_copy_test_table (col2,col3) from STDIN with CSV;
+SELECT * FROM drop_copy_test_table WHERE col3 = 1;
+ col2 | col3 
+------+------
+      |    1
+      |    1
+(2 rows)
+
+DROP TABLE drop_copy_test_table;
 -- There should be no "tt1" shard on the worker nodes
 \c - - - :worker_1_port
 SELECT relname FROM pg_class WHERE relname LIKE 'tt1%';

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -284,9 +284,11 @@ END;
 CREATE TABLE data_load_test (col1 int, col2 text, col3 text, "CoL4"")" int);
 INSERT INTO data_load_test VALUES (132, 'hello', 'world');
 INSERT INTO data_load_test VALUES (243, 'world', 'hello');
-ALTER TABLE data_load_test DROP COLUMN col2;
-SELECT create_distributed_table('data_load_test', 'col1');
-SELECT * FROM data_load_test;
+ALTER TABLE data_load_test DROP COLUMN col1;
+SELECT create_distributed_table('data_load_test', 'col3');
+SELECT * FROM data_load_test ORDER BY col2;
+-- make sure the tuple went to the right shard
+SELECT * FROM data_load_test WHERE col3 = 'world';
 DROP TABLE data_load_test;
 
 SET citus.shard_replication_factor TO default;

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -1903,17 +1903,22 @@ SELECT user_id, value_4 FROM test_view ORDER BY user_id, value_4;
 DROP VIEW test_view;
 
 -- Make sure we handle dropped columns correctly
-TRUNCATE raw_events_first;
+CREATE TABLE drop_col_table (col1 text, col2 text, col3 text);
+SELECT create_distributed_table('drop_col_table', 'col2');
 
-ALTER TABLE raw_events_first DROP COLUMN value_1;
+ALTER TABLE drop_col_table DROP COLUMN col1;
 
-INSERT INTO raw_events_first (user_id, value_4)
+INSERT INTO drop_col_table (col3, col2)
 SELECT value_4, user_id FROM raw_events_second LIMIT 5;
 
-SELECT user_id, value_4 FROM raw_events_first ORDER BY user_id;
+SELECT * FROM drop_col_table ORDER BY col2, col3;
+
+-- make sure the tuple went to the right shard
+SELECT * FROM drop_col_table WHERE col2 = '1';
 
 RESET client_min_messages;
 
+DROP TABLE drop_col_table;
 DROP TABLE raw_table;
 DROP TABLE summary_table;
 DROP TABLE raw_events_first CASCADE;


### PR DESCRIPTION
This change fixes #1605 by putting the burden of determining the partition column index on the caller. 

`COPY` and `create_distributed_table` generate tuples with NULL values in dropped columns in table-order even if the dropped column does not appear in the target list. After this change, we simply use the attribute number of the partition column - 1 as the partition column index.

`INSERT...SELECT` does not add dropped columns to tuples, but may not follow table order. It therefore looks up the attribute number of each column in the target list by name to determine whether it is the partition column. This logic remains the same, but is moved to the call site.