### PR TITLE
Make real-time executor work in transactions (and fix pg_partman)

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -821,9 +821,18 @@ OpenCopyConnections(CopyStmt *copyStatement, ShardConnections *shardConnections,
 		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);
 		char *nodeUser = CurrentUserName();
 		MultiConnection *connection = NULL;
-		uint32 connectionFlags = FOR_DML | CONNECTION_PER_PLACEMENT;
+		uint32 connectionFlags = FOR_DML;
 		StringInfo copyCommand = NULL;
 		PGresult *result = NULL;
+
+		/*
+		 * Make sure we use a separate connection per placement for hash-distributed
+		 * tables in order to allow multi-shard modifications in the same transaction.
+		 */
+		if (placement->partitionMethod == DISTRIBUTE_BY_HASH)
+		{
+			connectionFlags |= CONNECTION_PER_PLACEMENT;
+		}
 
 		connection = GetPlacementConnection(connectionFlags, placement, nodeUser);
 

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -54,6 +54,9 @@ typedef struct ConnectionReference
 	uint32 colocationGroupId;
 	uint32 representativeValue;
 
+	/* placementId of the placement, used only for append distributed tables */
+	uint64 placementId;
+
 	/* membership in MultiConnection->referencedPlacements */
 	dlist_node connectionNode;
 } ConnectionReference;
