### PR TITLE
isolation test coverage improvement

### DIFF
--- a/src/test/regress/expected/isolation_create_distributed_table.out
+++ b/src/test/regress/expected/isolation_create_distributed_table.out
@@ -1,0 +1,102 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s2-begin s1-create_distributed_table s2-create_distributed_table s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+
+create_distributed_table
+
+               
+step s2-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-create_distributed_table: <... completed>
+error in steps s1-commit s2-create_distributed_table: ERROR:  table "table_to_distribute" is already distributed
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-create_distributed_table s2-copy_to_local_table s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+
+create_distributed_table
+
+               
+step s2-copy_to_local_table: 
+	COPY table_to_distribute FROM PROGRAM 'echo "0\n1\n2\n3\n4\n5\n6\n7\n8"';
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-copy_to_local_table: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s2-copy_to_local_table s1-create_distributed_table s2-commit s1-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s2-copy_to_local_table: 
+	COPY table_to_distribute FROM PROGRAM 'echo "0\n1\n2\n3\n4\n5\n6\n7\n8"';
+
+step s1-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-create_distributed_table: <... completed>
+create_distributed_table
+
+               
+step s1-commit: 
+    COMMIT;
+
+
+starting permutation: s1-copy_to_local_table s1-begin s2-begin s1-create_distributed_table s2-create_distributed_table s1-commit s2-commit
+step s1-copy_to_local_table: 
+	COPY table_to_distribute FROM PROGRAM 'echo "0\n1\n2\n3\n4\n5\n6\n7\n8"';
+
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+
+create_distributed_table
+
+               
+step s2-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-create_distributed_table: <... completed>
+error in steps s1-commit s2-create_distributed_table: ERROR:  table "table_to_distribute" is already distributed
+step s2-commit: 
+	COMMIT;
+

--- a/src/test/regress/expected/isolation_master_append_table.out
+++ b/src/test/regress/expected/isolation_master_append_table.out
@@ -17,7 +17,7 @@ step s1-master_append_table_to_shard:
 
 master_append_table_to_shard
 
-0.0266667      
+0.213333       
 step s2-master_append_table_to_shard: 
 
    	SELECT	
@@ -33,118 +33,7 @@ step s1-commit:
 step s2-master_append_table_to_shard: <... completed>
 master_append_table_to_shard
 
-0.0266667      
-step s2-commit: 
-	COMMIT;
-
-
-starting permutation: s1-begin s2-begin s1-create_distributed_table s2-create_distributed_table s1-commit s2-commit
-step s1-begin: 
-    BEGIN;
-
-step s2-begin: 
-	BEGIN;
-
-step s1-create_distributed_table: 
-	SELECT create_distributed_table('table_to_distribute', 'id');
-
-create_distributed_table
-
-               
-step s2-create_distributed_table: 
-	SELECT create_distributed_table('table_to_distribute', 'id');
- <waiting ...>
-step s1-commit: 
-    COMMIT;
-
-step s2-create_distributed_table: <... completed>
-error in steps s1-commit s2-create_distributed_table: ERROR:  table "table_to_distribute" is already distributed
-step s2-commit: 
-	COMMIT;
-
-
-starting permutation: s1-begin s2-begin s1-master_append_table_to_shard s2-master_apply_delete_command s1-commit s2-commit
-step s1-begin: 
-    BEGIN;
-
-step s2-begin: 
-	BEGIN;
-
-step s1-master_append_table_to_shard: 
-   	SELECT	
-   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
-	FROM
-		pg_dist_shard
-	WHERE
-		'table_to_append'::regclass::oid = logicalrelid;
-
-master_append_table_to_shard
-
-0.0266667      
-step s2-master_apply_delete_command: 
-   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
-
-ERROR:  canceling statement due to user request
-step s1-commit: 
-    COMMIT;
-
-step s2-commit: 
-	COMMIT;
-
-
-starting permutation: s1-begin s2-begin s1-master_apply_delete_command s2-master_append_table_to_shard s1-commit s2-commit
-step s1-begin: 
-    BEGIN;
-
-step s2-begin: 
-	BEGIN;
-
-step s1-master_apply_delete_command: 
-   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
-
-master_apply_delete_command
-
-1              
-step s2-master_append_table_to_shard: 
-
-   	SELECT	
-   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
-	FROM
-		pg_dist_shard
-	WHERE
-		'table_to_append'::regclass::oid = logicalrelid;
-
-ERROR:  canceling statement due to user request
-step s1-commit: 
-    COMMIT;
-
-step s2-commit: 
-	COMMIT;
-
-
-starting permutation: s1-begin s2-begin s1-master_apply_delete_command s2-master_apply_delete_command s1-commit s2-commit
-step s1-begin: 
-    BEGIN;
-
-step s2-begin: 
-	BEGIN;
-
-step s1-master_apply_delete_command: 
-   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
-
-master_apply_delete_command
-
-1              
-step s2-master_apply_delete_command: 
-   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
- <waiting ...>
-step s1-commit: 
-    COMMIT;
-
-step s2-master_apply_delete_command: <... completed>
-master_apply_delete_command
-
-0              
+0.32           
 step s2-commit: 
 	COMMIT;
 

