### PR TITLE
Fix issue with multiple ANALYZE in transaction block

### DIFF
--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -25,6 +25,11 @@ COPY sharded_table TO STDOUT;
 COPY (SELECT COUNT(*) FROM sharded_table) TO STDOUT;
 0
 COMMIT;
+-- ANALYZE is supported in a transaction block
+BEGIN;
+ANALYZE sharded_table;
+ANALYZE sharded_table;
+END;
 -- cursors may not involve distributed tables
 DECLARE all_sharded_rows CURSOR FOR SELECT * FROM sharded_table;
 ERROR:  DECLARE CURSOR can only be used in transaction blocks

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -20,6 +20,12 @@ COPY sharded_table TO STDOUT;
 COPY (SELECT COUNT(*) FROM sharded_table) TO STDOUT;
 COMMIT;
 
+-- ANALYZE is supported in a transaction block
+BEGIN;
+ANALYZE sharded_table;
+ANALYZE sharded_table;
+END;
+
 -- cursors may not involve distributed tables
 DECLARE all_sharded_rows CURSOR FOR SELECT * FROM sharded_table;
 


### PR DESCRIPTION
We currently get an assert failure when running ANALYZE on a distributed table multiple times because we treat it as if it cannot run in a transaction block (like VACUUM). When asserts are disabled, this issue might cause the commit protocol to get messed up. 