### PR TITLE
Fix EXPLAIN error on bogus varattno with avg() and order by.

### DIFF
--- a/src/backend/distributed/planner/multi_master_planner.c
+++ b/src/backend/distributed/planner/multi_master_planner.c
@@ -159,7 +159,7 @@ BuildSelectStatement(Query *masterQuery, List *masterTargetList, CustomScan *rem
 		topLevelPlan = (Plan *) aggregationPlan;
 
 		/* fix the plan for EXPLAIN purposes */
-		set_dummy_tlist_references(topLevelPlan, 1);
+		/* set_dummy_tlist_references(topLevelPlan, 1); */
 	}
 	else
 	{
@@ -206,7 +206,7 @@ BuildSelectStatement(Query *masterQuery, List *masterTargetList, CustomScan *rem
 		topLevelPlan = distinctPlan;
 
 		/* fix the plan for EXPLAIN purposes */
-		set_dummy_tlist_references(topLevelPlan, 1);
+		/* set_dummy_tlist_references(topLevelPlan, 1); */
 	}
 
 	/* (4) add a sorting plan if needed */
@@ -238,7 +238,7 @@ BuildSelectStatement(Query *masterQuery, List *masterTargetList, CustomScan *rem
 												  masterQuery->distinctClause);
 
 		/* fix the plan for EXPLAIN purposes */
-		set_dummy_tlist_references(topLevelPlan, 1);
+		/* set_dummy_tlist_references(topLevelPlan, 1); */
 	}
 
 	/* (5) add a limit plan if needed */
@@ -250,8 +250,15 @@ BuildSelectStatement(Query *masterQuery, List *masterTargetList, CustomScan *rem
 		topLevelPlan = (Plan *) limitPlan;
 
 		/* fix the plan for EXPLAIN purposes */
-		set_dummy_tlist_references(topLevelPlan, 1);
+		/* set_dummy_tlist_references(topLevelPlan, 1); */
 	}
+
+	/*
+	 * To fix EXPLAIN in every cases, we might have to call the PostgreSQL
+	 * planner function set_plan_references, which requires a PlannerInfo *root
+	 * and the plan.
+	 */
+	/* topLevelplan = set_plan_references(root, topLevelPlan); */
 
 	/* (6) finally set our top level plan in the plan tree */
 	selectStatement->planTree = topLevelPlan;

--- a/src/backend/distributed/planner/postgres_planning_functions.c
+++ b/src/backend/distributed/planner/postgres_planning_functions.c
@@ -3,6 +3,7 @@
  * postgres_planning_function.c
  *    Includes planning routines copied from
  *    src/backend/optimizer/plan/createplan.c
+ *    src/backend/optimizer/plan/setrefs.c
  *
  * Portions Copyright (c) 1996-2017, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
@@ -14,6 +15,8 @@
 #include "postgres.h"
 
 #include "distributed/multi_master_planner.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
 #include "nodes/plannodes.h"
 #include "optimizer/tlist.h"
 
@@ -68,4 +71,70 @@ make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
 	node->uniqOperators = uniqOperators;
 
 	return node;