--- a/src/test/regress/expected/isolation_master_append_table.out
+++ b/src/test/regress/expected/isolation_master_append_table.out
@@ -1,0 +1,150 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s2-begin s1-master_append_table_to_shard s2-master_append_table_to_shard s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_append_table_to_shard: 
+   	SELECT	
+   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
+	FROM
+		pg_dist_shard
+	WHERE
+		'table_to_append'::regclass::oid = logicalrelid;
+
+master_append_table_to_shard
+
+0.0266667      
+step s2-master_append_table_to_shard: 
+
+   	SELECT	
+   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
+	FROM
+		pg_dist_shard
+	WHERE
+		'table_to_append'::regclass::oid = logicalrelid;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-master_append_table_to_shard: <... completed>
+master_append_table_to_shard
+
+0.0266667      
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-create_distributed_table s2-create_distributed_table s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+
+create_distributed_table
+
+               
+step s2-create_distributed_table: 
+	SELECT create_distributed_table('table_to_distribute', 'id');
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-create_distributed_table: <... completed>
+error in steps s1-commit s2-create_distributed_table: ERROR:  table "table_to_distribute" is already distributed
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-master_append_table_to_shard s2-master_apply_delete_command s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_append_table_to_shard: 
+   	SELECT	
+   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
+	FROM
+		pg_dist_shard
+	WHERE
+		'table_to_append'::regclass::oid = logicalrelid;
+
+master_append_table_to_shard
+
+0.0266667      
+step s2-master_apply_delete_command: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
+
+ERROR:  canceling statement due to user request
+step s1-commit: 
+    COMMIT;
+
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-master_apply_delete_command s2-master_append_table_to_shard s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_apply_delete_command: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
+
+master_apply_delete_command
+
+1              
+step s2-master_append_table_to_shard: 
+
+   	SELECT	
+   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
+	FROM
+		pg_dist_shard
+	WHERE
+		'table_to_append'::regclass::oid = logicalrelid;
+
+ERROR:  canceling statement due to user request
+step s1-commit: 
+    COMMIT;
+
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-master_apply_delete_command s2-master_apply_delete_command s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_apply_delete_command: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
+
+master_apply_delete_command
+
+1              
+step s2-master_apply_delete_command: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-master_apply_delete_command: <... completed>
+master_apply_delete_command
+
+0              
+step s2-commit: 
+	COMMIT;
+

