### PR TITLE
Add a debug message with distribution column value

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -438,6 +438,7 @@ CitusModifyBeginScan(CustomScanState *node, EState *estate, int eflags)
 			}
 
 			workerJob->taskList = taskList;
+			workerJob->partitionValueConst = ExtractInsertPartitionValueConst(jobQuery);
 		}
 
 		RebuildQueryStrings(jobQuery, taskList);

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -172,7 +172,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	restrictClauseList = WhereClauseList(modifyQuery->jointree);
 
 	prunedShardIntervalList =
-		PruneShards(relationId, tableId, restrictClauseList);
+		PruneShards(relationId, tableId, restrictClauseList, NULL);
 
 	CHECK_FOR_INTERRUPTS();
 

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -507,7 +507,7 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 	planningError = PlanRouterQuery(copiedSubquery, copyOfPlannerRestrictionContext,
 									&selectPlacementList, &selectAnchorShardId,
 									&relationShardList, replacePrunedQueryWithDummy,
-									&multiShardModifyQuery);
+									&multiShardModifyQuery, NULL);
 
 	Assert(!multiShardModifyQuery);
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2004,7 +2004,8 @@ BuildJobTreeTaskList(Job *jobTree, PlannerRestrictionContext *plannerRestriction
 																		 ->
 																		 relationRestrictionContext,
 																		 &
-																		 isMultiShardQuery);
+																		 isMultiShardQuery,
+																		 NULL);
 			sqlTaskList = QueryPushdownSqlTaskList(job->jobQuery, job->jobId,
 												   plannerRestrictionContext->
 												   relationRestrictionContext,
@@ -2929,7 +2930,7 @@ RangeTableFragmentsList(List *rangeTableList, List *whereClauseList,
 			ListCell *shardIntervalCell = NULL;
 			List *shardFragmentList = NIL;
 			List *prunedShardIntervalList = PruneShards(relationId, tableId,
-														whereClauseList);
+														whereClauseList, NULL);
 
 			/*
 			 * If we prune all shards for one table, query results will be empty.

--- a/src/backend/distributed/test/prune_shard_list.c
+++ b/src/backend/distributed/test/prune_shard_list.c
@@ -208,7 +208,7 @@ PrunedShardIdsForTable(Oid distributedTableId, List *whereClauseList)
 	int shardIdCount = -1;
 	Datum *shardIdDatumArray = NULL;
 
-	shardList = PruneShards(distributedTableId, tableId, whereClauseList);
+	shardList = PruneShards(distributedTableId, tableId, whereClauseList, NULL);
 
 	shardIdCount = list_length(shardList);
 	shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -84,6 +84,7 @@ copyJobInfo(Job *newnode, Job *from)
 	COPY_SCALAR_FIELD(subqueryPushdown);
 	COPY_SCALAR_FIELD(requiresMasterEvaluation);
 	COPY_SCALAR_FIELD(deferredPruning);
+	COPY_NODE_FIELD(partitionValueConst);
 }
 
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -319,6 +319,7 @@ OutJobFields(StringInfo str, const Job *node)
 	WRITE_BOOL_FIELD(subqueryPushdown);
 	WRITE_BOOL_FIELD(requiresMasterEvaluation);
 	WRITE_BOOL_FIELD(deferredPruning);
+	WRITE_NODE_FIELD(partitionValueConst);
 }
 
 

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -181,6 +181,7 @@ readJobInfo(Job *local_node)
 	READ_BOOL_FIELD(subqueryPushdown);
 	READ_BOOL_FIELD(requiresMasterEvaluation);
 	READ_BOOL_FIELD(deferredPruning);
+	READ_NODE_FIELD(partitionValueConst);
 }
 
 

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -127,6 +127,7 @@ typedef struct Job
 	bool subqueryPushdown;
 	bool requiresMasterEvaluation; /* only applies to modify jobs */
 	bool deferredPruning;
+	Const *partitionValueConst;
 } Job;
 
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -38,11 +38,14 @@ extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
 											  List **placementList, uint64 *anchorShardId,
 											  List **relationShardList, bool
 											  replacePrunedQueryWithDummy,
