### PR TITLE
Add select distinct, and distinct on support

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1805,13 +1805,6 @@ ErrorIfQueryNotSupported(Query *queryTree)
 		errorHint = filterHint;
 	}
 
-	if (queryTree->distinctClause)
-	{
-		preconditionsSatisfied = false;
-		errorMessage = "could not run distributed query with DISTINCT clause";
-		errorHint = filterHint;
-	}
-
 	if (queryTree->groupingSets)
 	{
 		preconditionsSatisfied = false;
@@ -2850,6 +2843,8 @@ MultiExtendedOpNode(Query *queryTree)
 	extendedOpNode->limitCount = queryTree->limitCount;
 	extendedOpNode->limitOffset = queryTree->limitOffset;
 	extendedOpNode->havingQual = queryTree->havingQual;
+	extendedOpNode->distinctClause = queryTree->distinctClause;
+	extendedOpNode->hasDistinctOn = queryTree->hasDistinctOn;
 
 	return extendedOpNode;
 }

--- a/src/backend/distributed/planner/postgres_planning_functions.c
+++ b/src/backend/distributed/planner/postgres_planning_functions.c
@@ -1,0 +1,71 @@
+/*-------------------------------------------------------------------------
+ *
+ * postgres_planning_function.c
+ *    Includes planning routines copied from
+ *    src/backend/optimizer/plan/createplan.c
+ *
+ * Portions Copyright (c) 1996-2017, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * This needs to be closely in sync with the core code.
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "distributed/multi_master_planner.h"
+#include "nodes/plannodes.h"
+#include "optimizer/tlist.h"
+
+
+/*
+ * make_unique_from_sortclauses creates and returns a unique node
+ * from provided distinct clause list.
+ * The functions is copied from postgresql from
+ * src/backend/optimizer/plan/createplan.c.
+ *
+ * distinctList is a list of SortGroupClauses, identifying the targetlist items
+ * that should be considered by the Unique filter.  The input path must
+ * already be sorted accordingly.
+ */
+Unique *
+make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
+{
+	Unique *node = makeNode(Unique);
+	Plan *plan = &node->plan;
+	int numCols = list_length(distinctList);
+	int keyno = 0;
+	AttrNumber *uniqColIdx;
+	Oid *uniqOperators;
+	ListCell *slitem;
+
+	plan->targetlist = lefttree->targetlist;
+	plan->qual = NIL;
+	plan->lefttree = lefttree;
+	plan->righttree = NULL;
+
+	/*
+	 * convert SortGroupClause list into arrays of attr indexes and equality
+	 * operators, as wanted by executor
+	 */
+	Assert(numCols > 0);
+	uniqColIdx = (AttrNumber *) palloc(sizeof(AttrNumber) * numCols);
+	uniqOperators = (Oid *) palloc(sizeof(Oid) * numCols);
+
+	foreach(slitem, distinctList)
+	{
+		SortGroupClause *sortcl = (SortGroupClause *) lfirst(slitem);
+		TargetEntry *tle = get_sortgroupclause_tle(sortcl, plan->targetlist);
+
+		uniqColIdx[keyno] = tle->resno;
+		uniqOperators[keyno] = sortcl->eqop;
+		Assert(OidIsValid(uniqOperators[keyno]));
+		keyno++;
+	}
+
+	node->numCols = numCols;
+	node->uniqColIdx = uniqColIdx;
+	node->uniqOperators = uniqOperators;
+
+	return node;
+}

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -292,6 +292,8 @@ OutMultiExtendedOp(OUTFUNC_ARGS)
 	WRITE_NODE_FIELD(limitCount);
 	WRITE_NODE_FIELD(limitOffset);
 	WRITE_NODE_FIELD(havingQual);
+	WRITE_BOOL_FIELD(hasDistinctOn);
+	WRITE_NODE_FIELD(distinctClause);
 
 	OutMultiUnaryNodeFields(str, (const MultiUnaryNode *) node);
 }

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -173,6 +173,8 @@ typedef struct MultiExtendedOp
 	Node *limitCount;
 	Node *limitOffset;
 	Node *havingQual;
+	List *distinctClause;
+	bool hasDistinctOn;
 } MultiExtendedOp;
 
 

--- a/src/include/distributed/multi_master_planner.h
+++ b/src/include/distributed/multi_master_planner.h
@@ -24,6 +24,7 @@ struct MultiPlan;
 struct CustomScan;
 extern PlannedStmt * MasterNodeSelectPlan(struct MultiPlan *multiPlan,
 										  struct CustomScan *dataScan);
+extern Unique * make_unique_from_sortclauses(Plan *lefttree, List *distinctList);
 
 
 #endif   /* MULTI_MASTER_PLANNER_H */

--- a/src/test/regress/expected/multi_behavioral_analytics_basics.out
+++ b/src/test/regress/expected/multi_behavioral_analytics_basics.out
@@ -454,4 +454,74 @@ SELECT count(*), count(DISTINCT user_id), avg(user_id) FROM agg_results;
  14371 |   101 | 50.5232064574490293
 (1 row)
 
-   
+-- DISTINCT in the outer query and DISTINCT in the subquery
+TRUNCATE agg_results;
+INSERT INTO agg_results(user_id)
+SELECT
+    DISTINCT users_ids.user_id
+FROM 
+   (SELECT DISTINCT user_id FROM users_table) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+    	users_table AS ma, events_table as short_list
+    WHERE 
+    	short_list.user_id = ma.user_id and ma.value_1 < 50 and short_list.event_type < 3
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  WHERE temp.value_1 < 50;
+-- get some statistics from the aggregated results to ensure the results are correct
+SELECT count(*), count(DISTINCT user_id), avg(user_id) FROM agg_results;
+ count | count |         avg         
+-------+-------+---------------------
+    27 |    27 | 54.0000000000000000
+(1 row)
+
+-- DISTINCT ON in the outer query and DISTINCT in the subquery
+TRUNCATE agg_results;
+INSERT INTO agg_results(user_id, value_1_agg, value_2_agg)
+SELECT
+    DISTINCT ON (users_ids.user_id) users_ids.user_id, temp.value_1, prob
+FROM 
+   (SELECT DISTINCT user_id FROM users_table) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 50 and short_list.event_type < 15
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  WHERE temp.value_1 < 50
+  ORDER BY 1, 2;
+SELECT count(*), count(DISTINCT user_id), avg(user_id), avg(value_1_agg) FROM agg_results;
+ count | count |         avg         |         avg         
+-------+-------+---------------------+---------------------
+    80 |    80 | 50.7875000000000000 | 10.0125000000000000
+(1 row)
+
+-- DISTINCT ON in the outer query and DISTINCT ON in the subquery
+TRUNCATE agg_results;
+INSERT INTO agg_results(user_id, value_1_agg, value_2_agg)
+SELECT
+    DISTINCT ON (users_ids.user_id) users_ids.user_id, temp.value_1, prob
+FROM 
+   (SELECT DISTINCT ON (user_id) user_id, value_2 FROM users_table ORDER BY 1,2) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 5000 and short_list.event_type < 3
+    ) temp 
+  ON users_ids.user_id = temp.user_id
+  ORDER BY 1, 2;
+SELECT count(*), count(DISTINCT user_id), avg(user_id), avg(value_1_agg) FROM agg_results;
+ count | count |         avg         |        avg         
+-------+-------+---------------------+--------------------
+    27 |    27 | 54.0000000000000000 | 9.8518518518518519
+(1 row)
+

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -626,16 +626,60 @@ DEBUG:  Plan is router executable
 SET client_min_messages TO INFO;
 truncate agg_events;
 SET client_min_messages TO DEBUG2;
