### PR TITLE
Refactor: use a temporary timestamp variable

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -62,6 +62,7 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 	DistributedTransactionId *distributedTransactionId = NULL;
 	ListCell *subIdCell = NULL;
 	List *activeSubXacts = NIL;
+	const char *timestamp = NULL;
 
 	Assert(transaction->transactionState == REMOTE_TRANS_INVALID);
 
@@ -84,12 +85,13 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 	 * seperate roundtrips for these two statements.
 	 */
 	distributedTransactionId = GetCurrentDistributedTransactionId();
+	timestamp = timestamptz_to_str(distributedTransactionId->timestamp);
 	appendStringInfo(beginAndSetDistributedTransactionId,
 					 "SELECT assign_distributed_transaction_id(%d, " UINT64_FORMAT
 					 ", '%s');",
 					 distributedTransactionId->initiatorNodeIdentifier,
 					 distributedTransactionId->transactionNumber,
-					 timestamptz_to_str(distributedTransactionId->timestamp));
+					 timestamp);
 
 	/* append in-progress savepoints for this transaction */
 	activeSubXacts = ActiveSubXacts();


### PR DESCRIPTION
It's against our coding convention to call functions inside parameter
lists; when single-stepping with a debugger it's difficult to determine
what the function returned.

That wouldn't be good enough reason to change this code but while
porting Citus to Windows I ran into this line of code.
assign_distributed_transaction_id was called with a weird timestamp and
I wasn't able to find the problem without first making this change.