### PR TITLE
Simplify optimizer [Phase 3]  - Move processing each part of the query into its own functions

### DIFF
--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -123,6 +123,10 @@ GroupedByDisjointPartitionColumn(List *tableNodeList, MultiExtendedOp *opNode)
 }
 
 
+/*
+ * ExtendedOpNodeContainsRepartitionSubquery is a utility function that
+ * returns true if the extended op node contains a re-partition subquery.
+ */
 static bool
 ExtendedOpNodeContainsRepartitionSubquery(MultiExtendedOp *originalOpNode)
 {


### PR DESCRIPTION
This the last PR intended for #2049 in 7.4.

This PR should be review after (or along with) #2070 and #2090. In general, **all there PRs don't change any of the logic at all**. Instead, the goal is to:

* Get rid of any code duplication
* Incremental changes to the optimizer made it slightly hard to follow the code, improve that and make it easier to implement new features
* Simplify the code by moving each part of query processing (e.g., `DISTINCT`, `LIMIT` etc) into its own function
* Make the interaction between each part of the query more obvious (e.g., How `DISTINCT` affects `LIMIT` etc)

Next steps (probably none of them is very urgent): 

* There are few quick wins we could implement soon, see [here](https://github.com/citusdata/citus/issues/2049#issuecomment-376133840) with title `Tasks that could be quick wins for Citus optimizer (Probably not realistic for 7.4, but, keeping the list here for future reference):`
* The processing of `LIMIT` and `ORDER BY` is very dependent on each other. It seems possible to separate them to some extent.
* `LIMIT` processing depends on too many things. Can't we try to simplify that?
* There are few `TODO` comments in the code now. I added those since those were quite confusing parts of the code. Now, the reader at least can understand why those codes are there.