--- a/src/test/regress/expected/isolation_master_apply_delete.out
+++ b/src/test/regress/expected/isolation_master_apply_delete.out
@@ -1,0 +1,109 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s2-begin s1-master_apply_delete_command_all_shard s2-master_apply_delete_command_all_shard s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_apply_delete_command_all_shard: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0$$);
+
+master_apply_delete_command
+
+1              
+step s2-master_apply_delete_command_all_shard: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0$$);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-master_apply_delete_command_all_shard: <... completed>
+master_apply_delete_command
+
+0              
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-master_apply_delete_command_all_shard s2-master_apply_delete_command_row s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_apply_delete_command_all_shard: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0$$);
+
+master_apply_delete_command
+
+1              
+step s2-master_apply_delete_command_row: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0 and id < 3$$);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-master_apply_delete_command_row: <... completed>
+master_apply_delete_command
+
+0              
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-master_apply_delete_command_row s2-master_apply_delete_command_all_shard s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_apply_delete_command_row: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0 and id < 3$$);
+
+master_apply_delete_command
+
+0              
+step s2-master_apply_delete_command_all_shard: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0$$);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-master_apply_delete_command_all_shard: <... completed>
+master_apply_delete_command
+
+1              
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-master_apply_delete_command_row s2-master_apply_delete_command_row s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-master_apply_delete_command_row: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0 and id < 3$$);
+
+master_apply_delete_command
+
+0              
+step s2-master_apply_delete_command_row: 
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0 and id < 3$$);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-master_apply_delete_command_row: <... completed>
+master_apply_delete_command
+
+0              
+step s2-commit: 
+	COMMIT;
+

--- a/src/test/regress/expected/isolation_multi_shard_modify_vs_all.out
+++ b/src/test/regress/expected/isolation_multi_shard_modify_vs_all.out
@@ -62,17 +62,17 @@ step s2-commit:
 	COMMIT;
 
 
-starting permutation: s1-begin s1-update_value_1_of_1_or_3 s2-begin s2-update_value_1_of_4_or_6 s1-commit s2-commit s2-select
+starting permutation: s1-begin s1-update_value_1_of_1_or_3_to_5 s2-begin s2-update_value_1_of_4_or_6_to_4 s1-commit s2-commit s2-select
 step s1-begin: 
     BEGIN;
 
-step s1-update_value_1_of_1_or_3: 
+step s1-update_value_1_of_1_or_3_to_5: 
 	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 1 or user_id = 3;
 
 step s2-begin: 
 	BEGIN;
 
-step s2-update_value_1_of_4_or_6: 
+step s2-update_value_1_of_4_or_6_to_4: 
 	UPDATE users_test_table SET value_1 = 4 WHERE user_id = 4 or user_id = 6;
 
 step s1-commit: 
@@ -94,23 +94,23 @@ user_id        value_1        value_2        value_3
 6              4              11             25             
 7              27             12             18             
 
-starting permutation: s1-begin s1-update_value_1_of_1_or_3 s2-begin s2-update_value_1_of_1_or_3 s1-commit s2-commit s2-select
+starting permutation: s1-begin s1-update_value_1_of_1_or_3_to_5 s2-begin s2-update_value_1_of_1_or_3_to_8 s1-commit s2-commit s2-select
 step s1-begin: 
     BEGIN;
 
-step s1-update_value_1_of_1_or_3: 
+step s1-update_value_1_of_1_or_3_to_5: 
 	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 1 or user_id = 3;
 
 step s2-begin: 
 	BEGIN;
 
-step s2-update_value_1_of_1_or_3: 
+step s2-update_value_1_of_1_or_3_to_8: 
 	UPDATE users_test_table SET value_1 = 8 WHERE user_id = 1 or user_id = 3;
  <waiting ...>
 step s1-commit: 
     COMMIT;
 
-step s2-update_value_1_of_1_or_3: <... completed>
+step s2-update_value_1_of_1_or_3_to_8: <... completed>
 step s2-commit: 
 	COMMIT;
 