--- we do not support DISTINCT ON clauses
+-- DISTINCT ON clauses are supported
+-- distinct on(non-partition column)
+-- values are pulled to master
 INSERT INTO agg_events (value_1_agg, user_id)
   SELECT
     DISTINCT ON (value_1) value_1, user_id
   FROM
     raw_events_first;
-DEBUG:  DISTINCT ON clauses are not allowed in distributed INSERT ... SELECT queries
+DEBUG:  DISTINCT ON (non-partition column) clauses are not allowed in distributed INSERT ... SELECT queries
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
-ERROR:  could not run distributed query with DISTINCT clause
-HINT:  Consider using an equality filter on the distributed table's partition column.
+SELECT user_id, value_1_agg FROM agg_events ORDER BY 1,2;
+ user_id | value_1_agg 
+---------+-------------
+       1 |          10
+       2 |          20
+       3 |          30
+       4 |          40
+       5 |          50
+       6 |          60
+       7 |            
+       8 |          80
+       9 |          90
+(9 rows)
+
+-- we don't want to see constraint vialotions, so truncate first
+SET client_min_messages TO INFO;
+truncate agg_events;
+SET client_min_messages TO DEBUG2;
+-- distinct on(partition column)
+-- queries are forwared to workers
+INSERT INTO agg_events (value_1_agg, user_id)
+  SELECT
+    DISTINCT ON (user_id) value_1, user_id
+  FROM
+    raw_events_first;
+DEBUG:  distributed statement: INSERT INTO public.agg_events_13300008 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT ON (user_id) user_id, value_1 FROM public.raw_events_first_13300000 raw_events_first WHERE ((worker_hash(user_id) >= '-2147483648'::integer) AND (worker_hash(user_id) <= '-1073741825'::integer))
+DEBUG:  distributed statement: INSERT INTO public.agg_events_13300009 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT ON (user_id) user_id, value_1 FROM public.raw_events_first_13300001 raw_events_first WHERE ((worker_hash(user_id) >= '-1073741824'::integer) AND (worker_hash(user_id) <= '-1'::integer))
+DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT ON (user_id) user_id, value_1 FROM public.raw_events_first_13300002 raw_events_first WHERE ((worker_hash(user_id) >= 0) AND (worker_hash(user_id) <= 1073741823))
+DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT DISTINCT ON (user_id) user_id, value_1 FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) >= 1073741824) AND (worker_hash(user_id) <= 2147483647))
+DEBUG:  Plan is router executable
+SELECT user_id, value_1_agg FROM agg_events ORDER BY 1,2;
+ user_id | value_1_agg 
+---------+-------------
+       1 |          10
+       2 |          20
+       3 |          30
+       4 |          40
+       5 |          50
+       6 |          60
+       7 |            
+       8 |          80
+       9 |          90
+(9 rows)
+
 -- We do not support some CTEs
 WITH fist_table_agg AS
   (SELECT sum(value_1) as v1_agg, user_id FROM raw_events_first GROUP BY user_id)

