### PR TITLE
Shard count increase in some tests

### DIFF
--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -3,6 +3,7 @@
 --
 -- Test checks whether constraints of distributed tables can be adjusted using
 -- the ALTER TABLE ... ADD CONSTRAINT ... command.
+SET citus.shard_count TO 32;
 SET citus.next_shard_id TO 1450000;
 SET citus.next_placement_id TO 1450000;
 -- Check "PRIMARY KEY CONSTRAINT"
@@ -28,16 +29,16 @@ INSERT INTO products VALUES(1, 'product_1', 1);
 -- Should error out, since we are trying to add a new row having a value on p_key column
 -- conflicting with the existing row.
 INSERT INTO products VALUES(1, 'product_1', 1);
-ERROR:  duplicate key value violates unique constraint "p_key_1450000"
+ERROR:  duplicate key value violates unique constraint "p_key_1450001"
 DETAIL:  Key (product_no)=(1) already exists.
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 ALTER TABLE products DROP CONSTRAINT p_key;
 INSERT INTO products VALUES(1, 'product_1', 1);
 -- Can not create constraint since it conflicts with the existing data
 ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(product_no);
-ERROR:  could not create unique index "p_key_1450000"
+ERROR:  could not create unique index "p_key_1450001"
 DETAIL:  Key (product_no)=(1) is duplicated.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 DROP TABLE products;
 -- Check "PRIMARY KEY CONSTRAINT" with reference table
 CREATE TABLE products_ref (
@@ -59,7 +60,7 @@ INSERT INTO products_ref VALUES(1, 'product_1', 1);
 -- Should error out, since we are trying to add new row having a value on p_key column
 -- conflicting with the existing row.
 INSERT INTO products_ref VALUES(1, 'product_1', 1);
-ERROR:  duplicate key value violates unique constraint "p_key_1450004"
+ERROR:  duplicate key value violates unique constraint "p_key_1450032"
 DETAIL:  Key (product_no)=(1) already exists.
 CONTEXT:  while executing command on localhost:57637
 DROP TABLE products_ref;
@@ -90,7 +91,7 @@ DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-par
 HINT:  Consider using hash partitioning.
 --- Error out since first and third rows have the same product_no		
 \COPY products_append FROM STDIN DELIMITER AS ',';
-ERROR:  duplicate key value violates unique constraint "p_key_1450005"
+ERROR:  duplicate key value violates unique constraint "p_key_1450033"
 DETAIL:  Key (product_no)=(1) already exists.
 DROP TABLE products_append;
 -- Check "UNIQUE CONSTRAINT"
@@ -111,25 +112,25 @@ ALTER TABLE unique_test_table ADD CONSTRAINT unn_id UNIQUE(id);
 -- Error out, since table can not have two rows with same id.
 INSERT INTO unique_test_table VALUES(1, 'Ahmet');
 INSERT INTO unique_test_table VALUES(1, 'Mehmet');
-ERROR:  duplicate key value violates unique constraint "unn_id_1450006"
+ERROR:  duplicate key value violates unique constraint "unn_id_1450035"
 DETAIL:  Key (id)=(1) already exists.
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 ALTER TABLE unique_test_table DROP CONSTRAINT unn_id;
 -- Insert row which will conflict with the next unique constraint command
 INSERT INTO unique_test_table VALUES(1, 'Mehmet');
 -- Can not create constraint since it conflicts with the existing data
 ALTER TABLE unique_test_table ADD CONSTRAINT unn_id UNIQUE(id);
-ERROR:  could not create unique index "unn_id_1450006"
+ERROR:  could not create unique index "unn_id_1450035"
 DETAIL:  Key (id)=(1) is duplicated.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 -- Can create unique constraint over multiple columns which must include
 -- distribution column
 ALTER TABLE unique_test_table ADD CONSTRAINT unn_id_name UNIQUE(id, name);
 -- Error out, since tables can not have two rows with same id and name.
 INSERT INTO unique_test_table VALUES(1, 'Mehmet');
-ERROR:  duplicate key value violates unique constraint "unn_id_name_1450006"
+ERROR:  duplicate key value violates unique constraint "unn_id_name_1450035"
 DETAIL:  Key (id, name)=(1, Mehmet) already exists.
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 DROP TABLE unique_test_table;
 -- Check "UNIQUE CONSTRAINT" with reference table
 CREATE TABLE unique_test_table_ref(id int, name varchar(20));
@@ -145,7 +146,7 @@ ALTER TABLE unique_test_table_ref ADD CONSTRAINT unn_id UNIQUE(id);
 -- Error out. Since the table can not have two rows with the same id. 
 INSERT INTO unique_test_table_ref VALUES(1, 'Ahmet');
 INSERT INTO unique_test_table_ref VALUES(1, 'Mehmet');
-ERROR:  duplicate key value violates unique constraint "unn_id_1450010"
+ERROR:  duplicate key value violates unique constraint "unn_id_1450066"
 DETAIL:  Key (id)=(1) already exists.
 CONTEXT:  while executing command on localhost:57637
 -- We can add unique constraint with multiple columns 
@@ -177,7 +178,7 @@ DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-par
 HINT:  Consider using hash partitioning.
 -- Error out. Table can not have two rows with the same id.		
 \COPY unique_test_table_append FROM STDIN DELIMITER AS ',';		
-ERROR:  duplicate key value violates unique constraint "unn_id_1450011"
+ERROR:  duplicate key value violates unique constraint "unn_id_1450067"
 DETAIL:  Key (id)=(1) already exists.
 DROP TABLE unique_test_table_append;
 -- Check "CHECK CONSTRAINT"
@@ -199,14 +200,14 @@ ALTER TABLE products ADD CONSTRAINT p_multi_check CHECK(price > discounted_price
 -- First and third queries will error out, because of conflicts with p_check and 
 -- p_multi_check, respectively.
 INSERT INTO products VALUES(1, 'product_1', -1, -2);
-ERROR:  new row for relation "products_1450012" violates check constraint "p_check_1450012"
+ERROR:  new row for relation "products_1450069" violates check constraint "p_check_1450069"
 DETAIL:  Failing row contains (1, product_1, -1, -2).
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 INSERT INTO products VALUES(1, 'product_1', 5, 3);
 INSERT INTO products VALUES(1, 'product_1', 2, 3);
-ERROR:  new row for relation "products_1450012" violates check constraint "p_multi_check_1450012"
+ERROR:  new row for relation "products_1450069" violates check constraint "p_multi_check_1450069"
 DETAIL:  Failing row contains (1, product_1, 2, 3).
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 DROP TABLE products;
 -- Check "CHECK CONSTRAINT" with reference table 
 CREATE TABLE products_ref (
@@ -227,12 +228,12 @@ ALTER TABLE products_ref ADD CONSTRAINT p_multi_check CHECK(price > discounted_p
 -- First and third queries will error out, because of conflicts with p_check and 
 -- p_multi_check, respectively.
 INSERT INTO products_ref VALUES(1, 'product_1', -1, -2);
-ERROR:  new row for relation "products_ref_1450016" violates check constraint "p_check_1450016"
+ERROR:  new row for relation "products_ref_1450100" violates check constraint "p_check_1450100"
 DETAIL:  Failing row contains (1, product_1, -1, -2).
 CONTEXT:  while executing command on localhost:57637
 INSERT INTO products_ref VALUES(1, 'product_1', 5, 3);
 INSERT INTO products_ref VALUES(1, 'product_1', 2, 3);
-ERROR:  new row for relation "products_ref_1450016" violates check constraint "p_multi_check_1450016"
+ERROR:  new row for relation "products_ref_1450100" violates check constraint "p_multi_check_1450100"
 DETAIL:  Failing row contains (1, product_1, 2, 3).
 CONTEXT:  while executing command on localhost:57637
 DROP TABLE products_ref;
@@ -254,7 +255,7 @@ ALTER TABLE products_append ADD CONSTRAINT p_check CHECK(price > 0);
 ALTER TABLE products_append ADD CONSTRAINT p_multi_check CHECK(price > discounted_price);
 -- Error out,since the third row conflicting with the p_multi_check
 \COPY products_append FROM STDIN DELIMITER AS ',';
-ERROR:  new row for relation "products_append_1450017" violates check constraint "p_multi_check"
+ERROR:  new row for relation "products_append_1450101" violates check constraint "p_multi_check"
 DETAIL:  Failing row contains (1,  Product_3, 8, 10).
 DROP TABLE products_append;
 -- Check "EXCLUSION CONSTRAINT"
@@ -282,9 +283,9 @@ INSERT INTO products VALUES(1,'product_1', 5);
 INSERT INTO products VALUES(1,'product_2', 10);
 INSERT INTO products VALUES(2,'product_2', 5);
 INSERT INTO products VALUES(2,'product_2', 5);
-ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450021"
+ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450126"
 DETAIL:  Key (product_no, name)=(2, product_2) conflicts with existing key (product_no, name)=(2, product_2).
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 DROP TABLE products;
 -- Check "EXCLUSION CONSTRAINT" with reference table
 CREATE TABLE products_ref (
@@ -306,7 +307,7 @@ ALTER TABLE products_ref ADD CONSTRAINT exc_pno_name EXCLUDE USING btree (produc
 INSERT INTO products_ref VALUES(1,'product_1', 5);
 INSERT INTO products_ref VALUES(1,'product_2', 10);
 INSERT INTO products_ref VALUES(2,'product_2', 5);
-ERROR:  conflicting key value violates exclusion constraint "exc_name_1450022"
+ERROR:  conflicting key value violates exclusion constraint "exc_name_1450134"
 DETAIL:  Key (name)=(product_2) conflicts with existing key (name)=(product_2).
 CONTEXT:  while executing command on localhost:57637
 DROP TABLE products_ref;
@@ -337,7 +338,7 @@ DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-par
 HINT:  Consider using hash partitioning.
 -- Error out since first and third can not pass the exclusion check.		
 \COPY products_append FROM STDIN DELIMITER AS ',';
-ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450023"
+ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450135"
 DETAIL:  Key (product_no, name)=(1,  Product_1) conflicts with existing key (product_no, name)=(1,  Product_1).
 DROP TABLE products_append;
 -- Check "NOT NULL"
@@ -357,7 +358,7 @@ ALTER TABLE products ALTER COLUMN name SET NOT NULL;
 INSERT INTO products VALUES(1,NULL,5);
 ERROR:  null value in column "name" violates not-null constraint
 DETAIL:  Failing row contains (1, null, 5).
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 INSERT INTO products VALUES(NULL,'product_1', 5);
 ERROR:  cannot perform an INSERT with NULL in the partition column
 DROP TABLE products;
@@ -457,7 +458,7 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regc
 (0 rows)
 
 \c - - - :worker_1_port
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
  Constraint | Definition 
 ------------+------------
 (0 rows)
@@ -477,14 +478,14 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regc
 (0 rows)
 
 \c - - - :worker_1_port
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
  Constraint | Definition 
 ------------+------------
 (0 rows)
 
 \c - - - :master_port
-SET citus.next_shard_id TO 1450038;
-SET citus.next_placement_id TO 1450038;
+SET citus.next_shard_id TO 1450234;
+SET citus.next_placement_id TO 1450234;
 DROP TABLE products;
 SET citus.shard_count to 2;
 -- Test if the ALTER TABLE %s ADD %s PRIMARY KEY %s works
@@ -514,8 +515,8 @@ ORDER BY
     1,2,3,4;
  nodename  | nodeport | success |        result        
 -----------+----------+---------+----------------------
- localhost |    57637 | t       | alter_pk_idx_1450038
- localhost |    57638 | t       | alter_pk_idx_1450038
+ localhost |    57637 | t       | alter_pk_idx_1450234
+ localhost |    57638 | t       | alter_pk_idx_1450234
 (2 rows)
 
 CREATE SCHEMA sc2;
@@ -545,8 +546,8 @@ ORDER BY
     1,2,3,4;
  nodename  | nodeport | success |        result        
 -----------+----------+---------+----------------------
- localhost |    57637 | t       | alter_pk_idx_1450040
- localhost |    57638 | t       | alter_pk_idx_1450040
+ localhost |    57637 | t       | alter_pk_idx_1450236
+ localhost |    57638 | t       | alter_pk_idx_1450236
 (2 rows)
 
 -- We are running almost the same test with a slight change on the constraint name because if the constraint has a different name than the index, Postgres renames the index.
@@ -580,8 +581,8 @@ ORDER BY
     1,2,3,4;
  nodename  | nodeport | success |        result        
 -----------+----------+---------+----------------------
- localhost |    57637 | t       | a_constraint_1450042
- localhost |    57638 | t       | a_constraint_1450042
+ localhost |    57637 | t       | a_constraint_1450238
+ localhost |    57638 | t       | a_constraint_1450238
 (2 rows)
 
 ALTER TABLE alter_add_prim_key DROP CONSTRAINT a_constraint;

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -452,10 +452,10 @@ Aggregate
                                 Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
                                 ->  Hash Join
                                       Hash Cond: (users.composite_id = events.composite_id)
-                                      ->  Seq Scan on users_1400033 users
+                                      ->  Seq Scan on users_1400289 users
                                             Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                       ->  Hash
-                                            ->  Seq Scan on events_1400029 events
+                                            ->  Seq Scan on events_1400285 events
                                                   Filter: ((event_type)::text = ANY ('{click,submit,pay}'::text[]))
 -- Union and left join subquery pushdown
 EXPLAIN (COSTS OFF)
@@ -543,24 +543,24 @@ HashAggregate
                                                         ->  Append
                                                               ->  Hash Join
                                                                     Hash Cond: (users.composite_id = events.composite_id)
-                                                                    ->  Seq Scan on users_1400033 users
+                                                                    ->  Seq Scan on users_1400289 users
                                                                           Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                                                     ->  Hash
-                                                                          ->  Seq Scan on events_1400029 events
+                                                                          ->  Seq Scan on events_1400285 events
                                                                                 Filter: ((event_type)::text = 'click'::text)
                                                               ->  Hash Join
                                                                     Hash Cond: (users_1.composite_id = events_1.composite_id)
-                                                                    ->  Seq Scan on users_1400033 users_1
+                                                                    ->  Seq Scan on users_1400289 users_1
                                                                           Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                                                     ->  Hash
-                                                                          ->  Seq Scan on events_1400029 events_1
+                                                                          ->  Seq Scan on events_1400285 events_1
                                                                                 Filter: ((event_type)::text = 'submit'::text)
                                                   ->  Hash
                                                         ->  Subquery Scan on subquery_2
                                                               ->  Unique
                                                                     ->  Sort
                                                                           Sort Key: ((events_2.composite_id).tenant_id), ((events_2.composite_id).user_id)
-                                                                          ->  Seq Scan on events_1400029 events_2
+                                                                          ->  Seq Scan on events_1400285 events_2
                                                                                 Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type) AND ((event_type)::text = 'pay'::text))
 -- Union, left join and having subquery pushdown
 EXPLAIN (COSTS OFF)
@@ -706,12 +706,12 @@ Limit
                                                   ->  Limit
                                                         ->  Sort
                                                               Sort Key: users.lastseen DESC
-                                                              ->  Seq Scan on users_1400033 users
+                                                              ->  Seq Scan on users_1400289 users
                                                                     Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                                   ->  Limit
                                                         ->  Sort
                                                               Sort Key: events.event_time DESC
-                                                              ->  Seq Scan on events_1400029 events
+                                                              ->  Seq Scan on events_1400285 events
                                                                     Filter: (composite_id = users.composite_id)
 RESET citus.subquery_pushdown;
 -- Test all tasks output

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -452,10 +452,10 @@ Aggregate
                                 Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id)
                                 ->  Hash Join
                                       Hash Cond: (users.composite_id = events.composite_id)
-                                      ->  Seq Scan on users_1400033 users
+                                      ->  Seq Scan on users_1400289 users
                                             Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                       ->  Hash
-                                            ->  Seq Scan on events_1400029 events
+                                            ->  Seq Scan on events_1400285 events
                                                   Filter: ((event_type)::text = ANY ('{click,submit,pay}'::text[]))
 -- Union and left join subquery pushdown
 EXPLAIN (COSTS OFF)
@@ -543,24 +543,24 @@ HashAggregate
                                                         ->  Append
                                                               ->  Hash Join
                                                                     Hash Cond: (users.composite_id = events.composite_id)
-                                                                    ->  Seq Scan on users_1400033 users
+                                                                    ->  Seq Scan on users_1400289 users
                                                                           Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                                                     ->  Hash
-                                                                          ->  Seq Scan on events_1400029 events
+                                                                          ->  Seq Scan on events_1400285 events
                                                                                 Filter: ((event_type)::text = 'click'::text)
                                                               ->  Hash Join
                                                                     Hash Cond: (users_1.composite_id = events_1.composite_id)
-                                                                    ->  Seq Scan on users_1400033 users_1
+                                                                    ->  Seq Scan on users_1400289 users_1
                                                                           Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                                                     ->  Hash
-                                                                          ->  Seq Scan on events_1400029 events_1
+                                                                          ->  Seq Scan on events_1400285 events_1
                                                                                 Filter: ((event_type)::text = 'submit'::text)
                                                   ->  Hash
                                                         ->  Subquery Scan on subquery_2
                                                               ->  Unique
                                                                     ->  Sort
                                                                           Sort Key: ((events_2.composite_id).tenant_id), ((events_2.composite_id).user_id)
-                                                                          ->  Seq Scan on events_1400029 events_2
+                                                                          ->  Seq Scan on events_1400285 events_2
                                                                                 Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type) AND ((event_type)::text = 'pay'::text))
 -- Union, left join and having subquery pushdown
 EXPLAIN (COSTS OFF)
@@ -706,12 +706,12 @@ Limit
                                                   ->  Limit
                                                         ->  Sort
                                                               Sort Key: users.lastseen DESC
-                                                              ->  Seq Scan on users_1400033 users
+                                                              ->  Seq Scan on users_1400289 users
                                                                     Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
                                                   ->  Limit
                                                         ->  Sort
                                                               Sort Key: events.event_time DESC
-                                                              ->  Seq Scan on events_1400029 events
+                                                              ->  Seq Scan on events_1400285 events
                                                                     Filter: (composite_id = users.composite_id)
 RESET citus.subquery_pushdown;
 -- Test all tasks output

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -3,7 +3,7 @@
 --
 SET citus.next_shard_id TO 1350000;
 -- set shard_count to 4 for faster tests, because we create/drop lots of shards in this test.
-SET citus.shard_count TO 4;
+SET citus.shard_count TO 32;
 -- create tables
 CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
 SELECT create_distributed_table('referenced_table', 'id', 'hash');
@@ -45,7 +45,7 @@ SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 ERROR:  cannot create foreign key constraint
 DETAIL:  Foreign key constraint can only be created on co-located tables.
 DROP TABLE referencing_table;
-SET citus.shard_count TO 4;
+SET citus.shard_count TO 32;
 -- test foreign constraint creation on non-partition columns
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(id) REFERENCES referenced_table(id));
 SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
