### PR TITLE
valgrind tests fix

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -818,8 +818,7 @@ DefaultCitusNoticeProcessor(void *arg, const char *message)
 	MultiConnection *connection = (MultiConnection *) arg;
 	char *nodeName = connection->hostname;
 	uint32 nodePort = connection->port;
-	char *chompedMessage = pchomp(message);
-	char *trimmedMessage = TrimLogLevel(chompedMessage);
+	char *trimmedMessage = TrimLogLevel(message);
 	char *level = strtok((char *) message, ":");
 
 	ereport(CitusNoticeLogLevel, (errmsg("%s", trimmedMessage),
@@ -829,7 +828,7 @@ DefaultCitusNoticeProcessor(void *arg, const char *message)
 
 
 /*
- * TrimLogLevel makes a copy of the string with the leading log level
+ * TrimLogLevel returns a copy of the string with the leading log level
  * and spaces removed such as
  *      From:
  *          INFO:  "normal2_102070": scanned 0 of 0 pages...
@@ -839,17 +838,18 @@ DefaultCitusNoticeProcessor(void *arg, const char *message)
 char *
 TrimLogLevel(const char *message)
 {
+	char *chompedMessage = pchomp(message);
 	size_t n;
 
 	n = 0;
-	while (n < strlen(message) && message[n] != ':')
+	while (n < strlen(chompedMessage) && chompedMessage[n] != ':')
 	{
 		n++;
 	}
 
 	do {
 		n++;
-	} while (n < strlen(message) && message[n] == ' ');
+	} while (n < strlen(chompedMessage) && chompedMessage[n] == ' ');
 
-	return pstrdup(message + n);
+	return chompedMessage + n;
 }


### PR DESCRIPTION
This PR fixes a Valgrind detected error. In terms of user experience, it shouldn't do any harm but better to be on the safe side. The error trace is the following;
```
==2059== VALGRINDERROR-BEGIN
==2059== Invalid read of size 1
==2059==    at 0x88AF9E: MemoryContextStrdup (mcxt.c:1067)
==2059==    by 0x88AFDC: pstrdup (mcxt.c:1079)
==2059==    by 0x5F5FBCF: TrimLogLevel (connection_management.c:854)
==2059==    by 0x5F5FBFB: DefaultCitusNoticeProcessor (connection_management.c:822)
==2059==    by 0x6471C4A: defaultNoticeReceiver (fe-connect.c:6309)
==2059==    by 0x6478544: pqInternalNotice (fe-exec.c:863)
==2059==    by 0x64789C7: check_tuple_field_number (fe-exec.c:2775)
==2059==    by 0x647ADE4: PQgetisnull (fe-exec.c:3145)
==2059==    by 0x5F6F882: EvaluateQueryResult (master_citus_tools.c:415)
==2059==    by 0x5F6F975: GetConnectionStatusAndResult (master_citus_tools.c:366)
==2059==    by 0x5F6FB52: ExecuteCommandsInParallelAndStoreResults (master_citus_tools.c:300)
==2059==    by 0x5F7003E: master_run_on_worker (master_citus_tools.c:133)
==2059==  Address 0x16757cbb is 9,755 bytes inside a block of size 16,384 alloc'd
==2059==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x883753: AllocSetAlloc (aset.c:760)
==2059==    by 0x88A21E: palloc (mcxt.c:862)
==2059==    by 0x614D73: ExprEvalPushStep (execExpr.c:2048)
==2059==    by 0x615074: ExecInitExprRec (execExpr.c:670)
==2059==    by 0x616EE2: ExecInitExpr (execExpr.c:130)
==2059==    by 0x614EEA: ExecInitExprList (execExpr.c:275)
==2059==    by 0x6251E3: ExecInitTableFunctionResult (execSRF.c:79)
==2059==    by 0x631332: ExecInitFunctionScan (nodeFunctionscan.c:364)
==2059==    by 0x6231FE: ExecInitNode (execProcnode.c:247)
==2059==    by 0x620079: InitPlan (execMain.c:1045)
==2059==    by 0x620299: standard_ExecutorStart (execMain.c:264)
==2059== 
==2059== VALGRINDERROR-END
==2059== VALGRINDERROR-BEGIN
==2059== Source and destination overlap in memcpy(0x16757cf0, 0x16757cbb, 1086)
==2059==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x88AFC1: memcpy (string3.h:53)
==2059==    by 0x88AFC1: MemoryContextStrdup (mcxt.c:1071)
==2059==    by 0x88AFDC: pstrdup (mcxt.c:1079)
==2059==    by 0x5F5FBCF: TrimLogLevel (connection_management.c:854)
==2059==    by 0x5F5FBFB: DefaultCitusNoticeProcessor (connection_management.c:822)
==2059==    by 0x6471C4A: defaultNoticeReceiver (fe-connect.c:6309)
==2059==    by 0x6478544: pqInternalNotice (fe-exec.c:863)
==2059==    by 0x64789C7: check_tuple_field_number (fe-exec.c:2775)
==2059==    by 0x647ADE4: PQgetisnull (fe-exec.c:3145)
==2059==    by 0x5F6F882: EvaluateQueryResult (master_citus_tools.c:415)
==2059==    by 0x5F6F975: GetConnectionStatusAndResult (master_citus_tools.c:366)
==2059==    by 0x5F6FB52: ExecuteCommandsInParallelAndStoreResults (master_citus_tools.c:300)
==2059== 
==2059== VALGRINDERROR-END
==2059== VALGRINDERROR-BEGIN
==2059== Invalid read of size 1
==2059==    at 0x4C32654: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x88AFC1: memcpy (string3.h:53)
==2059==    by 0x88AFC1: MemoryContextStrdup (mcxt.c:1071)
==2059==    by 0x88AFDC: pstrdup (mcxt.c:1079)
==2059==    by 0x5F5FBCF: TrimLogLevel (connection_management.c:854)
==2059==    by 0x5F5FBFB: DefaultCitusNoticeProcessor (connection_management.c:822)
==2059==    by 0x6471C4A: defaultNoticeReceiver (fe-connect.c:6309)
==2059==    by 0x6478544: pqInternalNotice (fe-exec.c:863)
==2059==    by 0x64789C7: check_tuple_field_number (fe-exec.c:2775)
==2059==    by 0x647ADE4: PQgetisnull (fe-exec.c:3145)
==2059==    by 0x5F6F882: EvaluateQueryResult (master_citus_tools.c:415)
==2059==    by 0x5F6F975: GetConnectionStatusAndResult (master_citus_tools.c:366)
==2059==    by 0x5F6FB52: ExecuteCommandsInParallelAndStoreResults (master_citus_tools.c:300)
==2059==  Address 0x16757ce7 is 9,799 bytes inside a block of size 16,384 alloc'd
==2059==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x883753: AllocSetAlloc (aset.c:760)
==2059==    by 0x88A21E: palloc (mcxt.c:862)
==2059==    by 0x614D73: ExprEvalPushStep (execExpr.c:2048)
==2059==    by 0x615074: ExecInitExprRec (execExpr.c:670)
==2059==    by 0x616EE2: ExecInitExpr (execExpr.c:130)
==2059==    by 0x614EEA: ExecInitExprList (execExpr.c:275)
==2059==    by 0x6251E3: ExecInitTableFunctionResult (execSRF.c:79)
==2059==    by 0x631332: ExecInitFunctionScan (nodeFunctionscan.c:364)
==2059==    by 0x6231FE: ExecInitNode (execProcnode.c:247)
==2059==    by 0x620079: InitPlan (execMain.c:1045)
==2059==    by 0x620299: standard_ExecutorStart (execMain.c:264)
==2059== 
==2059== VALGRINDERROR-END
==2059== VALGRINDERROR-BEGIN
==2059== Invalid read of size 1
==2059==    at 0x4C32758: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x88AFC1: memcpy (string3.h:53)
==2059==    by 0x88AFC1: MemoryContextStrdup (mcxt.c:1071)
==2059==    by 0x88AFDC: pstrdup (mcxt.c:1079)
==2059==    by 0x5F5FBCF: TrimLogLevel (connection_management.c:854)
==2059==    by 0x5F5FBFB: DefaultCitusNoticeProcessor (connection_management.c:822)
==2059==    by 0x6471C4A: defaultNoticeReceiver (fe-connect.c:6309)
==2059==    by 0x6478544: pqInternalNotice (fe-exec.c:863)
==2059==    by 0x64789C7: check_tuple_field_number (fe-exec.c:2775)
==2059==    by 0x647ADE4: PQgetisnull (fe-exec.c:3145)
==2059==    by 0x5F6F882: EvaluateQueryResult (master_citus_tools.c:415)
==2059==    by 0x5F6F975: GetConnectionStatusAndResult (master_citus_tools.c:366)
==2059==    by 0x5F6FB52: ExecuteCommandsInParallelAndStoreResults (master_citus_tools.c:300)
==2059==  Address 0x1675852b is 11,915 bytes inside a block of size 16,384 alloc'd
==2059==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x883753: AllocSetAlloc (aset.c:760)
==2059==    by 0x88A21E: palloc (mcxt.c:862)
==2059==    by 0x614D73: ExprEvalPushStep (execExpr.c:2048)
==2059==    by 0x615074: ExecInitExprRec (execExpr.c:670)
==2059==    by 0x616EE2: ExecInitExpr (execExpr.c:130)
==2059==    by 0x614EEA: ExecInitExprList (execExpr.c:275)
==2059==    by 0x6251E3: ExecInitTableFunctionResult (execSRF.c:79)
==2059==    by 0x631332: ExecInitFunctionScan (nodeFunctionscan.c:364)
==2059==    by 0x6231FE: ExecInitNode (execProcnode.c:247)
==2059==    by 0x620079: InitPlan (execMain.c:1045)
==2059==    by 0x620299: standard_ExecutorStart (execMain.c:264)
==2059== 
==2059== VALGRINDERROR-END
==2059== VALGRINDERROR-BEGIN
==2059== Invalid read of size 1
==2059==    at 0x4C32766: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x88AFC1: memcpy (string3.h:53)
==2059==    by 0x88AFC1: MemoryContextStrdup (mcxt.c:1071)
==2059==    by 0x88AFDC: pstrdup (mcxt.c:1079)
==2059==    by 0x5F5FBCF: TrimLogLevel (connection_management.c:854)
==2059==    by 0x5F5FBFB: DefaultCitusNoticeProcessor (connection_management.c:822)
==2059==    by 0x6471C4A: defaultNoticeReceiver (fe-connect.c:6309)
==2059==    by 0x6478544: pqInternalNotice (fe-exec.c:863)
==2059==    by 0x64789C7: check_tuple_field_number (fe-exec.c:2775)
==2059==    by 0x647ADE4: PQgetisnull (fe-exec.c:3145)
==2059==    by 0x5F6F882: EvaluateQueryResult (master_citus_tools.c:415)
==2059==    by 0x5F6F975: GetConnectionStatusAndResult (master_citus_tools.c:366)
==2059==    by 0x5F6FB52: ExecuteCommandsInParallelAndStoreResults (master_citus_tools.c:300)
==2059==  Address 0x1675852d is 11,917 bytes inside a block of size 16,384 alloc'd
==2059==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2059==    by 0x883753: AllocSetAlloc (aset.c:760)
==2059==    by 0x88A21E: palloc (mcxt.c:862)
==2059==    by 0x614D73: ExprEvalPushStep (execExpr.c:2048)
==2059==    by 0x615074: ExecInitExprRec (execExpr.c:670)
==2059==    by 0x616EE2: ExecInitExpr (execExpr.c:130)
==2059==    by 0x614EEA: ExecInitExprList (execExpr.c:275)
==2059==    by 0x6251E3: ExecInitTableFunctionResult (execSRF.c:79)
==2059==    by 0x631332: ExecInitFunctionScan (nodeFunctionscan.c:364)
==2059==    by 0x6231FE: ExecInitNode (execProcnode.c:247)
==2059==    by 0x620079: InitPlan (execMain.c:1045)
==2059==    by 0x620299: standard_ExecutorStart (execMain.c:264)
==2059== 
==2059== VALGRINDERROR-END
```