--- a/src/test/regress/expected/multi_select_distinct.out
+++ b/src/test/regress/expected/multi_select_distinct.out
@@ -1,0 +1,824 @@
+--
+-- MULTI_SELECT_DISTINCT
+--
+-- Tests select distinct, and select distinct on features.
+--
+-- function calls are supported
+SELECT DISTINCT l_orderkey, now() FROM lineitem_hash_part LIMIT 0;
+ l_orderkey | now 
+------------+-----
+(0 rows)
+
+SELECT DISTINCT l_partkey, 1 + (random() * 0)::int FROM lineitem_hash_part ORDER BY 1 DESC LIMIT 3; 
+ l_partkey | ?column? 
+-----------+----------
+    199973 |        1
+    199946 |        1
+    199943 |        1
+(3 rows)
+
+-- const expressions are supported
+SELECT DISTINCT l_orderkey, 1+1 FROM lineitem_hash_part ORDER BY 1 LIMIT 5;
+ l_orderkey | ?column? 
+------------+----------
+          1 |        2
+          2 |        2
+          3 |        2
+          4 |        2
+          5 |        2
+(5 rows)
+
+-- non const expressions are also supported
+SELECT DISTINCT l_orderkey, l_partkey + 1 FROM lineitem_hash_part ORDER BY 1, 2 LIMIT 5;
+ l_orderkey | ?column? 
+------------+----------
+          1 |     2133
+          1 |    15636
+          1 |    24028
+          1 |    63701
+          1 |    67311
+(5 rows)
+
+-- column expressions are supported
+SELECT DISTINCT l_orderkey, l_shipinstruct || l_shipmode FROM lineitem_hash_part ORDER BY 2 , 1 LIMIT 5;
+ l_orderkey |    ?column?    
+------------+----------------
+         32 | COLLECT CODAIR
+         39 | COLLECT CODAIR
+         66 | COLLECT CODAIR
+         70 | COLLECT CODAIR
+         98 | COLLECT CODAIR
+(5 rows)
+
+-- function calls with const input are supported
+SELECT DISTINCT l_orderkey, strpos('AIR', 'A') FROM lineitem_hash_part ORDER BY 1,2 LIMIT 5;
+ l_orderkey | strpos 
+------------+--------
+          1 |      1
+          2 |      1
+          3 |      1
+          4 |      1
+          5 |      1
+(5 rows)
+
+-- function calls with non-const input are supported
+SELECT DISTINCT l_orderkey, strpos(l_shipmode, 'I')
+	FROM lineitem_hash_part
+	WHERE strpos(l_shipmode, 'I') > 1
+	ORDER BY 2, 1
+	LIMIT 5;
+ l_orderkey | strpos 
+------------+--------
+          1 |      2
+          3 |      2
+          5 |      2
+         32 |      2
+         33 |      2
+(5 rows)
+
+-- distinct on partition column
+-- verify counts match with respect to count(distinct)
+CREATE TEMP TABLE temp_orderkeys AS SELECT DISTINCT l_orderkey FROM lineitem_hash_part;
+SELECT COUNT(*) FROM temp_orderkeys;
+ count 
+-------
+  2985
+(1 row)
+
+SELECT COUNT(DISTINCT l_orderkey) FROM lineitem_hash_part;
+ count 
+-------
+  2985
+(1 row)
+
+SELECT DISTINCT l_orderkey FROM lineitem_hash_part WHERE l_orderkey < 500 and l_partkey < 5000 order by 1;
+ l_orderkey 
+------------
+          1
+          3
+         32
+         35
+         39
+         65
+        129
+        130
+        134
+        164
+        194
+        228
+        261
+        290
+        320
+        321
+        354
+        418
+(18 rows)
+
+-- distinct on non-partition column
+SELECT DISTINCT l_partkey FROM lineitem_hash_part WHERE l_orderkey > 5 and l_orderkey < 20 order by 1;
+ l_partkey 
+-----------
+     79251
+     94780
+    139636
+    145243
+    151894
+    157238
+    163073
+    182052
+(8 rows)
+
+SELECT DISTINCT l_shipmode FROM lineitem_hash_part ORDER BY 1 DESC;
+ l_shipmode 
+------------
+ TRUCK     
+ SHIP      
+ REG AIR   
+ RAIL      
+ MAIL      
+ FOB       
+ AIR       
+(7 rows)
+
+-- distinct with multiple columns 
+SELECT DISTINCT l_orderkey, o_orderdate
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE l_orderkey < 10
+	ORDER BY l_orderkey;
+ l_orderkey | o_orderdate 
+------------+-------------
+          1 | 01-02-1996
+          2 | 12-01-1996
+          3 | 10-14-1993
+          4 | 10-11-1995
+          5 | 07-30-1994
+          6 | 02-21-1992
+          7 | 01-10-1996
+(7 rows)
+
+-- distinct on partition column with aggregate
+-- this is the same as the one without distinct due to group by
+SELECT DISTINCT l_orderkey, count(*)
+	FROM lineitem_hash_part
+	WHERE l_orderkey < 200
+	GROUP BY 1
+	HAVING count(*) > 5
+	ORDER BY 2 DESC, 1;
+ l_orderkey | count 
+------------+-------
+          7 |     7
+         68 |     7
+        129 |     7
+        164 |     7
+        194 |     7
+          1 |     6
+          3 |     6
+         32 |     6
+         35 |     6
+         39 |     6
+         67 |     6
+         69 |     6
+         70 |     6
+         71 |     6
+        134 |     6
+        135 |     6
+        163 |     6
+        192 |     6
+        197 |     6
+(19 rows)
+
+	
+-- explain the query to see actual plan
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_orderkey, count(*)
+		FROM lineitem_hash_part
+		WHERE l_orderkey < 200
+		GROUP BY 1
+		HAVING count(*) > 5
+		ORDER BY 2 DESC, 1;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint) DESC, remote_scan.l_orderkey
+   ->  HashAggregate
+         Group Key: remote_scan.l_orderkey
+         Filter: (COALESCE((pg_catalog.sum(remote_scan.worker_column_3))::bigint, '0'::bigint) > 5)
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  HashAggregate
+                           Group Key: l_orderkey
+                           Filter: (count(*) > 5)
+                           ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                 Filter: (l_orderkey < 200)
+(15 rows)
+
+-- distinct on non-partition column with aggregate
+-- this is the same as non-distinct version due to group by
+SELECT DISTINCT l_partkey, count(*)
+	FROM lineitem_hash_part
+	GROUP BY 1 
+	HAVING count(*) > 2
+	ORDER BY 1;
+ l_partkey | count 
+-----------+-------
+      1051 |     3
+      1927 |     3
+      6983 |     3
+     15283 |     3
+     87761 |     3
+    136884 |     3
+    149926 |     3
+    160895 |     3
+    177771 |     3
+    188804 |     3
+    199146 |     3
+(11 rows)
+
+	
+-- explain the query to see actual plan
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_partkey, count(*)
+		FROM lineitem_hash_part
+		GROUP BY 1 
+		HAVING count(*) > 2
+		ORDER BY 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: remote_scan.l_partkey
+   ->  HashAggregate
+         Group Key: remote_scan.l_partkey
+         Filter: (COALESCE((pg_catalog.sum(remote_scan.worker_column_3))::bigint, '0'::bigint) > 2)
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  HashAggregate
+                           Group Key: l_partkey
+                           ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+(13 rows)
+
+-- distinct on non-partition column and avg
+SELECT DISTINCT l_partkey, avg(l_linenumber)
+	FROM lineitem_hash_part
+	WHERE l_partkey < 500
+	GROUP BY 1 
+	HAVING avg(l_linenumber) > 2
+	ORDER BY 1;
+ l_partkey |        avg         
+-----------+--------------------
+        18 | 7.0000000000000000
+        79 | 6.0000000000000000
+       149 | 4.5000000000000000
+       175 | 5.0000000000000000
+       179 | 6.0000000000000000
+       182 | 3.0000000000000000
+       222 | 4.0000000000000000
+       278 | 3.0000000000000000
+       299 | 7.0000000000000000
+       308 | 7.0000000000000000
+       309 | 5.0000000000000000
+       321 | 3.0000000000000000
+       337 | 6.0000000000000000
+       364 | 3.0000000000000000
+       403 | 4.0000000000000000
+(15 rows)
+
+-- distinct on multiple non-partition columns
+SELECT DISTINCT l_partkey, l_suppkey
+	FROM lineitem_hash_part
+	WHERE l_shipmode = 'AIR' AND l_orderkey < 100
+	ORDER BY 1, 2;
+ l_partkey | l_suppkey 
+-----------+-----------
+      2132 |      4633
+      4297 |      1798
+     37531 |        35
+     44161 |      6666
+     44706 |      4707
+     67831 |      5350
+     85811 |      8320
+     94368 |      6878
+    108338 |       849
+    108570 |      8571
+    137267 |      4807
+    137469 |      9983
+    173489 |      3490
+    196156 |      1195
+    197921 |       441
+(15 rows)
+
+	
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_partkey, l_suppkey
+		FROM lineitem_hash_part
+		WHERE l_shipmode = 'AIR' AND l_orderkey < 100
+		ORDER BY 1, 2;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: remote_scan.l_partkey, remote_scan.l_suppkey
+   ->  HashAggregate
+         Group Key: remote_scan.l_partkey, remote_scan.l_suppkey
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  Unique
+                           ->  Sort
+                                 Sort Key: l_partkey, l_suppkey
+                                 ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       Filter: ((l_orderkey < 100) AND (l_shipmode = 'AIR'::bpchar))
+(14 rows)
+
+-- distinct on partition column
+SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey, l_suppkey
+	FROM lineitem_hash_part
+	WHERE l_orderkey < 35
+	ORDER BY 1;
+ l_orderkey | l_partkey | l_suppkey 
+------------+-----------+-----------
+          1 |    155190 |      7706
+          2 |    106170 |      1191
+          3 |      4297 |      1798
+          4 |     88035 |      5560
+          5 |    108570 |      8571
+          6 |    139636 |      2150
+          7 |    182052 |      9607
+         32 |     82704 |      7721
+         33 |     61336 |      8855
+         34 |     88362 |       871
+(10 rows)
+
+	
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey, l_suppkey
+		FROM lineitem_hash_part
+		WHERE l_orderkey < 35
+		ORDER BY 1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: remote_scan.l_orderkey
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  Unique
+                           ->  Sort
+                                 Sort Key: l_orderkey
+                                 ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       Filter: (l_orderkey < 35)
+(13 rows)
+
+-- distinct on non-partition column
+-- note order by is required here
+-- otherwise query results will be different since
+-- distinct on clause is on non-partition column
+SELECT DISTINCT ON (l_partkey) l_partkey, l_orderkey
+	FROM lineitem_hash_part
+	ORDER BY 1,2
+	LIMIT 20;
+ l_partkey | l_orderkey 
+-----------+------------
+        18 |      12005
+        79 |       5121
+        91 |       2883
+       149 |        807
+       175 |       4102
+       179 |       2117
+       182 |        548
+       195 |       2528
+       204 |      10048
+       222 |       9413
+       245 |       9446
+       278 |       1287
+       299 |       1122
+       308 |      11137
+       309 |       2374
+       318 |        321
+       321 |       5984
+       337 |      10403
+       350 |      13698
+       358 |       4323
+(20 rows)
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_partkey) l_partkey, l_orderkey
+		FROM lineitem_hash_part
+		ORDER BY 1,2
+		LIMIT 20;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: remote_scan.l_partkey, remote_scan.l_orderkey
+               ->  Custom Scan (Citus Real-Time)
+                     Task Count: 4
+                     Tasks Shown: One of 4
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 ->  Unique
+                                       ->  Sort
+                                             Sort Key: l_partkey, l_orderkey
+                                             ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+(14 rows)
+
+-- distinct on with joins
+-- each customer's first order key
+SELECT DISTINCT ON (o_custkey) o_custkey, l_orderkey
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE o_custkey < 15
+	ORDER BY 1,2;
+ o_custkey | l_orderkey 
+-----------+------------
+         1 |       9154
+         2 |      10563
+         4 |        320
+         5 |      11682
+         7 |      10402
+         8 |        102
+        10 |       1602
+        11 |      12800
+        13 |        994
+        14 |      11011
+(10 rows)
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (o_custkey) o_custkey, l_orderkey
+		FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+		WHERE o_custkey < 15
+		ORDER BY 1,2;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: remote_scan.o_custkey, remote_scan.l_orderkey
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  Unique
+                           ->  Sort
+                                 Sort Key: orders_hash_part.o_custkey, lineitem_hash_part.l_orderkey
+                                 ->  Hash Join
+                                       Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                                       ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       ->  Hash
+                                             ->  Seq Scan on orders_hash_part_360294 orders_hash_part
+                                                   Filter: (o_custkey < 15)
+(17 rows)
+
+-- explain without order by
+-- notice master plan has order by on distinct on column
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (o_custkey) o_custkey, l_orderkey
+		FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+		WHERE o_custkey < 15;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: remote_scan.o_custkey
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  Unique
+                           ->  Sort
+                                 Sort Key: orders_hash_part.o_custkey
+                                 ->  Hash Join
+                                       Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                                       ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       ->  Hash
+                                             ->  Seq Scan on orders_hash_part_360294 orders_hash_part
+                                                   Filter: (o_custkey < 15)
+(17 rows)
+
+-- each customer's each order's first l_partkey
+SELECT DISTINCT ON (o_custkey, l_orderkey) o_custkey, l_orderkey, l_linenumber, l_partkey
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE o_custkey < 20
+	ORDER BY 1,2,3;
+ o_custkey | l_orderkey | l_linenumber | l_partkey 
+-----------+------------+--------------+-----------
+         1 |       9154 |            1 |     86513
+         1 |      14656 |            1 |     59539
+         2 |      10563 |            1 |    147459
+         4 |        320 |            1 |      4415
+         4 |        739 |            1 |     84489
+         4 |      10688 |            1 |     45037
+         4 |      10788 |            1 |     50814
+         4 |      13728 |            1 |     86216
+         5 |      11682 |            1 |     31634
+         5 |      11746 |            1 |    180724
+         5 |      14308 |            1 |    157430
+         7 |      10402 |            1 |     53661
+         7 |      13031 |            1 |    112161
+         7 |      14145 |            1 |    138729
+         7 |      14404 |            1 |    143034
+         8 |        102 |            1 |     88914
+         8 |        164 |            1 |     91309
+         8 |      13601 |            1 |     40504
+        10 |       1602 |            1 |    182806
+        10 |       9862 |            1 |     86241
+        10 |      11431 |            1 |     62112
+        10 |      13124 |            1 |     29414
+        11 |      12800 |            1 |    152806
+        13 |        994 |            1 |     64486
+        13 |       1603 |            1 |     38191
+        13 |       4704 |            1 |     77934
+        13 |       9927 |            1 |       875
+        14 |      11011 |            1 |    172485
+        17 |        896 |            1 |     38675
+        17 |       5507 |            1 |      9600
+        19 |        353 |            1 |    119305
+        19 |       1504 |            1 |     81389
+        19 |       1669 |            1 |     78373
+        19 |       5893 |            1 |    133707
+        19 |       9954 |            1 |     92138
+        19 |      14885 |            1 |     36154
+(36 rows)
+
+-- explain without order by
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (o_custkey, l_orderkey) o_custkey, l_orderkey, l_linenumber, l_partkey
+		FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+		WHERE o_custkey < 20;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: remote_scan.o_custkey, remote_scan.l_orderkey
+         ->  Custom Scan (Citus Real-Time)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=57637 dbname=regression
+                     ->  Unique
+                           ->  Sort
+                                 Sort Key: orders_hash_part.o_custkey, lineitem_hash_part.l_orderkey
+                                 ->  Hash Join
+                                       Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                                       ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       ->  Hash
+                                             ->  Seq Scan on orders_hash_part_360294 orders_hash_part
+                                                   Filter: (o_custkey < 20)
+(17 rows)
+
+-- each customer's each order's last l_partkey
+SELECT DISTINCT ON (o_custkey, l_orderkey) o_custkey, l_orderkey, l_linenumber, l_partkey
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE o_custkey < 15
+	ORDER BY 1,2,3 DESC;
+ o_custkey | l_orderkey | l_linenumber | l_partkey 
+-----------+------------+--------------+-----------
+         1 |       9154 |            7 |    173448
+         1 |      14656 |            1 |     59539
+         2 |      10563 |            4 |    110741
+         4 |        320 |            2 |    192158
+         4 |        739 |            5 |    187523
+         4 |      10688 |            2 |    132574
+         4 |      10788 |            4 |    196473
+         4 |      13728 |            3 |     12450
+         5 |      11682 |            3 |    177152
+         5 |      11746 |            7 |    193807
+         5 |      14308 |            3 |    140916
+         7 |      10402 |            2 |     64514
+         7 |      13031 |            6 |      7761
+         7 |      14145 |            6 |    130723
+         7 |      14404 |            7 |     35349
+         8 |        102 |            4 |     61158
+         8 |        164 |            7 |      3037
+         8 |      13601 |            5 |     12470
+        10 |       1602 |            1 |    182806
+        10 |       9862 |            5 |    135675
+        10 |      11431 |            7 |      8563
+        10 |      13124 |            3 |     67055
+        11 |      12800 |            5 |    179110
+        13 |        994 |            4 |    130471
+        13 |       1603 |            2 |     65209
+        13 |       4704 |            3 |     63081
+        13 |       9927 |            6 |    119356
+        14 |      11011 |            7 |     95939
+(28 rows)
+
+-- subqueries
+SELECT DISTINCT l_orderkey, l_partkey
+	FROM (
+		SELECT l_orderkey, l_partkey
+		FROM lineitem_hash_part
+		) q
+	ORDER BY 1,2
+	LIMIT 10;
+ l_orderkey | l_partkey 
+------------+-----------
+          1 |      2132
+          1 |     15635
+          1 |     24027
+          1 |     63700
+          1 |     67310
+          1 |    155190
+          2 |    106170
+          3 |      4297
+          3 |     19036
+          3 |     29380
+(10 rows)
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_orderkey, l_partkey
+		FROM (
+			SELECT l_orderkey, l_partkey
+			FROM lineitem_hash_part
+			) q
+		ORDER BY 1,2
+		LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: remote_scan.l_orderkey, remote_scan.l_partkey
+         ->  HashAggregate
+               Group Key: remote_scan.l_orderkey, remote_scan.l_partkey
+               ->  Custom Scan (Citus Real-Time)
+                     Task Count: 4
+                     Tasks Shown: One of 4
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 ->  Sort
+                                       Sort Key: l_orderkey, l_partkey
+                                       ->  HashAggregate
+                                             Group Key: l_orderkey, l_partkey
+                                             ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+(16 rows)
+
+SELECT DISTINCT l_orderkey, cnt
+	FROM (
+		SELECT l_orderkey, count(*) as cnt
+		FROM lineitem_hash_part
+		GROUP BY 1
+		) q
+	ORDER BY 1,2
+	LIMIT 10;
+ l_orderkey | cnt 
+------------+-----
+          1 |   6
+          2 |   1
+          3 |   6
+          4 |   1
+          5 |   3
+          6 |   1
+          7 |   7
+         32 |   6
+         33 |   4
+         34 |   3
+(10 rows)
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_orderkey, cnt
+		FROM (
+			SELECT l_orderkey, count(*) as cnt
+			FROM lineitem_hash_part
+			GROUP BY 1
+			) q
+		ORDER BY 1,2
+		LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: remote_scan.l_orderkey, remote_scan.cnt
+         ->  HashAggregate
+               Group Key: remote_scan.l_orderkey, remote_scan.cnt
+               ->  Custom Scan (Citus Real-Time)
+                     Task Count: 4
+                     Tasks Shown: One of 4
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 ->  Sort
+                                       Sort Key: lineitem_hash_part.l_orderkey, (count(*))
+                                       ->  HashAggregate
+                                             Group Key: lineitem_hash_part.l_orderkey, count(*)
+                                             ->  HashAggregate
+                                                   Group Key: lineitem_hash_part.l_orderkey
+                                                   ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+(18 rows)
+
+-- distinct on partition column
+-- random() is added to inner query to prevent flattening
+SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey
+	FROM (
+		SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+		FROM lineitem_hash_part
+		) q
+	WHERE r > 1
+	ORDER BY 1,2
+	LIMIT 10;
+ l_orderkey | l_partkey 
+------------+-----------
+          1 |      2132
+          2 |    106170
+          3 |      4297
+          4 |     88035
+          5 |     37531
+          6 |    139636
+          7 |     79251
+         32 |      2743
+         33 |     33918
+         34 |     88362
+(10 rows)
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey
+		FROM (
+			SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+			FROM lineitem_hash_part
+			) q
+		WHERE r > 1
+		ORDER BY 1,2
+		LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: remote_scan.l_orderkey, remote_scan.l_partkey
+               ->  Custom Scan (Citus Real-Time)
+                     Task Count: 4
+                     Tasks Shown: One of 4
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 ->  Unique
+                                       ->  Sort
+                                             Sort Key: q.l_orderkey, q.l_partkey
+                                             ->  Subquery Scan on q
+                                                   Filter: (q.r > 1)
+                                                   ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+(16 rows)
+
+-- distinct on non-partition column
+SELECT DISTINCT ON (l_partkey) l_orderkey, l_partkey
+	FROM (
+		SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+		FROM lineitem_hash_part
+		) q
+	WHERE r > 1
+	ORDER BY 2,1
+	LIMIT 10;
+ l_orderkey | l_partkey 
+------------+-----------
+      12005 |        18
+       5121 |        79
+       2883 |        91
+        807 |       149
+       4102 |       175
+       2117 |       179
+        548 |       182
+       2528 |       195
+      10048 |       204
+       9413 |       222
+(10 rows)
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_partkey) l_orderkey, l_partkey
+		FROM (
+			SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+			FROM lineitem_hash_part
+			) q
+		WHERE r > 1
+		ORDER BY 2,1
+		LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: remote_scan.l_partkey, remote_scan.l_orderkey
+               ->  Custom Scan (Citus Real-Time)
+                     Task Count: 4
+                     Tasks Shown: One of 4
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 ->  Unique
+                                       ->  Sort
+                                             Sort Key: q.l_partkey, q.l_orderkey
+                                             ->  Subquery Scan on q
+                                                   Filter: (q.r > 1)
+                                                   ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+(16 rows)
+

