### PR TITLE
Fix issues in WaitForAllConnections

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -854,8 +854,7 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 				 * might have read from the socket, meaning we may not see the socket
 				 * becoming readable again, so better to check it now.
 				 */
-				if (event->events & WL_SOCKET_READABLE ||
-					event->events & WL_SOCKET_WRITEABLE)
+				if (event->events & (WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE))
 				{
 					int receiveStatus = PQconsumeInput(connection->pgConn);
 					if (receiveStatus == 0)
@@ -872,8 +871,21 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 
 				if (connectionIsReady)
 				{
+					/*
+					 * All pending connections are kept at the end of the allConnections
+					 * array and the connectionReady array matches the allConnections
+					 * array. The wait event set corresponds to the pending connections
+					 * subarray so we can get the index in the allConnections array by
+					 * taking the event index + the offset of the subarray.
+					 */
 					connectionIndex = event->pos + pendingConnectionsStartIndex;
+
 					connectionReady[connectionIndex] = true;
+
+					/*
+					 * When a connection is ready, we should build a new wait event
+					 * set that excludes this connection.
+					 */
 					rebuildWaitEventSet = true;
 				}
 			}
@@ -884,9 +896,24 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 			{
 				if (connectionReady[connectionIndex])
 				{
+					/*
+					 * Replace the ready connection with a connection from
+					 * the start of the pending connections subarray. This
+					 * may be the connection itself, in which case this is
+					 * a noop.
+					 */
 					allConnections[connectionIndex] =
 						allConnections[pendingConnectionsStartIndex];
+
+					/* offset of the pending connections subarray is now 1 higher */
 					pendingConnectionsStartIndex++;
+
+					/*
+					 * We've moved a pending connection into this position,
+					 * so we must reset the ready flag. Otherwise, we'd
+					 * falsely interpret it as ready in the next round.
+					 */
+					connectionReady[connectionIndex] = false;
 				}
 			}
 		}
@@ -933,6 +960,11 @@ BuildWaitEventSet(MultiConnection **allConnections, int totalConnectionCount,
 	{
 		MultiConnection *connection = allConnections[connectionIndex];
 		int socket = PQsocket(connection->pgConn);
+
+		/*
+		 * Always start by polling for both readability (server sent bytes)
+		 * and writeability (server is ready to receive bytes).
+		 */
 		int eventMask = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
 
 		AddWaitEventToSet(waitEventSet, eventMask, socket, NULL, (void *) connection);

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -831,7 +831,6 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 				}
 
 				connection = (MultiConnection *) event->user_data;
-				connectionIndex = event->pos + pendingConnectionsStartIndex;
 
 				if (event->events & WL_SOCKET_WRITEABLE)
 				{
@@ -844,7 +843,7 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 					else if (sendStatus == 0)
 					{
 						/* done writing, only wait for read events */
-						ModifyWaitEvent(waitEventSet, connectionIndex, WL_SOCKET_READABLE,
+						ModifyWaitEvent(waitEventSet, event->pos, WL_SOCKET_READABLE,
 										NULL);
 					}
 				}
@@ -866,6 +865,7 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 
 				if (connectionIsReady)
 				{
+					connectionIndex = event->pos + pendingConnectionsStartIndex;
 					connectionReady[connectionIndex] = true;
 					rebuildWaitEventSet = true;
 				}


### PR DESCRIPTION
We occasionally observe transactions getting stuck in `WaitForAllConnections`, which is used to wait for parallel BEGIN/COMMIT/ABORT (e.g. #1658). I haven't managed to reproduce the issue yet, but there are two obvious bugs in the current implementation and one subtle issue, which could cause `WaitForAllConnections` to get stuck. 

The first bug is that when calling `ModifyWaitEvent` we currently pass the index of the connection in the array of all connections, but we are supposed to use the index in the wait event set. Unfortunately, a wait event cannot be disabled once the connection is ready or failed. We therefore need to rebuild the wait event set with only the connections that are not yet ready, which are at the end of the full connection array, and we should pass the index in that subarray to `ModifyWaitEvent`. 

Using the index in the full array has undefined behaviour. Currently, this code path rarely gets exercised, because we will almost always be able to send a small "COMMIT" message without having to wait and check for writability. When I first started exercising it, it crashed the server. It might also cause the function to stop listening for writability on an unrelated socket, in which case we might never flush the COMMIT message on that socket. 

A second bug is that `connectionReady` is not reset after replacing a ready connection with a non-ready connection at the end of the `allConnections` array. This means that in the next round this connection will be marked as ready, regardless of whether it is.

Another change I made is to remove the call to `PQflush` in `BuildWaitEventSet`. By doing so, we simplify the code and make sure the aforementioned code path always gets exercised. Eventually the socket will always be writable, so we'll run through the `if (event->events & WL_SOCKET_WRITEABLE)` block at least once. If there is no data to send we just continue polling for reads only. 

This change also fixes a race condition that could cause `WaitEventSetWait` (`epoll`) to not trigger when the `COMMIT` completes, which would also cause `WaitForAllConnections` to get stuck. As it turns out, `PQflush` has a code path that reads data from the socket, which is triggered only if not all the data can be flushed (which would be quite rare). After we read data from the socket we should immediately check whether the connection is busy. The server probably won't send any more data, so the socket will not become readable again if all the bytes were already read in `PQflush`, hence we would get stuck in `epoll`. After this change we do the `PQisBusy` check also when a socket becomes writable to make sure we check it after `PQflush`. 