### PR TITLE
Prevent DROPping partitioned tables from workers

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -3813,6 +3813,8 @@ ProcessDropTableStmt(DropStmt *dropTableStatement)
 			continue;
 		}
 
+		EnsureCoordinator();
+
 		partitionList = PartitionList(relationId);
 		if (list_length(partitionList) == 0)
 		{

--- a/src/test/regress/expected/multi_mx_partitioning.out
+++ b/src/test/regress/expected/multi_mx_partitioning.out
@@ -241,6 +241,10 @@ SELECT inhrelid::regclass FROM pg_inherits WHERE inhparent = 'partitioning_test'
  partitioning_test_2013
 (4 rows)
 
+-- make sure DROPping from worker node is not allowed
+DROP TABLE partitioning_test;
+ERROR:  operation is not allowed on this node
+HINT:  Connect to the coordinator and run it again.
 \c - - - :master_port
 -- make sure we can repeatedly call start_metadata_sync_to_node
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);

--- a/src/test/regress/expected/multi_mx_partitioning_0.out
+++ b/src/test/regress/expected/multi_mx_partitioning_0.out
@@ -205,6 +205,9 @@ SELECT inhrelid::regclass FROM pg_inherits WHERE inhparent = 'partitioning_test'
 ERROR:  relation "partitioning_test" does not exist
 LINE 1: ...elid::regclass FROM pg_inherits WHERE inhparent = 'partition...
                                                              ^
+-- make sure DROPping from worker node is not allowed
+DROP TABLE partitioning_test;
+ERROR:  table "partitioning_test" does not exist
 \c - - - :master_port
 -- make sure we can repeatedly call start_metadata_sync_to_node
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);

--- a/src/test/regress/sql/multi_mx_partitioning.sql
+++ b/src/test/regress/sql/multi_mx_partitioning.sql
@@ -156,6 +156,9 @@ ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2009;
 
 SELECT inhrelid::regclass FROM pg_inherits WHERE inhparent = 'partitioning_test'::regclass;
 
+-- make sure DROPping from worker node is not allowed
+DROP TABLE partitioning_test;
+
 \c - - - :master_port
 
 -- make sure we can repeatedly call start_metadata_sync_to_node


### PR DESCRIPTION
We recently added partitionin support to Citus MX. We should not execute
DROP table commands from MX workers but at the moment we try to execute
such commands for partitioned tables. This PR fixes that problem by
adding check.