### PR TITLE
[WIP] Add coercion to COPY

### DIFF
--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -869,7 +869,7 @@ FilterAndPartitionTable(const char *filterQuery,
 			heap_deform_tuple(row, rowDescriptor, valueArray, isNullArray);
 
 			AppendCopyRowData(valueArray, isNullArray, rowDescriptor,
-							  rowOutputState, columnOutputFunctions);
+							  rowOutputState, columnOutputFunctions, NULL);
 
 			rowText = rowOutputState->fe_msgbuf;
 

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -1101,21 +1101,19 @@ INSERT INTO lineitem_hash_part
 WITH cte1 AS (SELECT * FROM cte1 LIMIT 5)
 SELECT s FROM cte1;
 Custom Scan (Citus INSERT ... SELECT via coordinator)
-  ->  Subquery Scan on citus_insert_select_subquery
+  ->  CTE Scan on cte1
         CTE cte1
           ->  Function Scan on generate_series s
-        ->  CTE Scan on cte1
-              CTE cte1
-                ->  Limit
-                      ->  CTE Scan on cte1 cte1_1
+        CTE cte1
+          ->  Limit
+                ->  CTE Scan on cte1 cte1_1
 EXPLAIN (COSTS OFF)
 INSERT INTO lineitem_hash_part
 ( SELECT s FROM generate_series(1,5) s) UNION
 ( SELECT s FROM generate_series(5,10) s);
 Custom Scan (Citus INSERT ... SELECT via coordinator)
-  ->  Subquery Scan on citus_insert_select_subquery
-        ->  HashAggregate
-              Group Key: s.s
-              ->  Append
-                    ->  Function Scan on generate_series s
-                    ->  Function Scan on generate_series s_1
+  ->  HashAggregate
+        Group Key: s.s
+        ->  Append
+              ->  Function Scan on generate_series s
+              ->  Function Scan on generate_series s_1

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -1101,21 +1101,19 @@ INSERT INTO lineitem_hash_part
 WITH cte1 AS (SELECT * FROM cte1 LIMIT 5)
 SELECT s FROM cte1;
 Custom Scan (Citus INSERT ... SELECT via coordinator)
-  ->  Subquery Scan on citus_insert_select_subquery
+  ->  CTE Scan on cte1
         CTE cte1
           ->  Function Scan on generate_series s
-        ->  CTE Scan on cte1
-              CTE cte1
-                ->  Limit
-                      ->  CTE Scan on cte1 cte1_1
+        CTE cte1
+          ->  Limit
+                ->  CTE Scan on cte1 cte1_1
 EXPLAIN (COSTS OFF)
 INSERT INTO lineitem_hash_part
 ( SELECT s FROM generate_series(1,5) s) UNION
 ( SELECT s FROM generate_series(5,10) s);
 Custom Scan (Citus INSERT ... SELECT via coordinator)
-  ->  Subquery Scan on citus_insert_select_subquery
-        ->  HashAggregate
-              Group Key: s.s
-              ->  Append
-                    ->  Function Scan on generate_series s
-                    ->  Function Scan on generate_series s_1
+  ->  HashAggregate
+        Group Key: s.s
+        ->  Append
+              ->  Function Scan on generate_series s
+              ->  Function Scan on generate_series s_1

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2504,6 +2504,144 @@ SELECT * FROM drop_col_table WHERE col2 = '1';
 (1 row)
 
 RESET client_min_messages;
