### PR TITLE
Prototype: Recursively plan all sublinks in WHERE if FROM recurs

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -104,7 +104,6 @@ static bool ExtractSetOperationStatmentWalker(Node *node, List **setOperationLis
 static DeferredErrorMessage * DeferErrorIfUnsupportedTableCombination(Query *queryTree);
 static bool WindowPartitionOnDistributionColumn(Query *query);
 static bool AllTargetExpressionsAreColumnReferences(List *targetEntryList);
-static bool IsDistributedTableRTE(Node *node);
 static FieldSelect * CompositeFieldRecursive(Expr *expression, Query *query);
 static bool FullCompositeFieldList(List *compositeFieldList);
 static MultiNode * MultiNodeTree(Query *queryTree);
@@ -1524,7 +1523,7 @@ FindNodeCheckInRangeTableList(List *rtable, bool (*check)(Node *))
  * is a range table relation entry that points to a distributed
  * relation (i.e., excluding reference tables).
  */
-static bool
+bool
 IsDistributedTableRTE(Node *node)
 {
 	RangeTblEntry *rangeTableEntry = NULL;

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -864,7 +864,8 @@ DeferErrorIfFromClauseRecurs(Query *queryTree)
 							 "cannot pushdown the subquery",
 							 "Reference tables are not allowed in FROM "
 							 "clause when the query has subqueries in "
-							 "WHERE clause", NULL);
+							 "WHERE clause and it references a column "
+							 "from another query", NULL);
 	}
 	else if (recurType == RECURRING_TUPLES_FUNCTION)
 	{
@@ -872,15 +873,17 @@ DeferErrorIfFromClauseRecurs(Query *queryTree)
 							 "cannot pushdown the subquery",
 							 "Functions are not allowed in FROM "
 							 "clause when the query has subqueries in "
-							 "WHERE clause", NULL);
+							 "WHERE clause and it references a column "
+							 "from another query", NULL);
 	}
 	else if (recurType == RECURRING_TUPLES_RESULT_FUNCTION)
 	{
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 							 "cannot pushdown the subquery",
 							 "Complex subqueries and CTEs are not allowed in "
-							 "the FROM clause when the query has subqueries in the "
-							 "WHERE clause", NULL);
+							 "the FROM clause when the query has correlated subqueries "
+							 "WHERE clause and it references a column "
+							 "from another query", NULL);
 	}
 	else if (recurType == RECURRING_TUPLES_EMPTY_JOIN_TREE)
 	{
@@ -888,7 +891,8 @@ DeferErrorIfFromClauseRecurs(Query *queryTree)
 							 "cannot pushdown the subquery",
 							 "Subqueries without FROM are not allowed in FROM "
 							 "clause when the outer query has subqueries in "
-							 "WHERE clause", NULL);
+							 "WHERE clause and it references a column "
+							 "from another query", NULL);
 	}
 
 	/*

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -113,6 +113,9 @@ typedef struct VarLevelsUpWalkerContext
 static DeferredErrorMessage * RecursivelyPlanSubqueriesAndCTEs(Query *query,
 															   RecursivePlanningContext *
 															   context);
+static bool ShouldRecursivelyPlanWhereClauseSubqueries(Query *query);
+static bool RecursivelyPlanAllSubqueries(Node *node,
+										 RecursivePlanningContext *planningContext);
 static DeferredErrorMessage * RecursivelyPlanCTEs(Query *query,
 												  RecursivePlanningContext *context);
 static bool RecursivelyPlanSubqueryWalker(Node *node, RecursivePlanningContext *context);
@@ -205,7 +208,81 @@ RecursivelyPlanSubqueriesAndCTEs(Query *query, RecursivePlanningContext *context
 	/* descend into subqueries */
 	query_tree_walker(query, RecursivelyPlanSubqueryWalker, context, 0);
 
+	/*
+	 * If the FROM clause is recurring (does not contain a distributed table),
+	 * then we cannot have any distributed tables appearing in subqueries in
+	 * the WHERE clause.
+	 */
+	if (ShouldRecursivelyPlanWhereClauseSubqueries(query))
+	{
+		/* replace all subqueries in the WHERE clause */
+		RecursivelyPlanAllSubqueries((Node *) query->jointree->quals, context);
+	}
+
 	return NULL;
+}
+
+
+/*
+ * ShouldRecursivelyPlanWhereClauseSubqueries returns whether the query has
+ * a WHERE clause and a recurring FROM clause (does not contain a distributed
+ * table).
+ */
+static bool
+ShouldRecursivelyPlanWhereClauseSubqueries(Query *query)
+{
+	FromExpr *joinTree = NULL;
+	Node *whereClause = NULL;
+
+	joinTree = query->jointree;
+	if (joinTree == NULL)
+	{
+		/* there is no FROM clause */
+		return false;
+	}
+
+	whereClause = joinTree->quals;
+	if (whereClause == NULL)
+	{
+		/* there is no WHERE clause */
+		return false;
+	}
+
+	if (FindNodeCheckInRangeTableList(query->rtable, IsDistributedTableRTE))
+	{
+		/* there is a distributed table in the FROM clause */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * RecursivelyPlanAllSubqueries descends into an expression tree and recursively
+ * plans all subqueries found from the top.
+ */
+static bool
+RecursivelyPlanAllSubqueries(Node *node, RecursivePlanningContext *planningContext)
+{
+	if (node == NULL)
+	{
+		return false;
+	}
+
+	if (IsA(node, Query))
+	{
+		Query *query = (Query *) node;
+
+		if (FindNodeCheckInRangeTableList(query->rtable, IsDistributedTableRTE))
+		{
+			RecursivelyPlanSubquery(query, planningContext);
+		}
+
+		return false;
+	}
+
+	return expression_tree_walker(node, RecursivelyPlanAllSubqueries, planningContext);
 }
 
 
@@ -437,19 +514,6 @@ ShouldRecursivelyPlanSubquery(Query *subquery)
 		return false;
 	}
 
-	/*
-	 * Even if we could recursively plan the subquery, we should ensure
-	 * that the subquery doesn't contain any references to the outer
-	 * queries.
-	 */
-	if (ContainsReferencesToOuterQuery(subquery))
-	{
-		elog(DEBUG2, "skipping recursive planning for the subquery since it "
-					 "contains references to outer queries");
-
-		return false;
-	}
-
 	return true;
 }
 
