### PR TITLE
Increase sleep time in a regression test to give Valgrind tests enough time

### DIFF
--- a/src/test/regress/expected/multi_mx_transaction_recovery.out
+++ b/src/test/regress/expected/multi_mx_transaction_recovery.out
@@ -132,7 +132,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-SELECT pg_sleep(0.2);
+-- Sleep 1 second to give Valgrind enough time to clear transactions
+SELECT pg_sleep(1);
  pg_sleep 
 ----------
  

--- a/src/test/regress/expected/multi_transaction_recovery.out
+++ b/src/test/regress/expected/multi_transaction_recovery.out
@@ -250,7 +250,8 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-SELECT pg_sleep(0.1);
+-- Sleep 1 second to give Valgrind enough time to clear transactions
+SELECT pg_sleep(1);
  pg_sleep 
 ----------
  

--- a/src/test/regress/sql/multi_mx_transaction_recovery.sql
+++ b/src/test/regress/sql/multi_mx_transaction_recovery.sql
@@ -76,7 +76,8 @@ SELECT count(*) FROM pg_dist_transaction;
 -- Test whether auto-recovery runs
 ALTER SYSTEM SET citus.recover_2pc_interval TO 10;
 SELECT pg_reload_conf();
-SELECT pg_sleep(0.2);
+-- Sleep 1 second to give Valgrind enough time to clear transactions
+SELECT pg_sleep(1);
 SELECT count(*) FROM pg_dist_transaction;
 ALTER SYSTEM RESET citus.recover_2pc_interval;
 SELECT pg_reload_conf();

--- a/src/test/regress/sql/multi_transaction_recovery.sql
+++ b/src/test/regress/sql/multi_transaction_recovery.sql
@@ -123,7 +123,8 @@ SELECT count(*) FROM pg_dist_transaction;
 -- Test whether auto-recovery runs
 ALTER SYSTEM SET citus.recover_2pc_interval TO 10;
 SELECT pg_reload_conf();
-SELECT pg_sleep(0.1);
+-- Sleep 1 second to give Valgrind enough time to clear transactions
+SELECT pg_sleep(1);
 SELECT count(*) FROM pg_dist_transaction;
 
 ALTER SYSTEM RESET citus.recover_2pc_interval;


### PR DESCRIPTION
I also manually tested on Valgrind to see that if 1 sec is enough.