### PR TITLE
Improve error messages for INSERT queries that have subqueries

### DIFF
--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1275,6 +1275,20 @@ SELECT * FROM summary_table ORDER BY id;
 ----+-----------+---------------+-------+---------
 (0 rows)
 
+-- we don't support subqueries in VALUES clause
+INSERT INTO summary_table (id) VALUES ((SELECT id FROM summary_table));
+ERROR:  subqueries are not supported within INSERT queries
+HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+INSERT INTO summary_table (id) VALUES (5), ((SELECT id FROM summary_table));
+ERROR:  subqueries are not supported within INSERT queries
+HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+-- similar queries with reference tables
+INSERT INTO reference_summary_table (id) VALUES ((SELECT id FROM summary_table));
+ERROR:  subqueries are not supported within INSERT queries
+HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+INSERT INTO summary_table (id) VALUES ((SELECT id FROM reference_summary_table));
+ERROR:  subqueries are not supported within INSERT queries
+HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
 DROP TABLE raw_table;
 DROP TABLE summary_table;
 DROP TABLE reference_raw_table;

--- a/src/test/regress/expected/multi_upsert.out
+++ b/src/test/regress/expected/multi_upsert.out
@@ -253,8 +253,8 @@ INSERT INTO dropcol_distributed AS dropcol (key, keep1) VALUES (1, '5') ON CONFL
 -- subquery in the SET clause
 INSERT INTO upsert_test (part_key, other_col) VALUES (1, 1) ON CONFLICT (part_key) DO
 	UPDATE SET other_col = (SELECT count(*) from upsert_test);
-ERROR:  subqueries are not supported in modifications across multiple shards
-DETAIL:  Consider using an equality filter on partition column "part_key" to target a single shard.
+ERROR:  subqueries are not supported within INSERT queries
+HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
 -- non mutable function call in the SET
 INSERT INTO upsert_test (part_key, other_col) VALUES (1, 1) ON CONFLICT (part_key) DO
 	UPDATE SET other_col = random()::int;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -821,6 +821,14 @@ EXECUTE prepared_delete_with_join(6);
 
 SELECT * FROM summary_table ORDER BY id;
 
+-- we don't support subqueries in VALUES clause
+INSERT INTO summary_table (id) VALUES ((SELECT id FROM summary_table));
+INSERT INTO summary_table (id) VALUES (5), ((SELECT id FROM summary_table));
+
+-- similar queries with reference tables
+INSERT INTO reference_summary_table (id) VALUES ((SELECT id FROM summary_table));
+INSERT INTO summary_table (id) VALUES ((SELECT id FROM reference_summary_table));
+
 DROP TABLE raw_table;
 DROP TABLE summary_table;
 DROP TABLE reference_raw_table;


### PR DESCRIPTION
DESCRIPTION: Improve error messages for INSERT queries that have subqueries

Fixes #2037 

Note that the previous error message seems wrong. That's why I changed the message altogether instead of updating it to cover reference tables (as it leads to #2037).