### PR TITLE
Ensure multi-row INSERT TL is all-Var

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -205,7 +205,9 @@ RouterCreateScan(CustomScan *scan)
 static bool
 IsMultiRowInsert(Query *query)
 {
-	return ExtractDistributedInsertValuesRTE(query) != NULL;
+	Index varno = 0;
+
+	return ExtractDistributedInsertValuesRTE(query, &varno) != NULL;
 }
 
 

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -46,7 +46,8 @@ RebuildQueryStrings(Query *originalQuery, List *taskList)
 {
 	ListCell *taskCell = NULL;
 	Oid relationId = ((RangeTblEntry *) linitial(originalQuery->rtable))->relid;
-	RangeTblEntry *valuesRTE = ExtractDistributedInsertValuesRTE(originalQuery);
+	Index varno = 0;
+	RangeTblEntry *valuesRTE = ExtractDistributedInsertValuesRTE(originalQuery, &varno);
 
 	foreach(taskCell, taskList)
 	{

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -48,7 +48,7 @@ extern RelationRestrictionContext * CopyRelationRestrictionContext(
 extern Oid ExtractFirstDistributedTableId(Query *query);
 extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern RangeTblEntry * ExtractInsertRangeTableEntry(Query *query);
-extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query);
+extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query, Index *varno);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
 


### PR DESCRIPTION
The changes here are mostly explained in the function comment for the new `NormalizeInsertTargetList` function, which ensures bare `DEFAULT` values are "denormalized" into each values list and replaced by a `Var` reference to those new elements.

Repeated here for ease of reference:

```c
/*
 * NormalizeInsertTargetList ensures all elements of multi-row INSERT target
 * lists are Vars. In multi-row INSERTs, most target list entries contain a Var
 * expression pointing to a position within the values_lists field of a VALUES
 * RTE, but non-NULL DEFAULT columns are handled differently. Instead of adding
 * the DEFAULT to each row, a single expression encoding the DEFAULT appears
 * in the target list. For consistency, we move these expressions into values
 * lists and replace them with an appropriately constructed Var.
 */
```

Fixes #1620

Intended as an alternative to #1621