### PR TITLE
Don't spinloop when trying to cleanup a failed connection

### DIFF
--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -2939,8 +2939,9 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 													   taskTracker);
 				}
 			}
-			else if (timedOut)
+			else if (resultStatus == CLIENT_RESULT_UNAVAILABLE || timedOut)
 			{
+				/* CLIENT_RESULT_UNAVAILABLE is returned if the connection failed somehow */
 				ereport(WARNING, (errmsg("could not receive response for cleanup query "
 										 "result for job " UINT64_FORMAT " on node "
 																		 "\"%s:%u\" with status %d",


### PR DESCRIPTION
Fixes #2181, with this patch the test output becomes:

```
brian=# SELECT bool_or(flag) FROM agg_test;
WARNING:  could not consume data from worker node
WARNING:  could not receive response for cleanup query result for job 310646931458 on node "localhost:9702" with status 1
HINT:  Manually clean job resources on node "localhost:9702" by running "SELECT task_tracker_cleanup_job(310646931458)" 
 bool_or 
---------
 t
(1 row)
```