### PR TITLE
Cache worker node array for faster iteration

### DIFF
--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2517,7 +2517,7 @@ PrepareWorkerNodeCache(void)
 static void
 InitializeWorkerNodeCache(void)
 {
-	HTAB *oldWorkerNodeHash = NULL;
+	HTAB *newWorkerNodeHash = NULL;
 	List *workerNodeList = NIL;
 	ListCell *workerNodeCell = NULL;
 	HASHCTL info;
@@ -2543,10 +2543,7 @@ InitializeWorkerNodeCache(void)
 	info.match = WorkerNodeCompare;
 	hashFlags = HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT | HASH_COMPARE;
 
-	oldWorkerNodeHash = WorkerNodeHash;
-	WorkerNodeHash = hash_create("Worker Node Hash",
-								 maxTableSize,
-								 &info, hashFlags);
+	newWorkerNodeHash = hash_create("Worker Node Hash", maxTableSize, &info, hashFlags);
 
 	/* read the list from pg_dist_node */
 	workerNodeList = ReadWorkerNodes(includeNodesFromOtherClusters);
@@ -2565,7 +2562,7 @@ InitializeWorkerNodeCache(void)
 
 		/* search for the worker node in the hash, and then insert the values */
 		hashKey = (void *) currentNode;
-		workerNode = (WorkerNode *) hash_search(WorkerNodeHash, hashKey,
+		workerNode = (WorkerNode *) hash_search(newWorkerNodeHash, hashKey,
 												HASH_ENTER, &handleFound);
 
 		/* fill the newly allocated workerNode in the cache */
@@ -2593,7 +2590,7 @@ InitializeWorkerNodeCache(void)
 	}
 
 	/* now, safe to destroy the old hash */
-	hash_destroy(oldWorkerNodeHash);
+	hash_destroy(WorkerNodeHash);
 
 	if (WorkerNodeArray != NULL)
 	{
@@ -2602,7 +2599,7 @@ InitializeWorkerNodeCache(void)
 
 	WorkerNodeCount = newWorkerNodeCount;
 	WorkerNodeArray = newWorkerNodeArray;
-
+	WorkerNodeHash = newWorkerNodeHash;
 }
 
 


### PR DESCRIPTION
DESCRIPTION: Performance improvements to reduce distributed planning time

We call `LookupNodeForGroup` whenever we look up a shard placement. This function iterates over the worker node hash, which means we spend noticable CPU time in `hash_seq_search` during query planning. This PR changes `LookupNodeForGroup` to use a cached array, which makes it much faster. Because it only stores pointers, is has negligible overhead.

After this change, pgbench throughput increased by ~5% even with just 2 worker nodes.