### PR TITLE
Properly use #ifdef HAVE_LIBCURL.

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -796,7 +796,7 @@ RegisterCitusConfigVariables(void)
 					 "and operating system name. This configuration value controls "
 					 "whether these reports are sent."),
 		&EnableStatisticsCollection,
-#if HAVE_LIBCURL
+#ifdef HAVE_LIBCURL
 		true,
 #else
 		false,
@@ -892,7 +892,7 @@ NormalizeWorkerListPath(void)
 static bool
 StatisticsCollectionGucCheckHook(bool *newval, void **extra, GucSource source)
 {
-#if HAVE_LIBCURL
+#ifdef HAVE_LIBCURL
 	return true;
 #else
 

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -23,6 +23,7 @@
 
 #include "access/xact.h"
 #include "catalog/pg_extension.h"
+#include "citus_version.h"
 #include "commands/extension.h"
 #include "libpq/pqsignal.h"
 #include "catalog/namespace.h"
@@ -312,7 +313,7 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 			(prevStatsCollectionFailed &&
 			 secondsSincePrevStatsCollection >= STATISTICS_COLLECTION_RETRY_INTERVAL))
 		{
-#if HAVE_LIBCURL
+#ifdef HAVE_LIBCURL
 			if (EnableStatisticsCollection)
 			{
 				MemoryContext statsCollectionContext =

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -10,6 +10,8 @@
 
 #include "postgres.h"
 
+#include "citus_version.h"
+
 bool EnableStatisticsCollection = true; /* send basic usage statistics to Citus */
 
 #ifdef HAVE_LIBCURL
@@ -18,7 +20,6 @@ bool EnableStatisticsCollection = true; /* send basic usage statistics to Citus 
 #include <sys/utsname.h>
 
 #include "access/xact.h"
-#include "citus_version.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/statistics_collection.h"
 #include "distributed/worker_manager.h"

--- a/src/include/distributed/statistics_collection.h
+++ b/src/include/distributed/statistics_collection.h
@@ -10,10 +10,12 @@
 #ifndef STATISTICS_COLLECTION_H
 #define STATISTICS_COLLECTION_H
 
+#include "citus_version.h"
+
 /* Config variables managed via guc.c */
 extern bool EnableStatisticsCollection;
 
-#if HAVE_LIBCURL
+#ifdef HAVE_LIBCURL
 
 #define STATS_COLLECTION_HOST "https://citus-statistics.herokuapp.com"
 #define HTTP_TIMEOUT_SECONDS 5


### PR DESCRIPTION
After #1702 `HAVE_LIBCURL` moved to `citus_version.h` instead of being a compiler `-D` flag. We need to include `citus_version.h` in every file we are checking for `HAVE_LIBCURL`.