### PR TITLE
Support UPDATE/DELETE with joins and subqueries

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -310,8 +310,7 @@ AcquireExecutorMultiShardLocks(List *taskList)
 		/*
 		 * If the task has a subselect, then we may need to lock the shards from which
 		 * the query selects as well to prevent the subselects from seeing different
-		 * results on different replicas. In particular this prevents INSERT..SELECT
-		 * commands from having different effects on different placements.
+		 * results on different replicas.
 		 */
 
 		if (RequiresConsistentSnapshot(task))
@@ -330,18 +329,17 @@ AcquireExecutorMultiShardLocks(List *taskList)
 
 /*
  * RequiresConsistentSnapshot returns true if the given task need to take
- * the necessary locks to ensure that a subquery in the INSERT ... SELECT
- * query returns the same output for all task placements.
+ * the necessary locks to ensure that a subquery in the modify query
+ * returns the same output for all task placements.
  */
 static bool
 RequiresConsistentSnapshot(Task *task)
 {
 	bool requiresIsolation = false;
 
-	if (!task->insertSelectQuery)
+	if (!task->modifyWithSubquery)
 	{
 		/*
-		 * Only INSERT/SELECT commands currently require SELECT isolation.
 		 * Other commands do not read from other shards.
 		 */
 

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -151,7 +151,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	{
 		bool multiShardQuery = true;
 		DeferredErrorMessage *error =
-			ModifyQuerySupported(modifyQuery, modifyQuery, multiShardQuery);
+			ModifyQuerySupported(modifyQuery, modifyQuery, multiShardQuery, NULL);
 
 		if (error)
 		{

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -58,7 +58,7 @@ RebuildQueryStrings(Query *originalQuery, List *taskList)
 		{
 			query = copyObject(originalQuery);
 		}
-		else if (task->insertSelectQuery)
+		else if (query->commandType == CMD_INSERT && task->modifyWithSubquery)
 		{
 			/* for INSERT..SELECT, adjust shard names in SELECT part */
 			RangeTblEntry *copiedInsertRte = NULL;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -593,9 +593,6 @@ CreateDistributedSelectPlan(uint64 planId, Query *originalQuery, Query *query,
 							ParamListInfo boundParams, bool hasUnresolvedParams,
 							PlannerRestrictionContext *plannerRestrictionContext)
 {
-	RelationRestrictionContext *relationRestrictionContext =
-		plannerRestrictionContext->relationRestrictionContext;
-
 	DistributedPlan *distributedPlan = NULL;
 	MultiTreeRoot *logicalPlan = NULL;
 	List *subPlanList = NIL;
@@ -608,7 +605,7 @@ CreateDistributedSelectPlan(uint64 planId, Query *originalQuery, Query *query,
 	 */
 
 	distributedPlan = CreateRouterPlan(originalQuery, query,
-									   relationRestrictionContext);
+									   plannerRestrictionContext);
 	if (distributedPlan != NULL)
 	{
 		if (distributedPlan->planningError == NULL)

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -245,7 +245,7 @@ CopyNodeTask(COPYFUNC_ARGS)
 	COPY_NODE_FIELD(taskExecution);
 	COPY_SCALAR_FIELD(upsertQuery);
 	COPY_SCALAR_FIELD(replicationModel);
-	COPY_SCALAR_FIELD(insertSelectQuery);
+	COPY_SCALAR_FIELD(modifyWithSubquery);
 	COPY_NODE_FIELD(relationShardList);
 	COPY_NODE_FIELD(rowValuesLists);
 }

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -454,7 +454,7 @@ OutTask(OUTFUNC_ARGS)
 	WRITE_NODE_FIELD(taskExecution);
 	WRITE_BOOL_FIELD(upsertQuery);
 	WRITE_CHAR_FIELD(replicationModel);
-	WRITE_BOOL_FIELD(insertSelectQuery);
+	WRITE_BOOL_FIELD(modifyWithSubquery);
 	WRITE_NODE_FIELD(relationShardList);
 	WRITE_NODE_FIELD(rowValuesLists);
 }

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -367,7 +367,7 @@ ReadTask(READFUNC_ARGS)
 	READ_NODE_FIELD(taskExecution);
 	READ_BOOL_FIELD(upsertQuery);
 	READ_CHAR_FIELD(replicationModel);
-	READ_BOOL_FIELD(insertSelectQuery);
+	READ_BOOL_FIELD(modifyWithSubquery);
 	READ_NODE_FIELD(relationShardList);
 	READ_NODE_FIELD(rowValuesLists);
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -27,13 +27,14 @@
 extern bool EnableRouterExecution;
 
 extern DistributedPlan * CreateRouterPlan(Query *originalQuery, Query *query,
-										  RelationRestrictionContext *restrictionContext);
+										  PlannerRestrictionContext *
+										  plannerRestrictionContext);
 extern DistributedPlan * CreateModifyPlan(Query *originalQuery, Query *query,
 										  PlannerRestrictionContext *
 										  plannerRestrictionContext);
 extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
-											  RelationRestrictionContext *
-											  restrictionContext,
+											  PlannerRestrictionContext *
+											  plannerRestrictionContext,
 											  List **placementList, uint64 *anchorShardId,
 											  List **relationShardList, bool
 											  replacePrunedQueryWithDummy,
@@ -45,7 +46,9 @@ extern List * TargetShardIntervalsForQuery(Query *query,
 extern List * WorkersContainingAllShards(List *prunedShardIntervalsList);
 extern List * IntersectPlacementList(List *lhsPlacementList, List *rhsPlacementList);
 extern DeferredErrorMessage * ModifyQuerySupported(Query *queryTree, Query *originalQuery,
-												   bool multiShardQuery);
+												   bool multiShardQuery,
+												   PlannerRestrictionContext *
+												   plannerRestrictionContext);
 extern List * ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex);
 extern RelationRestrictionContext * CopyRelationRestrictionContext(
 	RelationRestrictionContext *oldContext);
@@ -58,6 +61,7 @@ extern bool IsMultiRowInsert(Query *query);
 extern void AddShardIntervalRestrictionToSelect(Query *subqery,
 												ShardInterval *shardInterval);
 extern bool UpdateOrDeleteQuery(Query *query);
+extern List * WorkersContainingAllShards(List *prunedShardIntervalsList);
 
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/test/regress/expected/isolation_modify_with_subquery_vs_dml.out
+++ b/src/test/regress/expected/isolation_modify_with_subquery_vs_dml.out
@@ -1,0 +1,127 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s2-begin s2-modify_with_subquery_v1 s1-insert_to_events_test_table s2-commit s1-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s2-modify_with_subquery_v1: 
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+
+step s1-insert_to_events_test_table: 
+    INSERT INTO events_test_table VALUES(4,6,8,10);
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-insert_to_events_test_table: <... completed>
+step s1-commit: 
+    COMMIT;
+
+
+starting permutation: s1-begin s2-begin s2-modify_with_subquery_v1 s1-update_events_test_table s2-commit s1-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s2-modify_with_subquery_v1: 
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+
+step s1-update_events_test_table: 
+	UPDATE users_test_table SET value_1 = 3;
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-update_events_test_table: <... completed>
+step s1-commit: 
+    COMMIT;
+
+
+starting permutation: s1-begin s2-begin s2-modify_with_subquery_v1 s1-delete_events_test_table s2-commit s1-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s2-modify_with_subquery_v1: 
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+
+step s1-delete_events_test_table: 
+	DELETE FROM events_test_table WHERE user_id = 1 or user_id = 3;
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-delete_events_test_table: <... completed>
+step s1-commit: 
+    COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-insert_to_events_test_table s2-modify_with_subquery_v1 s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-insert_to_events_test_table: 
+    INSERT INTO events_test_table VALUES(4,6,8,10);
+
+step s2-modify_with_subquery_v1: 
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-modify_with_subquery_v1: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-update_events_test_table s2-modify_with_subquery_v1 s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-update_events_test_table: 
+	UPDATE users_test_table SET value_1 = 3;
+
+step s2-modify_with_subquery_v1: 
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-modify_with_subquery_v1: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s1-delete_events_test_table s2-modify_with_subquery_v1 s1-commit s2-commit
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s1-delete_events_test_table: 
+	DELETE FROM events_test_table WHERE user_id = 1 or user_id = 3;
+
+step s2-modify_with_subquery_v1: 
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-modify_with_subquery_v1: <... completed>
+step s2-commit: 
+	COMMIT;
+

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -816,9 +816,42 @@ Custom Scan (Citus Router)
         Node: host=localhost port=57638 dbname=regression
         ->  Delete on lineitem_hash_part_360044 lineitem_hash_part
               ->  Seq Scan on lineitem_hash_part_360044 lineitem_hash_part
+SET citus.explain_all_tasks TO off;
+-- Test update with subquery
+EXPLAIN (COSTS FALSE)
+	UPDATE lineitem_hash_part
+	SET l_suppkey = 12
+	FROM orders_hash_part
+	WHERE orders_hash_part.o_orderkey = lineitem_hash_part.l_orderkey;
+Custom Scan (Citus Router)
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Update on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Hash Join
+                    Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                    ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
+                    ->  Hash
+                          ->  Seq Scan on orders_hash_part_360045 orders_hash_part
+-- Test delete with subquery
+EXPLAIN (COSTS FALSE)
+	DELETE FROM lineitem_hash_part
+	USING orders_hash_part
+	WHERE orders_hash_part.o_orderkey = lineitem_hash_part.l_orderkey;
+Custom Scan (Citus Router)
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Delete on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Hash Join
+                    Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                    ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
+                    ->  Hash
+                          ->  Seq Scan on orders_hash_part_360045 orders_hash_part
 -- Test track tracker
 SET citus.task_executor_type TO 'task-tracker';
-SET citus.explain_all_tasks TO off;
 EXPLAIN (COSTS FALSE)
 	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
 Aggregate
@@ -1128,7 +1161,7 @@ SELECT l_orderkey FROM series JOIN keys ON (s = l_orderkey)
 ORDER BY s;
 Custom Scan (Citus Router)
   Output: remote_scan.l_orderkey
-  ->  Distributed Subplan 55_1
+  ->  Distributed Subplan 57_1
         ->  HashAggregate
               Output: remote_scan.l_orderkey
               Group Key: remote_scan.l_orderkey
@@ -1143,7 +1176,7 @@ Custom Scan (Citus Router)
                                 Group Key: lineitem_hash_part.l_orderkey
                                 ->  Seq Scan on public.lineitem_hash_part_360041 lineitem_hash_part
                                       Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
-  ->  Distributed Subplan 55_2
+  ->  Distributed Subplan 57_2
         ->  Function Scan on pg_catalog.generate_series s
               Output: s
               Function Call: generate_series(1, 10)
@@ -1159,13 +1192,13 @@ Custom Scan (Citus Router)
                     Sort Key: intermediate_result.s
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                           Output: intermediate_result.s
-                          Function Call: read_intermediate_result('55_2'::text, 'binary'::citus_copy_format)
+                          Function Call: read_intermediate_result('57_2'::text, 'binary'::citus_copy_format)
               ->  Sort
                     Output: intermediate_result_1.l_orderkey
                     Sort Key: intermediate_result_1.l_orderkey
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                           Output: intermediate_result_1.l_orderkey
-                          Function Call: read_intermediate_result('55_1'::text, 'binary'::citus_copy_format)
+                          Function Call: read_intermediate_result('57_1'::text, 'binary'::citus_copy_format)
 SELECT true AS valid FROM explain_json($$
   WITH result AS (
     SELECT l_quantity, count(*) count_quantity FROM lineitem

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -816,9 +816,42 @@ Custom Scan (Citus Router)
         Node: host=localhost port=57638 dbname=regression
         ->  Delete on lineitem_hash_part_360044 lineitem_hash_part
               ->  Seq Scan on lineitem_hash_part_360044 lineitem_hash_part
+SET citus.explain_all_tasks TO off;
+-- Test update with subquery
+EXPLAIN (COSTS FALSE)
+	UPDATE lineitem_hash_part
+	SET l_suppkey = 12
+	FROM orders_hash_part
+	WHERE orders_hash_part.o_orderkey = lineitem_hash_part.l_orderkey;
+Custom Scan (Citus Router)
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Update on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Hash Join
+                    Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                    ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
+                    ->  Hash
+                          ->  Seq Scan on orders_hash_part_360045 orders_hash_part
+-- Test delete with subquery
+EXPLAIN (COSTS FALSE)
+	DELETE FROM lineitem_hash_part
+	USING orders_hash_part
+	WHERE orders_hash_part.o_orderkey = lineitem_hash_part.l_orderkey;
+Custom Scan (Citus Router)
+  Task Count: 4
+  Tasks Shown: One of 4
+  ->  Task
+        Node: host=localhost port=57637 dbname=regression
+        ->  Delete on lineitem_hash_part_360041 lineitem_hash_part
+              ->  Hash Join
+                    Hash Cond: (lineitem_hash_part.l_orderkey = orders_hash_part.o_orderkey)
+                    ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
+                    ->  Hash
+                          ->  Seq Scan on orders_hash_part_360045 orders_hash_part
 -- Test track tracker
 SET citus.task_executor_type TO 'task-tracker';
-SET citus.explain_all_tasks TO off;
 EXPLAIN (COSTS FALSE)
 	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;
 Aggregate
@@ -1128,7 +1161,7 @@ SELECT l_orderkey FROM series JOIN keys ON (s = l_orderkey)
 ORDER BY s;
 Custom Scan (Citus Router)
   Output: remote_scan.l_orderkey
-  ->  Distributed Subplan 55_1
+  ->  Distributed Subplan 57_1
         ->  HashAggregate
               Output: remote_scan.l_orderkey
               Group Key: remote_scan.l_orderkey
@@ -1143,7 +1176,7 @@ Custom Scan (Citus Router)
                                 Group Key: lineitem_hash_part.l_orderkey
                                 ->  Seq Scan on public.lineitem_hash_part_360041 lineitem_hash_part
                                       Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
-  ->  Distributed Subplan 55_2
+  ->  Distributed Subplan 57_2
         ->  Function Scan on pg_catalog.generate_series s
               Output: s
               Function Call: generate_series(1, 10)
@@ -1159,13 +1192,13 @@ Custom Scan (Citus Router)
                     Sort Key: intermediate_result.s
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result
                           Output: intermediate_result.s
-                          Function Call: read_intermediate_result('55_2'::text, 'binary'::citus_copy_format)
+                          Function Call: read_intermediate_result('57_2'::text, 'binary'::citus_copy_format)
               ->  Sort
                     Output: intermediate_result_1.l_orderkey
                     Sort Key: intermediate_result_1.l_orderkey
                     ->  Function Scan on pg_catalog.read_intermediate_result intermediate_result_1
                           Output: intermediate_result_1.l_orderkey
-                          Function Call: read_intermediate_result('55_1'::text, 'binary'::citus_copy_format)
+                          Function Call: read_intermediate_result('57_1'::text, 'binary'::citus_copy_format)
 SELECT true AS valid FROM explain_json($$
   WITH result AS (
     SELECT l_quantity, count(*) count_quantity FROM lineitem

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -964,12 +964,10 @@ SELECT * FROM summary_table ORDER BY id;
 -- unsupported multi-shard updates
 UPDATE summary_table SET average_value = average_query.average FROM (
 	SELECT avg(value) AS average FROM raw_table) average_query;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 UPDATE summary_table SET average_value = average_value + 1 WHERE id =
   (SELECT id FROM raw_table WHERE value > 100);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 -- test complex queries
 UPDATE summary_table
 SET
@@ -1108,8 +1106,8 @@ SELECT master_modify_multiple_shards('
 		SELECT avg(value) AS average FROM raw_table WHERE id = 1
 		) average_query
 	WHERE id = 1');
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  cannot run multi shard modify query with master_modify_multiple_shards when the query involves subquery or join
+DETAIL:  Execute the query without using master_modify_multiple_shards()
 -- test connection API via using COPY
 -- COPY on SELECT part
 BEGIN;

--- a/src/test/regress/expected/multi_shard_modify.out
+++ b/src/test/regress/expected/multi_shard_modify.out
@@ -84,8 +84,8 @@ SELECT master_create_worker_shards('temp_nations', 4, 2);
 (1 row)
 
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test USING temp_nations WHERE multi_shard_modify_test.t_value = temp_nations.key AND temp_nations.name = ''foobar'' ');
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  cannot run multi shard modify query with master_modify_multiple_shards when the query involves subquery or join
+DETAIL:  Execute the query without using master_modify_multiple_shards()
 -- commands with a RETURNING clause are unsupported
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = 3 RETURNING *');
 ERROR:  master_modify_multiple_shards() does not support RETURNING
@@ -222,8 +222,8 @@ SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_key=3
 ERROR:  modifying the partition value of rows is not allowed
 -- UPDATEs with a FROM clause are unsupported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name = ''FAIL'' FROM temp_nations WHERE multi_shard_modify_test.t_key = 3 AND multi_shard_modify_test.t_value = temp_nations.key AND temp_nations.name = ''dummy'' ');
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  cannot run multi shard modify query with master_modify_multiple_shards when the query involves subquery or join
+DETAIL:  Execute the query without using master_modify_multiple_shards()
 -- commands with a RETURNING clause are unsupported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''FAIL'' WHERE t_key=4 RETURNING *');
 ERROR:  master_modify_multiple_shards() does not support RETURNING

--- a/src/test/regress/expected/multi_shard_update_delete.out
+++ b/src/test/regress/expected/multi_shard_update_delete.out
@@ -169,6 +169,10 @@ CREATE TABLE append_stage_table(id int, col_2 int);
 INSERT INTO append_stage_table VALUES(1,3);
 INSERT INTO append_stage_table VALUES(3,2);
 INSERT INTO append_stage_table VALUES(5,4);
+CREATE TABLE append_stage_table_2(id int, col_2 int);
+INSERT INTO append_stage_table_2 VALUES(8,3);
+INSERT INTO append_stage_table_2 VALUES(9,2);
+INSERT INTO append_stage_table_2 VALUES(10,4);
 CREATE TABLE test_append_table(id int, col_2 int);
 SELECT create_distributed_table('test_append_table','id','append');
  create_distributed_table 
@@ -194,7 +198,7 @@ SELECT master_create_empty_shard('test_append_table') AS new_shard_id;
       1440011
 (1 row)
 
-SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table_2', 'localhost', :master_port);
  master_append_table_to_shard 
 ------------------------------
                    0.00533333
@@ -204,15 +208,16 @@ UPDATE test_append_table SET col_2 = 5;
 SELECT * FROM test_append_table;
  id | col_2 
 ----+-------
-  1 |     5
-  3 |     5
-  5 |     5
+  8 |     5
+  9 |     5
+ 10 |     5
   1 |     5
   3 |     5
   5 |     5
 (6 rows)
 
 DROP TABLE append_stage_table;
+DROP TABLE append_stage_table_2;
 DROP TABLE test_append_table;
 -- Update multi shard of partitioned distributed table
 SET citus.multi_shard_modify_mode to 'parallel';
@@ -317,43 +322,24 @@ UPDATE tt2 SET col_2 = 3 RETURNING id, col_2;
 (5 rows)
 
 DROP TABLE tt2;
--- Multiple RTEs are not supported
+-- Multiple RTEs are only supported if subquery is pushdownable
 SET citus.multi_shard_modify_mode to DEFAULT;
-UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id; 
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-UPDATE users_test_table SET value_2 = (SELECT value_3 FROM users_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-UPDATE users_test_table SET value_2 = (SELECT value_2 FROM events_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-DELETE FROM users_test_table USING events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-DELETE FROM users_test_table WHERE users_test_table.user_id = (SELECT user_id FROM events_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-DELETE FROM users_test_table WHERE users_test_table.user_id = (SELECT value_1 FROM users_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
--- Cursors are not supported
-BEGIN;
-DECLARE test_cursor CURSOR FOR SELECT * FROM users_test_table;
-FETCH test_cursor;
- user_id | value_1 | value_2 | value_3 
----------+---------+---------+---------
-       8 |       0 |      13 |       0
+-- To test colocation between tables in modify query
+SET citus.shard_count to 6;
+CREATE TABLE events_test_table_2 (user_id int, value_1 int, value_2 int, value_3 int);
+SELECT create_distributed_table('events_test_table_2', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
 (1 row)
 
-UPDATE users_test_table SET value_2 = 5 WHERE CURRENT OF test_cursor;
-ERROR:  cannot run DML queries with cursors
-ROLLBACK;
--- Stable functions are supported
+\COPY events_test_table_2 FROM STDIN DELIMITER AS ',';
+CREATE TABLE events_test_table_local (user_id int, value_1 int, value_2 int, value_3 int);
+\COPY events_test_table_local FROM STDIN DELIMITER AS ',';
 CREATE TABLE test_table_1(id int, date_col timestamptz, col_3 int);
 INSERT INTO test_table_1 VALUES(1, '2014-04-05 08:32:12', 5);
 INSERT INTO test_table_1 VALUES(2, '2015-02-01 08:31:16', 7);
-INSERT INTO test_table_1 VALUES(3, '2011-01-12 08:35:19', 9);
+INSERT INTO test_table_1 VALUES(3, '2111-01-12 08:35:19', 9);
 SELECT create_distributed_table('test_table_1', 'id');
 NOTICE:  Copying data from local table...
  create_distributed_table 
@@ -361,11 +347,416 @@ NOTICE:  Copying data from local table...
  
 (1 row)
 
+-- We can pushdown query if there is partition key equality
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+DELETE FROM users_test_table
+USING  events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+UPDATE users_test_table
+SET    value_1 = 3
+WHERE  user_id IN (SELECT user_id
+              FROM   events_test_table);
+DELETE FROM users_test_table
+WHERE  user_id IN (SELECT user_id
+                   FROM events_test_table);
+DELETE FROM events_test_table_2
+WHERE now() > (SELECT max(date_col)
+               FROM test_table_1
+               WHERE test_table_1.id = events_test_table_2.user_id
+               GROUP BY id)
+RETURNING *;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       1 |       5 |       7 |       7
+       1 |      20 |      12 |      25
+       1 |      60 |      17 |      17
+(3 rows)
+
+UPDATE users_test_table
+SET    value_1 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id
+       AND events_test_table.user_id > 5;
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION
+              SELECT user_id
+              FROM   events_test_table);
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION
+              SELECT user_id
+              FROM   events_test_table) returning *;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       8 |       4 |      13 |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+       4 |       4 |       9 |       0
+       4 |       4 |      17 |       0
+      16 |       4 |         |       0
+       6 |       4 |      11 |       0
+       6 |       4 |      15 |       0
+       2 |       4 |       7 |       0
+       2 |       4 |      19 |       0
+(11 rows)
+
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION ALL
+              SELECT user_id
+              FROM   events_test_table) returning *;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       8 |       4 |      13 |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+       4 |       4 |       9 |       0
+       4 |       4 |      17 |       0
+      16 |       4 |         |       0
+       6 |       4 |      11 |       0
+       6 |       4 |      15 |       0
+       2 |       4 |       7 |       0
+       2 |       4 |      19 |       0
+(11 rows)
+
+UPDATE users_test_table
+SET value_1 = 5
+WHERE 
+  value_2 >  
+          (SELECT 
+              max(value_2) 
+           FROM 
+              events_test_table  
+           WHERE 
+              users_test_table.user_id = events_test_table.user_id
+           GROUP BY
+              user_id
+          );
+UPDATE users_test_table
+SET value_3 = 1
+WHERE 
+  value_2 >  
+          (SELECT 
+              max(value_2) 
+           FROM 
+              events_test_table 
+           WHERE 
+              users_test_table.user_id = events_test_table.user_id AND 
+              users_test_table.value_2 > events_test_table.value_2
+           GROUP BY
+              user_id
+          );
+UPDATE users_test_table
+SET value_2 = 4 
+WHERE
+  value_1 > 1 AND value_1 < 3
+  AND value_2 >= 1
+  AND user_id IN
+  (
+    SELECT
+      e1.user_id
+    FROM (
+      SELECT
+        user_id,
+        1 AS view_homepage
+      FROM events_test_table
+      WHERE
+         value_1 IN (0, 1)
+    ) e1 LEFT JOIN LATERAL (
+      SELECT
+        user_id,
+        1 AS use_demo
+      FROM events_test_table
+      WHERE
+        user_id = e1.user_id
+    ) e2 ON true
+);
+UPDATE users_test_table
+SET value_3 = 5
+WHERE value_2 IN (SELECT AVG(value_1) OVER (PARTITION BY user_id) FROM events_test_table WHERE events_test_table.user_id = users_test_table.user_id);
+-- Test it within transaction
+BEGIN;
+INSERT INTO users_test_table
+SELECT * FROM events_test_table
+WHERE events_test_table.user_id = 1 OR events_test_table.user_id = 5;
+SELECT SUM(value_2) FROM users_test_table;
+ sum 
+-----
+ 169
+(1 row)
+
+UPDATE users_test_table
+SET value_2 = 1
+FROM events_test_table
+WHERE users_test_table.user_id = events_test_table.user_id;
+SELECT SUM(value_2) FROM users_test_table;
+ sum 
+-----
+  97
+(1 row)
+
+COMMIT;
+-- Test with schema
+CREATE SCHEMA sec_schema;
+CREATE TABLE sec_schema.tt1(id int, value_1 int);
+SELECT create_distributed_table('sec_schema.tt1','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO sec_schema.tt1 values(1,1),(2,2),(7,7),(9,9);
+UPDATE sec_schema.tt1
+SET value_1 = 11
+WHERE id < (SELECT max(value_2) FROM events_test_table_2
+             WHERE sec_schema.tt1.id = events_test_table_2.user_id
+             GROUP BY user_id)
+RETURNING *;
+ id | value_1 
+----+---------
+  7 |      11
+  9 |      11
+(2 rows)
+
+DROP SCHEMA sec_schema CASCADE;
+NOTICE:  drop cascades to table sec_schema.tt1
+-- We don't need partition key equality with reference tables
+UPDATE events_test_table
+SET    value_2 = 5
+FROM   users_reference_copy_table
+WHERE  users_reference_copy_table.user_id = events_test_table.value_1;
+-- Both reference tables and hash distributed tables can be used in subquery
+UPDATE events_test_table as ett
+SET    value_2 = 6
+WHERE ett.value_3 IN (SELECT utt.value_3 
+                                    FROM users_test_table as utt, users_reference_copy_table as uct
+                                    WHERE utt.user_id = uct.user_id AND utt.user_id = ett.user_id);
+-- We don't need equality check with constant values in sub-select
+UPDATE users_reference_copy_table
+SET    value_2 = 6
+WHERE  user_id IN (SELECT 2);
+UPDATE users_reference_copy_table
+SET    value_2 = 6
+WHERE  value_1 IN (SELECT 2);
+UPDATE users_test_table
+SET    value_2 = 6
+WHERE  user_id IN (SELECT 2);
+UPDATE users_test_table
+SET    value_2 = 6
+WHERE  value_1 IN (SELECT 2);
+-- Can only use immutable functions
+UPDATE test_table_1
+SET    col_3 = 6
+WHERE  date_col IN (SELECT now());
+ERROR:  cannot push down this subquery
+DETAIL:  Subqueries without a FROM clause can only contain immutable functions
+-- Test with prepared statements
+SELECT COUNT(*) FROM users_test_table WHERE value_1 = 0;
+ count 
+-------
+     0
+(1 row)
+
+PREPARE foo_plan_2(int,int) AS UPDATE users_test_table
+                               SET value_1 = $1, value_3 = $2
+                               FROM events_test_table
+                               WHERE users_test_table.user_id = events_test_table.user_id;
+EXECUTE foo_plan_2(1,5);
+EXECUTE foo_plan_2(3,15);
+EXECUTE foo_plan_2(5,25);
+EXECUTE foo_plan_2(7,35);
+EXECUTE foo_plan_2(9,45);
+EXECUTE foo_plan_2(0,0);
+SELECT COUNT(*) FROM users_test_table WHERE value_1 = 0;
+ count 
+-------
+     6
+(1 row)
+
+-- Test with varying WHERE expressions
+UPDATE users_test_table
+SET value_1 = 7
+FROM events_test_table
+WHERE users_test_table.user_id = events_test_table.user_id OR FALSE;
+UPDATE users_test_table
+SET value_1 = 7
+FROM events_test_table
+WHERE users_test_table.user_id = events_test_table.user_id AND TRUE;
+-- Test with inactive shard-placement
+-- manually set shardstate of one placement of users_test_table as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1440000;
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+ERROR:  cannot find a worker that has active placements for all shards in the query
+-- manually set shardstate of one placement of events_test_table as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1440004;
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+ERROR:  cannot find a worker that has active placements for all shards in the query
+UPDATE pg_dist_shard_placement SET shardstate = 1 WHERE shardid = 1440000;
+UPDATE pg_dist_shard_placement SET shardstate = 1 WHERE shardid = 1440004;
+-- Subquery must return single value to use it with comparison operators
+UPDATE users_test_table as utt
+SET    value_1 = 3
+WHERE value_2 > (SELECT value_3 FROM events_test_table as ett WHERE utt.user_id = ett.user_id);
+ERROR:  more than one row returned by a subquery used as an expression
+CONTEXT:  while executing command on localhost:57637
+-- We can not pushdown a query if the target relation is reference table
+UPDATE users_reference_copy_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_reference_copy_table.user_id = events_test_table.user_id;
+ERROR:  only reference tables may be queried when targeting a reference table with multi shard UPDATE/DELETE queries with multiple tables 
+-- We cannot push down it if the query has outer join and using
+UPDATE events_test_table
+SET value_2 = users_test_table.user_id
+FROM users_test_table
+FULL OUTER JOIN events_test_table e2 USING (user_id)
+WHERE e2.user_id = events_test_table.user_id RETURNING events_test_table.value_2;
+ERROR:  a join with USING causes an internal naming conflict, use ON instead
+-- We can not pushdown query if there is no partition key equality
+UPDATE users_test_table
+SET    value_1 = 1
+WHERE  user_id IN (SELECT Count(value_1)
+              FROM   events_test_table
+              GROUP  BY user_id);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_1 = (SELECT Count(*)
+                  FROM   events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION
+              SELECT value_1
+              FROM   events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              INTERSECT
+              SELECT Sum(value_1)
+              FROM   events_test_table
+              GROUP  BY user_id);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_2 = (SELECT value_3
+                  FROM   users_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET value_2 = 2
+WHERE
+  value_2 >
+          (SELECT
+              max(value_2)
+           FROM
+              events_test_table
+           WHERE
+              users_test_table.user_id > events_test_table.user_id AND
+              users_test_table.value_1 = events_test_table.value_1
+           GROUP BY
+              user_id
+          );
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET (value_1, value_2) = (2,1)
+WHERE  user_id IN
+       (SELECT user_id
+        FROM   users_test_table
+        INTERSECT
+        SELECT user_id
+        FROM   events_test_table);
+ERROR:  cannot push down this subquery
+DETAIL:  Intersect and Except are currently unsupported
+-- Reference tables can not locate on the outer part of the outer join
+UPDATE users_test_table
+SET value_1 = 4
+WHERE user_id IN
+    (SELECT DISTINCT e2.user_id
+     FROM users_reference_copy_table
+     LEFT JOIN users_test_table e2 ON (e2.user_id = users_reference_copy_table.value_1)) RETURNING *;
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a reference table in the outer part of the outer join
+-- Volatile functions are also not supported
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id * random();
+ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
+UPDATE users_test_table
+SET    value_2 = 5 * random()
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+ERROR:  functions used in UPDATE queries on distributed tables must not be VOLATILE
+UPDATE users_test_table
+SET    value_2 = 5
+WHERE  users_test_table.user_id IN (SELECT user_id * random() FROM events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+-- Local tables are not supported
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table_local
+WHERE  users_test_table.user_id = events_test_table_local.user_id;
+ERROR:  relation events_test_table_local is not distributed
+UPDATE users_test_table
+SET    value_2 = 5
+WHERE  users_test_table.user_id IN(SELECT user_id FROM events_test_table_local);
+ERROR:  relation events_test_table_local is not distributed
+UPDATE events_test_table_local
+SET    value_2 = 5
+FROM   users_test_table
+WHERE  events_test_table_local.user_id = users_test_table.user_id;
+ERROR:  relation events_test_table_local is not distributed
+-- Shard counts of tables must be equal to pushdown the query
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table_2
+WHERE  users_test_table.user_id = events_test_table_2.user_id;
+ERROR:  cannot push down this subquery
+DETAIL:  Shards of relations in subquery need to have 1-to-1 shard partitioning
+-- Should error out due to multiple row return from subquery, but we can not get this information within 
+-- subquery pushdown planner. This query will be sent to worker with recursive planner.
+DELETE FROM users_test_table
+WHERE  users_test_table.user_id = (SELECT user_id
+                                   FROM   events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+-- Cursors are not supported
+BEGIN;
+DECLARE test_cursor CURSOR FOR SELECT * FROM users_test_table;
+FETCH test_cursor;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       8 |       4 |      13 |       0
+(1 row)
+
+UPDATE users_test_table SET value_2 = 5 WHERE CURRENT OF test_cursor;
+ERROR:  cannot run DML queries with cursors
+ROLLBACK;
+-- Stable functions are supported
 SELECT * FROM test_table_1;
  id |           date_col           | col_3 
 ----+------------------------------+-------
   1 | Sat Apr 05 08:32:12 2014 PDT |     5
-  3 | Wed Jan 12 08:35:19 2011 PST |     9
+  3 | Mon Jan 12 08:35:19 2111 PST |     9
   2 | Sun Feb 01 08:31:16 2015 PST |     7
 (3 rows)
 
@@ -374,15 +765,16 @@ SELECT * FROM test_table_1;
  id |           date_col           | col_3 
 ----+------------------------------+-------
   1 | Sat Apr 05 08:32:12 2014 PDT |     3
-  3 | Wed Jan 12 08:35:19 2011 PST |     3
+  3 | Mon Jan 12 08:35:19 2111 PST |     9
   2 | Sun Feb 01 08:31:16 2015 PST |     3
 (3 rows)
 
 DELETE FROM test_table_1 WHERE date_col < current_timestamp;
 SELECT * FROM test_table_1;
- id | date_col | col_3 
-----+----------+-------
-(0 rows)
+ id |           date_col           | col_3 
+----+------------------------------+-------
+  3 | Mon Jan 12 08:35:19 2111 PST |     9
+(1 row)
 
 DROP TABLE test_table_1;
 -- Volatile functions are not supported

--- a/src/test/regress/expected/multi_shard_update_delete_0.out
+++ b/src/test/regress/expected/multi_shard_update_delete_0.out
@@ -169,6 +169,10 @@ CREATE TABLE append_stage_table(id int, col_2 int);
 INSERT INTO append_stage_table VALUES(1,3);
 INSERT INTO append_stage_table VALUES(3,2);
 INSERT INTO append_stage_table VALUES(5,4);
+CREATE TABLE append_stage_table_2(id int, col_2 int);
+INSERT INTO append_stage_table_2 VALUES(8,3);
+INSERT INTO append_stage_table_2 VALUES(9,2);
+INSERT INTO append_stage_table_2 VALUES(10,4);
 CREATE TABLE test_append_table(id int, col_2 int);
 SELECT create_distributed_table('test_append_table','id','append');
  create_distributed_table 
@@ -194,7 +198,7 @@ SELECT master_create_empty_shard('test_append_table') AS new_shard_id;
       1440011
 (1 row)
 
-SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table', 'localhost', :master_port);
+SELECT * FROM master_append_table_to_shard(1440011, 'append_stage_table_2', 'localhost', :master_port);
  master_append_table_to_shard 
 ------------------------------
                    0.00533333
@@ -204,15 +208,16 @@ UPDATE test_append_table SET col_2 = 5;
 SELECT * FROM test_append_table;
  id | col_2 
 ----+-------
-  1 |     5
-  3 |     5
-  5 |     5
+  8 |     5
+  9 |     5
+ 10 |     5
   1 |     5
   3 |     5
   5 |     5
 (6 rows)
 
 DROP TABLE append_stage_table;
+DROP TABLE append_stage_table_2;
 DROP TABLE test_append_table;
 -- Update multi shard of partitioned distributed table
 SET citus.multi_shard_modify_mode to 'parallel';
@@ -340,43 +345,24 @@ UPDATE tt2 SET col_2 = 3 RETURNING id, col_2;
 (5 rows)
 
 DROP TABLE tt2;
--- Multiple RTEs are not supported
+-- Multiple RTEs are only supported if subquery is pushdownable
 SET citus.multi_shard_modify_mode to DEFAULT;
-UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id; 
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-UPDATE users_test_table SET value_2 = (SELECT value_3 FROM users_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-UPDATE users_test_table SET value_2 = (SELECT value_2 FROM events_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-DELETE FROM users_test_table USING events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-DELETE FROM users_test_table WHERE users_test_table.user_id = (SELECT user_id FROM events_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
-DELETE FROM users_test_table WHERE users_test_table.user_id = (SELECT value_1 FROM users_test_table);
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
--- Cursors are not supported
-BEGIN;
-DECLARE test_cursor CURSOR FOR SELECT * FROM users_test_table;
-FETCH test_cursor;
- user_id | value_1 | value_2 | value_3 
----------+---------+---------+---------
-       8 |       0 |      13 |       0
+-- To test colocation between tables in modify query
+SET citus.shard_count to 6;
+CREATE TABLE events_test_table_2 (user_id int, value_1 int, value_2 int, value_3 int);
+SELECT create_distributed_table('events_test_table_2', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
 (1 row)
 
-UPDATE users_test_table SET value_2 = 5 WHERE CURRENT OF test_cursor;
-ERROR:  cannot run DML queries with cursors
-ROLLBACK;
--- Stable functions are supported
+\COPY events_test_table_2 FROM STDIN DELIMITER AS ',';
+CREATE TABLE events_test_table_local (user_id int, value_1 int, value_2 int, value_3 int);
+\COPY events_test_table_local FROM STDIN DELIMITER AS ',';
 CREATE TABLE test_table_1(id int, date_col timestamptz, col_3 int);
 INSERT INTO test_table_1 VALUES(1, '2014-04-05 08:32:12', 5);
 INSERT INTO test_table_1 VALUES(2, '2015-02-01 08:31:16', 7);
-INSERT INTO test_table_1 VALUES(3, '2011-01-12 08:35:19', 9);
+INSERT INTO test_table_1 VALUES(3, '2111-01-12 08:35:19', 9);
 SELECT create_distributed_table('test_table_1', 'id');
 NOTICE:  Copying data from local table...
  create_distributed_table 
@@ -384,11 +370,416 @@ NOTICE:  Copying data from local table...
  
 (1 row)
 
+-- We can pushdown query if there is partition key equality
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+DELETE FROM users_test_table
+USING  events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+UPDATE users_test_table
+SET    value_1 = 3
+WHERE  user_id IN (SELECT user_id
+              FROM   events_test_table);
+DELETE FROM users_test_table
+WHERE  user_id IN (SELECT user_id
+                   FROM events_test_table);
+DELETE FROM events_test_table_2
+WHERE now() > (SELECT max(date_col)
+               FROM test_table_1
+               WHERE test_table_1.id = events_test_table_2.user_id
+               GROUP BY id)
+RETURNING *;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       1 |       5 |       7 |       7
+       1 |      20 |      12 |      25
+       1 |      60 |      17 |      17
+(3 rows)
+
+UPDATE users_test_table
+SET    value_1 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id
+       AND events_test_table.user_id > 5;
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION
+              SELECT user_id
+              FROM   events_test_table);
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION
+              SELECT user_id
+              FROM   events_test_table) returning *;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       8 |       4 |      13 |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+       4 |       4 |       9 |       0
+       4 |       4 |      17 |       0
+      16 |       4 |         |       0
+       6 |       4 |      11 |       0
+       6 |       4 |      15 |       0
+       2 |       4 |       7 |       0
+       2 |       4 |      19 |       0
+(11 rows)
+
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION ALL
+              SELECT user_id
+              FROM   events_test_table) returning *;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       8 |       4 |      13 |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+      20 |       4 |         |       0
+       4 |       4 |       9 |       0
+       4 |       4 |      17 |       0
+      16 |       4 |         |       0
+       6 |       4 |      11 |       0
+       6 |       4 |      15 |       0
+       2 |       4 |       7 |       0
+       2 |       4 |      19 |       0
+(11 rows)
+
+UPDATE users_test_table
+SET value_1 = 5
+WHERE 
+  value_2 >  
+          (SELECT 
+              max(value_2) 
+           FROM 
+              events_test_table  
+           WHERE 
+              users_test_table.user_id = events_test_table.user_id
+           GROUP BY
+              user_id
+          );
+UPDATE users_test_table
+SET value_3 = 1
+WHERE 
+  value_2 >  
+          (SELECT 
+              max(value_2) 
+           FROM 
+              events_test_table 
+           WHERE 
+              users_test_table.user_id = events_test_table.user_id AND 
+              users_test_table.value_2 > events_test_table.value_2
+           GROUP BY
+              user_id
+          );
+UPDATE users_test_table
+SET value_2 = 4 
+WHERE
+  value_1 > 1 AND value_1 < 3
+  AND value_2 >= 1
+  AND user_id IN
+  (
+    SELECT
+      e1.user_id
+    FROM (
+      SELECT
+        user_id,
+        1 AS view_homepage
+      FROM events_test_table
+      WHERE
+         value_1 IN (0, 1)
+    ) e1 LEFT JOIN LATERAL (
+      SELECT
+        user_id,
+        1 AS use_demo
+      FROM events_test_table
+      WHERE
+        user_id = e1.user_id
+    ) e2 ON true
+);
+UPDATE users_test_table
+SET value_3 = 5
+WHERE value_2 IN (SELECT AVG(value_1) OVER (PARTITION BY user_id) FROM events_test_table WHERE events_test_table.user_id = users_test_table.user_id);
+-- Test it within transaction
+BEGIN;
+INSERT INTO users_test_table
+SELECT * FROM events_test_table
+WHERE events_test_table.user_id = 1 OR events_test_table.user_id = 5;
+SELECT SUM(value_2) FROM users_test_table;
+ sum 
+-----
+ 169
+(1 row)
+
+UPDATE users_test_table
+SET value_2 = 1
+FROM events_test_table
+WHERE users_test_table.user_id = events_test_table.user_id;
+SELECT SUM(value_2) FROM users_test_table;
+ sum 
+-----
+  97
+(1 row)
+
+COMMIT;
+-- Test with schema
+CREATE SCHEMA sec_schema;
+CREATE TABLE sec_schema.tt1(id int, value_1 int);
+SELECT create_distributed_table('sec_schema.tt1','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO sec_schema.tt1 values(1,1),(2,2),(7,7),(9,9);
+UPDATE sec_schema.tt1
+SET value_1 = 11
+WHERE id < (SELECT max(value_2) FROM events_test_table_2
+             WHERE sec_schema.tt1.id = events_test_table_2.user_id
+             GROUP BY user_id)
+RETURNING *;
+ id | value_1 
+----+---------
+  7 |      11
+  9 |      11
+(2 rows)
+
+DROP SCHEMA sec_schema CASCADE;
+NOTICE:  drop cascades to table sec_schema.tt1
+-- We don't need partition key equality with reference tables
+UPDATE events_test_table
+SET    value_2 = 5
+FROM   users_reference_copy_table
+WHERE  users_reference_copy_table.user_id = events_test_table.value_1;
+-- Both reference tables and hash distributed tables can be used in subquery
+UPDATE events_test_table as ett
+SET    value_2 = 6
+WHERE ett.value_3 IN (SELECT utt.value_3 
+                                    FROM users_test_table as utt, users_reference_copy_table as uct
+                                    WHERE utt.user_id = uct.user_id AND utt.user_id = ett.user_id);
+-- We don't need equality check with constant values in sub-select
+UPDATE users_reference_copy_table
+SET    value_2 = 6
+WHERE  user_id IN (SELECT 2);
+UPDATE users_reference_copy_table
+SET    value_2 = 6
+WHERE  value_1 IN (SELECT 2);
+UPDATE users_test_table
+SET    value_2 = 6
+WHERE  user_id IN (SELECT 2);
+UPDATE users_test_table
+SET    value_2 = 6
+WHERE  value_1 IN (SELECT 2);
+-- Can only use immutable functions
+UPDATE test_table_1
+SET    col_3 = 6
+WHERE  date_col IN (SELECT now());
+ERROR:  cannot push down this subquery
+DETAIL:  Subqueries without a FROM clause can only contain immutable functions
+-- Test with prepared statements
+SELECT COUNT(*) FROM users_test_table WHERE value_1 = 0;
+ count 
+-------
+     0
+(1 row)
+
+PREPARE foo_plan_2(int,int) AS UPDATE users_test_table
+                               SET value_1 = $1, value_3 = $2
+                               FROM events_test_table
+                               WHERE users_test_table.user_id = events_test_table.user_id;
+EXECUTE foo_plan_2(1,5);
+EXECUTE foo_plan_2(3,15);
+EXECUTE foo_plan_2(5,25);
+EXECUTE foo_plan_2(7,35);
+EXECUTE foo_plan_2(9,45);
+EXECUTE foo_plan_2(0,0);
+SELECT COUNT(*) FROM users_test_table WHERE value_1 = 0;
+ count 
+-------
+     6
+(1 row)
+
+-- Test with varying WHERE expressions
+UPDATE users_test_table
+SET value_1 = 7
+FROM events_test_table
+WHERE users_test_table.user_id = events_test_table.user_id OR FALSE;
+UPDATE users_test_table
+SET value_1 = 7
+FROM events_test_table
+WHERE users_test_table.user_id = events_test_table.user_id AND TRUE;
+-- Test with inactive shard-placement
+-- manually set shardstate of one placement of users_test_table as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1440000;
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+ERROR:  cannot find a worker that has active placements for all shards in the query
+-- manually set shardstate of one placement of events_test_table as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1440004;
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+ERROR:  cannot find a worker that has active placements for all shards in the query
+UPDATE pg_dist_shard_placement SET shardstate = 1 WHERE shardid = 1440000;
+UPDATE pg_dist_shard_placement SET shardstate = 1 WHERE shardid = 1440004;
+-- Subquery must return single value to use it with comparison operators
+UPDATE users_test_table as utt
+SET    value_1 = 3
+WHERE value_2 > (SELECT value_3 FROM events_test_table as ett WHERE utt.user_id = ett.user_id);
+ERROR:  more than one row returned by a subquery used as an expression
+CONTEXT:  while executing command on localhost:57637
+-- We can not pushdown a query if the target relation is reference table
+UPDATE users_reference_copy_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_reference_copy_table.user_id = events_test_table.user_id;
+ERROR:  only reference tables may be queried when targeting a reference table with multi shard UPDATE/DELETE queries with multiple tables 
+-- We cannot push down it if the query has outer join and using
+UPDATE events_test_table
+SET value_2 = users_test_table.user_id
+FROM users_test_table
+FULL OUTER JOIN events_test_table e2 USING (user_id)
+WHERE e2.user_id = events_test_table.user_id RETURNING events_test_table.value_2;
+ERROR:  a join with USING causes an internal naming conflict, use ON instead
+-- We can not pushdown query if there is no partition key equality
+UPDATE users_test_table
+SET    value_1 = 1
+WHERE  user_id IN (SELECT Count(value_1)
+              FROM   events_test_table
+              GROUP  BY user_id);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_1 = (SELECT Count(*)
+                  FROM   events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              UNION
+              SELECT value_1
+              FROM   events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_1 = 4
+WHERE  user_id IN (SELECT user_id
+              FROM   users_test_table
+              INTERSECT
+              SELECT Sum(value_1)
+              FROM   events_test_table
+              GROUP  BY user_id);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET    value_2 = (SELECT value_3
+                  FROM   users_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET value_2 = 2
+WHERE
+  value_2 >
+          (SELECT
+              max(value_2)
+           FROM
+              events_test_table
+           WHERE
+              users_test_table.user_id > events_test_table.user_id AND
+              users_test_table.value_1 = events_test_table.value_1
+           GROUP BY
+              user_id
+          );
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+UPDATE users_test_table
+SET (value_1, value_2) = (2,1)
+WHERE  user_id IN
+       (SELECT user_id
+        FROM   users_test_table
+        INTERSECT
+        SELECT user_id
+        FROM   events_test_table);
+ERROR:  cannot push down this subquery
+DETAIL:  Intersect and Except are currently unsupported
+-- Reference tables can not locate on the outer part of the outer join
+UPDATE users_test_table
+SET value_1 = 4
+WHERE user_id IN
+    (SELECT DISTINCT e2.user_id
+     FROM users_reference_copy_table
+     LEFT JOIN users_test_table e2 ON (e2.user_id = users_reference_copy_table.value_1)) RETURNING *;
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a reference table in the outer part of the outer join
+-- Volatile functions are also not supported
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id * random();
+ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
+UPDATE users_test_table
+SET    value_2 = 5 * random()
+FROM   events_test_table
+WHERE  users_test_table.user_id = events_test_table.user_id;
+ERROR:  functions used in UPDATE queries on distributed tables must not be VOLATILE
+UPDATE users_test_table
+SET    value_2 = 5
+WHERE  users_test_table.user_id IN (SELECT user_id * random() FROM events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+-- Local tables are not supported
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table_local
+WHERE  users_test_table.user_id = events_test_table_local.user_id;
+ERROR:  relation events_test_table_local is not distributed
+UPDATE users_test_table
+SET    value_2 = 5
+WHERE  users_test_table.user_id IN(SELECT user_id FROM events_test_table_local);
+ERROR:  relation events_test_table_local is not distributed
+UPDATE events_test_table_local
+SET    value_2 = 5
+FROM   users_test_table
+WHERE  events_test_table_local.user_id = users_test_table.user_id;
+ERROR:  relation events_test_table_local is not distributed
+-- Shard counts of tables must be equal to pushdown the query
+UPDATE users_test_table
+SET    value_2 = 5
+FROM   events_test_table_2
+WHERE  users_test_table.user_id = events_test_table_2.user_id;
+ERROR:  cannot push down this subquery
+DETAIL:  Shards of relations in subquery need to have 1-to-1 shard partitioning
+-- Should error out due to multiple row return from subquery, but we can not get this information within 
+-- subquery pushdown planner. This query will be sent to worker with recursive planner.
+DELETE FROM users_test_table
+WHERE  users_test_table.user_id = (SELECT user_id
+                                   FROM   events_test_table);
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+-- Cursors are not supported
+BEGIN;
+DECLARE test_cursor CURSOR FOR SELECT * FROM users_test_table;
+FETCH test_cursor;
+ user_id | value_1 | value_2 | value_3 
+---------+---------+---------+---------
+       8 |       4 |      13 |       0
+(1 row)
+
+UPDATE users_test_table SET value_2 = 5 WHERE CURRENT OF test_cursor;
+ERROR:  cannot run DML queries with cursors
+ROLLBACK;
+-- Stable functions are supported
 SELECT * FROM test_table_1;
  id |           date_col           | col_3 
 ----+------------------------------+-------
   1 | Sat Apr 05 08:32:12 2014 PDT |     5
-  3 | Wed Jan 12 08:35:19 2011 PST |     9
+  3 | Mon Jan 12 08:35:19 2111 PST |     9
   2 | Sun Feb 01 08:31:16 2015 PST |     7
 (3 rows)
 
@@ -397,15 +788,16 @@ SELECT * FROM test_table_1;
  id |           date_col           | col_3 
 ----+------------------------------+-------
   1 | Sat Apr 05 08:32:12 2014 PDT |     3
-  3 | Wed Jan 12 08:35:19 2011 PST |     3
+  3 | Mon Jan 12 08:35:19 2111 PST |     9
   2 | Sun Feb 01 08:31:16 2015 PST |     3
 (3 rows)
 
 DELETE FROM test_table_1 WHERE date_col < current_timestamp;
 SELECT * FROM test_table_1;
- id | date_col | col_3 
-----+----------+-------
-(0 rows)
+ id |           date_col           | col_3 
+----+------------------------------+-------
+  3 | Mon Jan 12 08:35:19 2111 PST |     9
+(1 row)
 
 DROP TABLE test_table_1;
 -- Volatile functions are not supported

--- a/src/test/regress/expected/with_modifying.out
+++ b/src/test/regress/expected/with_modifying.out
@@ -378,6 +378,8 @@ raw_data AS (
 	DELETE FROM modify_table WHERE id >= (SELECT min(id) FROM select_data WHERE id > 10) RETURNING *
 )
 INSERT INTO summary_table SELECT id, COUNT(*) AS counter FROM raw_data GROUP BY id;
+ERROR:  cannot push down this subquery
+DETAIL:  Aggregates without group by are currently unsupported when a subquery references a column from another query
 INSERT INTO modify_table VALUES (21, 1), (22, 2), (23, 3);
 -- read ids from the same table
 WITH distinct_ids AS (
@@ -390,7 +392,7 @@ update_data AS (
 SELECT count(*) FROM update_data;
  count 
 -------
-     3
+     6
 (1 row)
 
 -- read ids from a different table
@@ -418,7 +420,7 @@ WITH update_data AS (
 SELECT COUNT(*) FROM update_data;
  count 
 -------
-     1
+     2
 (1 row)
 
 WITH delete_rows AS (
@@ -427,10 +429,13 @@ WITH delete_rows AS (
 SELECT * FROM delete_rows ORDER BY id, val;
  id | val 
 ----+-----
+ 11 | 100
+ 12 | 300
+ 13 | 100
  21 | 300
  22 | 200
  23 | 100
-(3 rows)
+(6 rows)
 
 WITH delete_rows AS (
 	DELETE FROM summary_table WHERE id > 10 RETURNING *
@@ -438,10 +443,7 @@ WITH delete_rows AS (
 SELECT * FROM delete_rows ORDER BY id, counter;
  id | counter 
 ----+---------
- 11 |       1
- 12 |       1
- 13 |       1
-(3 rows)
+(0 rows)
 
 -- Check modifiying CTEs inside a transaction
 BEGIN;
@@ -526,8 +528,11 @@ WITH deleted_rows AS (
 	DELETE FROM modify_table WHERE id IN (SELECT id FROM modify_table WHERE val = 4) RETURNING *
 )
 SELECT * FROM deleted_rows;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ id | val 
+----+-----
+  2 |   4
+(1 row)
+
 WITH select_rows AS (
 	SELECT id FROM modify_table WHERE val = 4
 ),
@@ -537,15 +542,13 @@ deleted_rows AS (
 SELECT * FROM deleted_rows;
  id | val 
 ----+-----
-  2 |   4
-(1 row)
+(0 rows)
 
 WITH deleted_rows AS (
 	DELETE FROM modify_table WHERE val IN (SELECT val FROM modify_table WHERE id = 3) RETURNING *
 )
 SELECT * FROM deleted_rows;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 WITH select_rows AS (
 	SELECT val FROM modify_table WHERE id = 3
 ),
@@ -562,8 +565,7 @@ WITH deleted_rows AS (
 	DELETE FROM modify_table WHERE ctid IN (SELECT ctid FROM modify_table WHERE id = 1) RETURNING *
 )
 SELECT * FROM deleted_rows;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 WITH select_rows AS (
 	SELECT ctid FROM modify_table WHERE id = 1
 ),
@@ -644,8 +646,7 @@ raw_data AS (
 	RETURNING id, val
 )
 SELECT * FROM raw_data ORDER BY val;
-ERROR:  cannot perform distributed planning for the given modification
-DETAIL:  Joins are not supported in distributed modifications.
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 -- Test with replication factor 2
 SET citus.shard_replication_factor to 2;
 DROP TABLE modify_table;

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -25,6 +25,7 @@ test: isolation_create_restore_point
 
 test: isolation_create_distributed_table isolation_master_append_table isolation_master_apply_delete
 test: isolation_multi_shard_modify_vs_all
+test: isolation_modify_with_subquery_vs_dml
 test: isolation_hash_copy_vs_all
 test: isolation_append_copy_vs_all
 test: isolation_range_copy_vs_all

--- a/src/test/regress/specs/isolation_modify_with_subquery_vs_dml.spec
+++ b/src/test/regress/specs/isolation_modify_with_subquery_vs_dml.spec
@@ -1,0 +1,91 @@
+setup
+{	
+	SET citus.shard_replication_factor to 2;
+
+	CREATE TABLE users_test_table(user_id int, value_1 int, value_2 int, value_3 int);
+	SELECT create_distributed_table('users_test_table', 'user_id');
+	INSERT INTO users_test_table VALUES
+	(1, 5, 6, 7),
+	(2, 12, 7, 18),
+	(3, 23, 8, 25),
+	(4, 42, 9, 23),
+	(5, 35, 10, 17),
+	(6, 21, 11, 25),
+	(7, 27, 12, 18);
+
+	CREATE TABLE events_test_table (user_id int, value_1 int, value_2 int, value_3 int);
+	SELECT create_distributed_table('events_test_table', 'user_id');
+	INSERT INTO events_test_table VALUES
+	(1, 5, 7, 7),
+	(3, 11, 78, 18),
+	(5, 22, 9, 25),
+	(7, 41, 10, 23),
+	(1, 20, 12, 25),
+	(3, 26, 13, 18),
+	(5, 17, 14, 4);
+}
+
+teardown
+{
+	DROP TABLE users_test_table;
+	DROP TABLE events_test_table;
+	SET citus.shard_replication_factor to 1;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-insert_to_events_test_table"
+{
+    INSERT INTO events_test_table VALUES(4,6,8,10);
+}
+
+step "s1-update_events_test_table"
+{
+	UPDATE users_test_table SET value_1 = 3;
+}
+
+step "s1-delete_events_test_table"
+{
+	DELETE FROM events_test_table WHERE user_id = 1 or user_id = 3;
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+	BEGIN;
+}
+
+step "s2-modify_with_subquery_v1"
+{
+    UPDATE users_test_table SET value_2 = 5 FROM events_test_table WHERE users_test_table.user_id = events_test_table.user_id;
+}
+
+step "s2-modify_with_subquery_v2" 
+{
+	UPDATE users_test_table SET value_1 = 3 WHERE user_id IN (SELECT user_id FROM events_test_table);
+}
+
+step "s2-commit"
+{
+	COMMIT;
+}
+
+# tests to check locks on subqueries are taken
+permutation "s1-begin" "s2-begin" "s2-modify_with_subquery_v1" "s1-insert_to_events_test_table" "s2-commit" "s1-commit"
+permutation "s1-begin" "s2-begin" "s2-modify_with_subquery_v1" "s1-update_events_test_table" "s2-commit" "s1-commit"
+permutation "s1-begin" "s2-begin" "s2-modify_with_subquery_v1" "s1-delete_events_test_table" "s2-commit" "s1-commit"
+permutation "s1-begin" "s2-begin" "s1-insert_to_events_test_table" "s2-modify_with_subquery_v1" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s1-update_events_test_table" "s2-modify_with_subquery_v1" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s1-delete_events_test_table" "s2-modify_with_subquery_v1" "s1-commit" "s2-commit"
+

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -392,9 +392,23 @@ EXPLAIN (COSTS FALSE)
 EXPLAIN (COSTS FALSE)
 	DELETE FROM lineitem_hash_part;
 
+SET citus.explain_all_tasks TO off;
+
+-- Test update with subquery
+EXPLAIN (COSTS FALSE)
+	UPDATE lineitem_hash_part
+	SET l_suppkey = 12
+	FROM orders_hash_part
+	WHERE orders_hash_part.o_orderkey = lineitem_hash_part.l_orderkey;
+
+-- Test delete with subquery
+EXPLAIN (COSTS FALSE)
+	DELETE FROM lineitem_hash_part
+	USING orders_hash_part
+	WHERE orders_hash_part.o_orderkey = lineitem_hash_part.l_orderkey;
+
 -- Test track tracker
 SET citus.task_executor_type TO 'task-tracker';
-SET citus.explain_all_tasks TO off;
 
 EXPLAIN (COSTS FALSE)
 	SELECT avg(l_linenumber) FROM lineitem WHERE l_orderkey > 9030;

--- a/src/test/regress/sql/with_modifying.sql
+++ b/src/test/regress/sql/with_modifying.sql
@@ -221,6 +221,7 @@ SELECT * FROM modify_table ORDER BY id, val;
 SELECT * FROM anchor_table ORDER BY id;
 
 INSERT INTO modify_table VALUES (11, 1), (12, 2), (13, 3);
+
 WITH select_data AS (
 	SELECT * FROM modify_table
 ),


### PR DESCRIPTION
DESCRIPTION: Adds support for pushdownable subqueries and joins in distributed UPDATE/DELETE

With this PR we begin to support modify queries with multiple range table entries if these queries are pushdownable. Following items have been implemented as part of the PR.

* Check whether the modify query with multiple range table entries is pushdownable in `ModifyQuerySupported` function.
* Use `QueryPushdownSqlTaskList` for modify queries with multiple range table entries. 
* Within `QueryPushdownTaskCreate`, set task's anchor shard id as the id of the target table to obtain the correct lock on relation and select tables.
* Change `insertSelectQuery` flag to `modifyMultipleTableQuery`. In addition to INSERT ... SELECT query, msud with multiple tables also access multiple table (We need to use that flag in `RequiresConsistentSnapshot` function)
* Modify queries with multiples RTEs will not be supported with `master_modify_multiple_shards` UDF.
* Instead of `RelationRestrictionContext`, `PlannerRestrictionContext` will be passed to `CreaterRouterPlan`, since we need to apply check over multiple tables for MSUD with multiple tables in the router planner path.