@@ -200,6 +200,47 @@ user_id        value_1        value_2        value_3
 5              17             14             4              
 3              11             78             18             
 
+starting permutation: s1-begin s2-begin s1-update_value_1_of_1_or_3_to_5 s2-update_value_1_of_1_or_3_to_8 s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-update_value_1_of_1_or_3_to_5: 
+	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 1 or user_id = 3;
+
+step s2-update_value_1_of_1_or_3_to_8: 
+	UPDATE users_test_table SET value_1 = 8 WHERE user_id = 1 or user_id = 3;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-update_value_1_of_1_or_3_to_8: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s2-update_value_1_of_1_or_3_to_8 s1-update_value_1_of_2_or_4_to_5 s2-commit s1-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s2-update_value_1_of_1_or_3_to_8: 
+	UPDATE users_test_table SET value_1 = 8 WHERE user_id = 1 or user_id = 3;
+
+step s1-update_value_1_of_2_or_4_to_5: 
+	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 2 or user_id = 4;
+
+step s2-commit: 
+	COMMIT;
+
+step s1-commit: 
+    COMMIT;
+
+
 starting permutation: s1-begin s1-change_connection_mode_to_sequential s1-update_all_value_1 s2-begin s2-change_connection_mode_to_sequential s2-update_all_value_1 s1-commit s2-commit s2-select
 step s1-begin: 
     BEGIN;
@@ -239,14 +280,14 @@ user_id        value_1        value_2        value_3
 6              6              11             25             
 7              6              12             18             
 
-starting permutation: s1-begin s1-change_connection_mode_to_sequential s1-update_value_1_of_1_or_3 s2-begin s2-change_connection_mode_to_sequential s2-update_value_1_of_1_or_3 s1-commit s2-commit s2-select
+starting permutation: s1-begin s1-change_connection_mode_to_sequential s1-update_value_1_of_1_or_3_to_5 s2-begin s2-change_connection_mode_to_sequential s2-update_value_1_of_1_or_3_to_8 s1-commit s2-commit s2-select
 step s1-begin: 
     BEGIN;
 
 step s1-change_connection_mode_to_sequential: 
     set citus.multi_shard_modify_mode to 'sequential';
 
-step s1-update_value_1_of_1_or_3: 
+step s1-update_value_1_of_1_or_3_to_5: 
 	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 1 or user_id = 3;
 
 step s2-begin: 
@@ -255,13 +296,13 @@ step s2-begin:
 step s2-change_connection_mode_to_sequential: 
     set citus.multi_shard_modify_mode to 'sequential';
 
-step s2-update_value_1_of_1_or_3: 
+step s2-update_value_1_of_1_or_3_to_8: 
 	UPDATE users_test_table SET value_1 = 8 WHERE user_id = 1 or user_id = 3;
  <waiting ...>
 step s1-commit: 
     COMMIT;
 
-step s2-update_value_1_of_1_or_3: <... completed>
+step s2-update_value_1_of_1_or_3_to_8: <... completed>
 step s2-commit: 
 	COMMIT;
 
@@ -278,14 +319,14 @@ user_id        value_1        value_2        value_3
 6              21             11             25             
 7              27             12             18             
 
-starting permutation: s1-begin s1-change_connection_mode_to_sequential s1-update_value_1_of_1_or_3 s2-begin s2-change_connection_mode_to_sequential s2-update_value_1_of_4_or_6 s1-commit s2-commit s2-select
+starting permutation: s1-begin s1-change_connection_mode_to_sequential s1-update_value_1_of_1_or_3_to_5 s2-begin s2-change_connection_mode_to_sequential s2-update_value_1_of_4_or_6_to_4 s1-commit s2-commit s2-select
 step s1-begin: 
     BEGIN;
 
 step s1-change_connection_mode_to_sequential: 
     set citus.multi_shard_modify_mode to 'sequential';
 