--- a/src/test/regress/expected/multi_subquery_behavioral_analytics.out
+++ b/src/test/regress/expected/multi_subquery_behavioral_analytics.out
@@ -2071,6 +2071,83 @@ FROM
   WHERE 
     users_table.value_1 < 50 AND test_join_function_2(users_table.user_id, temp.user_id);
 ERROR:  unsupported clause type
+-- DISTINCT in the outer query and DISTINCT in the subquery
+SELECT
+    DISTINCT users_ids.user_id
+FROM 
+   (SELECT DISTINCT user_id FROM users_table) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 50 and short_list.event_type < 3
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  WHERE temp.value_1 < 50
+  ORDER BY 1
+  LIMIT 5;
+ user_id 
+---------
+       1
+       6
+      16
+      21
+      26
+(5 rows)
+
+-- DISTINCT ON in the outer query and DISTINCT in the subquery
+SELECT
+    DISTINCT ON (users_ids.user_id) users_ids.user_id, temp.value_1, prob
+FROM 
+   (SELECT DISTINCT user_id FROM users_table) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 50 and short_list.event_type < 15
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  WHERE temp.value_1 < 50
+  ORDER BY 1, 2
+  LIMIT 5;
+ user_id | value_1 |          prob          
+---------+---------+------------------------
+       1 |       6 | 0.50000000000000000000
+       2 |       2 | 0.50000000000000000000
+       4 |       3 | 0.50000000000000000000
+       6 |       3 | 0.50000000000000000000
+       7 |       2 | 0.50000000000000000000
+(5 rows)
+
+-- DISTINCT ON in the outer query and DISTINCT ON in the subquery
+SELECT
+    DISTINCT ON (users_ids.user_id) users_ids.user_id, temp.value_1, prob
+FROM 
+   (SELECT DISTINCT ON (user_id) user_id, value_1 FROM users_table ORDER BY 1,2) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 25 and short_list.event_type < 3
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  ORDER BY 1,2
+  LIMIT 5;
+ user_id | value_1 |          prob          
+---------+---------+------------------------
+       1 |       6 | 0.50000000000000000000
+       6 |       3 | 0.50000000000000000000
+      16 |       4 | 0.50000000000000000000
+      21 |       0 | 0.50000000000000000000
+      26 |       5 | 0.50000000000000000000
+(5 rows)
+
 DROP FUNCTION test_join_function_2(integer, integer);
 SET citus.enable_router_execution TO TRUE;
 SET citus.subquery_pushdown to OFF;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -143,7 +143,7 @@ test: multi_outer_join
 # is independed from the rest of the group, it is added to increase parallelism.
 # ---
 test: multi_create_fdw
