### PR TITLE
Make sure that sequential DDL opens a single connection to each node

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -3137,7 +3137,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 
 		PG_TRY();
 		{
-			ExecuteTasksSequentiallyWithoutResults(ddlJob->taskList);
+			ExecuteDDLTasksSequentiallyWithoutResults(ddlJob->taskList);
 
 			if (shouldSyncMetadata)
 			{

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -41,7 +41,7 @@ extern TupleTableSlot * RouterSelectExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterMultiModifyExecScan(CustomScanState *node);
 
 extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
-extern void ExecuteTasksSequentiallyWithoutResults(List *taskList);
+extern void ExecuteDDLTasksSequentiallyWithoutResults(List *taskList);
 
 extern List * BuildPlacementSelectList(uint32 groupId, List *relationShardList);
 


### PR DESCRIPTION
Fixes #2188 

Another attempt to implement #2185. 

We preferred using the code-path that executes single task router
queries (e.g., ExecuteSingleModifyTask()) in order not to invent
a new executor that is only applicable for DDL commands that require
sequential execution.

Adding the regression tests is not very simple given that the only current user of the code `CREATE INDEX CONCURRENTLY` cannot be executed inside a transaction. Once we implement foreign keys tasks, I'll add the tests. (Now, you can simply enable `log_connections` on the worker and see the connections)


