### PR TITLE
Remove an ifdef surrounding strtoull

### DIFF
--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -839,7 +839,7 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 	}
 
 	errno = 0;
-	tableSize = strtoull(tableSizeString, &tableSizeStringEnd, 0);
+	tableSize = pg_strtouint64(tableSizeString, &tableSizeStringEnd, 0);
 	if (errno != 0 || (*tableSizeStringEnd) != '\0')
 	{
 		PQclear(queryResult);

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -19,6 +19,7 @@
 #include "distributed/multi_server_executor.h"
 #include "nodes/parsenodes.h"
 #include "nodes/readfuncs.h"
+#include "utils/builtins.h"
 
 
 /*
@@ -158,7 +159,7 @@ CitusSetTag(Node *node, int tag)
 #define atooid(x)  ((Oid) strtoul((x), NULL, 10))
 
 /* XXX: Citus */
-#define atoull(x)  ((uint64) strtoull((x), NULL, 10))
+#define atoull(x)  ((uint64) pg_strtouint64((x), NULL, 10))
 
 #define strtobool(x)  ((*(x) == 't') ? true : false)
 

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -784,19 +784,14 @@ ExtractShardId(const char *tableName)
 	}
 	shardIdString++;
 
-#ifdef HAVE_STRTOULL
 	errno = 0;
-	shardId = strtoull(shardIdString, &shardIdStringEnd, 0);
+	shardId = pg_strtouint64(shardIdString, &shardIdStringEnd, 0);
 
 	if (errno != 0 || (*shardIdStringEnd != '\0'))
 	{
 		ereport(ERROR, (errmsg("could not extract shardId from table name \"%s\"",
 							   tableName)));
 	}
-#else
-	ereport(ERROR, (errmsg("could not extract shardId from table name"),
-					errhint("Your platform does not support strtoull()")));
-#endif
 
 	return shardId;
 }


### PR DESCRIPTION
We use strtoull in a few other places and do not wrap the calls with
ifdef, this commit makes us more consistent. Since we probably want to
require that you have strtoull it makes sense to fail at compile time,
not when you try to use the function.