### PR TITLE
LIMIT push-down when there is group by on distribution column.

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -3322,16 +3322,6 @@ WorkerLimitCount(MultiExtendedOp *originalOpNode,
 		workerLimitNode = (Node *) MakeIntegerConstInt64(workerLimitCount);
 	}
 
-	/* display debug message on limit push down */
-	if (workerLimitNode != NULL)
-	{
-		Const *workerLimitConst = (Const *) workerLimitNode;
-		int64 workerLimitCount = DatumGetInt64(workerLimitConst->constvalue);
-
-		ereport(DEBUG1, (errmsg("push down of limit count: " INT64_FORMAT,
-								workerLimitCount)));
-	}
-
 	return workerLimitNode;
 }
 

--- a/src/test/regress/expected/multi_having_pushdown.out
+++ b/src/test/regress/expected/multi_having_pushdown.out
@@ -22,8 +22,8 @@ EXPLAIN (COSTS FALSE)
     FROM lineitem_hash
     GROUP BY l_orderkey HAVING sum(l_quantity) > 24
     ORDER BY 2 DESC, 1 ASC LIMIT 3;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: sum((sum(remote_scan.revenue))) DESC, remote_scan.l_orderkey
@@ -35,11 +35,14 @@ EXPLAIN (COSTS FALSE)
                      Tasks Shown: One of 32
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
-                           ->  HashAggregate
-                                 Group Key: l_orderkey
-                                 Filter: (sum(l_quantity) > '24'::numeric)
-                                 ->  Seq Scan on lineitem_hash_590000 lineitem_hash
-(15 rows)
+                           ->  Limit
+                                 ->  Sort
+                                       Sort Key: (sum((l_extendedprice * l_discount))) DESC, l_orderkey
+                                       ->  HashAggregate
+                                             Group Key: l_orderkey
+                                             Filter: (sum(l_quantity) > '24'::numeric)
+                                             ->  Seq Scan on lineitem_hash_590000 lineitem_hash
+(18 rows)
 
 -- but don't push down when table is distributed by append
 EXPLAIN (COSTS FALSE)
@@ -95,8 +98,8 @@ EXPLAIN (COSTS FALSE)
     FROM lineitem_hash
     GROUP BY l_shipmode, l_orderkey HAVING sum(l_quantity) > 24
     ORDER BY 3 DESC, 1, 2 LIMIT 3;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: sum((sum(remote_scan.revenue))) DESC, remote_scan.l_shipmode, remote_scan.l_orderkey
@@ -108,11 +111,14 @@ EXPLAIN (COSTS FALSE)
                      Tasks Shown: One of 32
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
-                           ->  HashAggregate
-                                 Group Key: l_shipmode, l_orderkey
-                                 Filter: (sum(l_quantity) > '24'::numeric)
-                                 ->  Seq Scan on lineitem_hash_590000 lineitem_hash
-(15 rows)
+                           ->  Limit
+                                 ->  Sort
+                                       Sort Key: (sum((l_extendedprice * l_discount))) DESC, l_shipmode, l_orderkey
+                                       ->  HashAggregate
+                                             Group Key: l_shipmode, l_orderkey
+                                             Filter: (sum(l_quantity) > '24'::numeric)
+                                             ->  Seq Scan on lineitem_hash_590000 lineitem_hash
+(18 rows)
 
 -- couple more checks with joins
 EXPLAIN (COSTS FALSE)
@@ -121,8 +127,8 @@ EXPLAIN (COSTS FALSE)
     WHERE o_orderkey = l_orderkey
     GROUP BY l_orderkey, o_orderkey, l_shipmode HAVING sum(l_quantity) > 24
     ORDER BY 1 DESC LIMIT 3;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: sum((sum(remote_scan.revenue))) DESC
