### PR TITLE
Cache the partition column Var

### DIFF
--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -1350,8 +1350,6 @@ Var *
 DistPartitionKey(Oid relationId)
 {
 	DistTableCacheEntry *partitionEntry = DistributedTableCacheEntry(relationId);
-	Node *variableNode = NULL;
-	Var *partitionKey = NULL;
 
 	/* reference tables do not have partition column */
 	if (partitionEntry->partitionMethod == DISTRIBUTE_BY_NONE)
@@ -1359,13 +1357,7 @@ DistPartitionKey(Oid relationId)
 		return NULL;
 	}
 
-	/* now obtain partition key and build the var node */
-	variableNode = stringToNode(partitionEntry->partitionKeyString);
-
-	partitionKey = (Var *) variableNode;
-	Assert(IsA(variableNode, Var));
-
-	return partitionKey;
+	return copyObject(partitionEntry->partitionColumn);
 }
 
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -49,6 +49,7 @@ typedef struct
 
 	/* pg_dist_partition metadata for this table */
 	char *partitionKeyString;
+	Var *partitionColumn;
 	char partitionMethod;
 	uint32 colocationId;
 	char replicationModel;


### PR DESCRIPTION
We currently cache the partition column string from `pg_dist_partition`, but re-parse it whenever we call `DistPartitionKey` (or `PartitionColumn`), which we do a lot and causes noticable CPU overhead. This PR adds the parsed partition column to the cache. `DistPartitionKey` now returns a copy of the partition column instead of (re-)parsing it. 