### PR TITLE
 Count distinct feature

### DIFF
--- a/src/test/regress/expected/multi_agg_approximate_distinct.out
+++ b/src/test/regress/expected/multi_agg_approximate_distinct.out
@@ -16,9 +16,11 @@ WHERE name = 'hll'
 \c - - - :master_port
 -- Try to execute count(distinct) when approximate distincts aren't enabled
 SELECT count(distinct l_orderkey) FROM lineitem;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+  2985
+(1 row)
+
 -- Check approximate count(distinct) at different precisions / error rates
 SET citus.count_distinct_error_rate = 0.1;
 SELECT count(distinct l_orderkey) FROM lineitem;
@@ -200,6 +202,8 @@ SELECT
 -- Check that we can revert config and disable count(distinct) approximations
 SET citus.count_distinct_error_rate = 0.0;
 SELECT count(distinct l_orderkey) FROM lineitem;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+  2985
+(1 row)
+

--- a/src/test/regress/expected/multi_agg_approximate_distinct_0.out
+++ b/src/test/regress/expected/multi_agg_approximate_distinct_0.out
@@ -31,9 +31,11 @@ WHERE name = 'hll'
 \c - - - :master_port
 -- Try to execute count(distinct) when approximate distincts aren't enabled
 SELECT count(distinct l_orderkey) FROM lineitem;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+  2985
+(1 row)
+
 -- Check approximate count(distinct) at different precisions / error rates
 SET citus.count_distinct_error_rate = 0.1;
 SELECT count(distinct l_orderkey) FROM lineitem;
@@ -147,6 +149,8 @@ HINT:  You need to have the hll extension loaded.
 -- Check that we can revert config and disable count(distinct) approximations
 SET citus.count_distinct_error_rate = 0.0;
 SELECT count(distinct l_orderkey) FROM lineitem;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+  2985
