### PR TITLE
Add base schedule for only running specific regression tests

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -45,6 +45,11 @@ check-worker: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/worker_schedule $(EXTRA_TESTS)
 
+# check-base only sets up a testing environment so you can specify all your tests using EXTRA_TESTS
+check-base: all
+	$(pg_regress_multi_check) --load-extension=citus \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/base_schedule $(EXTRA_TESTS)
+
 check-multi: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)

--- a/src/test/regress/base_schedule
+++ b/src/test/regress/base_schedule
@@ -1,0 +1,7 @@
+# ----------
+# Only run few basic tests to set up a testing environment
+# ----------
+test: multi_cluster_management
+test: multi_test_helpers
+test: multi_create_table multi_behavioral_analytics_create_table
+test: multi_load_data


### PR DESCRIPTION
This change adds a base schedule to make it easier to run a specific regression test using the `EXTRA_TESTS` flag.

For example, to only run the `with_basics` and `with_join` tests you would run: 
```
make check-base -C src/test/regress/ EXTRA_TESTS="with_basics with_join"
```

which only takes 14 seconds.