### PR TITLE
Replace uint with uint32

### DIFF
--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -933,7 +933,7 @@ AddNodeMetadata(char *nodeName, int32 nodePort, int32 groupId, char *nodeRack,
 	}
 	else
 	{
-		uint maxGroupId = GetMaxGroupId();
+		uint32 maxGroupId = GetMaxGroupId();
 
 		if (groupId > maxGroupId)
 		{


### PR DESCRIPTION
A mistake I made which breaks the build on some platforms, `uint` isn't part of any C standard.