### PR TITLE
ALTER TABLE .. REPLICA IDENTITY support is implemented

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -1897,6 +1897,7 @@ ErrorIfUnsupportedDropIndexStmt(DropStmt *dropIndexStatement)
  * ALTER TABLE SET|DROP NOT NULL
  * ALTER TABLE SET|DROP DEFAULT
  * ALTER TABLE ADD|DROP CONSTRAINT
+ * ALTER TABLE REPLICA IDENTITY
  */
 static void
 ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
@@ -2036,11 +2037,12 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 			case AT_DropConstraint:
 			case AT_EnableTrigAll:
 			case AT_DisableTrigAll:
+			case AT_ReplicaIdentity:
 			{
 				/*
 				 * We will not perform any special check for ALTER TABLE DROP CONSTRAINT
 				 * , ALTER TABLE .. ALTER COLUMN .. SET NOT NULL and ALTER TABLE ENABLE/
-				 * DISABLE TRIGGER ALL
+				 * DISABLE TRIGGER ALL, ALTER TABLE .. REPLICA IDENTITY ..
 				 */
 				break;
 			}

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -27,6 +27,7 @@
 #include "access/stratnum.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_class.h"
 #include "catalog/pg_constraint.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/relay_utility.h"
@@ -108,6 +109,17 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 				{
 					char **indexName = &(command->name);
 					AppendShardIdToName(indexName, shardId);
+				}
+				else if (command->subtype == AT_ReplicaIdentity)
+				{
+					ReplicaIdentityStmt *replicaIdentity =
+						(ReplicaIdentityStmt *) command->def;
+
+					if (replicaIdentity->identity_type == REPLICA_IDENTITY_INDEX)
+					{
+						char **indexName = &(replicaIdentity->name);
+						AppendShardIdToName(indexName, shardId);
+					}
 				}
 			}
 

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -286,22 +286,23 @@ SELECT UNNEST(get_colocated_table_array('table6_append'))::regclass ORDER BY 1;
 (1 row)
 
 -- check co-located shard list
-SELECT get_colocated_shard_array(1300000) ORDER BY 1;
- get_colocated_shard_array 
----------------------------
- {1300000,1300004}
+SELECT UNNEST(get_colocated_shard_array(1300000))::regclass ORDER BY 1;
+ unnest  
+---------
+ 1300000
+ 1300004
+(2 rows)
+
+SELECT UNNEST(get_colocated_shard_array(1300016))::regclass ORDER BY 1;
+ unnest  
+---------
+ 1300016
 (1 row)
 
-SELECT get_colocated_shard_array(1300016) ORDER BY 1;
- get_colocated_shard_array 
----------------------------
- {1300016}
-(1 row)
-
-SELECT get_colocated_shard_array(1300020) ORDER BY 1;
- get_colocated_shard_array 
----------------------------
- {1300020}
+SELECT UNNEST(get_colocated_shard_array(1300020))::regclass ORDER BY 1;
+ unnest  
+---------
+ 1300020
 (1 row)
 
 -- check FindShardIntervalIndex function

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -240,9 +240,36 @@ COMMIT;
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
 
 -- Create single-shard table (to avoid deadlocks in the upcoming test hackery)
-CREATE TABLE single_shard_items (id integer, name text);
+CREATE TABLE single_shard_items (id integer NOT NULL, name text);
 SELECT master_create_distributed_table('single_shard_items', 'id', 'hash');
 SELECT master_create_worker_shards('single_shard_items', 1, 2);
+
+-- Verify that ALTER TABLE .. REPLICATION IDENTITY [USING INDEX]* .. works
+CREATE UNIQUE INDEX replica_idx on single_shard_items(id);
+
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+
+ALTER TABLE single_shard_items REPLICA IDENTITY nothing;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+
+ALTER TABLE single_shard_items REPLICA IDENTITY full;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+
+ALTER TABLE single_shard_items REPLICA IDENTITY USING INDEX replica_idx;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+
+ALTER TABLE single_shard_items REPLICA IDENTITY default, REPLICA IDENTITY USING INDEX replica_idx, REPLICA IDENTITY nothing;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+
+ALTER TABLE single_shard_items ADD COLUMN test_col int, REPLICA IDENTITY full;
+
+DROP INDEX replica_idx;
+ALTER TABLE single_shard_items REPLICA IDENTITY default;
 
 -- Drop the column from the worker...
 \c - - - :worker_2_port

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -539,7 +539,7 @@ SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'lineitem_alter';
 (0 rows)
 
 -- Create single-shard table (to avoid deadlocks in the upcoming test hackery)
