### PR TITLE
Allow pushing down GROUP BYs when at least there is one distribution

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1105,12 +1105,14 @@ TargetListOnPartitionColumn(Query *query, List *targetEntryList)
 
 		FindReferencedTableColumn(targetExpression, NIL, query, &relationId, &column);
 
-		/* if the expression belongs to reference table directly returns false */
+		/*
+		 * If the expression belongs to a reference table continue searching for
+		 * other partition keys.
+		 */
 		if (IsDistributedTable(relationId) && PartitionMethod(relationId) ==
 			DISTRIBUTE_BY_NONE)
 		{
-			targetListOnPartitionColumn = false;
-			break;
+			continue;
 		}
 
 		if (isPartitionColumn)

--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -1166,6 +1166,20 @@ SELECT foo.user_id FROM
 ) as foo;
 ERROR:  cannot push down this subquery
 DETAIL:  Group by list without partition column is currently unsupported
+-- supported since the group by contains at least one distributed table
+SELECT foo.user_id FROM
+(
+  SELECT r.user_id, random() FROM users_table m JOIN events_reference_table r ON int4eq(m.user_id, r.user_id)
+  GROUP BY r.user_id, m.user_id
+) as foo
+ORDER BY 1 LIMIT 3;
+ user_id 
+---------
+       0
+       1
+       2
+(3 rows)
+
 -- not supported since distinct is on the reference table column
 SELECT foo.user_id FROM
 (
@@ -1180,6 +1194,19 @@ SELECT foo.user_id FROM
 ) as foo;
 ERROR:  cannot push down this subquery
 DETAIL:  Distinct on columns without partition column is currently unsupported
+-- supported since the distinct on contains at least one distributed table
+SELECT foo.user_id FROM
+(
+  SELECT DISTINCT ON(r.user_id, m.user_id) r.user_id, random() FROM users_table m JOIN events_reference_table r ON int4eq(m.user_id, r.user_id)
+) as foo
+ORDER BY 1 LIMIT 3;
+ user_id 
+---------
+       0
+       1
+       2
+(3 rows)
+
 DROP TABLE user_buy_test_table;
 DROP TABLE users_ref_test_table;
 DROP TABLE users_return_test_table;

--- a/src/test/regress/sql/multi_subquery_complex_reference_clause.sql
+++ b/src/test/regress/sql/multi_subquery_complex_reference_clause.sql
@@ -932,6 +932,14 @@ SELECT foo.user_id FROM
   GROUP BY r.user_id
 ) as foo;
 
+-- supported since the group by contains at least one distributed table
+SELECT foo.user_id FROM
+(
+  SELECT r.user_id, random() FROM users_table m JOIN events_reference_table r ON int4eq(m.user_id, r.user_id)
+  GROUP BY r.user_id, m.user_id
+) as foo
+ORDER BY 1 LIMIT 3;
+
 -- not supported since distinct is on the reference table column
 SELECT foo.user_id FROM
 (
@@ -943,6 +951,13 @@ SELECT foo.user_id FROM
 (
   SELECT DISTINCT ON(r.user_id) r.user_id, random() FROM users_table m JOIN events_reference_table r ON int4eq(m.user_id, r.user_id)
 ) as foo;
+
+-- supported since the distinct on contains at least one distributed table
+SELECT foo.user_id FROM
+(
+  SELECT DISTINCT ON(r.user_id, m.user_id) r.user_id, random() FROM users_table m JOIN events_reference_table r ON int4eq(m.user_id, r.user_id)
+) as foo
+ORDER BY 1 LIMIT 3;
 
 DROP TABLE user_buy_test_table;
 DROP TABLE users_ref_test_table;


### PR DESCRIPTION
column in the target list