-											  bool *multiShardModifyQuery);
+											  bool *multiShardModifyQuery,
+											  Const **partitionValueConst);
 extern List * RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError);
+extern Const * ExtractInsertPartitionValueConst(Query *query);
 extern List * TargetShardIntervalsForQuery(Query *query,
 										   RelationRestrictionContext *restrictionContext,
-										   bool *multiShardQuery);
+										   bool *multiShardQuery,
+										   Const **partitionValueConst);
 extern List * WorkersContainingAllShards(List *prunedShardIntervalsList);
 extern List * IntersectPlacementList(List *lhsPlacementList, List *rhsPlacementList);
 extern DeferredErrorMessage * ModifyQuerySupported(Query *queryTree, Query *originalQuery,

--- a/src/include/distributed/shard_pruning.h
+++ b/src/include/distributed/shard_pruning.h
@@ -17,7 +17,8 @@
 #define INVALID_SHARD_INDEX -1
 
 /* Function declarations for shard pruning */
-extern List * PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList);
+extern List * PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
+						  Const **partitionValueConst);
 extern bool ContainsFalseClause(List *whereClauseList);
 
 #endif /* SHARD_PRUNING_H_ */

--- a/src/test/regress/expected/multi_hash_pruning.out
+++ b/src/test/regress/expected/multi_hash_pruning.out
@@ -37,6 +37,7 @@ SELECT count(*) FROM orders_hash_partitioned;
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count 
 -------
      0
@@ -45,6 +46,7 @@ DEBUG:  Plan is router executable
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
  count 
 -------
      0
@@ -53,6 +55,7 @@ DEBUG:  Plan is router executable
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
  count 
 -------
      0
@@ -61,6 +64,7 @@ DEBUG:  Plan is router executable
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = 4;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 4
  count 
 -------
      0
@@ -70,6 +74,7 @@ SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = 1 AND o_clerk = 'aaa';
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count 
 -------
      0
