### PR TITLE
Execute multi-row INSERTs sequentially

### DIFF
--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -28,8 +28,6 @@ typedef struct CitusScanState
 } CitusScanState;
 
 
-extern CustomExecMethods RouterMultiModifyCustomExecMethods;
-
 extern Node * RealTimeCreateScan(CustomScan *scan);
 extern Node * TaskTrackerCreateScan(CustomScan *scan);
 extern Node * RouterCreateScan(CustomScan *scan);

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -36,7 +36,7 @@ extern bool AllModificationsCommutative;
 extern bool EnableDeadlockPrevention;
 
 extern void CitusModifyBeginScan(CustomScanState *node, EState *estate, int eflags);
-extern TupleTableSlot * RouterSingleModifyExecScan(CustomScanState *node);
+extern TupleTableSlot * RouterSequentialModifyExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterSelectExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterMultiModifyExecScan(CustomScanState *node);
 

--- a/src/test/regress/expected/isolation_concurrent_dml.out
+++ b/src/test/regress/expected/isolation_concurrent_dml.out
@@ -59,11 +59,10 @@ step s1-multi-insert:
 
 step s2-multi-insert-overlap: 
     INSERT INTO test_concurrent_dml VALUES (1), (4);
- <waiting ...>
+
 step s1-commit: 
     COMMIT;
 
-step s2-multi-insert-overlap: <... completed>
 
 starting permutation: s1-begin s2-begin s1-multi-insert s2-multi-insert s1-commit s2-commit
 master_create_worker_shards

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -221,16 +221,23 @@ INSERT INTO researchers VALUES (10, 6, 'Lamport Leslie');
 ERROR:  cannot establish a new connection for placement 1200003, since DML has been executed on a connection that is in use
 CONTEXT:  COPY researchers, line 2: "10,6,Lesport Lampie"
 ROLLBACK;
--- but it is allowed after a multi-row insert
+-- COPY cannot be performed after a multi-row INSERT that uses one connection
 BEGIN;
 INSERT INTO researchers VALUES (2, 1, 'Knuth Donald'), (10, 6, 'Lamport Leslie');
 \copy researchers from stdin delimiter ','
+ERROR:  cannot establish a new connection for placement 1200003, since DML has been executed on a connection that is in use
+CONTEXT:  COPY researchers, line 2: "10,6,Lesport Lampie"
 ROLLBACK;
 -- after a COPY you can modify multiple shards, since they'll use different connections
 BEGIN;
 \copy researchers from stdin delimiter ','
 INSERT INTO researchers VALUES (2, 1, 'Knuth Donald');
 INSERT INTO researchers VALUES (10, 6, 'Lamport Leslie');
+ROLLBACK;
+-- after a COPY you can perform a multi-row INSERT
+BEGIN;
+\copy researchers from stdin delimiter ','
+INSERT INTO researchers VALUES (2, 1, 'Knuth Donald'), (10, 6, 'Lamport Leslie');
 ROLLBACK;
 -- COPY can happen before single row INSERT
 BEGIN;

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -180,7 +180,7 @@ INSERT INTO researchers VALUES (10, 6, 'Lamport Leslie');
 \.
 ROLLBACK;
 
--- but it is allowed after a multi-row insert
+-- COPY cannot be performed after a multi-row INSERT that uses one connection
 BEGIN;
 INSERT INTO researchers VALUES (2, 1, 'Knuth Donald'), (10, 6, 'Lamport Leslie');
 \copy researchers from stdin delimiter ','
@@ -197,6 +197,15 @@ BEGIN;
 \.
 INSERT INTO researchers VALUES (2, 1, 'Knuth Donald');
 INSERT INTO researchers VALUES (10, 6, 'Lamport Leslie');
+ROLLBACK;
+
+-- after a COPY you can perform a multi-row INSERT
+BEGIN;
+\copy researchers from stdin delimiter ','
+3,1,Duth Knonald
+10,6,Lesport Lampie
+\.
+INSERT INTO researchers VALUES (2, 1, 'Knuth Donald'), (10, 6, 'Lamport Leslie');
 ROLLBACK;
 
 -- COPY can happen before single row INSERT


### PR DESCRIPTION
This PR changes multi-row INSERTs to use sequential execution, over a single connection per worker. The current approach uses the multi-shard execution infrastructure for parallel DDL, but this causes poor performance (see #1604) due to the high number of connections.

Latency-wise, sequential execution is not the optimal way to execute a multi-row INSERT, but it gives substantially lower latency and higher throughput than the current approach.

Before:

1 shard: 1900 tps = 190,000 rows/sec (17ms avg)
2 shards: 246 tps = 24,600 rows/sec (131ms avg)
4 shards: 175 tps = 17,500 rows/sec (182ms avg)
8 shards: 132 tps = 13,200 rows/sec (240ms avg)
16 shards: 92 tps = 9,200 rows/sec (351ms avg)
32 shards: 58 tps = 5,800 rows/sec (555ms avg)

After:

1 shard: 2081 tps = 208,100 rows/sec (15ms avg)
2 shards: 1484 tps = 148,400 rows/sec (22ms avg)
4 shards: 1221 tps = 122,100 rows/sec (26ms avg)
8 shards: 893 tps = 89,300 rows/sec (36ms avg)
16 shards: 622 tps = 62,200 rows/sec (51ms avg)
32 shards: 385 tps = 38,500 rows/sec (83ms avg)