### PR TITLE
Allow default columns in multi-row INSERTs

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -100,7 +100,6 @@ static CustomExecMethods CoordinatorInsertSelectCustomExecMethods = {
 static void PrepareMasterJobDirectory(Job *workerJob);
 static void LoadTuplesIntoTupleStore(CitusScanState *citusScanState, Job *workerJob);
 static Relation StubRelation(TupleDesc tupleDescriptor);
-static bool IsMultiRowInsert(Query *query);
 
 
 /*
@@ -192,20 +191,6 @@ RouterCreateScan(CustomScan *scan)
 	}
 
 	return (Node *) scanState;
-}
-
-
-/*
- * IsMultiRowInsert returns whether the given query is a multi-row INSERT.
- *
- * It does this by determining whether the query is an INSERT that has an
- * RTE_VALUES. Single-row INSERTs will have their RTE_VALUES optimised away
- * in transformInsertStmt, and instead use the target list.
- */
-static bool
-IsMultiRowInsert(Query *query)
-{
-	return ExtractDistributedInsertValuesRTE(query) != NULL;
 }
 
 

--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -110,27 +110,12 @@ ExecuteMasterEvaluableFunctions(Query *query, PlanState *planState)
 	ListCell *rteCell = NULL;
 	ListCell *cteCell = NULL;
 	Node *modifiedNode = NULL;
+	bool isMultiRowInsert = false;
 
 	if (query->jointree && query->jointree->quals)
 	{
 		query->jointree->quals = PartiallyEvaluateExpression(query->jointree->quals,
 															 planState);
-	}
-
-	foreach(targetEntryCell, query->targetList)
-	{
-		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
-
-		/* performance optimization for the most common cases */
-		if (IsA(targetEntry->expr, Const) || IsA(targetEntry->expr, Var))
-		{
-			continue;
-		}
-
-		modifiedNode = PartiallyEvaluateExpression((Node *) targetEntry->expr,
-												   planState);
-
-		targetEntry->expr = (Expr *) modifiedNode;
 	}
 
 	foreach(rteCell, query->rtable)
@@ -144,6 +129,34 @@ ExecuteMasterEvaluableFunctions(Query *query, PlanState *planState)
 		else if (rte->rtekind == RTE_VALUES)
 		{
 			EvaluateValuesListsItems(rte->values_lists, planState);
+			isMultiRowInsert = (query->commandType == CMD_INSERT);
+		}
+	}
+
+	/*
+	 * For multi-row INSERTs, functions are evaluated by expanding the
+	 * values_lists with the default expressions in the target list and
+	 * performing function evaluation on the values_lists. Expressions
+	 * in the target list should not be evaluated since they serve only
+	 * as templates and evaluating them would cause unexpected results
+	 * (e.g. sequences being called one more time).
+	 */
+	if (!isMultiRowInsert)
+	{
+		foreach(targetEntryCell, query->targetList)
+		{
+			TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
+
+			/* performance optimization for the most common cases */
+			if (IsA(targetEntry->expr, Const) || IsA(targetEntry->expr, Var))
+			{
+				continue;
+			}
+
+			modifiedNode = PartiallyEvaluateExpression((Node *) targetEntry->expr,
+													   planState);
+
+			targetEntry->expr = (Expr *) modifiedNode;
 		}
 	}
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -49,7 +49,7 @@ extern Oid ExtractFirstDistributedTableId(Query *query);
 extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query);
-extern List * ExpandValuesLists(List *targetList, List *valuesLists);
+extern bool IsMultiRowInsert(Query *query);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -49,6 +49,7 @@ extern Oid ExtractFirstDistributedTableId(Query *query);
 extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query);
+extern List * ExpandValuesLists(List *targetList, List *valuesLists);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
 

--- a/src/test/regress/expected/isolation_insert_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_vs_all.out
@@ -687,15 +687,14 @@ create_distributed_table
 step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a\\n1, b\\n2, c\\n3, d\\n4, e' WITH CSV;
 step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
-WARNING:  INSERT has more target columns than expressions
 step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
-ERROR:  could not modify any active placements
-step s2-ddl-drop-column: ALTER TABLE insert_hash DROP new_column;
+step s2-ddl-drop-column: ALTER TABLE insert_hash DROP new_column; <waiting ...>
 step s1-commit: COMMIT;
+step s2-ddl-drop-column: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
-5              
+8              
 step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
 run_command_on_workers
 
@@ -897,13 +896,11 @@ step s1-begin: BEGIN;
 step s1-ddl-add-column: ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
 step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm'); <waiting ...>
 step s1-commit: COMMIT;
-WARNING:  INSERT has more target columns than expressions
 step s2-insert-multi-row: <... completed>
-error in steps s1-commit s2-insert-multi-row: ERROR:  could not modify any active placements
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
 
-5              
+8              
 step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''insert_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
 run_command_on_workers
 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -690,6 +690,182 @@ INSERT INTO app_analytics_events (app_id, name) VALUES (103, 'Mynt') RETURNING *
   3 |    103 | Mynt
 (1 row)
 
