### PR TITLE
Add support for (VACUUM | ANALYZE) VERBOSE

### DIFF
--- a/src/backend/distributed/transaction/multi_shard_transaction.c
+++ b/src/backend/distributed/transaction/multi_shard_transaction.c
@@ -81,7 +81,7 @@ OpenTransactionsForAllTasks(List *taskList, int connectionFlags)
 		else
 		{
 			/* can only open connections for DDL and DML commands */
-			Assert(task->taskType == DDL_TASK);
+			Assert(task->taskType == DDL_TASK || VACUUM_ANALYZE_TASK);
 
 			accessType = PLACEMENT_ACCESS_DDL;
 		}

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -237,6 +237,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			 */
 			SubPlanLevel = 0;
 			UnSetDistributedTransactionId();
+			UnsetCitusNoticeLevel();
 			break;
 		}
 
@@ -352,6 +353,8 @@ CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId,
 			{
 				CoordinatedRemoteTransactionsSavepointRollback(subId);
 			}
+
+			UnsetCitusNoticeLevel();
 			break;
 		}
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -21,6 +21,9 @@
 /* maximum (textual) lengths of hostname and port */
 #define MAX_NODE_LENGTH 255 /* includes 0 byte */
 
+/* default notice level */
+#define DEFAULT_CITUS_NOTICE_LEVEL DEBUG1
+
 /* forward declare, to avoid forcing large headers on everyone */
 struct pg_conn; /* target of the PGconn typedef */
 struct MemoryContextData;
@@ -164,6 +167,12 @@ extern void FinishConnectionListEstablishment(List *multiConnectionList);
 extern void FinishConnectionEstablishment(MultiConnection *connection);
 extern void ClaimConnectionExclusively(MultiConnection *connection);
 extern void UnclaimConnection(MultiConnection *connection);
+
+/* dealing with notice handler */
+extern void SetCitusNoticeProcessor(MultiConnection *connection);
+extern void SetCitusNoticeLevel(int level);
+extern char * TrimLogLevel(const char *message);
+extern void UnsetCitusNoticeLevel(void);
 
 
 #endif /* CONNECTION_MANAGMENT_H */

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -84,7 +84,8 @@ typedef enum
 	MERGE_FETCH_TASK = 5,
 	MODIFY_TASK = 6,
 	ROUTER_TASK = 7,
-	DDL_TASK = 8
+	DDL_TASK = 8,
+	VACUUM_ANALYZE_TASK = 9
 } TaskType;
 
 

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -469,7 +469,3 @@ SELECT 1 FROM citus_create_restore_point('regression-test');
         1
 (1 row)
 
--- TODO: support VERBOSE
--- VACUUM VERBOSE dustbunnies;
--- VACUUM (FULL, VERBOSE) dustbunnies;
--- ANALYZE VERBOSE dustbunnies;

--- a/src/test/regress/expected/multi_utilities_0.out
+++ b/src/test/regress/expected/multi_utilities_0.out
@@ -472,7 +472,3 @@ SELECT 1 FROM citus_create_restore_point('regression-test');
         1
 (1 row)
 
--- TODO: support VERBOSE
--- VACUUM VERBOSE dustbunnies;
--- VACUUM (FULL, VERBOSE) dustbunnies;
--- ANALYZE VERBOSE dustbunnies;

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -292,8 +292,3 @@ SELECT citus_truncate_trigger();
 
 -- confirm that citus_create_restore_point works
 SELECT 1 FROM citus_create_restore_point('regression-test');
-
--- TODO: support VERBOSE
--- VACUUM VERBOSE dustbunnies;
--- VACUUM (FULL, VERBOSE) dustbunnies;
--- ANALYZE VERBOSE dustbunnies;


### PR DESCRIPTION
DESCRIPTION: Add support for (VACUUM | ANALYZE) VERBOSE

This PR adds support for (VACUUM | ANALYZE) VERBOSE on distributed tables. The idea is to use the notice hook and change the log direction from logfile to the console.

The notice handler is implemented as we discussed in the mail thread `Citus Notice Handler`. For now, the default for the notices is set to DEBUG1. It is chosen consciously to not allow all of the notices to go to the console. When we set it to NOTICE or INFO, we have some weird cases we should consider. 
For example, if we set the notice level to NOTICE and run;
```
SELECT create_distributed_table('schema.table', 'i');
```

We print to the console `Schema 'schema' already exists, skipping` for each connection and I don't think this is a good user experience. So, I left it as DEBUG1.

As @onderkalaci suggested, one approach we should consider is that instead of having a static `CitusNoticeLogLevel`, we might parse the message we get from the connection and learn which level used in the worker and use the respective log level in the coordinator for reporting. However, I don't really think that this problem is related to that PR. If we want to implement this mechanism, I propose to do it with another PR.

fixes #1050 