### PR TITLE
Add GUC for specifying sslmode in connections to workers

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -22,7 +22,6 @@
 #include "distributed/backend_data.h"
 #include "distributed/citus_nodefuncs.h"
 #include "distributed/connection_management.h"
-#include "distributed/connection_management.h"
 #include "distributed/distributed_deadlock_detection.h"
 #include "distributed/maintenanced.h"
 #include "distributed/master_metadata_utility.h"
@@ -107,6 +106,16 @@ static const struct config_enum_entry use_secondary_nodes_options[] = {
 static const struct config_enum_entry multi_shard_commit_protocol_options[] = {
 	{ "1pc", COMMIT_PROTOCOL_1PC, false },
 	{ "2pc", COMMIT_PROTOCOL_2PC, false },
+	{ NULL, 0, false }
+};
+
+static const struct config_enum_entry citus_ssl_mode_options[] = {
+	{ "disable", CITUS_SSL_MODE_DISABLE, false },
+	{ "allow", CITUS_SSL_MODE_ALLOW, false },
+	{ "prefer", CITUS_SSL_MODE_PREFER, false },
+	{ "require", CITUS_SSL_MODE_REQUIRE, false },
+	{ "verify-ca", CITUS_SSL_MODE_VERIFY_CA, false },
+	{ "verify-full", CITUS_SSL_MODE_VERIFY_FULL, false },
 	{ NULL, 0, false }
 };
 
@@ -303,6 +312,19 @@ RegisterCitusConfigVariables(void)
 		GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 	NormalizeWorkerListPath();
+
+	DefineCustomEnumVariable(
+		"citus.sslmode",
+		gettext_noop("SSL mode to use for connections to worker nodes."),
+		gettext_noop("When connecting to a worker node, specify whether the SSL mode"
+					 "mode for the connection is 'disable', 'allow', 'prefer' "
+					 "(the default), 'require', 'verify-ca' or 'verify-full'."),
+		&CitusSSLMode,
+		CITUS_SSL_MODE_PREFER,
+		citus_ssl_mode_options,
+		PGC_POSTMASTER,
+		GUC_SUPERUSER_ONLY,
+		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
 		"citus.binary_master_copy_format",

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -14,6 +14,7 @@
 #include "distributed/transaction_management.h"
 #include "distributed/remote_transaction.h"
 #include "lib/ilist.h"
+#include "utils/guc.h"
 #include "utils/hsearch.h"
 #include "utils/timestamp.h"
 
@@ -106,6 +107,23 @@ typedef struct ConnectionHashEntry
 	dlist_head *connections;
 } ConnectionHashEntry;
 
+/*
+ * SSL modes available for connecting to worker nodes.
+ */
+enum CitusSSLMode
+{
+	CITUS_SSL_MODE_DISABLE = 1 << 0,
+	CITUS_SSL_MODE_ALLOW = 1 << 1,
+	CITUS_SSL_MODE_PREFER = 1 << 2,
+	CITUS_SSL_MODE_REQUIRE = 1 << 3,
+	CITUS_SSL_MODE_VERIFY_CA = 1 << 4,
+	CITUS_SSL_MODE_VERIFY_FULL = 1 << 5
+};
+
+
+/* SSL mode to use when connecting to worker nodes */
+extern int CitusSSLMode;
+
 /* maximum duration to wait for connection */
 extern int NodeConnectionTimeout;
 
@@ -133,6 +151,7 @@ extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 int32 port,
 														 const char *user,
 														 const char *database);
+extern char * CitusSSLModeString(void);
 extern void CloseNodeConnectionsAfterTransaction(char *nodeName, int nodePort);
 extern void CloseConnection(MultiConnection *connection);
 extern void ShutdownConnection(MultiConnection *connection);


### PR DESCRIPTION
In Citus Cloud, we'll need to bypass/disable pgbouncer for logical replication connections between workers, but this means that we connect directly to worker nodes using the default postgres connection settings (`sslmode=prefer`), which would be a slight regression on the security front from the pgbouncer setting (`sslmode=require`). To make sure that we don't regress, allow cloud to specify the sslmode to use in connections opened by Citus via a GUC in postgresql.conf.