### PR TITLE
(WIP) Internals Monitor

### DIFF
--- a/src/backend/distributed/citus--7.4-2--7.4-3.sql
+++ b/src/backend/distributed/citus--7.4-2--7.4-3.sql
@@ -11,3 +11,65 @@ COMMENT ON FUNCTION worker_hash_partition_table(bigint, integer, text, text, oid
     IS 'hash partition query results';
 
 RESET search_path;
+
+CREATE FUNCTION citus_connections_hash()
+RETURNS TABLE (
+    hostname TEXT,
+    port INT,
+    "user" TEXT,
+    database TEXT,
+    socket INT,
+    sessionLifespan BOOLEAN,
+    claimedExclusively BOOLEAN,
+    connectionStart Timestamp WITH TIME ZONE,
+    transactionState TEXT,
+    transactionCritical BOOLEAN,
+    transactionFailed BOOLEAN,
+    preparedName TEXT,
+    dontKill BOOLEAN
+)
+AS 'MODULE_PATHNAME', 'citus_connections_hash'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION citus_zombie_connections()
+RETURNS TABLE (
+    hostname TEXT,
+    port INT,
+    "user" TEXT,
+    database TEXT,
+    socket INT,
+    sessionLifespan BOOLEAN,
+    claimedExclusively BOOLEAN,
+    connectionStart Timestamp WITH TIME ZONE,
+    transactionState TEXT,
+    transactionCritical BOOLEAN,
+    transactionFailed BOOLEAN,
+    preparedName TEXT,
+    dontKill BOOLEAN
+)
+AS 'MODULE_PATHNAME', 'citus_zombie_connections'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION dont_kill_multiconnection(INTEGER) RETURNS VOID
+AS 'MODULE_PATHNAME', 'dont_kill_multiconnection'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION cleanup_zombie_connections() RETURNS VOID
+AS 'MODULE_PATHNAME', 'cleanup_zombie_connections'
+LANGUAGE C STRICT;
+
+
+CREATE FUNCTION citus_connection_placement_hash()
+RETURNS TABLE (
+    placementId BIGINT,
+    failed BOOLEAN,
+    hasSecondary BOOLEAN,
+    username TEXT,
+    connection_socket INT,
+    hadDML BOOLEAN,
+    hadDDL BOOLEAN,
+    colocationGroupId INT,
+    representativeValue INT
+)
+AS 'MODULE_PATHNAME', 'citus_connection_placement_hash'
+LANGUAGE C STRICT;

--- a/src/backend/distributed/citus--7.4-2--7.4-3.sql
+++ b/src/backend/distributed/citus--7.4-2--7.4-3.sql
@@ -73,3 +73,21 @@ RETURNS TABLE (
 )
 AS 'MODULE_PATHNAME', 'citus_connection_placement_hash'
 LANGUAGE C STRICT;
+
+CREATE FUNCTION remote_command_logs()
+RETURNS TABLE (
+    socketId INTEGER,
+    hostname TEXT,
+    port INTEGER,
+    "user" TEXT,
+    database TEXT,
+    query TEXT
+)
+AS 'MODULE_PATHNAME', 'remote_command_logs'
+LANGUAGE C STRICT;
+
+
+CREATE FUNCTION clear_remote_command_logs()
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'clear_remote_command_logs'
+LANGUAGE C STRICT;

--- a/src/backend/distributed/citus--7.4-2--7.4-3.sql
+++ b/src/backend/distributed/citus--7.4-2--7.4-3.sql
@@ -10,8 +10,6 @@ COMMENT ON FUNCTION worker_hash_partition_table(bigint, integer, text, text, oid
                                                 anyarray)
     IS 'hash partition query results';
 
-RESET search_path;
-
 CREATE FUNCTION citus_connections_hash()
 RETURNS TABLE (
     hostname TEXT,
@@ -86,8 +84,14 @@ RETURNS TABLE (
 AS 'MODULE_PATHNAME', 'remote_command_logs'
 LANGUAGE C STRICT;
 
-
 CREATE FUNCTION clear_remote_command_logs()
 RETURNS VOID
 AS 'MODULE_PATHNAME', 'clear_remote_command_logs'
 LANGUAGE C STRICT;
+
+CREATE FUNCTION xact_modification_level()
+RETURNS TEXT
+AS 'MODULE_PATHNAME', 'xact_modification_level'
+LANGUAGE C STRICT;
+
+RESET search_path;

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -764,7 +764,9 @@ AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit)
 			}
 			else
 			{
+				MemoryContext oldContext = MemoryContextSwitchTo(TopMemoryContext);
 				ZombieConnections = lappend(ZombieConnections, connection);
+				MemoryContextSwitchTo(oldContext);
 			}
 		}
 		else

