### PR TITLE
Free per-tuple COPY memory in INSERT...SELECT via coordinator

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2010,6 +2010,14 @@ CitusCopyDestReceiverReceive(TupleTableSlot *slot, DestReceiver *dest)
 
 	copyDest->tuplesSent++;
 
+	/*
+	 * Release per tuple memory allocated in this function. If we're writing
+	 * the results of an INSERT ... SELECT then the SELECT execution will use
+	 * its own executor state and reset the per tuple expression context
+	 * separately.
+	 */
+	ResetPerTupleExprContext(executorState);
+
 	return true;
 }
 


### PR DESCRIPTION
When doing an `INSERT...SELECT` via the coordinator we don't free per-tuple memory that's allocated on the `COPY` side of things, because the `CopyDestReceiver` uses an executor state that's separate from the `SELECT` execution, which already gets reset after every tuple by the executor.

Fixes #1634