### PR TITLE
Do not use new connection in table size functions

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -210,7 +210,7 @@ DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId, char *sizeQ
 	char *tableSizeString;
 	uint64 tableSize = 0;
 	MultiConnection *connection = NULL;
-	uint32 connectionFlag = FORCE_NEW_CONNECTION;
+	uint32 connectionFlag = 0;
 	PGresult *result = NULL;
 	int queryResult = 0;
 	List *sizeList = NIL;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that could cause table size functions to open a new connection on every call

Fixes #2004 