### PR TITLE
Update build instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ why we ask this as well as instructions for how to proceed, see the
 
   sudo apt-get install -y postgresql-server-dev-9.6 postgresql-9.6 \
                           libedit-dev libselinux1-dev libxslt-dev  \
-                          libpam0g-dev git flex make
+                          libpam0g-dev git flex make libssl-dev    \
+                          libkrb5-dev
   ```
 
 2. Get, build, and test the code


### PR DESCRIPTION
While building master today on Ubuntu I discovered that I now needed two more libraries installed.

I haven't tested whether all the libraries in the list are actually still needed, but the build works for me when they, plus the two new ones, are present.