### PR TITLE
Don't copy utilityStmt into the incorrect memory context

### DIFF
--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1233,9 +1233,31 @@ SELECT copy_in_plpgsql();
  
 (1 row)
 
+-- test prepared COPY on a non-distributed table
+CREATE TABLE local_ddl (x int);
+CREATE OR REPLACE FUNCTION local_copy_in_plpgsql()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    COPY local_ddl (x) FROM PROGRAM 'echo 1' WITH CSV;
+END;
+$BODY$ LANGUAGE plpgsql;
+SELECT local_copy_in_plpgsql();
+ local_copy_in_plpgsql 
+-----------------------
+ 
+(1 row)
+
+SELECT local_copy_in_plpgsql();
+ local_copy_in_plpgsql 
+-----------------------
+ 
+(1 row)
+
 DROP FUNCTION ddl_in_plpgsql();
 DROP FUNCTION copy_in_plpgsql();
 DROP TABLE prepare_ddl;
+DROP TABLE local_ddl;
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();
 DROP FUNCTION plpgsql_test_2();

--- a/src/test/regress/sql/multi_prepare_plsql.sql
+++ b/src/test/regress/sql/multi_prepare_plsql.sql
@@ -563,9 +563,24 @@ $BODY$ LANGUAGE plpgsql;
 SELECT copy_in_plpgsql();
 SELECT copy_in_plpgsql();
 
+-- test prepared COPY on a non-distributed table
+CREATE TABLE local_ddl (x int);
+
+CREATE OR REPLACE FUNCTION local_copy_in_plpgsql()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    COPY local_ddl (x) FROM PROGRAM 'echo 1' WITH CSV;
+END;
+$BODY$ LANGUAGE plpgsql;
+
+SELECT local_copy_in_plpgsql();
+SELECT local_copy_in_plpgsql();
+
 DROP FUNCTION ddl_in_plpgsql();
 DROP FUNCTION copy_in_plpgsql();
 DROP TABLE prepare_ddl;
+DROP TABLE local_ddl;
 
 -- clean-up functions
 DROP FUNCTION plpgsql_test_1();


### PR DESCRIPTION
While working on #2119 I discovered #2127, `plpgsql` functions which call `COPY` fail on the second invocation. There's a full explanation in #2127, but the important part is that we `copyObject` into a memory context which gets thrown away. This PR removes the copy.

I don't think this is the right solution. I wonder if you have any feedback which could point me to the correct solution. Some ideas I've come up with:
1. Also remove [the other copy](https://github.com/citusdata/citus/commit/853f07dd33fbe8c243337c663025714022c61e82#diff-a8033caa333591e68f4fb7a599757296R279) which was introduced with this one. It's not a bad thing that we scribble on the parsetree we're given.
2. Somehow figure out which memory context `pstmt` is in, and `copyObject` into that context.
3. Detect when we're inside SPI, or otherwise working with cached plans, and copy into `CacheMemoryContext`.

(2) seems like the best solution, but I'm not sure it's possible.
 