### PR TITLE
Block only 2PCs instead of all writes in citus_create_restore_point

### DIFF
--- a/src/test/regress/expected/isolation_create_restore_point.out
+++ b/src/test/regress/expected/isolation_create_restore_point.out
@@ -6,6 +6,7 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-create-distributed: 
 	CREATE TABLE test_create_distributed_table (test_id integer NOT NULL, data text);
@@ -31,20 +32,20 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-insert: 
 	INSERT INTO restore_table VALUES (1,'hello');
 
 step s2-create-restore: 
 	SELECT 1 FROM citus_create_restore_point('citus-test');
- <waiting ...>
-step s1-commit: 
-	COMMIT;
 
-step s2-create-restore: <... completed>
 ?column?       
 
 1              
+step s1-commit: 
+	COMMIT;
+
 
 starting permutation: s1-begin s1-modify-multiple s2-create-restore s1-commit
 create_distributed_table
@@ -52,23 +53,20 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-modify-multiple: 
-	SELECT master_modify_multiple_shards($$UPDATE restore_table SET data = 'world'$$);
+	UPDATE restore_table SET data = 'world';
 
-master_modify_multiple_shards
-
-0              
 step s2-create-restore: 
 	SELECT 1 FROM citus_create_restore_point('citus-test');
- <waiting ...>
-step s1-commit: 
-	COMMIT;
 
-step s2-create-restore: <... completed>
 ?column?       
 
 1              
+step s1-commit: 
+	COMMIT;
+
 
 starting permutation: s1-begin s1-ddl s2-create-restore s1-commit
 create_distributed_table
@@ -76,20 +74,20 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-ddl: 
 	ALTER TABLE restore_table ADD COLUMN x int;
 
 step s2-create-restore: 
 	SELECT 1 FROM citus_create_restore_point('citus-test');
- <waiting ...>
-step s1-commit: 
-	COMMIT;
 
-step s2-create-restore: <... completed>
 ?column?       
 
 1              
+step s1-commit: 
+	COMMIT;
+
 
 starting permutation: s1-begin s1-copy s2-create-restore s1-commit
 create_distributed_table
@@ -97,10 +95,35 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-copy: 
 	COPY restore_table FROM PROGRAM 'echo 1,hello' WITH CSV;
 
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s1-recover s2-create-restore s1-commit
+create_distributed_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-recover: 
+	SELECT recover_prepared_transactions();
+
+recover_prepared_transactions
+
+0              
 step s2-create-restore: 
 	SELECT 1 FROM citus_create_restore_point('citus-test');
  <waiting ...>
@@ -118,6 +141,7 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-drop: 
 	DROP TABLE restore_table;
@@ -139,6 +163,7 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-add-node: 
 	SELECT 1 FROM master_add_inactive_node('localhost', 9999);
@@ -163,6 +188,7 @@ create_distributed_table
                
 step s1-begin: 
 	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-remove-node: 
 	SELECT master_remove_node('localhost', 9999);
@@ -180,3 +206,95 @@ step s2-create-restore: <... completed>
 ?column?       
 
 1              
+
+starting permutation: s1-begin s1-create-restore s2-create-restore s1-commit
+create_distributed_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test-2');
+
+?column?       
+
+1              
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-restore: <... completed>
+?column?       
+
+1              
+
+starting permutation: s2-begin s2-create-restore s1-modify-multiple s2-commit
+create_distributed_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-modify-multiple: 
+	UPDATE restore_table SET data = 'world';
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-modify-multiple: <... completed>
+
+starting permutation: s2-begin s2-create-restore s1-ddl s2-commit
+create_distributed_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-ddl: 
+	ALTER TABLE restore_table ADD COLUMN x int;
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-ddl: <... completed>
+
+starting permutation: s2-begin s2-create-restore s1-multi-statement s2-commit
+create_distributed_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-multi-statement: 
+	SET citus.multi_shard_commit_protocol TO '2pc';
+	BEGIN;
+	INSERT INTO restore_table VALUES (1,'hello');
+	INSERT INTO restore_table VALUES (2,'hello');
+	COMMIT;
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-multi-statement: <... completed>


### PR DESCRIPTION
`citus_create_restore_point` currently blocks all writes, which gives a fully consistent restore point, but also blocks all writes until all open write transactions have finished. This behaviour is generally undesirable.

Fortunately, we can achieve the main goal of `citus_create_restore_point` by taking an exclusive lock on `pg_dist_transaction`, which blocks 2PCs just before commit, which ensures the restore point is consistent in terms of DDL, reference tables replicas, and committed distributed transactions when using 2PC. It does not block 1PCs, since those do not write to `pg_dist_transaction`, but this seems like a reasonable trade-off since 1PC fundamentally doesn't provide atomicity guarantees.

By only blocking at commit time, `citus_create_restore_point` at most has to wait until all in-progress commits finish, which is at most 1 round trip.

Adds some additional isolation tests to make sure we're blocking 2PCs.