--- a/src/backend/distributed/utils/internals_monitor.c
+++ b/src/backend/distributed/utils/internals_monitor.c
@@ -123,6 +123,8 @@ cleanup_zombie_connections(PG_FUNCTION_ARGS)
 		MultiConnection *connection = lfirst(connectionCell);
 		ShutdownConnection(connection);
 	}
+	list_free(ZombieConnections);
+	ZombieConnections = NIL;
 	PG_RETURN_VOID();
 }
 
@@ -170,8 +172,6 @@ SetupReturnSet(FunctionCallInfo fcinfo, List *valuesTupleList, List *nullsTupleL
 	int i = 0;
 
 	FuncCallContext *functionContext = SRF_FIRSTCALL_INIT();
-
-	elog(WARNING, "tupleCount: %d", tupleCount);
 
 	/*
 	 * Switch to multi_call_memory_ctx so the results calculated here

--- a/src/backend/distributed/utils/internals_monitor.c
+++ b/src/backend/distributed/utils/internals_monitor.c
@@ -1,0 +1,168 @@
+/*-------------------------------------------------------------------------
+ *
+ * internals_monitor.c
+ *   UDFs for monitoring internal data structures of Citus.
+ *
+ * Copyright (c) 2018, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/hash.h"
+#include "access/htup_details.h"
+#include "fmgr.h"
+#include "funcapi.h"
+#include "utils/builtins.h"
+#include "distributed/connection_management.h"
+
+PG_FUNCTION_INFO_V1(citus_connections_hash);
+
+static void SetupReturnSet(FunctionCallInfo fcinfo, List *values, List *nulls);
+static Datum NextRecord(FunctionCallInfo fcinfo);
+static Datum DatumCopy(Datum datum, bool datumTypeByValue, int datumTypeLength);
+
+extern HTAB *ConnectionHash;
+
+Datum
+citus_connections_hash(PG_FUNCTION_ARGS)
+{
+	if (SRF_IS_FIRSTCALL())
+	{
+		List *valuesTupleList = NIL;
+		List *nullsTupleList = NIL;
+		HASH_SEQ_STATUS status;
+		ConnectionHashEntry *entry;
+
+		hash_seq_init(&status, ConnectionHash);
+		while ((entry = (ConnectionHashEntry *) hash_seq_search(&status)) != 0)
+		{
+			dlist_iter iter;
+
+			dlist_foreach(iter, entry->connections)
+			{
+				MultiConnection *connection =
+					dlist_container(MultiConnection, connectionNode, iter.cur);
+				Datum *valuesTuple = palloc0(8 * sizeof(Datum));
+				bool *nullsTuple = palloc0(8 * sizeof(bool));
+
+				valuesTuple[0] = CStringGetTextDatum(connection->hostname);
+				valuesTuple[1] = Int32GetDatum(connection->port);
+				valuesTuple[2] = CStringGetTextDatum(connection->user);
+				valuesTuple[3] = CStringGetTextDatum(connection->database);
+				valuesTuple[4] = Int32GetDatum(PQsocket(connection->pgConn));
+				valuesTuple[5] = BoolGetDatum(connection->sessionLifespan);
+				valuesTuple[6] = BoolGetDatum(connection->claimedExclusively);
+				valuesTuple[7] = TimestampTzGetDatum(connection->connectionStart);
+
+				valuesTupleList = lappend(valuesTupleList, valuesTuple);
+				nullsTupleList = lappend(nullsTupleList, nullsTuple);
+			}
+		}
+
+		SetupReturnSet(fcinfo, valuesTupleList, nullsTupleList);
+	}
+
+	return NextRecord(fcinfo);
+}
+
+
+static void
+SetupReturnSet(FunctionCallInfo fcinfo, List *valuesTupleList, List *nullsTupleList)
+{
+	MemoryContext oldContext = NULL;
+	TupleDesc tupleDescriptor = NULL;
+	int tupleCount = list_length(valuesTupleList);
+	Datum **valuesCopy = NULL;
+	bool **nullsCopy = NULL;
+	ListCell *valuesCell, *nullsCell;
+	int i = 0;
+
+	FuncCallContext *functionContext = SRF_FIRSTCALL_INIT();
+
+	elog(WARNING, "tupleCount: %d", tupleCount);
+
+	/*
+	 * Switch to multi_call_memory_ctx so the results calculated here
+	 * stays for the next call.
+	 */
+	oldContext = MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
+
+	get_call_result_type(fcinfo, NULL, &tupleDescriptor);
+
+	valuesCopy = palloc0(tupleCount * sizeof(Datum *));
+	nullsCopy = palloc0(tupleCount * sizeof(bool *));
+	forboth(valuesCell, valuesTupleList, nullsCell, nullsTupleList)
+	{
+		Datum *values = lfirst(valuesCell);
+		bool *nulls = lfirst(nullsCell);
+		int j;
+		valuesCopy[i] = palloc0(tupleDescriptor->natts * sizeof(Datum));
+		nullsCopy[i] = palloc0(tupleDescriptor->natts * sizeof(Datum));
+
+		for (j = 0; j < tupleDescriptor->natts; j++)
+		{
+			nullsCopy[i][j] = nulls[j];
+			if (!nulls[j])
+			{
+				valuesCopy[i][j] = DatumCopy(values[j],
+											 tupleDescriptor->attrs[j]->attbyval,
+											 tupleDescriptor->attrs[j]->attlen);
+			}
+		}
+		i++;
+	}
+
+	/* save results for future use */
+	functionContext->max_calls = tupleCount;
+	functionContext->user_fctx = list_make2(valuesCopy, nullsCopy);
+	functionContext->tuple_desc = tupleDescriptor;
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+
+static Datum
+NextRecord(FunctionCallInfo fcinfo)
+{
+	FuncCallContext *functionContext = SRF_PERCALL_SETUP();
+
+	if (functionContext->call_cntr < functionContext->max_calls)
+	{
+		int i = functionContext->call_cntr;
+		TupleDesc tupleDescriptor = functionContext->tuple_desc;
+		Datum **values = linitial(functionContext->user_fctx);
+		bool **nulls = lsecond(functionContext->user_fctx);
+
+		HeapTuple heapTuple = heap_form_tuple(tupleDescriptor, values[i], nulls[i]);
+		SRF_RETURN_NEXT(functionContext, HeapTupleGetDatum(heapTuple));
+	}
+	else
+	{
+		SRF_RETURN_DONE(functionContext);
+	}
+}
+
+
+/* Creates a copy of the given datum. */
+static Datum
+DatumCopy(Datum datum, bool datumTypeByValue, int datumTypeLength)
+{
+	Datum datumCopy = 0;
+
+	if (datumTypeByValue)
+	{
+		datumCopy = datum;
+	}
+	else
+	{
+		uint32 datumLength = att_addlength_datum(0, datumTypeLength, datum);
+		char *datumData = palloc0(datumLength);
+		memcpy(datumData, DatumGetPointer(datum), datumLength);
+
+		datumCopy = PointerGetDatum(datumData);
+	}
+
+	return datumCopy;
+}

--- a/src/backend/distributed/utils/internals_monitor.c
+++ b/src/backend/distributed/utils/internals_monitor.c
@@ -26,6 +26,7 @@ PG_FUNCTION_INFO_V1(cleanup_zombie_connections);
 PG_FUNCTION_INFO_V1(citus_connection_placement_hash);
 PG_FUNCTION_INFO_V1(remote_command_logs);
 PG_FUNCTION_INFO_V1(clear_remote_command_logs);
+PG_FUNCTION_INFO_V1(xact_modification_level);
 
 static void CreateMultiConnectionTuple(MultiConnection *connection, Datum **valuesTuple,
 									   bool **nullsTuple);
@@ -211,6 +212,18 @@ clear_remote_command_logs(PG_FUNCTION_ARGS)
 	/* TODO: free contents of RemoteCommandLogs */
 	RemoteCommandLogs = NIL;
 	PG_RETURN_VOID();
+}
+
+
+Datum
+xact_modification_level(PG_FUNCTION_ARGS)
+{
+	const char *modificationLevelStr[] = {
+		"XACT_MODIFICATION_INVALID",
+		"XACT_MODIFICATION_NONE",
+		"XACT_MODIFICATION_DATA"
+	};
+	PG_RETURN_DATUM(CStringGetTextDatum(modificationLevelStr[XactModificationLevel]));
 }
 
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -85,6 +85,12 @@ typedef struct MultiConnection
 
 	/* number of bytes sent to PQputCopyData() since last flush */
 	uint64 copyBytesWrittenSinceLastFlush;
