### PR TITLE
Prototype: Properly interpret the result of GetRemoteCommandResult()

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1401,7 +1401,22 @@ StoreQueryResult(CitusScanState *scanState, MultiConnection *connection,
 		bool doRaiseInterrupts = true;
 
 		PGresult *result = GetRemoteCommandResult(connection, doRaiseInterrupts);
-		if (result == NULL)
+
+		if (PQstatus(connection->pgConn) == CONNECTION_BAD)
+		{
+			if (failOnError)
+			{
+				ReportResultError(connection, result, ERROR);
+			}
+			else
+			{
+				ReportResultError(connection, result, WARNING);
+			}
+
+			commandFailed = true;
+			break;
+		}
+		else if (result == NULL)
 		{
 			break;
 		}


### PR DESCRIPTION
This is a WIP PR yet aims to fix #1926

See the [comment](https://github.com/citusdata/citus/issues/1926#issuecomment-355289153) for the details.

Note that this WIP only fixes single occurrence of the same bug, this should be expanded to fix all occurrences as mentioned in the  [comment](https://github.com/citusdata/citus/issues/1926#issuecomment-355289153).
  