@@ -78,6 +83,7 @@ DEBUG:  Plan is router executable
 SELECT count(*) FROM orders_hash_partitioned WHERE o_orderkey = abs(-1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count 
 -------
      0
@@ -179,6 +185,7 @@ SELECT count(*) FROM
        (SELECT o_orderkey FROM orders_hash_partitioned WHERE o_orderkey = 1) AS orderkeys;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count 
 -------
      0
@@ -322,6 +329,7 @@ SELECT count(*) FROM orders_hash_partitioned
 	WHERE o_orderkey = random() AND o_orderkey = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count 
 -------
      0
@@ -355,6 +363,7 @@ SELECT count(*)
 	AND orders2.o_orderkey is NULL;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count 
 -------
      0

--- a/src/test/regress/expected/multi_mx_router_planner.out
+++ b/src/test/regress/expected/multi_mx_router_planner.out
@@ -67,6 +67,7 @@ DEBUG:  Plan is router executable
 SELECT * FROM articles_hash_mx WHERE author_id = 10 AND id = 50;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  id | author_id |   title   | word_count 
 ----+-----------+-----------+------------
  50 |        10 | anjanette |      19519
@@ -76,6 +77,7 @@ DEBUG:  Plan is router executable
 SELECT title FROM articles_hash_mx WHERE author_id = 10;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
    title    
 ------------
  aggrandize
@@ -91,6 +93,7 @@ SELECT title, word_count FROM articles_hash_mx
 	ORDER BY word_count DESC NULLS LAST;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
    title    | word_count 
 ------------+------------
  anjanette  |      19519
@@ -107,6 +110,7 @@ SELECT title, id FROM articles_hash_mx
 	LIMIT 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
   title  | id 
 ---------+----
  aruru   |  5
@@ -178,6 +182,7 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash_mx
 	ORDER BY sum(word_count) DESC;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  author_id | corpus_size 
 -----------+-------------
          1 |       35894
@@ -217,6 +222,7 @@ WITH first_author AS ( SELECT id FROM articles_hash_mx WHERE author_id = 1)
 SELECT * FROM first_author;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -231,6 +237,7 @@ WITH first_author AS ( SELECT id FROM articles_hash_mx WHERE author_id = 1)
 SELECT title FROM articles_hash_mx WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
     title     
 --------------
  arsenous
@@ -246,6 +253,7 @@ id_title AS (SELECT id, title from articles_hash_mx WHERE author_id = 1)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | id |    title     
 ----+-----------+----+--------------
   1 |         1 |  1 | arsenous
@@ -271,9 +279,11 @@ SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
 DEBUG:  generating subplan 66_1 for CTE id_author: SELECT id, author_id FROM public.articles_hash_mx WHERE (author_id OPERATOR(pg_catalog.=) 1)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 DEBUG:  generating subplan 66_2 for CTE id_title: SELECT id, title FROM public.articles_hash_mx WHERE (author_id OPERATOR(pg_catalog.=) 2)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
 DEBUG:  Plan 66 query after replacing subqueries and CTEs: SELECT id_author.id, id_author.author_id, id_title.id, id_title.title FROM (SELECT intermediate_result.id, intermediate_result.author_id FROM read_intermediate_result('66_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, author_id bigint)) id_author, (SELECT intermediate_result.id, intermediate_result.title FROM read_intermediate_result('66_2'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, title character varying(20))) id_title WHERE (id_author.id OPERATOR(pg_catalog.=) id_title.id)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
@@ -285,27 +295,35 @@ DEBUG:  Plan is router executable
 INSERT INTO company_employees_mx values(1, 1, 0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees_mx values(1, 2, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees_mx values(1, 3, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees_mx values(1, 4, 2);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees_mx values(1, 5, 4);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees_mx values(3, 1, 0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
 INSERT INTO company_employees_mx values(3, 15, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
 INSERT INTO company_employees_mx values(3, 3, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
 -- find employees at top 2 level within company hierarchy
 WITH RECURSIVE hierarchy as (
 	SELECT *, 1 AS level
@@ -320,6 +338,7 @@ WITH RECURSIVE hierarchy as (
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  company_id | employee_id | manager_id | level 
 ------------+-------------+------------+-------
           1 |           1 |          0 |     1
@@ -399,6 +418,7 @@ HINT:  Consider using an equality filter on the distributed table's partition co
 SELECT * FROM articles_hash_mx, position('om' in 'Thomas') WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count | position 
 ----+-----------+--------------+------------+----------
   1 |         1 | arsenous     |       9572 |        3
@@ -461,6 +481,7 @@ DEBUG:  generating subplan 87_1 for subquery SELECT id, word_count FROM public.a
 DEBUG:  Plan 87 query after replacing subqueries and CTEs: SELECT articles_hash_mx.id, test.word_count FROM public.articles_hash_mx, (SELECT intermediate_result.id, intermediate_result.word_count FROM read_intermediate_result('87_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, word_count integer)) test WHERE ((test.id OPERATOR(pg_catalog.=) articles_hash_mx.id) AND (articles_hash_mx.author_id OPERATOR(pg_catalog.=) 1)) ORDER BY articles_hash_mx.id
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | word_count 
 ----+------------
   1 |       9572
@@ -482,6 +503,7 @@ SELECT *
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -526,6 +548,7 @@ SELECT id as article_id, word_count * id as random_value
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  article_id | random_value 
 ------------+--------------
           1 |         9572
@@ -542,6 +565,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             17277
@@ -557,6 +581,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -580,6 +605,7 @@ DEBUG:  Plan is router executable
 DEBUG:  Plan 96 query after replacing subqueries and CTEs: SELECT a.author_id AS first_author, b.word_count AS second_word_count FROM public.articles_hash_mx a, (SELECT intermediate_result.id, intermediate_result.author_id, intermediate_result.title, intermediate_result.word_count FROM read_intermediate_result('96_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, author_id bigint, title character varying(20), word_count integer)) b WHERE ((a.author_id OPERATOR(pg_catalog.=) 2) AND (a.author_id OPERATOR(pg_catalog.=) b.author_id)) LIMIT 3
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
  first_author | second_word_count 
 --------------+-------------------
 (0 rows)
@@ -591,6 +617,7 @@ SELECT *
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -606,6 +633,7 @@ SELECT *
 	OFFSET 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
  11 |         1 | alamo    |       1347
@@ -621,6 +649,7 @@ SELECT *
 	OFFSET 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
  31 |         1 | athwartships |       7271
@@ -636,6 +665,7 @@ SELECT id
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -652,6 +682,7 @@ SELECT distinct id
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -667,6 +698,7 @@ SELECT avg(word_count)
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
         avg         
 --------------------
  12356.400000000000
@@ -679,6 +711,7 @@ SELECT max(word_count) as max, min(word_count) as min,
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
   max  | min  |  sum  | cnt 
 -------+------+-------+-----
  18185 | 2728 | 61782 |   5
@@ -691,6 +724,7 @@ SELECT max(word_count)
 	GROUP BY author_id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
   max  
 -------
  11814
@@ -835,6 +869,7 @@ SELECT *
 	WHERE author_id = 1 and author_id >= 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -864,6 +899,7 @@ SELECT *
 	WHERE author_id = 1 and (id = 1 or id = 41);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -876,6 +912,7 @@ SELECT *
 	WHERE author_id = 1 and (id = random()::int  * 0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | title | word_count 
 ----+-----------+-------+------------
 (0 rows)
@@ -913,6 +950,7 @@ SELECT *
 	WHERE author_id = abs(-1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -954,6 +992,7 @@ SELECT *
 	WHERE author_id = 1 and (id = abs(id - 2));
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -978,6 +1017,7 @@ SELECT *
 	WHERE (author_id = 1) = true;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -993,6 +1033,7 @@ SELECT *
 	WHERE (author_id = 1) and id between 0 and 20;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -1005,6 +1046,7 @@ SELECT *
 	WHERE (author_id = 1) and (id = 1 or id = 31) and title like '%s';
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1017,6 +1059,7 @@ SELECT *
 	WHERE (id = 1 or id = 31) and title like '%s' and (author_id = 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1029,6 +1072,7 @@ SELECT *
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1044,6 +1088,7 @@ SELECT *
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1) and (word_count < 3000 or word_count > 8000);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -1057,6 +1102,7 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	WHERE author_id = 5;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
    prev   |  title   | word_count 
 ----------+----------+------------
           | afrasia  |        864
@@ -1072,6 +1118,7 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	ORDER BY word_count DESC;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
    prev   |  title   | word_count 
 ----------+----------+------------
  aminate  | aruru    |      11389
@@ -1086,6 +1133,7 @@ SELECT id, MIN(id) over (order by word_count)
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | min 
 ----+-----
  11 |  11
@@ -1100,6 +1148,7 @@ SELECT id, word_count, AVG(word_count) over (order by word_count)
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | word_count |          avg          
 ----+------------+-----------------------
  11 |       1347 | 1347.0000000000000000
@@ -1114,6 +1163,7 @@ SELECT word_count, rank() OVER (PARTITION BY author_id ORDER BY word_count)
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  word_count | rank 
 ------------+------
        1347 |    1
@@ -1150,6 +1200,7 @@ SELECT
 		author_id = 5;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
  c 
 ---
  5
@@ -1192,6 +1243,7 @@ SELECT *
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1211,6 +1263,7 @@ DECLARE test_cursor CURSOR FOR
 		ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 FETCH test_cursor;
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -1238,6 +1291,7 @@ COPY (
 	ORDER BY id) TO STDOUT;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 1	1	arsenous	9572
 11	1	alamo	1347
 21	1	arcading	5890
@@ -1252,12 +1306,14 @@ CREATE TEMP TABLE temp_articles_hash_mx as
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 -- router plannable queries may include filter for aggragates
 SELECT count(*), count(*) FILTER (WHERE id < 3)
 	FROM articles_hash_mx
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count | count 
 -------+-------
      5 |     1
@@ -1280,6 +1336,7 @@ PREPARE author_1_articles as
 EXECUTE author_1_articles;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1297,6 +1354,7 @@ PREPARE author_articles(int) as
 EXECUTE author_articles(1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1323,6 +1381,7 @@ CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash_mx ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_max_id() line 5 at SQL statement
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash_mx ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_max_id() line 5 at SQL statement
@@ -1349,6 +1408,7 @@ CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		FROM articles_hash_mx ah
 		WHERE author_id = 1"
@@ -1367,6 +1427,7 @@ CREATE MATERIALIZED VIEW mv_articles_hash_mx AS
 	SELECT * FROM articles_hash_mx WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 SELECT * FROM mv_articles_hash_mx;
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -1400,6 +1461,7 @@ SELECT id
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -127,6 +127,7 @@ DEBUG:  Plan is router executable
 SELECT * FROM articles_hash WHERE author_id = 10 AND id = 50;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  id | author_id |   title   | word_count 
 ----+-----------+-----------+------------
  50 |        10 | anjanette |      19519
@@ -136,6 +137,7 @@ DEBUG:  Plan is router executable
 SELECT title FROM articles_hash WHERE author_id = 10;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
    title    
 ------------
  aggrandize
@@ -151,6 +153,7 @@ SELECT title, word_count FROM articles_hash
 	ORDER BY word_count DESC NULLS LAST;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
    title    | word_count 
 ------------+------------
  anjanette  |      19519
@@ -167,6 +170,7 @@ SELECT title, id FROM articles_hash
 	LIMIT 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
   title  | id 
 ---------+----
  aruru   |  5
@@ -238,6 +242,7 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles_hash
 	ORDER BY sum(word_count) DESC;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  author_id | corpus_size 
 -----------+-------------
          1 |       35894
@@ -277,6 +282,7 @@ WITH first_author AS ( SELECT id FROM articles_hash WHERE author_id = 1)
 SELECT * FROM first_author;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -291,6 +297,7 @@ WITH first_author AS ( SELECT id FROM articles_hash WHERE author_id = 1)
 SELECT title FROM articles_hash WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
     title     
 --------------
  arsenous
@@ -306,6 +313,7 @@ id_title AS (SELECT id, title from articles_hash WHERE author_id = 1)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | id |    title     
 ----+-----------+----+--------------
   1 |         1 |  1 | arsenous
@@ -331,9 +339,11 @@ SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
 DEBUG:  generating subplan 67_1 for CTE id_author: SELECT id, author_id FROM public.articles_hash WHERE (author_id OPERATOR(pg_catalog.=) 1)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 DEBUG:  generating subplan 67_2 for CTE id_title: SELECT id, title FROM public.articles_hash WHERE (author_id OPERATOR(pg_catalog.=) 2)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
 DEBUG:  Plan 67 query after replacing subqueries and CTEs: SELECT id_author.id, id_author.author_id, id_title.id, id_title.title FROM (SELECT intermediate_result.id, intermediate_result.author_id FROM read_intermediate_result('67_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, author_id bigint)) id_author, (SELECT intermediate_result.id, intermediate_result.title FROM read_intermediate_result('67_2'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, title character varying(20))) id_title WHERE (id_author.id OPERATOR(pg_catalog.=) id_title.id)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
@@ -358,27 +368,35 @@ SELECT master_create_worker_shards('company_employees', 4, 1);
 INSERT INTO company_employees values(1, 1, 0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees values(1, 2, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees values(1, 3, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees values(1, 4, 2);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees values(1, 5, 4);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 INSERT INTO company_employees values(3, 1, 0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
 INSERT INTO company_employees values(3, 15, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
 INSERT INTO company_employees values(3, 3, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 3
 -- find employees at top 2 level within company hierarchy
 WITH RECURSIVE hierarchy as (
 	SELECT *, 1 AS level
@@ -393,6 +411,7 @@ WITH RECURSIVE hierarchy as (
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  company_id | employee_id | manager_id | level 
 ------------+-------------+------------+-------
           1 |           1 |          0 |     1
@@ -541,6 +560,7 @@ HINT:  Consider using an equality filter on the distributed table's partition co
 SELECT * FROM articles_hash, position('om' in 'Thomas') WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count | position 
 ----+-----------+--------------+------------+----------
   1 |         1 | arsenous     |       9572 |        3
@@ -585,6 +605,7 @@ WHERE author_id IN (SELECT author_id FROM articles_hash WHERE author_id = 2)
 ORDER BY articles_hash.id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
  id | author_id |   title    | word_count 
 ----+-----------+------------+------------
   2 |         2 | abducing   |      13642
@@ -618,6 +639,7 @@ DEBUG:  generating subplan 95_1 for subquery SELECT id, word_count FROM public.a
 DEBUG:  Plan 95 query after replacing subqueries and CTEs: SELECT articles_hash.id, test.word_count FROM public.articles_hash, (SELECT intermediate_result.id, intermediate_result.word_count FROM read_intermediate_result('95_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, word_count integer)) test WHERE ((test.id OPERATOR(pg_catalog.=) articles_hash.id) AND (articles_hash.author_id OPERATOR(pg_catalog.=) 1)) ORDER BY articles_hash.id
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | word_count 
 ----+------------
   1 |       9572
@@ -639,6 +661,7 @@ SELECT *
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -683,6 +706,7 @@ SELECT id as article_id, word_count * id as random_value
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  article_id | random_value 
 ------------+--------------
           1 |         9572
@@ -699,6 +723,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             17277
@@ -714,6 +739,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -737,6 +763,7 @@ DEBUG:  Plan is router executable
 DEBUG:  Plan 104 query after replacing subqueries and CTEs: SELECT a.author_id AS first_author, b.word_count AS second_word_count FROM public.articles_hash a, (SELECT intermediate_result.id, intermediate_result.author_id, intermediate_result.title, intermediate_result.word_count FROM read_intermediate_result('104_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint, author_id bigint, title character varying(20), word_count integer)) b WHERE ((a.author_id OPERATOR(pg_catalog.=) 2) AND (a.author_id OPERATOR(pg_catalog.=) b.author_id)) LIMIT 3
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
  first_author | second_word_count 
 --------------+-------------------
 (0 rows)
@@ -748,6 +775,7 @@ SELECT *
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -763,6 +791,7 @@ SELECT *
 	OFFSET 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
  11 |         1 | alamo    |       1347
@@ -778,6 +807,7 @@ SELECT *
 	OFFSET 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
  31 |         1 | athwartships |       7271
@@ -793,6 +823,7 @@ SELECT id
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -809,6 +840,7 @@ SELECT DISTINCT id
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -824,6 +856,7 @@ SELECT avg(word_count)
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
         avg         
 --------------------
  12356.400000000000
@@ -836,6 +869,7 @@ SELECT max(word_count) as max, min(word_count) as min,
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
   max  | min  |  sum  | cnt 
 -------+------+-------+-----
  18185 | 2728 | 61782 |   5
@@ -848,6 +882,7 @@ SELECT max(word_count)
 	GROUP BY author_id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
   max  
 -------
  11814
@@ -1013,6 +1048,7 @@ SELECT *
 	WHERE author_id = 1 and author_id >= 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1042,6 +1078,7 @@ SELECT *
 	WHERE author_id = 1 and (id = 1 or id = 41);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -1054,6 +1091,7 @@ SELECT *
 	WHERE author_id = 1 and (id = random()::int  * 0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | title | word_count 
 ----+-----------+-------+------------
 (0 rows)
@@ -1091,6 +1129,7 @@ SELECT *
 	WHERE author_id = abs(-1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1132,6 +1171,7 @@ SELECT *
 	WHERE author_id = 1 and (id = abs(id - 2));
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -1156,6 +1196,7 @@ SELECT *
 	WHERE (author_id = 1) = true;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1171,6 +1212,7 @@ SELECT *
 	WHERE (author_id = 1) and id between 0 and 20;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -1183,6 +1225,7 @@ SELECT *
 	WHERE (author_id = 1) and (id = 1 or id = 31) and title like '%s';
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1195,6 +1238,7 @@ SELECT *
 	WHERE (id = 1 or id = 31) and title like '%s' and (author_id = 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1207,6 +1251,7 @@ SELECT *
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1222,6 +1267,7 @@ SELECT *
 	WHERE (title like '%s' or title like 'a%') and (author_id = 1) and (word_count < 3000 or word_count > 8000);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -1235,6 +1281,7 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	WHERE author_id = 5;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
    prev   |  title   | word_count 
 ----------+----------+------------
           | afrasia  |        864
@@ -1250,6 +1297,7 @@ SELECT LAG(title, 1) over (ORDER BY word_count) prev, title, word_count
 	ORDER BY word_count DESC;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
    prev   |  title   | word_count 
 ----------+----------+------------
  aminate  | aruru    |      11389
@@ -1264,6 +1312,7 @@ SELECT id, MIN(id) over (order by word_count)
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | min 
 ----+-----
  11 |  11
@@ -1278,6 +1327,7 @@ SELECT id, word_count, AVG(word_count) over (order by word_count)
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | word_count |          avg          
 ----+------------+-----------------------
  11 |       1347 | 1347.0000000000000000
@@ -1292,6 +1342,7 @@ SELECT word_count, rank() OVER (PARTITION BY author_id ORDER BY word_count)
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  word_count | rank 
 ------------+------
        1347 |    1
@@ -1382,6 +1433,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	WHERE a.author_id = 10 and a.author_id = b.author_id and int4eq(1, 1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -1451,6 +1503,7 @@ SELECT * FROM (
 ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1468,6 +1521,7 @@ SELECT * FROM (
 ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -1482,6 +1536,7 @@ INTERSECT
 (SELECT * FROM articles_hash WHERE author_id = 2 and 1=0);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | title | word_count 
 ----+-----------+-------+------------
 (0 rows)
@@ -1492,6 +1547,7 @@ id_title AS (SELECT id, title from articles_hash WHERE author_id = 1 and 1=0)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | id | title 
 ----+-----------+----+-------
 (0 rows)
@@ -1501,6 +1557,7 @@ id_title AS (SELECT id, title from articles_hash WHERE author_id = 1)
 SELECT * FROM id_author, id_title WHERE id_author.id = id_title.id and 1=0;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id | id | title 
 ----+-----------+----+-------
 (0 rows)
@@ -1518,6 +1575,7 @@ WITH RECURSIVE hierarchy as (
 SELECT * FROM hierarchy WHERE LEVEL <= 2 and 1=0;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  company_id | employee_id | manager_id | level 
 ------------+-------------+------------+-------
 (0 rows)
@@ -1535,6 +1593,7 @@ WITH RECURSIVE hierarchy as (
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  company_id | employee_id | manager_id | level 
 ------------+-------------+------------+-------
           1 |           1 |          0 |     1
@@ -1553,6 +1612,7 @@ WITH RECURSIVE hierarchy as (
 SELECT * FROM hierarchy WHERE LEVEL <= 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  company_id | employee_id | manager_id | level 
 ------------+-------------+------------+-------
 (0 rows)
@@ -1759,6 +1819,7 @@ SELECT * FROM articles_hash ar join authors_range au on (ar.author_id = au.id)
 	WHERE ar.author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
  id | author_id | title | word_count | name | id 
 ----+-----------+-------+------------+------+----
 (0 rows)
@@ -1881,6 +1942,7 @@ SELECT author_id FROM articles_hash
 	LIMIT 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 WARNING:  relation "public.articles_hash" does not exist
 CONTEXT:  while executing command on localhost:57637
 ERROR:  could not receive query results
@@ -1918,6 +1980,7 @@ SELECT * FROM articles_hash
 	LIMIT 5;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 WARNING:  relation "public.articles_hash" does not exist
 CONTEXT:  while executing command on localhost:57637
 ERROR:  could not receive query results
@@ -1941,6 +2004,7 @@ SELECT
 		author_id = 5;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 5
  c 
 ---
  5
@@ -1983,6 +2047,7 @@ SELECT *
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -2002,6 +2067,7 @@ SELECT *
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -2021,6 +2087,7 @@ DECLARE test_cursor CURSOR FOR
 		ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 FETCH test_cursor;
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
@@ -2056,6 +2123,7 @@ COPY (
 	ORDER BY id) TO STDOUT;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 1	1	arsenous	9572
 11	1	alamo	1347
 21	1	arcading	5890
@@ -2070,12 +2138,14 @@ CREATE TEMP TABLE temp_articles_hash as
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 -- router plannable queries may include filter for aggragates
 SELECT count(*), count(*) FILTER (WHERE id < 3)
 	FROM articles_hash
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  count | count 
 -------+-------
      5 |     1
@@ -2098,6 +2168,7 @@ PREPARE author_1_articles as
 EXECUTE author_1_articles;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -2115,6 +2186,7 @@ PREPARE author_articles(int) as
 EXECUTE author_articles(1);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -2141,6 +2213,7 @@ CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_max_id() line 5 at SQL statement
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 CONTEXT:  SQL statement "SELECT MAX(id) FROM articles_hash ah
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_max_id() line 5 at SQL statement
@@ -2167,6 +2240,7 @@ CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		WHERE author_id = 1"
 PL/pgSQL function author_articles_id_word_count() line 4 at RETURN QUERY
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 CONTEXT:  SQL statement "SELECT ah.id, ah.word_count
 		FROM articles_hash ah
 		WHERE author_id = 1"
@@ -2185,6 +2259,7 @@ CREATE MATERIALIZED VIEW mv_articles_hash_empty AS
 	SELECT * FROM articles_hash WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 SELECT * FROM mv_articles_hash_empty;
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
@@ -2219,6 +2294,7 @@ SELECT id
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -2238,6 +2314,7 @@ SELECT id
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -414,6 +414,7 @@ SELECT *
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -457,6 +458,7 @@ SELECT id as article_id, word_count * id as random_value
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  article_id | random_value 
 ------------+--------------
           1 |         9572
@@ -474,6 +476,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             17277
@@ -489,6 +492,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -503,6 +507,7 @@ SELECT *
 	LIMIT 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -519,6 +524,7 @@ SELECT id
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -539,6 +545,7 @@ SELECT avg(word_count)
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
         avg         
 --------------------
  12356.400000000000
@@ -552,6 +559,7 @@ SELECT max(word_count) as max, min(word_count) as min,
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
   max  | min  |  sum  | cnt 
 -------+------+-------+-----
  18185 | 2728 | 61782 |   5

--- a/src/test/regress/expected/multi_simple_queries_0.out
+++ b/src/test/regress/expected/multi_simple_queries_0.out
@@ -358,6 +358,7 @@ SELECT *
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
@@ -401,6 +402,7 @@ SELECT id as article_id, word_count * id as random_value
 	WHERE author_id = 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  article_id | random_value 
 ------------+--------------
           1 |         9572
@@ -418,6 +420,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             17277
@@ -433,6 +436,7 @@ SELECT a.author_id as first_author, b.word_count as second_word_count
 	LIMIT 3;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 10
  first_author | second_word_count 
 --------------+-------------------
            10 |             19519
@@ -447,6 +451,7 @@ SELECT *
 	LIMIT 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id | author_id |  title   | word_count 
 ----+-----------+----------+------------
   1 |         1 | arsenous |       9572
@@ -463,6 +468,7 @@ SELECT id
 	ORDER BY id;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
  id 
 ----
   1
@@ -483,6 +489,7 @@ SELECT avg(word_count)
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
         avg         
 --------------------
  12356.400000000000
@@ -496,6 +503,7 @@ SELECT max(word_count) as max, min(word_count) as min,
 	WHERE author_id = 2;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 2
   max  | min  |  sum  | cnt 
 -------+------+-------+-----
  18185 | 2728 | 61782 |   5


### PR DESCRIPTION
DESCRIPTION: Show the distribution column value for router queries in a debug message

This PR adds a detail to the "Plan is router executable" debug message with the distribution column value. This is not in itself very useful, but adds some useful infrastructure for implementing landlord, which requires the ability to extract the distribution column value from a distributed plan. Doing so requires some careful code surgery, so putting this up for feedback.