### PR TITLE
Fix attaching partition to a distributed table in schema

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -874,7 +874,7 @@ ProcessCreateTableStmtPartitionOf(CreateStmt *createStatement)
 											  missingOk);
 			Var *parentDistributionColumn = DistPartitionKey(parentRelationId);
 			char parentDistributionMethod = DISTRIBUTE_BY_HASH;
-			char *parentRelationName = get_rel_name(parentRelationId);
+			char *parentRelationName = generate_qualified_relation_name(parentRelationId);
 			bool viaDeprecatedAPI = false;
 
 			CreateDistributedTable(relationId, parentDistributionColumn,
@@ -952,11 +952,11 @@ ProcessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement)
 			{
 				Var *distributionColumn = DistPartitionKey(relationId);
 				char distributionMethod = DISTRIBUTE_BY_HASH;
-				char *relationName = get_rel_name(relationId);
+				char *parentRelationName = generate_qualified_relation_name(relationId);
 				bool viaDeprecatedAPI = false;
 
 				CreateDistributedTable(partitionRelationId, distributionColumn,
-									   distributionMethod, relationName,
+									   distributionMethod, parentRelationName,
 									   viaDeprecatedAPI);
 			}
 		}

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1255,3 +1255,127 @@ SELECT create_distributed_table('partitioning_test', 'id');
 (1 row)
 
 DROP TABLE partitioning_test;
