### PR TITLE
Only drop sequences on workers with metadata

### DIFF
--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -297,8 +297,8 @@ master_drop_sequences(PG_FUNCTION_ARGS)
 	{
 		appendStringInfoString(dropSeqCommand, " CASCADE");
 
-		SendCommandToWorkers(ALL_WORKERS, DISABLE_DDL_PROPAGATION);
-		SendCommandToWorkers(ALL_WORKERS, dropSeqCommand->data);
+		SendCommandToWorkers(WORKERS_WITH_METADATA, DISABLE_DDL_PROPAGATION);
+		SendCommandToWorkers(WORKERS_WITH_METADATA, dropSeqCommand->data);
 	}
 
 	PG_RETURN_VOID();

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -1079,15 +1079,8 @@ SELECT nextval('mx_table_with_sequence_c_seq');
  562949953421313
 (1 row)
 
--- Check that dropping the mx table with sequences works as expected, even the metadata
--- syncing is stopped to one of the workers
+-- Check that dropping the mx table with sequences works as expected
 \c - - - :master_port
-SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
- stop_metadata_sync_to_node 
-----------------------------
- 
-(1 row)
-
 DROP TABLE mx_table_with_sequence;
 \d mx_table_with_sequence
 \ds mx_table_with_sequence_b_seq

--- a/src/test/regress/expected/multi_transactional_drop_shards.out
+++ b/src/test/regress/expected/multi_transactional_drop_shards.out
@@ -653,6 +653,29 @@ ORDER BY
 (0 rows)
 
 \c - - - :master_port
+-- try using the coordinator as a worker and then dropping the table
+SELECT master_add_node('localhost', :master_port);
+NOTICE:  Replicating reference table "transactional_drop_reference" to the node localhost:57636
+                        master_add_node                        
+---------------------------------------------------------------
+ (1380010,1380008,localhost,57636,default,f,t,primary,default)
+(1 row)
+
+CREATE TABLE citus_local (id serial, k int);
+SELECT create_distributed_table('citus_local', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO citus_local (k) VALUES (2);
+DROP TABLE citus_local;
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
 -- clean the workspace
 DROP TABLE transactional_drop_shards, transactional_drop_reference;
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -464,10 +464,8 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='mx_table_with_
 SELECT nextval('mx_table_with_sequence_b_seq');
 SELECT nextval('mx_table_with_sequence_c_seq');
 
--- Check that dropping the mx table with sequences works as expected, even the metadata
--- syncing is stopped to one of the workers
+-- Check that dropping the mx table with sequences works as expected
 \c - - - :master_port
-SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
 DROP TABLE mx_table_with_sequence;
 \d mx_table_with_sequence
 \ds mx_table_with_sequence_b_seq

--- a/src/test/regress/sql/multi_transactional_drop_shards.sql
+++ b/src/test/regress/sql/multi_transactional_drop_shards.sql
@@ -363,6 +363,14 @@ ORDER BY
 
 \c - - - :master_port
 
+-- try using the coordinator as a worker and then dropping the table
+SELECT master_add_node('localhost', :master_port);
+CREATE TABLE citus_local (id serial, k int);
+SELECT create_distributed_table('citus_local', 'id');
+INSERT INTO citus_local (k) VALUES (2);
+DROP TABLE citus_local;
+SELECT master_remove_node('localhost', :master_port);
+
 -- clean the workspace
 DROP TABLE transactional_drop_shards, transactional_drop_reference;
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);


### PR DESCRIPTION
Not high priority, but I had some spare time while waiting for regression tests to finish and this has been bugging me for a while, since it kills off a legit way of using and testing Citus (coordinator = only worker). We only create sequences on workers for MX tables, but we try to drop them for all distributed tables, and this causes a deadlock when the coordinator is a worker because it tries to drop the sequence both locally and remotely.

Fixes #1269 