### PR TITLE
Log remote commands sent via MultiClientSendQuery

### DIFF
--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -397,7 +397,7 @@ MultiClientSendQuery(int32 connectionId, const char *query)
 	connection = ClientConnectionArray[connectionId];
 	Assert(connection != NULL);
 
-	querySent = PQsendQuery(connection->pgConn, query);
+	querySent = SendRemoteCommand(connection, query);
 	if (querySent == 0)
 	{
 		char *errorMessage = pchomp(PQerrorMessage(connection->pgConn));

--- a/src/backend/distributed/master/master_citus_tools.c
+++ b/src/backend/distributed/master/master_citus_tools.c
@@ -271,12 +271,7 @@ ExecuteCommandsInParallelAndStoreResults(StringInfo *nodeNameArray, int *nodePor
 			continue;
 		}
 
-		/*
-		 * NB: this intentionally uses PQsendQuery rather than
-		 * SendRemoteCommand as multiple commands are allowed.
-		 */
-		querySent = PQsendQuery(connection->pgConn, queryString);
-
+		querySent = SendRemoteCommand(connection, queryString);
 		if (querySent == 0)
 		{
 			StoreErrorMessage(connection, queryResultString);


### PR DESCRIPTION
It's quite hard to keep track of how a query with recursively planned CTEs and subqueries is being executed because the tasks of multi-shard queries can only be logged in the planner, while the task(s) of single-shard queries can only be logged in the executor. This change logs all commands that are sent via `SendRemoteCommand`.