### PR TITLE
Fix bug related to incrementing an index not properly

### DIFF
--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -745,11 +745,14 @@ GenerateCommonEquivalence(List *attributeEquivalenceList,
 	addedEquivalenceIds = bms_add_member(addedEquivalenceIds,
 										 firstEquivalenceClass->equivalenceId);
 
-	for (; equivalenceClassIndex < equivalenceListSize; ++equivalenceClassIndex)
+	while (equivalenceClassIndex < equivalenceListSize)
 	{
-		AttributeEquivalenceClass *currentEquivalenceClass =
-			list_nth(attributeEquivalenceList, equivalenceClassIndex);
+		AttributeEquivalenceClass *currentEquivalenceClass = NULL;
 		ListCell *equivalenceMemberCell = NULL;
+		bool restartLoop = false;
+
+		currentEquivalenceClass = list_nth(attributeEquivalenceList,
+										   equivalenceClassIndex);
 
 		/*
 		 * This is an optimization. If we already added the same equivalence class,
@@ -758,6 +761,8 @@ GenerateCommonEquivalence(List *attributeEquivalenceList,
 		 */
 		if (bms_is_member(currentEquivalenceClass->equivalenceId, addedEquivalenceIds))
 		{
+			equivalenceClassIndex++;
+
 			continue;
 		}
 
@@ -781,10 +786,19 @@ GenerateCommonEquivalence(List *attributeEquivalenceList,
 				 * But, we should somehow restart from the beginning to test that
 				 * whether the already skipped ones are equal or not.
 				 */
-				equivalenceClassIndex = 0;
+				restartLoop = true;
 
 				break;
 			}
+		}
+
+		if (restartLoop)
+		{
+			equivalenceClassIndex = 0;
+		}
+		else
+		{
+			++equivalenceClassIndex;
 		}
 	}
 


### PR DESCRIPTION
This bug seems to exist since Citus 6.1. but is not apparent until we have #1839. 

The algorithm for finding the common relation restrictions seems to be setting the loop index wrongly (i.e., `GenerateCommonEquivalence()`). This issue could only be observed with `UNION`s among `JOIN`s, which are implemented with #1839. So, this is a bug in the master branch, **doesn't apply for 7.1 or other releases.**

In summary, we might skip some of the restrictions while forming the common restriction list due incrementing an index not properly. Say, we have the following restrictions:
```
(relationId-rteIdentity-varattno-varno)
(16731=2=1=1)
(16735=3=1=2)
(16731=1=1=1)
(16735=3=1=2)
```

And, we picked the following restriction for the `firstEquivalenceClass`
```
(16731=1=1=1)
```

Now that, we'd skip restriction eq. among `(16731=2=1=1)` and `(16735=3=1=2)` in the next iterations since the index starts from `1`, where it should have started from `0`.

For example, the following query may fail on the regression tests:
```SQL
SELECT * FROM
(
(
  SELECT value_2, user_id
  FROM users_table
)
UNION
(
  SELECT sum(users_table.value_2), user_id
  FROM users_table RIGHT JOIN events_table USING (user_id)
  GROUP BY user_id
)
) ftop
ORDER BY 2, 1
LIMIT 10;
```

This query has the explained rte indexes, where `(16731=1=1=1)` belongs to the top query. Very oddly, the above query fails on Mac, not on linux. That might be related to the order of restrictions that Citus picks up from Postgre hooks.