### PR TITLE
Improve error handling on failures

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -65,24 +65,7 @@ IsResponseOK(PGresult *result)
 void
 ForgetResults(MultiConnection *connection)
 {
-	while (true)
-	{
-		PGresult *result = NULL;
-		const bool dontRaiseErrors = false;
-
-		result = GetRemoteCommandResult(connection, dontRaiseErrors);
-		if (result == NULL)
-		{
-			break;
-		}
-		if (PQresultStatus(result) == PGRES_COPY_IN)
-		{
-			PQputCopyEnd(connection->pgConn, NULL);
-
-			/* TODO: mark transaction as failed, once we can. */
-		}
-		PQclear(result);
-	}
+	ClearResults(connection, false);
 }
 
 

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1446,6 +1446,12 @@ StoreQueryResult(CitusScanState *scanState, MultiConnection *connection,
 
 			commandFailed = true;
 
+			/* an error happened, there is nothing we can do more */
+			if (resultStatus == PGRES_FATAL_ERROR)
+			{
+				break;
+			}
+
 			/* continue, there could be other lingering results due to row mode */
 			continue;
 		}
@@ -1564,6 +1570,12 @@ ConsumeQueryResult(MultiConnection *connection, bool failOnError, int64 *rows)
 			PQclear(result);
 
 			commandFailed = true;
+
+			/* an error happened, there is nothing we can do more */
+			if (status == PGRES_FATAL_ERROR)
+			{
+				break;
+			}
 
 			/* continue, there could be other lingering results due to row mode */
 			continue;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -369,8 +369,8 @@ SELECT create_distributed_table('t1', 'a');
 WARNING:  function assign_distributed_transaction_id(integer, integer, unknown) does not exist
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 CONTEXT:  while executing command on localhost:57637
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
-CONTEXT:  while executing command on localhost:57637
+ERROR:  connection error: localhost:57637
+DETAIL:  another command is already in progress
 \c regression
 \c - - - :worker_1_port
 DROP DATABASE another;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that could lead to unexpected results after failures on the worker nodes

Fixes #1926. 

Commit message which is good to post here as well: 
```
    This commit checks the connection status right after any IO happens
    on the socket.
    
    This is necessary since before this commit we didn't pass any information
    to the higher level functions whether we're done with the connection
    (e.g., no IO required anymore) or an error happened during the IO.
```