### PR TITLE
Ensure sigle-shard modifying CTEs are part of distributed transaction

### DIFF
--- a/src/backend/distributed/executor/subplan_execution.c
+++ b/src/backend/distributed/executor/subplan_execution.c
@@ -15,6 +15,7 @@
 #include "distributed/multi_physical_planner.h"
 #include "distributed/recursive_planning.h"
 #include "distributed/subplan_execution.h"
+#include "distributed/transaction_management.h"
 #include "distributed/worker_manager.h"
 #include "executor/executor.h"
 
@@ -42,6 +43,14 @@ ExecuteSubPlans(DistributedPlan *distributedPlan)
 		/* no subplans to execute */
 		return;
 	}
+
+	/*
+	 * Make sure that this transaction has a distributed transaction ID.
+	 *
+	 * Intermediate results of subplans will be stored in a directory that is
+	 * derived from the distributed transaction ID.
+	 */
+	BeginOrContinueCoordinatedTransaction();
 
 	nodeList = ActiveReadableNodeList();
 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -297,6 +297,16 @@ ERROR:  relation bidders is not distributed
 -- commands containing a CTE are supported
 WITH new_orders AS (INSERT INTO limit_orders VALUES (411, 'FLO', 12, '2017-07-02 16:32:15', 'buy', 66))
 DELETE FROM limit_orders WHERE id < 0;
+-- we have to be careful that modifying CTEs are part of the transaction and can thus roll back
+WITH new_orders AS (INSERT INTO limit_orders VALUES (412, 'FLO', 12, '2017-07-02 16:32:15', 'buy', 66))
+DELETE FROM limit_orders RETURNING id / 0;
+ERROR:  division by zero
+CONTEXT:  while executing command on localhost:57638
+SELECT * FROM limit_orders WHERE id = 412;
+ id | symbol | bidder_id | placed_at | kind | limit_price 
+----+--------+-----------+-----------+------+-------------
+(0 rows)
+
 INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell', 20.69);
 -- simple UPDATE
 UPDATE limit_orders SET symbol = 'GM' WHERE id = 246;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -201,6 +201,11 @@ DELETE FROM limit_orders USING bidders WHERE limit_orders.id = 246 AND
 WITH new_orders AS (INSERT INTO limit_orders VALUES (411, 'FLO', 12, '2017-07-02 16:32:15', 'buy', 66))
 DELETE FROM limit_orders WHERE id < 0;
 
+-- we have to be careful that modifying CTEs are part of the transaction and can thus roll back
+WITH new_orders AS (INSERT INTO limit_orders VALUES (412, 'FLO', 12, '2017-07-02 16:32:15', 'buy', 66))
+DELETE FROM limit_orders RETURNING id / 0;
+SELECT * FROM limit_orders WHERE id = 412;
+
 INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell', 20.69);
 
 -- simple UPDATE


### PR DESCRIPTION
Router plannable (single-shard) modifying CTEs might not open a transaction block because the command is executed before the `RemoteFileDestReceiverStartup` function is called. This could lead the modifying CTE to commit while the transaction rolls back. Fix this by moving the call to `BeginOrContinueCoordinatedTransaction` into `CreateRemoteFileDestReceiver`, which is called before we go into the executor.