### PR TITLE
Show distributed subplan ID in EXPLAIN output

### DIFF
--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -140,6 +140,17 @@ RecursivelyPlanSubqueriesAndCTEs(Query *query,
 	DeferredErrorMessage *error = NULL;
 	RecursivePlanningContext context;
 
+	context.level = 0;
+	context.planId = planId;
+	context.subPlanList = NIL;
+	context.plannerRestrictionContext = plannerRestrictionContext;
+
+	error = RecursivelyPlanCTEs(query, &context);
+	if (error != NULL)
+	{
+		return error;
+	}
+
 	if (SubqueryPushdown)
 	{
 		/*
@@ -153,17 +164,6 @@ RecursivelyPlanSubqueriesAndCTEs(Query *query,
 		 * subquery_pushdown is enabled.
 		 */
 		return NULL;
-	}
-
-	context.level = 0;
-	context.planId = planId;
-	context.subPlanList = NIL;
-	context.plannerRestrictionContext = plannerRestrictionContext;
-
-	error = RecursivelyPlanCTEs(query, &context);
-	if (error != NULL)
-	{
-		return error;
 	}
 
 	/* XXX: plan subqueries */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -713,6 +713,7 @@ Limit
                                                               Sort Key: events.event_time DESC
                                                               ->  Seq Scan on events_1400029 events
                                                                     Filter: (composite_id = users.composite_id)
+RESET citus.subquery_pushdown;
 -- Test all tasks output
 SET citus.explain_all_tasks TO on;
 EXPLAIN (COSTS FALSE)
@@ -1115,3 +1116,75 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
         ->  Append
               ->  Function Scan on generate_series s
               ->  Function Scan on generate_series s_1
+-- explain with recursive planning
+EXPLAIN (COSTS OFF, VERBOSE true)
+WITH keys AS (
+  SELECT DISTINCT l_orderkey FROM lineitem_hash_part
+),
+series AS (
+  SELECT s FROM generate_series(1,10) s
+)
+SELECT l_orderkey FROM series JOIN keys ON (s = l_orderkey)
+ORDER BY s;
+Custom Scan (Citus Router)
+  Output: remote_scan.l_orderkey
+  ->  Distributed Subplan 54_1
+        ->  HashAggregate
+              Output: remote_scan.l_orderkey
+              Group Key: remote_scan.l_orderkey
+              ->  Custom Scan (Citus Real-Time)
+                    Output: remote_scan.l_orderkey
+                    Task Count: 4
+                    Tasks Shown: One of 4
+                    ->  Task
+                          Node: host=localhost port=57637 dbname=regression
+                          ->  HashAggregate
+                                Output: l_orderkey
+                                Group Key: lineitem_hash_part.l_orderkey
+                                ->  Seq Scan on public.lineitem_hash_part_360038 lineitem_hash_part
+                                      Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+  ->  Distributed Subplan 54_2
+        ->  Function Scan on pg_catalog.generate_series s
+              Output: s
+              Function Call: generate_series(1, 10)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=57638 dbname=regression
+        ->  Merge Join
+              Output: intermediate_result_1.l_orderkey, intermediate_result.s
+              Merge Cond: (intermediate_result.s = intermediate_result_1.l_orderkey)
+              ->  Sort
+                    Output: intermediate_result.s
+                    Sort Key: intermediate_result.s
+                    ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
+                          Output: intermediate_result.s
+                          Function Call: read_intermediate_result('54_2'::text, 'binary'::citus_copy_format)
+              ->  Sort
+                    Output: intermediate_result_1.l_orderkey
+                    Sort Key: intermediate_result_1.l_orderkey
+                    ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
+                          Output: intermediate_result_1.l_orderkey
+                          Function Call: read_intermediate_result('54_1'::text, 'binary'::citus_copy_format)
+SELECT true AS valid FROM explain_json($$
+  WITH result AS (
+    SELECT l_quantity, count(*) count_quantity FROM lineitem
+	GROUP BY l_quantity ORDER BY count_quantity, l_quantity
+  ),
+  series AS (
+    SELECT s FROM generate_series(1,10) s
+  )
+  SELECT * FROM result JOIN series ON (s = count_quantity) JOIN orders_hash_part ON (s = o_orderkey)
+$$);
+t
+SELECT true AS valid FROM explain_xml($$
+  WITH result AS (
+    SELECT l_quantity, count(*) count_quantity FROM lineitem
+	GROUP BY l_quantity ORDER BY count_quantity, l_quantity
+  ),
+  series AS (
+    SELECT s FROM generate_series(1,10) s
+  )
+  SELECT * FROM result JOIN series ON (s = l_quantity) JOIN orders_hash_part ON (s = o_orderkey)
+$$);
+t

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -713,6 +713,7 @@ Limit
                                                               Sort Key: events.event_time DESC
                                                               ->  Seq Scan on events_1400029 events
                                                                     Filter: (composite_id = users.composite_id)
+RESET citus.subquery_pushdown;
 -- Test all tasks output
 SET citus.explain_all_tasks TO on;
 EXPLAIN (COSTS FALSE)
@@ -1115,3 +1116,75 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
         ->  Append
               ->  Function Scan on generate_series s
               ->  Function Scan on generate_series s_1
+-- explain with recursive planning
+EXPLAIN (COSTS OFF, VERBOSE true)
+WITH keys AS (
+  SELECT DISTINCT l_orderkey FROM lineitem_hash_part
+),
+series AS (
+  SELECT s FROM generate_series(1,10) s
+)
+SELECT l_orderkey FROM series JOIN keys ON (s = l_orderkey)
+ORDER BY s;
+Custom Scan (Citus Router)
+  Output: remote_scan.l_orderkey
+  ->  Distributed Subplan 54_1
+        ->  HashAggregate
+              Output: remote_scan.l_orderkey
+              Group Key: remote_scan.l_orderkey
+              ->  Custom Scan (Citus Real-Time)
+                    Output: remote_scan.l_orderkey
+                    Task Count: 4
+                    Tasks Shown: One of 4
+                    ->  Task
+                          Node: host=localhost port=57637 dbname=regression
+                          ->  HashAggregate
+                                Output: l_orderkey
+                                Group Key: lineitem_hash_part.l_orderkey
+                                ->  Seq Scan on public.lineitem_hash_part_360038 lineitem_hash_part
+                                      Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+  ->  Distributed Subplan 54_2
+        ->  Function Scan on pg_catalog.generate_series s
+              Output: s
+              Function Call: generate_series(1, 10)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=57638 dbname=regression
+        ->  Merge Join
+              Output: intermediate_result_1.l_orderkey, intermediate_result.s
+              Merge Cond: (intermediate_result.s = intermediate_result_1.l_orderkey)
+              ->  Sort
+                    Output: intermediate_result.s
+                    Sort Key: intermediate_result.s
+                    ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
+                          Output: intermediate_result.s
+                          Function Call: read_intermediate_result('54_2'::text, 'binary'::citus_copy_format)
+              ->  Sort
+                    Output: intermediate_result_1.l_orderkey
+                    Sort Key: intermediate_result_1.l_orderkey
+                    ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
+                          Output: intermediate_result_1.l_orderkey
+                          Function Call: read_intermediate_result('54_1'::text, 'binary'::citus_copy_format)
+SELECT true AS valid FROM explain_json($$
+  WITH result AS (
+    SELECT l_quantity, count(*) count_quantity FROM lineitem
+	GROUP BY l_quantity ORDER BY count_quantity, l_quantity
+  ),
+  series AS (
+    SELECT s FROM generate_series(1,10) s
+  )
+  SELECT * FROM result JOIN series ON (s = count_quantity) JOIN orders_hash_part ON (s = o_orderkey)
+$$);
+t
+SELECT true AS valid FROM explain_xml($$
+  WITH result AS (
+    SELECT l_quantity, count(*) count_quantity FROM lineitem
+	GROUP BY l_quantity ORDER BY count_quantity, l_quantity
+  ),
+  series AS (
+    SELECT s FROM generate_series(1,10) s
+  )
+  SELECT * FROM result JOIN series ON (s = l_quantity) JOIN orders_hash_part ON (s = o_orderkey)
+$$);
+t


### PR DESCRIPTION
Small change to the explain output for subplans to add the subplan ID. In verbose mode, you can then see where the result of the subplan gets used (e.g. `Distributed Subplan 5_1` is used by `Function Call: read_intermediate_result('5_1'::text, 'binary'::citus_copy_format)`).

Example output:
```sql
EXPLAIN (VERBOSE true) WITH date_range AS (SELECT d::date FROM generate_series('1998-11-01', '1998-11-30', interval '1 day') d),
review_counts AS (SELECT review_date, count(*) FROM customer_reviews JOIN date_range ON (review_date = d) GROUP BY review_date)
SELECT d AS date, Coalesce(count, 0) AS review_count FROM date_range LEFT JOIN review_counts ON (review_date = d);
                                                                               QUERY PLAN                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
   Output: remote_scan.date, remote_scan.review_count
   ->  Distributed Subplan 5_1
         ->  Function Scan on pg_catalog.generate_series d  (cost=0.00..12.50 rows=1000 width=4)
               Output: (d)::date
               Function Call: generate_series('1998-11-01 00:00:00+01'::timestamp with time zone, '1998-11-30 00:00:00+01'::timestamp with time zone, '1 day'::interval)
   ->  Distributed Subplan 5_2
         ->  HashAggregate  (cost=0.00..0.00 rows=0 width=0)
               Output: remote_scan.review_date, COALESCE((pg_catalog.sum(remote_scan.count))::bigint, '0'::bigint)
               Group Key: remote_scan.review_date
               ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
                     Output: remote_scan.review_date, remote_scan.count
                     Task Count: 32
                     Tasks Shown: One of 32
                     ->  Task
                           Node: host=localhost port=9700 dbname=postgres
                           ->  HashAggregate  (cost=1952.71..1956.36 rows=365 width=12)
                                 Output: customer_reviews.review_date, count(*)
                                 Group Key: customer_reviews.review_date
                                 ->  Hash Join  (cost=954.83..1702.58 rows=50025 width=4)
                                       Output: customer_reviews.review_date
                                       Hash Cond: (intermediate_result.d = customer_reviews.review_date)
                                       ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result  (cost=0.00..10.00 rows=1000 width=4)
                                             Output: intermediate_result.d
                                             Function Call: read_intermediate_result('5_1'::text, 'binary'::citus_copy_format)
                                       ->  Hash  (cost=726.59..726.59 rows=18259 width=4)
                                             Output: customer_reviews.review_date
                                             ->  Seq Scan on public.customer_reviews_102008 customer_reviews  (cost=0.00..726.59 rows=18259 width=4)
                                                   Output: customer_reviews.review_date
   Task Count: 1
   Tasks Shown: All
   ->  Task
         Node: host=localhost port=9700 dbname=postgres
         ->  Merge Left Join  (cost=119.66..199.66 rows=5000 width=12)
               Output: intermediate_result.d, COALESCE(intermediate_result_1.count, '0'::bigint)
               Merge Cond: (intermediate_result.d = intermediate_result_1.review_date)
               ->  Sort  (cost=59.83..62.33 rows=1000 width=4)
                     Output: intermediate_result.d
                     Sort Key: intermediate_result.d
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result  (cost=0.00..10.00 rows=1000 width=4)
                           Output: intermediate_result.d
                           Function Call: read_intermediate_result('5_1'::text, 'binary'::citus_copy_format)
               ->  Sort  (cost=59.83..62.33 rows=1000 width=12)
                     Output: intermediate_result_1.count, intermediate_result_1.review_date
                     Sort Key: intermediate_result_1.review_date
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1  (cost=0.00..10.00 rows=1000 width=12)
                           Output: intermediate_result_1.count, intermediate_result_1.review_date
                           Function Call: read_intermediate_result('5_2'::text, 'binary'::citus_copy_format)
(48 rows)

```