-test: multi_complex_count_distinct
+test: multi_complex_count_distinct multi_select_distinct
 test: multi_distribution_metadata
 test: multi_generate_ddl_commands
 test: multi_create_shards

--- a/src/test/regress/sql/multi_behavioral_analytics_basics.sql
+++ b/src/test/regress/sql/multi_behavioral_analytics_basics.sql
@@ -417,4 +417,68 @@ FROM
 
 -- get some statistics from the aggregated results to ensure the results are correct
 SELECT count(*), count(DISTINCT user_id), avg(user_id) FROM agg_results;
-   
+
+-- DISTINCT in the outer query and DISTINCT in the subquery
+TRUNCATE agg_results;
+
+INSERT INTO agg_results(user_id)
+SELECT
+    DISTINCT users_ids.user_id
+FROM 
+   (SELECT DISTINCT user_id FROM users_table) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+    	users_table AS ma, events_table as short_list
+    WHERE 
+    	short_list.user_id = ma.user_id and ma.value_1 < 50 and short_list.event_type < 3
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  WHERE temp.value_1 < 50;
+
+-- get some statistics from the aggregated results to ensure the results are correct
+SELECT count(*), count(DISTINCT user_id), avg(user_id) FROM agg_results;
+
+-- DISTINCT ON in the outer query and DISTINCT in the subquery
+TRUNCATE agg_results;
+
+INSERT INTO agg_results(user_id, value_1_agg, value_2_agg)
+SELECT
+    DISTINCT ON (users_ids.user_id) users_ids.user_id, temp.value_1, prob
+FROM 
+   (SELECT DISTINCT user_id FROM users_table) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 50 and short_list.event_type < 15
+    ) temp 
+  ON users_ids.user_id = temp.user_id 
+  WHERE temp.value_1 < 50
+  ORDER BY 1, 2;
+
+SELECT count(*), count(DISTINCT user_id), avg(user_id), avg(value_1_agg) FROM agg_results;
+
+-- DISTINCT ON in the outer query and DISTINCT ON in the subquery
+TRUNCATE agg_results;
+
+INSERT INTO agg_results(user_id, value_1_agg, value_2_agg)
+SELECT
+    DISTINCT ON (users_ids.user_id) users_ids.user_id, temp.value_1, prob
+FROM 
+   (SELECT DISTINCT ON (user_id) user_id, value_2 FROM users_table ORDER BY 1,2) as users_ids
+        JOIN 
+   (SELECT  
+      ma.user_id, ma.value_1, (GREATEST(coalesce(ma.value_4 / 250, 0.0) + GREATEST(1.0))) / 2 AS prob
+    FROM 
+      users_table AS ma, events_table as short_list
+    WHERE 
+      short_list.user_id = ma.user_id and ma.value_1 < 5000 and short_list.event_type < 3
+    ) temp 
+  ON users_ids.user_id = temp.user_id
+  ORDER BY 1, 2;
+
+SELECT count(*), count(DISTINCT user_id), avg(user_id), avg(value_1_agg) FROM agg_results;

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -478,12 +478,31 @@ SET client_min_messages TO INFO;
 truncate agg_events;
 SET client_min_messages TO DEBUG2;
 
