### PR TITLE
Invalidate worker and group ID cache in maintenance daemon

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -281,7 +281,7 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		 * this causes us to cache a stale pg_dist_node OID. We'd actually expect
 		 * all invalidations to arrive after obtaining a lock in LockCitusExtension.
 		 */
-		ClearMetadataOIDCache();
+		InvalidateMetadataSystemCache();
 
 		/*
 		 * Perform Work.  If a specific task needs to be called sooner than

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2713,18 +2713,21 @@ InvalidateDistRelationCacheCallback(Datum argument, Oid relationId)
 	 */
 	if (relationId != InvalidOid && relationId == MetadataCache.distPartitionRelationId)
 	{
-		ClearMetadataOIDCache();
+		InvalidateMetadataSystemCache();
 	}
 }
 
 
 /*
- * ClearMetadataOIDCache resets all the cached OIDs and the extensionLoaded flag.
+ * InvalidateMetadataSystemCache resets all the cached OIDs and the extensionLoaded flag,
+ * and invalidates the worker node and local group ID caches.
  */
 void
-ClearMetadataOIDCache(void)
+InvalidateMetadataSystemCache(void)
 {
 	memset(&MetadataCache, 0, sizeof(MetadataCache));
+	workerNodeHashValid = false;
+	LocalGroupId = -1;
 }
 
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -86,7 +86,7 @@ extern List * DistTableOidList(void);
 extern List * ShardPlacementList(uint64 shardId);
 extern void CitusInvalidateRelcacheByRelid(Oid relationId);
 extern void CitusInvalidateRelcacheByShardId(int64 shardId);
-extern void ClearMetadataOIDCache(void);
+extern void InvalidateMetadataSystemCache(void);
 
 extern bool CitusHasBeenLoaded(void);
 extern bool CheckCitusVersion(int elevel);


### PR DESCRIPTION
We routinely clear the OID cache in the maintenance daemon to handle late OID invalidations, but this means we start ignoring invalidations of `pg_dist_node` in case of worker node addition/removal/change. Since the maintenance daemon uses the cached worker list, this may cause it to keep connecting to a stale set of nodes. This PR invalidates the worker node hash along with the OIDs to prevent this situation from occurring. It also invalidates the local group ID since it has the same problem.

Fixes #1636