### PR TITLE
Use custom compiled PostgreSQL on push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   global:
     # GitHub API token for citus-bot
     - secure: degV+qb2xHiea7E2dGk/WLvmYjq4ZsBn6ZPko+YhRcNm2GRXRaU3FqMBIecPtsEEFYaL5GwCQq/CgBf9aQxgDQ+t2CrmtGTtI9AGAbVBl//amNeJOoLe6QvrDpSQX5pUxwDLCng8cvoQK7ZxGlNCzDKiu4Ep4DUWgQVpauJkQ9nHjtSMZvUqCoI9h1lBy9Mxh7YFfHPW2PAXCqpV4VlNiIYF84UKdX3MXKLy9Yt0JBSNTWLZFp/fFw2qNwzFvN94rF3ZvFSD7Wp6CIhT6R5/6k6Zx8YQIrjWhgm6OVy1osUA8X7W79h2ISPqKqMNVJkjJ+N8S4xuQU0kfejnQ74Ie/uJiHCmbW5W2TjpL1aU3FQpPsGwR8h0rSeHhJAJzd8Ma+z8vvnnQHDyvetPBB0WgA/VMQCu8uEutyfYw2hDmB2+l2dDwkViaI7R95bReAGrpd5uNqklAXuR7yOeArz0ZZpHV0aZHGcNBxznMaZExSVZ5DVPW38UPn7Kgse8BnOWeLgnA1hJVp6CmBCtu+hKYt+atBPgRbM8IUINnKKZf/Sk6HeJIJZs662jD8/X93vFi0ZtyV2jEKJpouWw8j4vrGGsaDzTEUcyJgDqZj7tPJptM2L5B3BcFJmkGj2HO3N+LGDarJrVBBSiEjhTgx4NnLiKZnUbMx547mCRg2akk2w=
-    # During pull request builds (not push builds), use custom-built PostgreSQL
-    - USE_CUSTOM_PG="${TRAVIS_PULL_REQUEST_SHA}"
+    # During push builds (not pull request builds), use custom-built PostgreSQL
+    - USE_CUSTOM_PG=$([ -z $TRAVIS_PULL_REQUEST_SHA ] && echo "true")
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Previously we compiled PostgreSQL for PR builds and we used already compiled PostgreSQL packages for push builds. Compiling PostgreSQL allows us to run isolation/vanilla tests. Thus we only ran those tests for PR builds. We did not used compiled PostgreSQL for both builds because;
- We wanted to run our tests against packages
- Compiling takes too much time.

However, there are some benefits in using custom compiled PostgreSQL in push builds instead of PR builds such as;
- At the moment, we do not run isolation/vanilla tests until we open a PR, which does not make any sense.
- After merging a PR (i.e. after push to the master) push builds run and we do not run isolation tests.
- While merging community to enterprise, we have to open a temporary PR to make travis run isolation/vanilla tests.
- With this change master branch will have its own cache that means every branch originated from master branch can re-use master branch's cache. (Currently we cannot use cache for the first PR build)

With this PR we switch from using custom compiled for PR builds to push builds.