### PR TITLE
Fix cancellation of real time queries

### DIFF
--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -199,6 +199,16 @@ MultiRealTimeExecute(Job *job)
 		{
 			MultiClientWait(waitInfo);
 		}
+
+#ifdef WIN32
+
+		/*
+		 * Don't call CHECK_FOR_INTERRUPTS because we want to clean up after ourselves,
+		 * calling pgwin32_dispatch_queued_signals sets QueryCancelPending so we leave
+		 * the loop.
+		 */
+		pgwin32_dispatch_queued_signals();
+#endif
 	}
 
 	MultiClientFreeWaitInfo(waitInfo);


### PR DESCRIPTION
Fix `multi_real_time_transaction` test on Windows, without this change it blocks forever.