@@ -85,18 +85,18 @@ SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 -- test inserts
 -- test insert to referencing table while there is NO corresponding value in referenced table
 INSERT INTO referencing_table VALUES(1, 1);
-ERROR:  insert or update on table "referencing_table_1350008" violates foreign key constraint "referencing_table_ref_id_fkey_1350008"
-DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350004".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "referencing_table_1350065" violates foreign key constraint "referencing_table_ref_id_fkey_1350065"
+DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350033".
+CONTEXT:  while executing command on localhost:57638
 -- test insert to referencing while there is corresponding value in referenced table
 INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 -- test deletes
 -- test delete from referenced table while there is corresponding value in referencing table
 DELETE FROM referenced_table WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350004" violates foreign key constraint "referencing_table_ref_id_fkey_1350008" on table "referencing_table_1350008"
-DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350008".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350033" violates foreign key constraint "referencing_table_ref_id_fkey_1350065" on table "referencing_table_1350065"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350065".
+CONTEXT:  while executing command on localhost:57638
 -- test delete from referenced table while there is NO corresponding value in referencing table
 DELETE FROM referencing_table WHERE ref_id = 1;
 DELETE FROM referenced_table WHERE id = 1;
@@ -189,9 +189,9 @@ SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 DELETE FROM referenced_table WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350020" violates foreign key constraint "referencing_table_ref_id_fkey_1350024" on table "referencing_table_1350024"
-DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350024".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350161" violates foreign key constraint "referencing_table_ref_id_fkey_1350193" on table "referencing_table_1350193"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350193".
+CONTEXT:  while executing command on localhost:57638
 BEGIN;
 DELETE FROM referenced_table WHERE id = 1;
 DELETE FROM referencing_table WHERE ref_id = 1;
