### PR TITLE
Ensure the two copies of citus.control are kept in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   allow_failures:
     - env: PGVERSION=11
 before_install:
-  - git clone -b v0.7.6 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b add-citus-control-check --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - curl https://install.citusdata.com/community/deb.sh | sudo bash
@@ -38,7 +38,9 @@ install:
       apt-get download "postgresql-${PGVERSION}-hll=2.10.2.citus-1"
       sudo dpkg --force-confold --force-confdef --force-all -i *hll*.deb
     fi
-before_script: citus_indent --quiet --check
+before_script:
+  - citus_indent --quiet --check
+  - check_citus_control
 script: CFLAGS=-Werror pg_travis_multi_test check
 after_success:
   - sync_to_enterprise

--- a/citus.control
+++ b/citus.control
@@ -1,5 +1,5 @@
 # Citus extension
-comment = 'Citus distributed database'
+omment = 'Citus distributed database'
 default_version = '7.4-3'
 module_pathname = '$libdir/citus'
 relocatable = false

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,4 +1,7 @@
 # Citus extension
+# There is a copy of this file in the root directory of the repository. Any changes made
+# to this file need to be made to that file as well (it supports builds on Windows; those
+# don't use Make and need more hand-holding)
 comment = 'Citus distributed database'
 default_version = '7.4-3'
 module_pathname = '$libdir/citus'


### PR DESCRIPTION
1. Leave a comment reminding they must be kept in sync
2. Add a check to travis which diffs the two files and confirms they're identical