+-- make sure casts are handled correctly
+CREATE TABLE coerce_events(user_id int, time timestamp, value_1 numeric);
+SELECT create_distributed_table('coerce_events', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE coerce_agg (user_id int, value_1_agg int);
+SELECT create_distributed_table('coerce_agg', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO coerce_events(user_id, value_1) VALUES (1, 1), (2, 2), (10, 10);
+-- numeric -> int (straight function)
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop
+ORDER BY 2 DESC, 1 DESC
+LIMIT 5;
+-- int -> text
+ALTER TABLE coerce_agg ALTER COLUMN value_1_agg TYPE text;
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop
+LIMIT 5;
+SELECT * FROM coerce_agg;
+ user_id | value_1_agg 
+---------+-------------
+      10 | 10
+       1 | 1
+       1 | 1
+      10 | 10
+       2 | 2
+       2 | 2
+(6 rows)
+
+TRUNCATE coerce_agg;
+-- int -> char(1)
+ALTER TABLE coerce_agg ALTER COLUMN value_1_agg TYPE char(1);
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop
+LIMIT 5;
+ERROR:  value too long for type character(1)
+DETAIL:  (null)
+SELECT * FROM coerce_agg;
+ user_id | value_1_agg 
+---------+-------------
+(0 rows)
+
+TRUNCATE coerce_agg;
+TRUNCATE coerce_events;
+-- char(5) -> char(1)
+ALTER TABLE coerce_events ALTER COLUMN value_1 TYPE char(5);
+INSERT INTO coerce_events(user_id, value_1) VALUES (1, 'aaaaa'), (2, 'bbbbb');
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop
+LIMIT 5;
+ERROR:  value too long for type character(1)
+DETAIL:  (null)
+-- char(1) -> char(5)
+ALTER TABLE coerce_events ALTER COLUMN value_1 TYPE char(1) USING value_1::char(1);
+ALTER TABLE coerce_agg ALTER COLUMN value_1_agg TYPE char(5);
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop
+LIMIT 5;
+SELECT * FROM coerce_agg;
+ user_id | value_1_agg 
+---------+-------------
+       1 | a    
+       2 | b    
+(2 rows)
+
+TRUNCATE coerce_agg;
+TRUNCATE coerce_events;
+-- integer -> integer (check VALUE < 5)
+ALTER TABLE coerce_events ALTER COLUMN value_1 TYPE integer USING NULL;
+ALTER TABLE coerce_agg ALTER COLUMN value_1_agg TYPE integer USING NULL;
+ALTER TABLE coerce_agg ADD CONSTRAINT small_number CHECK (value_1_agg < 5);
+INSERT INTO coerce_events (user_id, value_1) VALUES (1, 1), (10, 10);
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop;
+ERROR:  new row for relation "coerce_agg_13300060" violates check constraint "small_number_13300060"
+DETAIL:  Failing row contains (10, 10).
+CONTEXT:  while executing command on localhost:57637
+SELECT * FROM coerce_agg;
+ user_id | value_1_agg 
+---------+-------------
+(0 rows)
+
+-- integer[3] -> text[3]
+TRUNCATE coerce_events;
+ALTER TABLE coerce_events ALTER COLUMN value_1 TYPE integer[3] USING NULL;
+INSERT INTO coerce_events(user_id, value_1) VALUES (1, '{1,1,1}'), (2, '{2,2,2}');
+ALTER TABLE coerce_agg DROP COLUMN value_1_agg;
+ALTER TABLE coerce_agg ADD COLUMN value_1_agg text[3];
+INSERT INTO coerce_agg(user_id, value_1_agg)
+SELECT *
+FROM (
+  SELECT user_id, value_1
+  FROM coerce_events
+) AS ftop
+LIMIT 5;
+SELECT * FROM coerce_agg;
+ user_id | value_1_agg 
+---------+-------------
+       1 | {1,1,1}
+       2 | {2,2,2}
+(2 rows)
+
+-- wrap in a transaction to improve performance
+BEGIN;
+DROP TABLE coerce_events;
+DROP TABLE coerce_agg;
 DROP TABLE drop_col_table;
 DROP TABLE raw_table;
 DROP TABLE summary_table;
@@ -2516,3 +2654,4 @@ DROP TABLE table_with_serial;
 DROP TABLE text_table;
 DROP TABLE char_table;
 DROP TABLE table_with_starts_with_defaults;
+COMMIT;


### PR DESCRIPTION
Was meant to be a solution to https://github.com/citusdata/citus/issues/1685 but might be the wrong solution, doesn't handle CoerceViaIO nodes. Opening PR to get comments and feedback before diving any deeper.

**Motivation**

For INSERT/SELECT, it's possible to build queries which include implicit casts. In postgres this is represented something like `Query(InsertQuery, SelectQuery, Coercions)`. Our current logic turns that into `COPY(SelectQuery, DestinationRelation)` by stripping out the coercions and coercing the target list entries in SelectQuery. That causes some crashes, described in #1685, because the coercions don't update the types which other parts of the query expect those target list entries to have.

**Solution**

INSERT/SELECT no longer coerces the TargetList entries and passes them off to COPY.

COPY looks at the data types of all columns in the select query, compares those with the types of the columns in the insert query, and "manually" calls the relevant conversion functions before pushing tuples into `COPY`.

**Remaining Work**

This works great for types which have a single conversion function, however there are also `COERCION_PATH_COERCEVIAIO` pairs of types which require two functions to be called in order to to the coercion. Those are not yet supported.