### PR TITLE
 Make REPORTS_BASE_URL configurable and enable stats collection in tests. 

### DIFF
--- a/configure
+++ b/configure
@@ -686,6 +686,7 @@ enable_option_checking
 with_extra_version
 enable_coverage
 with_libcurl
+with_reports_hostname
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1316,6 +1317,9 @@ Optional Packages:
                           append STRING to version
   --without-libcurl       do not use libcurl for anonymous statistics
                           collection
+  --with-reports-hostname=HOSTNAME
+                          Use HOSTNAME as hostname for statistics collection
+                          and update checks
 
 Some influential environment variables:
   PG_CONFIG   Location to find pg_config for target PostgreSQL instalation
@@ -4111,6 +4115,36 @@ fi
 
 
 fi
+
+# REPORTS_BASE_URL definition
+
+
+
+# Check whether --with-reports-hostname was given.
+if test "${with_reports_hostname+set}" = set; then :
+  withval=$with_reports_hostname;
+  case $withval in
+    yes)
+      as_fn_error $? "argument required for --with-reports-hostname option" "$LINENO" 5
+      ;;
+    no)
+      as_fn_error $? "argument required for --with-reports-hostname option" "$LINENO" 5
+      ;;
+    *)
+      REPORTS_BASE_URL="https://${withval}"
+      ;;
+  esac
+
+else
+  REPORTS_BASE_URL="https://reports.citusdata.com"
+fi
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define REPORTS_BASE_URL "$REPORTS_BASE_URL"
+_ACEOF
+
 
 CITUS_CFLAGS="$CITUS_CFLAGS"
 

--- a/configure.in
+++ b/configure.in
@@ -191,6 +191,14 @@ failure.  It is possible the compiler isn't looking in the proper directory.
 Use --without-libcurl to disable libcurl support.])])
 fi
 
+# REPORTS_BASE_URL definition
+PGAC_ARG_REQ(with, reports-hostname, [HOSTNAME],
+             [Use HOSTNAME as hostname for statistics collection and update checks],
+             [REPORTS_BASE_URL="https://${withval}"],
+             [REPORTS_BASE_URL="https://reports.citusdata.com"])
+AC_DEFINE_UNQUOTED(REPORTS_BASE_URL, "$REPORTS_BASE_URL",
+                   [Base URL for statistics collection and update checks])
+
 AC_SUBST(CITUS_CFLAGS, "$CITUS_CFLAGS")
 AC_SUBST(CITUS_LDFLAGS, "$LIBS")
 AC_SUBST(POSTGRES_SRCDIR, "$POSTGRES_SRCDIR")

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -114,7 +114,7 @@ CollectBasicUsageStatistics(void)
 
 	CommitTransactionCommand();
 
-	return SendHttpPostJsonRequest(STATS_COLLECTION_HOST "/v1/usage_reports",
+	return SendHttpPostJsonRequest(REPORTS_BASE_URL "/v1/usage_reports",
 								   fields->data, HTTP_TIMEOUT_SECONDS);
 }
 

--- a/src/include/citus_config.h.in
+++ b/src/include/citus_config.h.in
@@ -79,6 +79,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* Base URL for statistics collection and update checks */
+#undef REPORTS_BASE_URL
+
 /* The size of `void *', as computed by sizeof. */
 #undef SIZEOF_VOID_P
 

--- a/src/include/citus_version.h.in
+++ b/src/include/citus_version.h.in
@@ -23,3 +23,6 @@
 
 /* Define to 1 if you have the `curl' library (-lcurl). */
 #undef HAVE_LIBCURL
+
+/* Base URL for statistics collection and update checks */
+#undef REPORTS_BASE_URL

--- a/src/include/distributed/statistics_collection.h
+++ b/src/include/distributed/statistics_collection.h
@@ -17,7 +17,6 @@ extern bool EnableStatisticsCollection;
 
 #ifdef HAVE_LIBCURL
 
-#define STATS_COLLECTION_HOST "https://citus-statistics.herokuapp.com"
 #define HTTP_TIMEOUT_SECONDS 5
 
 extern void WarnIfSyncDNS(void);

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -43,44 +43,36 @@ check-full: check-multi check-multi-mx check-multi-task-tracker-extra check-work
 # for check-worker. But that's harmless besides a few cycles.
 check-worker: all
 	$(pg_regress_multi_check) --load-extension=citus \
-	--server-option=citus.enable_statistics_collection=0 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/worker_schedule $(EXTRA_TESTS)
 
 check-multi: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
-	--server-option=citus.enable_statistics_collection=0 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
 check-multi-vg: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --valgrind \
-	--server-option=citus.enable_statistics_collection=0 \
 	--pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(VALGRIND_LOG_FILE) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
 check-isolation: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
-	--server-option=citus.enable_statistics_collection=0 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/isolation_schedule $(EXTRA_TESTS)
 
 check-vanilla: all tempinstall-main
-	$(pg_regress_multi_check) --load-extension=citus --vanillatest \
-	--server-option=citus.enable_statistics_collection=0
+	$(pg_regress_multi_check) --load-extension=citus --vanillatest
 
 check-multi-mx: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
-	--server-option=citus.enable_statistics_collection=0 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_mx_schedule $(EXTRA_TESTS)
 
 check-multi-task-tracker-extra: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
-	--server-option=citus.enable_statistics_collection=0 \
 	--server-option=citus.task_executor_type=task-tracker \
 	--server-option=citus.large_table_shard_count=1 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_task_tracker_extra_schedule $(EXTRA_TESTS)
 
 check-follower-cluster: all
 	$(pg_regress_multi_check) --load-extension=citus --follower-cluster \
-	--server-option=citus.enable_statistics_collection=0 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_follower_schedule $(EXTRA_TESTS)
 
 clean distclean maintainer-clean:


### PR DESCRIPTION
Making `REPORTS_BASE_URL` configurable so we can avoid sending data to our main stats server, but be still able to run statistics collection to make sure it doesn't crash.

Also, enabling statistics collection in tests. After this change and the changes in #1726, tests pass locally.