+-- Test multi-row insert with serial in the partition column
+INSERT INTO app_analytics_events (app_id, name)
+VALUES (104, 'Wayz'), (105, 'Mynt') RETURNING *;
+ id | app_id | name 
+----+--------+------
+  5 |    105 | Mynt
+  4 |    104 | Wayz
+(2 rows)
+
+INSERT INTO app_analytics_events (id, name)
+VALUES (DEFAULT, 'Foo'), (300, 'Wah') RETURNING *;
+ id  | app_id | name 
+-----+--------+------
+   6 |        | Foo
+ 300 |        | Wah
+(2 rows)
+
+PREPARE prep(varchar) AS
+INSERT INTO app_analytics_events (id, name)
+VALUES (DEFAULT, $1 || '.1'), (400 , $1 || '.2') RETURNING *;
+EXECUTE prep('version-1');
+ id  | app_id |    name     
+-----+--------+-------------
+   7 |        | version-1.1
+ 400 |        | version-1.2
+(2 rows)
+
+EXECUTE prep('version-2');
+ id  | app_id |    name     
+-----+--------+-------------
+   8 |        | version-2.1
+ 400 |        | version-2.2
+(2 rows)
+
+EXECUTE prep('version-3');
+ id  | app_id |    name     
+-----+--------+-------------
+ 400 |        | version-3.2
+   9 |        | version-3.1
+(2 rows)
+
+EXECUTE prep('version-4');
+ id  | app_id |    name     
+-----+--------+-------------
+  10 |        | version-4.1
+ 400 |        | version-4.2
+(2 rows)
+
+EXECUTE prep('version-5');
+ id  | app_id |    name     
+-----+--------+-------------
+ 400 |        | version-5.2
+  11 |        | version-5.1
+(2 rows)
+
+EXECUTE prep('version-6');
+ id  | app_id |    name     
+-----+--------+-------------
+ 400 |        | version-6.2
+  12 |        | version-6.1
+(2 rows)
+
+SELECT * FROM app_analytics_events ORDER BY id, name;
+ id  | app_id |      name       
+-----+--------+-----------------
+   1 |    101 | Fauxkemon Geaux
+   2 |    102 | Wayz
+   3 |    103 | Mynt
+   4 |    104 | Wayz
+   5 |    105 | Mynt
+   6 |        | Foo
+   7 |        | version-1.1
+   8 |        | version-2.1
+   9 |        | version-3.1
+  10 |        | version-4.1
+  11 |        | version-5.1
+  12 |        | version-6.1
+ 300 |        | Wah
+ 400 |        | version-1.2
+ 400 |        | version-2.2
+ 400 |        | version-3.2
+ 400 |        | version-4.2
+ 400 |        | version-5.2
+ 400 |        | version-6.2
+(19 rows)
+
+TRUNCATE app_analytics_events;
+-- Test multi-row insert with a dropped column
+ALTER TABLE app_analytics_events DROP COLUMN app_id;
+INSERT INTO app_analytics_events (name)
+VALUES ('Wayz'), ('Mynt') RETURNING *;
+ id | name 
+----+------
+ 14 | Mynt
+ 13 | Wayz
+(2 rows)
+
+SELECT * FROM app_analytics_events ORDER BY id;
+ id | name 
+----+------
+ 13 | Wayz
+ 14 | Mynt
+(2 rows)
+
+DROP TABLE app_analytics_events;
+-- Test multi-row insert with a dropped column before the partition column
+CREATE TABLE app_analytics_events (id int default 3, app_id integer, name text);
+SELECT create_distributed_table('app_analytics_events', 'name');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE app_analytics_events DROP COLUMN app_id;
+INSERT INTO app_analytics_events (name)
+VALUES ('Wayz'), ('Mynt') RETURNING *;
+ id | name 
+----+------
+  3 | Mynt
+  3 | Wayz
+(2 rows)
+
+SELECT * FROM app_analytics_events WHERE name = 'Wayz';
+ id | name 
+----+------
+  3 | Wayz
+(1 row)
+
+DROP TABLE app_analytics_events;
+-- Test multi-row insert with serial in a reference table
+CREATE TABLE app_analytics_events (id serial, app_id integer, name text);
+SELECT create_reference_table('app_analytics_events');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+INSERT INTO app_analytics_events (app_id, name)
+VALUES (104, 'Wayz'), (105, 'Mynt') RETURNING *;
+ id | app_id | name 
+----+--------+------
+  1 |    104 | Wayz
+  2 |    105 | Mynt
+(2 rows)
+
+SELECT * FROM app_analytics_events ORDER BY id;
+ id | app_id | name 
+----+--------+------
+  1 |    104 | Wayz
+  2 |    105 | Mynt
+(2 rows)
+
+DROP TABLE app_analytics_events;
+-- Test multi-row insert with serial in a non-partition column
+CREATE TABLE app_analytics_events (id int, app_id serial, name text);
+SELECT create_distributed_table('app_analytics_events', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO app_analytics_events (id, name)
+VALUES (99, 'Wayz'), (98, 'Mynt') RETURNING name, app_id;
+ name | app_id 
+------+--------
+ Mynt |      2
+ Wayz |      1
+(2 rows)
+
+SELECT * FROM app_analytics_events ORDER BY id;
+ id | app_id | name 
+----+--------+------
+ 98 |      2 | Mynt
+ 99 |      1 | Wayz
+(2 rows)
+
 DROP TABLE app_analytics_events;
 -- test UPDATE with subqueries
 CREATE TABLE raw_table (id bigint, value bigint);


### PR DESCRIPTION
Default columns in multi-row `INSERT` commands are represented as `Const` or expressions in the target list, while values in the `VALUES` section are represented with a `Var` in the target list that refers to an column index in `values_lists`. The current implementation only considers the latter which results incorrect queries on shards when columns with default values are defined.

This change adds default expressions to the `values_lists` of the `originalQuery` early on in planning. This is not the prettiest solution, since the resulting `Query *` is not entirely valid, but it can be deparsed and it avoids a complete redesign. The change also clears up some assumptions around the partition column being a `Var`, which might not be the case.

I first tried a solution which only the `rowValuesLists` were expanded to leave the query untouched, but the main issue with that approach is that `rowValuesLists` may get generated after function evaluation, in which case default expressions are not evaluated (apart from some other issues like needing to evaluate expressions in `rowValuesLists` separately).

Fixes #1620.