### PR TITLE
Skip call to ActiveReadableNodeList when there are no subplans

### DIFF
--- a/src/backend/distributed/executor/subplan_execution.c
+++ b/src/backend/distributed/executor/subplan_execution.c
@@ -34,8 +34,16 @@ ExecuteSubPlans(DistributedPlan *distributedPlan)
 	uint64 planId = distributedPlan->planId;
 	List *subPlanList = distributedPlan->subPlanList;
 	ListCell *subPlanCell = NULL;
-	List *nodeList = ActiveReadableNodeList();
+	List *nodeList = NIL;
 	bool writeLocalFile = false;
+
+	if (subPlanList == NIL)
+	{
+		/* no subplans to execute */
+		return;
+	}
+
+	nodeList = ActiveReadableNodeList();
 
 	foreach(subPlanCell, subPlanList)
 	{


### PR DESCRIPTION
Minor performance optimisation. I noticed the call to `ActiveReadableNodeList` in `ExecuteSubplans` shows up when profiling SELECT lookups in 2% of samples, but we don't need to call it when there are no subplans.