### PR TITLE
Stabilize the output of a multi_router_planner test

### DIFF
--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -1902,7 +1902,8 @@ SELECT
 	FROM
 		articles_hash
  	GROUP BY
-		author_id;
+		author_id
+	ORDER BY c;
  c 
 ---
  4

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -911,7 +911,8 @@ SELECT
 	FROM
 		articles_hash
  	GROUP BY
-		author_id;
+		author_id
+	ORDER BY c;
 
 -- queries inside transactions can be router plannable
 BEGIN;


### PR DESCRIPTION
This test caused a build of https://github.com/citusdata/citus/pull/1982 to fail