+}
+
+
+/*
+ * set_dummy_tlist_references
+ *	  Replace the targetlist of an upper-level plan node with a simple
+ *	  list of OUTER_VAR references to its child.
+ *
+ * This is used for plan types like Sort and Append that don't evaluate
+ * their targetlists.  Although the executor doesn't care at all what's in
+ * the tlist, EXPLAIN needs it to be realistic.
+ *
+ * Note: we could almost use set_upper_references() here, but it fails for
+ * Append for lack of a lefttree subplan.  Single-purpose code is faster
+ * anyway.
+ */
+void
+set_dummy_tlist_references(Plan *plan, int rtoffset)
+{
+	List	   *output_targetlist;
+	ListCell   *l;
+
+	output_targetlist = NIL;
+	foreach(l, plan->targetlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(l);
+		Var		   *oldvar = (Var *) tle->expr;
+		Var		   *newvar;
+
+		/*
+		 * As in search_indexed_tlist_for_non_var(), we prefer to keep Consts
+		 * as Consts, not Vars referencing Consts.  Here, there's no speed
+		 * advantage to be had, but it makes EXPLAIN output look cleaner, and
+		 * again it avoids confusing the executor.
+		 */
+		if (IsA(oldvar, Const))
+		{
+			/* just reuse the existing TLE node */
+			output_targetlist = lappend(output_targetlist, tle);
+			continue;
+		}
+
+		newvar = makeVar(OUTER_VAR,
+						 tle->resno,
+						 exprType((Node *) oldvar),
+						 exprTypmod((Node *) oldvar),
+						 exprCollation((Node *) oldvar),
+						 0);
+		if (IsA(oldvar, Var))
+		{
+			newvar->varnoold = oldvar->varno + rtoffset;
+			newvar->varoattno = oldvar->varattno;
+		}
+		else
+		{
+			newvar->varnoold = 0;	/* wasn't ever a plain Var */
+			newvar->varoattno = 0;
+		}
+
+		tle = flatCopyTargetEntry(tle);
+		tle->expr = (Expr *) newvar;
+		output_targetlist = lappend(output_targetlist, tle);
+	}
+	plan->targetlist = output_targetlist;
+
+	/* We don't touch plan->qual here */
 }

--- a/src/include/distributed/multi_master_planner.h
+++ b/src/include/distributed/multi_master_planner.h
@@ -25,6 +25,7 @@ struct CustomScan;
 extern PlannedStmt * MasterNodeSelectPlan(struct DistributedPlan *distributedPlan,
 										  struct CustomScan *dataScan);
 extern Unique * make_unique_from_sortclauses(Plan *lefttree, List *distinctList);
+extern void set_dummy_tlist_references(Plan *plan, int rtoffset);
 
 
 #endif   /* MULTI_MASTER_PLANNER_H */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -43,7 +43,7 @@ EXPLAIN (COSTS FALSE, FORMAT TEXT)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity;
 Sort
-  Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))))::bigint, '0'::bigint), remote_scan.l_quantity
+  Sort Key: (COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint)), remote_scan.l_quantity
   ->  HashAggregate
         Group Key: remote_scan.l_quantity
         ->  Custom Scan (Citus Real-Time)
@@ -60,7 +60,7 @@ EXPLAIN (COSTS FALSE, FORMAT TEXT)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity;
 Sort
-  Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))))::bigint, '0'::bigint), remote_scan.l_quantity
+  Sort Key: (COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint)), remote_scan.l_quantity
   ->  GroupAggregate
         Group Key: remote_scan.l_quantity
         ->  Sort
@@ -83,7 +83,7 @@ EXPLAIN (COSTS FALSE, FORMAT JSON)
     "Plan": {
       "Node Type": "Sort",
       "Parallel Aware": false,
-      "Sort Key": ["COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))))::bigint, '0'::bigint)", "remote_scan.l_quantity"],
+      "Sort Key": ["(COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))", "remote_scan.l_quantity"],
       "Plans": [
         {
           "Node Type": "Aggregate",
@@ -154,7 +154,7 @@ EXPLAIN (COSTS FALSE, FORMAT XML)
       <Node-Type>Sort</Node-Type>
       <Parallel-Aware>false</Parallel-Aware>
       <Sort-Key>
-        <Item>COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))))::bigint, '0'::bigint)</Item>
+        <Item>(COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))</Item>
         <Item>remote_scan.l_quantity</Item>
       </Sort-Key>
       <Plans>
@@ -228,7 +228,7 @@ EXPLAIN (COSTS FALSE, FORMAT YAML)
     Node Type: "Sort"
     Parallel Aware: false
     Sort Key: 
-      - "COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))))::bigint, '0'::bigint)"
+      - "(COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))"
       - "remote_scan.l_quantity"
     Plans: 
       - Node Type: "Aggregate"
