### PR TITLE
Prevent canceling backends that are active but not involved in the distributed deadlock

### DIFF
--- a/src/backend/distributed/transaction/distributed_deadlock_detection.c
+++ b/src/backend/distributed/transaction/distributed_deadlock_detection.c
@@ -134,7 +134,7 @@ CheckForDistributedDeadlocks(void)
 	{
 		bool deadlockFound = false;
 		List *deadlockPath = NIL;
-		TransactionNode *transactionNodeStack[edgeCount];
+		TransactionNode *transactionNodeStack[edgeCount + 1];
 
 		/* we're only interested in finding deadlocks originating from this node */
 		if (transactionNode->transactionId.initiatorNodeIdentifier != localGroupId)

--- a/src/backend/distributed/transaction/distributed_deadlock_detection.c
+++ b/src/backend/distributed/transaction/distributed_deadlock_detection.c
@@ -307,7 +307,7 @@ PrependOutgoingNodesToQueue(TransactionNode *transactionNode, int currentStackDe
 		queuedNode->transactionNode = waitForTransaction;
 		queuedNode->currentStackDepth = currentStackDepth;
 
-		*toBeVisitedNodes = lappend(*toBeVisitedNodes, queuedNode);
+		*toBeVisitedNodes = lcons(queuedNode, *toBeVisitedNodes);
 	}
 }
 

--- a/src/test/regress/expected/isolation_distributed_deadlock_detection.out
+++ b/src/test/regress/expected/isolation_distributed_deadlock_detection.out
@@ -874,3 +874,85 @@ step s1-finish:
 step s2-finish: 
   COMMIT;
 
+
+starting permutation: s1-begin s2-begin s3-begin s4-begin s5-begin s1-update-1 s3-update-3 s2-update-4 s2-update-3 s4-update-2 s5-random-adv-lock s4-random-adv-lock s3-update-1 s1-update-2-4 deadlock-checker-call deadlock-checker-call s5-finish s4-finish s2-finish s1-finish s3-finish
+step s1-begin: 
+  BEGIN;
+
+step s2-begin: 
+  BEGIN;
+
+step s3-begin: 
+  BEGIN;
+
+step s4-begin: 
+  BEGIN;
+
+step s5-begin: 
+  BEGIN;
+
+step s1-update-1: 
+  UPDATE deadlock_detection_test SET some_val = 1 WHERE user_id = 1;
+
+step s3-update-3: 
+  UPDATE deadlock_detection_test SET some_val = 3 WHERE user_id = 3;
+
+step s2-update-4: 
+  UPDATE deadlock_detection_test SET some_val = 2 WHERE user_id = 4;
+
+step s2-update-3: 
+  UPDATE deadlock_detection_test SET some_val = 2 WHERE user_id = 3;
+ <waiting ...>
+step s4-update-2: 
+  UPDATE deadlock_detection_test SET some_val = 4 WHERE user_id = 2;
+
+step s5-random-adv-lock: 
+  SELECT pg_advisory_xact_lock(8765);
+
+pg_advisory_xact_lock
+
+               
+step s4-random-adv-lock: 
+  SELECT pg_advisory_xact_lock(8765);
+ <waiting ...>
+step s3-update-1: 
+  UPDATE deadlock_detection_test SET some_val = 3 WHERE user_id = 1;
+ <waiting ...>
+step s1-update-2-4: 
+  UPDATE deadlock_detection_test SET some_val = 1 WHERE user_id = 2 OR user_id = 4;
+ <waiting ...>
+step deadlock-checker-call: 
+  SELECT check_distributed_deadlocks();
+
+check_distributed_deadlocks
+
+t              
+step s2-update-3: <... completed>
+error in steps deadlock-checker-call s2-update-3: ERROR:  canceling the transaction since it was involved in a distributed deadlock
+step deadlock-checker-call: 
+  SELECT check_distributed_deadlocks();
+
+check_distributed_deadlocks
+
+f              
+step s5-finish: 
+  COMMIT;
+
+step s4-random-adv-lock: <... completed>
+pg_advisory_xact_lock
+
+               
+step s4-finish: 
+  COMMIT;
+
+step s1-update-2-4: <... completed>
+step s2-finish: 
+  COMMIT;
+
+step s1-finish: 
+  COMMIT;
+
+step s3-update-1: <... completed>
+step s3-finish: 
+  COMMIT;
+


### PR DESCRIPTION
DESCRIPTION: Prevent canceling backends that are not involved in the distributed deadlock

**Should be backported to 7.0, 7.1 and 7.2**

Fixes #1960 

With this fix, we traverse the graph with DFS which was originally
intended. Note that, before the fix, we traverse the graph with BFS
which might lead to killing some unrelated backend that is not
involved in the distributed deadlock.

We also add one more commit which is not very likely to cause any issues
but would prevent wrong memory accesses.


How to understand the effect of the change:

Generate @lithp 's scenario mentioned in the issue (slightly more complex), follow the steps in the order written as below in the comment starting with `step`:

```
A--B--C--A
 \
  D
```
Exact form is the following:

![screen shot 2018-01-19 at 14 40 03](https://user-images.githubusercontent.com/7829470/35151385-2fc14d10-fd2f-11e7-8849-ce19b1cdb091.png)


With the following queries (Note that `events_table` DDL can be found in the regression tests):
```SQL
-- simulate transaction (A)
BEGIN;

-- step 0
UPDATE events_table SET event_type = 1 WHERE user_id = 1;

-- step 6
UPDATE events_table SET event_type = 1;

-- simulate transaction (B)
BEGIN;

-- step 3
UPDATE events_table SET event_type = 1 WHERE user_id = 4;

-- step 4
UPDATE events_table SET event_type = 1 WHERE user_id = 3;


-- simulate transaction (C)
BEGIN;
-- step 2
UPDATE events_table SET event_type = 1 WHERE user_id = 3;

-- step 5
UPDATE events_table SET event_type = 1 WHERE user_id = 1;

-- simulate transaction (D)
BEGIN;
-- step 1
UPDATE events_table SET event_type = 1 WHERE user_id = 2;

```


Before the fix, you'd see that the deadlock detection adds `transaction D` to the deadlock path, which is actually not involved in the transaction.

To debug it: 
1. Enable distributed deadlock detection logs: `citus.log_distributed_deadlock_detection` to `ON`
2. Disable Postgres deadlock detection `ALTER SYSTEM SET deadlock_timeout TO '1h'`
3. Disable Citus deadlock detection `ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1`
4. On all four transactions, set the `citus.log_remote_commands` TO `on`
5. After step 6, run ` SELECT check_distributed_deadlocks();` and observe the postmaster logs w/wout the fix. You'll see that without the fix, Citus would add transaction `D` to the deadlock path, which is obviously wrong.



