### PR TITLE
DistributedTableSize should not emit oid when erring out

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -169,8 +169,13 @@ DistributedTableSize(Oid relationId, char *sizeQuery)
 							   " blocks which contain multi-shard data modifications")));
 	}
 
-	/* try to open relation, will error out if the relation does not exist */
-	relation = relation_open(relationId, AccessShareLock);
+	relation = try_relation_open(relationId, AccessShareLock);
+
+	if (relation == NULL)
+	{
+		ereport(ERROR,
+				(errmsg("could not compute table size: relation does not exist")));
+	}
 
 	ErrorIfNotSuitableToGetSize(relationId);
 

--- a/src/test/regress/expected/isolation_drop_vs_all.out
+++ b/src/test/regress/expected/isolation_drop_vs_all.out
@@ -174,7 +174,7 @@ step s1-drop: DROP TABLE drop_hash;
 step s2-table-size: SELECT citus_total_relation_size('drop_hash'); <waiting ...>
 step s1-commit: COMMIT;
 step s2-table-size: <... completed>
-error in steps s1-commit s2-table-size: ERROR:  could not open relation with OID 23227
+error in steps s1-commit s2-table-size: ERROR:  could not compute table size: relation does not exist
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM drop_hash;
 ERROR:  relation "drop_hash" does not exist

--- a/src/test/regress/expected/isolation_drop_vs_all_0.out
+++ b/src/test/regress/expected/isolation_drop_vs_all_0.out
@@ -174,7 +174,7 @@ step s1-drop: DROP TABLE drop_hash;
 step s2-table-size: SELECT citus_total_relation_size('drop_hash'); <waiting ...>
 step s1-commit: COMMIT;
 step s2-table-size: <... completed>
-error in steps s1-commit s2-table-size: ERROR:  could not open relation with OID 22183
+error in steps s1-commit s2-table-size: ERROR:  could not compute table size: relation does not exist
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM drop_hash;
 ERROR:  relation "drop_hash" does not exist

--- a/src/test/regress/expected/multi_size_queries.out
+++ b/src/test/regress/expected/multi_size_queries.out
@@ -8,11 +8,11 @@ ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1390000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1390000;
 -- Tests with invalid relation IDs
 SELECT citus_table_size(1);
-ERROR:  could not open relation with OID 1
+ERROR:  could not compute table size: relation does not exist
 SELECT citus_relation_size(1);
-ERROR:  could not open relation with OID 1
+ERROR:  could not compute table size: relation does not exist
 SELECT citus_total_relation_size(1);
-ERROR:  could not open relation with OID 1
+ERROR:  could not compute table size: relation does not exist
 -- Tests with non-distributed table
 CREATE TABLE non_distributed_table (x int);
 SELECT citus_table_size('non_distributed_table');


### PR DESCRIPTION
Addresses complaint in #1694 and will fix the test errors in #1691 once merged.