--- we do not support DISTINCT ON clauses
+-- DISTINCT ON clauses are supported
+-- distinct on(non-partition column)
+-- values are pulled to master
 INSERT INTO agg_events (value_1_agg, user_id)
   SELECT
     DISTINCT ON (value_1) value_1, user_id
   FROM
     raw_events_first;
+
+SELECT user_id, value_1_agg FROM agg_events ORDER BY 1,2;
+
+-- we don't want to see constraint vialotions, so truncate first
+SET client_min_messages TO INFO;
+truncate agg_events;
+SET client_min_messages TO DEBUG2;
+
+-- distinct on(partition column)
+-- queries are forwared to workers
+INSERT INTO agg_events (value_1_agg, user_id)
+  SELECT
+    DISTINCT ON (user_id) value_1, user_id
+  FROM
+    raw_events_first;
+
+SELECT user_id, value_1_agg FROM agg_events ORDER BY 1,2;
 
 -- We do not support some CTEs
 WITH fist_table_agg AS

--- a/src/test/regress/sql/multi_select_distinct.sql
+++ b/src/test/regress/sql/multi_select_distinct.sql
@@ -1,0 +1,245 @@
+--
+-- MULTI_SELECT_DISTINCT
+--
+-- Tests select distinct, and select distinct on features.
+--
+
+
+-- function calls are supported
+SELECT DISTINCT l_orderkey, now() FROM lineitem_hash_part LIMIT 0;
+
+SELECT DISTINCT l_partkey, 1 + (random() * 0)::int FROM lineitem_hash_part ORDER BY 1 DESC LIMIT 3; 
+
+-- const expressions are supported
+SELECT DISTINCT l_orderkey, 1+1 FROM lineitem_hash_part ORDER BY 1 LIMIT 5;
+
+-- non const expressions are also supported
+SELECT DISTINCT l_orderkey, l_partkey + 1 FROM lineitem_hash_part ORDER BY 1, 2 LIMIT 5;
+
+-- column expressions are supported
+SELECT DISTINCT l_orderkey, l_shipinstruct || l_shipmode FROM lineitem_hash_part ORDER BY 2 , 1 LIMIT 5;
+
+-- function calls with const input are supported
+SELECT DISTINCT l_orderkey, strpos('AIR', 'A') FROM lineitem_hash_part ORDER BY 1,2 LIMIT 5;
+
+-- function calls with non-const input are supported
+SELECT DISTINCT l_orderkey, strpos(l_shipmode, 'I')
+	FROM lineitem_hash_part
+	WHERE strpos(l_shipmode, 'I') > 1
+	ORDER BY 2, 1
+	LIMIT 5;
+
+-- distinct on partition column
+-- verify counts match with respect to count(distinct)
+CREATE TEMP TABLE temp_orderkeys AS SELECT DISTINCT l_orderkey FROM lineitem_hash_part;
+SELECT COUNT(*) FROM temp_orderkeys;
+SELECT COUNT(DISTINCT l_orderkey) FROM lineitem_hash_part;
+
+SELECT DISTINCT l_orderkey FROM lineitem_hash_part WHERE l_orderkey < 500 and l_partkey < 5000 order by 1;
+
+-- distinct on non-partition column
+SELECT DISTINCT l_partkey FROM lineitem_hash_part WHERE l_orderkey > 5 and l_orderkey < 20 order by 1;
+
+SELECT DISTINCT l_shipmode FROM lineitem_hash_part ORDER BY 1 DESC;
+
+-- distinct with multiple columns 
+SELECT DISTINCT l_orderkey, o_orderdate
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE l_orderkey < 10
+	ORDER BY l_orderkey;
+
+-- distinct on partition column with aggregate
+-- this is the same as the one without distinct due to group by
+SELECT DISTINCT l_orderkey, count(*)
+	FROM lineitem_hash_part
+	WHERE l_orderkey < 200
+	GROUP BY 1
+	HAVING count(*) > 5
+	ORDER BY 2 DESC, 1;
+	
+-- explain the query to see actual plan
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_orderkey, count(*)
+		FROM lineitem_hash_part
+		WHERE l_orderkey < 200
+		GROUP BY 1
+		HAVING count(*) > 5
+		ORDER BY 2 DESC, 1;
+
+-- distinct on non-partition column with aggregate
+-- this is the same as non-distinct version due to group by
+SELECT DISTINCT l_partkey, count(*)
+	FROM lineitem_hash_part
+	GROUP BY 1 
+	HAVING count(*) > 2
+	ORDER BY 1;
+	
+-- explain the query to see actual plan
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_partkey, count(*)
+		FROM lineitem_hash_part
+		GROUP BY 1 
+		HAVING count(*) > 2
+		ORDER BY 1;
+
+-- distinct on non-partition column and avg
+SELECT DISTINCT l_partkey, avg(l_linenumber)
+	FROM lineitem_hash_part
+	WHERE l_partkey < 500
+	GROUP BY 1 
+	HAVING avg(l_linenumber) > 2
+	ORDER BY 1;
+
+-- distinct on multiple non-partition columns
+SELECT DISTINCT l_partkey, l_suppkey
+	FROM lineitem_hash_part
+	WHERE l_shipmode = 'AIR' AND l_orderkey < 100
+	ORDER BY 1, 2;
+	
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_partkey, l_suppkey
+		FROM lineitem_hash_part
+		WHERE l_shipmode = 'AIR' AND l_orderkey < 100
+		ORDER BY 1, 2;
+
+-- distinct on partition column
+SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey, l_suppkey
+	FROM lineitem_hash_part
+	WHERE l_orderkey < 35
+	ORDER BY 1;
+	
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey, l_suppkey
+		FROM lineitem_hash_part
+		WHERE l_orderkey < 35
+		ORDER BY 1;
+
+-- distinct on non-partition column
+-- note order by is required here
+-- otherwise query results will be different since
+-- distinct on clause is on non-partition column
+SELECT DISTINCT ON (l_partkey) l_partkey, l_orderkey
+	FROM lineitem_hash_part
+	ORDER BY 1,2
+	LIMIT 20;
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_partkey) l_partkey, l_orderkey
+		FROM lineitem_hash_part
+		ORDER BY 1,2
+		LIMIT 20;
+
+-- distinct on with joins
+-- each customer's first order key
+SELECT DISTINCT ON (o_custkey) o_custkey, l_orderkey
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE o_custkey < 15
+	ORDER BY 1,2;
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (o_custkey) o_custkey, l_orderkey
+		FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+		WHERE o_custkey < 15
+		ORDER BY 1,2;
+
+-- explain without order by
+-- notice master plan has order by on distinct on column
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (o_custkey) o_custkey, l_orderkey
+		FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+		WHERE o_custkey < 15;
+
+-- each customer's each order's first l_partkey
+SELECT DISTINCT ON (o_custkey, l_orderkey) o_custkey, l_orderkey, l_linenumber, l_partkey
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE o_custkey < 20
+	ORDER BY 1,2,3;
+
+-- explain without order by
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (o_custkey, l_orderkey) o_custkey, l_orderkey, l_linenumber, l_partkey
+		FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+		WHERE o_custkey < 20;
+
+-- each customer's each order's last l_partkey
+SELECT DISTINCT ON (o_custkey, l_orderkey) o_custkey, l_orderkey, l_linenumber, l_partkey
+	FROM lineitem_hash_part JOIN orders_hash_part ON (l_orderkey = o_orderkey) 
+	WHERE o_custkey < 15
+	ORDER BY 1,2,3 DESC;
+
+-- subqueries
+SELECT DISTINCT l_orderkey, l_partkey
+	FROM (
+		SELECT l_orderkey, l_partkey
+		FROM lineitem_hash_part
+		) q
+	ORDER BY 1,2
+	LIMIT 10;
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_orderkey, l_partkey
+		FROM (
+			SELECT l_orderkey, l_partkey
+			FROM lineitem_hash_part
+			) q
+		ORDER BY 1,2
+		LIMIT 10;
+
+SELECT DISTINCT l_orderkey, cnt
+	FROM (
+		SELECT l_orderkey, count(*) as cnt
+		FROM lineitem_hash_part
+		GROUP BY 1
+		) q
+	ORDER BY 1,2
+	LIMIT 10;
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT l_orderkey, cnt
+		FROM (
+			SELECT l_orderkey, count(*) as cnt
+			FROM lineitem_hash_part
+			GROUP BY 1
+			) q
+		ORDER BY 1,2
+		LIMIT 10;
+-- distinct on partition column
+-- random() is added to inner query to prevent flattening
+SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey
+	FROM (
+		SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+		FROM lineitem_hash_part
+		) q
+	WHERE r > 1
+	ORDER BY 1,2
+	LIMIT 10;
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_orderkey) l_orderkey, l_partkey
+		FROM (
+			SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+			FROM lineitem_hash_part
+			) q
+		WHERE r > 1
+		ORDER BY 1,2
+		LIMIT 10;
+
+-- distinct on non-partition column
+SELECT DISTINCT ON (l_partkey) l_orderkey, l_partkey
+	FROM (
+		SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+		FROM lineitem_hash_part
+		) q
+	WHERE r > 1
+	ORDER BY 2,1
+	LIMIT 10;
+
+EXPLAIN (COSTS FALSE)
+	SELECT DISTINCT ON (l_partkey) l_orderkey, l_partkey
+		FROM (
+			SELECT l_orderkey, l_partkey, (random()*10)::int + 2 as r
+			FROM lineitem_hash_part
+			) q
+		WHERE r > 1
+		ORDER BY 2,1
+		LIMIT 10;