@@ -134,15 +140,18 @@ EXPLAIN (COSTS FALSE)
                      Tasks Shown: One of 32
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
-                           ->  HashAggregate
-                                 Group Key: lineitem_hash.l_orderkey, orders_hash.o_orderkey, lineitem_hash.l_shipmode
-                                 Filter: (sum(lineitem_hash.l_quantity) > '24'::numeric)
-                                 ->  Hash Join
-                                       Hash Cond: (orders_hash.o_orderkey = lineitem_hash.l_orderkey)
-                                       ->  Seq Scan on orders_hash_590032 orders_hash
-                                       ->  Hash
-                                             ->  Seq Scan on lineitem_hash_590000 lineitem_hash
-(19 rows)
+                           ->  Limit
+                                 ->  Sort
+                                       Sort Key: (sum((lineitem_hash.l_extendedprice * lineitem_hash.l_discount))) DESC
+                                       ->  HashAggregate
+                                             Group Key: lineitem_hash.l_orderkey, orders_hash.o_orderkey, lineitem_hash.l_shipmode
+                                             Filter: (sum(lineitem_hash.l_quantity) > '24'::numeric)
+                                             ->  Hash Join
+                                                   Hash Cond: (orders_hash.o_orderkey = lineitem_hash.l_orderkey)
+                                                   ->  Seq Scan on orders_hash_590032 orders_hash
+                                                   ->  Hash
+                                                         ->  Seq Scan on lineitem_hash_590000 lineitem_hash
+(22 rows)
 
 EXPLAIN (COSTS FALSE)
     SELECT sum(l_extendedprice * l_discount) as revenue

--- a/src/test/regress/expected/multi_limit_clause.out
+++ b/src/test/regress/expected/multi_limit_clause.out
@@ -1,6 +1,14 @@
 --
 -- MULTI_LIMIT_CLAUSE
 --
+CREATE TABLE lineitem_hash (LIKE lineitem);
+SELECT create_distributed_table('lineitem_hash', 'l_orderkey', 'hash');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO lineitem_hash SELECT * FROM lineitem;
 -- Display debug messages on limit clause push down.
 SET client_min_messages TO DEBUG1;
 -- Check that we can correctly handle the Limit clause in distributed queries.
@@ -203,4 +211,91 @@ DEBUG:  push down of limit count: 1
        1.00 |       0.00 | 99167.304347826087
 (1 row)
 