-step s1-update_value_1_of_1_or_3: 
+step s1-update_value_1_of_1_or_3_to_5: 
 	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 1 or user_id = 3;
 
 step s2-begin: 
@@ -294,7 +335,7 @@ step s2-begin:
 step s2-change_connection_mode_to_sequential: 
     set citus.multi_shard_modify_mode to 'sequential';
 
-step s2-update_value_1_of_4_or_6: 
+step s2-update_value_1_of_4_or_6_to_4: 
 	UPDATE users_test_table SET value_1 = 4 WHERE user_id = 4 or user_id = 6;
 
 step s1-commit: 
@@ -315,3 +356,56 @@ user_id        value_1        value_2        value_3
 5              35             10             17             
 6              4              11             25             
 7              27             12             18             
+
+starting permutation: s1-begin s2-begin s1-change_connection_mode_to_sequential s2-change_connection_mode_to_sequential s1-update_value_1_of_1_or_3_to_5 s2-update_value_1_of_1_or_3_to_8 s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-change_connection_mode_to_sequential: 
+    set citus.multi_shard_modify_mode to 'sequential';
+
+step s2-change_connection_mode_to_sequential: 
+    set citus.multi_shard_modify_mode to 'sequential';
+
+step s1-update_value_1_of_1_or_3_to_5: 
+	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 1 or user_id = 3;
+
+step s2-update_value_1_of_1_or_3_to_8: 
+	UPDATE users_test_table SET value_1 = 8 WHERE user_id = 1 or user_id = 3;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-update_value_1_of_1_or_3_to_8: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-change_connection_mode_to_sequential s2-change_connection_mode_to_sequential s2-update_value_1_of_1_or_3_to_8 s1-update_value_1_of_2_or_4_to_5 s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-change_connection_mode_to_sequential: 
+    set citus.multi_shard_modify_mode to 'sequential';
+
+step s2-change_connection_mode_to_sequential: 
+    set citus.multi_shard_modify_mode to 'sequential';
+
+step s2-update_value_1_of_1_or_3_to_8: 
+	UPDATE users_test_table SET value_1 = 8 WHERE user_id = 1 or user_id = 3;
+
+step s1-update_value_1_of_2_or_4_to_5: 
+	UPDATE users_test_table SET value_1 = 5 WHERE user_id = 2 or user_id = 4;
+
+step s1-commit: 
+    COMMIT;
+
+step s2-commit: 
+	COMMIT;
+

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -23,7 +23,7 @@ test: isolation_distributed_deadlock_detection
 # writes, run this test serially.
 test: isolation_create_restore_point
 
-test: isolation_master_append_table
+test: isolation_create_distributed_table isolation_master_append_table isolation_master_apply_delete
 test: isolation_multi_shard_modify_vs_all
 test: isolation_hash_copy_vs_all
 test: isolation_append_copy_vs_all

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -38,3 +38,4 @@ test: isolation_delete_vs_all
 test: isolation_truncate_vs_all
 test: isolation_drop_vs_all
 test: isolation_ddl_vs_all
+test: isolation_master_append_table

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -23,6 +23,7 @@ test: isolation_distributed_deadlock_detection
 # writes, run this test serially.
 test: isolation_create_restore_point
 
+test: isolation_master_append_table
 test: isolation_multi_shard_modify_vs_all
 test: isolation_hash_copy_vs_all
 test: isolation_append_copy_vs_all
@@ -38,4 +39,3 @@ test: isolation_delete_vs_all
 test: isolation_truncate_vs_all
 test: isolation_drop_vs_all
 test: isolation_ddl_vs_all
-test: isolation_master_append_table