### PR DESCRIPTION
This work adds select distinct support for real-time queries, distinct on top level query of subqueries, distinct on insert into select queries.

Following syntax is supported
```sql
select distinct column_1, column_2, ... from [distributed_table | reference_table];

select distinct on (partition_column) some_other_columns from [distributed_table];

select distinct on (non_partition_column) some_other_columns from [distributed_table | reference_table];
```

distinct/distinct on clause on subqueries are also supported
```sql
select distinct [subquery_target_columns] from (subquery)
```
Subquery is any subquery supported by Citus.

Distinct clauses with aggregates are also supported, however use of distinct queries with aggregates does not make much sense since there is also group by dictating the distinctness of the query target list.

```sql
select distinct a, sum(b)
from some_table
group by a;
```

Due to definition of ```distinct on``` it is recommended that it is alway used by an order by clause since ordering of rows may change in distributed environment.

```sql
select distinct on(a) a, b
from some_table;
```

will return different results than
```sql
select distinct on(a) a, b
from some_table
order by a, b;
```
Notice that PostgreSQL requires that order by clause includes distinct on clauses in the beginning of order list.

```sql
select distinct on (a,b) a,b,c
from some_table
order by a,b,c;
````
is valid but

```sql
select distinct on (a,b) a,b,c
from some_table
order by a, c, b;
````
 is not.

Distinct targets can be of anything that PostgreSQL allows which include but not limited to columns, constants, expressions, function calls.

distinct/distinct on is also supported in insert into .. select queries. Since this queries require that that insert target list to include partition column in correct location, select distinct has to include partition column. The query would work as expected.

However, if the query contains select distinct on without partition column inside on clause, the query would still work, but it would pull all data to coordinator node to perform distinct operation, then it would distributed data back to worker nodes. Therefore it should be used with caution.

Fixes #1307
Fixes #625 


Testing
- select on a single table on range/append/hash partitioned tables
- select on a single reference table (becomes router plannable)
- select on a co-located joins
- select on hash partitioned table vs reference table
- select on re-partition join on hash tables
- select distinct on top level query in subqueries (with + without join)
- select distinct on inner query in subqueries (with + without join)
- insert into select distinct on single table and co-located joins
- insert into select distinct when distinct is inside inner subquery
- all of above with select distinct on()
