### PR TITLE
Move call to RemoveIntermediateResultsDirectory

### DIFF
--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -159,7 +159,6 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			 * transaction management. Do so before doing other work, so the
 			 * callbacks still can perform work if needed.
 			 */
-			RemoveIntermediateResultsDirectory();
 			ResetShardPlacementTransactionState();
 
 			if (CurrentCoordinatedTransactionState == COORD_TRANS_PREPARED)
@@ -256,6 +255,8 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 
 		case XACT_EVENT_PRE_COMMIT:
 		{
+			RemoveIntermediateResultsDirectory();
+
 			/* nothing further to do if there's no managed remote xacts */
 			if (CurrentCoordinatedTransactionState == COORD_TRANS_NONE)
 			{


### PR DESCRIPTION
Errors thrown in the COMMIT handler will cause Postgres to abort,
there's nothing it can do it abort the transaction by the time that
handler is called!

`RemoveIntermediateResultsDirectory` is problematic for two reasons:
- It has calls to ereport(ERROR which have been known to trigger
- It makes memory allocations which raise ERRORs when they fail

Once the COMMIT process has begun we don't use the intermediate results,
so it's safe to remove them a little earlier in the process. A failure
here will abort the transaction. That's pretty unnecessary, it's not
that important that we remove the results, but it's still better than a
crash.

(Meant to address https://github.com/citusdata/citus-enterprise/issues/231 and https://github.com/citusdata/citus/issues/2086)