### PR TITLE
Run recursive_dml_queries_mx test on its own

### DIFF
--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -23,7 +23,8 @@ test: multi_mx_copy_data multi_mx_router_planner
 test: multi_mx_schema_support multi_mx_tpch_query1 multi_mx_tpch_query10
 test: multi_mx_tpch_query12 multi_mx_tpch_query14 multi_mx_tpch_query19
 test: multi_mx_tpch_query3 multi_mx_tpch_query6 multi_mx_tpch_query7
-test: multi_mx_tpch_query7_nested multi_mx_ddl recursive_dml_queries_mx
+test: multi_mx_tpch_query7_nested multi_mx_ddl
+test: recursive_dml_queries_mx
 test: multi_mx_repartition_udt_prepare
 test: multi_mx_repartition_join_w1 multi_mx_repartition_join_w2 multi_mx_repartition_udt_w1 multi_mx_repartition_udt_w2
 test: multi_mx_metadata 


### PR DESCRIPTION
We keep getting some Travis errors where `multi_mx_ddl` queries a table from `information_schema` and then tries to resolve a table name in the `recursive_dml_queries_mx` schema, but by the time it does the schema is already dropped.