### PR TITLE
Fix crash on Windows where there is no detail

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -1233,9 +1233,10 @@ ReportCopyError(MultiConnection *connection, PGresult *result)
 	{
 		/* probably a constraint violation, show remote message and detail */
 		char *remoteDetail = PQresultErrorField(result, PG_DIAG_MESSAGE_DETAIL);
+		bool haveDetail = remoteDetail != NULL;
 
 		ereport(ERROR, (errmsg("%s", remoteMessage),
-						errdetail("%s", remoteDetail)));
+						haveDetail ? errdetail("%s", remoteDetail) : 0));
 	}
 	else
 	{

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2618,7 +2618,6 @@ FROM (
 ) AS ftop
 LIMIT 5;
 ERROR:  value too long for type character(1)
-DETAIL:  (null)
 SELECT * FROM coerce_agg;
  user_id | value_1_agg 
 ---------+-------------
@@ -2637,7 +2636,6 @@ FROM (
 ) AS ftop
 LIMIT 5;
 ERROR:  value too long for type character(1)
-DETAIL:  (null)
 -- char(1) -> char(5)
 ALTER TABLE coerce_events ALTER COLUMN value_1 TYPE char(1) USING value_1::char(1);
 ALTER TABLE coerce_agg ALTER COLUMN value_1_agg TYPE char(5);


### PR DESCRIPTION
I'm not sure why the behavior is different on Windows but unfortunately it is.