### PR TITLE
Use correct output function when skipping jsonb validation.

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -75,6 +75,7 @@
 #include "executor/executor.h"
 #include "libpq/pqformat.h"
 #include "nodes/makefuncs.h"
+#include "parser/parse_func.h"
 #include "tsearch/ts_locale.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -469,6 +470,15 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 				 * prepending a version number.
 				 */
 				fmgr_info(textSendAsJsonbFunctionId,
+						  &copyDest->columnOutputFunctions[columnIndex]);
+			}
+			else
+			{
+				List *nameList = list_make2(makeString("pg_catalog"),
+											makeString("textout"));
+				Oid paramOids[1] = { TEXTOID };
+				Oid textoutFunctionId = LookupFuncName(nameList, 1, paramOids, false);
+				fmgr_info(textoutFunctionId,
 						  &copyDest->columnOutputFunctions[columnIndex]);
 			}
 		}

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -835,6 +835,24 @@ red	{"r":255,"g":0,"b":0
 \.
 
 TRUNCATE copy_jsonb;
+
+-- JSONB when there is a complex column should work. Complex columns force
+-- non binary copy format between master and workers.
+CREATE TYPE complex_for_copy_test AS (r double precision, i double precision);
+SELECT 1 FROM run_command_on_workers('CREATE TYPE complex_for_copy_test AS (r double precision, i double precision)');
+CREATE TABLE copy_jsonb_with_complex(key int, value_1 jsonb, value_2 complex_for_copy_test);
+SELECT create_distributed_table('copy_jsonb_with_complex', 'key');
+
+\COPY copy_jsonb_with_complex FROM STDIN
+1	{"f1": 3803, "f2": "v1", "f3": {"f4": 1}}	(10,9)
+2	{"f5": null, "f6": true}	(20,19)
+\.
+SELECT * FROM copy_jsonb_with_complex ORDER BY key;
+
+DROP TABLE copy_jsonb_with_complex;
+SELECT 1 FROM run_command_on_workers('DROP TYPE complex_for_copy_test');
+DROP TYPE complex_for_copy_test;
+
 SET citus.skip_jsonb_validation_in_copy TO off;
 
 -- JSONB from text should work

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -1121,6 +1121,40 @@ SELECT * FROM copy_jsonb ORDER BY key;
 ERROR:  invalid input syntax for type json
 DETAIL:  The input string ended unexpectedly.
 TRUNCATE copy_jsonb;
+-- JSONB when there is a complex column should work. Complex columns force
+-- non binary copy format between master and workers.
+CREATE TYPE complex_for_copy_test AS (r double precision, i double precision);
+SELECT 1 FROM run_command_on_workers('CREATE TYPE complex_for_copy_test AS (r double precision, i double precision)');
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+CREATE TABLE copy_jsonb_with_complex(key int, value_1 jsonb, value_2 complex_for_copy_test);
+SELECT create_distributed_table('copy_jsonb_with_complex', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+\COPY copy_jsonb_with_complex FROM STDIN
+SELECT * FROM copy_jsonb_with_complex ORDER BY key;
+ key |                  value_1                  | value_2 
+-----+-------------------------------------------+---------
+   1 | {"f1": 3803, "f2": "v1", "f3": {"f4": 1}} | (10,9)
+   2 | {"f5": null, "f6": true}                  | (20,19)
+(2 rows)
+
+DROP TABLE copy_jsonb_with_complex;
+SELECT 1 FROM run_command_on_workers('DROP TYPE complex_for_copy_test');
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+DROP TYPE complex_for_copy_test;
 SET citus.skip_jsonb_validation_in_copy TO off;
 -- JSONB from text should work
 \COPY copy_jsonb (key, value) FROM STDIN


### PR DESCRIPTION
Fixes #2039.

When we have a complex column or a user defined type in the schema, we use text format to copy
between the coordinator and the workers. We were not using the correct output function for jsonb
columns in this case when we skipped jsonb validation in the coordinator. This patch fixes that.