### PR TITLE
Include sys/stat.h for S_IRUSR and S_IWUSR.

### DIFF
--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -19,6 +19,7 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "access/xact.h"


### PR DESCRIPTION
Fixes #1958.