### PR TITLE
Do not raise errors in the real-time executor

### DIFF
--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -249,6 +249,11 @@ CleanupTaskExecution(TaskExecution *taskExecution)
 bool
 TaskExecutionFailed(TaskExecution *taskExecution)
 {
+	if (taskExecution->criticalErrorOccurred)
+	{
+		return true;
+	}
+
 	if (taskExecution->failureCount >= MAX_TASK_EXECUTION_FAILURES)
 	{
 		return true;

--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -145,6 +145,7 @@ struct TaskExecution
 	uint32 querySourceNodeIndex; /* only applies to map fetch tasks */
 	int32 dataFetchTaskIndex;
 	uint32 failureCount;
+	bool criticalErrorOccurred;
 };
 
 

--- a/src/test/regress/expected/subquery_and_cte.out
+++ b/src/test/regress/expected/subquery_and_cte.out
@@ -435,6 +435,42 @@ FROM
      ) as bar  
 WHERE foo.user_id = bar.user_id;
 ERROR:  recursive CTEs are not supported in distributed queries
+-- We error-out when there's an error in execution of the query. By repeating it
+-- multiple times, we increase the chance of this test failing before PR #1903.
+SET client_min_messages TO ERROR;
+DO $$
+DECLARE
+	errors_received INTEGER;
+BEGIN
+errors_received := 0;
+FOR i IN 1..3 LOOP
+	BEGIN
+		WITH cte as (
+			SELECT
+				user_id, value_2
+			from
+				events_table
+		)
+		SELECT * FROM users_table where value_2 < (
+			SELECT
+				min(cte.value_2)
+			FROM
+				cte
+			WHERE
+				users_table.user_id=cte.user_id
+			GROUP BY
+				user_id, cte.value_2);
+	EXCEPTION WHEN OTHERS THEN
+		IF SQLERRM LIKE 'failed to execute task%' THEN
+			errors_received := errors_received + 1;
+		END IF;
+	END;
+END LOOP;
+RAISE '(%/3) failed to execute one of the tasks', errors_received;
+END;
+$$;
+ERROR:  (3/3) failed to execute one of the tasks
+CONTEXT:  PL/pgSQL function inline_code_block line 29 at RAISE
 SET client_min_messages TO DEFAULT;
 DROP SCHEMA subquery_and_ctes CASCADE;
 NOTICE:  drop cascades to table users_table_local


### PR DESCRIPTION
Fixes #1902 

In #1785 we added an error to the real-time executor if an error occurred on a connection with a critical transaction (e.g. a DDL command was performed prior to the SELECT, or an intermediate result was sent over the connection). Throwing an error means that we skip the cancellation logic in the real-time executor and go straight to the abort handler. Unfortunately, the abort handler currently cannot handle connections that have a `COPY (SELECT ...) TO STDOUT` in progress, because `NonblockingForgetResults` gets stuck in a loop. 

The `NonblockingForgetResults` function exists to avoid getting blocked on network I/O (waiting for the worker) in the abort handler, which previously caused users to sometimes have to cancel twice. This function did not consider real-time executor queries because those never ran in a transaction block prior to #1785 and therefore `StartRemoteTransactionAbort` was never called. This problem is fixed separately in #1905.

For the moment the only reliable way we have to cancel a real-time query is to drop into the `PQcancel` logic at the end of the real-time executor and perform cleanup. This PR changes the real-time executor to avoid throwing an error and instead adds a flag to the TaskExecution to immediately drop out of the execution loop when a failure occurs on a connection with a critical transaction.

A tricky part of this approach is that the real-time executor already observes the error in `MultiClientCopyData` and it does not let us distinguish between a connection/node failure and a query error, and also allows one more real-time executor round before we handle the `EXEC_TASK_FAILED` state. This causes warnings from other tasks to show up in the output as well.

In addition, because the real-time executor might reuse one of the connections that was used to copy the intermediate result to the worker, it might run a failing query inside the transaction block that created the intermediate result, which will then abort and instantly remove the intermediate result, causing errors in other transactions that are trying to open the result file.

While this PR fixes the critical issue (getting permanently stuck in an infinite loop), we may see confusing warnings like "result 25_1 does not exist" when an error occurs in the transaction that created the intermediate result.

```
# SELECT * FROM test WHERE x = (SELECT x FROM test WHERE x = 1 LIMIT 2 OFFSET 0);
WARNING:  more than one row returned by a subquery used as an expression
WARNING:  result "25_1" does not exist
WARNING:  more than one row returned by a subquery used as an expression
ERROR:  failed to execute task 1
```

I haven't come up with a nice and simple solution to this problem yet.