### PR TITLE
EXEC_BACKEND support

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -170,8 +170,13 @@ _PG_init(void)
 	/*
 	 * Extend the database directory structure before continuing with
 	 * initialization - one of the later steps might require them to exist.
+	 * If in a sub-process (windows / EXEC_BACKEND) this already has been
+	 * done.
 	 */
-	CreateRequiredDirectories();
+	if (!IsUnderPostmaster)
+	{
+		CreateRequiredDirectories();
+	}
 
 	/*
 	 * Register Citus configuration variables. Do so before intercepting

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -297,7 +297,10 @@ void
 InitializeBackendManagement(void)
 {
 	/* allocate shared memory */
-	RequestAddinShmemSpace(BackendManagementShmemSize());
+	if (!IsUnderPostmaster)
+	{
+		RequestAddinShmemSpace(BackendManagementShmemSize());
+	}
 
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = BackendManagementShmemInit;

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -107,7 +107,10 @@ static bool LockCitusExtension(void);
 void
 InitializeMaintenanceDaemon(void)
 {
-	RequestAddinShmemSpace(MaintenanceDaemonShmemSize());
+	if (!IsUnderPostmaster)
+	{
+		RequestAddinShmemSpace(MaintenanceDaemonShmemSize());
+	}
 
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = MaintenanceDaemonShmemInit;

--- a/src/backend/distributed/worker/task_tracker.c
+++ b/src/backend/distributed/worker/task_tracker.c
@@ -100,11 +100,16 @@ TaskTrackerRegister(void)
 {
 	BackgroundWorker worker;
 
-	/* organize and register initialization of required shared memory */
-	RequestAddinShmemSpace(TaskTrackerShmemSize());
-
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = TaskTrackerShmemInit;
+
+	if (IsUnderPostmaster)
+	{
+		return;
+	}
+
+	/* organize and register initialization of required shared memory */
+	RequestAddinShmemSpace(TaskTrackerShmemSize());
 
 	/* and that the task tracker is started as background worker */
 	memset(&worker, 0, sizeof(worker));

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -189,7 +189,7 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 	 */
 	LWLockAcquire(&WorkerTasksSharedState->taskHashLock, LW_EXCLUSIVE);
 
-	hash_seq_init(&status, WorkerTasksSharedState->taskHash);
+	hash_seq_init(&status, TaskTrackerTaskHash);
 
 	currentTask = (WorkerTask *) hash_seq_search(&status);
 	while (currentTask != NULL)
@@ -415,8 +415,7 @@ CleanupTask(WorkerTask *workerTask)
 	}
 
 	/* remove the task from the shared hash */
-	taskRemoved = hash_search(WorkerTasksSharedState->taskHash, hashKey, HASH_REMOVE,
-							  NULL);
+	taskRemoved = hash_search(TaskTrackerTaskHash, hashKey, HASH_REMOVE, NULL);
 	if (taskRemoved == NULL)
 	{
 		ereport(FATAL, (errmsg("worker task hash corrupted")));

--- a/src/include/distributed/task_tracker.h
+++ b/src/include/distributed/task_tracker.h
@@ -101,9 +101,6 @@ typedef struct WorkerTask
  */
 typedef struct WorkerTasksSharedStateData
 {
-	/* Hash table shared by the task tracker and task tracker protocol functions */
-	HTAB *taskHash;
-
 	/* Lock protecting workerNodesHash */
 	int taskHashTrancheId;
 #if (PG_VERSION_NUM >= 100000)
@@ -123,6 +120,7 @@ extern int MaxTaskStringSize;
 
 /* State shared by the task tracker and task tracker protocol functions */
 extern WorkerTasksSharedStateData *WorkerTasksSharedState;
+extern HTAB *TaskTrackerTaskHash;
 
 /* Entry point */
 extern void TaskTrackerMain(Datum main_arg);


### PR DESCRIPTION
To test this you'll have to do two things:

1. Build an `EXEC_BACKEND` version of postgres. You need to re-configure postgres. Here's the command I use:

    ```
    ./configure '--enable-cassert' '--enable-debug' 'CFLAGS=-ggdb -Og -g3 -fno-omit-frame-pointer -DEXEC_BACKEND' '--prefix' '/home/brian/Work/pg-10-exec-backend'
    ```

    the important part is `CFLAGS=-DEXEC_BACKEND`.

2. Disable ASLR. Postgres always keeps its shared memory segments in the same place and uses absolute addresses within that shared memory. This is _usually_ fine, but occasionally that address conflicts with the address of the new process and postgres fails to attach the shared memory segments and the backend fails and the Citus regression test fails.

    Disable it by running this command as root:

    `echo 0 >/proc/sys/kernel/randomize_va_space`

    Don't forget to reset it (it was probably `2` previously) when you're done testing!