+(1 row)
+

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -107,11 +107,20 @@ SELECT count(*) FROM priority_orders join air_shipped_lineitems ON (o_orderkey =
    700
 (1 row)
 
--- count distinct on partition column is not supported
+-- count distinct on partition column is supported
 SELECT count(distinct o_orderkey) FROM priority_orders join air_shipped_lineitems ON (o_orderkey = l_orderkey);
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+   551
+(1 row)
+
+-- count distinct on non-partition column is supported
+SELECT count(distinct o_orderpriority) FROM priority_orders join air_shipped_lineitems ON (o_orderkey = l_orderkey);
+ count 
+-------
+     2
+(1 row)
+
 -- count distinct on partition column is supported on router queries
 SELECT count(distinct o_orderkey) FROM priority_orders join air_shipped_lineitems
 	ON (o_orderkey = l_orderkey)

--- a/src/test/regress/input/multi_agg_distinct.source
+++ b/src/test/regress/input/multi_agg_distinct.source
@@ -56,22 +56,20 @@ SELECT p_partkey, count(distinct l_orderkey) FROM lineitem_range, part
 
 RESET citus.large_table_shard_count;
 
--- Check that we don't support count(distinct) on non-partition column, and
--- complex expressions.
-
+-- Check that we support count(distinct) on non-partition column.
 SELECT count(distinct l_partkey) FROM lineitem_range;
+
+-- Check that we don't support complex expressions.
 SELECT count(distinct (l_orderkey + 1)) FROM lineitem_range;
 
 -- Now test append partitioned tables. First run count(distinct) on a single
 -- sharded table.
-
 SELECT count(distinct p_mfgr) FROM part;
 SELECT p_mfgr, count(distinct p_partkey) FROM part GROUP BY p_mfgr ORDER BY p_mfgr;
 
--- We don't support count(distinct) queries if table is append partitioned and
--- has multiple shards
-
-SELECT count(distinct o_orderkey) FROM orders;
+-- We support count(distinct) queries on append partitioned tables
+-- both on partition column, and non-partition column.
+SELECT count(distinct o_orderkey), count(distinct o_custkey) FROM orders;
 
 -- Hash partitioned tables:
 
@@ -99,13 +97,13 @@ SELECT master_create_worker_shards('lineitem_hash', 4, 1);
 \copy lineitem_hash FROM '@abs_srcdir@/data/lineitem.2.data' with delimiter '|'
 
 -- aggregate(distinct) on partition column is allowed
-
 SELECT count(distinct l_orderkey) FROM lineitem_hash;
 SELECT avg(distinct l_orderkey) FROM lineitem_hash;
 
--- count(distinct) on non-partition column or expression is not allowed
-
+-- count(distinct) on non-partition column is allowed
 SELECT count(distinct l_partkey) FROM lineitem_hash;
+
+-- count(distinct) on column expression is not allowed
 SELECT count(distinct (l_orderkey + 1)) FROM lineitem_hash;
 
 -- agg(distinct) is allowed if we group by partition column
@@ -114,5 +112,17 @@ SELECT l_orderkey, count(distinct l_partkey) INTO range_results FROM lineitem_ra
 
 -- they should return the same results
 SELECT * FROM hash_results h, range_results r WHERE h.l_orderkey = r.l_orderkey AND h.count != r.count;
+
+-- count(distinct) is allowed if we group by non-partition column
+SELECT l_partkey, count(distinct l_orderkey) INTO hash_results_np FROM lineitem_hash GROUP BY l_partkey;
+SELECT l_partkey, count(distinct l_orderkey) INTO range_results_np FROM lineitem_range GROUP BY l_partkey;
+
+-- they should return the same results
+SELECT * FROM hash_results_np h, range_results_np r WHERE h.l_partkey = r.l_partkey AND h.count != r.count;
+
+-- other agg(distinct) are not allowed on non-partition columns even they are grouped
+-- on non-partition columns
+SELECT SUM(distinct l_partkey) FROM lineitem_hash;
+SELECT l_shipmode, sum(distinct l_partkey) FROM lineitem_hash GROUP BY l_shipmode;
 
 DROP TABLE lineitem_hash;

--- a/src/test/regress/input/multi_complex_count_distinct.source
+++ b/src/test/regress/input/multi_complex_count_distinct.source
@@ -41,8 +41,22 @@ SELECT
 	GROUP BY l_orderkey
 	ORDER BY 2 DESC, 1 DESC
 	LIMIT 10;
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
 
--- it is not supported if there is no grouping or grouping is on non-partition field
+-- it is also supported if there is no grouping or grouping is on non-partition field
+SELECT
+	count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	ORDER BY 1 DESC
+	LIMIT 10;
+
+EXPLAIN (COSTS false, VERBOSE true)
 SELECT
 	count(DISTINCT l_partkey)
 	FROM lineitem_hash
@@ -55,6 +69,96 @@ SELECT
 	GROUP BY l_shipmode
 	ORDER BY 2 DESC, 1 DESC
 	LIMIT 10;
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_shipmode, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- mixed mode count distinct, grouped by partition column
+SELECT
+	l_orderkey, count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 3 DESC, 2 DESC, 1
+	LIMIT 10;
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_orderkey, count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 3 DESC, 2 DESC, 1
+	LIMIT 10;
+
+-- partition/non-partition column count distinct no grouping
+SELECT
+	count(distinct l_orderkey), count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash;
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	count(distinct l_orderkey), count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash;
+
+-- distinct/non-distinct on partition and non-partition columns
+SELECT
+	count(distinct l_orderkey), count(l_orderkey),
+	count(distinct l_partkey), count(l_partkey),
+	count(distinct l_shipmode), count(l_shipmode)
+	FROM lineitem_hash;
+
+-- mixed mode count distinct, grouped by non-partition column
+SELECT
+	l_shipmode, count(distinct l_partkey), count(distinct l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	ORDER BY 1, 2 DESC, 3 DESC;
+
+-- mixed mode count distinct, grouped by non-partition column
+-- having on partition column
+SELECT
+	l_shipmode, count(distinct l_partkey), count(distinct l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_orderkey) > 1300
+	ORDER BY 1, 2 DESC;
+
+-- same but having clause is not on target list
+SELECT
+	l_shipmode, count(distinct l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_orderkey) > 1300
+	ORDER BY 1, 2 DESC;
+
+-- mixed mode count distinct, grouped by non-partition column
+-- having on non-partition column
+SELECT
+	l_shipmode, count(distinct l_partkey), count(distinct l_suppkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_suppkey) > 1550
+	ORDER BY 1, 2 DESC;
+
+-- same but having clause is not on target list
+SELECT
+	l_shipmode, count(distinct l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_suppkey) > 1550
+	ORDER BY 1, 2 DESC;
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_shipmode, count(distinct l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_suppkey) > 1550
+	ORDER BY 1, 2 DESC;
 
 -- count distinct is supported on single table subqueries
 SELECT *
@@ -75,13 +179,67 @@ SELECT *
 	ORDER BY 2 DESC, 1 DESC
 	LIMIT 10;
 
--- count distinct with filters
-SELECT
-	l_orderkey, count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
-	FROM lineitem_hash
-	GROUP BY l_orderkey
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT *
+	FROM (
+		SELECT
+			l_partkey, count(DISTINCT l_orderkey)
+			FROM lineitem_hash
+			GROUP BY l_partkey) sub
 	ORDER BY 2 DESC, 1 DESC
 	LIMIT 10;
+
+-- count distinct with filters
+SELECT
+	l_orderkey,
+	count(DISTINCT l_suppkey) FILTER (WHERE l_shipmode = 'AIR'),
+	count(DISTINCT l_suppkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 3 DESC, 1
+	LIMIT 10;
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_orderkey,
+	count(DISTINCT l_suppkey) FILTER (WHERE l_shipmode = 'AIR'),
+	count(DISTINCT l_suppkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 3 DESC, 1
+	LIMIT 10;
+
+-- group by on non-partition column
+SELECT
+	l_suppkey, count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash
+	GROUP BY l_suppkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+-- explaining the same query fails
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_suppkey, count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash
+	GROUP BY l_suppkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+
+-- without group by, on partition column
+SELECT
+	count(DISTINCT l_orderkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash;
+
+-- without group by, on non-partition column
+SELECT
+	count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash;
+
+SELECT
+	count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR'),
+	count(DISTINCT l_partkey),
+	count(DISTINCT l_shipdate)
+	FROM lineitem_hash;
 
 -- filter column already exists in target list
 SELECT *

--- a/src/test/regress/output/multi_agg_distinct.source
+++ b/src/test/regress/output/multi_agg_distinct.source
@@ -73,12 +73,14 @@ SELECT p_partkey, count(distinct l_orderkey) FROM lineitem_range, part
 (10 rows)
 
 RESET citus.large_table_shard_count;
--- Check that we don't support count(distinct) on non-partition column, and
--- complex expressions.
+-- Check that we support count(distinct) on non-partition column.
 SELECT count(distinct l_partkey) FROM lineitem_range;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+ 11661
+(1 row)
+
+-- Check that we don't support complex expressions.
 SELECT count(distinct (l_orderkey + 1)) FROM lineitem_range;
 ERROR:  cannot compute aggregate (distinct)
 DETAIL:  aggregate (distinct) on complex expressions is unsupported
@@ -101,12 +103,14 @@ SELECT p_mfgr, count(distinct p_partkey) FROM part GROUP BY p_mfgr ORDER BY p_mf
  Manufacturer#5            |   185
 (5 rows)
 
--- We don't support count(distinct) queries if table is append partitioned and
--- has multiple shards
-SELECT count(distinct o_orderkey) FROM orders;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+-- We support count(distinct) queries on append partitioned tables
+-- both on partition column, and non-partition column.
+SELECT count(distinct o_orderkey), count(distinct o_custkey) FROM orders;
+ count | count 
+-------+-------
+  2984 |   923
+(1 row)
+
 -- Hash partitioned tables:
 CREATE TABLE lineitem_hash (
 	l_orderkey bigint not null,
@@ -152,11 +156,14 @@ SELECT avg(distinct l_orderkey) FROM lineitem_hash;
  7463.9474036850921273
 (1 row)
 
--- count(distinct) on non-partition column or expression is not allowed
+-- count(distinct) on non-partition column is allowed
 SELECT count(distinct l_partkey) FROM lineitem_hash;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+ 11661
+(1 row)
+
+-- count(distinct) on column expression is not allowed
 SELECT count(distinct (l_orderkey + 1)) FROM lineitem_hash;
 ERROR:  cannot compute aggregate (distinct)
 DETAIL:  aggregate (distinct) on complex expressions is unsupported
@@ -170,4 +177,21 @@ SELECT * FROM hash_results h, range_results r WHERE h.l_orderkey = r.l_orderkey 
 ------------+-------+------------+-------
 (0 rows)
 
+-- count(distinct) is allowed if we group by non-partition column
+SELECT l_partkey, count(distinct l_orderkey) INTO hash_results_np FROM lineitem_hash GROUP BY l_partkey;
+SELECT l_partkey, count(distinct l_orderkey) INTO range_results_np FROM lineitem_range GROUP BY l_partkey;
+-- they should return the same results
+SELECT * FROM hash_results_np h, range_results_np r WHERE h.l_partkey = r.l_partkey AND h.count != r.count;
+ l_partkey | count | l_partkey | count 
+-----------+-------+-----------+-------
+(0 rows)
+
+-- other agg(distinct) are not allowed on non-partition columns even they are grouped
+-- on non-partition columns
+SELECT SUM(distinct l_partkey) FROM lineitem_hash;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  table partitioning is unsuitable for aggregate (distinct)
+SELECT l_shipmode, sum(distinct l_partkey) FROM lineitem_hash GROUP BY l_shipmode;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  table partitioning is unsuitable for aggregate (distinct)
 DROP TABLE lineitem_hash;

--- a/src/test/regress/output/multi_complex_count_distinct.source
+++ b/src/test/regress/output/multi_complex_count_distinct.source
@@ -58,24 +58,346 @@ SELECT
       14624 |     7
 (10 rows)
 
--- it is not supported if there is no grouping or grouping is on non-partition field
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_orderkey, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint))))::bigint, '0'::bigint)
+   ->  Sort
+         Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint)
+         Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint) DESC, remote_scan.l_orderkey DESC
+         ->  HashAggregate
+               Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint)
+               Group Key: remote_scan.l_orderkey
+               ->  Custom Scan (Citus Task-Tracker)
+                     Output: remote_scan.l_orderkey, remote_scan.count
+                     Task Count: 8
+                     Tasks Shown: One of 8
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 Output: l_orderkey, (count(DISTINCT l_partkey))
+                                 ->  Sort
+                                       Output: l_orderkey, (count(DISTINCT l_partkey))
+                                       Sort Key: (count(DISTINCT lineitem_hash.l_partkey)) DESC, lineitem_hash.l_orderkey DESC
+                                       ->  GroupAggregate
+                                             Output: l_orderkey, count(DISTINCT l_partkey)
+                                             Group Key: lineitem_hash.l_orderkey
+                                             ->  Sort
+                                                   Output: l_orderkey, l_partkey
+                                                   Sort Key: lineitem_hash.l_orderkey DESC
+                                                   ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                                                         Output: l_orderkey, l_partkey
+(27 rows)
+
+-- it is also supported if there is no grouping or grouping is on non-partition field
 SELECT
 	count(DISTINCT l_partkey)
 	FROM lineitem_hash
 	ORDER BY 1 DESC
 	LIMIT 10;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ count 