+-- make sure we can attach partitions to a distributed table in a schema
+CREATE SCHEMA partitioning_schema;
+CREATE TABLE partitioning_schema."schema-test"(id int, time date) PARTITION BY RANGE (time);
+SELECT create_distributed_table('partitioning_schema."schema-test"', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE partitioning_schema."schema-test_2009"(id int, time date);
+ALTER TABLE partitioning_schema."schema-test" ATTACH PARTITION partitioning_schema."schema-test_2009" FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+-- attached partition is distributed as well
+SELECT 
+	logicalrelid 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+ORDER BY 1;
+              logicalrelid              
+----------------------------------------
+ partitioning_schema."schema-test"
+ partitioning_schema."schema-test_2009"
+(2 rows)
+
+SELECT 
+	logicalrelid, count(*) 
+FROM
+    pg_dist_shard 
+WHERE
+    logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+              logicalrelid              | count 
+----------------------------------------+-------
+ partitioning_schema."schema-test"      |     4
+ partitioning_schema."schema-test_2009" |     4
+(2 rows)
+
+DROP TABLE partitioning_schema."schema-test";
+-- make sure we can create partition of a distributed table in a schema
+CREATE TABLE partitioning_schema."schema-test"(id int, time date) PARTITION BY RANGE (time);
+SELECT create_distributed_table('partitioning_schema."schema-test"', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE partitioning_schema."schema-test_2009" PARTITION OF partitioning_schema."schema-test" FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+-- newly created partition is distributed as well
+SELECT 
+	logicalrelid 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+ORDER BY 1;
+              logicalrelid              
+----------------------------------------
+ partitioning_schema."schema-test"
+ partitioning_schema."schema-test_2009"
+(2 rows)
+
+SELECT 
+	logicalrelid, count(*) 
+FROM
+    pg_dist_shard 
+WHERE
+    logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+              logicalrelid              | count 
+----------------------------------------+-------
+ partitioning_schema."schema-test"      |     4
+ partitioning_schema."schema-test_2009" |     4
+(2 rows)
+
+DROP TABLE partitioning_schema."schema-test";
+-- make sure creating partitioned tables works while search_path is set
+CREATE TABLE partitioning_schema."schema-test"(id int, time date) PARTITION BY RANGE (time);
+SET search_path = partitioning_schema;
+SELECT create_distributed_table('"schema-test"', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE partitioning_schema."schema-test_2009" PARTITION OF "schema-test" FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+-- newly created partition is distributed as well
+SELECT 
+	logicalrelid 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+ORDER BY 1;
+    logicalrelid    
+--------------------
+ "schema-test"
+ "schema-test_2009"
+(2 rows)
+
+SELECT 
+	logicalrelid, count(*) 
+FROM
+    pg_dist_shard 
+WHERE
+    logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+    logicalrelid    | count 
+--------------------+-------
+ "schema-test"      |     4
+ "schema-test_2009" |     4
+(2 rows)
+
+DROP SCHEMA partitioning_schema CASCADE;
+NOTICE:  drop cascades to table "schema-test"

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -1143,3 +1143,123 @@ LINE 1: SELECT create_distributed_table('partitioning_test', 'id');
                                         ^
 DROP TABLE partitioning_test;
 ERROR:  table "partitioning_test" does not exist
+-- make sure we can attach partitions to a distributed table in a schema
+CREATE SCHEMA partitioning_schema;
+CREATE TABLE partitioning_schema."schema-test"(id int, time date) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: ...titioning_schema."schema-test"(id int, time date) PARTITION ...
+                                                             ^
+SELECT create_distributed_table('partitioning_schema."schema-test"', 'id');
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 1: SELECT create_distributed_table('partitioning_schema."schema...
+                                        ^
+CREATE TABLE partitioning_schema."schema-test_2009"(id int, time date);
+ALTER TABLE partitioning_schema."schema-test" ATTACH PARTITION partitioning_schema."schema-test_2009" FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+ERROR:  syntax error at or near "ATTACH"
+LINE 1: ALTER TABLE partitioning_schema."schema-test" ATTACH PARTITI...
+                                                      ^
+-- attached partition is distributed as well
+SELECT 
+	logicalrelid 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+ORDER BY 1;
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 6:  logicalrelid IN ('partitioning_schema."schema-test"'::regcl...
+                          ^
+SELECT 
+	logicalrelid, count(*) 
+FROM
+    pg_dist_shard 
+WHERE
+    logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 6:     logicalrelid IN ('partitioning_schema."schema-test"'::re...
+                             ^
+DROP TABLE partitioning_schema."schema-test";
+ERROR:  table "schema-test" does not exist
+-- make sure we can create partition of a distributed table in a schema
+CREATE TABLE partitioning_schema."schema-test"(id int, time date) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: ...titioning_schema."schema-test"(id int, time date) PARTITION ...
+                                                             ^
+SELECT create_distributed_table('partitioning_schema."schema-test"', 'id');
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 1: SELECT create_distributed_table('partitioning_schema."schema...
+                                        ^
+CREATE TABLE partitioning_schema."schema-test_2009" PARTITION OF partitioning_schema."schema-test" FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: ...EATE TABLE partitioning_schema."schema-test_2009" PARTITION ...
+                                                             ^
+-- newly created partition is distributed as well
+SELECT 
+	logicalrelid 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+ORDER BY 1;
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 6:  logicalrelid IN ('partitioning_schema."schema-test"'::regcl...
+                          ^
+SELECT 
+	logicalrelid, count(*) 
+FROM
+    pg_dist_shard 
+WHERE
+    logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 6:     logicalrelid IN ('partitioning_schema."schema-test"'::re...
+                             ^
+DROP TABLE partitioning_schema."schema-test";
+ERROR:  table "schema-test" does not exist
+-- make sure creating partitioned tables works while search_path is set
+CREATE TABLE partitioning_schema."schema-test"(id int, time date) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: ...titioning_schema."schema-test"(id int, time date) PARTITION ...
+                                                             ^
+SET search_path = partitioning_schema;
+SELECT create_distributed_table('"schema-test"', 'id');
+ERROR:  relation "schema-test" does not exist
+LINE 1: SELECT create_distributed_table('"schema-test"', 'id');
+                                        ^
+CREATE TABLE partitioning_schema."schema-test_2009" PARTITION OF "schema-test" FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: ...EATE TABLE partitioning_schema."schema-test_2009" PARTITION ...
+                                                             ^
+-- newly created partition is distributed as well
+SELECT 
+	logicalrelid 
+FROM 
+	pg_dist_partition 
+WHERE 
+	logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+ORDER BY 1;
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 6:  logicalrelid IN ('partitioning_schema."schema-test"'::regcl...
+                          ^
+SELECT 
+	logicalrelid, count(*) 
+FROM
+    pg_dist_shard 
+WHERE
+    logicalrelid IN ('partitioning_schema."schema-test"'::regclass, 'partitioning_schema."schema-test_2009"'::regclass)
+GROUP BY
+	logicalrelid
+ORDER BY
+	1,2;
+ERROR:  relation "partitioning_schema.schema-test" does not exist
+LINE 6:     logicalrelid IN ('partitioning_schema."schema-test"'::re...
+                             ^
+DROP SCHEMA partitioning_schema CASCADE;
+NOTICE:  drop cascades to table "schema-test_2009"


### PR DESCRIPTION
Fixes #1772 

While attaching a partition to a distributed table in schema, we mistakenly
used unqualified name to find partitioned table's oid. This caused problems
while using partitioned tables with schemas. We are fixing this issue in
this PR.