@@ -269,7 +269,7 @@ EXPLAIN (COSTS FALSE, FORMAT TEXT)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity;
 Sort
-  Sort Key: COALESCE((pg_catalog.sum((COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint))))::bigint, '0'::bigint), remote_scan.l_quantity
+  Sort Key: (COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint)), remote_scan.l_quantity
   ->  HashAggregate
         Group Key: remote_scan.l_quantity
         ->  Custom Scan (Citus Real-Time)
@@ -653,7 +653,53 @@ GROUP BY
 	count_pay
 ORDER BY
 	count_pay;
-ERROR:  bogus varattno for OUTER_VAR var: 3
+Sort
+  Sort Key: remote_scan.count_pay
+  ->  HashAggregate
+        Group Key: remote_scan.count_pay
+        ->  Custom Scan (Citus Real-Time)
+              Task Count: 4
+              Tasks Shown: One of 4
+              ->  Task
+                    Node: host=localhost port=57637 dbname=regression
+                    ->  GroupAggregate
+                          Group Key: subquery_top.count_pay
+                          ->  Sort
+                                Sort Key: subquery_top.count_pay
+                                ->  Subquery Scan on subquery_top
+                                      ->  GroupAggregate
+                                            Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), subquery_2.count_pay
+                                            Filter: (array_ndims(array_agg(('action=>1'::text) ORDER BY events.event_time)) > 0)
+                                            ->  Sort
+                                                  Sort Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), subquery_2.count_pay
+                                                  ->  Hash Left Join
+                                                        Hash Cond: (users.composite_id = subquery_2.composite_id)
+                                                        ->  HashAggregate
+                                                              Group Key: ((users.composite_id).tenant_id), ((users.composite_id).user_id), users.composite_id, ('action=>1'::text), events.event_time
+                                                              ->  Append
+                                                                    ->  Hash Join
+                                                                          Hash Cond: (users.composite_id = events.composite_id)
+                                                                          ->  Seq Scan on users_1400033 users
+                                                                                Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
+                                                                          ->  Hash
+                                                                                ->  Seq Scan on events_1400029 events
+                                                                                      Filter: ((event_type)::text = 'click'::text)
+                                                                    ->  Hash Join
+                                                                          Hash Cond: (users_1.composite_id = events_1.composite_id)
+                                                                          ->  Seq Scan on users_1400033 users_1
+                                                                                Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type))
+                                                                          ->  Hash
+                                                                                ->  Seq Scan on events_1400029 events_1
+                                                                                      Filter: ((event_type)::text = 'submit'::text)
+                                                        ->  Hash
+                                                              ->  Subquery Scan on subquery_2
+                                                                    ->  GroupAggregate
+                                                                          Group Key: events_2.composite_id
+                                                                          Filter: (count(*) > 2)
+                                                                          ->  Sort
+                                                                                Sort Key: events_2.composite_id
+                                                                                ->  Seq Scan on events_1400029 events_2
+                                                                                      Filter: ((composite_id >= '(1,-9223372036854775808)'::user_composite_type) AND (composite_id <= '(1,9223372036854775807)'::user_composite_type) AND ((event_type)::text = 'pay'::text))
 -- Lateral join subquery pushdown
 -- set subquery_pushdown due to limit in the query
 SET citus.subquery_pushdown to ON;
@@ -1136,6 +1182,26 @@ Custom Scan (Citus INSERT ... SELECT via coordinator)
         ->  Append
               ->  Function Scan on generate_series s
               ->  Function Scan on generate_series s_1
