### PR TITLE
Fix self-deadlock in create_distributed_table caused by long table names

### DIFF
--- a/src/test/regress/expected/multi_name_lengths.out
+++ b/src/test/regress/expected/multi_name_lengths.out
@@ -21,11 +21,11 @@ SELECT master_create_worker_shards('too_long_12345678901234567890123456789012345
 
 \c - - - :worker_1_port
 \dt too_long_*
-                                      List of relations
- Schema |                              Name                               | Type  |  Owner   
---------+-----------------------------------------------------------------+-------+----------
- public | too_long_12345678901234567890123456789012345678_e0119164_225000 | table | postgres
- public | too_long_12345678901234567890123456789012345678_e0119164_225001 | table | postgres
+                                     List of relations
+ Schema |                              Name                              | Type  |  Owner   
+--------+----------------------------------------------------------------+-------+----------
+ public | too_long_1234567890123456789012345678901234567_e0119164_225000 | table | postgres
+ public | too_long_1234567890123456789012345678901234567_e0119164_225001 | table | postgres
 (2 rows)
 
 \c - - - :master_port
@@ -39,9 +39,9 @@ SELECT shard_name(NULL, 666666);
 SELECT shard_name(0, 666666);
 ERROR:  object_name does not reference a valid relation
 SELECT shard_name('too_long_12345678901234567890123456789012345678901234567890'::regclass, 666666);
-                               shard_name                               
-------------------------------------------------------------------------
- public.too_long_12345678901234567890123456789012345678_e0119164_666666
+                              shard_name                               
+-----------------------------------------------------------------------
+ public.too_long_1234567890123456789012345678901234567_e0119164_666666
 (1 row)
 
 SELECT shard_name('too_long_12345678901234567890123456789012345678901234567890'::regclass, NULL);
@@ -109,9 +109,9 @@ NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 \c - - - :worker_1_port
 SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_lengths_225002'::regclass;
-                           Constraint                            |                                        Definition                                         
------------------------------------------------------------------+-------------------------------------------------------------------------------------------
- nl_checky_1234567890123456789012345678901234567_b16df46d_225002 | CHECK (date_col_12345678901234567890123456789012345678901234567890 >= '01-01-2014'::date)
+                           Constraint                           |                                        Definition                                         
+----------------------------------------------------------------+-------------------------------------------------------------------------------------------
+ nl_checky_123456789012345678901234567890123456_b16df46d_225002 | CHECK (date_col_12345678901234567890123456789012345678901234567890 >= '01-01-2014'::date)
 (1 row)
 
 \c - - - :master_port
@@ -126,13 +126,13 @@ NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 \c - - - :worker_1_port
 \d tmp_idx_*
-Index "public.tmp_idx_123456789012345678901234567890123456789_5e470afa_225002"
+Index "public.tmp_idx_12345678901234567890123456789012345678_5e470afa_225002"
  Column |  Type   | Definition 
 --------+---------+------------
  col2   | integer | col2
 btree, for table "public.name_lengths_225002"
 
-Index "public.tmp_idx_123456789012345678901234567890123456789_5e470afa_225003"
+Index "public.tmp_idx_12345678901234567890123456789012345678_5e470afa_225003"
  Column |  Type   | Definition 
 --------+---------+------------
  col2   | integer | col2
@@ -147,25 +147,25 @@ NOTICE:  using one-phase commit for distributed DDL commands
 HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
 \c - - - :worker_1_port
 \d tmp_idx_*
-Index "public.tmp_idx_123456789012345678901234567890123456789_599636aa_225002"
+Index "public.tmp_idx_12345678901234567890123456789012345678_599636aa_225002"
  Column |  Type   | Definition 
 --------+---------+------------
  col2   | integer | col2
 btree, for table "public.name_lengths_225002"
 
-Index "public.tmp_idx_123456789012345678901234567890123456789_599636aa_225003"
+Index "public.tmp_idx_12345678901234567890123456789012345678_599636aa_225003"
  Column |  Type   | Definition 
 --------+---------+------------
  col2   | integer | col2
 btree, for table "public.name_lengths_225003"
 
-Index "public.tmp_idx_123456789012345678901234567890123456789_5e470afa_225002"
+Index "public.tmp_idx_12345678901234567890123456789012345678_5e470afa_225002"
  Column |  Type   | Definition 
 --------+---------+------------
  col2   | integer | col2
 btree, for table "public.name_lengths_225002"
 
-Index "public.tmp_idx_123456789012345678901234567890123456789_5e470afa_225003"
+Index "public.tmp_idx_12345678901234567890123456789012345678_5e470afa_225003"
  Column |  Type   | Definition 
 --------+---------+------------
  col2   | integer | col2
@@ -226,9 +226,9 @@ SELECT master_create_worker_shards('sneaky_name_lengths', '2', '2');
 \c - - - :worker_1_port
 \di public.sneaky*225006
                                                     List of relations
- Schema |                              Name                               | Type  |  Owner   |           Table            
---------+-----------------------------------------------------------------+-------+----------+----------------------------
- public | sneaky_name_lengths_int_col_1234567890123456789_6402d2cd_225006 | index | postgres | sneaky_name_lengths_225006
+ Schema |                              Name                              | Type  |  Owner   |           Table            
+--------+----------------------------------------------------------------+-------+----------+----------------------------
+ public | sneaky_name_lengths_int_col_123456789012345678_6402d2cd_225006 | index | postgres | sneaky_name_lengths_225006
 (1 row)
 
 SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225006'::regclass;
@@ -261,9 +261,9 @@ SELECT master_create_worker_shards('sneaky_name_lengths', '2', '2');
 \c - - - :worker_1_port
 \di unique*225008
                                                     List of relations
- Schema |                              Name                               | Type  |  Owner   |           Table            
---------+-----------------------------------------------------------------+-------+----------+----------------------------
- public | unique_1234567890123456789012345678901234567890_a5986f27_225008 | index | postgres | sneaky_name_lengths_225008
+ Schema |                              Name                              | Type  |  Owner   |           Table            
+--------+----------------------------------------------------------------+-------+----------+----------------------------
+ public | unique_123456789012345678901234567890123456789_a5986f27_225008 | index | postgres | sneaky_name_lengths_225008
 (1 row)
 
 \c - - - :master_port
@@ -287,11 +287,11 @@ SELECT master_create_worker_shards('too_long_12345678901234567890123456789012345
 
 \c - - - :worker_1_port
 \dt *225000000000*
-                                      List of relations
- Schema |                              Name                               | Type  |  Owner   
---------+-----------------------------------------------------------------+-------+----------
- public | too_long_1234567890123456789012345678901_e0119164_2250000000000 | table | postgres
- public | too_long_1234567890123456789012345678901_e0119164_2250000000001 | table | postgres
+                                     List of relations
+ Schema |                              Name                              | Type  |  Owner   
+--------+----------------------------------------------------------------+-------+----------
+ public | too_long_123456789012345678901234567890_e0119164_2250000000000 | table | postgres
+ public | too_long_123456789012345678901234567890_e0119164_2250000000001 | table | postgres
 (2 rows)
 
 \c - - - :master_port
@@ -359,11 +359,29 @@ SELECT master_create_worker_shards('multi_name_lengths.too_long_1234567890123456
 SELECT shard_name('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass, min(shardid))
 FROM pg_dist_shard
 WHERE logicalrelid = 'multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass;
-                                     shard_name                                     
-------------------------------------------------------------------------------------
- multi_name_lengths.too_long_1234567890123456789012345678901_e0119164_2250000000004
+                                    shard_name                                     
+-----------------------------------------------------------------------------------
+ multi_name_lengths.too_long_123456789012345678901234567890_e0119164_2250000000004
 (1 row)
 
+DROP TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890;
+-- verify that we can create shard placements with long names in a transaction
+-- (this could be problematic due to array type name collisions)
+BEGIN;
+CREATE TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890 (
+        col1 integer not null,
+        col2 integer not null);
+SELECT create_distributed_table('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE INDEX indexlng_12345678901234567890123456789012345678901234567890
+ON multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890 (col1);
+NOTICE:  using one-phase commit for distributed DDL commands
+HINT:  You can enable two-phase commit for extra safety with: SET citus.multi_shard_commit_protocol TO '2pc'
+COMMIT;
 DROP TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890;
 -- Clean up.
 DROP TABLE name_lengths CASCADE;

--- a/src/test/regress/sql/multi_name_lengths.sql
+++ b/src/test/regress/sql/multi_name_lengths.sql
@@ -172,6 +172,18 @@ SELECT shard_name('multi_name_lengths.too_long_123456789012345678901234567890123
 FROM pg_dist_shard
 WHERE logicalrelid = 'multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890'::regclass;
 
+DROP TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890;
+
+-- verify that we can create shard placements with long names in a transaction
+-- (this could be problematic due to array type name collisions)
+BEGIN;
+CREATE TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890 (
+        col1 integer not null,
+        col2 integer not null);
+SELECT create_distributed_table('multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890', 'col1');
+CREATE INDEX indexlng_12345678901234567890123456789012345678901234567890
+ON multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890 (col1);
+COMMIT;
 
 DROP TABLE multi_name_lengths.too_long_12345678901234567890123456789012345678901234567890;
 


### PR DESCRIPTION
Fixes #1664 