### PR TITLE
Redefine read_intermediate_result as not parallel safe

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -13,7 +13,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	6.2-1 6.2-2 6.2-3 6.2-4 \
 	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5 7.0-6 7.0-7 7.0-8 7.0-9 7.0-10 7.0-11 7.0-12 7.0-13 7.0-14 7.0-15 \
 	7.1-1 7.1-2 7.1-3 7.1-4 \
-	7.2-1 7.2-2 7.2-3
+	7.2-1 7.2-2 7.2-3 7.2-4
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -184,6 +184,8 @@ $(EXTENSION)--7.2-1.sql: $(EXTENSION)--7.1-4.sql $(EXTENSION)--7.1-4--7.2-1.sql
 $(EXTENSION)--7.2-2.sql: $(EXTENSION)--7.2-1.sql $(EXTENSION)--7.2-1--7.2-2.sql
 	cat $^ > $@
 $(EXTENSION)--7.2-3.sql: $(EXTENSION)--7.2-2.sql $(EXTENSION)--7.2-2--7.2-3.sql
+	cat $^ > $@
+$(EXTENSION)--7.2-4.sql: $(EXTENSION)--7.2-3.sql $(EXTENSION)--7.2-3--7.2-4.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.2-3--7.2-4.sql
+++ b/src/backend/distributed/citus--7.2-3--7.2-4.sql
@@ -1,0 +1,8 @@
+/* citus--7.2-3--7.2-4 */
+
+CREATE OR REPLACE FUNCTION pg_catalog.read_intermediate_result(result_id text, format pg_catalog.citus_copy_format default 'csv')
+    RETURNS SETOF record
+    LANGUAGE C STRICT VOLATILE
+    AS 'MODULE_PATHNAME', $$read_intermediate_result$$;
+COMMENT ON FUNCTION pg_catalog.read_intermediate_result(text,pg_catalog.citus_copy_format)
+    IS 'read a file and return it as a set of records';

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.2-3'
+default_version = '7.2-4'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -132,6 +132,7 @@ ALTER EXTENSION citus UPDATE TO '7.1-4';
 ALTER EXTENSION citus UPDATE TO '7.2-1';
 ALTER EXTENSION citus UPDATE TO '7.2-2';
 ALTER EXTENSION citus UPDATE TO '7.2-3';
+ALTER EXTENSION citus UPDATE TO '7.2-4';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -132,6 +132,7 @@ ALTER EXTENSION citus UPDATE TO '7.1-4';
 ALTER EXTENSION citus UPDATE TO '7.2-1';
 ALTER EXTENSION citus UPDATE TO '7.2-2';
 ALTER EXTENSION citus UPDATE TO '7.2-3';
+ALTER EXTENSION citus UPDATE TO '7.2-4';
 
 -- show running version
 SHOW citus.version;


### PR DESCRIPTION
While playing with CTEs, I ran into an issue with postgres 10 parallelisation:

```sql
CREATE TABLE customer_reviews                                                                           
(                                                                                                                              
    customer_id TEXT NOT NULL,
    review_date DATE,
    review_rating INTEGER,
    review_votes INTEGER,
    review_helpful_votes INTEGER,
    product_id CHAR(10),
    product_title TEXT,
    product_sales_rank BIGINT,
    product_group TEXT,
    product_category TEXT,
    product_subcategory TEXT,
    similar_product_ids CHAR(10)[]
);
SELECT create_distributed_table('customer_reviews','customer_id');
 \COPY customer_reviews FROM 'customer_reviews_1998.csv' WITH CSV

WITH date_range AS (SELECT d::date FROM generate_series('1998-11-01', '1998-11-30', interval '1 day') d),
review_counts AS (SELECT review_date, count(*) FROM customer_reviews JOIN date_range ON (review_date = d) GROUP BY review_date)
SELECT d AS date, Coalesce(count, 0) AS review_count FROM date_range LEFT JOIN review_counts ON (review_date = d);
WARNING:  result "1_1" does not exist
WARNING:  result "1_1" does not exist
WARNING:  result "1_1" does not exist
ERROR:  failed to execute task 10
```

This is because PG10 decides to parallelise some of the tasks and the parallel workers don't have a distributed transaction ID set and therefore cannot find the intermediate result.

I optimistically marked `read_intermediate_result` as parallel safe, but it is not. This PR marks it as unsafe.

After this change:

```sql
WITH date_range AS (SELECT d::date FROM generate_series('1998-11-01', '1998-11-30', interval '1 day') d),
review_counts AS (SELECT review_date, count(*) FROM customer_reviews JOIN date_range ON (review_date = d) GROUP BY review_date)
SELECT d AS date, Coalesce(count, 0) AS review_count FROM date_range LEFT JOIN review_counts ON (review_date = d);
    date    | review_count 
------------+--------------
 1998-11-01 |         1840
 1998-11-02 |         2000
 1998-11-03 |         2155
...
```