@@ -227,9 +227,9 @@ INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 BEGIN;
 DELETE FROM referenced_table WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350028" violates foreign key constraint "referencing_table_ref_id_fkey_1350032" on table "referencing_table_1350032"
-DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350032".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350225" violates foreign key constraint "referencing_table_ref_id_fkey_1350257" on table "referencing_table_1350257"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350257".
+CONTEXT:  while executing command on localhost:57638
 DELETE FROM referencing_table WHERE ref_id = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
@@ -265,9 +265,9 @@ SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 UPDATE referenced_table SET test_column = 10 WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350036" violates foreign key constraint "referencing_table_ref_id_fkey_1350040" on table "referencing_table_1350040"
-DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350040".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350289" violates foreign key constraint "referencing_table_ref_id_fkey_1350321" on table "referencing_table_1350321"
+DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350321".
+CONTEXT:  while executing command on localhost:57638
 BEGIN;
 UPDATE referenced_table SET test_column = 10 WHERE id = 1;
 UPDATE referencing_table SET id = 10 WHERE ref_id = 1;
@@ -305,9 +305,9 @@ INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 BEGIN;
 UPDATE referenced_table SET test_column = 20 WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350044" violates foreign key constraint "referencing_table_ref_id_fkey_1350048" on table "referencing_table_1350048"
-DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350048".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350353" violates foreign key constraint "referencing_table_ref_id_fkey_1350385" on table "referencing_table_1350385"
+DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350385".
+CONTEXT:  while executing command on localhost:57638
 UPDATE referencing_table SET id = 20 WHERE ref_id = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
@@ -366,9 +366,9 @@ SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 (1 row)
 
 INSERT INTO referencing_table VALUES(null, 2);
-ERROR:  insert or update on table "referencing_table_1350067" violates foreign key constraint "referencing_table_ref_id_fkey_1350067"
+ERROR:  insert or update on table "referencing_table_1350536" violates foreign key constraint "referencing_table_ref_id_fkey_1350536"
 DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 SELECT * FROM referencing_table;
  id | ref_id 
 ----+--------
@@ -474,27 +474,27 @@ ERROR:  number of referencing and referenced columns for foreign key disagree
 -- test foreign constraint creation while existing tables does not satisfy the constraint
 INSERT INTO referencing_table VALUES(1, 1);
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id) REFERENCES referenced_table(id);
-ERROR:  insert or update on table "referencing_table_1350080" violates foreign key constraint "test_constraint_1350080"
-DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350076".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "referencing_table_1350585" violates foreign key constraint "test_constraint_1350585"
+DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350553".
+CONTEXT:  while executing command on localhost:57638
 -- test foreign constraint with correct conditions
 DELETE FROM referencing_table WHERE ref_id = 1;
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id) REFERENCES referenced_table(id);
 -- test inserts
 -- test insert to referencing table while there is NO corresponding value in referenced table
 INSERT INTO referencing_table VALUES(1, 1);
-ERROR:  insert or update on table "referencing_table_1350080" violates foreign key constraint "test_constraint_1350080"
-DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350076".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "referencing_table_1350585" violates foreign key constraint "test_constraint_1350585"
+DETAIL:  Key (ref_id)=(1) is not present in table "referenced_table_1350553".
+CONTEXT:  while executing command on localhost:57638
 -- test insert to referencing while there is corresponding value in referenced table
 INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 -- test deletes
 -- test delete from referenced table while there is corresponding value in referencing table
 DELETE FROM referenced_table WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350076" violates foreign key constraint "test_constraint_1350080" on table "referencing_table_1350080"
-DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350080".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350553" violates foreign key constraint "test_constraint_1350585" on table "referencing_table_1350585"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350585".
+CONTEXT:  while executing command on localhost:57638
 -- test delete from referenced table while there is NO corresponding value in referencing table
 DELETE FROM referencing_table WHERE ref_id = 1;
 DELETE FROM referenced_table WHERE id = 1;
@@ -522,9 +522,9 @@ ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id)
 INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 DELETE FROM referenced_table WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350076" violates foreign key constraint "test_constraint_1350080" on table "referencing_table_1350080"
-DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350080".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350553" violates foreign key constraint "test_constraint_1350585" on table "referencing_table_1350585"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350585".
+CONTEXT:  while executing command on localhost:57638
 BEGIN;
 DELETE FROM referenced_table WHERE id = 1;
 DELETE FROM referencing_table WHERE ref_id = 1;
@@ -546,9 +546,9 @@ INSERT INTO referenced_table VALUES(1, 1);
 INSERT INTO referencing_table VALUES(1, 1);
 BEGIN;
 DELETE FROM referenced_table WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350076" violates foreign key constraint "test_constraint_1350080" on table "referencing_table_1350080"
-DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350080".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350553" violates foreign key constraint "test_constraint_1350585" on table "referencing_table_1350585"
+DETAIL:  Key (id)=(1) is still referenced from table "referencing_table_1350585".
+CONTEXT:  while executing command on localhost:57638
 DELETE FROM referencing_table WHERE ref_id = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
@@ -568,9 +568,9 @@ ALTER TABLE referencing_table DROP CONSTRAINT test_constraint;
 -- test ON UPDATE NO ACTION + DEFERABLE + INITIALLY DEFERRED
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) ON UPDATE NO ACTION DEFERRABLE INITIALLY DEFERRED;
 UPDATE referenced_table SET test_column = 10 WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350076" violates foreign key constraint "test_constraint_1350080" on table "referencing_table_1350080"
-DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350080".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350553" violates foreign key constraint "test_constraint_1350585" on table "referencing_table_1350585"
+DETAIL:  Key (id, test_column)=(1, 1) is still referenced from table "referencing_table_1350585".
+CONTEXT:  while executing command on localhost:57638
 BEGIN;
 UPDATE referenced_table SET test_column = 10 WHERE id = 1;
 UPDATE referencing_table SET id = 10 WHERE ref_id = 1;
@@ -592,9 +592,9 @@ ALTER TABLE referencing_table DROP CONSTRAINT test_constraint;
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) ON UPDATE RESTRICT;
 BEGIN;
 UPDATE referenced_table SET test_column = 20 WHERE id = 1;
-ERROR:  update or delete on table "referenced_table_1350076" violates foreign key constraint "test_constraint_1350080" on table "referencing_table_1350080"
-DETAIL:  Key (id, test_column)=(1, 10) is still referenced from table "referencing_table_1350080".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  update or delete on table "referenced_table_1350553" violates foreign key constraint "test_constraint_1350585" on table "referencing_table_1350585"
+DETAIL:  Key (id, test_column)=(1, 10) is still referenced from table "referencing_table_1350585".
+CONTEXT:  while executing command on localhost:57638
 UPDATE referencing_table SET id = 20 WHERE ref_id = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
@@ -626,9 +626,9 @@ ALTER TABLE referencing_table DROP CONSTRAINT test_constraint;
 -- test MATCH FULL
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH FULL;
 INSERT INTO referencing_table VALUES(null, 2);
-ERROR:  insert or update on table "referencing_table_1350083" violates foreign key constraint "test_constraint_1350083"
+ERROR:  insert or update on table "referencing_table_1350608" violates foreign key constraint "test_constraint_1350608"
 DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
-CONTEXT:  while executing command on localhost:57638
+CONTEXT:  while executing command on localhost:57637
 SELECT * FROM referencing_table;
  id | ref_id 
 ----+--------
@@ -658,9 +658,9 @@ ALTER TABLE cyclic_reference_table1 ADD CONSTRAINT cyclic_constraint1 FOREIGN KE
 ALTER TABLE cyclic_reference_table2 ADD CONSTRAINT cyclic_constraint2 FOREIGN KEY(id, table1_id) REFERENCES cyclic_reference_table1(table2_id, id) DEFERRABLE INITIALLY DEFERRED;
 -- test insertion to a table which has cyclic foreign constraints, we expect that to fail
 INSERT INTO cyclic_reference_table1 VALUES(1, 1);
-ERROR:  insert or update on table "cyclic_reference_table1_1350084" violates foreign key constraint "cyclic_constraint1_1350084"
-DETAIL:  Key (id, table2_id)=(1, 1) is not present in table "cyclic_reference_table2_1350088".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "cyclic_reference_table1_1350617" violates foreign key constraint "cyclic_constraint1_1350617"
+DETAIL:  Key (id, table2_id)=(1, 1) is not present in table "cyclic_reference_table2_1350649".
+CONTEXT:  while executing command on localhost:57638
 -- proper insertion to table with cyclic dependency
 BEGIN;
 INSERT INTO cyclic_reference_table1 VALUES(1, 1);
@@ -740,9 +740,9 @@ SELECT create_distributed_table('self_referencing_table1', 'id', 'hash');
 INSERT INTO self_referencing_table1 VALUES(1, 1, 1);
 -- we expect this query to fail
 INSERT INTO self_referencing_table1 VALUES(1, 2, 3);
-ERROR:  insert or update on table "self_referencing_table1_1350092" violates foreign key constraint "self_referencing_table1_id_fkey_1350092"
-DETAIL:  Key (id, other_column_ref)=(1, 3) is not present in table "self_referencing_table1_1350092".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "self_referencing_table1_1350681" violates foreign key constraint "self_referencing_table1_id_fkey_1350681"
+DETAIL:  Key (id, other_column_ref)=(1, 3) is not present in table "self_referencing_table1_1350681".
+CONTEXT:  while executing command on localhost:57638
 -- verify that rows are actually inserted
 SELECT * FROM self_referencing_table1;
  id | other_column | other_column_ref 
@@ -765,9 +765,9 @@ ALTER TABLE self_referencing_table2 ADD CONSTRAINT self_referencing_fk_constrain
 INSERT INTO self_referencing_table2 VALUES(1, 1, 1);
 -- we expect this query to fail
 INSERT INTO self_referencing_table2 VALUES(1, 2, 3);
-ERROR:  insert or update on table "self_referencing_table2_1350096" violates foreign key constraint "self_referencing_fk_constraint_1350096"
-DETAIL:  Key (id, other_column_ref)=(1, 3) is not present in table "self_referencing_table2_1350096".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "self_referencing_table2_1350713" violates foreign key constraint "self_referencing_fk_constraint_1350713"
+DETAIL:  Key (id, other_column_ref)=(1, 3) is not present in table "self_referencing_table2_1350713".
+CONTEXT:  while executing command on localhost:57638
 -- verify that rows are actually inserted
 SELECT * FROM self_referencing_table2;
  id | other_column | other_column_ref 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1,3 +1,4 @@
+SET citus.shard_count TO 32;
 SET citus.next_shard_id TO 750000;
 -- ===================================================================
 -- test end-to-end modification functionality

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -394,7 +394,7 @@ ORDER BY logicalrelid;
               logicalrelid               | partmethod | colocationid | repmodel 
 -----------------------------------------+------------+--------------+----------
  replicate_reference_table_reference_one | n          |      1370002 | t
- replicate_reference_table_hash          | h          |      1360004 | c
+ replicate_reference_table_hash          | h          |      1360005 | c
 (2 rows)
 
 BEGIN;

--- a/src/test/regress/expected/multi_subquery_window_functions.out
+++ b/src/test/regress/expected/multi_subquery_window_functions.out
@@ -743,14 +743,14 @@ EXPLAIN (COSTS FALSE, VERBOSE TRUE)
                                                                      ->  Sort
                                                                            Output: users_table.user_id, users_table.value_2
                                                                            Sort Key: users_table.user_id
-                                                                           ->  Seq Scan on public.users_table_1400000 users_table
+                                                                           ->  Seq Scan on public.users_table_1400256 users_table
                                                                                  Output: users_table.user_id, users_table.value_2
                                                                ->  WindowAgg
                                                                      Output: events_table.user_id, sum(events_table.value_2) OVER (?)
                                                                      ->  Sort
                                                                            Output: events_table.user_id, events_table.value_2
                                                                            Sort Key: events_table.user_id
-                                                                           ->  Seq Scan on public.events_table_1400004 events_table
+                                                                           ->  Seq Scan on public.events_table_1400260 events_table
                                                                                  Output: events_table.user_id, events_table.value_2
                                              ->  HashAggregate
                                                    Output: users_table_1.user_id, sum((sum(users_table_1.value_2) OVER (?)))
@@ -764,14 +764,14 @@ EXPLAIN (COSTS FALSE, VERBOSE TRUE)
                                                                      ->  Sort
                                                                            Output: users_table_1.user_id, users_table_1.value_2
                                                                            Sort Key: users_table_1.user_id
-                                                                           ->  Seq Scan on public.users_table_1400000 users_table_1
+                                                                           ->  Seq Scan on public.users_table_1400256 users_table_1
                                                                                  Output: users_table_1.user_id, users_table_1.value_2
                                                                ->  WindowAgg
                                                                      Output: events_table_1.user_id, sum(events_table_1.value_2) OVER (?)
                                                                      ->  Sort
                                                                            Output: events_table_1.user_id, events_table_1.value_2
                                                                            Sort Key: events_table_1.user_id
