### PR TITLE
Add pg_dist_authinfo schema and validation

### DIFF
--- a/citus.control
+++ b/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.5-1'
+default_version = '7.5-2'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -16,7 +16,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	7.2-1 7.2-2 7.2-3 \
 	7.3-1 7.3-2 7.3-3 \
 	7.4-1 7.4-2 7.4-3 \
-	7.5-1
+	7.5-1 7.5-2
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -201,6 +201,8 @@ $(EXTENSION)--7.4-2.sql: $(EXTENSION)--7.4-1.sql $(EXTENSION)--7.4-1--7.4-2.sql
 $(EXTENSION)--7.4-3.sql: $(EXTENSION)--7.4-2.sql $(EXTENSION)--7.4-2--7.4-3.sql
 	cat $^ > $@
 $(EXTENSION)--7.5-1.sql: $(EXTENSION)--7.4-3.sql $(EXTENSION)--7.4-3--7.5-1.sql
+	cat $^ > $@
+$(EXTENSION)--7.5-2.sql: $(EXTENSION)--7.5-1.sql $(EXTENSION)--7.5-1--7.5-2.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.5-1--7.5-2.sql
+++ b/src/backend/distributed/citus--7.5-1--7.5-2.sql
@@ -1,0 +1,34 @@
+/* citus--7.5-1--7.5-2 */
+SET search_path = 'pg_catalog';
+
+-- note that we're not dropping the older version of the function
+CREATE FUNCTION pg_catalog.role_exists(name)
+    RETURNS boolean
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$role_exists$$;
+COMMENT ON FUNCTION role_exists(name) IS 'returns whether a role exists';
+
+CREATE FUNCTION pg_catalog.authinfo_valid(text)
+	RETURNS boolean
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$authinfo_valid$$;
+COMMENT ON FUNCTION authinfo_valid(text) IS 'returns whether an authinfo is valid';
+
+CREATE TABLE citus.pg_dist_authinfo (
+	nodeid integer NOT NULL,
+	rolename name NOT NULL
+	              CONSTRAINT role_exists
+								CHECK (role_exists(rolename)),
+	authinfo text NOT NULL
+	              CONSTRAINT authinfo_valid
+								CHECK (authinfo_valid(authinfo))
+);
+
+CREATE UNIQUE INDEX pg_dist_authinfo_identification_index
+ON citus.pg_dist_authinfo (rolename, nodeid DESC);
+
+ALTER TABLE citus.pg_dist_authinfo SET SCHEMA pg_catalog;
+
+REVOKE ALL ON pg_catalog.pg_dist_authinfo FROM PUBLIC;
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.5-1'
+default_version = '7.5-2'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_metadata_access.out
+++ b/src/test/regress/expected/multi_metadata_access.out
@@ -18,9 +18,10 @@ WHERE
     AND ext.extname = 'citus'
     AND nsp.nspname = 'pg_catalog'
     AND NOT has_table_privilege(pg_class.oid, 'select');
- oid 
------
-(0 rows)
+       oid        
+------------------
+ pg_dist_authinfo
+(1 row)
 
 RESET role;
 DROP USER no_access;

--- a/src/test/regress/expected/multi_utility_warnings.out
+++ b/src/test/regress/expected/multi_utility_warnings.out
@@ -14,3 +14,7 @@ HINT:  Connect to worker nodes directly to manually create all necessary users a
 CREATE USER new_user;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+INSERT INTO pg_dist_authinfo VALUES (0, 'new_user', 'password=1234');
+ERROR:  cannot write to pg_dist_authinfo
+DETAIL:  Citus Community Edition does not support the use of custom authentication options.
+HINT:  To learn more about using advanced authentication schemes with Citus, please contact us at https://citusdata.com/about/contact_us

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -129,7 +129,7 @@ test: multi_create_schema
 
 # ----------
 # Tests to check if we inform the user about potential caveats of creating new
-# databases, schemas, and roles.
+# databases, schemas, roles, and authentication information.
 # ----------
 test: multi_utility_warnings
 

--- a/src/test/regress/sql/multi_utility_warnings.sql
+++ b/src/test/regress/sql/multi_utility_warnings.sql
@@ -14,3 +14,5 @@ CREATE DATABASE new_database;
 CREATE ROLE new_role;
 
 CREATE USER new_user;
+
+INSERT INTO pg_dist_authinfo VALUES (0, 'new_user', 'password=1234');

--- a/windows/include/citus_version.h
+++ b/windows/include/citus_version.h
@@ -5,7 +5,7 @@
 #define CITUS_EDITION "community"
 
 /* Extension version expected by this Citus build */
-#define CITUS_EXTENSIONVERSION "7.5-1"
+#define CITUS_EXTENSIONVERSION "7.5-2"
 
 /* Citus major version as a string */
 #define CITUS_MAJORVERSION "7.5"


### PR DESCRIPTION
This table will be used by Citus Enterprise to populate authentication-related fields in outbound connections; Citus Community lacks support for this functionality.