+-- explain avg() aggregate with an order by clause
+EXPLAIN (COSTS OFF, VERBOSE true)
+select l_orderkey, avg(l_discount) from lineitem group by 1 order by 2 desc;
+Sort
+  Output: remote_scan.l_orderkey, ((sum(remote_scan.avg) / pg_catalog.sum(remote_scan.avg_1)))
+  Sort Key: ((sum(remote_scan.avg) / pg_catalog.sum(remote_scan.avg_1))) DESC
+  ->  HashAggregate
+        Output: remote_scan.l_orderkey, (sum(remote_scan.avg) / pg_catalog.sum(remote_scan.avg_1))
+        Group Key: remote_scan.l_orderkey
+        ->  Custom Scan (Citus Real-Time)
+              Output: remote_scan.l_orderkey, remote_scan.avg, remote_scan.avg_1
+              Task Count: 8
+              Tasks Shown: One of 8
+              ->  Task
+                    Node: host=localhost port=57637 dbname=regression
+                    ->  HashAggregate
+                          Output: l_orderkey, sum(l_discount), count(l_discount)
+                          Group Key: lineitem.l_orderkey
+                          ->  Seq Scan on public.lineitem_290001 lineitem
+                                Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
 -- explain with recursive planning
 EXPLAIN (COSTS OFF, VERBOSE true)
 WITH keys AS (
@@ -1148,7 +1214,7 @@ SELECT l_orderkey FROM series JOIN keys ON (s = l_orderkey)
 ORDER BY s;
 Custom Scan (Citus Router)
   Output: remote_scan.l_orderkey
-  ->  Distributed Subplan 55_1
+  ->  Distributed Subplan 56_1
         ->  HashAggregate
               Output: remote_scan.l_orderkey
               Group Key: remote_scan.l_orderkey
@@ -1163,7 +1229,7 @@ Custom Scan (Citus Router)
                                 Group Key: lineitem_hash_part.l_orderkey
                                 ->  Seq Scan on public.lineitem_hash_part_360038 lineitem_hash_part
                                       Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
-  ->  Distributed Subplan 55_2
+  ->  Distributed Subplan 56_2
         ->  Function Scan on pg_catalog.generate_series s
               Output: s
               Function Call: generate_series(1, 10)
@@ -1179,13 +1245,13 @@ Custom Scan (Citus Router)
                     Sort Key: intermediate_result.s
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                           Output: intermediate_result.s
-                          Function Call: read_intermediate_result('55_2'::text, 'binary'::citus_copy_format)
+                          Function Call: read_intermediate_result('56_2'::text, 'binary'::citus_copy_format)
               ->  Sort
                     Output: intermediate_result_1.l_orderkey
                     Sort Key: intermediate_result_1.l_orderkey
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                           Output: intermediate_result_1.l_orderkey
-                          Function Call: read_intermediate_result('55_1'::text, 'binary'::citus_copy_format)
+                          Function Call: read_intermediate_result('56_1'::text, 'binary'::citus_copy_format)
 SELECT true AS valid FROM explain_json($$
   WITH result AS (
     SELECT l_quantity, count(*) count_quantity FROM lineitem

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -530,6 +530,10 @@ INSERT INTO lineitem_hash_part
 ( SELECT s FROM generate_series(1,5) s) UNION
 ( SELECT s FROM generate_series(5,10) s);
 
+-- explain avg() aggregate with an order by clause
+EXPLAIN (COSTS OFF, VERBOSE true)
+select l_orderkey, avg(l_discount) from lineitem group by 1 order by 2 desc;
+
 -- explain with recursive planning
 EXPLAIN (COSTS OFF, VERBOSE true)
 WITH keys AS (


### PR DESCRIPTION
Description: NOT READY YET, I will have to add regression tests and all. Stay tuned ;-)

It turns out that we missed some extra steps in how we build the master's
query plan here, namely we don't call into set_plan_references(), which is
responsible for having a plan ready for both EXPLAIN and plan cache
invalidation.

In this commit we use a less invasive change and call the function
set_dummy_tlist_references() that only cares about the EXPLAINability of a
plan. It's called recursively on a whole plan in set_plan_references(),
instead of doing that we call it at each new level we manually add to our
master's plan, to the same effect.

The set_dummy_tlist_references() is not exported by PostgreSQL, so this
commit also adds it to our local set of planner function copies that we have
to do for being an extension.

Fixes #520.
Fixes #756.