### PR TITLE
Fix a relcache reference leak in stats collection.

### DIFF
--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -397,6 +397,7 @@ DistributedTablesSize(List *distTableOids)
 		if (PartitionMethod(relationId) == DISTRIBUTE_BY_HASH &&
 			!SingleReplicatedTable(relationId))
 		{
+			heap_close(relation, AccessShareLock);
 			continue;
 		}
 


### PR DESCRIPTION
In DistributedTablesSize() we didn't close the relations that had
replication factor > 2. This caused relcache reference leaks, and
warning messages like following in logs:
```
    WARNING:  relcache reference leak: relation "researchers" not closed
```