### PR TITLE
Improve connection error reporting

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -67,6 +67,7 @@
 #include "distributed/multi_shard_transaction.h"
 #include "distributed/placement_connection.h"
 #include "distributed/remote_commands.h"
+#include "distributed/remote_transaction.h"
 #include "distributed/resource_lock.h"
 #include "distributed/shard_pruning.h"
 #include "distributed/version_compat.h"
@@ -842,8 +843,9 @@ OpenCopyConnections(CopyStmt *copyStatement, ShardConnections *shardConnections,
 			}
 			else
 			{
-				ReportConnectionError(connection, WARNING);
-				MarkRemoteTransactionFailed(connection, true);
+				const bool raiseErrors = true;
+
+				HandleRemoteTransactionConnectionError(connection, raiseErrors);
 
 				failedPlacementCount++;
 				continue;

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -244,7 +244,8 @@ ReportConnectionError(MultiConnection *connection, int elevel)
 	char *nodeName = connection->hostname;
 	int nodePort = connection->port;
 
-	ereport(elevel, (errmsg("connection error: %s:%d", nodeName, nodePort),
+	ereport(elevel, (errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("connection error: %s:%d", nodeName, nodePort),
 					 errdetail("%s", pchomp(PQerrorMessage(connection->pgConn)))));
 }
 

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -243,10 +243,17 @@ ReportConnectionError(MultiConnection *connection, int elevel)
 {
 	char *nodeName = connection->hostname;
 	int nodePort = connection->port;
+	PGconn *pgConn = connection->pgConn;
+	char *messageDetail = NULL;
+
+	if (pgConn != NULL)
+	{
+		messageDetail = pchomp(PQerrorMessage(pgConn));
+	}
 
 	ereport(elevel, (errcode(ERRCODE_CONNECTION_FAILURE),
 					 errmsg("connection error: %s:%d", nodeName, nodePort),
-					 errdetail("%s", pchomp(PQerrorMessage(connection->pgConn)))));
+					 messageDetail != NULL ? errdetail("%s", messageDetail) : 0));
 }
 
 

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1277,16 +1277,18 @@ SendQueryInSingleRowMode(MultiConnection *connection, char *query,
 
 	if (querySent == 0)
 	{
-		MarkRemoteTransactionFailed(connection, false);
-		ReportConnectionError(connection, WARNING);
+		const bool raiseErrors = false;
+
+		HandleRemoteTransactionConnectionError(connection, raiseErrors);
 		return false;
 	}
 
 	singleRowMode = PQsetSingleRowMode(connection->pgConn);
 	if (singleRowMode == 0)
 	{
-		MarkRemoteTransactionFailed(connection, false);
-		ReportConnectionError(connection, WARNING);
+		const bool raiseErrors = false;
+
+		HandleRemoteTransactionConnectionError(connection, raiseErrors);
 		return false;
 	}
 

--- a/src/include/distributed/remote_transaction.h
+++ b/src/include/distributed/remote_transaction.h
@@ -11,6 +11,7 @@
 #define REMOTE_TRANSACTION_H
 
 
+#include "libpq-fe.h"
 #include "nodes/pg_list.h"
 #include "lib/ilist.h"
 
@@ -107,6 +108,10 @@ extern void RemoteTransactionBeginIfNecessary(struct MultiConnection *connection
 extern void RemoteTransactionsBeginIfNecessary(List *connectionList);
 
 /* other public functionality */
+extern void HandleRemoteTransactionConnectionError(struct MultiConnection *connection,
+												   bool raiseError);
+extern void HandleRemoteTransactionResultError(struct MultiConnection *connection,
+											   PGresult *result, bool raiseErrors);
 extern void MarkRemoteTransactionFailed(struct MultiConnection *connection,
 										bool allowErrorPromotion);
 extern void MarkRemoteTransactionCritical(struct MultiConnection *connection);

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -878,14 +878,12 @@ FOR EACH ROW EXECUTE PROCEDURE reject_bad_reference();
 \set VERBOSITY terse
 -- try without wrapping inside a transaction
 INSERT INTO reference_modifying_xacts VALUES (999, 3);
-WARNING:  illegal value
-ERROR:  failure on connection marked as essential: localhost:57637
+ERROR:  illegal value
 -- same test within a transaction
 BEGIN;
 INSERT INTO reference_modifying_xacts VALUES (999, 3);
 COMMIT;
-WARNING:  illegal value
-ERROR:  failure on connection marked as essential: localhost:57637
+ERROR:  illegal value
 -- all placements should be healthy
 SELECT   s.logicalrelid::regclass::text, sp.shardstate, count(*)
 FROM     pg_dist_shard_placement AS sp,
@@ -977,8 +975,7 @@ BEGIN;
 INSERT INTO reference_modifying_xacts VALUES (12, 12);
 INSERT INTO hash_modifying_xacts VALUES (997, 1);
 COMMIT;
-WARNING:  illegal value
-ERROR:  failure on connection marked as essential: localhost:57637
+ERROR:  illegal value
 -- ensure that the values didn't go into the reference table
 SELECT * FROM reference_modifying_xacts WHERE key = 12;
  key | value 
@@ -1180,13 +1177,11 @@ ALTER USER test_user RENAME TO test_user_new;
  \c - test_user - :master_port
 -- should fail since the worker doesn't have test_user anymore
 INSERT INTO reference_failure_test VALUES (1, '1');
-WARNING:  connection error: localhost:57637
-ERROR:  failure on connection marked as essential: localhost:57637
+ERROR:  connection error: localhost:57637
 -- the same as the above, but wrapped within a transaction
 BEGIN;
 INSERT INTO reference_failure_test VALUES (1, '1');
-WARNING:  connection error: localhost:57637
-ERROR:  failure on connection marked as essential: localhost:57637
+ERROR:  connection error: localhost:57637
 COMMIT;
 BEGIN;
 COPY reference_failure_test FROM STDIN WITH (FORMAT 'csv');

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -712,11 +712,14 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 (1 row)
 
 -- test adding an invalid node while we have reference tables to replicate
--- set client message level to ERROR to suppress OS-dependent host name resolution warnings
+-- set client message level to ERROR and verbosity to terse to supporess
+-- OS-dependent host name resolution warnings
 SET client_min_messages to ERROR;
+\set VERBOSITY terse
 SELECT master_add_node('invalid-node-name', 9999);
-ERROR:  failure on connection marked as essential: invalid-node-name:9999
+ERROR:  connection error: invalid-node-name:9999
 SET client_min_messages to DEFAULT;
+\set VERBOSITY default
 -- drop unnecassary tables
 DROP TABLE initially_not_replicated_reference_table;
 -- reload pg_dist_shard_placement table

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -654,10 +654,9 @@ BEGIN;
 CREATE INDEX single_index_2 ON single_shard_items(id);
 CREATE INDEX single_index_3 ON single_shard_items(name);
 COMMIT;
-WARNING:  duplicate key value violates unique constraint "ddl_commands_command_key"
+ERROR:  duplicate key value violates unique constraint "ddl_commands_command_key"
 DETAIL:  Key (command)=(CREATE INDEX) already exists.
 CONTEXT:  while executing command on localhost:57638
-ERROR:  failure on connection marked as essential: localhost:57638
 -- Nothing from the block should have committed
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'single_shard_items' ORDER BY 1;
  indexname | tablename 

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -458,11 +458,15 @@ ORDER BY 1,4,5;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 -- test adding an invalid node while we have reference tables to replicate
--- set client message level to ERROR to suppress OS-dependent host name resolution warnings
+-- set client message level to ERROR and verbosity to terse to supporess
+-- OS-dependent host name resolution warnings
 SET client_min_messages to ERROR;
+\set VERBOSITY terse
+
 SELECT master_add_node('invalid-node-name', 9999);
 
 SET client_min_messages to DEFAULT;
+\set VERBOSITY default
 
 -- drop unnecassary tables
 DROP TABLE initially_not_replicated_reference_table;


### PR DESCRIPTION
DESCRIPTION: Add specialised error codes for connection failures
DESCRIPTION: Improve error messages on connection failure

We had a request to add a meaningful error code for connection failures, such that they could be distinguished from other types of failure and may require immediate action (e.g. switching to a different cluster in a very high availability scenario). I used ERRCODE_CONNECTION_FAILURE, since Postgres only uses that when it loses connection to the client, meaning clients would never see such a code in other cases.

While at it, I decided to address two more common complaints about Citus' error reporting on connection failures.

We throw "failure on connection marked as essential" errors in many failure cases after showing a warning containing a description of the problem. Since ORMs typically only record errors, the user does not know what happened. I noticed we very often do `ReportConnectionError` + `MarkRemoteTransactionFailed`. I combined these into a single function which can use the original error message from the client.

Finally, we sometimes showed "connection pointer is NULL" in the detail when a connection timeout occurred because in that cased we passed a `NULL` `PGconn *` to `PQerrorMessage`. For now I removed the detail in that case.