### PR TITLE
Reduce default shard count in regression tests to improve performance

### DIFF
--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -30,16 +30,16 @@ INSERT INTO products VALUES(1, 'product_1', 1);
 -- Should error out, since we are trying to add a new row having a value on p_key column
 -- conflicting with the existing row.
 INSERT INTO products VALUES(1, 'product_1', 1);
-ERROR:  duplicate key value violates unique constraint "p_key_1450001"
+ERROR:  duplicate key value violates unique constraint "p_key_1450000"
 DETAIL:  Key (product_no)=(1) already exists.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 ALTER TABLE products DROP CONSTRAINT p_key;
 INSERT INTO products VALUES(1, 'product_1', 1);
 -- Can not create constraint since it conflicts with the existing data
 ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(product_no);
-ERROR:  could not create unique index "p_key_1450001"
+ERROR:  could not create unique index "p_key_1450000"
 DETAIL:  Key (product_no)=(1) is duplicated.
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 DROP TABLE products;
 -- Check "PRIMARY KEY CONSTRAINT" with reference table
 CREATE TABLE products_ref (
@@ -61,7 +61,7 @@ INSERT INTO products_ref VALUES(1, 'product_1', 1);
 -- Should error out, since we are trying to add new row having a value on p_key column
 -- conflicting with the existing row.
 INSERT INTO products_ref VALUES(1, 'product_1', 1);
-ERROR:  duplicate key value violates unique constraint "p_key_1450032"
+ERROR:  duplicate key value violates unique constraint "p_key_1450004"
 DETAIL:  Key (product_no)=(1) already exists.
 CONTEXT:  while executing command on localhost:57637
 DROP TABLE products_ref;
@@ -92,7 +92,7 @@ DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-par
 HINT:  Consider using hash partitioning.
 --- Error out since first and third rows have the same product_no		
 \COPY products_append FROM STDIN DELIMITER AS ',';
-ERROR:  duplicate key value violates unique constraint "p_key_1450033"
+ERROR:  duplicate key value violates unique constraint "p_key_1450005"
 DETAIL:  Key (product_no)=(1) already exists.
 DROP TABLE products_append;
 -- Check "UNIQUE CONSTRAINT"
@@ -113,25 +113,25 @@ ALTER TABLE unique_test_table ADD CONSTRAINT unn_id UNIQUE(id);
 -- Error out, since table can not have two rows with same id.
 INSERT INTO unique_test_table VALUES(1, 'Ahmet');
 INSERT INTO unique_test_table VALUES(1, 'Mehmet');
-ERROR:  duplicate key value violates unique constraint "unn_id_1450035"
+ERROR:  duplicate key value violates unique constraint "unn_id_1450006"
 DETAIL:  Key (id)=(1) already exists.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 ALTER TABLE unique_test_table DROP CONSTRAINT unn_id;
 -- Insert row which will conflict with the next unique constraint command
 INSERT INTO unique_test_table VALUES(1, 'Mehmet');
 -- Can not create constraint since it conflicts with the existing data
 ALTER TABLE unique_test_table ADD CONSTRAINT unn_id UNIQUE(id);
-ERROR:  could not create unique index "unn_id_1450035"
+ERROR:  could not create unique index "unn_id_1450006"
 DETAIL:  Key (id)=(1) is duplicated.
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 -- Can create unique constraint over multiple columns which must include
 -- distribution column
 ALTER TABLE unique_test_table ADD CONSTRAINT unn_id_name UNIQUE(id, name);
 -- Error out, since tables can not have two rows with same id and name.
 INSERT INTO unique_test_table VALUES(1, 'Mehmet');
-ERROR:  duplicate key value violates unique constraint "unn_id_name_1450035"
+ERROR:  duplicate key value violates unique constraint "unn_id_name_1450006"
 DETAIL:  Key (id, name)=(1, Mehmet) already exists.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 DROP TABLE unique_test_table;
 -- Check "UNIQUE CONSTRAINT" with reference table
 CREATE TABLE unique_test_table_ref(id int, name varchar(20));
@@ -147,7 +147,7 @@ ALTER TABLE unique_test_table_ref ADD CONSTRAINT unn_id UNIQUE(id);
 -- Error out. Since the table can not have two rows with the same id. 
 INSERT INTO unique_test_table_ref VALUES(1, 'Ahmet');
 INSERT INTO unique_test_table_ref VALUES(1, 'Mehmet');
-ERROR:  duplicate key value violates unique constraint "unn_id_1450066"
+ERROR:  duplicate key value violates unique constraint "unn_id_1450010"
 DETAIL:  Key (id)=(1) already exists.
 CONTEXT:  while executing command on localhost:57637
 -- We can add unique constraint with multiple columns 
@@ -179,7 +179,7 @@ DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-par
 HINT:  Consider using hash partitioning.
 -- Error out. Table can not have two rows with the same id.		
 \COPY unique_test_table_append FROM STDIN DELIMITER AS ',';		
-ERROR:  duplicate key value violates unique constraint "unn_id_1450067"
+ERROR:  duplicate key value violates unique constraint "unn_id_1450011"
 DETAIL:  Key (id)=(1) already exists.
 DROP TABLE unique_test_table_append;
 -- Check "CHECK CONSTRAINT"
@@ -201,14 +201,14 @@ ALTER TABLE products ADD CONSTRAINT p_multi_check CHECK(price > discounted_price
 -- First and third queries will error out, because of conflicts with p_check and 
 -- p_multi_check, respectively.
 INSERT INTO products VALUES(1, 'product_1', -1, -2);
-ERROR:  new row for relation "products_1450069" violates check constraint "p_check_1450069"
+ERROR:  new row for relation "products_1450012" violates check constraint "p_check_1450012"
 DETAIL:  Failing row contains (1, product_1, -1, -2).
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 INSERT INTO products VALUES(1, 'product_1', 5, 3);
 INSERT INTO products VALUES(1, 'product_1', 2, 3);
-ERROR:  new row for relation "products_1450069" violates check constraint "p_multi_check_1450069"
+ERROR:  new row for relation "products_1450012" violates check constraint "p_multi_check_1450012"
 DETAIL:  Failing row contains (1, product_1, 2, 3).
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 DROP TABLE products;
 -- Check "CHECK CONSTRAINT" with reference table 
 CREATE TABLE products_ref (
@@ -229,12 +229,12 @@ ALTER TABLE products_ref ADD CONSTRAINT p_multi_check CHECK(price > discounted_p
 -- First and third queries will error out, because of conflicts with p_check and 
 -- p_multi_check, respectively.
 INSERT INTO products_ref VALUES(1, 'product_1', -1, -2);
-ERROR:  new row for relation "products_ref_1450100" violates check constraint "p_check_1450100"
+ERROR:  new row for relation "products_ref_1450016" violates check constraint "p_check_1450016"
 DETAIL:  Failing row contains (1, product_1, -1, -2).
 CONTEXT:  while executing command on localhost:57637
 INSERT INTO products_ref VALUES(1, 'product_1', 5, 3);
 INSERT INTO products_ref VALUES(1, 'product_1', 2, 3);
-ERROR:  new row for relation "products_ref_1450100" violates check constraint "p_multi_check_1450100"
+ERROR:  new row for relation "products_ref_1450016" violates check constraint "p_multi_check_1450016"
 DETAIL:  Failing row contains (1, product_1, 2, 3).
 CONTEXT:  while executing command on localhost:57637
 DROP TABLE products_ref;
@@ -256,7 +256,7 @@ ALTER TABLE products_append ADD CONSTRAINT p_check CHECK(price > 0);
 ALTER TABLE products_append ADD CONSTRAINT p_multi_check CHECK(price > discounted_price);
 -- Error out,since the third row conflicting with the p_multi_check
 \COPY products_append FROM STDIN DELIMITER AS ',';
-ERROR:  new row for relation "products_append_1450101" violates check constraint "p_multi_check"
+ERROR:  new row for relation "products_append_1450017" violates check constraint "p_multi_check"
 DETAIL:  Failing row contains (1,  Product_3, 8, 10).
 DROP TABLE products_append;
 -- Check "EXCLUSION CONSTRAINT"
@@ -284,9 +284,9 @@ INSERT INTO products VALUES(1,'product_1', 5);
 INSERT INTO products VALUES(1,'product_2', 10);
 INSERT INTO products VALUES(2,'product_2', 5);
 INSERT INTO products VALUES(2,'product_2', 5);
-ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450126"
+ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450021"
 DETAIL:  Key (product_no, name)=(2, product_2) conflicts with existing key (product_no, name)=(2, product_2).
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 DROP TABLE products;
 -- Check "EXCLUSION CONSTRAINT" with reference table
 CREATE TABLE products_ref (
@@ -308,7 +308,7 @@ ALTER TABLE products_ref ADD CONSTRAINT exc_pno_name EXCLUDE USING btree (produc
 INSERT INTO products_ref VALUES(1,'product_1', 5);
 INSERT INTO products_ref VALUES(1,'product_2', 10);
 INSERT INTO products_ref VALUES(2,'product_2', 5);
-ERROR:  conflicting key value violates exclusion constraint "exc_name_1450134"
+ERROR:  conflicting key value violates exclusion constraint "exc_name_1450022"
 DETAIL:  Key (name)=(product_2) conflicts with existing key (name)=(product_2).
 CONTEXT:  while executing command on localhost:57637
 DROP TABLE products_ref;
@@ -339,7 +339,7 @@ DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-par
 HINT:  Consider using hash partitioning.
 -- Error out since first and third can not pass the exclusion check.		
 \COPY products_append FROM STDIN DELIMITER AS ',';
-ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450135"
+ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450023"
 DETAIL:  Key (product_no, name)=(1,  Product_1) conflicts with existing key (product_no, name)=(1,  Product_1).
 DROP TABLE products_append;
 -- Check "NOT NULL"
@@ -359,7 +359,7 @@ ALTER TABLE products ALTER COLUMN name SET NOT NULL;
 INSERT INTO products VALUES(1,NULL,5);
 ERROR:  null value in column "name" violates not-null constraint
 DETAIL:  Failing row contains (1, null, 5).
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 INSERT INTO products VALUES(NULL,'product_1', 5);
 ERROR:  cannot perform an INSERT with NULL in the partition column
 DROP TABLE products;
@@ -459,7 +459,7 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regc
 (0 rows)
 
 \c - - - :worker_1_port
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
  Constraint | Definition 
 ------------+------------
 (0 rows)
@@ -481,7 +481,7 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regc
 (0 rows)
 
 \c - - - :worker_1_port
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
  Constraint | Definition 
 ------------+------------
 (0 rows)
@@ -516,8 +516,8 @@ ORDER BY
     1,2,3,4;
  nodename  | nodeport | success |        result        
 -----------+----------+---------+----------------------
- localhost |    57637 | t       | alter_pk_idx_1450234
- localhost |    57638 | t       | alter_pk_idx_1450234
+ localhost |    57637 | t       | alter_pk_idx_1450038
+ localhost |    57638 | t       | alter_pk_idx_1450038
 (2 rows)
 
 CREATE SCHEMA sc2;
@@ -549,8 +549,8 @@ ORDER BY
     1,2,3,4;
  nodename  | nodeport | success |        result        
 -----------+----------+---------+----------------------
- localhost |    57637 | t       | alter_pk_idx_1450236
- localhost |    57638 | t       | alter_pk_idx_1450236
+ localhost |    57637 | t       | alter_pk_idx_1450040
+ localhost |    57638 | t       | alter_pk_idx_1450040
 (2 rows)
 
 -- We are running almost the same test with a slight change on the constraint name because if the constraint has a different name than the index, Postgres renames the index.
@@ -584,8 +584,8 @@ ORDER BY
     1,2,3,4;
  nodename  | nodeport | success |        result        
 -----------+----------+---------+----------------------
- localhost |    57637 | t       | a_constraint_1450238
- localhost |    57638 | t       | a_constraint_1450238
+ localhost |    57637 | t       | a_constraint_1450042
+ localhost |    57638 | t       | a_constraint_1450042
 (2 rows)
 
 ALTER TABLE alter_add_prim_key DROP CONSTRAINT a_constraint;

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -413,7 +413,7 @@ WHERE
 	AND pg_dist_shard_placement.nodeport = :worker_2_port;
  count 
 -------
-    32
+     4
 (1 row)
 
 	

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -388,7 +388,7 @@ SELECT create_distributed_table('table2_groupC', 'id');
 (1 row)
 
 -- change shard count
-SET citus.shard_count = 4;
+SET citus.shard_count = 8;
 CREATE TABLE table1_groupD ( id int );
 SELECT create_distributed_table('table1_groupD', 'id');
  create_distributed_table 
@@ -433,11 +433,11 @@ SELECT * FROM pg_dist_colocation
     ORDER BY colocationid;
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-            3 |         32 |                 2 |                     23
+            3 |          4 |                 2 |                     23
             4 |          2 |                 2 |                     23
             5 |          2 |                 1 |                     23
             6 |          2 |                 2 |                     25
-            7 |          4 |                 2 |                     23
+            7 |          8 |                 2 |                     23
 (5 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
@@ -557,11 +557,11 @@ SELECT * FROM pg_dist_colocation
     ORDER BY colocationid;
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-            3 |         32 |                 2 |                     23
+            3 |          4 |                 2 |                     23
             4 |          2 |                 2 |                     23
             5 |          2 |                 1 |                     23
             6 |          2 |                 2 |                     25
-            7 |          4 |                 2 |                     23
+            7 |          8 |                 2 |                     23
            11 |          3 |                 2 |                     23
 (6 rows)
 
@@ -617,21 +617,21 @@ ERROR:  cannot colocate tables table1_groupe and table_bigint
 DETAIL:  Distribution column types don't match for table1_groupe and table_bigint.
 -- check worker table schemas
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.table3_groupE_1300050'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.table3_groupE_1300062'::regclass;
     Column    |  Type   | Modifiers 
 --------------+---------+-----------
  dummy_column | text    | 
  id           | integer | 
 (2 rows)
 
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='schema_collocation.table4_groupE_1300052'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='schema_collocation.table4_groupE_1300064'::regclass;
  Column |  Type   | Modifiers 
 --------+---------+-----------
  id     | integer | 
 (1 row)
 
 \c - - - :master_port
-SET citus.next_shard_id TO 1300068;
+SET citus.next_shard_id TO 1300080;
 CREATE TABLE table1_groupF ( id int );
 SELECT create_reference_table('table1_groupF');
  create_reference_table 
@@ -652,11 +652,11 @@ SELECT * FROM pg_dist_colocation
     ORDER BY colocationid;
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-            3 |         32 |                 2 |                     23
+            3 |          4 |                 2 |                     23
             4 |          2 |                 2 |                     23
             5 |          2 |                 1 |                     23
             6 |          2 |                 2 |                     25
-            7 |          4 |                 2 |                     23
+            7 |          8 |                 2 |                     23
            11 |          3 |                 2 |                     23
 (6 rows)
 
@@ -731,79 +731,103 @@ ORDER BY
  table2_groupc                    | 1300032 | t            |    57637 | -2147483648   | -1
  table2_groupc                    | 1300033 | t            |    57637 | 0             | 2147483647
  table2_groupc                    | 1300033 | t            |    57638 | 0             | 2147483647
- table1_groupd                    | 1300034 | t            |    57637 | -2147483648   | -1073741825
- table1_groupd                    | 1300034 | t            |    57638 | -2147483648   | -1073741825
- table1_groupd                    | 1300035 | t            |    57638 | -1073741824   | -1
- table1_groupd                    | 1300035 | t            |    57637 | -1073741824   | -1
- table1_groupd                    | 1300036 | t            |    57637 | 0             | 1073741823
- table1_groupd                    | 1300036 | t            |    57638 | 0             | 1073741823
- table1_groupd                    | 1300037 | t            |    57638 | 1073741824    | 2147483647
- table1_groupd                    | 1300037 | t            |    57637 | 1073741824    | 2147483647
- table2_groupd                    | 1300038 | t            |    57638 | -2147483648   | -1073741825
- table2_groupd                    | 1300038 | t            |    57637 | -2147483648   | -1073741825
- table2_groupd                    | 1300039 | t            |    57637 | -1073741824   | -1
- table2_groupd                    | 1300039 | t            |    57638 | -1073741824   | -1
- table2_groupd                    | 1300040 | t            |    57638 | 0             | 1073741823
- table2_groupd                    | 1300040 | t            |    57637 | 0             | 1073741823
- table2_groupd                    | 1300041 | t            |    57637 | 1073741824    | 2147483647
- table2_groupd                    | 1300041 | t            |    57638 | 1073741824    | 2147483647
- table3_groupd                    | 1300042 | f            |    57637 | -2147483648   | -1073741825
- table3_groupd                    | 1300042 | f            |    57638 | -2147483648   | -1073741825
- table3_groupd                    | 1300043 | f            |    57638 | -1073741824   | -1
- table3_groupd                    | 1300043 | f            |    57637 | -1073741824   | -1
- table3_groupd                    | 1300044 | f            |    57637 | 0             | 1073741823
- table3_groupd                    | 1300044 | f            |    57638 | 0             | 1073741823
- table3_groupd                    | 1300045 | f            |    57638 | 1073741824    | 2147483647
- table3_groupd                    | 1300045 | f            |    57637 | 1073741824    | 2147483647
- table1_groupe                    | 1300046 | t            |    57637 | -2147483648   | -1
- table1_groupe                    | 1300046 | t            |    57638 | -2147483648   | -1
- table1_groupe                    | 1300047 | t            |    57638 | 0             | 2147483647
- table1_groupe                    | 1300047 | t            |    57637 | 0             | 2147483647
- table2_groupe                    | 1300048 | t            |    57638 | -2147483648   | -1
- table2_groupe                    | 1300048 | t            |    57637 | -2147483648   | -1
- table2_groupe                    | 1300049 | t            |    57637 | 0             | 2147483647
- table2_groupe                    | 1300049 | t            |    57638 | 0             | 2147483647
- table3_groupe                    | 1300050 | t            |    57637 | -2147483648   | -1
- table3_groupe                    | 1300050 | t            |    57638 | -2147483648   | -1
- table3_groupe                    | 1300051 | t            |    57638 | 0             | 2147483647
- table3_groupe                    | 1300051 | t            |    57637 | 0             | 2147483647
- schema_collocation.table4_groupe | 1300052 | t            |    57638 | -2147483648   | -1
- schema_collocation.table4_groupe | 1300052 | t            |    57637 | -2147483648   | -1
- schema_collocation.table4_groupe | 1300053 | t            |    57637 | 0             | 2147483647
- schema_collocation.table4_groupe | 1300053 | t            |    57638 | 0             | 2147483647
- table1_group_none_1              | 1300054 | t            |    57637 | -2147483648   | -1
- table1_group_none_1              | 1300054 | t            |    57638 | -2147483648   | -1
- table1_group_none_1              | 1300055 | t            |    57638 | 0             | 2147483647
- table1_group_none_1              | 1300055 | t            |    57637 | 0             | 2147483647
- table2_group_none_1              | 1300056 | t            |    57638 | -2147483648   | -1
- table2_group_none_1              | 1300056 | t            |    57637 | -2147483648   | -1
- table2_group_none_1              | 1300057 | t            |    57637 | 0             | 2147483647
- table2_group_none_1              | 1300057 | t            |    57638 | 0             | 2147483647
- table1_group_none_2              | 1300058 | t            |    57637 | -2147483648   | -1
- table1_group_none_2              | 1300058 | t            |    57638 | -2147483648   | -1
- table1_group_none_2              | 1300059 | t            |    57638 | 0             | 2147483647
- table1_group_none_2              | 1300059 | t            |    57637 | 0             | 2147483647
- table4_groupe                    | 1300060 | t            |    57637 | -2147483648   | -1
- table4_groupe                    | 1300060 | t            |    57638 | -2147483648   | -1
- table4_groupe                    | 1300061 | t            |    57638 | 0             | 2147483647
- table4_groupe                    | 1300061 | t            |    57637 | 0             | 2147483647
- table1_group_none_3              | 1300062 | t            |    57637 | -2147483648   | -715827884
- table1_group_none_3              | 1300062 | t            |    57638 | -2147483648   | -715827884
- table1_group_none_3              | 1300063 | t            |    57638 | -715827883    | 715827881
- table1_group_none_3              | 1300063 | t            |    57637 | -715827883    | 715827881
- table1_group_none_3              | 1300064 | t            |    57637 | 715827882     | 2147483647
- table1_group_none_3              | 1300064 | t            |    57638 | 715827882     | 2147483647
- table1_group_default             | 1300065 | t            |    57637 | -2147483648   | -715827884
- table1_group_default             | 1300065 | t            |    57638 | -2147483648   | -715827884
- table1_group_default             | 1300066 | t            |    57638 | -715827883    | 715827881
- table1_group_default             | 1300066 | t            |    57637 | -715827883    | 715827881
- table1_group_default             | 1300067 | t            |    57637 | 715827882     | 2147483647
- table1_group_default             | 1300067 | t            |    57638 | 715827882     | 2147483647
- table1_groupf                    | 1300068 | t            |    57637 |               | 
- table1_groupf                    | 1300068 | t            |    57638 |               | 
- table2_groupf                    | 1300069 | t            |    57637 |               | 
- table2_groupf                    | 1300069 | t            |    57638 |               | 
-(84 rows)
+ table1_groupd                    | 1300034 | t            |    57637 | -2147483648   | -1610612737
+ table1_groupd                    | 1300034 | t            |    57638 | -2147483648   | -1610612737
+ table1_groupd                    | 1300035 | t            |    57638 | -1610612736   | -1073741825
+ table1_groupd                    | 1300035 | t            |    57637 | -1610612736   | -1073741825
+ table1_groupd                    | 1300036 | t            |    57637 | -1073741824   | -536870913
+ table1_groupd                    | 1300036 | t            |    57638 | -1073741824   | -536870913
+ table1_groupd                    | 1300037 | t            |    57638 | -536870912    | -1
+ table1_groupd                    | 1300037 | t            |    57637 | -536870912    | -1
+ table1_groupd                    | 1300038 | t            |    57637 | 0             | 536870911
+ table1_groupd                    | 1300038 | t            |    57638 | 0             | 536870911
+ table1_groupd                    | 1300039 | t            |    57638 | 536870912     | 1073741823
+ table1_groupd                    | 1300039 | t            |    57637 | 536870912     | 1073741823
+ table1_groupd                    | 1300040 | t            |    57637 | 1073741824    | 1610612735
+ table1_groupd                    | 1300040 | t            |    57638 | 1073741824    | 1610612735
+ table1_groupd                    | 1300041 | t            |    57638 | 1610612736    | 2147483647
+ table1_groupd                    | 1300041 | t            |    57637 | 1610612736    | 2147483647
+ table2_groupd                    | 1300042 | t            |    57638 | -2147483648   | -1610612737
+ table2_groupd                    | 1300042 | t            |    57637 | -2147483648   | -1610612737
+ table2_groupd                    | 1300043 | t            |    57637 | -1610612736   | -1073741825
+ table2_groupd                    | 1300043 | t            |    57638 | -1610612736   | -1073741825
+ table2_groupd                    | 1300044 | t            |    57638 | -1073741824   | -536870913
+ table2_groupd                    | 1300044 | t            |    57637 | -1073741824   | -536870913
+ table2_groupd                    | 1300045 | t            |    57637 | -536870912    | -1
+ table2_groupd                    | 1300045 | t            |    57638 | -536870912    | -1
+ table2_groupd                    | 1300046 | t            |    57638 | 0             | 536870911
+ table2_groupd                    | 1300046 | t            |    57637 | 0             | 536870911
+ table2_groupd                    | 1300047 | t            |    57637 | 536870912     | 1073741823
+ table2_groupd                    | 1300047 | t            |    57638 | 536870912     | 1073741823
+ table2_groupd                    | 1300048 | t            |    57638 | 1073741824    | 1610612735
+ table2_groupd                    | 1300048 | t            |    57637 | 1073741824    | 1610612735
+ table2_groupd                    | 1300049 | t            |    57637 | 1610612736    | 2147483647
+ table2_groupd                    | 1300049 | t            |    57638 | 1610612736    | 2147483647
+ table3_groupd                    | 1300050 | f            |    57637 | -2147483648   | -1610612737
+ table3_groupd                    | 1300050 | f            |    57638 | -2147483648   | -1610612737
+ table3_groupd                    | 1300051 | f            |    57638 | -1610612736   | -1073741825
+ table3_groupd                    | 1300051 | f            |    57637 | -1610612736   | -1073741825
+ table3_groupd                    | 1300052 | f            |    57637 | -1073741824   | -536870913
+ table3_groupd                    | 1300052 | f            |    57638 | -1073741824   | -536870913
+ table3_groupd                    | 1300053 | f            |    57638 | -536870912    | -1
+ table3_groupd                    | 1300053 | f            |    57637 | -536870912    | -1
+ table3_groupd                    | 1300054 | f            |    57637 | 0             | 536870911
+ table3_groupd                    | 1300054 | f            |    57638 | 0             | 536870911
+ table3_groupd                    | 1300055 | f            |    57638 | 536870912     | 1073741823
+ table3_groupd                    | 1300055 | f            |    57637 | 536870912     | 1073741823
+ table3_groupd                    | 1300056 | f            |    57637 | 1073741824    | 1610612735
+ table3_groupd                    | 1300056 | f            |    57638 | 1073741824    | 1610612735
+ table3_groupd                    | 1300057 | f            |    57638 | 1610612736    | 2147483647
+ table3_groupd                    | 1300057 | f            |    57637 | 1610612736    | 2147483647
+ table1_groupe                    | 1300058 | t            |    57637 | -2147483648   | -1
+ table1_groupe                    | 1300058 | t            |    57638 | -2147483648   | -1
+ table1_groupe                    | 1300059 | t            |    57638 | 0             | 2147483647
+ table1_groupe                    | 1300059 | t            |    57637 | 0             | 2147483647
+ table2_groupe                    | 1300060 | t            |    57638 | -2147483648   | -1
+ table2_groupe                    | 1300060 | t            |    57637 | -2147483648   | -1
+ table2_groupe                    | 1300061 | t            |    57637 | 0             | 2147483647
+ table2_groupe                    | 1300061 | t            |    57638 | 0             | 2147483647
+ table3_groupe                    | 1300062 | t            |    57637 | -2147483648   | -1
+ table3_groupe                    | 1300062 | t            |    57638 | -2147483648   | -1
+ table3_groupe                    | 1300063 | t            |    57638 | 0             | 2147483647
+ table3_groupe                    | 1300063 | t            |    57637 | 0             | 2147483647
+ schema_collocation.table4_groupe | 1300064 | t            |    57638 | -2147483648   | -1
+ schema_collocation.table4_groupe | 1300064 | t            |    57637 | -2147483648   | -1
+ schema_collocation.table4_groupe | 1300065 | t            |    57637 | 0             | 2147483647
+ schema_collocation.table4_groupe | 1300065 | t            |    57638 | 0             | 2147483647
+ table1_group_none_1              | 1300066 | t            |    57637 | -2147483648   | -1
+ table1_group_none_1              | 1300066 | t            |    57638 | -2147483648   | -1
+ table1_group_none_1              | 1300067 | t            |    57638 | 0             | 2147483647
+ table1_group_none_1              | 1300067 | t            |    57637 | 0             | 2147483647
+ table2_group_none_1              | 1300068 | t            |    57638 | -2147483648   | -1
+ table2_group_none_1              | 1300068 | t            |    57637 | -2147483648   | -1
+ table2_group_none_1              | 1300069 | t            |    57637 | 0             | 2147483647
+ table2_group_none_1              | 1300069 | t            |    57638 | 0             | 2147483647
+ table1_group_none_2              | 1300070 | t            |    57637 | -2147483648   | -1
+ table1_group_none_2              | 1300070 | t            |    57638 | -2147483648   | -1
+ table1_group_none_2              | 1300071 | t            |    57638 | 0             | 2147483647
+ table1_group_none_2              | 1300071 | t            |    57637 | 0             | 2147483647
+ table4_groupe                    | 1300072 | t            |    57637 | -2147483648   | -1
+ table4_groupe                    | 1300072 | t            |    57638 | -2147483648   | -1
+ table4_groupe                    | 1300073 | t            |    57638 | 0             | 2147483647
+ table4_groupe                    | 1300073 | t            |    57637 | 0             | 2147483647
+ table1_group_none_3              | 1300074 | t            |    57637 | -2147483648   | -715827884
+ table1_group_none_3              | 1300074 | t            |    57638 | -2147483648   | -715827884
+ table1_group_none_3              | 1300075 | t            |    57638 | -715827883    | 715827881
+ table1_group_none_3              | 1300075 | t            |    57637 | -715827883    | 715827881
+ table1_group_none_3              | 1300076 | t            |    57637 | 715827882     | 2147483647
+ table1_group_none_3              | 1300076 | t            |    57638 | 715827882     | 2147483647
+ table1_group_default             | 1300077 | t            |    57637 | -2147483648   | -715827884
+ table1_group_default             | 1300077 | t            |    57638 | -2147483648   | -715827884
+ table1_group_default             | 1300078 | t            |    57638 | -715827883    | 715827881
+ table1_group_default             | 1300078 | t            |    57637 | -715827883    | 715827881
+ table1_group_default             | 1300079 | t            |    57637 | 715827882     | 2147483647
+ table1_group_default             | 1300079 | t            |    57638 | 715827882     | 2147483647
+ table1_groupf                    | 1300080 | t            |    57637 |               | 
+ table1_groupf                    | 1300080 | t            |    57638 |               | 
+ table2_groupf                    | 1300081 | t            |    57637 |               | 
+ table2_groupf                    | 1300081 | t            |    57638 |               | 
+(108 rows)
 
 -- reset colocation ids to test mark_tables_colocated
 ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1;
@@ -835,7 +859,7 @@ ERROR:  cannot colocate tables table1_groupb and table1_groupd
 DETAIL:  Shard counts don't match for table1_groupb and table1_groupd.
 SELECT mark_tables_colocated('table1_groupB', ARRAY['table1_groupE']);
 ERROR:  cannot colocate tables table1_groupb and table1_groupe
-DETAIL:  Shard 1300026 of table1_groupb and shard 1300046 of table1_groupe have different number of shard placements.
+DETAIL:  Shard 1300026 of table1_groupb and shard 1300058 of table1_groupe have different number of shard placements.
 SELECT mark_tables_colocated('table1_groupB', ARRAY['table1_groupF']);
 ERROR:  cannot colocate tables table1_groupb and table1_groupf
 DETAIL:  Replication models don't match for table1_groupb and table1_groupf.
@@ -918,7 +942,7 @@ SELECT * FROM pg_dist_colocation
 --------------+------------+-------------------+------------------------
             2 |          2 |                 1 |                     23
             3 |          2 |                 2 |                     25
-            4 |          4 |                 2 |                     23
+            4 |          8 |                 2 |                     23
             5 |          2 |                 2 |                     23
 (4 rows)
 
@@ -962,7 +986,7 @@ SELECT * FROM pg_dist_colocation
 --------------+------------+-------------------+------------------------
             2 |          2 |                 1 |                     23
             3 |          2 |                 2 |                     25
-            4 |          4 |                 2 |                     23
+            4 |          8 |                 2 |                     23
 (3 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -700,13 +700,13 @@ INSERT INTO tt2 SELECT * FROM tt1 WHERE id = 1;
 COMMIT;
 -- Table should exist on the worker node
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360430'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360066'::regclass;
  Column |  Type   | Modifiers 
 --------+---------+-----------
  id     | integer | 
 (1 row)
 
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt2_360462'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt2_360070'::regclass;
  Column |  Type   | Modifiers 
 --------+---------+-----------
  id     | integer | 
@@ -728,13 +728,13 @@ SELECT create_distributed_table('append_tt1','id','append');
 SELECT master_create_empty_shard('append_tt1');
  master_create_empty_shard 
 ---------------------------
-                    360494
+                    360074
 (1 row)
 
 ROLLBACK;
 -- Table exists on the worker node.
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.append_tt1_360494'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.append_tt1_360074'::regclass;
  Column |  Type   | Modifiers 
 --------+---------+-----------
  id     | integer | 
@@ -771,7 +771,7 @@ SELECT * FROM tt1 WHERE id = 1;
 COMMIT;
 -- Placements should be created on the worker
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360495'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360075'::regclass;
  Column |  Type   | Modifiers 
 --------+---------+-----------
  id     | integer | 

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -757,20 +757,20 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_hash_part_360290 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360038 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_hash_part_360291 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360291 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360039 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360039 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_hash_part_360292 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360292 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360040 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360040 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_hash_part_360293 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360293 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
 	
 EXPLAIN (COSTS FALSE)
 	UPDATE lineitem_hash_part
@@ -781,13 +781,13 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_hash_part_360290 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360038 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                     Filter: ((l_orderkey = 1) OR (l_orderkey = 3))
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_hash_part_360291 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360291 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360039 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360039 lineitem_hash_part
                     Filter: ((l_orderkey = 1) OR (l_orderkey = 3))
 -- Test multi shard delete
 EXPLAIN (COSTS FALSE)
@@ -797,20 +797,20 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Delete on lineitem_hash_part_360290 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360038 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Delete on lineitem_hash_part_360291 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360291 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360039 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360039 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Delete on lineitem_hash_part_360292 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360292 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360040 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360040 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Delete on lineitem_hash_part_360293 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360293 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
 -- Test track tracker
 SET citus.task_executor_type TO 'task-tracker';
 SET citus.explain_all_tasks TO off;
@@ -1072,7 +1072,7 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
               ->  Task
                     Node: host=localhost port=57637 dbname=regression
                     ->  Limit
-                          ->  Seq Scan on orders_hash_part_360295 orders_hash_part
+                          ->  Seq Scan on orders_hash_part_360043 orders_hash_part
 SELECT true AS valid FROM explain_json($$
   INSERT INTO lineitem_hash_part (l_orderkey)
   SELECT o_orderkey FROM orders_hash_part LIMIT 3;
@@ -1089,7 +1089,7 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
               ->  Task
                     Node: host=localhost port=57637 dbname=regression
                     ->  Limit
-                          ->  Seq Scan on orders_hash_part_360295 orders_hash_part
+                          ->  Seq Scan on orders_hash_part_360043 orders_hash_part
 EXPLAIN (COSTS OFF)
 INSERT INTO lineitem_hash_part (l_orderkey)
 SELECT s FROM generate_series(1,5) s;

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -757,20 +757,20 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_hash_part_360290 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360038 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_hash_part_360291 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360291 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360039 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360039 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_hash_part_360292 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360292 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360040 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360040 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_hash_part_360293 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360293 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
 	
 EXPLAIN (COSTS FALSE)
 	UPDATE lineitem_hash_part
@@ -781,13 +781,13 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Update on lineitem_hash_part_360290 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360038 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                     Filter: ((l_orderkey = 1) OR (l_orderkey = 3))
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Update on lineitem_hash_part_360291 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360291 lineitem_hash_part
+        ->  Update on lineitem_hash_part_360039 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360039 lineitem_hash_part
                     Filter: ((l_orderkey = 1) OR (l_orderkey = 3))
 -- Test multi shard delete
 EXPLAIN (COSTS FALSE)
@@ -797,20 +797,20 @@ Custom Scan (Citus Router)
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Delete on lineitem_hash_part_360290 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360038 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Delete on lineitem_hash_part_360291 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360291 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360039 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360039 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57637 dbname=regression
-        ->  Delete on lineitem_hash_part_360292 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360292 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360040 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360040 lineitem_hash_part
   ->  Task
         Node: host=localhost port=57638 dbname=regression
-        ->  Delete on lineitem_hash_part_360293 lineitem_hash_part
-              ->  Seq Scan on lineitem_hash_part_360293 lineitem_hash_part
+        ->  Delete on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
 -- Test track tracker
 SET citus.task_executor_type TO 'task-tracker';
 SET citus.explain_all_tasks TO off;
@@ -1072,7 +1072,7 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
               ->  Task
                     Node: host=localhost port=57637 dbname=regression
                     ->  Limit
-                          ->  Seq Scan on orders_hash_part_360295 orders_hash_part
+                          ->  Seq Scan on orders_hash_part_360043 orders_hash_part
 SELECT true AS valid FROM explain_json($$
   INSERT INTO lineitem_hash_part (l_orderkey)
   SELECT o_orderkey FROM orders_hash_part LIMIT 3;
@@ -1089,7 +1089,7 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
               ->  Task
                     Node: host=localhost port=57637 dbname=regression
                     ->  Limit
-                          ->  Seq Scan on orders_hash_part_360295 orders_hash_part
+                          ->  Seq Scan on orders_hash_part_360043 orders_hash_part
 EXPLAIN (COSTS OFF)
 INSERT INTO lineitem_hash_part (l_orderkey)
 SELECT s FROM generate_series(1,5) s;

--- a/src/test/regress/expected/multi_having_pushdown.out
+++ b/src/test/regress/expected/multi_having_pushdown.out
@@ -31,8 +31,8 @@ EXPLAIN (COSTS FALSE)
                Group Key: remote_scan.l_orderkey
                Filter: (sum(remote_scan.worker_column_3) > '24'::numeric)
                ->  Custom Scan (Citus Real-Time)
-                     Task Count: 32
-                     Tasks Shown: One of 32
+                     Task Count: 4
+                     Tasks Shown: One of 4
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
                            ->  Limit
@@ -83,8 +83,8 @@ EXPLAIN (COSTS FALSE)
                Group Key: remote_scan.l_shipmode
                Filter: (sum(remote_scan.worker_column_3) > '24'::numeric)
                ->  Custom Scan (Citus Real-Time)
-                     Task Count: 32
-                     Tasks Shown: One of 32
+                     Task Count: 4
+                     Tasks Shown: One of 4
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
                            ->  HashAggregate
@@ -107,8 +107,8 @@ EXPLAIN (COSTS FALSE)
                Group Key: remote_scan.l_shipmode, remote_scan.l_orderkey
                Filter: (sum(remote_scan.worker_column_4) > '24'::numeric)
                ->  Custom Scan (Citus Real-Time)
-                     Task Count: 32
-                     Tasks Shown: One of 32
+                     Task Count: 4
+                     Tasks Shown: One of 4
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
                            ->  Limit
@@ -136,8 +136,8 @@ EXPLAIN (COSTS FALSE)
                Group Key: remote_scan.worker_column_2, remote_scan.worker_column_3, remote_scan.worker_column_4
                Filter: (sum(remote_scan.worker_column_5) > '24'::numeric)
                ->  Custom Scan (Citus Real-Time)
-                     Task Count: 32
-                     Tasks Shown: One of 32
+                     Task Count: 4
+                     Tasks Shown: One of 4
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
                            ->  Limit
@@ -148,7 +148,7 @@ EXPLAIN (COSTS FALSE)
                                              Filter: (sum(lineitem_hash.l_quantity) > '24'::numeric)
                                              ->  Hash Join
                                                    Hash Cond: (orders_hash.o_orderkey = lineitem_hash.l_orderkey)
-                                                   ->  Seq Scan on orders_hash_590032 orders_hash
+                                                   ->  Seq Scan on orders_hash_590004 orders_hash
                                                    ->  Hash
                                                          ->  Seq Scan on lineitem_hash_590000 lineitem_hash
 (22 rows)
@@ -168,15 +168,15 @@ EXPLAIN (COSTS FALSE)
                Group Key: remote_scan.worker_column_2, remote_scan.worker_column_3
                Filter: (sum(remote_scan.worker_column_4) > '24'::numeric)
                ->  Custom Scan (Citus Real-Time)
-                     Task Count: 32
-                     Tasks Shown: One of 32
+                     Task Count: 4
+                     Tasks Shown: One of 4
                      ->  Task
                            Node: host=localhost port=57637 dbname=regression
                            ->  HashAggregate
                                  Group Key: lineitem_hash.l_shipmode, orders_hash.o_clerk
                                  ->  Hash Join
                                        Hash Cond: (orders_hash.o_orderkey = lineitem_hash.l_orderkey)
-                                       ->  Seq Scan on orders_hash_590032 orders_hash
+                                       ->  Seq Scan on orders_hash_590004 orders_hash
                                        ->  Hash
                                              ->  Seq Scan on lineitem_hash_590000 lineitem_hash
 (18 rows)

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -636,16 +636,16 @@ ORDER BY
 	logicalrelid, shardid;
         logicalrelid         | shardid | nodename  | nodeport 
 -----------------------------+---------+-----------+----------
- mx_test_schema_1.mx_table_1 | 1310104 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310105 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310106 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310107 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310108 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310109 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310110 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310111 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310112 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310113 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310020 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310021 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310022 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310023 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310024 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310025 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310026 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310027 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310028 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310029 | localhost |    57637
 (10 rows)
 
 	
@@ -686,16 +686,16 @@ ORDER BY
 	logicalrelid, shardid;
         logicalrelid         | shardid | nodename  | nodeport 
 -----------------------------+---------+-----------+----------
- mx_test_schema_1.mx_table_1 | 1310104 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310105 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310106 | localhost |    57637
- mx_test_schema_1.mx_table_1 | 1310107 | localhost |    57638
- mx_test_schema_1.mx_table_1 | 1310108 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310109 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310110 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310111 | localhost |    57637
- mx_test_schema_2.mx_table_2 | 1310112 | localhost |    57638
- mx_test_schema_2.mx_table_2 | 1310113 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310020 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310021 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310022 | localhost |    57637
+ mx_test_schema_1.mx_table_1 | 1310023 | localhost |    57638
+ mx_test_schema_1.mx_table_1 | 1310024 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310025 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310026 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310027 | localhost |    57637
+ mx_test_schema_2.mx_table_2 | 1310028 | localhost |    57638
+ mx_test_schema_2.mx_table_2 | 1310029 | localhost |    57637
 (10 rows)
 
 -- Check that metadata of MX tables don't exist on the non-metadata worker
@@ -1277,8 +1277,8 @@ ORDER BY
  	nodeport;
  logicalrelid | partmethod | repmodel | shardid | placementid | nodename  | nodeport 
 --------------+------------+----------+---------+-------------+-----------+----------
- mx_ref       | n          | t        | 1310183 |      100183 | localhost |    57637
- mx_ref       | n          | t        | 1310183 |      100184 | localhost |    57638
+ mx_ref       | n          | t        | 1310071 |      100071 | localhost |    57637
+ mx_ref       | n          | t        | 1310071 |      100072 | localhost |    57638
 (2 rows)
 
 	
@@ -1363,7 +1363,7 @@ FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement
 WHERE logicalrelid='mx_ref'::regclass;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
- 1310184 | localhost |    57637
+ 1310072 | localhost |    57637
 (1 row)
 
 \c - - - :worker_1_port
@@ -1372,7 +1372,7 @@ FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement
 WHERE logicalrelid='mx_ref'::regclass;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
- 1310184 | localhost |    57637
+ 1310072 | localhost |    57637
 (1 row)
 
 \c - - - :master_port
@@ -1389,8 +1389,8 @@ WHERE logicalrelid='mx_ref'::regclass
 ORDER BY shardid, nodeport;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
- 1310184 | localhost |    57637
- 1310184 | localhost |    57638
+ 1310072 | localhost |    57637
+ 1310072 | localhost |    57638
 (2 rows)
 
 \c - - - :worker_1_port
@@ -1400,8 +1400,8 @@ WHERE logicalrelid='mx_ref'::regclass
 ORDER BY shardid, nodeport;
  shardid | nodename  | nodeport 
 ---------+-----------+----------
- 1310184 | localhost |    57637
- 1310184 | localhost |    57638
+ 1310072 | localhost |    57637
+ 1310072 | localhost |    57638
 (2 rows)
 
 -- Get the metadata back into a consistent state

--- a/src/test/regress/expected/multi_select_distinct.out
+++ b/src/test/regress/expected/multi_select_distinct.out
@@ -211,7 +211,7 @@ EXPLAIN (COSTS FALSE)
                      ->  HashAggregate
                            Group Key: l_orderkey
                            Filter: (count(*) > 5)
-                           ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                           ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                                  Filter: (l_orderkey < 200)
 (15 rows)
 
@@ -259,7 +259,7 @@ EXPLAIN (COSTS FALSE)
                      Node: host=localhost port=57637 dbname=regression
                      ->  HashAggregate
                            Group Key: l_partkey
-                           ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                           ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
 (13 rows)
 
 -- distinct on non-partition column and avg
@@ -332,7 +332,7 @@ EXPLAIN (COSTS FALSE)
                      ->  Unique
                            ->  Sort
                                  Sort Key: l_partkey, l_suppkey
-                                 ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                 ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                                        Filter: ((l_orderkey < 100) AND (l_shipmode = 'AIR'::bpchar))
 (14 rows)
 
@@ -374,7 +374,7 @@ EXPLAIN (COSTS FALSE)
                      ->  Unique
                            ->  Sort
                                  Sort Key: l_orderkey
-                                 ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                 ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                                        Filter: (l_orderkey < 35)
 (13 rows)
 
@@ -430,7 +430,7 @@ EXPLAIN (COSTS FALSE)
                                  ->  Unique
                                        ->  Sort
                                              Sort Key: l_partkey, l_orderkey
-                                             ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                             ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
 (14 rows)
 
 -- distinct on with joins
@@ -473,9 +473,9 @@ EXPLAIN (COSTS FALSE)
                                  Sort Key: orders_hash_part.o_custkey, lineitem_hash_part.l_orderkey
                                  ->  Hash Join
                                        Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
-                                       ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                                        ->  Hash
-                                             ->  Seq Scan on orders_hash_part_360294 orders_hash_part
+                                             ->  Seq Scan on orders_hash_part_360042 orders_hash_part
                                                    Filter: (o_custkey < 15)
 (17 rows)
 
@@ -500,9 +500,9 @@ EXPLAIN (COSTS FALSE)
                                  Sort Key: orders_hash_part.o_custkey
                                  ->  Hash Join
                                        Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
-                                       ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                                        ->  Hash
-                                             ->  Seq Scan on orders_hash_part_360294 orders_hash_part
+                                             ->  Seq Scan on orders_hash_part_360042 orders_hash_part
                                                    Filter: (o_custkey < 15)
 (17 rows)
 
@@ -571,9 +571,9 @@ EXPLAIN (COSTS FALSE)
                                  Sort Key: orders_hash_part.o_custkey, lineitem_hash_part.l_orderkey
                                  ->  Hash Join
                                        Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
-                                       ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                       ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
                                        ->  Hash
-                                             ->  Seq Scan on orders_hash_part_360294 orders_hash_part
+                                             ->  Seq Scan on orders_hash_part_360042 orders_hash_part
                                                    Filter: (o_custkey < 20)
 (17 rows)
 
@@ -661,7 +661,7 @@ EXPLAIN (COSTS FALSE)
                                        Sort Key: l_orderkey, l_partkey
                                        ->  HashAggregate
                                              Group Key: l_orderkey, l_partkey
-                                             ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                             ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
 (16 rows)
 
 SELECT DISTINCT l_orderkey, cnt
@@ -714,7 +714,7 @@ EXPLAIN (COSTS FALSE)
                                              Group Key: lineitem_hash_part.l_orderkey, count(*)
                                              ->  HashAggregate
                                                    Group Key: lineitem_hash_part.l_orderkey
-                                                   ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                                   ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
 (18 rows)
 
 -- distinct on partition column
@@ -767,7 +767,7 @@ EXPLAIN (COSTS FALSE)
                                              Sort Key: q.l_orderkey, q.l_partkey
                                              ->  Subquery Scan on q
                                                    Filter: (q.r > 1)
-                                                   ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                                   ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
 (16 rows)
 
 -- distinct on non-partition column
@@ -819,6 +819,6 @@ EXPLAIN (COSTS FALSE)
                                              Sort Key: q.l_partkey, q.l_orderkey
                                              ->  Subquery Scan on q
                                                    Filter: (q.r > 1)
-                                                   ->  Seq Scan on lineitem_hash_part_360290 lineitem_hash_part
+                                                   ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
 (16 rows)
 

--- a/src/test/regress/expected/multi_shard_update_delete.out
+++ b/src/test/regress/expected/multi_shard_update_delete.out
@@ -179,10 +179,10 @@ SELECT create_distributed_table('test_append_table','id','append');
 SELECT master_create_empty_shard('test_append_table');
  master_create_empty_shard 
 ---------------------------
-                   1440066
+                   1440010
 (1 row)
 
-SELECT * FROM master_append_table_to_shard(1440066, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440010, 'append_stage_table', 'localhost', :master_port);
  master_append_table_to_shard 
 ------------------------------
                     0.0266667
@@ -191,10 +191,10 @@ SELECT * FROM master_append_table_to_shard(1440066, 'append_stage_table', 'local
 SELECT master_create_empty_shard('test_append_table') AS new_shard_id;
  new_shard_id 
 --------------
-      1440067
+      1440011
 (1 row)
 
-SELECT * FROM master_append_table_to_shard(1440067, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table', 'localhost', :master_port);
  master_append_table_to_shard 
 ------------------------------
                     0.0266667
@@ -248,14 +248,14 @@ UPDATE tt1 SET col_2 = 12 WHERE col_2 > 10 and col_2 < 20;
 -- Update rows from partititon tt1_510
 UPDATE tt1 SET col_2 = 7 WHERE col_2 < 10 and col_2 > 5;
 COMMIT;
-SELECT * FROM tt1;
+SELECT * FROM tt1 ORDER BY id;
  id | col_2 
 ----+-------
-  8 |    12
-  4 |     7
-  7 |     7
-  6 |    12
   2 |    12
+  4 |     7
+  6 |    12
+  7 |     7
+  8 |    12
   9 |     7
 (6 rows)
 
@@ -266,7 +266,7 @@ UPDATE tt1 SET col_2 = 7 WHERE col_2 < 10 and col_2 > 5;
 DELETE FROM tt1_510;
 DELETE FROM tt1_1120;
 COMMIT;
-SELECT * FROM tt1;
+SELECT * FROM tt1 ORDER BY id;
  id | col_2 
 ----+-------
 (0 rows)
@@ -284,13 +284,13 @@ BEGIN;
 \COPY tt2 FROM STDIN DELIMITER AS ',';
 UPDATE tt2 SET col_2 = 1;
 COMMIT;
-SELECT * FROM tt2;
+SELECT * FROM tt2 ORDER BY id;
  id | col_2 
 ----+-------
   1 |     1
-  7 |     1
-  3 |     1
   2 |     1
+  3 |     1
+  7 |     1
   9 |     1
 (5 rows)
 
@@ -299,10 +299,10 @@ UPDATE tt2 SET col_2 = 5 RETURNING id, col_2;
  id | col_2 
 ----+-------
   1 |     5
-  7 |     5
   3 |     5
-  2 |     5
+  7 |     5
   9 |     5
+  2 |     5
 (5 rows)
 
 SET citus.multi_shard_modify_mode to sequential;
@@ -310,10 +310,10 @@ UPDATE tt2 SET col_2 = 3 RETURNING id, col_2;
  id | col_2 
 ----+-------
   1 |     3
-  7 |     3
   3 |     3
-  2 |     3
+  7 |     3
   9 |     3
+  2 |     3
 (5 rows)
 
 DROP TABLE tt2;

--- a/src/test/regress/expected/multi_shard_update_delete_0.out
+++ b/src/test/regress/expected/multi_shard_update_delete_0.out
@@ -179,10 +179,10 @@ SELECT create_distributed_table('test_append_table','id','append');
 SELECT master_create_empty_shard('test_append_table');
  master_create_empty_shard 
 ---------------------------
-                   1440066
+                   1440010
 (1 row)
 
-SELECT * FROM master_append_table_to_shard(1440066, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440010, 'append_stage_table', 'localhost', :master_port);
  master_append_table_to_shard 
 ------------------------------
                     0.0266667
@@ -191,10 +191,10 @@ SELECT * FROM master_append_table_to_shard(1440066, 'append_stage_table', 'local
 SELECT master_create_empty_shard('test_append_table') AS new_shard_id;
  new_shard_id 
 --------------
-      1440067
+      1440011
 (1 row)
 
-SELECT * FROM master_append_table_to_shard(1440067, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table', 'localhost', :master_port);
  master_append_table_to_shard 
 ------------------------------
                     0.0266667
@@ -272,9 +272,9 @@ LINE 1: UPDATE tt1 SET col_2 = 12 WHERE col_2 > 10 and col_2 < 20;
 UPDATE tt1 SET col_2 = 7 WHERE col_2 < 10 and col_2 > 5;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
-SELECT * FROM tt1;
+SELECT * FROM tt1 ORDER BY id;
 ERROR:  relation "tt1" does not exist
-LINE 1: SELECT * FROM tt1;
+LINE 1: SELECT * FROM tt1 ORDER BY id;
                       ^
 -- Modify main table and partition table within same transaction
 BEGIN;
@@ -289,9 +289,9 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 DELETE FROM tt1_1120;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
-SELECT * FROM tt1;
+SELECT * FROM tt1 ORDER BY id;
 ERROR:  relation "tt1" does not exist
-LINE 1: SELECT * FROM tt1;
+LINE 1: SELECT * FROM tt1 ORDER BY id;
                       ^
 DROP TABLE tt1;
 ERROR:  table "tt1" does not exist
@@ -307,13 +307,13 @@ BEGIN;
 \COPY tt2 FROM STDIN DELIMITER AS ',';
 UPDATE tt2 SET col_2 = 1;
 COMMIT;
-SELECT * FROM tt2;
+SELECT * FROM tt2 ORDER BY id;
  id | col_2 
 ----+-------
   1 |     1
-  7 |     1
-  3 |     1
   2 |     1
+  3 |     1
+  7 |     1
   9 |     1
 (5 rows)
 
@@ -322,10 +322,10 @@ UPDATE tt2 SET col_2 = 5 RETURNING id, col_2;
  id | col_2 
 ----+-------
   1 |     5
-  7 |     5
   3 |     5
-  2 |     5
+  7 |     5
   9 |     5
+  2 |     5
 (5 rows)
 
 SET citus.multi_shard_modify_mode to sequential;
@@ -333,10 +333,10 @@ UPDATE tt2 SET col_2 = 3 RETURNING id, col_2;
  id | col_2 
 ----+-------
   1 |     3
-  7 |     3
   3 |     3
-  2 |     3
+  7 |     3
   9 |     3
+  2 |     3
 (5 rows)
 
 DROP TABLE tt2;

--- a/src/test/regress/expected/multi_truncate.out
+++ b/src/test/regress/expected/multi_truncate.out
@@ -320,7 +320,7 @@ SELECT * FROM test_local_truncate;
 SELECT master_drop_all_shards('test_local_truncate', 'pubic', 'test_local_truncate');
  master_drop_all_shards 
 ------------------------
-                     32
+                      4
 (1 row)
 
 DELETE FROM pg_dist_partition WHERE logicalrelid = 'test_local_truncate'::regclass;
@@ -356,7 +356,7 @@ SELECT * FROM test_local_truncate;
 SELECT master_drop_all_shards('test_local_truncate', 'pubic', 'test_local_truncate');
  master_drop_all_shards 
 ------------------------
-                     32
+                      4
 (1 row)
 
 DELETE FROM pg_dist_partition WHERE logicalrelid = 'test_local_truncate'::regclass;

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -426,7 +426,6 @@ CREATE TABLE trigger_table (
 );
 
 SELECT create_distributed_table('trigger_table', 'id');
-
 -- first set a trigger on a shard
 \c - - - :worker_1_port
 
@@ -438,7 +437,7 @@ CREATE FUNCTION update_value() RETURNS trigger AS $up$
 $up$ LANGUAGE plpgsql;
 
 CREATE TRIGGER update_value
-BEFORE INSERT ON trigger_table_220056
+BEFORE INSERT ON trigger_table_220028
 FOR EACH ROW EXECUTE PROCEDURE update_value();
 
 \c - - - :master_port

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -4,7 +4,7 @@
 # Regression tests that exercise distributed planning/execution functionality.
 #
 # All new regression tests are expected to be run by this schedule. Tests that
-# do not set specific task executor type should also be added to 
+# do not set specific task executor type should also be added to
 # multi_task_tracker_extra_schedule.
 #
 # Note that we use variant comparison files to test version dependent regression
@@ -49,7 +49,7 @@ test: multi_partitioning
 # Miscellaneous tests to check our query planning behavior
 # ----------
 test: multi_deparse_shard_query multi_distributed_transaction_id
-test: multi_basic_queries multi_complex_expressions 
+test: multi_basic_queries multi_complex_expressions
 test: multi_explain
 test: multi_subquery multi_subquery_complex_queries multi_subquery_behavioral_analytics
 test: multi_subquery_complex_reference_clause multi_subquery_window_functions
@@ -168,7 +168,7 @@ test: multi_subtransactions
 test: multi_copy
 
 # ---------
-# multi_router_planner creates hash partitioned tables. 
+# multi_router_planner creates hash partitioned tables.
 # ---------
 test: multi_router_planner
 
@@ -188,7 +188,7 @@ test: multi_size_queries
 test: multi_drop_extension
 
 # ----------
-# multi_metadata_sync tests the propagation of mx-related metadata changes to metadata workers 
+# multi_metadata_sync tests the propagation of mx-related metadata changes to metadata workers
 # multi_unsupported_worker_operations tests that unsupported operations error out on metadata workers
 # ----------
 test: multi_metadata_sync

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -891,7 +891,7 @@ CREATE FUNCTION update_value() RETURNS trigger AS $up$
     END;
 $up$ LANGUAGE plpgsql;
 CREATE TRIGGER update_value
-BEFORE INSERT ON trigger_table_220056
+BEFORE INSERT ON trigger_table_220028
 FOR EACH ROW EXECUTE PROCEDURE update_value();
 \c - - - :master_port
 INSERT INTO trigger_table VALUES (1, 'trigger disabled');

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -238,6 +238,7 @@ push(@pgOptions, '-c', "shared_preload_libraries=citus");
 push(@pgOptions, '-c', "wal_level=logical");
 
 # Citus options set for the tests
+push(@pgOptions, '-c', "citus.shard_count=4");
 push(@pgOptions, '-c', "citus.shard_max_size=300kB");
 push(@pgOptions, '-c', "citus.max_running_tasks_per_node=4");
 push(@pgOptions, '-c', "citus.expire_cached_shards=on");

--- a/src/test/regress/sql/multi_alter_table_add_constraints.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints.sql
@@ -398,10 +398,9 @@ ROLLBACK;
 
 -- There should be no constraint on master and worker(s) 
 SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regclass;
-
 \c - - - :worker_1_port
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
 
 \c - - - :master_port
 
@@ -418,7 +417,7 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regc
 
 \c - - - :worker_1_port
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
 
 \c - - - :master_port
 DROP TABLE products;

--- a/src/test/regress/sql/multi_colocation_utils.sql
+++ b/src/test/regress/sql/multi_colocation_utils.sql
@@ -184,7 +184,7 @@ CREATE TABLE table2_groupC ( id text );
 SELECT create_distributed_table('table2_groupC', 'id');
 
 -- change shard count
-SET citus.shard_count = 4;
+SET citus.shard_count = 8;
 
 CREATE TABLE table1_groupD ( id int );
 SELECT create_distributed_table('table1_groupD', 'id');
@@ -285,14 +285,13 @@ SELECT create_distributed_table('table_failing', 'id', colocate_with => NULL);
 -- check with different distribution column types
 CREATE TABLE table_bigint ( id bigint );
 SELECT create_distributed_table('table_bigint', 'id', colocate_with => 'table1_groupE');
-
 -- check worker table schemas
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.table3_groupE_1300050'::regclass;
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='schema_collocation.table4_groupE_1300052'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.table3_groupE_1300062'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='schema_collocation.table4_groupE_1300064'::regclass;
 
 \c - - - :master_port
-SET citus.next_shard_id TO 1300068;
+SET citus.next_shard_id TO 1300080;
 
 CREATE TABLE table1_groupF ( id int );
 SELECT create_reference_table('table1_groupF');

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -377,11 +377,10 @@ INSERT INTO tt1 VALUES(1);
 INSERT INTO tt2 SELECT * FROM tt1 WHERE id = 1;
 COMMIT;
 
-
 -- Table should exist on the worker node
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360430'::regclass;
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt2_360462'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360066'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt2_360070'::regclass;
 \c - - - :master_port
 
 DROP TABLE tt1;
@@ -397,7 +396,7 @@ ROLLBACK;
 
 -- Table exists on the worker node.
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.append_tt1_360494'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.append_tt1_360074'::regclass;
 \c - - - :master_port
 
 -- There should be no table on the worker node
@@ -417,7 +416,7 @@ COMMIT;
 
 -- Placements should be created on the worker
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360495'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid = 'public.tt1_360075'::regclass;
 \c - - - :master_port
 
 DROP TABLE tt1;

--- a/src/test/regress/sql/multi_shard_update_delete.sql
+++ b/src/test/regress/sql/multi_shard_update_delete.sql
@@ -138,9 +138,9 @@ INSERT INTO append_stage_table VALUES(5,4);
 CREATE TABLE test_append_table(id int, col_2 int);
 SELECT create_distributed_table('test_append_table','id','append');
 SELECT master_create_empty_shard('test_append_table');
-SELECT * FROM master_append_table_to_shard(1440066, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440010, 'append_stage_table', 'localhost', :master_port);
 SELECT master_create_empty_shard('test_append_table') AS new_shard_id;
-SELECT * FROM master_append_table_to_shard(1440067, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table', 'localhost', :master_port);
 UPDATE test_append_table SET col_2 = 5;
 SELECT * FROM test_append_table;
 
@@ -169,7 +169,7 @@ UPDATE tt1 SET col_2 = 12 WHERE col_2 > 10 and col_2 < 20;
 -- Update rows from partititon tt1_510
 UPDATE tt1 SET col_2 = 7 WHERE col_2 < 10 and col_2 > 5;
 COMMIT;
-SELECT * FROM tt1;
+SELECT * FROM tt1 ORDER BY id;
 
 -- Modify main table and partition table within same transaction
 BEGIN;
@@ -178,7 +178,7 @@ UPDATE tt1 SET col_2 = 7 WHERE col_2 < 10 and col_2 > 5;
 DELETE FROM tt1_510;
 DELETE FROM tt1_1120;
 COMMIT;
-SELECT * FROM tt1;
+SELECT * FROM tt1 ORDER BY id;
 DROP TABLE tt1;
 
 -- Update and copy in the same transaction
@@ -195,7 +195,7 @@ BEGIN;
 \.
 UPDATE tt2 SET col_2 = 1;
 COMMIT;
-SELECT * FROM tt2;
+SELECT * FROM tt2 ORDER BY id;
 
 -- Test returning with both type of executors
 UPDATE tt2 SET col_2 = 5 RETURNING id, col_2;


### PR DESCRIPTION
Shard count is decreased from 32 to 4
Important note: The major change happened in multi_colocation_utils tests since I had to change the shard_count of one block of tables from 4 to 8 which had the replication factor as 2 and this resulted to affect the output of some queries. However, it is all handled.

This PR gives us ~22.25% gain in time for us according to my experiments. You can see my measurements from these gists ([before](https://gist.github.com/furkansahin/70c9aac9091706e10456fc7f30eec2ff), [after](https://gist.github.com/furkansahin/0d1e71b37017021f1d521b825ba03fe3)). Keep in mind that each time is the time for the next test vertically. 
You can see the total times at the end of both files.
Before: 164 sec (Thanks to my monstrous mac)
After: 127 sec (Thanks to lower shard count)
The effect is obvious in travis tests too.

In addition to the time gain, lower shard count will give us a chance to parallelize the tests more by decreasing the number of connections we use. 

Ps. In case anyone interested, I used the tool called [gnomon](https://github.com/paypal/gnomon) to print the times next to the tests.