### PR TITLE
Don't spam the log with deadlock messages

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -63,7 +63,6 @@ void _PG_init(void);
 static void multi_log_hook(ErrorData *edata);
 static void CreateRequiredDirectories(void);
 static void RegisterCitusConfigVariables(void);
-static void WarningForEnableDeadlockPrevention(bool newval, void *extra);
 static bool ErrorIfNotASuitableDeadlockFactor(double *newval, void **extra,
 											  GucSource source);
 static void NormalizeWorkerListPath(void);
@@ -487,7 +486,7 @@ RegisterCitusConfigVariables(void)
 		true,
 		PGC_USERSET,
 		GUC_NO_SHOW_ALL,
-		NULL, WarningForEnableDeadlockPrevention, NULL);
+		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
 		"citus.enable_ddl_propagation",
@@ -919,18 +918,6 @@ RegisterCitusConfigVariables(void)
 
 	/* warn about config items in the citus namespace that are not registered above */
 	EmitWarningsOnPlaceholders("citus");
-}
-
-
-/*
- * Inform the users about the deprecated flag.
- */
-static void
-WarningForEnableDeadlockPrevention(bool newval, void *extra)
-{
-	ereport(WARNING, (errcode(ERRCODE_WARNING_DEPRECATED_FEATURE),
-					  errmsg("citus.enable_deadlock_prevention is deprecated and it has "
-							 "no effect. The flag will be removed in the next release.")));
 }
 
 


### PR DESCRIPTION
When building postgres you can pass a flag to configure: `'CFLAGS=-DEXEC_BACKEND'`, which emulates the Windows forking behavior. On `EXEC_BACKEND` builds of postgres we emit this deadlock detection message every time a new backend is started. It makes the logs pretty useless!