-                                                                           ->  Seq Scan on public.events_table_1400004 events_table_1
+                                                                           ->  Seq Scan on public.events_table_1400260 events_table_1
                                                                                  Output: events_table_1.user_id, events_table_1.value_2
 (62 rows)
 

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -240,7 +240,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_one_worker'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360000 | c
+ h          | f             |      1360001 | c
 (1 row)
 
 SELECT
@@ -262,7 +262,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360000 |          1 |                 1 |                     23
+      1360001 |          1 |                 1 |                     23
 (1 row)
 
 SELECT
@@ -354,7 +354,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360001 | c
+ h          | f             |      1360002 | c
 (1 row)
 
 SELECT
@@ -376,7 +376,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360001 |          1 |                 2 |                     23
+      1360002 |          1 |                 2 |                     23
 (1 row)
 
 SELECT
@@ -468,7 +468,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_both_healthy'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360002 | c
+ h          | f             |      1360003 | c
 (1 row)
 
 SELECT
@@ -490,7 +490,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360002 |          1 |                 2 |                     23
+      1360003 |          1 |                 2 |                     23
 (1 row)
 
 SELECT
@@ -584,7 +584,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360003 | c
+ h          | f             |      1360004 | c
 (1 row)
 
 SELECT
@@ -606,7 +606,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360003 |          1 |                 1 |                     23
+      1360004 |          1 |                 1 |                     23
 (1 row)
 
 SELECT
@@ -639,7 +639,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360003 | c
+ h          | f             |      1360004 | c
 (1 row)
 
 SELECT
@@ -661,7 +661,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360003 |          1 |                 1 |                     23
+      1360004 |          1 |                 1 |                     23
 (1 row)
 
 SELECT
@@ -697,7 +697,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360003 | c
+ h          | f             |      1360004 | c
 (1 row)
 
 SELECT
@@ -719,7 +719,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360003 |          1 |                 1 |                     23
+      1360004 |          1 |                 1 |                     23
 (1 row)
 
 SELECT
@@ -823,7 +823,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_mx'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360004 | s
+ h          | f             |      1360005 | s
 (1 row)
 
 SELECT
@@ -845,7 +845,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+      1360005 |          1 |                 1 |                     23
 (1 row)
 
 SELECT
@@ -875,7 +875,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_mx'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360004 | s
+ h          | f             |      1360005 | s
 (1 row)
 
 SELECT
@@ -897,7 +897,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+      1360005 |          1 |                 1 |                     23
 (1 row)
 
 SELECT
@@ -944,7 +944,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_mx'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- h          | f             |      1360005 | c
+ h          | f             |      1360006 | c
 (1 row)
 
 SELECT
@@ -966,7 +966,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1360005 |          1 |                 2 |                     23
+      1360006 |          1 |                 2 |                     23
 (1 row)
 
 SELECT

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -792,7 +792,7 @@ EXPLAIN (COSTS FALSE) SELECT user_id FROM recent_selected_users GROUP BY 1 ORDER
                            Group Key: users_table.user_id
                            ->  Hash Join
                                  Hash Cond: (users_table.user_id = ru.user_id)
-                                 ->  Seq Scan on users_table_1400000 users_table
+                                 ->  Seq Scan on users_table_1400256 users_table
                                        Filter: ((value_1 >= 1) AND (value_1 < 3))
                                  ->  Hash
                                        ->  Subquery Scan on ru
@@ -801,7 +801,7 @@ EXPLAIN (COSTS FALSE) SELECT user_id FROM recent_selected_users GROUP BY 1 ORDER
                                                    ->  HashAggregate
                                                          Group Key: users_table_1.user_id
                                                          Filter: (max(users_table_1."time") > '2017-11-23 16:20:33.264457'::timestamp without time zone)
-                                                         ->  Seq Scan on users_table_1400000 users_table_1
+                                                         ->  Seq Scan on users_table_1400256 users_table_1
 (23 rows)
 
 EXPLAIN (COSTS FALSE) SELECT *
@@ -832,9 +832,9 @@ EXPLAIN (COSTS FALSE) SELECT *
                                                    Filter: (max(users_table."time") > '2017-11-23 16:20:33.264457'::timestamp without time zone)
                                                    ->  Sort
                                                          Sort Key: users_table.user_id
-                                                         ->  Seq Scan on users_table_1400000 users_table
+                                                         ->  Seq Scan on users_table_1400256 users_table
                                                                Filter: ((user_id < 4) AND (user_id > 1))
-                                 ->  Seq Scan on users_table_1400000 users_table_1
+                                 ->  Seq Scan on users_table_1400256 users_table_1
                                        Filter: ((value_1 >= 1) AND (value_1 < 3) AND (user_id < 4) AND (user_id > 1))
 (23 rows)
 
@@ -861,7 +861,7 @@ EXPLAIN (COSTS FALSE) SELECT et.* FROM recent_10_users JOIN events_table et USIN
                                                                Sort Key: (max("time")) DESC
                                                                ->  HashAggregate
                                                                      Group Key: user_id
-                                                                     ->  Seq Scan on users_table_1400000 users_table
+                                                                     ->  Seq Scan on users_table_1400256 users_table
                Task Count: 4
                Tasks Shown: One of 4
                ->  Task
@@ -873,7 +873,7 @@ EXPLAIN (COSTS FALSE) SELECT et.* FROM recent_10_users JOIN events_table et USIN
                                        Hash Cond: (intermediate_result.user_id = et.user_id)
                                        ->  Function Scan on read_intermediate_result intermediate_result
                                        ->  Hash
-                                             ->  Seq Scan on events_table_1400004 et
+                                             ->  Seq Scan on events_table_1400260 et
 (33 rows)
 
 SET citus.subquery_pushdown to ON;
@@ -893,7 +893,7 @@ EXPLAIN (COSTS FALSE) SELECT et.* FROM recent_10_users JOIN events_table et USIN
                                  Sort Key: et."time" DESC
                                  ->  Hash Join
                                        Hash Cond: (et.user_id = recent_10_users.user_id)
-                                       ->  Seq Scan on events_table_1400004 et
+                                       ->  Seq Scan on events_table_1400260 et
                                        ->  Hash
                                              ->  Subquery Scan on recent_10_users
                                                    ->  Limit
@@ -901,7 +901,7 @@ EXPLAIN (COSTS FALSE) SELECT et.* FROM recent_10_users JOIN events_table et USIN
                                                                Sort Key: (max(users_table."time")) DESC
                                                                ->  HashAggregate
                                                                      Group Key: users_table.user_id
-                                                                     ->  Seq Scan on users_table_1400000 users_table
+                                                                     ->  Seq Scan on users_table_1400256 users_table
 (22 rows)
 
 RESET citus.subquery_pushdown;

--- a/src/test/regress/expected/subquery_and_cte.out
+++ b/src/test/regress/expected/subquery_and_cte.out
@@ -1,8 +1,7 @@
 -- ===================================================================
 -- test recursive planning functionality with subqueries and CTEs
 -- ===================================================================
-CREATE SCHEMA subquery_and_ctes;
-SET search_path TO subquery_and_ctes, public;
+SET search_path TO subquery_and_ctes;
 CREATE TABLE users_table_local AS SELECT * FROM users_table;
 SET client_min_messages TO DEBUG1;
 -- CTEs are recursively planned, and subquery foo is also recursively planned
@@ -30,12 +29,12 @@ FROM
      ORDER BY 1 DESC LIMIT 5
      ) as foo 
 	  WHERE foo.user_id = cte.user_id;
