### PR TITLE
Skip JSON validation on coordinator during COPY

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -14,7 +14,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	7.0-1 7.0-2 7.0-3 7.0-4 7.0-5 7.0-6 7.0-7 7.0-8 7.0-9 7.0-10 7.0-11 7.0-12 7.0-13 7.0-14 7.0-15 \
 	7.1-1 7.1-2 7.1-3 7.1-4 \
     7.2-1 7.2-2 7.2-3 \
-	7.3-1
+	7.3-1 7.3-2
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -187,6 +187,8 @@ $(EXTENSION)--7.2-2.sql: $(EXTENSION)--7.2-1.sql $(EXTENSION)--7.2-1--7.2-2.sql
 $(EXTENSION)--7.2-3.sql: $(EXTENSION)--7.2-2.sql $(EXTENSION)--7.2-2--7.2-3.sql
 	cat $^ > $@
 $(EXTENSION)--7.3-1.sql: $(EXTENSION)--7.2-3.sql $(EXTENSION)--7.2-3--7.3-1.sql
+	cat $^ > $@
+$(EXTENSION)--7.3-2.sql: $(EXTENSION)--7.3-1.sql $(EXTENSION)--7.3-1--7.3-2.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.3-1--7.3-2.sql
+++ b/src/backend/distributed/citus--7.3-1--7.3-2.sql
@@ -1,0 +1,6 @@
+/* citus--7.3-1--7.3-2 */
+
+CREATE FUNCTION pg_catalog.citus_text_send_as_jsonb(text)
+RETURNS bytea
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT
+AS 'MODULE_PATHNAME', $$citus_text_send_as_jsonb$$;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.3-1'
+default_version = '7.3-2'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -508,6 +508,22 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.skip_jsonb_validation_in_copy",
+		gettext_noop("Skip validation of JSONB columns on the coordinator during COPY "
+					 "into a distributed table"),
+		gettext_noop("Parsing large JSON objects may incur significant CPU overhead, "
+					 "which can lower COPY throughput. If this GUC is set (the default), "
+					 "JSON parsing is skipped on the coordinator, which means you cannot "
+					 "see the line number in case of malformed JSON, but throughput will "
+					 "be higher. This setting does not apply if the input format is "
+					 "binary."),
+		&SkipJsonbValidationInCopy,
+		true,
+		PGC_USERSET,
+		0,
+		NULL, NULL, NULL);
+
 	DefineCustomIntVariable(
 		"citus.shard_count",
 		gettext_noop("Sets the number of shards for a new hash-partitioned table"

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -121,6 +121,7 @@ typedef struct MetadataCacheData
 	Oid readIntermediateResultFuncId;
 	Oid extraDataContainerFuncId;
 	Oid workerHashFunctionId;
+	Oid textSendAsJsonbFunctionId;
 	Oid extensionOwner;
 	Oid binaryCopyFormatId;
 	Oid textCopyFormatId;
@@ -1938,6 +1939,24 @@ CitusWorkerHashFunctionId(void)
 	}
 
 	return MetadataCache.workerHashFunctionId;
+}
+
+
+/* return oid of the citus_text_send_as_jsonb(text) function */
+Oid
+CitusTextSendAsJsonbFunctionId(void)
+{
+	if (MetadataCache.textSendAsJsonbFunctionId == InvalidOid)
+	{
+		List *nameList = list_make2(makeString("pg_catalog"),
+									makeString("citus_text_send_as_jsonb"));
+		Oid paramOids[1] = { TEXTOID };
+
+		MetadataCache.textSendAsJsonbFunctionId =
+			LookupFuncName(nameList, 1, paramOids, false);
+	}
+
+	return MetadataCache.textSendAsJsonbFunctionId;
 }
 
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -130,6 +130,7 @@ extern Oid CitusCopyFormatTypeId(void);
 extern Oid CitusReadIntermediateResultFuncId(void);
 extern Oid CitusExtraDataContainerFuncId(void);
 extern Oid CitusWorkerHashFunctionId(void);
+extern Oid CitusTextSendAsJsonbFunctionId(void);
 
 /* enum oids */
 extern Oid PrimaryNodeRoleId(void);

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -108,6 +108,10 @@ typedef struct CitusCopyDestReceiver
 } CitusCopyDestReceiver;
 
 
+/* GUCs */
+extern bool SkipJsonbValidationInCopy;
+
+
 /* function declarations for copying into a distributed table */
 extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   List *columnNameList,

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -812,3 +812,46 @@ CREATE UNLOGGED TABLE trigger_flush AS
 SELECT 1 AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h FROM generate_series(1,150000) s;
 SELECT create_distributed_table('trigger_flush','a');
 ABORT;