+-- We can push down LIMIT clause when we group by partition column of a hash
+-- partitioned table.
+SELECT l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_orderkey | count 
+------------+-------
+      14885 |     7
+      14884 |     7
+      14821 |     7
+      14790 |     7
+      14785 |     7
+(5 rows)
+
+SELECT l_orderkey
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY l_orderkey LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_orderkey 
+------------
+          1
+          2
+          3
+          4
+          5
+(5 rows)
+
+-- Don't push down if not grouped by partition column.
+SELECT max(l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_linestatus
+	ORDER BY 1 DESC LIMIT 2;
+  max  
+-------
+ 14947
+ 14916
+(2 rows)
+
+-- Don't push down if table is distributed by append
+SELECT l_orderkey, max(l_shipdate)
+	FROM lineitem
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 LIMIT 5;
+ l_orderkey |    max     
+------------+------------
+       4678 | 11-27-1998
+      12384 | 11-26-1998
+       1124 | 11-25-1998
+      11523 | 11-22-1998
+      14694 | 11-21-1998
+(5 rows)
+
+-- Push down if grouped by multiple columns one of which is partition column.
+SELECT
+	l_linestatus, l_orderkey, max(l_shipdate)
+	FROM lineitem_hash
+	GROUP BY l_linestatus, l_orderkey
+	ORDER BY 3 DESC, 1, 2 LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_linestatus | l_orderkey |    max     
+--------------+------------+------------
+ O            |       4678 | 11-27-1998
+ O            |      12384 | 11-26-1998
+ O            |       1124 | 11-25-1998
+ O            |      11523 | 11-22-1998
+ O            |      14694 | 11-21-1998
+(5 rows)
+
+-- Don't push down if grouped by multiple columns none of which is partition column.
+SELECT
+	l_linestatus, l_shipmode, max(l_shipdate)
+	FROM lineitem_hash
+	GROUP BY l_linestatus, l_shipmode
+	ORDER BY 3 DESC, 1, 2 LIMIT 5;
+ l_linestatus | l_shipmode |    max     
+--------------+------------+------------
+ O            | AIR        | 11-27-1998
+ O            | RAIL       | 11-26-1998
+ O            | SHIP       | 11-21-1998
+ O            | REG AIR    | 11-19-1998
+ O            | TRUCK      | 11-17-1998
+(5 rows)
+
 SET client_min_messages TO NOTICE;
+DROP TABLE lineitem_hash;

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -1497,6 +1497,7 @@ SELECT author_id FROM articles_hash
 	ORDER BY
 		author_id
 	LIMIT 1;
+DEBUG:  push down of limit count: 1
  author_id 
 -----------
          1
@@ -1709,6 +1710,7 @@ SELECT author_id FROM articles_append
 	ORDER BY
 		author_id
 	LIMIT 1;
+DEBUG:  push down of limit count: 1
 WARNING:  relation "public.articles_append" does not exist
 CONTEXT:  while executing command on localhost:57638
 WARNING:  relation "public.articles_append" does not exist
@@ -1723,6 +1725,7 @@ SELECT author_id FROM articles_append
 	ORDER BY
 		author_id
 	LIMIT 1;
+DEBUG:  push down of limit count: 1
 WARNING:  relation "public.articles_append" does not exist
 CONTEXT:  while executing command on localhost:57638
 WARNING:  relation "public.articles_append" does not exist
@@ -1769,6 +1772,7 @@ SELECT * FROM articles_hash
 	ORDER BY
 		author_id, id
 	LIMIT 5;
+DEBUG:  push down of limit count: 5
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -1497,7 +1497,6 @@ SELECT author_id FROM articles_hash
 	ORDER BY
 		author_id
 	LIMIT 1;
-DEBUG:  push down of limit count: 1
  author_id 
 -----------
          1
@@ -1710,7 +1709,6 @@ SELECT author_id FROM articles_append
 	ORDER BY
 		author_id
 	LIMIT 1;
-DEBUG:  push down of limit count: 1
 WARNING:  relation "public.articles_append" does not exist
 CONTEXT:  while executing command on localhost:57638
 WARNING:  relation "public.articles_append" does not exist
@@ -1725,7 +1723,6 @@ SELECT author_id FROM articles_append
 	ORDER BY
 		author_id
 	LIMIT 1;
-DEBUG:  push down of limit count: 1
 WARNING:  relation "public.articles_append" does not exist
 CONTEXT:  while executing command on localhost:57638
 WARNING:  relation "public.articles_append" does not exist
@@ -1772,7 +1769,6 @@ SELECT * FROM articles_hash
 	ORDER BY
 		author_id, id
 	LIMIT 5;
-DEBUG:  push down of limit count: 5
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -57,9 +57,9 @@ test: multi_subquery_union multi_subquery_in_where_clause multi_subquery_misc
 test: multi_reference_table
 test: multi_outer_join_reference
 test: multi_single_relation_subquery
-test: multi_agg_distinct multi_agg_approximate_distinct multi_limit_clause multi_limit_clause_approximate
+test: multi_agg_distinct multi_agg_approximate_distinct multi_limit_clause_approximate
 test: multi_average_expression multi_working_columns multi_having_pushdown
-test: multi_array_agg
+test: multi_array_agg multi_limit_clause
 test: multi_agg_type_conversion multi_count_type_conversion
 test: multi_partition_pruning
 test: multi_join_pruning multi_hash_pruning

--- a/src/test/regress/multi_task_tracker_extra_schedule
+++ b/src/test/regress/multi_task_tracker_extra_schedule
@@ -30,9 +30,9 @@ test: multi_load_data
 # Miscellaneous tests to check our query planning behavior
 # ----------
 test: multi_basic_queries multi_complex_expressions 
-test: multi_agg_distinct multi_limit_clause multi_limit_clause_approximate
+test: multi_agg_distinct multi_limit_clause_approximate
 test: multi_average_expression multi_working_columns
-test: multi_array_agg
+test: multi_array_agg multi_limit_clause
 test: multi_agg_type_conversion multi_count_type_conversion
 test: multi_hash_pruning
 test: multi_query_directory_cleanup


### PR DESCRIPTION
Push-down LIMIT and ORDER BY clauses when the query is grouped by distribution column. We don't push-down when distribution method is append, since in that case a distribution column value can appear in multiple shards.

This fixes #1589.