### PR TITLE
Throw an error if placements cannot be found in router executor

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -628,6 +628,13 @@ ExecuteSingleSelectTask(CitusScanState *scanState, Task *task)
 			placementAccessList = list_make1(placementAccess);
 		}
 
+		if (placementAccessList == NIL)
+		{
+			ereport(ERROR, (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							errmsg("a placement was moved after the SELECT was "
+								   "planned")));
+		}
+
 		connection = GetPlacementListConnection(connectionFlags, placementAccessList,
 												NULL);
 


### PR DESCRIPTION
It seems the router executor has the same issue as the real-time executor when the placement metadata changes in between planning and execution. 

I used a serialisation error here to signal to the client that it should retry. We did this previously for writes if a rebalance was ongoing:
https://github.com/citusdata/citus/blob/release-6.0/src/backend/distributed/executor/multi_router_executor.c#L229

The more permanent fix is to take metadata locks prior to looking up placement metadata (#1983) and to only look up placement metadata the executor as we did for writes, but that's more involved.

Fixes #2156 