### PR TITLE
Fix incorrect limit pushdown when distinct clause is not superset of group by

### DIFF
--- a/src/include/distributed/multi_logical_optimizer.h
+++ b/src/include/distributed/multi_logical_optimizer.h
@@ -138,5 +138,6 @@ extern bool IsPartitionColumn(Expr *columnExpression, Query *query);
 extern void FindReferencedTableColumn(Expr *columnExpression, List *parentQueryList,
 									  Query *query, Oid *relationId, Var **column);
 
+extern bool IsGroupBySubsetOfDistinct(List *groupClause, List *distinctClause);
 
 #endif   /* MULTI_LOGICAL_OPTIMIZER_H */

--- a/src/test/regress/expected/multi_limit_clause.out
+++ b/src/test/regress/expected/multi_limit_clause.out
@@ -297,5 +297,227 @@ SELECT
  O            | TRUCK      | 11-17-1998
 (5 rows)
 
+-- Push down limit even if there is distinct on
+SELECT
+	DISTINCT ON (l_orderkey, l_linenumber) l_orderkey, l_linenumber
+	FROM lineitem_hash
+	GROUP BY l_orderkey, l_linenumber
+	ORDER BY l_orderkey, l_linenumber
+	LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_orderkey | l_linenumber 
+------------+--------------
+          1 |            1
+          1 |            2
+          1 |            3
+          1 |            4
+          1 |            5
+(5 rows)
+
+-- Don't push down limit when group by clause not included in distinct on
+SELECT
+	DISTINCT ON (l_linenumber) l_orderkey, l_linenumber
+	FROM lineitem_hash
+	GROUP BY l_orderkey, l_linenumber
+	ORDER BY l_linenumber, l_orderkey
+	LIMIT 5;
+ l_orderkey | l_linenumber 
+------------+--------------
+          1 |            1
+          1 |            2
+          1 |            3
+          1 |            4
+          1 |            5
+(5 rows)
+
+-- Push down limit when there is const in distinct on
+-- referring to a column such that group by clause
+-- list is contained in distinct on
+SELECT
+	DISTINCT ON (l_linenumber, 1) l_orderkey, l_linenumber
+	FROM lineitem_hash
+	GROUP BY l_orderkey, l_linenumber
+	ORDER BY l_linenumber, l_orderkey
+	LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_orderkey | l_linenumber 
+------------+--------------
+          1 |            1
+          2 |            1
+          3 |            1
+          4 |            1
+          5 |            1
+(5 rows)
+
+-- Don't push down limit when there is const expression in distinct on
+-- even if there is a group by on the expression
+-- This is due to fact that postgres removes (1+1) from distinct on
+-- clause but keeps it in group by list.
+SELECT
+	DISTINCT ON (l_linenumber, 1+1, l_linenumber) l_orderkey, l_linenumber
+	FROM lineitem_hash
+	GROUP BY l_orderkey, (1+1), l_linenumber
+	ORDER BY l_linenumber, (1+1), l_orderkey
+	LIMIT 5;
+ l_orderkey | l_linenumber 
+------------+--------------
+          1 |            1
+          1 |            2
+          1 |            3
+          1 |            4
+          1 |            5
+(5 rows)
+
+-- Don't push down limit when there is const reference
+-- does not point to a column to make distinct clause superset
+-- of group by
+SELECT
+	DISTINCT ON (l_linenumber, 2) l_orderkey, l_linenumber
+	FROM lineitem_hash
+	GROUP BY l_orderkey, l_linenumber
+	ORDER BY l_linenumber, l_orderkey
+	LIMIT 5;
+ l_orderkey | l_linenumber 
+------------+--------------
+          1 |            1
+          1 |            2
+          1 |            3
+          1 |            4
+          1 |            5
+(5 rows)
+
+-- Push down limit even when there is a column expression
+-- in distinct clause provided that distinct clause covers
+-- group by expression, and there is no aggregates in the query.
+SELECT
+	DISTINCT ON (l_orderkey + 1) l_orderkey + 1
+	FROM lineitem_hash
+	GROUP BY l_orderkey + 1
+	ORDER BY l_orderkey + 1
+	LIMIT 5;
+DEBUG:  push down of limit count: 5
+ ?column? 
+----------
+        2
+        3
+        4
+        5
+        6
+(5 rows)
+
+-- Limit is not pushed down when there are aggregates in the query
+-- This is because group by is not on distribution column itself
+-- but on an expression on distribution column
+SELECT
+	DISTINCT ON (l_orderkey + 1, count(*)) l_orderkey + 1, count(*)
+	FROM lineitem_hash
+	GROUP BY l_orderkey + 1
+	ORDER BY l_orderkey + 1 , 2
+	LIMIT 5;
+ ?column? | count 
+----------+-------
+        2 |     6
+        3 |     1
+        4 |     6
+        5 |     1
+        6 |     3
+(5 rows)
+
+-- same query with column instead of column expression, limit is pushed down
+-- because group by is on distribution column
+SELECT
+	DISTINCT ON (l_orderkey, count(*)) l_orderkey, count(*)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY l_orderkey , 2
+	LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_orderkey | count 
+------------+-------
+          1 |     6
+          2 |     1
+          3 |     6
+          4 |     1
+          5 |     3
+(5 rows)
+
+-- limit is not pushed down because distinct clause
+-- does not cover group by clause
+SELECT
+	DISTINCT ON (count(*)) l_orderkey, count(*)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1
+	LIMIT 2;
+ l_orderkey | count 
+------------+-------
+          7 |     7
+          1 |     6
+(2 rows)
+
+-- push down limit if there is a window function in distinct on
+SELECT
+	DISTINCT ON (l_orderkey, RANK() OVER (partition by l_orderkey)) l_orderkey, RANK() OVER (partition by l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY l_orderkey , 2
+	LIMIT 5;
+DEBUG:  push down of limit count: 5
+ l_orderkey | rank 
+------------+------
+          1 |    1
+          2 |    1
+          3 |    1
+          4 |    1
+          5 |    1
+(5 rows)
+
+-- do not push down limit if there is an aggragete in distinct on
+-- we should be able to push this down, but query goes to subquery
+-- planner and we can't safely determine it is grouped by partition
+-- column.
+SELECT
+	DISTINCT ON (l_orderkey, RANK() OVER (partition by l_orderkey)) l_orderkey, count(*), RANK() OVER (partition by l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY l_orderkey , 3, 2
+	LIMIT 5;
+ l_orderkey | count | rank 
+------------+-------+------
+          1 |     6 |    1
+          2 |     1 |    1
+          3 |     6 |    1
+          4 |     1 |    1
+          5 |     3 |    1
+(5 rows)
+
+-- limit is not pushed down due to same reason
+SELECT
+	DISTINCT ON (l_orderkey, count(*) OVER (partition by l_orderkey)) l_orderkey, l_linenumber, count(*), count(*) OVER (partition by l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey, l_linenumber
+	ORDER BY l_orderkey , count(*) OVER (partition by l_orderkey), count(*), l_linenumber
+	LIMIT 5;
+ l_orderkey | l_linenumber | count | count 
+------------+--------------+-------+-------
+          1 |            1 |     1 |     6
+          2 |            1 |     1 |     1
+          3 |            1 |     1 |     6
+          4 |            1 |     1 |     1
+          5 |            1 |     1 |     3
+(5 rows)
+
+-- limit is not pushed down since distinct clause is not superset of group clause
+SELECT
+	DISTINCT ON (RANK() OVER (partition by l_orderkey)) l_orderkey, RANK() OVER (partition by l_orderkey)
+	FROM lineitem_hash
+	GROUP BY l_orderkey
+	ORDER BY 2 DESC, 1 
+	LIMIT 5;
+ l_orderkey | rank 
+------------+------
+          1 |    1
+(1 row)
+
 SET client_min_messages TO NOTICE;
 DROP TABLE lineitem_hash;

--- a/src/test/regress/expected/multi_select_distinct.out
+++ b/src/test/regress/expected/multi_select_distinct.out
@@ -3,6 +3,7 @@
 --
 -- Tests select distinct, and select distinct on features.
 --
+ANALYZE lineitem_hash_part;
 -- function calls are supported
 SELECT DISTINCT l_orderkey, now() FROM lineitem_hash_part LIMIT 0;
  l_orderkey | now 
@@ -360,13 +361,10 @@ EXPLAIN (COSTS FALSE)
                            Tasks Shown: One of 4
                            ->  Task
                                  Node: host=localhost port=57637 dbname=regression
-                                 ->  Limit
-                                       ->  Sort
-                                             Sort Key: l_suppkey, l_linenumber
-                                             ->  HashAggregate
-                                                   Group Key: l_suppkey, l_linenumber
-                                                   ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
-(18 rows)
+                                 ->  HashAggregate
+                                       Group Key: l_suppkey, l_linenumber
+                                       ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
+(15 rows)
 
 -- check the plan if the hash aggreate is disabled. Similar to the explain of 
 -- the query above.
@@ -394,13 +392,10 @@ EXPLAIN (COSTS FALSE)
                                        Tasks Shown: One of 4
                                        ->  Task
                                              Node: host=localhost port=57637 dbname=regression
-                                             ->  Limit
-                                                   ->  Sort
-                                                         Sort Key: l_suppkey, l_linenumber
-                                                         ->  HashAggregate
-                                                               Group Key: l_suppkey, l_linenumber
-                                                               ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
-(21 rows)
+                                             ->  HashAggregate
+                                                   Group Key: l_suppkey, l_linenumber
+                                                   ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
+(18 rows)
 
 SET enable_hashagg TO on;
 -- Similar to the above query, not with count but avg. Only difference with the
@@ -930,15 +925,12 @@ EXPLAIN (COSTS FALSE)
                            Tasks Shown: One of 4
                            ->  Task
                                  Node: host=localhost port=57637 dbname=regression
-                                 ->  Limit
+                                 ->  GroupAggregate
+                                       Group Key: l_orderkey
                                        ->  Sort
-                                             Sort Key: (array_length(array_agg(l_linenumber), 1))
-                                             ->  GroupAggregate
-                                                   Group Key: l_orderkey
-                                                   ->  Sort
-                                                         Sort Key: l_orderkey
-                                                         ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
-(20 rows)
+                                             Sort Key: l_orderkey
+                                             ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
+(17 rows)
 
 -- check the plan if the hash aggreate is disabled. 
 SET enable_hashagg TO off;
@@ -965,15 +957,12 @@ EXPLAIN (COSTS FALSE)
                                        Tasks Shown: One of 4
                                        ->  Task
                                              Node: host=localhost port=57637 dbname=regression
-                                             ->  Limit
+                                             ->  GroupAggregate
+                                                   Group Key: l_orderkey
                                                    ->  Sort
-                                                         Sort Key: (array_length(array_agg(l_linenumber), 1))
-                                                         ->  GroupAggregate
-                                                               Group Key: l_orderkey
-                                                               ->  Sort
-                                                                     Sort Key: l_orderkey
-                                                                     ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
-(23 rows)
+                                                         Sort Key: l_orderkey
+                                                         ->  Seq Scan on lineitem_hash_part_360038 lineitem_hash_part
+(20 rows)
 
 		
 SET enable_hashagg TO on;

--- a/src/test/regress/sql/multi_select_distinct.sql
+++ b/src/test/regress/sql/multi_select_distinct.sql
@@ -4,6 +4,7 @@
 -- Tests select distinct, and select distinct on features.
 --
 
+ANALYZE lineitem_hash_part;
 
 -- function calls are supported
 SELECT DISTINCT l_orderkey, now() FROM lineitem_hash_part LIMIT 0;


### PR DESCRIPTION
DESCRIPTION: bugfix on incorrect limit pushdown when distinct (on) clause is not superset of group by clause

Pushing down limit and order by into workers may produce
wrong output when distinct on() clause has expressions,
aggregates, or window functions.

This checking allows pushing down of limits only if
distinct clause is a superset of group by clause. i.e. it contains  all clauses in group by.

Fixes #2034 