### PR TITLE
Fix write and copy functions for TaskExecution.

### DIFF
--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -269,6 +269,7 @@ CopyNodeTaskExecution(COPYFUNC_ARGS)
 	COPY_SCALAR_FIELD(currentNodeIndex);
 	COPY_SCALAR_FIELD(querySourceNodeIndex);
 	COPY_SCALAR_FIELD(failureCount);
+	COPY_SCALAR_FIELD(criticalErrorOccurred);
 }
 
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -479,6 +479,7 @@ OutTaskExecution(OUTFUNC_ARGS)
 	WRITE_UINT_FIELD(currentNodeIndex);
 	WRITE_UINT_FIELD(querySourceNodeIndex);
 	WRITE_UINT_FIELD(failureCount);
+	WRITE_BOOL_FIELD(criticalErrorOccurred);
 }
 
 


### PR DESCRIPTION
We were missing `criticalErrorOccurred` from  `CopyNodeTaskExecution()` and `OutTaskExecution()`. This PR fixes it.

I'm not sure if this can result in something very bad, I need to look more.