-DEBUG:  generating subplan 2_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 2_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 3_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 3_2 for CTE dist_cte: SELECT user_id FROM public.events_table
+DEBUG:  generating subplan 3_2 for CTE dist_cte: SELECT user_id FROM subquery_and_ctes.events_table
 DEBUG:  Plan 3 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('3_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('3_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 2_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  generating subplan 2_2 for subquery SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
 DEBUG:  Plan 2 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('2_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('2_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo WHERE (foo.user_id = cte.user_id)
  count 
 -------
@@ -68,13 +67,13 @@ FROM
      ORDER BY 1 DESC LIMIT 5
      ) as foo, events_table
 	  WHERE foo.user_id = cte.user_id AND events_table.user_id = cte.user_id;
-DEBUG:  generating subplan 6_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 6_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 7_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 7_2 for CTE dist_cte: SELECT user_id FROM public.events_table
+DEBUG:  generating subplan 7_2 for CTE dist_cte: SELECT user_id FROM subquery_and_ctes.events_table
 DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('7_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 6_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
-DEBUG:  Plan 6 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('6_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('6_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo, public.events_table WHERE ((foo.user_id = cte.user_id) AND (events_table.user_id = cte.user_id))
+DEBUG:  generating subplan 6_2 for subquery SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  Plan 6 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('6_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('6_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo, subquery_and_ctes.events_table WHERE ((foo.user_id = cte.user_id) AND (events_table.user_id = cte.user_id))
  count 
 -------
  30608
@@ -98,13 +97,13 @@ WHERE
 	users_table.user_id = cte.user_id AND
 	users_table.user_id IN (SELECT DISTINCT value_2 FROM users_table WHERE value_1 >= 1 AND value_1 <= 20 ORDER BY 1 LIMIT 5)
     ORDER BY 1 DESC;
-DEBUG:  generating subplan 10_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 10_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 11_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 11_2 for CTE dist_cte: SELECT user_id FROM public.events_table
+DEBUG:  generating subplan 11_2 for CTE dist_cte: SELECT user_id FROM subquery_and_ctes.events_table
 DEBUG:  Plan 11 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('11_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('11_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 10_2 for subquery SELECT DISTINCT value_2 FROM public.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20)) ORDER BY value_2 LIMIT 5
-DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT DISTINCT cte.user_id FROM public.users_table, (SELECT intermediate_result.user_id FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE ((users_table.user_id = cte.user_id) AND (users_table.user_id IN (SELECT intermediate_result.value_2 FROM read_intermediate_result('10_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)))) ORDER BY cte.user_id DESC
+DEBUG:  generating subplan 10_2 for subquery SELECT DISTINCT value_2 FROM subquery_and_ctes.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20)) ORDER BY value_2 LIMIT 5
+DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT DISTINCT cte.user_id FROM subquery_and_ctes.users_table, (SELECT intermediate_result.user_id FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE ((users_table.user_id = cte.user_id) AND (users_table.user_id IN (SELECT intermediate_result.value_2 FROM read_intermediate_result('10_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)))) ORDER BY cte.user_id DESC
  user_id 
 ---------
        4
@@ -131,11 +130,11 @@ FROM cte
 WHERE 
 	cte.user_id IN (SELECT DISTINCT user_id FROM users_table WHERE value_1 >= 1 AND value_1 <= 20)
     ORDER BY 1 DESC;
-DEBUG:  generating subplan 14_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 14_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 15_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 15_2 for CTE dist_cte: SELECT user_id FROM public.events_table
+DEBUG:  generating subplan 15_2 for CTE dist_cte: SELECT user_id FROM subquery_and_ctes.events_table
 DEBUG:  Plan 15 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('15_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('15_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
-DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT DISTINCT user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('14_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE (user_id IN (SELECT DISTINCT users_table.user_id FROM public.users_table WHERE ((users_table.value_1 >= 1) AND (users_table.value_1 <= 20)))) ORDER BY user_id DESC
+DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT DISTINCT user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('14_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE (user_id IN (SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table WHERE ((users_table.value_1 >= 1) AND (users_table.value_1 <= 20)))) ORDER BY user_id DESC
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs are not allowed in the FROM clause when the query has subqueries in the WHERE clause
 -- CTEs inside a subquery and the final query becomes a router
@@ -154,7 +153,7 @@ FROM
 	     event_type IN (1,2,3,4)
 	     ) SELECT * FROM cte ORDER BY 1 DESC
      ) as foo;
-DEBUG:  generating subplan 17_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 17_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
 DEBUG:  Plan 17 query after replacing subqueries and CTEs: SELECT user_id FROM (SELECT cte.user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('17_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte ORDER BY cte.user_id DESC) foo
  user_id 
 ---------
@@ -193,12 +192,12 @@ FROM
 	    
      ) as bar  
 WHERE foo.user_id = bar.user_id;
-DEBUG:  generating subplan 19_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
-DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT bar.user_id FROM (SELECT cte.user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte ORDER BY cte.user_id DESC) foo, (SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))) bar WHERE (foo.user_id = bar.user_id)
+DEBUG:  generating subplan 19_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT bar.user_id FROM (SELECT cte.user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte ORDER BY cte.user_id DESC) foo, (SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))) bar WHERE (foo.user_id = bar.user_id)
  user_id 
 ---------
-       5
        1
+       5
        4
        3
        6
@@ -246,10 +245,10 @@ FROM
      ) as bar  
 WHERE foo.user_id = bar.user_id
 ORDER BY 1 DESC LIMIT 5;
-DEBUG:  generating subplan 21_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
-DEBUG:  generating subplan 21_2 for CTE cte: SELECT events_table.event_type, users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (users_table.value_1 = ANY (ARRAY[1, 2])))
+DEBUG:  generating subplan 21_1 for CTE cte: SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 21_2 for CTE cte: SELECT events_table.event_type, users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (users_table.value_1 = ANY (ARRAY[1, 2])))
 DEBUG:  push down of limit count: 2
-DEBUG:  generating subplan 21_3 for subquery SELECT users_table.user_id, some_events.event_type FROM public.users_table, (SELECT cte.event_type, cte.user_id FROM (SELECT intermediate_result.event_type, intermediate_result.user_id FROM read_intermediate_result('21_2'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer, user_id integer)) cte ORDER BY cte.event_type DESC) some_events WHERE ((users_table.user_id = some_events.user_id) AND (some_events.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY some_events.event_type, users_table.user_id LIMIT 2
+DEBUG:  generating subplan 21_3 for subquery SELECT users_table.user_id, some_events.event_type FROM subquery_and_ctes.users_table, (SELECT cte.event_type, cte.user_id FROM (SELECT intermediate_result.event_type, intermediate_result.user_id FROM read_intermediate_result('21_2'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer, user_id integer)) cte ORDER BY cte.event_type DESC) some_events WHERE ((users_table.user_id = some_events.user_id) AND (some_events.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY some_events.event_type, users_table.user_id LIMIT 2
 DEBUG:  Plan 21 query after replacing subqueries and CTEs: SELECT DISTINCT bar.user_id FROM (SELECT cte.user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('21_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte ORDER BY cte.user_id DESC) foo, (SELECT intermediate_result.user_id, intermediate_result.event_type FROM read_intermediate_result('21_3'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, event_type integer)) bar WHERE (foo.user_id = bar.user_id) ORDER BY bar.user_id DESC LIMIT 5
  user_id 
 ---------
@@ -283,14 +282,14 @@ SELECT * FROM
 			foo.user_id = events_table.value_2
 ORDER BY 3 DESC, 2 DESC, 1 DESC 
 LIMIT 5;
-DEBUG:  generating subplan 25_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 25_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 26_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 26_2 for CTE dist_cte: SELECT user_id FROM public.events_table
+DEBUG:  generating subplan 26_2 for CTE dist_cte: SELECT user_id FROM subquery_and_ctes.events_table
 DEBUG:  Plan 26 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('26_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('26_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
-DEBUG:  generating subplan 25_2 for CTE cte_in_where: SELECT DISTINCT value_2 FROM public.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20)) ORDER BY value_2 LIMIT 5
+DEBUG:  generating subplan 25_2 for CTE cte_in_where: SELECT DISTINCT value_2 FROM subquery_and_ctes.users_table WHERE ((value_1 >= 1) AND (value_1 <= 20)) ORDER BY value_2 LIMIT 5
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 25_3 for subquery SELECT DISTINCT cte.user_id FROM public.users_table, (SELECT intermediate_result.user_id FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE ((users_table.user_id = cte.user_id) AND (users_table.user_id IN (SELECT cte_in_where.value_2 FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('25_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) cte_in_where))) ORDER BY cte.user_id DESC
-DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT foo.user_id, events_table.user_id, events_table."time", events_table.event_type, events_table.value_2, events_table.value_3, events_table.value_4 FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('25_3'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo, public.events_table WHERE (foo.user_id = events_table.value_2) ORDER BY events_table."time" DESC, events_table.user_id DESC, foo.user_id DESC LIMIT 5
+DEBUG:  generating subplan 25_3 for subquery SELECT DISTINCT cte.user_id FROM subquery_and_ctes.users_table, (SELECT intermediate_result.user_id FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte WHERE ((users_table.user_id = cte.user_id) AND (users_table.user_id IN (SELECT cte_in_where.value_2 FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('25_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) cte_in_where))) ORDER BY cte.user_id DESC
+DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT foo.user_id, events_table.user_id, events_table."time", events_table.event_type, events_table.value_2, events_table.value_3, events_table.value_4 FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('25_3'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo, subquery_and_ctes.events_table WHERE (foo.user_id = events_table.value_2) ORDER BY events_table."time" DESC, events_table.user_id DESC, foo.user_id DESC LIMIT 5
 DEBUG:  push down of limit count: 5
  user_id | user_id |              time               | event_type | value_2 | value_3 | value_4 
 ---------+---------+---------------------------------+------------+---------+---------+---------
@@ -332,16 +331,16 @@ FROM
      ORDER BY 1 DESC LIMIT 5
      ) as foo 
 	  WHERE foo.user_id = cte.user_id;
-DEBUG:  generating subplan 30_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 30_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table, (SELECT DISTINCT users_table.value_2 FROM subquery_and_ctes.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM subquery_and_ctes.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 31_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 31_2 for CTE dist_cte: SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))
+DEBUG:  generating subplan 31_2 for CTE dist_cte: SELECT events_table.user_id FROM subquery_and_ctes.events_table, (SELECT DISTINCT users_table.value_2 FROM subquery_and_ctes.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM subquery_and_ctes.users_table ORDER BY users_table.value_1 LIMIT 3)))
 DEBUG:  push down of limit count: 3
-DEBUG:  generating subplan 32_1 for subquery SELECT DISTINCT value_1 FROM public.users_table ORDER BY value_1 LIMIT 3
-DEBUG:  generating subplan 32_2 for subquery SELECT DISTINCT value_2 FROM public.users_table OFFSET 0
-DEBUG:  Plan 32 query after replacing subqueries and CTEs: SELECT events_table.user_id FROM public.events_table, (SELECT intermediate_result.value_2 FROM read_intermediate_result('32_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT intermediate_result.value_1 FROM read_intermediate_result('32_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))))
+DEBUG:  generating subplan 32_1 for subquery SELECT DISTINCT value_1 FROM subquery_and_ctes.users_table ORDER BY value_1 LIMIT 3
+DEBUG:  generating subplan 32_2 for subquery SELECT DISTINCT value_2 FROM subquery_and_ctes.users_table OFFSET 0
+DEBUG:  Plan 32 query after replacing subqueries and CTEs: SELECT events_table.user_id FROM subquery_and_ctes.events_table, (SELECT intermediate_result.value_2 FROM read_intermediate_result('32_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT intermediate_result.value_1 FROM read_intermediate_result('32_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))))
 DEBUG:  Plan 31 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('31_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('31_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 30_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  generating subplan 30_2 for subquery SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
 DEBUG:  Plan 30 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('30_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('30_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo WHERE (foo.user_id = cte.user_id)
  count 
 -------
@@ -386,18 +385,18 @@ FROM
 ) as foo, users_table WHERE foo.cnt > users_table.value_2 
 ORDER BY 3 DESC, 1 DESC, 2 DESC, 4 DESC
 LIMIT 5;
-DEBUG:  generating subplan 36_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
+DEBUG:  generating subplan 36_1 for CTE cte: WITH local_cte AS (SELECT users_table_local.user_id, users_table_local."time", users_table_local.value_1, users_table_local.value_2, users_table_local.value_3, users_table_local.value_4 FROM subquery_and_ctes.users_table_local), dist_cte AS (SELECT events_table.user_id FROM subquery_and_ctes.events_table, (SELECT DISTINCT users_table.value_2 FROM subquery_and_ctes.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM subquery_and_ctes.users_table ORDER BY users_table.value_1 LIMIT 3)))) SELECT dist_cte.user_id FROM (local_cte JOIN dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  generating subplan 37_1 for CTE local_cte: SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM subquery_and_ctes.users_table_local
-DEBUG:  generating subplan 37_2 for CTE dist_cte: SELECT events_table.user_id FROM public.events_table, (SELECT DISTINCT users_table.value_2 FROM public.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM public.users_table ORDER BY users_table.value_1 LIMIT 3)))
+DEBUG:  generating subplan 37_2 for CTE dist_cte: SELECT events_table.user_id FROM subquery_and_ctes.events_table, (SELECT DISTINCT users_table.value_2 FROM subquery_and_ctes.users_table OFFSET 0) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT DISTINCT users_table.value_1 FROM subquery_and_ctes.users_table ORDER BY users_table.value_1 LIMIT 3)))
 DEBUG:  push down of limit count: 3
-DEBUG:  generating subplan 38_1 for subquery SELECT DISTINCT value_1 FROM public.users_table ORDER BY value_1 LIMIT 3
-DEBUG:  generating subplan 38_2 for subquery SELECT DISTINCT value_2 FROM public.users_table OFFSET 0
-DEBUG:  Plan 38 query after replacing subqueries and CTEs: SELECT events_table.user_id FROM public.events_table, (SELECT intermediate_result.value_2 FROM read_intermediate_result('38_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT intermediate_result.value_1 FROM read_intermediate_result('38_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))))
+DEBUG:  generating subplan 38_1 for subquery SELECT DISTINCT value_1 FROM subquery_and_ctes.users_table ORDER BY value_1 LIMIT 3
+DEBUG:  generating subplan 38_2 for subquery SELECT DISTINCT value_2 FROM subquery_and_ctes.users_table OFFSET 0
+DEBUG:  Plan 38 query after replacing subqueries and CTEs: SELECT events_table.user_id FROM subquery_and_ctes.events_table, (SELECT intermediate_result.value_2 FROM read_intermediate_result('38_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) foo WHERE ((events_table.user_id = foo.value_2) AND (events_table.user_id IN (SELECT intermediate_result.value_1 FROM read_intermediate_result('38_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))))
 DEBUG:  Plan 37 query after replacing subqueries and CTEs: SELECT dist_cte.user_id FROM ((SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('37_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) local_cte JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('37_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) dist_cte ON ((dist_cte.user_id = local_cte.user_id)))
 DEBUG:  push down of limit count: 5
-DEBUG:  generating subplan 36_2 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
+DEBUG:  generating subplan 36_2 for subquery SELECT DISTINCT users_table.user_id FROM subquery_and_ctes.users_table, subquery_and_ctes.events_table WHERE ((users_table.user_id = events_table.user_id) AND (events_table.event_type = ANY (ARRAY[1, 2, 3, 4]))) ORDER BY users_table.user_id DESC LIMIT 5
 DEBUG:  generating subplan 36_3 for subquery SELECT count(*) AS cnt FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('36_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) cte, (SELECT intermediate_result.user_id FROM read_intermediate_result('36_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo WHERE (foo.user_id = cte.user_id)
-DEBUG:  Plan 36 query after replacing subqueries and CTEs: SELECT foo.cnt, users_table.user_id, users_table."time", users_table.value_1, users_table.value_2, users_table.value_3, users_table.value_4 FROM (SELECT intermediate_result.cnt FROM read_intermediate_result('36_3'::text, 'binary'::citus_copy_format) intermediate_result(cnt bigint)) foo, public.users_table WHERE (foo.cnt > users_table.value_2) ORDER BY users_table."time" DESC, foo.cnt DESC, users_table.user_id DESC, users_table.value_1 DESC LIMIT 5
+DEBUG:  Plan 36 query after replacing subqueries and CTEs: SELECT foo.cnt, users_table.user_id, users_table."time", users_table.value_1, users_table.value_2, users_table.value_3, users_table.value_4 FROM (SELECT intermediate_result.cnt FROM read_intermediate_result('36_3'::text, 'binary'::citus_copy_format) intermediate_result(cnt bigint)) foo, subquery_and_ctes.users_table WHERE (foo.cnt > users_table.value_2) ORDER BY users_table."time" DESC, foo.cnt DESC, users_table.user_id DESC, users_table.value_1 DESC LIMIT 5
 DEBUG:  push down of limit count: 5
  cnt | user_id |              time               | value_1 | value_2 | value_3 | value_4 
 -----+---------+---------------------------------+---------+---------+---------+---------
@@ -437,5 +436,8 @@ WHERE foo.user_id = bar.user_id;
 ERROR:  recursive CTEs are not supported in distributed queries
 SET client_min_messages TO DEFAULT;
 DROP SCHEMA subquery_and_ctes CASCADE;
-NOTICE:  drop cascades to table users_table_local
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table users_table
+drop cascades to table events_table
+drop cascades to table users_table_local
 SET search_path TO public;

--- a/src/test/regress/expected/with_basics.out
+++ b/src/test/regress/expected/with_basics.out
@@ -1,6 +1,7 @@
 -- Test the basic CTE functionality and expected error messages
+SET search_path TO 'with_basics';
 CREATE TYPE xy AS (x int, y int);
-SELECT run_command_on_workers('CREATE TYPE xy AS (x int, y int)');
+SELECT run_command_on_workers('CREATE TYPE with_basics.xy AS (x int, y int)');
       run_command_on_workers       
 -----------------------------------
  (localhost,57637,t,"CREATE TYPE")
@@ -773,3 +774,8 @@ SELECT user_id, value_1 FROM cte_user_with_view ORDER BY 1, 2 LIMIT 10 OFFSET 2;
 
 DROP VIEW basic_view;
 DROP VIEW cte_view;
+DROP SCHEMA with_basics CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table users_table
+drop cascades to table events_table
+drop cascades to type xy

--- a/src/test/regress/input/multi_behavioral_analytics_create_table.source
+++ b/src/test/regress/input/multi_behavioral_analytics_create_table.source
@@ -5,7 +5,7 @@
 SET citus.next_shard_id TO 1400000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1400000;
 SET citus.shard_replication_factor = 1;
-SET citus.shard_count = 4;
+SET citus.shard_count = 32;
 
 CREATE SCHEMA with_basics;
 SET search_path TO 'with_basics';
@@ -19,6 +19,20 @@ SELECT create_distributed_table('events_table', 'user_id');
 COPY users_table FROM '@abs_srcdir@/data/users_table.data' WITH CSV;
 COPY events_table FROM '@abs_srcdir@/data/events_table.data' WITH CSV;
 
+SET citus.shard_count = 96;
+CREATE SCHEMA subquery_and_ctes;
+SET search_path TO subquery_and_ctes;
+
+CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('users_table', 'user_id');
+
+CREATE TABLE events_table (user_id int, time timestamp, event_type int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('events_table', 'user_id');
+
+COPY users_table FROM '@abs_srcdir@/data/users_table.data' WITH CSV;
+COPY events_table FROM '@abs_srcdir@/data/events_table.data' WITH CSV;
+
+SET citus.shard_count TO DEFAULT;
 SET search_path TO DEFAULT;
 
 CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);

--- a/src/test/regress/input/multi_behavioral_analytics_create_table.source
+++ b/src/test/regress/input/multi_behavioral_analytics_create_table.source
@@ -7,6 +7,20 @@ ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1400000;
 SET citus.shard_replication_factor = 1;
 SET citus.shard_count = 4;
 
+CREATE SCHEMA with_basics;
+SET search_path TO 'with_basics';
+
+CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('users_table', 'user_id');
+
+CREATE TABLE events_table (user_id int, time timestamp, event_type int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('events_table', 'user_id');
+
+COPY users_table FROM '@abs_srcdir@/data/users_table.data' WITH CSV;
+COPY events_table FROM '@abs_srcdir@/data/events_table.data' WITH CSV;
+
+SET search_path TO DEFAULT;
+
 CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
 SELECT create_distributed_table('users_table', 'user_id');
 

--- a/src/test/regress/output/multi_behavioral_analytics_create_table.source
+++ b/src/test/regress/output/multi_behavioral_analytics_create_table.source
@@ -5,7 +5,7 @@
 SET citus.next_shard_id TO 1400000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1400000;
 SET citus.shard_replication_factor = 1;
-SET citus.shard_count = 4;
+SET citus.shard_count = 32;
 CREATE SCHEMA with_basics;
 SET search_path TO 'with_basics';
 CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
@@ -24,6 +24,26 @@ SELECT create_distributed_table('events_table', 'user_id');
 
 COPY users_table FROM '@abs_srcdir@/data/users_table.data' WITH CSV;
 COPY events_table FROM '@abs_srcdir@/data/events_table.data' WITH CSV;
+SET citus.shard_count = 96;
+CREATE SCHEMA subquery_and_ctes;
+SET search_path TO subquery_and_ctes;
+CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('users_table', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE events_table (user_id int, time timestamp, event_type int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('events_table', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+COPY users_table FROM '@abs_srcdir@/data/users_table.data' WITH CSV;
+COPY events_table FROM '@abs_srcdir@/data/events_table.data' WITH CSV;
+SET citus.shard_count TO DEFAULT;
 SET search_path TO DEFAULT;
 CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
 SELECT create_distributed_table('users_table', 'user_id');

--- a/src/test/regress/output/multi_behavioral_analytics_create_table.source
+++ b/src/test/regress/output/multi_behavioral_analytics_create_table.source
@@ -6,6 +6,25 @@ SET citus.next_shard_id TO 1400000;
 ALTER SEQUENCE pg_catalog.pg_dist_jobid_seq RESTART 1400000;
 SET citus.shard_replication_factor = 1;
 SET citus.shard_count = 4;
+CREATE SCHEMA with_basics;
+SET search_path TO 'with_basics';
+CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('users_table', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE events_table (user_id int, time timestamp, event_type int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('events_table', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+COPY users_table FROM '@abs_srcdir@/data/users_table.data' WITH CSV;
+COPY events_table FROM '@abs_srcdir@/data/events_table.data' WITH CSV;
+SET search_path TO DEFAULT;
 CREATE TABLE users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
 SELECT create_distributed_table('users_table', 'user_id');
  create_distributed_table 

--- a/src/test/regress/sql/multi_alter_table_add_constraints.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints.sql
@@ -3,7 +3,7 @@
 --
 -- Test checks whether constraints of distributed tables can be adjusted using
 -- the ALTER TABLE ... ADD CONSTRAINT ... command.
-
+SET citus.shard_count TO 32;
 SET citus.next_shard_id TO 1450000;
 SET citus.next_placement_id TO 1450000;
 
@@ -398,9 +398,10 @@ ROLLBACK;
 
 -- There should be no constraint on master and worker(s) 
 SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regclass;
+
 \c - - - :worker_1_port
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
 
 \c - - - :master_port
 
@@ -414,14 +415,13 @@ ROLLBACK;
 
 -- There should be no constraint on master and worker(s) 
 SELECT "Constraint", "Definition" FROM table_checks WHERE relid='products'::regclass;
-
 \c - - - :worker_1_port
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450034'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.products_1450202'::regclass;
 
 \c - - - :master_port
-SET citus.next_shard_id TO 1450038;
-SET citus.next_placement_id TO 1450038;
+SET citus.next_shard_id TO 1450234;
+SET citus.next_placement_id TO 1450234;
 
 DROP TABLE products;
 

--- a/src/test/regress/sql/multi_foreign_key.sql
+++ b/src/test/regress/sql/multi_foreign_key.sql
@@ -5,7 +5,7 @@
 SET citus.next_shard_id TO 1350000;
 
 -- set shard_count to 4 for faster tests, because we create/drop lots of shards in this test.
-SET citus.shard_count TO 4;
+SET citus.shard_count TO 32;
 
 -- create tables
 CREATE TABLE referenced_table(id int UNIQUE, test_column int, PRIMARY KEY(id, test_column));
@@ -37,7 +37,7 @@ SET citus.shard_count TO 8;
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
 SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 DROP TABLE referencing_table;
-SET citus.shard_count TO 4;
+SET citus.shard_count TO 32;
 
 -- test foreign constraint creation on non-partition columns
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(id) REFERENCES referenced_table(id));

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -1,4 +1,4 @@
-
+SET citus.shard_count TO 32;
 SET citus.next_shard_id TO 750000;
 
 

--- a/src/test/regress/sql/subquery_and_cte.sql
+++ b/src/test/regress/sql/subquery_and_cte.sql
@@ -1,8 +1,7 @@
 -- ===================================================================
 -- test recursive planning functionality with subqueries and CTEs
 -- ===================================================================
-CREATE SCHEMA subquery_and_ctes;
-SET search_path TO subquery_and_ctes, public;
+SET search_path TO subquery_and_ctes;
 
 
 CREATE TABLE users_table_local AS SELECT * FROM users_table;

--- a/src/test/regress/sql/with_basics.sql
+++ b/src/test/regress/sql/with_basics.sql
@@ -1,7 +1,8 @@
 -- Test the basic CTE functionality and expected error messages
+SET search_path TO 'with_basics';
 
 CREATE TYPE xy AS (x int, y int);
-SELECT run_command_on_workers('CREATE TYPE xy AS (x int, y int)');
+SELECT run_command_on_workers('CREATE TYPE with_basics.xy AS (x int, y int)');
 
 -- CTEs in FROM should work
 WITH cte AS (
@@ -507,3 +508,4 @@ SELECT user_id, value_1 FROM cte_user_with_view ORDER BY 1, 2 LIMIT 10 OFFSET 2;
 
 DROP VIEW basic_view;
 DROP VIEW cte_view;
+DROP SCHEMA with_basics CASCADE;


### PR DESCRIPTION
This PR increases the shard_count in multi_alter_table_add_constraints.sql, multi_foreign_key.sql, multi_modifications.sql, with_basics.sql from 4 to 32 and subquery_and_cte from 4 to 96
fixes #1828 