### PR TITLE
hash based targetEntry problem solution

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -32,6 +32,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/relation.h"
+#include "nodes/print.h"
 #include "optimizer/clauses.h"
 #include "optimizer/prep.h"
 #include "optimizer/tlist.h"
@@ -42,6 +43,7 @@
 #include "utils/syscache.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+
 
 
 /* Config variable managed via guc.c */
@@ -55,6 +57,22 @@ typedef struct QualifierWalkerContext
 	List *outerJoinQualifierList;
 } QualifierWalkerContext;
 
+typedef struct JoinMutatorContext
+{
+	Query *originalQuery;
+	HTAB *hash;
+} JoinMutatorContext;
+
+typedef struct RTableJoinWalkerState
+{
+	HTAB *hashTable;
+} RTableJoinWalkerState;
+
+typedef struct JoinAliasMapping
+{
+	Var *joinalias;
+	RangeTblEntry *join;
+} JoinAliasMapping;
 
 /*
  * RecurringTuplesType is used to distinguish different types of expressions
@@ -178,6 +196,9 @@ static List * CreateSubqueryTargetEntryList(List *columnList);
 static void UpdateVarMappingsForExtendedOpNode(List *columnList,
 											   List *subqueryTargetEntryList);
 static MultiTable * MultiSubqueryPushdownTable(Query *subquery);
+
+
+static Node *flatten_join_citus_mutator(Node *node, JoinMutatorContext *jcontext);
 
 
 /*
@@ -3959,9 +3980,87 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 	 * uniqueColumnList. Columns mentioned in multiProject node and multiExtendedOp
 	 * node are indexed with their respective position in uniqueColumnList.
 	 */
+
+//	PlannerInfo *root = palloc0(sizeof(PlannerInfo));
+//	root->parse = queryTree;
+//
+//	flatten_join_alias_vars(root, (Node *) queryTree);
+
+	targetEntryList = queryTree->targetList;
+
+	elog(INFO, "%s", pretty_format_node_dump(nodeToString((Node *)targetEntryList)));
+
+
+
+	RTableJoinWalkerState *rTableJoinWalkerState = NULL;
+	Size rTableJoinWalkerStateSize = sizeof(RTableJoinWalkerState);
+
+	rTableJoinWalkerState = (RTableJoinWalkerState *) palloc0(rTableJoinWalkerStateSize);
+	int32 hashTableSize = 0;
+	HASHCTL hashInfo;
+
+	hashTableSize = 10;
+	memset(&hashInfo, 0, sizeof(hashInfo));
+	hashInfo.keysize = sizeof(Var *);
+	hashInfo.entrysize = sizeof(JoinAliasMapping);
+	hashInfo.hcxt = CurrentMemoryContext;
+	rTableJoinWalkerState->hashTable = hash_create("RTable Join Alias Map", hashTableSize, &hashInfo,
+									   HASH_ELEM | HASH_CONTEXT);
+
+	ListCell *rteCell = NIL;
+	List *rteList = queryTree->rtable;
+
+	foreach(rteCell, rteList)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(rteCell);
+		if (rte->rtekind == RTE_JOIN)
+		{
+			List *aliasVars = rte->joinaliasvars;
+			ListCell *aliasVarCell = NIL;
+
+			foreach(aliasVarCell, aliasVars)
+			{
+				char found = 0;
+				Node *avar = (Node *) lfirst(aliasVarCell);
+				JoinAliasMapping *item = hash_search(rTableJoinWalkerState->hashTable, (void *) rte, HASH_ENTER, &found);
+
+	//			Assert(found == 0);
+				item->joinalias = avar;
+			}
+
+		}
+	}
+
+	elog(INFO, "%s", pretty_format_node_dump(nodeToString((Node *)rTableJoinWalkerState->hashTable)));
+
+	JoinMutatorContext jcontext;
+	jcontext.originalQuery = queryTree;
+	jcontext.hash = rTableJoinWalkerState->hashTable;
+
+	List *newTargetEntryList = NIL;
+	ListCell *targetEntryCell = NULL;
+	foreach(targetEntryCell, targetEntryList)
+	{
+		TargetEntry *originalTargetEntry = (TargetEntry *) lfirst(targetEntryCell);
+		TargetEntry *newTargetEntry = copyObject(originalTargetEntry);
+		Expr *originalExpression = originalTargetEntry->expr;
+		Expr *newExpression = NULL;
+		Node *newNode = flatten_join_citus_mutator((Node *)originalExpression, &jcontext);
+		newExpression = (Expr *)newNode;
+		newTargetEntry->expr = newExpression;
+		newTargetEntryList = lappend(newTargetEntryList, newTargetEntry);
+	}
+
+	targetEntryList = newTargetEntryList;
+	queryTree->targetList = targetEntryList;
+	elog(INFO, "%s", pretty_format_node_dump(nodeToString((Node *)targetEntryList)));
+
 	targetColumnList = pull_var_clause_default((Node *) targetEntryList);
+
 	havingClauseColumnList = pull_var_clause_default(queryTree->havingQual);
 	columnList = list_concat(targetColumnList, havingClauseColumnList);
+
+
 
 	/* create a target entry for each unique column */
 	subqueryTargetEntryList = CreateSubqueryTargetEntryList(columnList);
@@ -4027,6 +4126,44 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 	currentTopNode = (MultiNode *) extendedOpNode;
 
 	return currentTopNode;
+}
+
+
+static Node *
+flatten_join_citus_mutator(Node *originalNode, JoinMutatorContext *jcontext)
+{
+	Node *newNode = NULL;
+	Query *queryTree = jcontext->originalQuery;
+	HTAB *hashTable = jcontext->hash;
+	if (originalNode == NULL)
+	{
+		return NULL;
+	}
+
+	if (IsA(originalNode, Var))
+	{
+		Var *var = (Var *) originalNode;
+		RangeTblEntry *rte = rt_fetch(var->varno, queryTree->rtable);
+
+		if (rte->rtekind != RTE_JOIN)
+		{
+			char *found = 0;
+			JoinAliasMapping *item = hash_search(hashTable, (void *) rte,
+												 HASH_FIND, &found);
+			elog(INFO, "%s", pretty_format_node_dump(nodeToString((Node *) var)));
+			if(found)
+			{
+				newNode = copyObject(item->join);
+				if (IsA(newNode, Var))
+					((Var *) newNode)->location = var->location;
+				elog(INFO, "%s", pretty_format_node_dump(nodeToString((Node *) newNode)));
+				return newNode;
+			}
+		}
+	}
+
+	return expression_tree_mutator(originalNode, flatten_join_citus_mutator,
+			  (void *) jcontext);
 }
 
 


### PR DESCRIPTION
This PR is created just to help the issue #1995 

This is a proposed solution and not yet implemented.
Currently `window_function_pushdown_support` PR uses a walker to change the target entries. Currently,  if a target entry refers to join, we replace it with the conjugate of the column from the joinaliaslist. This creates some problem for subqueries. (the more detailed problem definition can be find in #1995).

I propose that let's not flip the target entries which refers to the result of a join to joinalias but we replace the one which refers to joinalias to the result of a join. Basically what it does is that it iterates over the range table entries and creates a hashmap from the RTE_JOINs as (key: joinalias, value: join_itself). By the help of this hashmap, in our already implemented walker, if we find an expression which is in hashtable, we are going to replace it with the one in value.