### PR TITLE
Make sure that sequential DDL opens a single connection to each node

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -3137,7 +3137,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 
 		PG_TRY();
 		{
-			ExecuteTasksSequentiallyWithoutResults(ddlJob->taskList);
+			ExecuteDDLTasksSequentiallyWithoutResults(ddlJob->taskList);
 
 			if (shouldSyncMetadata)
 			{

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -41,7 +41,7 @@ extern TupleTableSlot * RouterSelectExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterMultiModifyExecScan(CustomScanState *node);
 
 extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
-extern void ExecuteTasksSequentiallyWithoutResults(List *taskList);
+extern void ExecuteDDLTasksSequentiallyWithoutResults(List *taskList);
 
 extern List * BuildPlacementSelectList(uint32 groupId, List *relationShardList);
 


### PR DESCRIPTION
This is pre-requisite for foreign keys to reference tables where we have to send the `ALTER TABLE dist_table ADD CONSTRAINT my_fkey FOREIGN KEY (a) REFERENCES reference_table (a);
` commands over a single connection to prevent self-deadlocks.

I wish I could have avoided adding a new function `ExecuteSingleDDLTaskWithoutResults ()`. However, the other code-paths that do similar things such as `ExecuteSingleModifyTask()` does too many extra things, requires API changes etc or `ExecuteModifyTasks()` calls `OpenTransactionsForAllTasks()` which claims connections exclusively.  

I'm open to suggestions to use existing `API`s if any of you guide me towards. For example, one another trial I did was [here](https://github.com/citusdata/citus/compare/seq_ddl_execution) which is incomplete because we're still claiming the connection exclusively in that branch. So, those kind of changes that we add `if/else/booleans params`are also not very appealing.

And, I see being in this situation is a good candidiate to add #2183 (cc: @pykello)

