### PR TITLE
Support immutable table functions as reference tables

### DIFF
--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -1314,6 +1314,12 @@ ContainsUnionSubquery(Query *queryTree)
 		return false;
 	}
 
+	/* subquery without FROM */
+	if (joiningRangeTableCount == 0)
+	{
+		return false;
+	}
+
 	subqueryRteIndex = linitial_int(joinTreeTableIndexList);
 	rangeTableEntry = rt_fetch(subqueryRteIndex, rangeTableList);
 	if (rangeTableEntry->rtekind != RTE_SUBQUERY)

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -210,8 +210,6 @@ extern List * TableEntryList(List *rangeTableList);
 extern List * UsedTableEntryList(Query *query);
 extern bool ExtractRangeTableRelationWalker(Node *node, List **rangeTableList);
 extern bool ExtractRangeTableEntryWalker(Node *node, List **rangeTableList);
-extern bool ExtractRangeTableRelationWalkerWithRTEExpand(Node *node,
-														 List **rangeTableList);
 extern List * pull_var_clause_default(Node *node);
 extern bool OperatorImplementsEquality(Oid opno);
 

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -287,7 +287,6 @@ extern Const * MakeInt4Constant(Datum constantValue);
 extern int CompareShardPlacements(const void *leftElement, const void *rightElement);
 extern bool ShardIntervalsOverlap(ShardInterval *firstInterval,
 								  ShardInterval *secondInterval);
-extern bool HasReferenceTable(Node *node);
 
 /* function declarations for Task and Task list operations */
 extern bool TasksEqual(const Task *a, const Task *b);

--- a/src/test/regress/expected/multi_insert_select_non_pushable_queries.out
+++ b/src/test/regress/expected/multi_insert_select_non_pushable_queries.out
@@ -694,7 +694,7 @@ FROM (
         users_table.value_1 > 10 AND users_table.value_1 < 12
         ) u LEFT JOIN LATERAL (
           SELECT event_type, time
-          FROM events_table, (SELECT 1 as x) as f
+          FROM events_table, (SELECT random()::int as x) as f
           WHERE user_id = u.user_id AND
           events_table.event_type > 10 AND events_table.event_type < 12
         ) t ON true
@@ -702,4 +702,4 @@ FROM (
 ) AS shard_union
 ORDER BY user_lastseen DESC;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause can only contain immutable functions

--- a/src/test/regress/expected/multi_subquery.out
+++ b/src/test/regress/expected/multi_subquery.out
@@ -71,6 +71,12 @@ FROM
 		l_orderkey) AS unit_prices;
 ERROR:  cannot pushdown the subquery since all relations are not joined using distribution keys
 DETAIL:  Each relation should be joined with at least one another relation using distribution keys and equality operator.
