### PR TITLE
Use unique constraint index for transaction record deletion

### DIFF
--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -478,8 +478,8 @@ DeleteTransactionRecord(int32 groupId, char *transactionName)
 {
 	Relation pgDistTransaction = NULL;
 	SysScanDesc scanDescriptor = NULL;
-	ScanKeyData scanKey[1];
-	int scanKeyCount = 1;
+	ScanKeyData scanKey[2];
+	int scanKeyCount = 2;
 	bool indexOK = true;
 	HeapTuple heapTuple = NULL;
 	bool heapTupleFound = false;
@@ -488,9 +488,11 @@ DeleteTransactionRecord(int32 groupId, char *transactionName)
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_transaction_groupid,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(groupId));
+	ScanKeyInit(&scanKey[1], Anum_pg_dist_transaction_gid,
+				BTEqualStrategyNumber, F_TEXTEQ, CStringGetTextDatum(transactionName));
 
 	scanDescriptor = systable_beginscan(pgDistTransaction,
-										DistTransactionGroupIndexId(), indexOK,
+										DistTransactionRecordIndexId(), indexOK,
 										NULL, scanKeyCount, scanKey);
 
 	heapTuple = systable_getnext(scanDescriptor);

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -113,6 +113,7 @@ typedef struct MetadataCacheData
 	Oid distPlacementGroupidIndexId;
 	Oid distTransactionRelationId;
 	Oid distTransactionGroupIndexId;
+	Oid distTransactionRecordIndexId;
 	Oid extraDataContainerFuncId;
 	Oid workerHashFunctionId;
 	Oid extensionOwner;
@@ -1793,6 +1794,17 @@ DistTransactionGroupIndexId(void)
 						 &MetadataCache.distTransactionGroupIndexId);
 
 	return MetadataCache.distTransactionGroupIndexId;
+}
+
+
+/* return oid of pg_dist_transaction_unique_constraint */
+Oid
+DistTransactionRecordIndexId(void)
+{
+	CachedRelationLookup("pg_dist_transaction_unique_constraint",
+						 &MetadataCache.distTransactionRecordIndexId);
+
+	return MetadataCache.distTransactionRecordIndexId;
 }
 
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -117,6 +117,7 @@ extern Oid DistPlacementShardidIndexId(void);
 extern Oid DistPlacementPlacementidIndexId(void);
 extern Oid DistTransactionRelationId(void);
 extern Oid DistTransactionGroupIndexId(void);
+extern Oid DistTransactionRecordIndexId(void);
 extern Oid DistPlacementGroupidIndexId(void);
 
 /* function oids */


### PR DESCRIPTION
`DeleteTransactionRecord` is currently using the `pg_dist_transaction_group_index` index, meaning it scans all the records for a particular worker every time it is called. It should be using the `pg_dist_transaction_unique_constraint` which points to a single record.

We should backport this, since `recover_prepared_transactions` is currently very slow when there is a large number of recovery records. We could do some further optimisations of `recover_prepared_transactions` for the next release, but this fix should make a 5 order of magnitude difference.