### PR TITLE
Subqueries containing functions go through subquery pushdown

### DIFF
--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -251,10 +251,21 @@ SELECT count(*) FROM
     10
 (1 row)
 
+SELECT count(*) FROM user_buy_test_table LEFT JOIN (SELECT * FROM generate_series(1,10) id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
+ count 
+-------
+     4
+(1 row)
+
 -- table function cannot be the outer relationship in an outer join
 SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table RIGHT JOIN generate_series(1,10) AS users_ref_test_table(id)
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a table function in the outer part of the outer join
+SELECT count(*) FROM user_buy_test_table RIGHT JOIN (SELECT * FROM generate_series(1,10) id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
 ERROR:  cannot pushdown the subquery
 DETAIL:  There exist a table function in the outer part of the outer join
 -- volatile functions cannot be used as table expressions

--- a/src/test/regress/sql/multi_subquery_complex_reference_clause.sql
+++ b/src/test/regress/sql/multi_subquery_complex_reference_clause.sql
@@ -150,10 +150,16 @@ SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table LEFT JOIN generate_series(1,10) AS users_ref_test_table(id)
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
 
+SELECT count(*) FROM user_buy_test_table LEFT JOIN (SELECT * FROM generate_series(1,10) id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
+
 -- table function cannot be the outer relationship in an outer join
 SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table RIGHT JOIN generate_series(1,10) AS users_ref_test_table(id)
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
+
+SELECT count(*) FROM user_buy_test_table RIGHT JOIN (SELECT * FROM generate_series(1,10) id) users_ref_test_table
+ON user_buy_test_table.item_id = users_ref_test_table.id;
 
 -- volatile functions cannot be used as table expressions
 SELECT count(*) FROM


### PR DESCRIPTION
This change makes sure that when we plug a `(SELECT * FROM read_records_file(...) AS ..)` into a query it will actually go through subquery pushdown. Otherwise, it might get rewritten to `read_records_file(...) AS ..` and go into the logical planner, where it gets treated poorly.