### PR TITLE
Prototype: Recursively plan sublinks in WHERE clause except IN/ANY

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -104,7 +104,6 @@ static bool ExtractSetOperationStatmentWalker(Node *node, List **setOperationLis
 static DeferredErrorMessage * DeferErrorIfUnsupportedTableCombination(Query *queryTree);
 static bool WindowPartitionOnDistributionColumn(Query *query);
 static bool AllTargetExpressionsAreColumnReferences(List *targetEntryList);
-static bool IsDistributedTableRTE(Node *node);
 static FieldSelect * CompositeFieldRecursive(Expr *expression, Query *query);
 static bool FullCompositeFieldList(List *compositeFieldList);
 static MultiNode * MultiNodeTree(Query *queryTree);
@@ -1524,7 +1523,7 @@ FindNodeCheckInRangeTableList(List *rtable, bool (*check)(Node *))
  * is a range table relation entry that points to a distributed
  * relation (i.e., excluding reference tables).
  */
-static bool
+bool
 IsDistributedTableRTE(Node *node)
 {
 	RangeTblEntry *rangeTableEntry = NULL;

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -116,6 +116,7 @@ static DeferredErrorMessage * RecursivelyPlanSubqueriesAndCTEs(Query *query,
 static DeferredErrorMessage * RecursivelyPlanCTEs(Query *query,
 												  RecursivePlanningContext *context);
 static bool RecursivelyPlanSubqueryWalker(Node *node, RecursivePlanningContext *context);
+static bool ShouldRecursivelyPlanSubLink(SubLink *subLink, bool subLinkIsNegated);
 static bool ShouldRecursivelyPlanSubquery(Query *subquery);
 static bool IsLocalTableRTE(Node *node);
 static void RecursivelyPlanSubquery(Query *subquery,
@@ -358,15 +359,40 @@ RecursivelyPlanCTEs(Query *query, RecursivePlanningContext *planningContext)
 static bool
 RecursivelyPlanSubqueryWalker(Node *node, RecursivePlanningContext *context)
 {
+	bool expressionIsNegated = false;
+	SubLink *subLink = NULL;
+
 	if (node == NULL)
 	{
 		return false;
 	}
 
+	if (IsA(node, BoolExpr))
+	{
+		BoolExpr *boolExpr = (BoolExpr *) node;
+
+		if (boolExpr->boolop == NOT_EXPR)
+		{
+			expressionIsNegated = true;
+
+			/* in case of a NOT IN, drop into sublink logic below */
+			node = (Node *) linitial(boolExpr->args);
+		}
+	}
+
+	if (IsA(node, SubLink))
+	{
+		subLink = (SubLink *) node;
+		node = subLink->subselect;
+	}
+
 	if (IsA(node, Query))
 	{
 		Query *query = (Query *) node;
+
 		DeferredErrorMessage *error = NULL;
+
+		Assert(IsA(query, Query));
 
 		context->level += 1;
 
@@ -381,12 +407,13 @@ RecursivelyPlanSubqueryWalker(Node *node, RecursivePlanningContext *context)
 		}
 		context->level -= 1;
 
-		/*
-		 * Recursively plan this subquery if it cannot be pushed down and is
-		 * eligible for recursive planning.
-		 */
-		if (ShouldRecursivelyPlanSubquery(query))
+		if (ShouldRecursivelyPlanSubLink(subLink, expressionIsNegated) ||
+			ShouldRecursivelyPlanSubquery(query))
 		{
+			/*
+			 * Recursively plan this subquery if it cannot be pushed down and is
+			 * eligible for recursive planning.
+			 */
 			RecursivelyPlanSubquery(query, context);
 		}
 
@@ -395,6 +422,44 @@ RecursivelyPlanSubqueryWalker(Node *node, RecursivePlanningContext *context)
 	}
 
 	return expression_tree_walker(node, RecursivelyPlanSubqueryWalker, context);
+}
+
+
+/*
+ * ShouldRecursivelyPlanSubLink checks whether a sublink should be recursively planned.
+ * This is the case when it contains a distributed table, does not have references to
+ * outer queries, and is not of the form partition_column IN
+ */
+static bool
+ShouldRecursivelyPlanSubLink(SubLink *subLink, bool subLinkIsNegated)
+{
+	Query *query = NULL;
+
+	if (subLink == NULL || !IsA(subLink, SubLink))
+	{
+		/* there is no sublink to recursively plan */
+		return false;
+	}
+
+	query = (Query *) subLink->subselect;
+	Assert(IsA(query, Query));
+
+	if (subLink->subLinkType == ANY_SUBLINK && !subLinkIsNegated)
+	{
+		/*
+		 * IN (SELECT partition_column FROM distributed_table) query may be
+		 * pushed down.
+		 */
+		return false;
+	}
+
+	if (!FindNodeCheckInRangeTableList(query->rtable, IsDistributedTableRTE))
+	{
+		/* sublinks without distributed tables can be pushed down */
+		return false;
+	}
+
+	return true;
 }
 
 
@@ -434,19 +499,6 @@ ShouldRecursivelyPlanSubquery(Query *subquery)
 		 * Citus can plan this and execute via repartitioning. Thus,
 		 * no need to recursively plan.
 		 */
-		return false;
-	}
-
-	/*
-	 * Even if we could recursively plan the subquery, we should ensure
-	 * that the subquery doesn't contain any references to the outer
-	 * queries.
-	 */
-	if (ContainsReferencesToOuterQuery(subquery))
-	{
-		elog(DEBUG2, "skipping recursive planning for the subquery since it "
-					 "contains references to outer queries");
-
 		return false;
 	}
 
@@ -510,6 +562,19 @@ RecursivelyPlanSubquery(Query *subquery, RecursivePlanningContext *planningConte
 
 	Query *resultQuery = NULL;
 	Query *debugQuery = NULL;
+
+	/*
+	 * Even if we could recursively plan the subquery, we should ensure
+	 * that the subquery doesn't contain any references to the outer
+	 * queries.
+	 */
+	if (ContainsReferencesToOuterQuery(subquery))
+	{
+		elog(DEBUG2, "skipping recursive planning for the subquery since it "
+					 "contains references to outer queries");
+
+		return;
+	}
 
 	/*
 	 * Subquery will go through the standard planner, thus to properly deparse it

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -197,6 +197,7 @@ extern PlannerRestrictionContext * FilterPlannerRestrictionForQuery(
 extern bool SafeToPushdownWindowFunction(Query *query, StringInfo *errorDetail);
 extern bool TargetListOnPartitionColumn(Query *query, List *targetEntryList);
 extern bool FindNodeCheckInRangeTableList(List *rtable, bool (*check)(Node *));
+extern bool IsDistributedTableRTE(Node *node);
 extern bool ContainsReadIntermediateResultFunction(Node *node);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);

--- a/src/test/regress/expected/multi_subquery_behavioral_analytics.out
+++ b/src/test/regress/expected/multi_subquery_behavioral_analytics.out
@@ -779,7 +779,6 @@ SELECT count(*), count(DISTINCT user_id), avg(user_id) FROM assets;
 
 DROP TABLE assets;
 -- count number of distinct users who have value_1 equal to 5 or 13 but not 3
--- original query that fails
 SELECT count(*) FROM
 (
   SELECT 
@@ -794,8 +793,11 @@ SELECT count(*) FROM
   HAVING 
     count(distinct value_1) = 2
 ) as foo;
-ERROR:  cannot pushdown the subquery since all relations are not joined using distribution keys
-DETAIL:  Each relation should be joined with at least one another relation using distribution keys and equality operator.
+ count 
+-------
+     1
+(1 row)
+
 -- previous push down query
 SELECT subquery_count FROM
     (SELECT count(*) as subquery_count FROM

--- a/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
@@ -413,7 +413,7 @@ ORDER BY 1, 2;
        5 |       5
 (2 rows)
 
--- reference tables are not allowed if there is sublink
+-- reference tables are allowed if the sublink is recursively planned
 SELECT
   count(*) 
 FROM 
@@ -421,9 +421,12 @@ FROM
 WHERE user_id 
   NOT IN
 (SELECT users_table.value_2 FROM users_table JOIN users_reference_table as u2 ON users_table.value_2 = u2.value_2);
-ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
--- reference tables are not allowed if there is sublink
+ count 
+-------
+    10
+(1 row)
+
+-- reference tables are allowed if the sublink is recursively planned
 SELECT count(*)
 FROM
   (SELECT 
@@ -432,8 +435,11 @@ FROM
     (SELECT users_table.value_2
      FROM users_table
      JOIN users_reference_table AS u2 ON users_table.value_2 = u2.value_2);
-ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
+ count 
+-------
+    10
+(1 row)
+
 -- reference tables are not allowed if there is sublink
 SELECT user_id,
        count(*)

--- a/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
+++ b/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
@@ -643,7 +643,6 @@ SELECT count(*), count(DISTINCT user_id), avg(user_id) FROM assets;
 DROP TABLE assets;
 
 -- count number of distinct users who have value_1 equal to 5 or 13 but not 3
--- original query that fails
 SELECT count(*) FROM
 (
   SELECT 

--- a/src/test/regress/sql/multi_subquery_in_where_reference_clause.sql
+++ b/src/test/regress/sql/multi_subquery_in_where_reference_clause.sql
@@ -353,7 +353,7 @@ SELECT user_id, value_2 FROM users_table WHERE
 )
 ORDER BY 1, 2;
 
--- reference tables are not allowed if there is sublink
+-- reference tables are allowed if the sublink is recursively planned
 SELECT
   count(*) 
 FROM 
@@ -363,7 +363,7 @@ WHERE user_id
 (SELECT users_table.value_2 FROM users_table JOIN users_reference_table as u2 ON users_table.value_2 = u2.value_2);
 
 
--- reference tables are not allowed if there is sublink
+-- reference tables are allowed if the sublink is recursively planned
 SELECT count(*)
 FROM
   (SELECT 


### PR DESCRIPTION
Recursively plan non-correlated sublinks in WHERE except IN/ANY, which might be pushdownable.

Needs regression tests.