--- a/src/test/regress/specs/isolation_create_distributed_table.spec
+++ b/src/test/regress/specs/isolation_create_distributed_table.spec
@@ -1,0 +1,63 @@
+setup
+{	
+  	CREATE TABLE table_to_distribute(id int);
+}
+
+teardown
+{
+	DROP TABLE table_to_distribute CASCADE;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-create_distributed_table"
+{
+	SELECT create_distributed_table('table_to_distribute', 'id');
+}
+
+step "s1-copy_to_local_table"
+{
+	COPY table_to_distribute FROM PROGRAM 'echo "0\n1\n2\n3\n4\n5\n6\n7\n8"';
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+	BEGIN;
+}
+
+step "s2-create_distributed_table"
+{
+	SELECT create_distributed_table('table_to_distribute', 'id');
+}
+
+step "s2-copy_to_local_table"
+{
+	COPY table_to_distribute FROM PROGRAM 'echo "0\n1\n2\n3\n4\n5\n6\n7\n8"';
+}
+
+step "s2-commit"
+{
+	COMMIT;
+}
+
+#concurrent create_distributed_table on empty table
+permutation "s1-begin" "s2-begin" "s1-create_distributed_table" "s2-create_distributed_table" "s1-commit" "s2-commit"
+
+#concurrent create_distributed_table vs. copy to table
+permutation "s1-begin" "s2-begin" "s1-create_distributed_table" "s2-copy_to_local_table" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s2-copy_to_local_table" "s1-create_distributed_table" "s2-commit" "s1-commit"
+
+#concurrent create_distributed_table on non-empty table
+permutation "s1-copy_to_local_table" "s1-begin" "s2-begin" "s1-create_distributed_table" "s2-create_distributed_table" "s1-commit" "s2-commit"

--- a/src/test/regress/specs/isolation_master_append_table.spec
+++ b/src/test/regress/specs/isolation_master_append_table.spec
@@ -1,20 +1,21 @@
 setup
 {	
-	ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 230000;
-
   	CREATE TABLE table_to_append(id int);
   	CREATE TABLE table_to_be_appended(id int);
+  	CREATE TABLE table_to_distribute(id int);
 
   	SELECT create_distributed_table('table_to_append', 'id', 'append');
-  	INSERT INTO table_to_be_appended VALUES(0),(1),(2),(3),(4),(5);
+  	INSERT INTO table_to_be_appended VALUES(1),(2),(3),(4),(5),(6);
+  	INSERT INTO table_to_distribute SELECT generate_series(1,100);
 
-  	COPY table_to_append FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+  	COPY table_to_append FROM PROGRAM 'echo "0\n7\n8\n9\n10"';
 }
 
 teardown
 {
 	DROP TABLE table_to_append CASCADE;
 	DROP TABLE table_to_be_appended CASCADE;
+	DROP TABLE table_to_distribute CASCADE;
 }
 
 session "s1"
@@ -22,6 +23,11 @@ session "s1"
 step "s1-begin"
 {
     BEGIN;
+}
+
+step "s1-create_distributed_table"
+{
+	SELECT create_distributed_table('table_to_distribute', 'id');
 }
 
 step "s1-master_append_table_to_shard"
@@ -32,6 +38,11 @@ step "s1-master_append_table_to_shard"
 		pg_dist_shard
 	WHERE
 		'table_to_append'::regclass::oid = logicalrelid;
+}
+
+step "s1-master_apply_delete_command"
+{
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
 }
 
 step "s1-commit"
@@ -46,6 +57,11 @@ step "s2-begin"
 	BEGIN;
 }
 
+step "s2-create_distributed_table"
+{
+	SELECT create_distributed_table('table_to_distribute', 'id');
+}
+
 step "s2-master_append_table_to_shard"
 {
 
@@ -56,9 +72,26 @@ step "s2-master_append_table_to_shard"
 	WHERE
 		'table_to_append'::regclass::oid = logicalrelid;
 }
+
+step "s2-master_apply_delete_command"
+{
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
+}
+
 step "s2-commit"
 {
 	COMMIT;
 }
 
+# concurrent master_append_table_to_shard tests
 permutation "s1-begin" "s2-begin" "s1-master_append_table_to_shard" "s2-master_append_table_to_shard" "s1-commit" "s2-commit"