-CREATE TABLE single_shard_items (id integer, name text);
+CREATE TABLE single_shard_items (id integer NOT NULL, name text);
 SELECT master_create_distributed_table('single_shard_items', 'id', 'hash');
  master_create_distributed_table 
 ---------------------------------
@@ -552,6 +552,80 @@ SELECT master_create_worker_shards('single_shard_items', 1, 2);
  
 (1 row)
 
+-- Verify that ALTER TABLE .. REPLICATION IDENTITY [USING INDEX]* .. works
+CREATE UNIQUE INDEX replica_idx on single_shard_items(id);
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+ relreplident 
+--------------
+ d
+(1 row)
+
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,d)
+ (localhost,57638,t,d)
+(2 rows)
+
+ALTER TABLE single_shard_items REPLICA IDENTITY nothing;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+ relreplident 
+--------------
+ n
+(1 row)
+
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,n)
+ (localhost,57638,t,n)
+(2 rows)
+
+ALTER TABLE single_shard_items REPLICA IDENTITY full;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+ relreplident 
+--------------
+ f
+(1 row)
+
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,f)
+ (localhost,57638,t,f)
+(2 rows)
+
+ALTER TABLE single_shard_items REPLICA IDENTITY USING INDEX replica_idx;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+ relreplident 
+--------------
+ i
+(1 row)
+
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,i)
+ (localhost,57638,t,i)
+(2 rows)
+
+ALTER TABLE single_shard_items REPLICA IDENTITY default, REPLICA IDENTITY USING INDEX replica_idx, REPLICA IDENTITY nothing;
+SELECT relreplident FROM pg_class WHERE relname = 'single_shard_items';
+ relreplident 
+--------------
+ n
+(1 row)
+
+SELECT run_command_on_workers('SELECT relreplident FROM pg_class WHERE relname LIKE ''single_shard_items_%'' LIMIT 1;');
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,n)
+ (localhost,57638,t,n)
+(2 rows)
+
+ALTER TABLE single_shard_items ADD COLUMN test_col int, REPLICA IDENTITY full;
+DROP INDEX replica_idx;
+ALTER TABLE single_shard_items REPLICA IDENTITY default;
 -- Drop the column from the worker...
 \c - - - :worker_2_port
 ALTER TABLE lineitem_alter_220000 DROP COLUMN first;

--- a/src/test/regress/sql/multi_colocation_utils.sql
+++ b/src/test/regress/sql/multi_colocation_utils.sql
@@ -139,9 +139,9 @@ SELECT UNNEST(get_colocated_table_array('table5_groupX'))::regclass ORDER BY 1;
 SELECT UNNEST(get_colocated_table_array('table6_append'))::regclass ORDER BY 1;
 
 -- check co-located shard list
-SELECT get_colocated_shard_array(1300000) ORDER BY 1;
-SELECT get_colocated_shard_array(1300016) ORDER BY 1;
-SELECT get_colocated_shard_array(1300020) ORDER BY 1;
+SELECT UNNEST(get_colocated_shard_array(1300000))::regclass ORDER BY 1;
+SELECT UNNEST(get_colocated_shard_array(1300016))::regclass ORDER BY 1;
+SELECT UNNEST(get_colocated_shard_array(1300020))::regclass ORDER BY 1;
 
 -- check FindShardIntervalIndex function
 SELECT find_shard_interval_index(1300000);


### PR DESCRIPTION
I made a small change in multi_utility.c to allow ALTER TABLE .. REPLICA IDENTITY queries to be processed just like the other Alter Table queries. 

Another change in the RelayEventExtendNames to catch if the function call is made for a ALTER TABLE REPLICA IDENTITY query and if it has USING INDEX add the shard id into the index name as well.

