### PR TITLE
Copy range filters to joined tables

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -561,6 +561,7 @@ CopyShardInterval(ShardInterval *srcInterval, ShardInterval *destInterval)
 	destInterval->minValueExists = srcInterval->minValueExists;
 	destInterval->maxValueExists = srcInterval->maxValueExists;
 	destInterval->shardId = srcInterval->shardId;
+	destInterval->shardIndex = srcInterval->shardIndex;
 
 	destInterval->minValue = 0;
 	if (destInterval->minValueExists)

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -3931,3 +3931,35 @@ OperatorImplementsEquality(Oid opno)
 
 	return equalityOperator;
 }
+
+
+bool
+OperatorImplementsComparison(Oid opno)
+{
+	bool comparisonOperator = false;
+	List *btreeIntepretationList = get_op_btree_interpretation(opno);
+	ListCell *btreeInterpretationCell = NULL;
+	foreach(btreeInterpretationCell, btreeIntepretationList)
+	{
+		OpBtreeInterpretation *btreeIntepretation = (OpBtreeInterpretation *)
+													lfirst(btreeInterpretationCell);
+		switch (btreeIntepretation->strategy)
+		{
+			case BTLessStrategyNumber:
+			case BTLessEqualStrategyNumber:
+			case BTGreaterEqualStrategyNumber:
+			case BTGreaterStrategyNumber:
+			{
+				comparisonOperator = true;
+				break;
+			}
+
+			default:
+			{
+				break;
+			}
+		}
+	}
+
+	return comparisonOperator;
+}

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -1128,6 +1128,9 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 
 		cacheEntry->arrayOfPlacementArrays[shardIndex] = placementArray;
 		cacheEntry->arrayOfPlacementArrayLengths[shardIndex] = numberOfPlacements;
+
+		/* store the shard index in the ShardInterval */
+		shardInterval->shardIndex = shardIndex;
 	}
 
 	cacheEntry->shardIntervalArrayLength = shardIntervalArrayLength;

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -67,6 +67,7 @@ typedef struct ShardInterval
 	Datum minValue;     /* a shard's typed min value datum */
 	Datum maxValue;     /* a shard's typed max value datum */
 	uint64 shardId;
+	int shardIndex;
 } ShardInterval;
 
 

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -221,6 +221,6 @@ extern bool ExtractRangeTableRelationWalker(Node *node, List **rangeTableList);
 extern bool ExtractRangeTableEntryWalker(Node *node, List **rangeTableList);
 extern List * pull_var_clause_default(Node *node);
 extern bool OperatorImplementsEquality(Oid opno);
-
+extern bool OperatorImplementsComparison(Oid opno);
 
 #endif   /* MULTI_LOGICAL_PLANNER_H */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -39,6 +39,10 @@ extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
 											  replacePrunedQueryWithDummy,
 											  bool *multiShardModifyQuery);
 extern List * RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError);
+extern List * TargetShardIntervalsForQuery(Query *query,
+										   RelationRestrictionContext *restrictionContext,
+										   bool *multiShardQuery);
+extern List * WorkersContainingAllShards(List *prunedShardIntervalsList);
 extern List * IntersectPlacementList(List *lhsPlacementList, List *rhsPlacementList);
 extern DeferredErrorMessage * ModifyQuerySupported(Query *queryTree,
 												   bool multiShardQuery);

--- a/src/test/regress/expected/multi_subquery.out
+++ b/src/test/regress/expected/multi_subquery.out
@@ -818,9 +818,6 @@ SET client_min_messages TO DEBUG2;
 SELECT * FROM
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE a = 'onder' GROUP BY a)
 AS foo;
-DEBUG:  Skipping the target shard interval 570033 because SELECT query is pruned away for the interval
-DEBUG:  Skipping the target shard interval 570034 because SELECT query is pruned away for the interval
-DEBUG:  Skipping the target shard interval 570036 because SELECT query is pruned away for the interval
  count 
 -------
 (0 rows)
@@ -828,9 +825,6 @@ DEBUG:  Skipping the target shard interval 570036 because SELECT query is pruned
 SELECT * FROM
 	(SELECT count(*) FROM subquery_pruning_varchar_test_table WHERE 'eren' = a GROUP BY a)
 AS foo;
-DEBUG:  Skipping the target shard interval 570033 because SELECT query is pruned away for the interval
-DEBUG:  Skipping the target shard interval 570035 because SELECT query is pruned away for the interval
-DEBUG:  Skipping the target shard interval 570036 because SELECT query is pruned away for the interval
  count 
 -------
 (0 rows)


### PR DESCRIPTION
Postgres correctly copies equality filters on joined relations to other ones when creating relation restrictions.  This helps shard pruning.

However, it does not do the same for the range filters. Therefore we end up doing less than optimal shard pruning. This becomes an  issue when you have subquery joins, and have lots of (1000++) shards.

This commit first determines filter dependencies between shards by looking at join restrictions. Then computes a filter dependency structure after flattening out dependencies. Finally copies range filters to depended relations.

Only range filters on the distribution columns are copied, the other filters are not changed. Also, only range distributed tables are processed.  Filters on reference, or hash distributed tables are not copied.

After this work, we will perform more aggressive shard pruning, and create less number of worker queries.

- [ ] Check/rebase parent PR #2013 
- [ ] Resolve memory issues related to relation restriction creation
- [ ] Refactor relation_restriction_equivalance related part
- [ ] Update regression tests
