### PR TITLE
Add check for connection failures during multishard update

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1141,8 +1141,11 @@ ExecuteModifyTasks(List *taskList, bool expectResults, ParamListInfo paramListIn
 											 &currentAffectedTupleCount);
 			}
 
-			/* should have rolled back on error */
-			Assert(queryOK);
+			/* We error out if the worker fails to return a result for the query. */
+			if (!queryOK)
+			{
+				ReportConnectionError(connection, ERROR);
+			}
 
 			if (placementIndex == 0)
 			{


### PR DESCRIPTION
multi shard executor expected a worker query to return a data. If the worker query fails, coordinator crashes.

This work introduces additional check to see if the worker process completed, and reports connection error if an issue is encountered.

Fixes #1763 