+
+#concurrent create_distributed_table
+permutation "s1-begin" "s2-begin" "s1-create_distributed_table" "s2-create_distributed_table" "s1-commit" "s2-commit"
+
+# concurrent master_append_table_to_shard vs master_apply_delete_command tests
+permutation "s1-begin" "s2-begin" "s1-master_append_table_to_shard" "s2-master_apply_delete_command" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command" "s2-master_append_table_to_shard" "s1-commit" "s2-commit"
+
+#concurrent master_apply_delete_command vs master_apply_delete_command
+permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command" "s2-master_apply_delete_command" "s1-commit" "s2-commit"

--- a/src/test/regress/specs/isolation_master_append_table.spec
+++ b/src/test/regress/specs/isolation_master_append_table.spec
@@ -1,0 +1,64 @@
+setup
+{	
+	ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 230000;
+
+  	CREATE TABLE table_to_append(id int);
+  	CREATE TABLE table_to_be_appended(id int);
+
+  	SELECT create_distributed_table('table_to_append', 'id', 'append');
+  	INSERT INTO table_to_be_appended VALUES(0),(1),(2),(3),(4),(5);
+
+  	COPY table_to_append FROM PROGRAM 'echo "1\n2\n3\n4\n5"';
+}
+
+teardown
+{
+	DROP TABLE table_to_append CASCADE;
+	DROP TABLE table_to_be_appended CASCADE;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-master_append_table_to_shard"
+{
+   	SELECT	
+   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
+	FROM
+		pg_dist_shard
+	WHERE
+		'table_to_append'::regclass::oid = logicalrelid;
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+	BEGIN;
+}
+
+step "s2-master_append_table_to_shard"
+{
+
+   	SELECT	
+   		master_append_table_to_shard(shardid, 'table_to_be_appended', 'localhost', 57636)
+	FROM
+		pg_dist_shard
+	WHERE
+		'table_to_append'::regclass::oid = logicalrelid;
+}
+step "s2-commit"
+{
+	COMMIT;
+}
+
+permutation "s1-begin" "s2-begin" "s1-master_append_table_to_shard" "s2-master_append_table_to_shard" "s1-commit" "s2-commit"

--- a/src/test/regress/specs/isolation_master_append_table.spec
+++ b/src/test/regress/specs/isolation_master_append_table.spec
@@ -2,20 +2,17 @@ setup
 {	
   	CREATE TABLE table_to_append(id int);
   	CREATE TABLE table_to_be_appended(id int);
-  	CREATE TABLE table_to_distribute(id int);
 
   	SELECT create_distributed_table('table_to_append', 'id', 'append');
-  	INSERT INTO table_to_be_appended VALUES(1),(2),(3),(4),(5),(6);
-  	INSERT INTO table_to_distribute SELECT generate_series(1,100);
+  	INSERT INTO table_to_be_appended SELECT generate_series(1,1000);
 
-  	COPY table_to_append FROM PROGRAM 'echo "0\n7\n8\n9\n10"';
+  	COPY table_to_append FROM PROGRAM 'echo "0\n7\n8\n9\n10000"';
 }
 
 teardown
 {
 	DROP TABLE table_to_append CASCADE;
 	DROP TABLE table_to_be_appended CASCADE;
-	DROP TABLE table_to_distribute CASCADE;
 }
 
 session "s1"
@@ -23,11 +20,6 @@ session "s1"
 step "s1-begin"
 {
     BEGIN;
-}
-
-step "s1-create_distributed_table"
-{
-	SELECT create_distributed_table('table_to_distribute', 'id');
 }
 
 step "s1-master_append_table_to_shard"
@@ -38,11 +30,6 @@ step "s1-master_append_table_to_shard"
 		pg_dist_shard
 	WHERE
 		'table_to_append'::regclass::oid = logicalrelid;
-}
-
-step "s1-master_apply_delete_command"
-{
-   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
 }
 
 step "s1-commit"