@@ -510,6 +574,19 @@ RecursivelyPlanSubquery(Query *subquery, RecursivePlanningContext *planningConte
 
 	Query *resultQuery = NULL;
 	Query *debugQuery = NULL;
+
+	/*
+	 * Even if we could recursively plan the subquery, we should ensure
+	 * that the subquery doesn't contain any references to the outer
+	 * queries.
+	 */
+	if (ContainsReferencesToOuterQuery(subquery))
+	{
+		elog(DEBUG2, "skipping recursive planning for the subquery since it "
+					 "contains references to outer queries");
+
+		return;
+	}
 
 	/*
 	 * Subquery will go through the standard planner, thus to properly deparse it

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -197,6 +197,7 @@ extern PlannerRestrictionContext * FilterPlannerRestrictionForQuery(
 extern bool SafeToPushdownWindowFunction(Query *query, StringInfo *errorDetail);
 extern bool TargetListOnPartitionColumn(Query *query, List *targetEntryList);
 extern bool FindNodeCheckInRangeTableList(List *rtable, bool (*check)(Node *));
+extern bool IsDistributedTableRTE(Node *node);
 extern bool ContainsReadIntermediateResultFunction(Node *node);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);

--- a/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
@@ -413,7 +413,7 @@ ORDER BY 1, 2;
        5 |       5
 (2 rows)
 
--- reference tables are not allowed if there is sublink
+-- when using a reference table in FROM the subquery in WHERE is recursively planned
 SELECT
   count(*) 
 FROM 
@@ -421,9 +421,11 @@ FROM
 WHERE user_id 
   NOT IN
 (SELECT users_table.value_2 FROM users_table JOIN users_reference_table as u2 ON users_table.value_2 = u2.value_2);
-ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
--- reference tables are not allowed if there is sublink
+ count 
+-------
+    10
+(1 row)
+
 SELECT count(*)
 FROM
   (SELECT 
@@ -432,8 +434,11 @@ FROM
     (SELECT users_table.value_2
      FROM users_table
      JOIN users_reference_table AS u2 ON users_table.value_2 = u2.value_2);
-ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
+ count 
+-------
+    10
+(1 row)
+
 -- reference tables are not allowed if there is sublink
 SELECT user_id,
        count(*)

--- a/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
@@ -63,7 +63,7 @@ WHERE
       )
 LIMIT 3;
 ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
+DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause and it references a column from another query
 -- immutable functions are also treated as reference tables
 SELECT
   user_id
@@ -80,7 +80,7 @@ WHERE
       )
 LIMIT 3;
 ERROR:  cannot pushdown the subquery
-DETAIL:  Functions are not allowed in FROM clause when the query has subqueries in WHERE clause
+DETAIL:  Functions are not allowed in FROM clause when the query has subqueries in WHERE clause and it references a column from another query
 -- subqueries without FROM are also treated as reference tables
 SELECT
   user_id
@@ -97,7 +97,7 @@ WHERE
       )
 LIMIT 3;
 ERROR:  cannot pushdown the subquery
-DETAIL:  Subqueries without FROM are not allowed in FROM clause when the outer query has subqueries in WHERE clause
+DETAIL:  Subqueries without FROM are not allowed in FROM clause when the outer query has subqueries in WHERE clause and it references a column from another query
 -- join with distributed table prevents FROM from recurring
 SELECT
   DISTINCT user_id
@@ -454,7 +454,7 @@ ORDER BY 2 DESC,
          1 DESC
 LIMIT 5;
 ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause
+DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause and it references a column from another query
 -- reference tables are not allowed if there is sublink
 -- this time in the subquery
 SELECT *

--- a/src/test/regress/expected/subqueries_not_supported.out
+++ b/src/test/regress/expected/subqueries_not_supported.out
@@ -60,23 +60,6 @@ FROM
 		LIMIT 5
 	) as foo;
 ERROR:  array_agg with order by is unsupported
--- we don't support queries with recurring tuples in the FROM
--- clause and subquery in WHERE clause
-SELECT
-	* 
-FROM
-	(
-		SELECT 
-			users_table.user_id 
-		FROM 
-			users_table, (SELECT user_id FROM events_table) as evs
-		WHERE users_table.user_id = evs.user_id
-		LIMIT 5
-	) as foo WHERE user_id IN (SELECT count(*) FROM users_table GROUP BY user_id);
-DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 10_1 for subquery SELECT users_table.user_id FROM public.users_table, (SELECT events_table.user_id FROM public.events_table) evs WHERE (users_table.user_id = evs.user_id) LIMIT 5
-ERROR:  cannot pushdown the subquery
-DETAIL:  Complex subqueries and CTEs are not allowed in the FROM clause when the query has subqueries in the WHERE clause
 -- we don't support recursive subqueries when router executor is disabled
 SET citus.enable_router_execution TO false;
 SELECT
@@ -93,7 +76,7 @@ FROM
      ) as foo
     ORDER BY 1 DESC;
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 12_1 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  generating subplan 10_1 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
 ERROR:  cannot handle complex subqueries when the router executor is disabled
 SET citus.enable_router_execution TO true;
 -- window functions are not allowed if they're not partitioned on the distribution column
@@ -138,7 +121,7 @@ FROM
     	(SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
 	ON(foo.value_2 = bar.value_2);
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 17_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) LIMIT 5
+DEBUG:  generating subplan 15_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) LIMIT 5
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 SET client_min_messages TO DEFAULT;

--- a/src/test/regress/expected/subquery_and_cte.out
+++ b/src/test/regress/expected/subquery_and_cte.out
@@ -423,6 +423,586 @@ FROM
      ) as bar  
 WHERE foo.user_id = bar.user_id;
 ERROR:  recursive CTEs are not supported in distributed queries
+--CTEs can be used as a recurring tuple with subqueries in WHERE
+WITH event_id AS (
+	SELECT user_id as events_user_id, time as events_time, event_type
+	FROM events_table
+)
+SELECT
+	count(*)
+FROM
+	event_id
+WHERE
+	events_user_id IN (SELECT user_id FROM users_table);
+DEBUG:  generating subplan 45_1 for CTE event_id: SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table
+DEBUG:  generating subplan 45_2 for subquery SELECT user_id FROM public.users_table
+ count 
+-------
+   101
+(1 row)
+
+--Correlated subqueries can not be used in WHERE clause
+WITH event_id AS (
+	SELECT user_id as events_user_id, time as events_time, event_type
+	FROM events_table
+)
+SELECT
+	count(*)
+FROM
+	event_id
+WHERE
+	events_user_id IN (SELECT user_id FROM users_table where users_table.time = events_time);
+DEBUG:  generating subplan 48_1 for CTE event_id: SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table
+ERROR:  cannot pushdown the subquery
+DETAIL:  Complex subqueries and CTEs are not allowed in the FROM clause when the query has correlated subqueries WHERE clause and it references a column from another query
+-- Recurring tuples as empty join tree
+SELECT
+	*
+FROM (
+	SELECT
+		1 AS id,
+		2 AS value_1,
+		3 AS value_3
+	) AS tt1
+WHERE
+	id
+IN (
+	SELECT
+		user_id
+	FROM
+	events_table
+   );
+DEBUG:  generating subplan 50_1 for subquery SELECT user_id FROM public.events_table
+ id | value_1 | value_3 
+----+---------+---------
+  1 |       2 |       3
+(1 row)
+
+-- Recurring tuples in from clause as CTE and SET operation in WHERE clause
+SELECT
+	COUNT(*)
+FROM
+	(
+		WITH event_id AS (
+			SELECT
+				user_id as events_user_id, time as events_time, event_type
+			FROM
+				events_table
+		)
+		SELECT
+			events_user_id, events_time, event_type
+		FROM
+			event_id
+		LIMIT
+			10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+IN
+	(
+		(SELECT
+			user_id
+		FROM
+			users_table
+		LIMIT
+			10
+		)
+		UNION ALL
+		(SELECT
+			value_1
+		FROM
+			users_table
+		LIMIT
+			10
+		)
+	);
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 52_1 for subquery SELECT user_id FROM public.users_table LIMIT 10
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 52_2 for subquery SELECT value_1 FROM public.users_table LIMIT 10
+DEBUG:  generating subplan 52_3 for subquery SELECT intermediate_result.user_id FROM read_intermediate_result('52_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION ALL SELECT intermediate_result.value_1 FROM read_intermediate_result('52_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer)
+DEBUG:  generating subplan 52_4 for CTE event_id: SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table
+DEBUG:  generating subplan 52_5 for subquery SELECT events_user_id, events_time, event_type FROM (SELECT intermediate_result.events_user_id, intermediate_result.events_time, intermediate_result.event_type FROM read_intermediate_result('52_4'::text, 'binary'::citus_copy_format) intermediate_result(events_user_id integer, events_time timestamp without time zone, event_type integer)) event_id LIMIT 10
+ count 
+-------
+    10
+(1 row)
+
+-- Recurring tuples in fram clause as SET operation on recursively plannable
+-- queries and CTE in WHERE clause
+SELECT
+	*
+FROM
+	(
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id ASC
+		LIMIT
+			10
+		)
+		UNION ALL
+		(SELECT
+			value_1
+		FROM
+			users_table
+		ORDER BY
+			value_1 ASC
+		LIMIT
+			10
+		)
+	) as SUB_TABLE
+WHERE
+	user_id
+IN
+	(
+	WITH event_id AS (
+		SELECT
+			user_id as events_user_id, time as events_time, event_type
+		FROM
+			events_table
+	)
+	SELECT
+		events_user_id
+	FROM
+		event_id
+	ORDER BY
+		events_user_id
+	LIMIT
+		10
+	);
+DEBUG:  generating subplan 58_1 for CTE event_id: SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table
+DEBUG:  generating subplan 58_2 for subquery SELECT events_user_id FROM (SELECT intermediate_result.events_user_id, intermediate_result.events_time, intermediate_result.event_type FROM read_intermediate_result('58_1'::text, 'binary'::citus_copy_format) intermediate_result(events_user_id integer, events_time timestamp without time zone, event_type integer)) event_id ORDER BY events_user_id LIMIT 10
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 58_3 for subquery SELECT user_id FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 58_4 for subquery SELECT value_1 FROM public.users_table ORDER BY value_1 LIMIT 10
+DEBUG:  generating subplan 58_5 for subquery SELECT intermediate_result.user_id FROM read_intermediate_result('58_3'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION ALL SELECT intermediate_result.value_1 FROM read_intermediate_result('58_4'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer)
+ user_id 
+---------
+       1
+       1
+       1
+       1
+       1
+       1
+       1
+(7 rows)
+
+-- Complex target list in WHERE clause
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		user_id as events_user_id, time as events_time, event_type
+	FROM
+		events_table
+	LIMIT
+		10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+<= (
+	SELECT
+		max(abs(value_1 * 1) + mod(value_1, 3)) as val_1
+	FROM
+		users_table
+);
+DEBUG:  generating subplan 64_1 for subquery SELECT max((abs((value_1 * 1)) + mod(value_1, 3))) AS val_1 FROM public.users_table
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 64_2 for subquery SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table LIMIT 10
+ count 
+-------
+    10
+(1 row)
+
+-- DISTINCT clause in WHERE
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		user_id as events_user_id, time as events_time, event_type
+	FROM
+		events_table
+	LIMIT
+		10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+IN (
+	SELECT
+		distinct value_1
+	FROM
+		users_table
+);
+DEBUG:  generating subplan 67_1 for subquery SELECT DISTINCT value_1 FROM public.users_table
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 67_2 for subquery SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table LIMIT 10
+ count 
+-------
+    10
+(1 row)
+
+-- AND in WHERE clause
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		user_id as events_user_id, time as events_time, event_type
+	FROM
+		events_table
+	LIMIT
+		10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+> (
+	SELECT
+		min(value_1)
+	FROM
+		users_table
+)
+AND
+	events_user_id
+< (
+	SELECT
+		max(value_2)
+	FROM
+		users_table
+);
+DEBUG:  generating subplan 70_1 for subquery SELECT min(value_1) AS min FROM public.users_table
+DEBUG:  generating subplan 70_2 for subquery SELECT max(value_2) AS max FROM public.users_table
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 70_3 for subquery SELECT user_id AS events_user_id, "time" AS events_time, event_type FROM public.events_table LIMIT 10
+ count 
+-------
+     4
+(1 row)
+
+-- Planning subqueries in WHERE clause in CTE recursively
+WITH cte AS (
+	SELECT
+		*
+	FROM
+		(SELECT
+			*
+		FROM
+			users_table
+		ORDER BY
+			user_id ASC,
+			value_2 DESC
+		LIMIT
+			10
+		) as sub_table
+	WHERE
+		user_id
+	IN
+		(SELECT
+			value_2
+		FROM
+			events_table
+		)
+)
+SELECT
+	COUNT(*)
+FROM
+	cte;
+DEBUG:  generating subplan 74_1 for CTE cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM (SELECT users_table.user_id, users_table."time", users_table.value_1, users_table.value_2, users_table.value_3, users_table.value_4 FROM public.users_table ORDER BY users_table.user_id, users_table.value_2 DESC LIMIT 10) sub_table WHERE (user_id IN (SELECT events_table.value_2 FROM public.events_table))
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 75_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table ORDER BY user_id, value_2 DESC LIMIT 10
+DEBUG:  generating subplan 75_2 for subquery SELECT value_2 FROM public.events_table
+ count 
+-------
+    10
+(1 row)
+
+-- Planing subquery in WHERE clause in FROM clause of a subquery recursively
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			*
+		FROM
+			users_table
+		ORDER BY
+			user_id ASC,
+			value_2 DESC
+		LIMIT
+			10
+		) as sub_table_1
+	WHERE
+		user_id
+	IN
+		(SELECT
+			value_2
+		FROM
+			events_table
+		)
+	) as sub_table_2;
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 78_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table ORDER BY user_id, value_2 DESC LIMIT 10
+DEBUG:  generating subplan 78_2 for subquery SELECT value_2 FROM public.events_table
+DEBUG:  generating subplan 78_3 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('78_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) sub_table_1 WHERE (user_id IN (SELECT intermediate_result.value_2 FROM read_intermediate_result('78_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)))
+ count 
+-------
+    10
+(1 row)
+
+-- Recurring table in the FROM clause of a subquery in the FROM clause
+-- Recurring table is created by joining a two recurrign table
+SELECT
+	SUM(user_id)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT 10) as t1
+		INNER JOIN
+		(SELECT
+			user_id as user_id_2
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT
+			10) as t2
+		ON
+			t1.user_id = t2.user_id_2
+		WHERE
+			t1.user_id
+		IN
+			(SELECT
+				value_2
+			FROM
+				events_table)
+	) as t3
+WHERE
+	user_id
+>
+	(SELECT
+		min(value_3)
+	FROM
+		events_table);
+DEBUG:  generating subplan 82_1 for subquery SELECT min(value_3) AS min FROM public.events_table
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 82_2 for subquery SELECT user_id FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 82_3 for subquery SELECT user_id AS user_id_2 FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  generating subplan 82_4 for subquery SELECT value_2 FROM public.events_table
+DEBUG:  generating subplan 82_5 for subquery SELECT t1.user_id, t2.user_id_2 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('82_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) t1 JOIN (SELECT intermediate_result.user_id_2 FROM read_intermediate_result('82_3'::text, 'binary'::citus_copy_format) intermediate_result(user_id_2 integer)) t2 ON ((t1.user_id = t2.user_id_2))) WHERE (t1.user_id IN (SELECT intermediate_result.value_2 FROM read_intermediate_result('82_4'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)))
+ sum 
+-----
+  67
+(1 row)
+
+-- Same example with the above query, but now check the rows with EXISTS
+SELECT
+	SUM(user_id)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT 10) as t1
+		INNER JOIN
+		(SELECT
+			user_id as user_id_2
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT
+			10) as t2
+		ON
+			t1.user_id = t2.user_id_2
+		WHERE
+			t1.user_id
+		IN
+			(SELECT
+				value_2
+			FROM
+				events_table)
+	) as t3
+WHERE EXISTS
+	(SELECT
+		1,2
+	FROM
+		events_table
+	WHERE
+		events_table.value_2 = user_id);
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 88_1 for subquery SELECT user_id FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 88_2 for subquery SELECT user_id AS user_id_2 FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  generating subplan 88_3 for subquery SELECT value_2 FROM public.events_table
+DEBUG:  generating subplan 88_4 for subquery SELECT t1.user_id, t2.user_id_2 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('88_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) t1 JOIN (SELECT intermediate_result.user_id_2 FROM read_intermediate_result('88_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id_2 integer)) t2 ON ((t1.user_id = t2.user_id_2))) WHERE (t1.user_id IN (SELECT intermediate_result.value_2 FROM read_intermediate_result('88_3'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)))
+DEBUG:  generating subplan 88_5 for subquery SELECT 1, 2 FROM public.events_table WHERE (value_2 = user_id)
+ sum 
+-----
+  67
+(1 row)
+
+-- Same query with the above one, yet now we check the row's NON-existence
+-- by NOT EXISTS. Note that, max value_2 of events_table is 5
+SELECT
+	SUM(user_id)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT 10) as t1
+		INNER JOIN
+		(SELECT
+			user_id as user_id_2
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT
+			10) as t2
+		ON
+			t1.user_id = t2.user_id_2
+		WHERE
+			t1.user_id
+		IN
+			(SELECT
+				value_2
+			FROM
+				events_table)
+	) as t3
+WHERE NOT EXISTS
+	(SELECT
+		1,2
+	FROM
+		events_table
+	WHERE
+		events_table.value_2 = user_id + 6);
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 94_1 for subquery SELECT user_id FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 94_2 for subquery SELECT user_id AS user_id_2 FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  generating subplan 94_3 for subquery SELECT value_2 FROM public.events_table
+DEBUG:  generating subplan 94_4 for subquery SELECT t1.user_id, t2.user_id_2 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('94_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) t1 JOIN (SELECT intermediate_result.user_id_2 FROM read_intermediate_result('94_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id_2 integer)) t2 ON ((t1.user_id = t2.user_id_2))) WHERE (t1.user_id IN (SELECT intermediate_result.value_2 FROM read_intermediate_result('94_3'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)))
+DEBUG:  generating subplan 94_5 for subquery SELECT 1, 2 FROM public.events_table WHERE (value_2 = (user_id + 6))
+ sum 
+-----
+  67
+(1 row)
+
+-- Check the existence of row by comparing it with the result of subquery in
+-- WHERE clause. Note that subquery is planned recursively since there is no
+-- distributed table in the from
+SELECT
+	*
+FROM
+	(SELECT
+		user_id, value_1
+	FROM
+		users_table
+	ORDER BY
+		user_id ASC,
+		value_1 ASC
+	LIMIT 10) as t3
+WHERE row(user_id, value_1) =
+	(SELECT
+		min(value_2) + 1, min(value_2) + 1
+	FROM
+		events_table);
+DEBUG:  generating subplan 100_1 for subquery SELECT (min(value_2) + 1), (min(value_2) + 1) FROM public.events_table
+DEBUG:  push down of limit count: 10
+DEBUG:  generating subplan 100_2 for subquery SELECT user_id, value_1 FROM public.users_table ORDER BY user_id, value_1 LIMIT 10
+ user_id | value_1 
+---------+---------
+       1 |       1
+(1 row)
+
+-- Recursively plan subquery in WHERE clause when the FROM clause has a subquery
+-- generated by generate_series function
+SELECT
+	*
+FROM
+	(SELECT
+		*
+	FROM
+		generate_series(1,10)
+	) as gst
+WHERE
+	generate_series
+IN
+	(SELECT
+		value_2
+	FROM
+		events_table
+	)
+ORDER BY
+	generate_series ASC;
+DEBUG:  generating subplan 103_1 for subquery SELECT value_2 FROM public.events_table
+ generate_series 
+-----------------
+               1
+               2
+               3
+               4
+               5
+(5 rows)
+
+-- Similar to the test above, now we also have a generate_series in WHERE clause
+SELECT
+	*
+FROM
+	(SELECT
+		*
+	FROM
+		generate_series(1,10)
+	) as gst
+WHERE
+	generate_series
+IN
+	(SELECT
+		user_id
+	FROM
+		users_table
+	WHERE
+		user_id
+	IN
+		(SELECT
+			*
+		FROM
+			generate_series(1,3)
+		)
+	)
+ORDER BY
+	generate_series ASC;
+DEBUG:  generating subplan 105_1 for subquery SELECT user_id FROM public.users_table WHERE (user_id IN (SELECT generate_series.generate_series FROM generate_series(1, 3) generate_series(generate_series)))
+ generate_series 
+-----------------
+               1
+               2
+               3
+(3 rows)
+
 SET client_min_messages TO DEFAULT;
 DROP SCHEMA subquery_and_ctes CASCADE;
 NOTICE:  drop cascades to table users_table_local

--- a/src/test/regress/expected/subquery_and_cte.out
+++ b/src/test/regress/expected/subquery_and_cte.out
@@ -108,9 +108,7 @@ DEBUG:  generating subplan 10_2 for subquery SELECT DISTINCT value_2 FROM public
 (4 rows)
 
 -- a very similar query as the above, but this time errors 
--- out since we don't support subqueries in WHERE clause
--- when there is only intermediate results on the range table
--- note that this time subquery in WHERE clause is not replaced
+-- out because the FROM clause is recurring, the WHERE clause is automatically replaced
 WITH cte AS (
 	WITH local_cte AS (
 		SELECT * FROM users_table_local
@@ -128,8 +126,17 @@ WHERE
 DEBUG:  generating subplan 14_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 15_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
 DEBUG:  generating subplan 15_2 for CTE dist_cte: SELECT user_id FROM public.events_table
-ERROR:  cannot pushdown the subquery
-DETAIL:  Complex subqueries and CTEs are not allowed in the FROM clause when the query has subqueries in the WHERE clause
+DEBUG:  generating subplan 14_2 for subquery SELECT DISTINCT user_id FROM public.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20))
+ user_id 
+---------
+       6
+       5
+       4
+       3
+       2
+       1
+(6 rows)
+
 -- CTEs inside a subquery and the final query becomes a router
 -- query
 SELECT
@@ -146,7 +153,7 @@ FROM
 	     event_type IN (1,2,3,4)
 	     ) SELECT * FROM cte ORDER BY 1 DESC
      ) as foo;
-DEBUG:  generating subplan 17_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 18_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
  user_id 
 ---------
        6
@@ -184,7 +191,7 @@ FROM
 	    
      ) as bar  
 WHERE foo.user_id = bar.user_id;
-DEBUG:  generating subplan 19_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 20_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
  user_id 
 ---------
        5
@@ -236,10 +243,10 @@ FROM
      ) as bar  
 WHERE foo.user_id = bar.user_id
 ORDER BY 1 DESC LIMIT 5;
-DEBUG:  generating subplan 21_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
-DEBUG:  generating subplan 21_2 for CTE cte: SELECT events_table.event_type, users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (users_table.value_1 = ANY (ARRAY[1, 2])))
+DEBUG:  generating subplan 22_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 22_2 for CTE cte: SELECT events_table.event_type, users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (users_table.value_1 = ANY (ARRAY[1, 2])))
 DEBUG:  push down of limit count: 2
-DEBUG:  generating subplan 21_3 for subquery SELECT users_table.user_id, some_events.event_type FROM public.users_table, (SELECT cte.event_type, cte.user_id FROM (SELECT intermediate_result.event_type, intermediate_result.user_id FROM read_intermediate_result('21_2'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer, user_id integer)) cte ORDER BY cte.event_type DESC) some_events WHERE ((users_table.user_id = some_events.user_id) AND (some_events.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY some_events.event_type, users_table.user_id LIMIT 2
+DEBUG:  generating subplan 22_3 for subquery SELECT users_table.user_id, some_events.event_type FROM public.users_table, (SELECT cte.event_type, cte.user_id FROM (SELECT intermediate_result.event_type, intermediate_result.user_id FROM read_intermediate_result('22_2'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer, user_id integer)) cte ORDER BY cte.event_type DESC) some_events WHERE ((users_table.user_id = some_events.user_id) AND (some_events.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY some_events.event_type, users_table.user_id LIMIT 2
  user_id 
 ---------
        1
@@ -272,12 +279,12 @@ SELECT * FROM
 			foo.user_id = events_table.value_2
 ORDER BY 3 DESC, 2 DESC, 1 DESC 
 LIMIT 5;
-DEBUG:  generating subplan 25_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
-DEBUG:  generating subplan 26_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 26_2 for CTE dist_cte: SELECT user_id FROM public.events_table
-DEBUG:  generating subplan 25_2 for CTE cte_in_where: SELECT DISTINCT value_2 FROM public.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20)) ORDER BY value_2 LIMIT 5
+DEBUG:  generating subplan 26_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 27_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
+DEBUG:  generating subplan 27_2 for CTE dist_cte: SELECT user_id FROM public.events_table
+DEBUG:  generating subplan 26_2 for CTE cte_in_where: SELECT DISTINCT value_2 FROM public.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20)) ORDER BY value_2 LIMIT 5
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 25_3 for subquery SELECT DISTINCT cte.user_id FROM public.users_table, (SELECT intermediate_result.user_id FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE ((users_table.user_id = cte.user_id) AND (users_table.user_id IN (SELECT cte_in_where.value_2 FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('25_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) cte_in_where))) ORDER BY cte.user_id DESC
+DEBUG:  generating subplan 26_3 for subquery SELECT DISTINCT cte.user_id FROM public.users_table, (SELECT intermediate_result.user_id FROM read_intermediate_result('26_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE ((users_table.user_id = cte.user_id) AND (users_table.user_id IN (SELECT cte_in_where.value_2 FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('26_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) cte_in_where))) ORDER BY cte.user_id DESC
 DEBUG:  push down of limit count: 5
  user_id | user_id |              time               | event_type | value_2 | value_3 | value_4 
 ---------+---------+---------------------------------+------------+---------+---------+---------
@@ -319,14 +326,14 @@ FROM
      ORDER BY 1 DESC LIMIT 5
      ) as foo 
 	  WHERE foo.user_id = cte.user_id;
-DEBUG:  generating subplan 30_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
-DEBUG:  generating subplan 31_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 31_2 for CTE dist_cte: SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))
+DEBUG:  generating subplan 31_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 32_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
+DEBUG:  generating subplan 32_2 for CTE dist_cte: SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))
 DEBUG:  push down of limit count: 3
-DEBUG:  generating subplan 32_1 for subquery SELECT DISTINCT value_1 FROM public.users_table ORDER BY value_1 LIMIT 3
-DEBUG:  generating subplan 32_2 for subquery SELECT DISTINCT value_2 FROM public.users_table OFFSET 0
+DEBUG:  generating subplan 33_1 for subquery SELECT DISTINCT value_1 FROM public.users_table ORDER BY value_1 LIMIT 3
+DEBUG:  generating subplan 33_2 for subquery SELECT DISTINCT value_2 FROM public.users_table OFFSET 0
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 30_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  generating subplan 31_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
  count 
 -------
    432
@@ -370,15 +377,15 @@ FROM
 ) as foo, users_table WHERE foo.cnt > users_table.value_2 
 ORDER BY 3 DESC, 1 DESC, 2 DESC, 4 DESC
 LIMIT 5;
-DEBUG:  generating subplan 36_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
-DEBUG:  generating subplan 37_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 37_2 for CTE dist_cte: SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))
+DEBUG:  generating subplan 37_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 38_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
+DEBUG:  generating subplan 38_2 for CTE dist_cte: SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))
 DEBUG:  push down of limit count: 3
-DEBUG:  generating subplan 38_1 for subquery SELECT DISTINCT value_1 FROM public.users_table ORDER BY value_1 LIMIT 3
-DEBUG:  generating subplan 38_2 for subquery SELECT DISTINCT value_2 FROM public.users_table OFFSET 0
+DEBUG:  generating subplan 39_1 for subquery SELECT DISTINCT value_1 FROM public.users_table ORDER BY value_1 LIMIT 3
+DEBUG:  generating subplan 39_2 for subquery SELECT DISTINCT value_2 FROM public.users_table OFFSET 0
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 36_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
-DEBUG:  generating subplan 36_3 for subquery SELECT count(*) AS cnt FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('36_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('36_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo WHERE (foo.user_id = cte.user_id)
+DEBUG:  generating subplan 37_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  generating subplan 37_3 for subquery SELECT count(*) AS cnt FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('37_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('37_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo WHERE (foo.user_id = cte.user_id)
 DEBUG:  push down of limit count: 5
  cnt | user_id |              time               | value_1 | value_2 | value_3 | value_4 
 -----+---------+---------------------------------+---------+---------+---------+---------

--- a/src/test/regress/expected/subquery_basics.out
+++ b/src/test/regress/expected/subquery_basics.out
@@ -345,3 +345,23 @@ DEBUG:  generating subplan 20_1 for subquery SELECT user_id, count(*) AS count_p
        3
 (2 rows)
 
+-- we support queries with recurring tuples in the FROM
+-- clause and subquery in WHERE clause
+SELECT
+	*
+FROM
+	(
+		SELECT
+			users_table.user_id
+		FROM
+			users_table, (SELECT user_id FROM events_table) as evs
+		WHERE users_table.user_id = evs.user_id
+		LIMIT 5
+	) as foo WHERE user_id IN (SELECT count(*) FROM users_table GROUP BY user_id);
+DEBUG:  push down of limit count: 5
+DEBUG:  generating subplan 22_1 for subquery SELECT users_table.user_id FROM public.users_table, (SELECT events_table.user_id FROM public.events_table) evs WHERE (users_table.user_id = evs.user_id) LIMIT 5
+DEBUG:  generating subplan 22_2 for subquery SELECT count(*) AS count FROM public.users_table GROUP BY user_id
+ user_id 
+---------
+(0 rows)
+

--- a/src/test/regress/expected/with_prepare.out
+++ b/src/test/regress/expected/with_prepare.out
@@ -174,6 +174,18 @@ FROM
 ORDER BY
   1, 2, 3, 4, 5, 6
 LIMIT 10;
+-- Prepare a statement with a sublink in WHERE clause and recurring tuple in FORM
+PREPARE prepared_test_6 AS
+WITH event_id AS (
+	SELECT user_id as events_user_id, time as events_time, event_type
+	FROM events_table
+)
+SELECT
+	count(*) 
+FROM
+	event_id
+WHERE
+	events_user_id IN (SELECT user_id FROM users_table);
 EXECUTE prepared_test_1;
  user_id |              time               | value_1 | value_2 | value_3 | value_4 
 ---------+---------------------------------+---------+---------+---------+---------
@@ -541,6 +553,42 @@ EXECUTE prepared_test_5(6, 7, 8);
        6 | Thu Nov 23 13:51:16.92838 2017  |       0 |       4 |       2 |        
        6 | Thu Nov 23 14:43:18.024104 2017 |       3 |       2 |       5 |        
 (10 rows)
+
+EXECUTE prepared_test_6;
+ count 
+-------
+   101
+(1 row)
+
+EXECUTE prepared_test_6;
+ count 
+-------
+   101
+(1 row)
+
+EXECUTE prepared_test_6;
+ count 
+-------
+   101
+(1 row)
+
+EXECUTE prepared_test_6;
+ count 
+-------
+   101
+(1 row)
+
+EXECUTE prepared_test_6;
+ count 
+-------
+   101
+(1 row)
+
+EXECUTE prepared_test_6;
+ count 
+-------
+   101
+(1 row)
 
 EXECUTE prepared_partition_column_insert(1);
 ERROR:  data-modifying statements are not supported in the WITH clauses of distributed queries

--- a/src/test/regress/sql/multi_subquery_in_where_reference_clause.sql
+++ b/src/test/regress/sql/multi_subquery_in_where_reference_clause.sql
@@ -353,7 +353,7 @@ SELECT user_id, value_2 FROM users_table WHERE
 )
 ORDER BY 1, 2;
 
--- reference tables are not allowed if there is sublink
+-- when using a reference table in FROM the subquery in WHERE is recursively planned
 SELECT
   count(*) 
 FROM 
@@ -362,8 +362,6 @@ WHERE user_id
   NOT IN
 (SELECT users_table.value_2 FROM users_table JOIN users_reference_table as u2 ON users_table.value_2 = u2.value_2);
 
-
--- reference tables are not allowed if there is sublink
 SELECT count(*)
 FROM
   (SELECT 

--- a/src/test/regress/sql/subqueries_not_supported.sql
+++ b/src/test/regress/sql/subqueries_not_supported.sql
@@ -58,20 +58,6 @@ FROM
 		LIMIT 5
 	) as foo;
 
--- we don't support queries with recurring tuples in the FROM
--- clause and subquery in WHERE clause
-SELECT
-	* 
-FROM
-	(
-		SELECT 
-			users_table.user_id 
-		FROM 
-			users_table, (SELECT user_id FROM events_table) as evs
-		WHERE users_table.user_id = evs.user_id
-		LIMIT 5
-	) as foo WHERE user_id IN (SELECT count(*) FROM users_table GROUP BY user_id);
-
 -- we don't support recursive subqueries when router executor is disabled
 SET citus.enable_router_execution TO false;
 SELECT

--- a/src/test/regress/sql/subquery_and_cte.sql
+++ b/src/test/regress/sql/subquery_and_cte.sql
@@ -317,6 +317,450 @@ FROM
      ) as bar  
 WHERE foo.user_id = bar.user_id;
 
+--CTEs can be used as a recurring tuple with subqueries in WHERE
+WITH event_id AS (
+	SELECT user_id as events_user_id, time as events_time, event_type
+	FROM events_table
+)
+SELECT
+	count(*)
+FROM
+	event_id
+WHERE
+	events_user_id IN (SELECT user_id FROM users_table);
+
+--Correlated subqueries can not be used in WHERE clause
+WITH event_id AS (
+	SELECT user_id as events_user_id, time as events_time, event_type
+	FROM events_table
+)
+SELECT
+	count(*)
+FROM
+	event_id
+WHERE
+	events_user_id IN (SELECT user_id FROM users_table where users_table.time = events_time);
+
+-- Recurring tuples as empty join tree
+SELECT
+	*
+FROM (
+	SELECT
+		1 AS id,
+		2 AS value_1,
+		3 AS value_3
+	) AS tt1
+WHERE
+	id
+IN (
+	SELECT
+		user_id
+	FROM
+	events_table
+   );
+
+-- Recurring tuples in from clause as CTE and SET operation in WHERE clause
+SELECT
+	COUNT(*)
+FROM
+	(
+		WITH event_id AS (
+			SELECT
+				user_id as events_user_id, time as events_time, event_type
+			FROM
+				events_table
+		)
+		SELECT
+			events_user_id, events_time, event_type
+		FROM
+			event_id
+		LIMIT
+			10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+IN
+	(
+		(SELECT
+			user_id
+		FROM
+			users_table
+		LIMIT
+			10
+		)
+		UNION ALL
+		(SELECT
+			value_1
+		FROM
+			users_table
+		LIMIT
+			10
+		)
+	);
+
+-- Recurring tuples in fram clause as SET operation on recursively plannable
+-- queries and CTE in WHERE clause
+SELECT
+	*
+FROM
+	(
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id ASC
+		LIMIT
+			10
+		)
+		UNION ALL
+		(SELECT
+			value_1
+		FROM
+			users_table
+		ORDER BY
+			value_1 ASC
+		LIMIT
+			10
+		)
+	) as SUB_TABLE
+WHERE
+	user_id
+IN
+	(
+	WITH event_id AS (
+		SELECT
+			user_id as events_user_id, time as events_time, event_type
+		FROM
+			events_table
+	)
+	SELECT
+		events_user_id
+	FROM
+		event_id
+	ORDER BY
+		events_user_id
+	LIMIT
+		10
+	);
+
+-- Complex target list in WHERE clause
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		user_id as events_user_id, time as events_time, event_type
+	FROM
+		events_table
+	LIMIT
+		10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+<= (
+	SELECT
+		max(abs(value_1 * 1) + mod(value_1, 3)) as val_1
+	FROM
+		users_table
+);
+
+-- DISTINCT clause in WHERE
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		user_id as events_user_id, time as events_time, event_type
+	FROM
+		events_table
+	LIMIT
+		10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+IN (
+	SELECT
+		distinct value_1
+	FROM
+		users_table
+);
+
+-- AND in WHERE clause
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		user_id as events_user_id, time as events_time, event_type
+	FROM
+		events_table
+	LIMIT
+		10
+	) as SUB_TABLE
+WHERE
+	events_user_id
+> (
+	SELECT
+		min(value_1)
+	FROM
+		users_table
+)
+AND
+	events_user_id
+< (
+	SELECT
+		max(value_2)
+	FROM
+		users_table
+);
+
+-- Planning subqueries in WHERE clause in CTE recursively
+WITH cte AS (
+	SELECT
+		*
+	FROM
+		(SELECT
+			*
+		FROM
+			users_table
+		ORDER BY
+			user_id ASC,
+			value_2 DESC
+		LIMIT
+			10
+		) as sub_table
+	WHERE
+		user_id
+	IN
+		(SELECT
+			value_2
+		FROM
+			events_table
+		)
+)
+SELECT
+	COUNT(*)
+FROM
+	cte;
+
+-- Planing subquery in WHERE clause in FROM clause of a subquery recursively
+SELECT
+	COUNT(*)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			*
+		FROM
+			users_table
+		ORDER BY
+			user_id ASC,
+			value_2 DESC
+		LIMIT
+			10
+		) as sub_table_1
+	WHERE
+		user_id
+	IN
+		(SELECT
+			value_2
+		FROM
+			events_table
+		)
+	) as sub_table_2;
+
+-- Recurring table in the FROM clause of a subquery in the FROM clause
+-- Recurring table is created by joining a two recurrign table
+SELECT
+	SUM(user_id)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT 10) as t1
+		INNER JOIN
+		(SELECT
+			user_id as user_id_2
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT
+			10) as t2
+		ON
+			t1.user_id = t2.user_id_2
+		WHERE
+			t1.user_id
+		IN
+			(SELECT
+				value_2
+			FROM
+				events_table)
+	) as t3
+WHERE
+	user_id
+>
+	(SELECT
+		min(value_3)
+	FROM
+		events_table);
+
+-- Same example with the above query, but now check the rows with EXISTS
+SELECT
+	SUM(user_id)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT 10) as t1
+		INNER JOIN
+		(SELECT
+			user_id as user_id_2
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT
+			10) as t2
+		ON
+			t1.user_id = t2.user_id_2
+		WHERE
+			t1.user_id
+		IN
+			(SELECT
+				value_2
+			FROM
+				events_table)
+	) as t3
+WHERE EXISTS
+	(SELECT
+		1,2
+	FROM
+		events_table
+	WHERE
+		events_table.value_2 = user_id);
+
+-- Same query with the above one, yet now we check the row's NON-existence
+-- by NOT EXISTS. Note that, max value_2 of events_table is 5
+SELECT
+	SUM(user_id)
+FROM
+	(SELECT
+		*
+	FROM
+		(SELECT
+			user_id
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT 10) as t1
+		INNER JOIN
+		(SELECT
+			user_id as user_id_2
+		FROM
+			users_table
+		ORDER BY
+			user_id
+		LIMIT
+			10) as t2
+		ON
+			t1.user_id = t2.user_id_2
+		WHERE
+			t1.user_id
+		IN
+			(SELECT
+				value_2
+			FROM
+				events_table)
+	) as t3
+WHERE NOT EXISTS
+	(SELECT
+		1,2
+	FROM
+		events_table
+	WHERE
+		events_table.value_2 = user_id + 6);
+
+-- Check the existence of row by comparing it with the result of subquery in
+-- WHERE clause. Note that subquery is planned recursively since there is no
+-- distributed table in the from
+SELECT
+	*
+FROM
+	(SELECT
+		user_id, value_1
+	FROM
+		users_table
+	ORDER BY
+		user_id ASC,
+		value_1 ASC
+	LIMIT 10) as t3
+WHERE row(user_id, value_1) =
+	(SELECT
+		min(value_2) + 1, min(value_2) + 1
+	FROM
+		events_table);
+
+-- Recursively plan subquery in WHERE clause when the FROM clause has a subquery
+-- generated by generate_series function
+SELECT
+	*
+FROM
+	(SELECT
+		*
+	FROM
+		generate_series(1,10)
+	) as gst
+WHERE
+	generate_series
+IN
+	(SELECT
+		value_2
+	FROM
+		events_table
+	)
+ORDER BY
+	generate_series ASC;
+
+-- Similar to the test above, now we also have a generate_series in WHERE clause
+SELECT
+	*
+FROM
+	(SELECT
+		*
+	FROM
+		generate_series(1,10)
+	) as gst
+WHERE
+	generate_series
+IN
+	(SELECT
+		user_id
+	FROM
+		users_table
+	WHERE
+		user_id
+	IN
+		(SELECT
+			*
+		FROM
+			generate_series(1,3)
+		)
+	)
+ORDER BY
+	generate_series ASC;
 
 SET client_min_messages TO DEFAULT;
 

--- a/src/test/regress/sql/subquery_and_cte.sql
+++ b/src/test/regress/sql/subquery_and_cte.sql
@@ -82,9 +82,7 @@ WHERE
     ORDER BY 1 DESC;
 
 -- a very similar query as the above, but this time errors 
--- out since we don't support subqueries in WHERE clause
--- when there is only intermediate results on the range table
--- note that this time subquery in WHERE clause is not replaced
+-- out because the FROM clause is recurring, the WHERE clause is automatically replaced
 WITH cte AS (
 	WITH local_cte AS (
 		SELECT * FROM users_table_local

--- a/src/test/regress/sql/subquery_basics.sql
+++ b/src/test/regress/sql/subquery_basics.sql
@@ -266,3 +266,16 @@ GROUP BY user_id
 HAVING count(*) > 1 AND sum(value_2) > 29
 ORDER BY 1;
 
+-- we support queries with recurring tuples in the FROM
+-- clause and subquery in WHERE clause
+SELECT
+	*
+FROM
+	(
+		SELECT
+			users_table.user_id
+		FROM
+			users_table, (SELECT user_id FROM events_table) as evs
+		WHERE users_table.user_id = evs.user_id
+		LIMIT 5
+	) as foo WHERE user_id IN (SELECT count(*) FROM users_table GROUP BY user_id);

--- a/src/test/regress/sql/with_prepare.sql
+++ b/src/test/regress/sql/with_prepare.sql
@@ -185,6 +185,18 @@ ORDER BY
   1, 2, 3, 4, 5, 6
 LIMIT 10;
 
+-- Prepare a statement with a sublink in WHERE clause and recurring tuple in FORM
+PREPARE prepared_test_6 AS
+WITH event_id AS (
+	SELECT user_id as events_user_id, time as events_time, event_type
+	FROM events_table
+)
+SELECT
+	count(*) 
+FROM
+	event_id
+WHERE
+	events_user_id IN (SELECT user_id FROM users_table);
 
 
 EXECUTE prepared_test_1;
@@ -221,6 +233,13 @@ EXECUTE prepared_test_5(3, 4, 5);
 EXECUTE prepared_test_5(4, 5, 6);
 EXECUTE prepared_test_5(5, 6, 7);
 EXECUTE prepared_test_5(6, 7, 8);
+
+EXECUTE prepared_test_6;
+EXECUTE prepared_test_6;
+EXECUTE prepared_test_6;
+EXECUTE prepared_test_6;
+EXECUTE prepared_test_6;
+EXECUTE prepared_test_6;
 
 EXECUTE prepared_partition_column_insert(1);
 


### PR DESCRIPTION
Recursively plan non-correlated sublinks in the WHERE clause if the FROM clause does not have a distributed table.

Needs regression tests.