+
+-- copy into a table with a JSONB column
+CREATE TABLE copy_jsonb (key text, value jsonb, extra jsonb default '["default"]'::jsonb);
+SELECT create_distributed_table('copy_jsonb', 'key');
+
+-- JSONB from text should work
+\COPY copy_jsonb (key, value) FROM STDIN
+blue	{"r":0,"g":0,"b":255}
+green	{"r":0,"g":255,"b":0}
+\.
+SELECT * FROM copy_jsonb ORDER BY key;
+
+-- JSONB from binary should work
+\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+SELECT * FROM copy_jsonb ORDER BY key;
+
+-- JSONB parsing error without validation: no line number
+\COPY copy_jsonb (key, value) FROM STDIN
+red	{"r":255,"g":0,"b":0
+\.
+
+TRUNCATE copy_jsonb;
+SET citus.skip_jsonb_validation_in_copy TO off;
+
+-- JSONB from text should work
+\COPY copy_jsonb (key, value) FROM STDIN
+blue	{"r":0,"g":0,"b":255}
+green	{"r":0,"g":255,"b":0}
+\.
+SELECT * FROM copy_jsonb ORDER BY key;
+
+-- JSONB from binary should work
+\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+SELECT * FROM copy_jsonb ORDER BY key;
+
+-- JSONB parsing error with validation: should see line number
+\COPY copy_jsonb (key, value) FROM STDIN
+red	{"r":255,"g":0,"b":0
+\.
+
+DROP TABLE copy_jsonb;

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -1087,3 +1087,66 @@ NOTICE:  Copying data from local table...
 (1 row)
 
 ABORT;
+-- copy into a table with a JSONB column
+CREATE TABLE copy_jsonb (key text, value jsonb, extra jsonb default '["default"]'::jsonb);
+SELECT create_distributed_table('copy_jsonb', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- JSONB from text should work
+\COPY copy_jsonb (key, value) FROM STDIN
+SELECT * FROM copy_jsonb ORDER BY key;
+  key  |           value            |    extra    
+-------+----------------------------+-------------
+ blue  | {"b": 255, "g": 0, "r": 0} | ["default"]
+ green | {"b": 0, "g": 255, "r": 0} | ["default"]
+(2 rows)
+
+-- JSONB from binary should work
+\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+SELECT * FROM copy_jsonb ORDER BY key;
+  key  |           value            |    extra    
+-------+----------------------------+-------------
+ blue  | {"b": 255, "g": 0, "r": 0} | ["default"]
+ blue  | {"b": 255, "g": 0, "r": 0} | ["default"]
+ green | {"b": 0, "g": 255, "r": 0} | ["default"]
+ green | {"b": 0, "g": 255, "r": 0} | ["default"]
+(4 rows)
+
+-- JSONB parsing error without validation: no line number
+\COPY copy_jsonb (key, value) FROM STDIN
+ERROR:  invalid input syntax for type json
+DETAIL:  The input string ended unexpectedly.
+TRUNCATE copy_jsonb;
+SET citus.skip_jsonb_validation_in_copy TO off;
+-- JSONB from text should work
+\COPY copy_jsonb (key, value) FROM STDIN
+SELECT * FROM copy_jsonb ORDER BY key;
+  key  |           value            |    extra    
+-------+----------------------------+-------------
+ blue  | {"b": 255, "g": 0, "r": 0} | ["default"]
+ green | {"b": 0, "g": 255, "r": 0} | ["default"]
+(2 rows)
+
+-- JSONB from binary should work
+\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+SELECT * FROM copy_jsonb ORDER BY key;
+  key  |           value            |    extra    
+-------+----------------------------+-------------
+ blue  | {"b": 255, "g": 0, "r": 0} | ["default"]
+ blue  | {"b": 255, "g": 0, "r": 0} | ["default"]
+ green | {"b": 0, "g": 255, "r": 0} | ["default"]
+ green | {"b": 0, "g": 255, "r": 0} | ["default"]
+(4 rows)
+
+-- JSONB parsing error with validation: should see line number
+\COPY copy_jsonb (key, value) FROM STDIN
+ERROR:  invalid input syntax for type json
+DETAIL:  The input string ended unexpectedly.
+CONTEXT:  JSON data, line 1: {"r":255,"g":0,"b":0
+COPY copy_jsonb, line 1, column value: "{"r":255,"g":0,"b":0"
+DROP TABLE copy_jsonb;


### PR DESCRIPTION
Some Citus users report poor COPY performance when ingesting large JSON objects. The reason is that parsing and validating large JSON objects consumes a lot of CPU time. However, it is not strictly necessary for the coordinator to parse the JSON, it is only useful for validation and returning the line number of line that contains the malformed JSON.

This PR introduces a GUC to skip JSON parsing when copying into a JSONB column that is not the partition column by treating it as text within the parsing functions. For sending the row to the worker in binary copy format, we still need to adhere to the encoding used by `json_send`  and `json_recv` (version number 1 followed by text). To that end I added a citus_text_send_as_jsonb function.

On a Citus Cloud formation of 1+2*r4.xlarge this improved single-session COPY throughput by 3.2x when ingesting 3KB JSON objects with 100 fields (from 14k/s to 45k/s).

Given the substantial benefit, I propose enabling this GUC by default to always have better COPY+JSONB performance. The downside of enabling is that the line number is no longer in the detail when the JSON is malformed, since the validation now happens on the worker, but this seems only relevant for debugging.