### PR TITLE
Handle errors that are discovered during abort

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -154,9 +154,6 @@ ClearResultsIfReady(MultiConnection *connection)
 		PGresult *result = NULL;
 		ExecStatusType resultStatus;
 
-		/* just in case there's a lot of results */
-		CHECK_FOR_INTERRUPTS();
-
 		/*
 		 * If busy, there might still be results already received and buffered
 		 * by the OS. As connection is in non-blocking mode, we can check for

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -382,7 +382,14 @@ StartRemoteTransactionAbort(MultiConnection *connection)
 	}
 	else
 	{
-		if (!NonblockingForgetResults(connection))
+		/*
+		 * In case of a cancellation, the connection might still be working
+		 * on some commands. Try to consume the results such that the
+		 * connection can be reused, but do not want to wait for commands
+		 * to finish. Instead we just close the connection if the command
+		 * is still busy.
+		 */
+		if (!ClearResultsIfReady(connection))
 		{
 			ShutdownConnection(connection);
 

--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -27,7 +27,7 @@ extern bool LogRemoteCommands;
 extern bool IsResponseOK(struct pg_result *result);
 extern void ForgetResults(MultiConnection *connection);
 extern bool ClearResults(MultiConnection *connection, bool raiseErrors);
-extern bool NonblockingForgetResults(MultiConnection *connection);
+extern bool ClearResultsIfReady(MultiConnection *connection);
 extern bool SqlStateMatchesCategory(char *sqlStateString, int category);
 
 /* report errors & warnings */


### PR DESCRIPTION
Fixes #1978 , though I suspect there might be an issue with ForgetResults and ClearResults as well.

Also did some slight refactoring of the NonblockingForgetResults function, since the naming was poor and it seemed to miss some PQclear cases.