### PR TITLE
Add test that checks whether distributed transaction ID survives pg_dist_partition invalidation

### DIFF
--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -77,7 +77,7 @@ step s4-get-all-transactions:
 initiator_node_identifiertransaction_numbertransaction_stamp
 
 
-starting permutation: s1-create-table s1-begin s1-insert s1-get-current-transaction-id s2-get-first-worker-active-transactions
+starting permutation: s1-create-table s1-begin s1-insert s1-get-current-transaction-id s2-get-first-worker-active-transactions s1-commit
 step s1-create-table: 
 	-- some tests also use distributed table
 	CREATE TABLE distributed_transaction_id_table(some_value int, other_value int);
@@ -110,3 +110,35 @@ step s2-get-first-worker-active-transactions:
 nodename       nodeport       success        result         
 
 localhost      57637          t              (0,289)        
+step s1-commit: 
+    COMMIT;
+
+
+starting permutation: s1-begin s1-assign-transaction-id s1-has-transaction-number s2-vacuum s1-has-transaction-number s1-commit
+step s1-begin: 
+    BEGIN;
+
+step s1-assign-transaction-id: 
+    SELECT assign_distributed_transaction_id(1, 1, '2015-01-01 00:00:00+0');
+
+assign_distributed_transaction_id
+
+               
+step s1-has-transaction-number: 
+    SELECT transaction_number > 0 FROM get_current_transaction_id();
+
+?column?       
+
+t              
+step s2-vacuum: 
+    VACUUM FULL pg_dist_partition;
+
+step s1-has-transaction-number: 
+    SELECT transaction_number > 0 FROM get_current_transaction_id();
+
+?column?       
+
+t              
+step s1-commit: 
+    COMMIT;
+


### PR DESCRIPTION
We somehow not able to merge this commit in #1889, probably due to some `git rebase` issue. This PR adds the missing regression test only.