### PR TITLE
Add support for renaming Distributed Tables

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -2740,12 +2740,7 @@ ErrorIfUnsupportedRenameStmt(RenameStmt *renameStmt)
 {
 	Assert(IsAlterTableRenameStmt(renameStmt));
 
-	if (renameStmt->renameType == OBJECT_TABLE)
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("renaming distributed tables is currently unsupported")));
-	}
-	else if (renameStmt->renameType == OBJECT_TABCONSTRAINT)
+	if (renameStmt->renameType == OBJECT_TABCONSTRAINT)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("renaming constraints belonging to distributed tables is "

--- a/src/test/regress/expected/multi_name_lengths.out
+++ b/src/test/regress/expected/multi_name_lengths.out
@@ -113,7 +113,8 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_len
 \c - - - :master_port
 -- Placeholders for RENAME operations
 ALTER TABLE name_lengths RENAME TO name_len_12345678901234567890123456789012345678901234567890;
-ERROR:  renaming distributed tables is currently unsupported
+ERROR:  shard name name_len_12345678901234567890123456789012345678_fcd8ab6f_225002 exceeds 63 characters
+CONTEXT:  while executing command on localhost:57638
 ALTER TABLE name_lengths RENAME CONSTRAINT unique_12345678901234567890123456789012345678901234567890 TO unique2_12345678901234567890123456789012345678901234567890;
 ERROR:  renaming constraints belonging to distributed tables is currently unsupported
 -- Verify that CREATE INDEX on already distributed table has proper shard names.

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1382,12 +1382,13 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.referen
 (0 rows)
 
 \c - - - :master_port
--- as we expect, renaming and setting WITH OIDS does not work for reference tables
-ALTER TABLE reference_table_ddl RENAME TO reference_table_ddl_test;
-ERROR:  renaming distributed tables is currently unsupported
+-- as we expect, setting WITH OIDS does not work for reference tables
 ALTER TABLE reference_table_ddl SET WITH OIDS;
 ERROR:  alter table command is currently unsupported
 DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT, ADD|DROP CONSTRAINT, ATTACH|DETACH PARTITION and TYPE subcommands are supported.
+-- now test the renaming of the table, and back to the expected name
+ALTER TABLE reference_table_ddl RENAME TO reference_table_ddl_test;
+ALTER TABLE reference_table_ddl_test RENAME TO reference_table_ddl;
 -- now test reference tables against some helper UDFs that Citus provides
 -- cannot delete / drop shards from a reference table
 SELECT master_apply_delete_command('DELETE FROM reference_table_ddl');

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1308,26 +1308,26 @@ SELECT logicalrelid FROM pg_dist_shard WHERE logicalrelid::regclass::text LIKE '
 (0 rows)
 
 -- now test DDL changes
-CREATE TABLE reference_table_ddl (value_1 int, value_2 float, value_3 text, value_4 timestamp);
-SELECT create_reference_table('reference_table_ddl');
+CREATE TABLE reference_schema.reference_table_ddl (value_1 int, value_2 float, value_3 text, value_4 timestamp);
+SELECT create_reference_table('reference_schema.reference_table_ddl');
  create_reference_table 
 ------------------------
  
 (1 row)
 
 -- CREATE & DROP index and check the workers
-CREATE INDEX reference_index_1 ON reference_table_ddl(value_1);
-CREATE INDEX reference_index_2 ON reference_table_ddl(value_2, value_3);
+CREATE INDEX reference_index_1 ON reference_schema.reference_table_ddl(value_1);
+CREATE INDEX reference_index_2 ON reference_schema.reference_table_ddl(value_2, value_3);
 -- should be able to create/drop UNIQUE index on a reference table
-CREATE UNIQUE INDEX reference_index_3 ON reference_table_ddl(value_1);
+CREATE UNIQUE INDEX reference_index_3 ON reference_schema.reference_table_ddl(value_1);
 -- should be able to add a column
-ALTER TABLE reference_table_ddl ADD COLUMN value_5 INTEGER;
-ALTER TABLE reference_table_ddl ALTER COLUMN value_5 SET DATA TYPE FLOAT;
-ALTER TABLE reference_table_ddl DROP COLUMN value_1;
-ALTER TABLE reference_table_ddl ALTER COLUMN value_2 SET DEFAULT 25.0;
-ALTER TABLE reference_table_ddl ALTER COLUMN value_3 SET NOT NULL;
+ALTER TABLE reference_schema.reference_table_ddl ADD COLUMN value_5 INTEGER;
+ALTER TABLE reference_schema.reference_table_ddl ALTER COLUMN value_5 SET DATA TYPE FLOAT;
+ALTER TABLE reference_schema.reference_table_ddl DROP COLUMN value_1;
+ALTER TABLE reference_schema.reference_table_ddl ALTER COLUMN value_2 SET DEFAULT 25.0;
+ALTER TABLE reference_schema.reference_table_ddl ALTER COLUMN value_3 SET NOT NULL;
 -- see that Citus applied all DDLs to the table
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.reference_table_ddl'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='reference_schema.reference_table_ddl'::regclass;
  Column  |            Type             |  Modifiers   
 ---------+-----------------------------+--------------
  value_2 | double precision            | default 25.0
@@ -1336,17 +1336,17 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.referen
  value_5 | double precision            | 
 (4 rows)
 
-\d reference_index_2
-    Index "public.reference_index_2"
+\d reference_schema.reference_index_2
+Index "reference_schema.reference_index_2"
  Column  |       Type       | Definition 
 ---------+------------------+------------
  value_2 | double precision | value_2
  value_3 | text             | value_3
-btree, for table "public.reference_table_ddl"
+btree, for table "reference_schema.reference_table_ddl"
 
 -- also to the shard placements
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.reference_table_ddl_1250019'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='reference_schema.reference_table_ddl_1250019'::regclass;
  Column  |            Type             |  Modifiers   
 ---------+-----------------------------+--------------
  value_2 | double precision            | default 25.0
@@ -1355,18 +1355,18 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.referen
  value_5 | double precision            | 
 (4 rows)
 
-\d reference_index_2_1250019
-Index "public.reference_index_2_1250019"
+\d reference_schema.reference_index_2_1250019
+Index "reference_schema.reference_index_2_1250019"
  Column  |       Type       | Definition 
 ---------+------------------+------------
  value_2 | double precision | value_2
  value_3 | text             | value_3
-btree, for table "public.reference_table_ddl_1250019"
+btree, for table "reference_schema.reference_table_ddl_1250019"
 
 \c - - - :master_port
-DROP INDEX reference_index_2;
+DROP INDEX reference_schema.reference_index_2;
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.reference_table_ddl_1250019'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='reference_schema.reference_table_ddl_1250019'::regclass;
  Column  |            Type             |  Modifiers   
 ---------+-----------------------------+--------------
  value_2 | double precision            | default 25.0
@@ -1375,7 +1375,7 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.referen
  value_5 | double precision            | 
 (4 rows)
 
-\di reference_index_2*
+\di reference_schema.reference_index_2*
           List of relations
  Schema | Name | Type | Owner | Table 
 --------+------+------+-------+-------
@@ -1383,31 +1383,31 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.referen
 
 \c - - - :master_port
 -- as we expect, setting WITH OIDS does not work for reference tables
-ALTER TABLE reference_table_ddl SET WITH OIDS;
+ALTER TABLE reference_schema.reference_table_ddl SET WITH OIDS;
 ERROR:  alter table command is currently unsupported
 DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT, ADD|DROP CONSTRAINT, ATTACH|DETACH PARTITION and TYPE subcommands are supported.
 -- now test the renaming of the table, and back to the expected name
-ALTER TABLE reference_table_ddl RENAME TO reference_table_ddl_test;
-ALTER TABLE reference_table_ddl_test RENAME TO reference_table_ddl;
+ALTER TABLE reference_schema.reference_table_ddl RENAME TO reference_table_ddl_test;
+ALTER TABLE reference_schema.reference_table_ddl_test RENAME TO reference_table_ddl;
 -- now test reference tables against some helper UDFs that Citus provides
 -- cannot delete / drop shards from a reference table
-SELECT master_apply_delete_command('DELETE FROM reference_table_ddl');
+SELECT master_apply_delete_command('DELETE FROM reference_schema.reference_table_ddl');
 ERROR:  cannot delete from distributed table
 DETAIL:  Delete statements on reference tables are not supported.
 -- cannot add shards
-SELECT master_create_empty_shard('reference_table_ddl');
-ERROR:  relation "reference_table_ddl" is a reference table
+SELECT master_create_empty_shard('reference_schema.reference_table_ddl');
+ERROR:  relation "reference_schema.reference_table_ddl" is a reference table
 DETAIL:  We currently don't support creating shards on reference tables
 -- master_modify_multiple_shards works, but, does it make sense to use at all?
-INSERT INTO reference_table_ddl (value_2, value_3) VALUES (7, 'aa');
-SELECT master_modify_multiple_shards('DELETE FROM reference_table_ddl WHERE value_2 = 7');
+INSERT INTO reference_schema.reference_table_ddl (value_2, value_3) VALUES (7, 'aa');
+SELECT master_modify_multiple_shards('DELETE FROM reference_schema.reference_table_ddl WHERE value_2 = 7');
  master_modify_multiple_shards 
 -------------------------------
                              1
 (1 row)
 
-INSERT INTO reference_table_ddl (value_2, value_3) VALUES (7, 'bb');
-SELECT master_modify_multiple_shards('DELETE FROM reference_table_ddl');
+INSERT INTO reference_schema.reference_table_ddl (value_2, value_3) VALUES (7, 'bb');
+SELECT master_modify_multiple_shards('DELETE FROM reference_schema.reference_table_ddl');
  master_modify_multiple_shards 
 -------------------------------
                              1
@@ -1415,13 +1415,14 @@ SELECT master_modify_multiple_shards('DELETE FROM reference_table_ddl');
 
 -- get/update the statistics
 SELECT part_storage_type, part_key, part_replica_count, part_max_size,
-           part_placement_policy FROM master_get_table_metadata('reference_table_ddl');
+           part_placement_policy
+  FROM master_get_table_metadata('reference_schema.reference_table_ddl');
  part_storage_type | part_key | part_replica_count | part_max_size | part_placement_policy 
 -------------------+----------+--------------------+---------------+-----------------------
  t                 |          |                  2 |        307200 |                     2
 (1 row)
 
-SELECT shardid AS a_shard_id  FROM pg_dist_shard WHERE logicalrelid = 'reference_table_ddl'::regclass \gset
+SELECT shardid AS a_shard_id  FROM pg_dist_shard WHERE logicalrelid = 'reference_schema.reference_table_ddl'::regclass \gset
 SELECT master_update_shard_statistics(:a_shard_id);
  master_update_shard_statistics 
 --------------------------------
@@ -1432,11 +1433,12 @@ CREATE TABLE append_reference_tmp_table (id INT);
 SELECT  master_append_table_to_shard(:a_shard_id, 'append_reference_tmp_table', 'localhost', :master_port);
 ERROR:  cannot append to shardId 1250019
 DETAIL:  We currently don't support appending to shards in hash-partitioned or reference tables
-SELECT master_get_table_ddl_events('reference_table_ddl');
-                                                                      master_get_table_ddl_events                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- CREATE TABLE public.reference_table_ddl (value_2 double precision DEFAULT 25.0, value_3 text NOT NULL, value_4 timestamp without time zone, value_5 double precision)
-(1 row)
+SELECT master_get_table_ddl_events('reference_schema.reference_table_ddl');
+                                                                           master_get_table_ddl_events                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE SCHEMA IF NOT EXISTS reference_schema AUTHORIZATION postgres
+ CREATE TABLE reference_schema.reference_table_ddl (value_2 double precision DEFAULT 25.0, value_3 text NOT NULL, value_4 timestamp without time zone, value_5 double precision)
+(2 rows)
 
 -- in reality, we wouldn't need to repair any reference table shard placements
 -- however, the test could be relevant for other purposes
@@ -1621,7 +1623,7 @@ INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
 ROLLBACK;
 -- clean up tables
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
-		   reference_table_test_fourth, reference_table_ddl, reference_table_composite;
+		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite;
 DROP SCHEMA reference_schema CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table reference_schema.reference_table_test_sixth

--- a/src/test/regress/input/multi_alter_table_statements.source
+++ b/src/test/regress/input/multi_alter_table_statements.source
@@ -148,9 +148,8 @@ ALTER TABLE lineitem_alter ADD COLUMN new_column non_existent_type;
 ALTER TABLE lineitem_alter ALTER COLUMN null_column SET NOT NULL;
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 
--- Verify that we error out on non-column RENAME statements
+-- Verify that we error out on RENAME CONSTRAINT statement
 
-ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
 ALTER TABLE lineitem_alter RENAME CONSTRAINT constraint_a TO constraint_b;
 
 -- Verify that IF EXISTS works as expected with RENAME statements
@@ -356,10 +355,30 @@ FROM
 ORDER BY attnum;
 \c - - - :master_port
 
+-- verify that we can rename distributed tables
+SHOW citus.enable_ddl_propagation;
+ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
+
+-- verify rename is performed
+SELECT relname FROM pg_class WHERE relname = 'lineitem_renamed';
+
+-- show rename worked on one worker, too
+\c - - - :worker_1_port
+SELECT relname FROM pg_class WHERE relname LIKE 'lineitem_renamed%'  ORDER BY relname;
+\c - - - :master_port
+
+-- revert it to original name
+ALTER TABLE lineitem_renamed RENAME TO lineitem_alter;
+
+-- show rename worked on one worker, too
+\c - - - :worker_1_port
+SELECT relname FROM pg_class WHERE relname LIKE 'lineitem_alter%' ORDER BY relname;
+\c - - - :master_port
+
 -- verify that we don't intercept DDL commands if propagation is turned off
 SET citus.enable_ddl_propagation to false;
 
--- table rename statement can be performed now
+-- table rename statement can be performed on the coordinator only now
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
 -- verify rename is performed
 SELECT relname FROM pg_class WHERE relname = 'lineitem_alter' or relname = 'lineitem_renamed';

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -377,9 +377,7 @@ ERROR:  column "null_column" contains null values
 CONTEXT:  while executing command on localhost:57638
 ALTER TABLE lineitem_alter ALTER COLUMN l_partkey SET DEFAULT 'a';
 ERROR:  invalid input syntax for integer: "a"
--- Verify that we error out on non-column RENAME statements
-ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
-ERROR:  renaming distributed tables is currently unsupported
+-- Verify that we error out on RENAME CONSTRAINT statement
 ALTER TABLE lineitem_alter RENAME CONSTRAINT constraint_a TO constraint_b;
 ERROR:  renaming constraints belonging to distributed tables is currently unsupported
 -- Verify that IF EXISTS works as expected with RENAME statements
@@ -784,9 +782,71 @@ ORDER BY attnum;
 (30 rows)
 
 \c - - - :master_port
+-- verify that we can rename distributed tables
+SHOW citus.enable_ddl_propagation;
+ citus.enable_ddl_propagation 
+------------------------------
+ on
+(1 row)
+
+ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
+-- verify rename is performed
+SELECT relname FROM pg_class WHERE relname = 'lineitem_renamed';
+     relname      
+------------------
+ lineitem_renamed
+(1 row)
+
+-- show rename worked on one worker, too
+\c - - - :worker_1_port
+SELECT relname FROM pg_class WHERE relname LIKE 'lineitem_renamed%'  ORDER BY relname;
+         relname         
+-------------------------
+ lineitem_renamed_220000
+ lineitem_renamed_220001
+ lineitem_renamed_220002
+ lineitem_renamed_220003
+ lineitem_renamed_220004
+ lineitem_renamed_220005
+ lineitem_renamed_220006
+ lineitem_renamed_220007
+ lineitem_renamed_220008
+ lineitem_renamed_220010
+ lineitem_renamed_220011
+ lineitem_renamed_220012
+ lineitem_renamed_220013
+ lineitem_renamed_220014
+(14 rows)
+
+\c - - - :master_port
+-- revert it to original name
+ALTER TABLE lineitem_renamed RENAME TO lineitem_alter;
+-- show rename worked on one worker, too
+\c - - - :worker_1_port
+SELECT relname FROM pg_class WHERE relname LIKE 'lineitem_alter%' ORDER BY relname;
+        relname        
+-----------------------
+ lineitem_alter_220000
+ lineitem_alter_220001
+ lineitem_alter_220002
+ lineitem_alter_220003
+ lineitem_alter_220004
+ lineitem_alter_220005
+ lineitem_alter_220006
+ lineitem_alter_220007
+ lineitem_alter_220008
+ lineitem_alter_220009
+ lineitem_alter_220010
+ lineitem_alter_220011
+ lineitem_alter_220012
+ lineitem_alter_220013
+ lineitem_alter_220014
+(15 rows)
+
+\c - - - :master_port
 -- verify that we don't intercept DDL commands if propagation is turned off
 SET citus.enable_ddl_propagation to false;
--- table rename statement can be performed now
+-- table rename statement can be performed on the coordinator only now
 ALTER TABLE lineitem_alter RENAME TO lineitem_renamed;
 -- verify rename is performed
 SELECT relname FROM pg_class WHERE relname = 'lineitem_alter' or relname = 'lineitem_renamed';

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -872,9 +872,12 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.referen
 \di reference_index_2*
 \c - - - :master_port
 
--- as we expect, renaming and setting WITH OIDS does not work for reference tables
-ALTER TABLE reference_table_ddl RENAME TO reference_table_ddl_test;
+-- as we expect, setting WITH OIDS does not work for reference tables
 ALTER TABLE reference_table_ddl SET WITH OIDS;
+
+-- now test the renaming of the table, and back to the expected name
+ALTER TABLE reference_table_ddl RENAME TO reference_table_ddl_test;
+ALTER TABLE reference_table_ddl_test RENAME TO reference_table_ddl;
 
 -- now test reference tables against some helper UDFs that Citus provides
 


### PR DESCRIPTION
This Pull Request implements support for renaming Distributed Tables, fixing #1249. It also adds a commit to edit the regression tests and have more coverage of non-default schema (not public, not in the search_path).

It might be better for me to rebase/squash the main commit and its follow-up make reindent pass though, but will that trigger another travis-ci run?