@@ -57,11 +44,6 @@ step "s2-begin"
 	BEGIN;
 }
 
-step "s2-create_distributed_table"
-{
-	SELECT create_distributed_table('table_to_distribute', 'id');
-}
-
 step "s2-master_append_table_to_shard"
 {
 
@@ -73,11 +55,6 @@ step "s2-master_append_table_to_shard"
 		'table_to_append'::regclass::oid = logicalrelid;
 }
 
-step "s2-master_apply_delete_command"
-{
-   	SELECT master_apply_delete_command($$DELETE FROM table_to_append WHERE id >= 0$$);
-}
-
 step "s2-commit"
 {
 	COMMIT;
@@ -85,13 +62,3 @@ step "s2-commit"
 
 # concurrent master_append_table_to_shard tests
 permutation "s1-begin" "s2-begin" "s1-master_append_table_to_shard" "s2-master_append_table_to_shard" "s1-commit" "s2-commit"
-
-#concurrent create_distributed_table
-permutation "s1-begin" "s2-begin" "s1-create_distributed_table" "s2-create_distributed_table" "s1-commit" "s2-commit"
-
-# concurrent master_append_table_to_shard vs master_apply_delete_command tests
-permutation "s1-begin" "s2-begin" "s1-master_append_table_to_shard" "s2-master_apply_delete_command" "s1-commit" "s2-commit"
-permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command" "s2-master_append_table_to_shard" "s1-commit" "s2-commit"
-
-#concurrent master_apply_delete_command vs master_apply_delete_command
-permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command" "s2-master_apply_delete_command" "s1-commit" "s2-commit"

--- a/src/test/regress/specs/isolation_master_apply_delete.spec
+++ b/src/test/regress/specs/isolation_master_apply_delete.spec
@@ -1,0 +1,63 @@
+setup
+{	
+  	CREATE TABLE table_to_delete_from(id int);
+
+  	SELECT create_distributed_table('table_to_delete_from', 'id', 'append');
+
+  	COPY table_to_delete_from FROM PROGRAM 'echo "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+}
+
+teardown
+{
+	DROP TABLE table_to_delete_from CASCADE;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-master_apply_delete_command_all_shard"
+{
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0$$);
+}
+
+step "s1-master_apply_delete_command_row"
+{
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0 and id < 3$$);
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+	BEGIN;
+}
+
+step "s2-master_apply_delete_command_all_shard"
+{
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0$$);
+}
+
+step "s2-master_apply_delete_command_row"
+{
+   	SELECT master_apply_delete_command($$DELETE FROM table_to_delete_from WHERE id >= 0 and id < 3$$);
+}
+
+step "s2-commit"
+{
+	COMMIT;
+}
+
+#concurrent master_apply_delete_command vs master_apply_delete_command
+permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command_all_shard" "s2-master_apply_delete_command_all_shard" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command_all_shard" "s2-master_apply_delete_command_row" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command_row" "s2-master_apply_delete_command_all_shard" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s1-master_apply_delete_command_row" "s2-master_apply_delete_command_row" "s1-commit" "s2-commit"


### PR DESCRIPTION
This PR is created to increase the coverage of the isolation tests by adding some of the concurrency tests such as;
* Two multi-shard update commands affecting the same rows [ADDED]
    - Sequential mode
    - Parallel Mode
* Two multi-shard update commands affecting different rows [ADDED]
    - Sequential mode
    - Parallel Mode
* master_append_table_to_shard, master_append_table_to_shard [ADDED]
* master_append_table_to_shard, master_apply_delete_command  [HELP IS NEEDED]
    - master_append_table_to_shard first
    - master_apply_delete_command first
* master_apply_delete_command, master_apply_delete_command [ADDED]
* create_distributed_table, create_distributed_table [ADDED]
