### PR TITLE
ANDs are being explicit for worker queries in pushdown

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -2133,6 +2133,19 @@ WorkerExtendedOpNode(MultiExtendedOp *originalOpNode,
 		(groupedByDisjointPartitionColumn || pushDownWindowFunction))
 	{
 		workerExtendedOpNode->havingQual = originalOpNode->havingQual;
+
+		/*
+		 * We converted the having expression to a list in subquery pushdown
+		 * planner. However, this query cannot be parsed as it is in the worker.
+		 * We should convert this back to being explicit for worker query
+		 * so that it can be parsed when it hits to the standard planner in
+		 * worker.
+		 */
+		if (IsA(workerExtendedOpNode->havingQual, List))
+		{
+			workerExtendedOpNode->havingQual =
+				(Node *) make_ands_explicit((List *) workerExtendedOpNode->havingQual);
+		}
 	}
 
 	return workerExtendedOpNode;

--- a/src/test/regress/expected/multi_having_pushdown.out
+++ b/src/test/regress/expected/multi_having_pushdown.out
@@ -183,3 +183,48 @@ EXPLAIN (COSTS FALSE)
 
 DROP TABLE lineitem_hash;
 DROP TABLE orders_hash;
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 4 AND min(value_2) < 1
+ORDER BY 1;
+ max 
+-----
+   4
+   5
+   5
+(3 rows)
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 4 AND min(value_2) < 1 OR count(*) > 10
+ORDER BY 1;
+ max 
+-----
+   4
+   5
+   5
+   5
+(4 rows)
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 4 AND min(value_2) < 1 AND count(*) > 20
+ORDER BY 1;
+ max 
+-----
+   5
+   5
+(2 rows)
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 0 AND count(*) FILTER (WHERE value_3=2) > 3 AND min(value_2) IN (0,1,2,3);
+ max 
+-----
+   5
+(1 row)
+

--- a/src/test/regress/sql/multi_having_pushdown.sql
+++ b/src/test/regress/sql/multi_having_pushdown.sql
@@ -55,3 +55,26 @@ EXPLAIN (COSTS FALSE)
 
 DROP TABLE lineitem_hash;
 DROP TABLE orders_hash;
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 4 AND min(value_2) < 1
+ORDER BY 1;
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 4 AND min(value_2) < 1 OR count(*) > 10
+ORDER BY 1;
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 4 AND min(value_2) < 1 AND count(*) > 20
+ORDER BY 1;
+
+SELECT max(value_1) 
+FROM users_table 
+GROUP BY user_id 
+HAVING max(value_2) > 0 AND count(*) FILTER (WHERE value_3=2) > 3 AND min(value_2) IN (0,1,2,3);


### PR DESCRIPTION
This is a fairly simple PR that changes the AND clauses in having explicit for worker queries for pushdown planner. Since, they are going to be switched back to be implicit in worker itself, we should provide them in explicit form. Otherwise, the worker errors-out saying the query syntax is wrong.

DESCRIPTION: Adds support for multiple ANDs in Having for push_down planner

fixes #2067 