### PR TITLE
Get shard resource locks for only DMLs

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1063,8 +1063,15 @@ ExecuteModifyTasks(List *taskList, bool expectResults, ParamListInfo paramListIn
 		LockPartitionRelations(firstShardInterval->relationId, RowExclusiveLock);
 	}
 
-	/* ensure that there are no concurrent modifications on the same shards */
-	AcquireExecutorMultiShardLocks(taskList);
+	/*
+	 * Ensure that there are no concurrent modifications on the same
+	 * shards. For DDL commands, we already obtained the appropriate
+	 * locks in ProcessUtility.
+	 */
+	if (firstTask->taskType == MODIFY_TASK)
+	{
+		AcquireExecutorMultiShardLocks(taskList);
+	}
 
 	BeginOrContinueCoordinatedTransaction();
 


### PR DESCRIPTION
We already take required locks on the table for DDL commands and there is no need to take shard resource locks.

Fixes #1891