+-- Subqueries without relation with a volatile functions (non-constant)
+SELECT count(*) FROM (
+   SELECT l_orderkey FROM lineitem_subquery JOIN (SELECT random()::int r) sub ON (l_orderkey = r)
+) b;
+ERROR:  cannot push down this subquery
+DETAIL:  Subqueries without a FROM clause can only contain immutable functions
 -- Check that we error out if there is non relation subqueries
 SELECT count(*) FROM
 (
@@ -78,7 +84,7 @@ SELECT count(*) FROM
    (SELECT 1::bigint)
 ) b;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 -- Check that we error out if queries in union do not include partition columns.
 SELECT count(*) FROM
 (

--- a/src/test/regress/expected/multi_subquery_behavioral_analytics.out
+++ b/src/test/regress/expected/multi_subquery_behavioral_analytics.out
@@ -1803,7 +1803,7 @@ ORDER BY 1,2;
 (2 rows)
 
 DROP FUNCTION array_index(ANYARRAY, ANYELEMENT);
--- a not supported query due to constant range table entry
+-- a query with a constant subquery
 SELECT count(*) as subquery_count
 FROM (
   SELECT 
@@ -1822,9 +1822,12 @@ FROM (
   ON a.user_id = b.user_id 
 WHERE b.user_id IS NULL
 GROUP BY a.user_id;
-ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
--- same with INNER JOIN
+ subquery_count 
+----------------
+              1
+(1 row)
+
+-- volatile function in the subquery
 SELECT count(*) as subquery_count
 FROM (
   SELECT 
@@ -1838,13 +1841,13 @@ FROM (
   ) as a
   INNER JOIN (
   SELECT
-    1 as user_id
+    random()::int as user_id
   ) AS b 
   ON a.user_id = b.user_id 
 WHERE b.user_id IS NULL
 GROUP BY a.user_id;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause can only contain immutable functions
 -- this is slightly different, we use RTE_VALUEs here
 SELECT Count(*) AS subquery_count 
 FROM (SELECT 
@@ -1866,7 +1869,7 @@ FROM (SELECT
 WHERE b.user_id IS NULL 
 GROUP BY a.user_id;  
 ERROR:  cannot push down this subquery
-DETAIL:  Table expressions other than simple relations and subqueries are currently unsupported
+DETAIL:  VALUES in multi-shard queries is currently unsupported
 -- same query without LIMIT/OFFSET returns 30 rows
 SET client_min_messages TO DEBUG1;
 -- now, lets use a simple expression on the LIMIT and explicit coercion on the OFFSET

--- a/src/test/regress/expected/multi_subquery_complex_queries.out
+++ b/src/test/regress/expected/multi_subquery_complex_queries.out
@@ -2440,7 +2440,7 @@ GROUP BY
 ORDER BY 
   types;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 -- similar to the above, but constant rte is on the right side of the query
 SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
 FROM
@@ -2495,5 +2495,5 @@ GROUP BY
 ORDER BY 
   types;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 SET citus.enable_router_execution TO TRUE;

--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -228,6 +228,91 @@ FROM
       97 | 71002659
 (10 rows)
 
+-- table function can be the inner relationship in a join
+SELECT count(*) FROM
+  (SELECT random() FROM user_buy_test_table JOIN generate_series(1,10) AS users_ref_test_table(id)
+  ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ count 
+-------
+    10
+(1 row)
+
+-- table function cannot be used without subquery pushdown
+SELECT count(*) FROM user_buy_test_table JOIN generate_series(1,10) AS users_ref_test_table(id)
+  ON user_buy_test_table.item_id = users_ref_test_table.id;
+ERROR:  could not run distributed query with complex table expressions
+HINT:  Consider using an equality filter on the distributed table's partition column.
+-- table function can be the inner relationship in an outer join
+SELECT count(*) FROM
+  (SELECT random() FROM user_buy_test_table LEFT JOIN generate_series(1,10) AS users_ref_test_table(id)
+  ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ count 
+-------
+    10
+(1 row)
+
+-- table function cannot be the outer relationship in an outer join
+SELECT count(*) FROM
+  (SELECT random() FROM user_buy_test_table RIGHT JOIN generate_series(1,10) AS users_ref_test_table(id)
+  ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a table function in the outer part of the outer join
+-- volatile functions cannot be used as table expressions
+SELECT count(*) FROM
+  (SELECT random() FROM user_buy_test_table JOIN random() AS users_ref_test_table(id)
+  ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ERROR:  cannot push down this subquery
+DETAIL:  Only immutable functions can be used as a table expressions in a multi-shard query
+-- cannot sneak in a volatile function as a parameter
+SELECT count(*) FROM
+  (SELECT random() FROM user_buy_test_table JOIN generate_series(random()::int,10) AS users_ref_test_table(id)
+  ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ERROR:  cannot push down this subquery
+DETAIL:  Only immutable functions can be used as a table expressions in a multi-shard query
+-- cannot perform a union with table function
+SELECT count(*) FROM
+  (SELECT user_id FROM user_buy_test_table
+   UNION ALL
+   SELECT id FROM generate_series(1,10) AS users_ref_test_table(id)) subquery_1;
+ERROR:  cannot push down this subquery
+DETAIL:  Table functions are not supported with union operator
+-- subquery without FROM can be the inner relationship in a join
+SELECT count(*) FROM
+  (SELECT random() FROM user_buy_test_table JOIN (SELECT 4 AS id) users_ref_test_table
+  ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ count 
+-------
+     1
+(1 row)
+
+-- subquery without FROM triggers subquery pushdown
+SELECT count(*) FROM user_buy_test_table JOIN (SELECT 5 AS id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
+ count 
+-------
+     1
+(1 row)
+
+-- subquery without FROM can be the inner relationship in an outer join
+SELECT count(*) FROM user_buy_test_table LEFT JOIN (SELECT 5 AS id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
+ count 
+-------
+     4
+(1 row)
+
+-- subquery without FROM cannot be the outer relationship in an outer join
+SELECT count(*) FROM user_buy_test_table RIGHT JOIN (SELECT 5 AS id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a subquery without FROM in the outer part of the outer join
+-- cannot perform a union with subquery without FROM
+SELECT count(*) FROM
+  (SELECT user_id FROM user_buy_test_table
+   UNION ALL
+   SELECT id FROM (SELECT 5 AS id) users_ref_test_table) subquery_1;
+ERROR:  cannot push down this subquery
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 -- should be able to pushdown since reference table is in the
 -- inner part of the left join
 SELECT

--- a/src/test/regress/expected/multi_subquery_in_where_clause.out
+++ b/src/test/regress/expected/multi_subquery_in_where_clause.out
@@ -499,16 +499,34 @@ FROM (
 ORDER BY 2 DESC, 1;
 ERROR:  cannot pushdown the subquery since all relations are not joined using distribution keys
 DETAIL:  Each relation should be joined with at least one another relation using distribution keys and equality operator.
--- subquery in where clause doesn't have a relation
-SELECT 
+-- subquery in where clause doesn't have a relation, but is constant
+SELECT
   user_id
-FROM 
+FROM
   users_table
-WHERE 
-  value_2 >  
-          (SELECT 1);
+WHERE
+  value_2 >
+          (SELECT 1)
+ORDER BY 1 ASC
+LIMIT 2;
+ user_id 
+---------
+       0
+       0
+(2 rows)
+
+-- subquery in where clause has a volatile function and no relation
+SELECT
+  user_id
+FROM
+  users_table
+WHERE
+  value_2 >
+          (SELECT random())
+ORDER BY 1 ASC
+LIMIT 2;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause can only contain immutable functions
 -- OFFSET is not supported in the subquey
 SELECT 
   user_id

--- a/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
@@ -64,6 +64,40 @@ WHERE
 LIMIT 3;
 ERROR:  cannot pushdown the subquery
 DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
+-- immutable functions are also treated as reference tables
+SELECT
+  user_id
+FROM
+  (SELECT user_id FROM generate_series(1,10) AS series(user_id)) users_reference_table
+WHERE
+  NOT EXISTS
+      (SELECT
+          value_2
+       FROM
+          events_table
+       WHERE
+          users_reference_table.user_id = events_table.user_id
+      )
+LIMIT 3;
+ERROR:  cannot pushdown the subquery
+DETAIL:  Functions are not allowed in FROM clause when the query has subqueries in WHERE clause
+-- subqueries without FROM are also treated as reference tables
+SELECT
+  user_id
+FROM
+  (SELECT  5 AS user_id) users_reference_table
+WHERE
+  NOT EXISTS
+      (SELECT
+          value_2
+       FROM
+          events_table
+       WHERE
+          users_reference_table.user_id = events_table.user_id
+      )
+LIMIT 3;
+ERROR:  cannot pushdown the subquery
+DETAIL:  Subqueries without FROM are not allowed in FROM clause when the outer query has subqueries in WHERE clause
 -- subqueries in WHERE with IN operator without equality
 SELECT 
   users_table.user_id, count(*)
@@ -86,6 +120,54 @@ LIMIT 3;
       87 |   117
       59 |   115
       46 |   115
+(3 rows)
+
+-- immutable functions are also treated as reference tables
+SELECT
+  users_table.user_id, count(*)
+FROM
+  users_table
+WHERE
+  value_2 IN
+          (SELECT
+              value_2
+           FROM
+              generate_series(1,10) AS events_reference_table(user_id)
+           WHERE
+              users_table.user_id > events_reference_table.user_id
+          )
+GROUP BY users_table.user_id
+ORDER BY 2 DESC, 1 DESC
+LIMIT 3;
+ user_id | count 
+---------+-------
+      12 |   121
+      87 |   117
+      59 |   115
+(3 rows)
+
+-- immutable functions are also treated as reference tables
+SELECT
+  users_table.user_id, count(*)
+FROM
+  users_table
+WHERE
+  value_2 IN
+          (SELECT
+              value_2
+           FROM
+              (SELECT 5 AS user_id) AS events_reference_table
+           WHERE
+              users_table.user_id > events_reference_table.user_id
+          )
+GROUP BY users_table.user_id
+ORDER BY 2 DESC, 1 DESC
+LIMIT 3;
+ user_id | count 
+---------+-------
+      12 |   121
+      87 |   117
+      59 |   115
 (3 rows)
 
 -- should error out since reference table exist on the left side 

--- a/src/test/regress/expected/multi_subquery_union.out
+++ b/src/test/regress/expected/multi_subquery_union.out
@@ -914,7 +914,7 @@ FROM
   (SELECT 1)
 ) b;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 -- we don't support subqueries without relations
 SELECT 
   *
@@ -925,7 +925,7 @@ FROM
   (SELECT (random() * 100)::int)
 ) b;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 -- we don't support subqueries without relations
 SELECT 
   user_id, value_3
@@ -946,7 +946,7 @@ FROM
 ORDER BY 1 DESC, 2 DESC
 LIMIT 5;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
 FROM
   ( SELECT *, random()
@@ -990,7 +990,7 @@ FROM
 GROUP BY types
 ORDER BY types;
 ERROR:  cannot push down this subquery
-DETAIL:  Subqueries without relations are unsupported
+DETAIL:  Subqueries without a FROM clause are not supported with union operator
 SET citus.enable_router_execution TO true;
 DROP TABLE events_reference_table;
 DROP TABLE users_reference_table;

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -715,12 +715,12 @@ CREATE VIEW cte_view_1 AS
 WITH c1 AS (SELECT * FROM users_table WHERE value_1 = 15) SELECT * FROM c1 WHERE value_2 < 500;
 SELECT * FROM cte_view_1;
 ERROR:  cannot push down this subquery
-DETAIL:  Table expressions other than simple relations and subqueries are currently unsupported
+DETAIL:  CTEs in multi-shard queries are currently unsupported
 -- this is single shard query but still not supported since it has view + cte
 -- router planner can't detect it
 SELECT * FROM cte_view_1 WHERE user_id = 8;
 ERROR:  cannot push down this subquery
-DETAIL:  Table expressions other than simple relations and subqueries are currently unsupported
+DETAIL:  CTEs in multi-shard queries are currently unsupported
 -- if CTE itself prunes down to a single shard than the view is supported (router plannable)
 CREATE VIEW cte_view_2 AS
 WITH c1 AS (SELECT * FROM users_table WHERE user_id = 8) SELECT * FROM c1 WHERE value_1 = 15;

--- a/src/test/regress/sql/multi_insert_select_non_pushable_queries.sql
+++ b/src/test/regress/sql/multi_insert_select_non_pushable_queries.sql
@@ -681,7 +681,7 @@ FROM (
         users_table.value_1 > 10 AND users_table.value_1 < 12
         ) u LEFT JOIN LATERAL (
           SELECT event_type, time
-          FROM events_table, (SELECT 1 as x) as f
+          FROM events_table, (SELECT random()::int as x) as f
           WHERE user_id = u.user_id AND
           events_table.event_type > 10 AND events_table.event_type < 12
         ) t ON true

--- a/src/test/regress/sql/multi_subquery.sql
+++ b/src/test/regress/sql/multi_subquery.sql
@@ -70,6 +70,11 @@ FROM
 	GROUP BY
 		l_orderkey) AS unit_prices;
 
+-- Subqueries without relation with a volatile functions (non-constant)
+SELECT count(*) FROM (
+   SELECT l_orderkey FROM lineitem_subquery JOIN (SELECT random()::int r) sub ON (l_orderkey = r)
+) b;
+
 -- Check that we error out if there is non relation subqueries
 SELECT count(*) FROM
 (

--- a/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
+++ b/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
@@ -1432,7 +1432,7 @@ SELECT * FROM run_command_on_workers('DROP FUNCTION array_index(ANYARRAY, ANYELE
 ORDER BY 1,2;
 DROP FUNCTION array_index(ANYARRAY, ANYELEMENT);
 
--- a not supported query due to constant range table entry
+-- a query with a constant subquery
 SELECT count(*) as subquery_count
 FROM (
   SELECT 
@@ -1452,7 +1452,7 @@ FROM (
 WHERE b.user_id IS NULL
 GROUP BY a.user_id;
 
--- same with INNER JOIN
+-- volatile function in the subquery
 SELECT count(*) as subquery_count
 FROM (
   SELECT 
@@ -1466,7 +1466,7 @@ FROM (
   ) as a
   INNER JOIN (
   SELECT
-    1 as user_id
+    random()::int as user_id
   ) AS b 
   ON a.user_id = b.user_id 
 WHERE b.user_id IS NULL

--- a/src/test/regress/sql/multi_subquery_in_where_clause.sql
+++ b/src/test/regress/sql/multi_subquery_in_where_clause.sql
@@ -433,14 +433,27 @@ FROM (
 ) q
 ORDER BY 2 DESC, 1;
 
--- subquery in where clause doesn't have a relation
-SELECT 
+-- subquery in where clause doesn't have a relation, but is constant
+SELECT
   user_id
-FROM 
+FROM
   users_table
-WHERE 
-  value_2 >  
-          (SELECT 1);
+WHERE
+  value_2 >
+          (SELECT 1)
+ORDER BY 1 ASC
+LIMIT 2;
+
+-- subquery in where clause has a volatile function and no relation
+SELECT
+  user_id
+FROM
+  users_table
+WHERE
+  value_2 >
+          (SELECT random())
+ORDER BY 1 ASC
+LIMIT 2;
 
 -- OFFSET is not supported in the subquey
 SELECT 


### PR DESCRIPTION
This PR adds some infrastructure for supporting recursive planning (see #1804), namely to treat immutable table functions in the same way as reference tables within query pushdown, which also adds a tiny bit of SQL support.

Reference tables can be used in distributed (sub)queries with only a few restrictions: they cannot be on the outside of an outer join, in a union, or appear in the FROM clause by themselves when there is a subquery in the WHERE clause. This is because the tuples from the reference table would be repeated in the output of every shard query. When a reference table is (inner) joined with a distributed table, each shard query will return a different partition of the overall join result, so those are allowed.

The same rules apply to an immutable table function, which will return the same set of tuples for every shard query. We can further expand this with some other constructs, such as VALUES and subqueries without tables, but I don't have an immediate need for those yet.

The way this will be used in #1804 is that unsupported subqueries and CTEs will be replaced by an immutable function that reads intermediate results from a file, after which the query becomes plannable.

I'd like to improve the error messages as well (mainly, move errdetail in to errmsg), but that seems better left to a separate PR.