### PR TITLE
Fix multi-row INSERT with RETURNING on reference tables

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -22,6 +22,7 @@
 #include "distributed/multi_master_planner.h"
 #include "distributed/multi_planner.h"
 #include "distributed/multi_router_executor.h"
+#include "distributed/multi_router_planner.h"
 #include "distributed/multi_resowner.h"
 #include "distributed/multi_server_executor.h"
 #include "distributed/multi_utility.h"
@@ -204,27 +205,7 @@ RouterCreateScan(CustomScan *scan)
 static bool
 IsMultiRowInsert(Query *query)
 {
-	ListCell *rteCell = NULL;
-	bool hasValuesRTE = false;
-
-	CmdType commandType = query->commandType;
-	if (commandType != CMD_INSERT)
-	{
-		return false;
-	}
-
-	foreach(rteCell, query->rtable)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(rteCell);
-
-		if (rte->rtekind == RTE_VALUES)
-		{
-			hasValuesRTE = true;
-			break;
-		}
-	}
-
-	return hasValuesRTE;
+	return ExtractDistributedInsertValuesRTE(query) != NULL;
 }
 
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -48,6 +48,7 @@ extern RelationRestrictionContext * CopyRelationRestrictionContext(
 extern Oid ExtractFirstDistributedTableId(Query *query);
 extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
+extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -888,9 +888,14 @@ SELECT create_reference_table('reference_summary_table');
 INSERT INTO reference_raw_table VALUES (1, 100);
 INSERT INTO reference_raw_table VALUES (1, 200);
 INSERT INTO reference_raw_table VALUES (1, 200);
-INSERT INTO reference_raw_table VALUES (1, 300);
-INSERT INTO reference_raw_table VALUES (2, 400);
-INSERT INTO reference_raw_table VALUES (2, 500);
+INSERT INTO reference_raw_table VALUES (1,300), (2, 400), (2,500) RETURNING *;
+ id | value 
+----+-------
+  1 |   300
+  2 |   400
+  2 |   500
+(3 rows)
+
 INSERT INTO reference_summary_table VALUES (1);
 INSERT INTO reference_summary_table VALUES (2);
 SELECT * FROM reference_summary_table ORDER BY id;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -588,9 +588,7 @@ SELECT create_reference_table('reference_summary_table');
 INSERT INTO reference_raw_table VALUES (1, 100);
 INSERT INTO reference_raw_table VALUES (1, 200);
 INSERT INTO reference_raw_table VALUES (1, 200);
-INSERT INTO reference_raw_table VALUES (1, 300);
-INSERT INTO reference_raw_table VALUES (2, 400);
-INSERT INTO reference_raw_table VALUES (2, 500);
+INSERT INTO reference_raw_table VALUES (1,300), (2, 400), (2,500) RETURNING *;
 
 INSERT INTO reference_summary_table VALUES (1);
 INSERT INTO reference_summary_table VALUES (2);


### PR DESCRIPTION
Fixes #1610.

I first tried returning a `valuesRTE` for reference tables in `ExtractDistributedInsertValuesRTE`, but then I realised we don't set the `rowValuesList` for reference table inserts. I decided to set the `rowValuesList` in for multi-row inserts on reference tables as well, such that multi-row INSERT on distributed tables and reference tables are handled in the same way, which seems less prone to bugs.