### PR TITLE
Fix crash in multi_copy test

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -992,13 +992,17 @@ BuildWaitEventSet(MultiConnection **allConnections, int totalConnectionCount,
 	WaitEventSet *waitEventSet = NULL;
 	int connectionIndex = 0;
 
-	/* we subtract 2 to make room for the WL_POSTMASTER_DEATH and WL_LATCH_SET events */
-	if (pendingConnectionCount > FD_SETSIZE - 2)
+	/*
+	 * subtract 3 to make room for WL_POSTMASTER_DEATH, WL_LATCH_SET, and
+	 * pgwin32_signal_event.
+	 */
+	if (pendingConnectionCount > FD_SETSIZE - 3)
 	{
-		pendingConnectionCount = FD_SETSIZE - 2;
+		pendingConnectionCount = FD_SETSIZE - 3;
 	}
 
 	/* allocate pending connections + 2 for the signal latch and postmaster death */
+	/* (CreateWaitEventSet makes room for pgwin32_signal_event automatically) */
 	waitEventSet = CreateWaitEventSet(CurrentMemoryContext, pendingConnectionCount + 2);
 
 	for (connectionIndex = 0; connectionIndex < pendingConnectionCount; connectionIndex++)

--- a/src/backend/distributed/executor/multi_real_time_executor.c
+++ b/src/backend/distributed/executor/multi_real_time_executor.c
@@ -199,6 +199,16 @@ MultiRealTimeExecute(Job *job)
 		{
 			MultiClientWait(waitInfo);
 		}
+
+#ifdef WIN32
+
+		/*
+		 * Don't call CHECK_FOR_INTERRUPTS because we want to clean up after ourselves,
+		 * calling pgwin32_dispatch_queued_signals sets QueryCancelPending so we leave
+		 * the loop.
+		 */
+		pgwin32_dispatch_queued_signals();
+#endif
 	}
 
 	MultiClientFreeWaitInfo(waitInfo);

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -230,8 +230,8 @@ END;
 -- pipe query output into a result file and create a table to check the result
 COPY (SELECT s, s*s FROM generate_series(1,5) s)
 TO PROGRAM
-  $$psql -h localhost -p 57636 -U postgres -d regression -c "BEGIN; COPY squares FROM STDIN WITH (format result); CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'binary') AS res(x int, x2 int); END;"$$
-WITH (FORMAT binary);
+  $$psql -h localhost -p 57636 -U postgres -d regression -c "BEGIN; COPY squares FROM STDIN WITH (format result); CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'text') AS res(x int, x2 int); END;"$$
+WITH (FORMAT text);
 SELECT * FROM squares ORDER BY x;
  x | x2 
 ---+----

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -825,8 +825,8 @@ green	{"r":0,"g":255,"b":0}
 SELECT * FROM copy_jsonb ORDER BY key;
 
 -- JSONB from binary should work
-\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
-\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+COPY copy_jsonb TO :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
+COPY copy_jsonb FROM :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
 SELECT * FROM copy_jsonb ORDER BY key;
 
 -- JSONB parsing error without validation: no line number
@@ -845,8 +845,8 @@ green	{"r":0,"g":255,"b":0}
 SELECT * FROM copy_jsonb ORDER BY key;
 
 -- JSONB from binary should work
-\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
-\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+COPY copy_jsonb TO :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
+COPY copy_jsonb FROM :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
 SELECT * FROM copy_jsonb ORDER BY key;
 
 -- JSONB parsing error with validation: should see line number

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -1110,8 +1110,8 @@ SELECT * FROM copy_jsonb ORDER BY key;
 (2 rows)
 
 -- JSONB from binary should work
-\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
-\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+COPY copy_jsonb TO :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
+COPY copy_jsonb FROM :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
 SELECT * FROM copy_jsonb ORDER BY key;
   key  |           value            |    extra    
 -------+----------------------------+-------------
@@ -1139,8 +1139,8 @@ SELECT * FROM copy_jsonb ORDER BY key;
 (2 rows)
 
 -- JSONB from binary should work
-\COPY copy_jsonb TO '/tmp/copy_jsonb.pgcopy' WITH (format binary)
-\COPY copy_jsonb FROM '/tmp/copy_jsonb.pgcopy' WITH (format binary)
+COPY copy_jsonb TO :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
+COPY copy_jsonb FROM :'temp_dir''copy_jsonb.pgcopy' WITH (format binary);
 SELECT * FROM copy_jsonb ORDER BY key;
   key  |           value            |    extra    
 -------+----------------------------+-------------

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -380,12 +380,14 @@ for my $workeroff (0 .. $#followerWorkerPorts)
 if ($usingWindows)
 {
 	print $fh "--variable=dev_null=\"/nul\" ";
-	print $fh "--variable=temp_dir=\"%TEMP%\\\"";
+	print $fh "--variable=temp_dir=\"%TEMP%\" ";
+	print $fh "--variable=psql=\"".catfile($bindir, "psql")."\" ";
 }
 else
 {
 	print $fh "--variable=dev_null=\"/dev/null\" ";	
-	print $fh "--variable=temp_dir=\"/tmp/\"";
+	print $fh "--variable=temp_dir=\"/tmp/\" ";
+	print $fh "--variable=psql=\"psql\" ";
 }
 
 

--- a/src/test/regress/sql/intermediate_results.sql
+++ b/src/test/regress/sql/intermediate_results.sql
@@ -114,8 +114,8 @@ END;
 -- pipe query output into a result file and create a table to check the result
 COPY (SELECT s, s*s FROM generate_series(1,5) s)
 TO PROGRAM
-  $$psql -h localhost -p 57636 -U postgres -d regression -c "BEGIN; COPY squares FROM STDIN WITH (format result); CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'binary') AS res(x int, x2 int); END;"$$
-WITH (FORMAT binary);
+  $$psql -h localhost -p 57636 -U postgres -d regression -c "BEGIN; COPY squares FROM STDIN WITH (format result); CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'text') AS res(x int, x2 int); END;"$$
+WITH (FORMAT text);
 
 SELECT * FROM squares ORDER BY x;
 


### PR DESCRIPTION
Without this change we crash on windows when COPYing into a table with more than 61 shards.