### PR TITLE
Change default to false for citus.skip_jsonb_validation_in_copy

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -519,9 +519,9 @@ RegisterCitusConfigVariables(void)
 					 "be higher. This setting does not apply if the input format is "
 					 "binary."),
 		&SkipJsonbValidationInCopy,
-		true,
+		false,
 		PGC_USERSET,
-		0,
+		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
 	DefineCustomIntVariable(

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -1120,6 +1120,8 @@ SELECT * FROM copy_jsonb ORDER BY key;
 \COPY copy_jsonb (key, value) FROM STDIN
 ERROR:  invalid input syntax for type json
 DETAIL:  The input string ended unexpectedly.
+CONTEXT:  JSON data, line 1: {"r":255,"g":0,"b":0
+COPY copy_jsonb, line 1, column value: "{"r":255,"g":0,"b":0"
 TRUNCATE copy_jsonb;
 SET citus.skip_jsonb_validation_in_copy TO off;
 -- JSONB from text should work


### PR DESCRIPTION
A workaround for #2039. Until we implement a proper fix, we turn off the optimization by default.