### PR TITLE
Fix schema support in partitioned tables

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -874,11 +874,14 @@ ProcessCreateTableStmtPartitionOf(CreateStmt *createStatement)
 											  missingOk);
 			Var *parentDistributionColumn = DistPartitionKey(parentRelationId);
 			char parentDistributionMethod = DISTRIBUTE_BY_HASH;
-			char *parentRelationName = get_rel_name(parentRelationId);
+			char *parentSchemaName = parentRelation->schemaname;
+			char *parentRelationName = parentRelation->relname;
+			char *qualifiedParentName = quote_qualified_identifier(parentSchemaName,
+																   parentRelationName);
 			bool viaDeprecatedAPI = false;
 
 			CreateDistributedTable(relationId, parentDistributionColumn,
-								   parentDistributionMethod, parentRelationName,
+								   parentDistributionMethod, qualifiedParentName,
 								   viaDeprecatedAPI);
 		}
 	}
@@ -952,11 +955,15 @@ ProcessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement)
 			{
 				Var *distributionColumn = DistPartitionKey(relationId);
 				char distributionMethod = DISTRIBUTE_BY_HASH;
-				char *relationName = get_rel_name(relationId);
+				RangeVar *parentRelation = alterTableStatement->relation;
+				char *parentSchemaName = parentRelation->schemaname;
+				char *parentRelationName = parentRelation->relname;
+				char *qualifiedParentName =
+					quote_qualified_identifier(parentSchemaName, parentRelationName);
 				bool viaDeprecatedAPI = false;
 
 				CreateDistributedTable(partitionRelationId, distributionColumn,
-									   distributionMethod, relationName,
+									   distributionMethod, qualifiedParentName,
 									   viaDeprecatedAPI);
 			}
 		}

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1244,6 +1244,40 @@ IF EXISTS
     multi_column_partitioning,
     partitioning_locks,
     partitioning_locks_for_select;
+-- create partitioned tables in schema
+CREATE SCHEMA partitioning;
+CREATE TABLE partitioning.test (col1 serial, col2 text, col3 timestamptz NOT NULL DEFAULT now()) PARTITION BY RANGE (col3);
+SELECT create_distributed_table('partitioning.test', 'col1');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE partitioning."test-1" (LIKE partitioning.test);
+ALTER TABLE partitioning.test ATTACH PARTITION partitioning."test-1" FOR VALUES FROM ('2017-11-08 09:00:00+00') TO ('2017-11-08 10:00:00+00');
+INSERT INTO partitioning.test (col2, col3) VALUES ('hello world', '2017-11-08 09:29:31+00');
+SELECT * FROM partitioning.test;
+ col1 |    col2     |             col3             
+------+-------------+------------------------------
+    1 | hello world | Wed Nov 08 01:29:31 2017 PST
+(1 row)
+
+ALTER TABLE partitioning.test DETACH PARTITION partitioning."test-1";
+SELECT * FROM partitioning.test;
+ col1 | col2 | col3 
+------+------+------
+(0 rows)
+
+CREATE TABLE partitioning."test-2" PARTITION OF partitioning.test FOR VALUES FROM ('2017-11-08 09:00:00+00') TO ('2017-11-08 10:00:00+00');
+INSERT INTO partitioning."test-2" (col2, col3) VALUES ('hello world', '2017-11-08 09:29:31+00');
+SELECT * FROM partitioning.test;
+ col1 |    col2     |             col3             
+------+-------------+------------------------------
+    2 | hello world | Wed Nov 08 01:29:31 2017 PST
+(1 row)
+
+DROP TABLE partitioning."test-2";
+DROP TABLE partitioning.test;
 -- make sure we can create a partitioned table with streaming replication
 SET citus.replication_model TO 'streaming';
 CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -814,6 +814,26 @@ IF EXISTS
     partitioning_locks,
     partitioning_locks_for_select;
 
+-- create partitioned tables in schema
+CREATE SCHEMA partitioning;
+CREATE TABLE partitioning.test (col1 serial, col2 text, col3 timestamptz NOT NULL DEFAULT now()) PARTITION BY RANGE (col3);
+SELECT create_distributed_table('partitioning.test', 'col1');
+
+CREATE TABLE partitioning."test-1" (LIKE partitioning.test);
+ALTER TABLE partitioning.test ATTACH PARTITION partitioning."test-1" FOR VALUES FROM ('2017-11-08 09:00:00+00') TO ('2017-11-08 10:00:00+00');
+INSERT INTO partitioning.test (col2, col3) VALUES ('hello world', '2017-11-08 09:29:31+00');
+SELECT * FROM partitioning.test;
+
+ALTER TABLE partitioning.test DETACH PARTITION partitioning."test-1";
+SELECT * FROM partitioning.test;
+
+CREATE TABLE partitioning."test-2" PARTITION OF partitioning.test FOR VALUES FROM ('2017-11-08 09:00:00+00') TO ('2017-11-08 10:00:00+00');
+INSERT INTO partitioning."test-2" (col2, col3) VALUES ('hello world', '2017-11-08 09:29:31+00');
+SELECT * FROM partitioning.test;
+
+DROP TABLE partitioning."test-2";
+DROP TABLE partitioning.test;
+
 -- make sure we can create a partitioned table with streaming replication
 SET citus.replication_model TO 'streaming';
 CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);


### PR DESCRIPTION
Pass a fully qualified name into CreateDistributedTable from the partitioning operations.

(interestingly, this partially enables pg_partman on distributed tables)

Fixes #1772 