+
+	/*
+	 * If set to true, instead of shutting down, goes to ZombieConnections,
+	 * so users can investigate the connection with monitoring UDFs.
+	 */
+	bool dontKill;
 } MultiConnection;
 
 
@@ -135,6 +141,8 @@ extern int NodeConnectionTimeout;
 
 /* the hash table */
 extern HTAB *ConnectionHash;
+
+extern List *ZombieConnections;
 
 /* context for all connection and transaction related memory */
 extern struct MemoryContextData *ConnectionContext;

--- a/src/include/distributed/placement_connection.h
+++ b/src/include/distributed/placement_connection.h
@@ -38,6 +38,91 @@ typedef struct ShardPlacementAccess
 	ShardPlacementAccessType accessType;
 } ShardPlacementAccess;
 
+/*
+ * A connection reference is used to register that a connection has been used
+ * to read or modify either a) a shard placement as a particular user b) a
+ * group of colocated placements (which depend on whether the reference is
+ * from ConnectionPlacementHashEntry or ColocatedPlacementHashEntry).
+ */
+typedef struct ConnectionReference
+{
+	/*
+	 * The user used to read/modify the placement. We cannot reuse connections
+	 * that were performed using a different role, since it would not have the
+	 * right permissions.
+	 */
+	const char *userName;
+
+	/* the connection */
+	MultiConnection *connection;
+
+	/*
+	 * Information about what the connection is used for. There can only be
+	 * one connection executing DDL/DML for a placement to avoid deadlock
+	 * issues/read-your-own-writes violations.  The difference between DDL/DML
+	 * currently is only used to emit more precise error messages.
+	 */
+	bool hadDML;
+	bool hadDDL;
+
+	/* colocation group of the placement, if any */
+	uint32 colocationGroupId;
+	uint32 representativeValue;
+
+	/* placementId of the placement, used only for append distributed tables */
+	uint64 placementId;
+
+	/* membership in MultiConnection->referencedPlacements */
+	dlist_node connectionNode;
+} ConnectionReference;
+
+
+struct ColocatedPlacementsHashEntry;
+
+
+/*
+ * Hash table mapping placements to a list of connections.
+ *
+ * This stores a list of connections for each placement, because multiple
+ * connections to the same placement may exist at the same time. E.g. a
+ * real-time executor query may reference the same placement in several
+ * sub-tasks.
+ *
+ * We keep track about a connection having executed DML or DDL, since we can
+ * only ever allow a single transaction to do either to prevent deadlocks and
+ * consistency violations (e.g. read-your-own-writes).
+ */
+
+/* hash key */
+typedef struct ConnectionPlacementHashKey
+{
+	uint64 placementId;
+} ConnectionPlacementHashKey;
+
+/* hash entry */
+typedef struct ConnectionPlacementHashEntry
+{
+	ConnectionPlacementHashKey key;
+
+	/* did any remote transactions fail? */
+	bool failed;
+
+	/* primary connection used to access the placement */
+	ConnectionReference *primaryConnection;
+
+	/* are any other connections reading from the placements? */
+	bool hasSecondaryConnections;
+
+	/* entry for the set of co-located placements */
+	struct ColocatedPlacementsHashEntry *colocatedEntry;
+
+	/* membership in ConnectionShardHashEntry->placementConnections */
+	dlist_node shardNode;
+} ConnectionPlacementHashEntry;
+
+/* hash table */
+extern HTAB *ConnectionPlacementHash;
+
 
 extern MultiConnection * GetPlacementConnection(uint32 flags,
 												struct ShardPlacement *placement,

--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -12,6 +12,7 @@
 #define REMOTE_COMMAND_H
 
 #include "distributed/connection_management.h"
+#include "lib/stringinfo.h"
 
 /* errors which ExecuteRemoteCommand might return */
 #define QUERY_SEND_FAILED 1
@@ -22,6 +23,17 @@ struct pg_result; /* target of the PGresult typedef */
 /* GUC, determining whether statements sent to remote nodes are logged */
 extern bool LogRemoteCommands;
 
+typedef struct
+{
+	int socket;
+	char hostname[MAX_NODE_LENGTH];
+	int32 port;
+	char user[NAMEDATALEN];
+	char database[NAMEDATALEN];
+	StringInfo query;
+} RemoteCommandLogRecord;
+
+extern List *RemoteCommandLogs;
 
 /* simple helpers */
 extern bool IsResponseOK(struct pg_result *result);

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -17,8 +17,7 @@ typedef enum
 {
 	XACT_MODIFICATION_INVALID = 0, /* placeholder initial value */
 	XACT_MODIFICATION_NONE,        /* no modifications have taken place */
-	XACT_MODIFICATION_DATA,        /* data modifications (DML) have occurred */
-	XACT_MODIFICATION_MULTI_SHARD  /* multi-shard modifications have occurred */
+	XACT_MODIFICATION_DATA         /* data modifications (DML) have occurred */
 } XactModificationType;
 
 


### PR DESCRIPTION
Being able to monitor internal data structures of Citus is useful for (1) understanding how Citus works, (2) Debugging.

- [x] `citus_connections_hash()` for monitoring `ConnectionHash` in `connection_management.c`.
- [x] `citus_connection_placements_hash()` for monitoring `ConnectionPlacementHash` in `placement_connection.c`.
- [x] List of queries sent over a connection.
- [x] transaction modification level.