### PR TITLE
Remove skip_jsonb_validation_in_copy GUC

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -508,22 +508,6 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
-	DefineCustomBoolVariable(
-		"citus.skip_jsonb_validation_in_copy",
-		gettext_noop("Skip validation of JSONB columns on the coordinator during COPY "
-					 "into a distributed table"),
-		gettext_noop("Parsing large JSON objects may incur significant CPU overhead, "
-					 "which can lower COPY throughput. If this GUC is set (the default), "
-					 "JSON parsing is skipped on the coordinator, which means you cannot "
-					 "see the line number in case of malformed JSON, but throughput will "
-					 "be higher. This setting does not apply if the input format is "
-					 "binary."),
-		&SkipJsonbValidationInCopy,
-		false,
-		PGC_USERSET,
-		GUC_NO_SHOW_ALL,
-		NULL, NULL, NULL);
-
 	DefineCustomIntVariable(
 		"citus.shard_count",
 		gettext_noop("Sets the number of shards for a new hash-partitioned table"

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -108,10 +108,6 @@ typedef struct CitusCopyDestReceiver
 } CitusCopyDestReceiver;
 
 
-/* GUCs */
-extern bool SkipJsonbValidationInCopy;
-
-
 /* function declarations for copying into a distributed table */
 extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   List *columnNameList,


### PR DESCRIPTION
We have a problem with `skip_jsonb_validation_in_copy` GUC (#2039 ). Until we fix this problem we remove the GUC.