@@ -357,6 +360,7 @@ StartPlacementListConnection(uint32 flags, List *placementAccessList,
 			placementConnection->hadDML = false;
 			placementConnection->userName = MemoryContextStrdup(TopTransactionContext,
 																userName);
+			placementConnection->placementId = placementAccess->placement->placementId;
 
 			/* record association with connection */
 			dlist_push_tail(&chosenConnection->referencedPlacements,
@@ -785,6 +789,14 @@ ConnectionAccessedDifferentPlacement(MultiConnection *connection,
 		ConnectionReference *connectionReference =
 			dlist_container(ConnectionReference, connectionNode, placementIter.cur);
 
+		/* handle append and range distributed tables */
+		if (placement->partitionMethod != DISTRIBUTE_BY_HASH &&
+			placement->placementId != connectionReference->placementId)
+		{
+			return true;
+		}
+
+		/* handle hash distributed tables */
 		if (placement->colocationGroupId != INVALID_COLOCATION_ID &&
 			placement->colocationGroupId == connectionReference->colocationGroupId &&
 			placement->representativeValue != connectionReference->representativeValue)

--- a/src/include/distributed/multi_client_executor.h
+++ b/src/include/distributed/multi_client_executor.h
@@ -14,6 +14,11 @@
 #ifndef MULTI_CLIENT_EXECUTOR_H
 #define MULTI_CLIENT_EXECUTOR_H
 
+
+#include "distributed/connection_management.h"
+#include "nodes/pg_list.h"
+
+
 #define INVALID_CONNECTION_ID -1  /* identifies an invalid connection */
 #define MAX_CONNECTION_COUNT 2048 /* simultaneous client connection count */
 #define STRING_BUFFER_SIZE 1024   /* buffer size for character arrays */
@@ -99,8 +104,12 @@ extern int32 MultiClientConnect(const char *nodeName, uint32 nodePort,
 								const char *nodeDatabase, const char *nodeUser);
 extern int32 MultiClientConnectStart(const char *nodeName, uint32 nodePort,
 									 const char *nodeDatabase, const char *nodeUser);
+extern int32 MultiClientPlacementConnectStart(List *placementAccessList,
+											  const char *userName);
 extern ConnectStatus MultiClientConnectPoll(int32 connectionId);
+extern MultiConnection * MultiClientGetConnection(int32 connectionId);
 extern void MultiClientDisconnect(int32 connectionId);
+extern void MultiClientReleaseConnection(int32 connectionId);
 extern bool MultiClientConnectionUp(int32 connectionId);
 extern bool MultiClientExecute(int32 connectionId, const char *query, void **queryResult,
 							   int *rowCount, int *columnCount);

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2132,13 +2132,21 @@ RETURNING *;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 ERROR:  RETURNING is not supported in INSERT ... SELECT via coordinator
 RESET client_min_messages;
--- INSERT ... SELECT and multi-shard SELECT in the same transaction is unsupported
+-- INSERT ... SELECT and multi-shard SELECT in the same transaction is supported
 TRUNCATE raw_events_first;
 BEGIN;
 INSERT INTO raw_events_first (user_id, value_1)
 SELECT s, s FROM generate_series(1, 5) s;
 SELECT user_id, value_1 FROM raw_events_first;
-ERROR:  cannot open new connections after the first modification command within a transaction
+ user_id | value_1 
+---------+---------
+       1 |       1
+       5 |       5
+       3 |       3
+       4 |       4
+       2 |       2
+(5 rows)
+
 ROLLBACK;
 -- INSERT ... SELECT and single-shard SELECT in the same transaction is supported
 TRUNCATE raw_events_first;

--- a/src/test/regress/expected/multi_real_time_transaction.out
+++ b/src/test/regress/expected/multi_real_time_transaction.out
@@ -1,0 +1,233 @@
+SET citus.next_shard_id TO 1610000;
+CREATE SCHEMA multi_real_time_transaction;
+SET search_path = 'multi_real_time_transaction';
+SET citus.shard_replication_factor to 1;
+CREATE TABLE test_table(id int, col_1 int, col_2 text);
+SELECT create_distributed_table('test_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY test_table FROM stdin delimiter ',';
+CREATE TABLE co_test_table(id int, col_1 int, col_2 text);
+SELECT create_distributed_table('co_test_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY co_test_table FROM stdin delimiter ',';
+CREATE TABLE ref_test_table(id int, col_1 int, col_2 text);
+SELECT create_reference_table('ref_test_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+\COPY ref_test_table FROM stdin delimiter ',';
+-- Test with select and router insert
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+INSERT INTO test_table VALUES(7,8,'gg');
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     7
+(1 row)
+
+ROLLBACK;
+-- Test with select and multi-row insert
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+INSERT INTO test_table VALUES (7,8,'gg'),(8,9,'hh'),(9,10,'ii');
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     9
+(1 row)
+
+ROLLBACK;
+-- Test with INSERT .. SELECT
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+INSERT INTO test_table SELECT * FROM co_test_table;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+    12
+(1 row)
+
+ROLLBACK;
+-- Test with COPY
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+\COPY test_table FROM stdin delimiter ',';
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     9
+(1 row)
+
+ROLLBACK;
+-- Test with router update
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  27
+(1 row)
+
+UPDATE test_table SET col_1 = 0 WHERE id = 2;
+DELETE FROM test_table WHERE id = 3;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  20
+(1 row)
+
+ROLLBACK;
+-- Test with multi-shard update
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  27
+(1 row)
+
+UPDATE test_table SET col_1 = 5;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  30
+(1 row)
+
+ROLLBACK;
+-- Test with subqueries
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  27
+(1 row)
+
+UPDATE
+	test_table
+SET
+	col_1 = 4
+WHERE
+	test_table.col_1 IN (SELECT co_test_table.col_1 FROM co_test_table WHERE co_test_table.id = 1)
+	AND test_table.id = 1;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  29
+(1 row)
+
+ROLLBACK;
+-- Test with partitioned table
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+SET citus.shard_replication_factor TO 1;
+-- create its partitions
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+SELECT create_distributed_table('partitioning_test', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+BEGIN;
+SELECT COUNT(*) FROM partitioning_test;
+ count 
+-------
+     2
+(1 row)
+
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+SELECT COUNT(*) FROM partitioning_test;
+ count 
+-------
+     4
+(1 row)
+
+COMMIT;
+DROP TABLE partitioning_test;
+-- Test with create-drop table
+BEGIN;
+CREATE TABLE test_table_inn(id int, num_1 int);
+SELECT create_distributed_table('test_table_inn','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_inn VALUES(1,3),(4,5),(6,7);
+SELECT COUNT(*) FROM test_table_inn;
+ count 
+-------
+     3
+(1 row)
+
+DROP TABLE test_table_inn;
+COMMIT;
+-- Test with utility functions
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+CREATE INDEX tt_ind_1 ON test_table(col_1);
+ALTER TABLE test_table ADD CONSTRAINT num_check CHECK (col_1 < 50);
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+ROLLBACK;
+-- Test with foreign key
+ALTER TABLE test_table ADD CONSTRAINT p_key_tt PRIMARY KEY (id);
+ALTER TABLE co_test_table ADD CONSTRAINT f_key_ctt FOREIGN KEY (id) REFERENCES test_table(id) ON DELETE CASCADE;
+BEGIN;
+DELETE FROM test_table where id = 1 or id = 3;
+SELECT * FROM co_test_table;
+ id | col_1 | col_2  
+----+-------+--------
+  2 |    30 | 'bb10'
+(1 row)
+
+ROLLBACK;
+DROP SCHEMA multi_real_time_transaction CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table test_table
+drop cascades to table co_test_table
+drop cascades to table ref_test_table

--- a/src/test/regress/expected/multi_real_time_transaction_0.out
+++ b/src/test/regress/expected/multi_real_time_transaction_0.out
@@ -1,0 +1,241 @@
+SET citus.next_shard_id TO 1610000;
+CREATE SCHEMA multi_real_time_transaction;
+SET search_path = 'multi_real_time_transaction';
+SET citus.shard_replication_factor to 1;
+CREATE TABLE test_table(id int, col_1 int, col_2 text);
+SELECT create_distributed_table('test_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY test_table FROM stdin delimiter ',';
+CREATE TABLE co_test_table(id int, col_1 int, col_2 text);
+SELECT create_distributed_table('co_test_table','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY co_test_table FROM stdin delimiter ',';
+CREATE TABLE ref_test_table(id int, col_1 int, col_2 text);
+SELECT create_reference_table('ref_test_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+\COPY ref_test_table FROM stdin delimiter ',';
+-- Test with select and router insert
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+INSERT INTO test_table VALUES(7,8,'gg');
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     7
+(1 row)
+
+ROLLBACK;
+-- Test with select and multi-row insert
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+INSERT INTO test_table VALUES (7,8,'gg'),(8,9,'hh'),(9,10,'ii');
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     9
+(1 row)
+
+ROLLBACK;
+-- Test with INSERT .. SELECT
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+INSERT INTO test_table SELECT * FROM co_test_table;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+    12
+(1 row)
+
+ROLLBACK;
+-- Test with COPY
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+\COPY test_table FROM stdin delimiter ',';
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     9
+(1 row)
+
+ROLLBACK;
+-- Test with router update
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  27
+(1 row)
+
+UPDATE test_table SET col_1 = 0 WHERE id = 2;
+DELETE FROM test_table WHERE id = 3;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  20
+(1 row)
+
+ROLLBACK;
+-- Test with multi-shard update
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  27
+(1 row)
+
+UPDATE test_table SET col_1 = 5;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  30
+(1 row)
+
+ROLLBACK;
+-- Test with subqueries
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  27
+(1 row)
+
+UPDATE
+	test_table
+SET
+	col_1 = 4
+WHERE
+	test_table.col_1 IN (SELECT co_test_table.col_1 FROM co_test_table WHERE co_test_table.id = 1)
+	AND test_table.id = 1;
+SELECT SUM(col_1) FROM test_table;
+ sum 
+-----
+  29
+(1 row)
+
+ROLLBACK;
+-- Test with partitioned table
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test(id int, time date) PARTITION ...
+                                                          ^
+SET citus.shard_replication_factor TO 1;
+-- create its partitions
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test_2009 PARTITION OF partitionin...
+                                            ^
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+ERROR:  syntax error at or near "PARTITION"
+LINE 1: CREATE TABLE partitioning_test_2010 PARTITION OF partitionin...
+                                            ^
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+                    ^
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+                    ^
+SELECT create_distributed_table('partitioning_test', 'id');
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: SELECT create_distributed_table('partitioning_test', 'id');
+                                        ^
+BEGIN;
+SELECT COUNT(*) FROM partitioning_test;
+ERROR:  relation "partitioning_test" does not exist
+LINE 1: SELECT COUNT(*) FROM partitioning_test;
+                             ^
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+SELECT COUNT(*) FROM partitioning_test;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+DROP TABLE partitioning_test;
+ERROR:  table "partitioning_test" does not exist
+-- Test with create-drop table
+BEGIN;
+CREATE TABLE test_table_inn(id int, num_1 int);
+SELECT create_distributed_table('test_table_inn','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_inn VALUES(1,3),(4,5),(6,7);
+SELECT COUNT(*) FROM test_table_inn;
+ count 
+-------
+     3
+(1 row)
+
+DROP TABLE test_table_inn;
+COMMIT;
+-- Test with utility functions
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+CREATE INDEX tt_ind_1 ON test_table(col_1);
+ALTER TABLE test_table ADD CONSTRAINT num_check CHECK (col_1 < 50);
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+ROLLBACK;
+-- Test with foreign key
+ALTER TABLE test_table ADD CONSTRAINT p_key_tt PRIMARY KEY (id);
+ALTER TABLE co_test_table ADD CONSTRAINT f_key_ctt FOREIGN KEY (id) REFERENCES test_table(id) ON DELETE CASCADE;
+BEGIN;
+DELETE FROM test_table where id = 1 or id = 3;
+SELECT * FROM co_test_table;
+ id | col_1 | col_2  
+----+-------+--------
+  2 |    30 | 'bb10'
+(1 row)
+
+ROLLBACK;
+DROP SCHEMA multi_real_time_transaction CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table test_table
+drop cascades to table co_test_table
+drop cascades to table ref_test_table

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -315,13 +315,13 @@ DROP FUNCTION log_ddl_tag();
 DROP TABLE ddl_commands;
 
 \c - - - :master_port
--- Distributed SELECTs cannot appear after ALTER
+-- Distributed SELECTs may appear after ALTER
 BEGIN;
 CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
 SELECT count(*) FROM lineitem_alter;
-COMMIT;
+ROLLBACK;
 
--- but are allowed before
+-- and before
 BEGIN;
 SELECT count(*) FROM lineitem_alter;
 CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -32,6 +32,7 @@ test: multi_read_from_secondaries
 test: multi_create_table
 test: multi_create_table_constraints multi_master_protocol multi_load_data multi_behavioral_analytics_create_table
 test: multi_behavioral_analytics_basics multi_behavioral_analytics_single_shard_queries multi_insert_select_non_pushable_queries multi_insert_select multi_insert_select_window multi_shard_update_delete
+test: multi_real_time_transaction
 
 # ----------
 # Tests for partitioning support

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -673,13 +673,17 @@ DROP EVENT TRIGGER log_ddl_tag;
 DROP FUNCTION log_ddl_tag();
 DROP TABLE ddl_commands;
 \c - - - :master_port
--- Distributed SELECTs cannot appear after ALTER
+-- Distributed SELECTs may appear after ALTER
 BEGIN;
 CREATE INDEX temp_index_2 ON lineitem_alter(l_orderkey);
 SELECT count(*) FROM lineitem_alter;
-ERROR:  cannot open new connections after the first modification command within a transaction
-COMMIT;
--- but are allowed before
+ count 
+-------
+ 18000
+(1 row)
+
+ROLLBACK;
+-- and before
 BEGIN;
 SELECT count(*) FROM lineitem_alter;
  count 

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -1716,7 +1716,7 @@ RETURNING *;
 
 RESET client_min_messages;
 
--- INSERT ... SELECT and multi-shard SELECT in the same transaction is unsupported
+-- INSERT ... SELECT and multi-shard SELECT in the same transaction is supported
 TRUNCATE raw_events_first;
 
 BEGIN;

--- a/src/test/regress/sql/multi_real_time_transaction.sql
+++ b/src/test/regress/sql/multi_real_time_transaction.sql
@@ -1,0 +1,147 @@
+SET citus.next_shard_id TO 1610000;
+
+CREATE SCHEMA multi_real_time_transaction;
+SET search_path = 'multi_real_time_transaction';
+SET citus.shard_replication_factor to 1;
+
+CREATE TABLE test_table(id int, col_1 int, col_2 text);
+SELECT create_distributed_table('test_table','id');
+\COPY test_table FROM stdin delimiter ',';
+1,2,'aa'
+2,3,'bb'
+3,4,'cc'
+4,5,'dd'
+5,6,'ee'
+6,7,'ff'
+\.
+
+CREATE TABLE co_test_table(id int, col_1 int, col_2 text);
+SELECT create_distributed_table('co_test_table','id');
+\COPY co_test_table FROM stdin delimiter ',';
+1,20,'aa10'
+2,30,'bb10'
+3,40,'cc10'
+3,4,'cc1'
+3,5,'cc2'
+1,2,'cc2'
+\.
+
+
+CREATE TABLE ref_test_table(id int, col_1 int, col_2 text);
+SELECT create_reference_table('ref_test_table');
+\COPY ref_test_table FROM stdin delimiter ',';
+1,2,'rr1'
+2,3,'rr2'
+3,4,'rr3'
+4,5,'rr4'
+\.
+
+-- Test with select and router insert
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+INSERT INTO test_table VALUES(7,8,'gg');
+SELECT COUNT(*) FROM test_table;
+ROLLBACK;
+
+-- Test with select and multi-row insert
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+INSERT INTO test_table VALUES (7,8,'gg'),(8,9,'hh'),(9,10,'ii');
+SELECT COUNT(*) FROM test_table;
+ROLLBACK;
+
+-- Test with INSERT .. SELECT
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+INSERT INTO test_table SELECT * FROM co_test_table;
+SELECT COUNT(*) FROM test_table;
+ROLLBACK;
+
+-- Test with COPY
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+\COPY test_table FROM stdin delimiter ',';
+8,9,'gg'
+9,10,'hh'
+10,11,'ii'
+\.
+SELECT COUNT(*) FROM test_table;
+ROLLBACK;
+
+-- Test with router update
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+UPDATE test_table SET col_1 = 0 WHERE id = 2;
+DELETE FROM test_table WHERE id = 3;
+SELECT SUM(col_1) FROM test_table;
+ROLLBACK;
+
+-- Test with multi-shard update
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+UPDATE test_table SET col_1 = 5;
+SELECT SUM(col_1) FROM test_table;
+ROLLBACK;
+
+-- Test with subqueries
+BEGIN;
+SELECT SUM(col_1) FROM test_table;
+UPDATE
+	test_table
+SET
+	col_1 = 4
+WHERE
+	test_table.col_1 IN (SELECT co_test_table.col_1 FROM co_test_table WHERE co_test_table.id = 1)
+	AND test_table.id = 1;
+SELECT SUM(col_1) FROM test_table;
+ROLLBACK;
+
+-- Test with partitioned table
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+SET citus.shard_replication_factor TO 1;
+
+-- create its partitions
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+SELECT create_distributed_table('partitioning_test', 'id');
+
+BEGIN;
+SELECT COUNT(*) FROM partitioning_test;
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+SELECT COUNT(*) FROM partitioning_test;
+COMMIT;
+
+DROP TABLE partitioning_test;
+
+-- Test with create-drop table
+BEGIN;
+CREATE TABLE test_table_inn(id int, num_1 int);
+SELECT create_distributed_table('test_table_inn','id');
+INSERT INTO test_table_inn VALUES(1,3),(4,5),(6,7);
+SELECT COUNT(*) FROM test_table_inn;
+DROP TABLE test_table_inn;
+COMMIT;
+
+-- Test with utility functions
+BEGIN;
+SELECT COUNT(*) FROM test_table;
+CREATE INDEX tt_ind_1 ON test_table(col_1);
+ALTER TABLE test_table ADD CONSTRAINT num_check CHECK (col_1 < 50);
+SELECT COUNT(*) FROM test_table;
+ROLLBACK;
+
+-- Test with foreign key
+ALTER TABLE test_table ADD CONSTRAINT p_key_tt PRIMARY KEY (id);
+ALTER TABLE co_test_table ADD CONSTRAINT f_key_ctt FOREIGN KEY (id) REFERENCES test_table(id) ON DELETE CASCADE;
+
+BEGIN;
+DELETE FROM test_table where id = 1 or id = 3;
+SELECT * FROM co_test_table;
+ROLLBACK;
+
+DROP SCHEMA multi_real_time_transaction CASCADE;


### PR DESCRIPTION
The real-time executor currently always opens new connections to SELECT from shards, which means it cannot see uncommitted writes and thus real-time SELECT after write errors out. It also does not register which shard placement it SELECTs from, which means DDL after real-time SELECT errors out.

This PR makes the real-time executor open its connections through `StartPlacementListConnection` to make sure it can be part of a transaction. For example, the following now works (recently came up in Slack):

```
postgres=# BEGIN;
BEGIN
Time: 0.165 ms
postgres=# SELECT count(*) FROM facilities;
 count 
-------
     0
(1 row)

Time: 70.727 ms
postgres=# INSERT INTO facilities (name) VALUES ('new-facility');
INSERT 0 1
Time: 1.436 ms
postgres=# SELECT count(*) FROM facilities;
 count 
-------
     1
(1 row)

Time: 7.623 ms
postgres=# END;
COMMIT
```

Importantly, it also enables most pg_partman functionality.

This mostly needs a lot of regression tests and some failure tests.