### PR TITLE
Set --leak-check to yes to detect memory leaks

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -183,7 +183,7 @@ exec $valgrindPath \\
     --quiet \\
     --suppressions=${postgresSrcdir}/src/tools/valgrind.supp \\
     --trace-children=yes --track-origins=yes --read-var-info=no \\
-    --leak-check=no \\
+    --leak-check=yes \\
     --error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END \\
     --log-file=$valgrindLogFile \\
     $bindir/postgres.orig \\


### PR DESCRIPTION
Previously we decided to set this to false because there are good number of
intentional, one-off memory leaks in PostgreSQL. However this option makes us
miss our memory leaks, so we are changing it back to --leak-check=yes.