### PR TITLE
(Don't review, WIP) LIMIT push-down when there is group by on distribution column.

### DIFF
--- a/src/test/regress/expected/multi_limit_clause.out
+++ b/src/test/regress/expected/multi_limit_clause.out
@@ -203,4 +203,89 @@ DEBUG:  push down of limit count: 1
        1.00 |       0.00 | 99167.304347826087
 (1 row)
 
+-- We can push down LIMIT clause when we group by partition column of a hash
+-- partitioned table.
+CREATE TABLE lineitem_temp (LIKE lineitem);
+SELECT create_distributed_table('lineitem_temp', 'l_orderkey');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO lineitem_temp SELECT * FROM lineitem;
+DEBUG:  INSERT target table and the source relation of the SELECT partition column value must be colocated in distributed INSERT ... SELECT
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+SELECT
+	l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_temp
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+DEBUG:  push down of limit count: 10
+ l_orderkey | count 
+------------+-------
+      14885 |     7
+      14884 |     7
+      14821 |     7
+      14790 |     7
+      14785 |     7
+      14755 |     7
+      14725 |     7
+      14694 |     7
+      14627 |     7
+      14624 |     7
+(10 rows)
+
+SELECT
+	l_orderkey
+	FROM lineitem_temp
+	GROUP BY l_orderkey
+	ORDER BY l_orderkey
+	LIMIT 10;
+DEBUG:  push down of limit count: 10
+ l_orderkey 
+------------
+          1
+          2
+          3
+          4
+          5
+          6
+          7
+         32
+         33
+         34
+(10 rows)
+
+-- Don't push down if not grouped by partition column.
+SELECT
+	max(l_orderkey)
+	FROM lineitem_temp
+	GROUP BY l_linestatus
+	ORDER BY 1 DESC
+	LIMIT 2;
+  max  
+-------
+ 14947
+ 14916
+(2 rows)
+
+-- Push down if grouped by multiple columns one of which is partition column.
+SELECT
+	l_linestatus, l_orderkey, max(l_shipdate)
+	FROM lineitem_temp
+	GROUP BY l_linestatus, l_orderkey
+	ORDER BY 3 DESC, 1, 2
+	LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_linestatus | l_orderkey |    max     
+--------------+------------+------------
+ O            |       4678 | 11-27-1998
+ O            |      12384 | 11-26-1998
+ O            |       1124 | 11-25-1998
+ O            |      11523 | 11-22-1998
+ O            |      14694 | 11-21-1998
+(5 rows)
+
 SET client_min_messages TO NOTICE;
+DROP TABLE lineitem_temp;

--- a/src/test/regress/sql/multi_limit_clause.sql
+++ b/src/test/regress/sql/multi_limit_clause.sql
@@ -59,4 +59,42 @@ SELECT l_quantity, l_discount, avg(l_partkey) FROM lineitem
 	GROUP BY l_quantity, l_discount
 	ORDER BY l_quantity, l_discount LIMIT 1;
 
+
+-- We can push down LIMIT clause when we group by partition column of a hash
+-- partitioned table.
+CREATE TABLE lineitem_temp (LIKE lineitem);
+SELECT create_distributed_table('lineitem_temp', 'l_orderkey');
+INSERT INTO lineitem_temp SELECT * FROM lineitem;
+
+SELECT
+	l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_temp
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+SELECT
+	l_orderkey
+	FROM lineitem_temp
+	GROUP BY l_orderkey
+	ORDER BY l_orderkey
+	LIMIT 10;
+
+-- Don't push down if not grouped by partition column.
+SELECT
+	max(l_orderkey)
+	FROM lineitem_temp
+	GROUP BY l_linestatus
+	ORDER BY 1 DESC
+	LIMIT 2;
+
+-- Push down if grouped by multiple columns one of which is partition column.
+SELECT
+	l_linestatus, l_orderkey, max(l_shipdate)
+	FROM lineitem_temp
+	GROUP BY l_linestatus, l_orderkey
+	ORDER BY 3 DESC, 1, 2
+	LIMIT 5;
+
 SET client_min_messages TO NOTICE;
+DROP TABLE lineitem_temp;


### PR DESCRIPTION
Push-down LIMIT and ORDER BY clauses when the query is grouped by distribution column. We don't push-down when distribution method is append, since in that case a distribution column value can appear in multiple shards.

This fixes #1589.