### PR TITLE
Use header define rather than -D flag

### DIFF
--- a/configure
+++ b/configure
@@ -3349,7 +3349,9 @@ if test "${with_libcurl+set}" = set; then :
   withval=$with_libcurl;
   case $withval in
     yes)
-      :
+
+$as_echo "#define HAVE_LIBCURL 1" >>confdefs.h
+
       ;;
     no)
       :
@@ -3361,6 +3363,8 @@ if test "${with_libcurl+set}" = set; then :
 
 else
   with_libcurl=yes
+
+$as_echo "#define HAVE_LIBCURL 1" >>confdefs.h
 
 fi
 
@@ -3826,7 +3830,6 @@ Use --without-libcurl to disable libcurl support." "$LINENO" 5
 fi
 
 
-  CITUS_CFLAGS="$CITUS_CFLAGS -DHAVE_LIBCURL"
 fi
 
 CITUS_CFLAGS="$CITUS_CFLAGS"

--- a/configure.in
+++ b/configure.in
@@ -144,7 +144,8 @@ fi
 # libcurl
 #
 PGAC_ARG_BOOL(with, libcurl, yes,
-              [do not use libcurl for anonymous statistics collection])
+              [do not use libcurl for anonymous statistics collection],
+              [AC_DEFINE([HAVE_LIBCURL], 1, [Define to 1 to build with libcurl support. (--with-libcurl)])])
 
 if test "$with_libcurl" = yes; then
   AC_CHECK_LIB(curl, curl_global_init, [],
@@ -156,7 +157,6 @@ Use --without-libcurl to disable anonymous statistics collection.])])
 If you have libcurl already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.
 Use --without-libcurl to disable libcurl support.])])
-  CITUS_CFLAGS="$CITUS_CFLAGS -DHAVE_LIBCURL"
 fi
 
 AC_SUBST(CITUS_CFLAGS, "$CITUS_CFLAGS")

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -23,7 +23,7 @@
 
 bool EnableStatisticsCollection = true; /* send basic usage statistics to Citus */
 
-#if HAVE_LIBCURL
+#ifdef HAVE_LIBCURL
 
 static uint64 NextPow2(uint64 n);
 static uint64 ClusterSize(List *distributedTableList);

--- a/src/include/citus_version.h.in
+++ b/src/include/citus_version.h.in
@@ -11,3 +11,6 @@
 
 /* Citus version as a number */
 #undef CITUS_VERSION_NUM
+
+/* Define to 1 if you have the `curl' library (-lcurl). */
+#undef HAVE_LIBCURL


### PR DESCRIPTION
Eclipse apparently doesn't scan build output looking for -D flags, so having the value actually appear in a header is nicer for those of us using IDEs.