+-------
+ 11661
+(1 row)
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	ORDER BY 1 DESC
+	LIMIT 10;
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: count(DISTINCT (count(DISTINCT (count(DISTINCT remote_scan.count)))))
+   ->  Sort
+         Output: count(DISTINCT (count(DISTINCT remote_scan.count)))
+         Sort Key: count(DISTINCT (count(DISTINCT remote_scan.count))) DESC
+         ->  Aggregate
+               Output: count(DISTINCT remote_scan.count)
+               ->  Custom Scan (Citus Task-Tracker)
+                     Output: remote_scan.count
+                     Task Count: 8
+                     Tasks Shown: One of 8
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  HashAggregate
+                                 Output: l_partkey
+                                 Group Key: lineitem_hash.l_partkey
+                                 ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                                       Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+(18 rows)
+
 SELECT
 	l_shipmode, count(DISTINCT l_partkey)
 	FROM lineitem_hash
 	GROUP BY l_shipmode
 	ORDER BY 2 DESC, 1 DESC
 	LIMIT 10;
-ERROR:  cannot compute aggregate (distinct)
-DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-HINT:  You can load the hll extension from contrib packages and enable distinct approximations.
+ l_shipmode | count 
+------------+-------
+ TRUCK      |  1757
+ MAIL       |  1730
+ AIR        |  1702
+ FOB        |  1700
+ RAIL       |  1696
+ SHIP       |  1684
+ REG AIR    |  1676
+(7 rows)
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_shipmode, count(DISTINCT l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+                                                                                                                           QUERY PLAN                                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: remote_scan.l_shipmode, count(DISTINCT (count(DISTINCT (count(DISTINCT remote_scan.count)))))
+   ->  Sort
+         Output: remote_scan.l_shipmode, count(DISTINCT (count(DISTINCT remote_scan.count)))
+         Sort Key: count(DISTINCT (count(DISTINCT remote_scan.count))) DESC, remote_scan.l_shipmode DESC
+         ->  GroupAggregate
+               Output: remote_scan.l_shipmode, count(DISTINCT remote_scan.count)
+               Group Key: remote_scan.l_shipmode
+               ->  Sort
+                     Output: remote_scan.l_shipmode, remote_scan.count
+                     Sort Key: remote_scan.l_shipmode DESC
+                     ->  Custom Scan (Citus Task-Tracker)
+                           Output: remote_scan.l_shipmode, remote_scan.count
+                           Task Count: 8
+                           Tasks Shown: One of 8
+                           ->  Task
+                                 Node: host=localhost port=57637 dbname=regression
+                                 ->  HashAggregate
+                                       Output: l_shipmode, l_partkey
+                                       Group Key: lineitem_hash.l_shipmode, lineitem_hash.l_partkey
+                                       ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                                             Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+(22 rows)
+
+-- mixed mode count distinct, grouped by partition column
+SELECT
+	l_orderkey, count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 3 DESC, 2 DESC, 1
+	LIMIT 10;
+ l_orderkey | count | count 
+------------+-------+-------
+        226 |     7 |     7
+       1316 |     7 |     7
+       1477 |     7 |     7
+       3555 |     7 |     7
+      12258 |     7 |     7
+      12835 |     7 |     7
+        768 |     7 |     6
+       1121 |     7 |     6
+       1153 |     7 |     6
+       1281 |     7 |     6
+(10 rows)
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_orderkey, count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 3 DESC, 2 DESC, 1
+	LIMIT 10;
+                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint))))::bigint, '0'::bigint), COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint))))::bigint, '0'::bigint))))::bigint, '0'::bigint)
+   ->  Sort
+         Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint), COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint))))::bigint, '0'::bigint)
+         Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint))))::bigint, '0'::bigint) DESC, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint) DESC, remote_scan.l_orderkey
+         ->  HashAggregate
+               Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint), COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint)
+               Group Key: remote_scan.l_orderkey
+               ->  Custom Scan (Citus Task-Tracker)
+                     Output: remote_scan.l_orderkey, remote_scan.count, remote_scan.count_1
+                     Task Count: 8
+                     Tasks Shown: One of 8
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 Output: l_orderkey, (count(DISTINCT l_partkey)), (count(DISTINCT l_shipmode))
+                                 ->  Sort
+                                       Output: l_orderkey, (count(DISTINCT l_partkey)), (count(DISTINCT l_shipmode))
+                                       Sort Key: (count(DISTINCT lineitem_hash.l_shipmode)) DESC, (count(DISTINCT lineitem_hash.l_partkey)) DESC, lineitem_hash.l_orderkey
+                                       ->  GroupAggregate
+                                             Output: l_orderkey, count(DISTINCT l_partkey), count(DISTINCT l_shipmode)
+                                             Group Key: lineitem_hash.l_orderkey
+                                             ->  Sort
+                                                   Output: l_orderkey, l_partkey, l_shipmode
+                                                   Sort Key: lineitem_hash.l_orderkey
+                                                   ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                                                         Output: l_orderkey, l_partkey, l_shipmode
+(27 rows)
+
+-- partition/non-partition column count distinct no grouping
+SELECT
+	count(distinct l_orderkey), count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash;
+ count | count | count 
+-------+-------+-------
+  2985 | 11661 |     7
+(1 row)
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	count(distinct l_orderkey), count(distinct l_partkey), count(distinct l_shipmode)
+	FROM lineitem_hash;
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: count(DISTINCT remote_scan.count), count(DISTINCT remote_scan.count_1), count(DISTINCT remote_scan.count_2)
+   ->  Custom Scan (Citus Task-Tracker)
+         Output: remote_scan.count, remote_scan.count_1, remote_scan.count_2
+         Task Count: 8
+         Tasks Shown: One of 8
+         ->  Task
+               Node: host=localhost port=57637 dbname=regression
+               ->  HashAggregate
+                     Output: l_orderkey, l_partkey, l_shipmode
+                     Group Key: lineitem_hash.l_orderkey, lineitem_hash.l_partkey, lineitem_hash.l_shipmode
+                     ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                           Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+(13 rows)
+
+-- distinct/non-distinct on partition and non-partition columns
+SELECT
+	count(distinct l_orderkey), count(l_orderkey),
+	count(distinct l_partkey), count(l_partkey),
+	count(distinct l_shipmode), count(l_shipmode)
+	FROM lineitem_hash;
+ count | count | count | count | count | count 
+-------+-------+-------+-------+-------+-------
+  2985 | 12000 | 11661 | 12000 |     7 | 12000
+(1 row)
+
+-- mixed mode count distinct, grouped by non-partition column
+SELECT
+	l_shipmode, count(distinct l_partkey), count(distinct l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	ORDER BY 1, 2 DESC, 3 DESC;
+ l_shipmode | count | count 
+------------+-------+-------
+ AIR        |  1702 |  1327
+ FOB        |  1700 |  1276
+ MAIL       |  1730 |  1299
+ RAIL       |  1696 |  1265
+ REG AIR    |  1676 |  1275
+ SHIP       |  1684 |  1289
+ TRUCK      |  1757 |  1333
+(7 rows)
+
+-- mixed mode count distinct, grouped by non-partition column
+-- having on partition column
+SELECT
+	l_shipmode, count(distinct l_partkey), count(distinct l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_orderkey) > 1300
+	ORDER BY 1, 2 DESC;
+ l_shipmode | count | count 
+------------+-------+-------
+ AIR        |  1702 |  1327
+ TRUCK      |  1757 |  1333
+(2 rows)
+
+-- same but having clause is not on target list
+SELECT
+	l_shipmode, count(distinct l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_orderkey) > 1300
+	ORDER BY 1, 2 DESC;
+ l_shipmode | count 
+------------+-------
+ AIR        |  1702
+ TRUCK      |  1757
+(2 rows)
+
+-- mixed mode count distinct, grouped by non-partition column
+-- having on non-partition column
+SELECT
+	l_shipmode, count(distinct l_partkey), count(distinct l_suppkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_suppkey) > 1550
+	ORDER BY 1, 2 DESC;
+ l_shipmode | count | count 
+------------+-------+-------
+ AIR        |  1702 |  1564
+ FOB        |  1700 |  1571
+ MAIL       |  1730 |  1573
+ RAIL       |  1696 |  1581
+ REG AIR    |  1676 |  1557
+ SHIP       |  1684 |  1554
+ TRUCK      |  1757 |  1602
+(7 rows)
+
+-- same but having clause is not on target list
+SELECT
+	l_shipmode, count(distinct l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_suppkey) > 1550
+	ORDER BY 1, 2 DESC;
+ l_shipmode | count 
+------------+-------
+ AIR        |  1702
+ FOB        |  1700
+ MAIL       |  1730
+ RAIL       |  1696
+ REG AIR    |  1676
+ SHIP       |  1684
+ TRUCK      |  1757
+(7 rows)
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_shipmode, count(distinct l_partkey)
+	FROM lineitem_hash
+	GROUP BY l_shipmode
+	HAVING count(distinct l_suppkey) > 1550
+	ORDER BY 1, 2 DESC;
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: remote_scan.l_shipmode, count(DISTINCT (count(DISTINCT remote_scan.count)))
+   Sort Key: remote_scan.l_shipmode, count(DISTINCT (count(DISTINCT remote_scan.count))) DESC
+   ->  GroupAggregate
+         Output: remote_scan.l_shipmode, count(DISTINCT remote_scan.count)
+         Group Key: remote_scan.l_shipmode
+         Filter: (count(DISTINCT remote_scan.worker_column_3) > 1550)
+         ->  Sort
+               Output: remote_scan.l_shipmode, remote_scan.count, remote_scan.worker_column_3
+               Sort Key: remote_scan.l_shipmode
+               ->  Custom Scan (Citus Task-Tracker)
+                     Output: remote_scan.l_shipmode, remote_scan.count, remote_scan.worker_column_3
+                     Task Count: 8
+                     Tasks Shown: One of 8
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  HashAggregate
+                                 Output: l_shipmode, l_partkey, l_suppkey
+                                 Group Key: lineitem_hash.l_shipmode, lineitem_hash.l_partkey, lineitem_hash.l_suppkey
+                                 ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                                       Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+(21 rows)
+
 -- count distinct is supported on single table subqueries
 SELECT *
 	FROM (
@@ -121,26 +443,151 @@ SELECT *
       1927 |     3
 (10 rows)
 
--- count distinct with filters
-SELECT
-	l_orderkey, count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
-	FROM lineitem_hash
-	GROUP BY l_orderkey
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT *
+	FROM (
+		SELECT
+			l_partkey, count(DISTINCT l_orderkey)
+			FROM lineitem_hash
+			GROUP BY l_partkey) sub
 	ORDER BY 2 DESC, 1 DESC
 	LIMIT 10;
- l_orderkey | count 
-------------+-------
-      12005 |     4
-       5409 |     4
-       4964 |     4
-      14848 |     3
-      14496 |     3
-      13473 |     3
-      13122 |     3
-      12929 |     3
-      12645 |     3
-      12417 |     3
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Limit
+   Output: remote_scan.l_partkey, remote_scan.count
+   ->  Sort
+         Output: remote_scan.l_partkey, remote_scan.count
+         Sort Key: remote_scan.count DESC, remote_scan.l_partkey DESC
+         ->  Custom Scan (Citus Task-Tracker)
+               Output: remote_scan.l_partkey, remote_scan.count
+               Task Count: 4
+               Tasks Shown: None, not supported for re-partition queries
+               ->  MapMergeJob
+                     Map Task Count: 8
+                     Merge Task Count: 4
+(12 rows)
+
+-- count distinct with filters
+SELECT
+	l_orderkey,
+	count(DISTINCT l_suppkey) FILTER (WHERE l_shipmode = 'AIR'),
+	count(DISTINCT l_suppkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 3 DESC, 1
+	LIMIT 10;
+ l_orderkey | count | count 
+------------+-------+-------
+       4964 |     4 |     7
+      12005 |     4 |     7
+       5409 |     4 |     6
+        164 |     3 |     7
+        322 |     3 |     7
+        871 |     3 |     7
+       1156 |     3 |     7
+       1574 |     3 |     7
+       2054 |     3 |     7
+       2309 |     3 |     7
 (10 rows)
+
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_orderkey,
+	count(DISTINCT l_suppkey) FILTER (WHERE l_shipmode = 'AIR'),
+	count(DISTINCT l_suppkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 3 DESC, 1
+	LIMIT 10;
+                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint))))::bigint, '0'::bigint), COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint))))::bigint, '0'::bigint))))::bigint, '0'::bigint)
+   ->  Sort
+         Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint), COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint))))::bigint, '0'::bigint)
+         Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint))))::bigint, '0'::bigint) DESC, COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint))))::bigint, '0'::bigint) DESC, remote_scan.l_orderkey
+         ->  HashAggregate
+               Output: remote_scan.l_orderkey, COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint), COALESCE((pg_catalog.sum(remote_scan.count_1))::bigint, '0'::bigint)
+               Group Key: remote_scan.l_orderkey
+               ->  Custom Scan (Citus Task-Tracker)
+                     Output: remote_scan.l_orderkey, remote_scan.count, remote_scan.count_1
+                     Task Count: 8
+                     Tasks Shown: One of 8
+                     ->  Task
+                           Node: host=localhost port=57637 dbname=regression
+                           ->  Limit
+                                 Output: l_orderkey, (count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode = 'AIR'::bpchar))), (count(DISTINCT l_suppkey))
+                                 ->  Sort
+                                       Output: l_orderkey, (count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode = 'AIR'::bpchar))), (count(DISTINCT l_suppkey))
+                                       Sort Key: (count(DISTINCT lineitem_hash.l_suppkey) FILTER (WHERE (lineitem_hash.l_shipmode = 'AIR'::bpchar))) DESC, (count(DISTINCT lineitem_hash.l_suppkey)) DESC, lineitem_hash.l_orderkey
+                                       ->  GroupAggregate
+                                             Output: l_orderkey, count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode = 'AIR'::bpchar)), count(DISTINCT l_suppkey)
+                                             Group Key: lineitem_hash.l_orderkey
+                                             ->  Sort
+                                                   Output: l_orderkey, l_suppkey, l_shipmode
+                                                   Sort Key: lineitem_hash.l_orderkey
+                                                   ->  Seq Scan on public.lineitem_hash_240000 lineitem_hash
+                                                         Output: l_orderkey, l_suppkey, l_shipmode
+(27 rows)
+
+-- group by on non-partition column
+SELECT
+	l_suppkey, count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash
+	GROUP BY l_suppkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ l_suppkey | count 
+-----------+-------
+      7680 |     4
+      7703 |     3
+      7542 |     3
+      7072 |     3
+      6335 |     3
+      5873 |     3
+      1318 |     3
+      1042 |     3
+       160 |     3
+      9872 |     2
+(10 rows)
+
+-- explaining the same query fails
+EXPLAIN (COSTS false, VERBOSE true)
+SELECT
+	l_suppkey, count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash
+	GROUP BY l_suppkey
+	ORDER BY 2 DESC, 1 DESC
+	LIMIT 10;
+ERROR:  bogus varattno for OUTER_VAR var: 3
+-- without group by, on partition column
+SELECT
+	count(DISTINCT l_orderkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash;
+ count 
+-------
+  1327
+(1 row)
+
+-- without group by, on non-partition column
+SELECT
+	count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR')
+	FROM lineitem_hash;
+ count 
+-------
+  1702
+(1 row)
+
+SELECT
+	count(DISTINCT l_partkey) FILTER (WHERE l_shipmode = 'AIR'),
+	count(DISTINCT l_partkey),
+	count(DISTINCT l_shipdate)
+	FROM lineitem_hash;
+ count | count | count 
+-------+-------+-------
+  1702 | 11661 |  2470
+(1 row)
 
 -- filter column already exists in target list
 SELECT *

--- a/src/test/regress/sql/multi_view.sql
+++ b/src/test/regress/sql/multi_view.sql
@@ -45,8 +45,11 @@ SELECT count(*) FROM orders_hash_part join air_shipped_lineitems ON (o_orderkey 
 -- join between views
 SELECT count(*) FROM priority_orders join air_shipped_lineitems ON (o_orderkey = l_orderkey);
 
--- count distinct on partition column is not supported
+-- count distinct on partition column is supported
 SELECT count(distinct o_orderkey) FROM priority_orders join air_shipped_lineitems ON (o_orderkey = l_orderkey);
+
+-- count distinct on non-partition column is supported
+SELECT count(distinct o_orderpriority) FROM priority_orders join air_shipped_lineitems ON (o_orderkey = l_orderkey);
 
 -- count distinct on partition column is supported on router queries
 SELECT count(distinct o_orderkey) FROM priority_orders join air_shipped_lineitems
@@ -70,7 +73,6 @@ SELECT count(*) FROM priority_orders right join lineitem_hash_part ON (o_orderke
 
 -- but view at the outer side is. This is essentially the same as a left join with arguments reversed.
 SELECT count(*) FROM lineitem_hash_part right join priority_orders ON (o_orderkey = l_orderkey) WHERE l_shipmode ='AIR';
-
 
 -- left join on router query is supported
 SELECT o_orderkey, l_linenumber FROM priority_orders left join air_shipped_lineitems ON (o_orderkey = l_orderkey)


### PR DESCRIPTION
Expands count distinct coverage by allowing more cases. We used to support count distinct only if we can push down distinct aggregate to worker query i.e. the count distinct clause was on the partition column of the table, or there was a grouping on the partition column.

Now we can support
- non-partition columns, with or without grouping on partition column
- partition, and non partition column in the same query
- having clause
- single table subqueries
- insert into select queries
- join queries where count distinct is on partition, or non-partition column.

We  first try to push down aggregate to worker query (original case), if we can't then we modify worker query to return distinct columns to coordinator node. We do that by adding distinct column targets to group by clauses. Then we perform count distinct operation on the coordinator node.

Note that, this approach has some performance implications as mentioned [here](https://github.com/citusdata/citus_docs/issues/476#issuecomment-337478187)

This work should reduce the cases where HLL is used as it can address anything that HLL can. However, if we start having performance issues due to very large number rows, then we can recommend hll use.


Fixes : #1256 
Fixes: #1021 


Following tests are performed
- count distinct on partition column of append, range, hash partitioned table
- count distinct on non partition column of reference, append, range, hash partitioned table
- mixed count/count distinct on partition/non partition columns
- count distinct on having clause
- count distinct on single table repartition subqueries
- count distinct on partition/non-partition column of join queries
- count distinct with filter
- count distinct in insert into select queries (these has to have partition column on select target and group by on partition column, thus existing behavior was already fine)

