### PR TITLE
Don't collect stats when there is a version mismatch.

### DIFF
--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -65,6 +65,16 @@ CollectBasicUsageStatistics(void)
 	memset(&unameData, 0, sizeof(unameData));
 
 	StartTransactionCommand();
+	/* 
+	 * If there is a version mismatch between loaded version and available
+	 * version, metadata functions will fail. We return early to avoid crashing.
+	 * This can happen when updating the Citus extension.
+	 */
+	if (!CheckCitusVersion(LOG_SERVER_ONLY))
+	{
+		CommitTransactionCommand();
+		return false;
+	}
 	distributedTables = DistributedTableList();
 	roundedDistTableCount = NextPow2(list_length(distributedTables));
 	roundedClusterSize = NextPow2(ClusterSize(distributedTables));

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -65,7 +65,8 @@ CollectBasicUsageStatistics(void)
 	memset(&unameData, 0, sizeof(unameData));
 
 	StartTransactionCommand();
-	/* 
+
+	/*
 	 * If there is a version mismatch between loaded version and available
 	 * version, metadata functions will fail. We return early to avoid crashing.
 	 * This can happen when updating the Citus extension.


### PR DESCRIPTION
The following scenario can cause an Assert() crash if we don't do this:
- Install Citus v7.0-15
- Restart server & run a query to start maintenanced.
- Install Citus v7.1
- Restart server & run a query. This will tell user to upgrade.
- Type "UPDATE EXTENSION c" & press tab. maintenanced will start and crash with Assert(CitusHasBeenLoaded() && CheckCitusVersion(WARNING));
    
This change checks Citus version before calling metadata functions so the crash doesn't happen.
