### PR TITLE
Set cost estimates for read_intermediate_result

### DIFF
--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -654,6 +654,28 @@ RemoveIntermediateResultsDirectory(void)
 
 
 /*
+ * IntermediateResultSize returns the file size of the intermediate result
+ * or -1 if the file does not exist.
+ */
+int64
+IntermediateResultSize(char *resultId)
+{
+	char *resultFileName = NULL;
+	struct stat fileStat;
+	int statOK = 0;
+
+	resultFileName = QueryResultFileName(resultId);
+	statOK = stat(resultFileName, &fileStat);
+	if (statOK < 0)
+	{
+		return -1;
+	}
+
+	return (int64) fileStat.st_size;
+}
+
+
+/*
  * read_intermediate_result is a UDF that returns a COPY-formatted intermediate
  * result file as a set of records. The file is parsed according to the columns
  * definition list specified by the user, e.g.:

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -26,6 +26,7 @@ extern DestReceiver * CreateRemoteFileDestReceiver(char *resultId, EState *execu
 												   writeLocalFile);
 extern void ReceiveQueryResultViaCopy(const char *resultId);
 extern void RemoveIntermediateResultsDirectory(void);
+extern int64 IntermediateResultSize(char *resultId);
 
 
 #endif /* INTERMEDIATE_RESULTS_H */

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -186,6 +186,47 @@ ON ((s).x = interested_in) ORDER BY 1,2;
 (3 rows)
 
 END;
+BEGIN;
+-- accurate row count estimates for primitive types
+SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,632) s');
+ create_intermediate_result 
+----------------------------
+                        632
+(1 row)
+
+EXPLAIN SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_result res  (cost=0.00..4.55 rows=632 width=8)
+(1 row)
+
+-- less accurate results for variable types
+SELECT create_intermediate_result('hellos', $$SELECT s, 'hello-'||s FROM generate_series(1,63) s$$);
+ create_intermediate_result 
+----------------------------
+                         63
+(1 row)
+
+EXPLAIN SELECT * FROM read_intermediate_result('hellos', 'binary') AS res (x int, y text);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_result res  (cost=0.00..0.32 rows=30 width=36)
+(1 row)
+
+-- not very accurate results for text encoding
+SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_squares');
+ create_intermediate_result 
+----------------------------
+                          4
+(1 row)
+
+EXPLAIN SELECT * FROM read_intermediate_result('stored_squares', 'text') AS res (s intermediate_results.square_type);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_result res  (cost=0.00..0.01 rows=1 width=32)
+(1 row)
+
+END;
 -- pipe query output into a result file and create a table to check the result
 COPY (SELECT s, s*s FROM generate_series(1,5) s)
 TO PROGRAM

--- a/src/test/regress/sql/intermediate_results.sql
+++ b/src/test/regress/sql/intermediate_results.sql
@@ -97,6 +97,20 @@ ON ((s).x = interested_in) ORDER BY 1,2;
 
 END;
 
+BEGIN;
+-- accurate row count estimates for primitive types
+SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,632) s');
+EXPLAIN SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
+
+-- less accurate results for variable types
+SELECT create_intermediate_result('hellos', $$SELECT s, 'hello-'||s FROM generate_series(1,63) s$$);
+EXPLAIN SELECT * FROM read_intermediate_result('hellos', 'binary') AS res (x int, y text);
+
+-- not very accurate results for text encoding
+SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_squares');
+EXPLAIN SELECT * FROM read_intermediate_result('stored_squares', 'text') AS res (s intermediate_results.square_type);
+END;
+
 -- pipe query output into a result file and create a table to check the result
 COPY (SELECT s, s*s FROM generate_series(1,5) s)
 TO PROGRAM


### PR DESCRIPTION
As part of #1804, we'll replace CTEs and subqueries with subqueries that call `read_intermediate_result`, which returns the result of the subquery. By default, postgres estimates all set-returning functions to return 1000 rows and have a cost of 10, which can lead to poor join plans when the actual number of rows returned by the function is very different. 

This PR allows postgres to pick better plans when executing queries on `read_intermediate_result` *on the workers*, by estimating the row count based on the size of the intermediate result. We also estimate the cost of parsing the file by summing up the cost of the input function for each column and multiplying it by the estimated number of rows. We then modify the cost in the path when we see a `read_intermediate_result` RTE via `set_rel_pathlist_hook`.