### PR TITLE
Add infrastructure for tracking relation accesses within a transaction block

### DIFF
--- a/src/backend/distributed/transaction/access_tracking.c
+++ b/src/backend/distributed/transaction/access_tracking.c
@@ -1,0 +1,153 @@
+/*-------------------------------------------------------------------------
+ *
+ * access_tracking.c
+ *
+ *   Transaction access tracking for Citus. The functions in this file
+ *   are intended to track the relation accesses within a transaction. The
+ *   logic here is mostly useful when a reference table is referred by
+ *   a distributed table via a foreign key. Whenever such a pair of tables
+ *   are acccesed inside a transaction, Citus should detect and act
+ *   accordingly.
+ *
+ * Copyright (c) 2018, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "miscadmin.h"
+
+
+#include "access/transam.h"
+#include "access/xact.h"
+#include "distributed/access_tracking.h"
+#include "storage/lwlock.h"
+#include "storage/proc.h"
+#include "utils/lsyscache.h"
+
+
+/* the following macros are copied from lmgr/lock.c */
+#define FAST_PATH_BITS_PER_SLOT 3
+#define FAST_PATH_LOCKNUMBER_OFFSET 1
+#define FAST_PATH_MASK ((1 << FAST_PATH_BITS_PER_SLOT) - 1)
+#define FAST_PATH_GET_BITS(proc, n) \
+	(((proc)->fpLockBits >> (FAST_PATH_BITS_PER_SLOT * n)) & FAST_PATH_MASK)
+
+
+/* this function is only exported in the regression tests */
+PG_FUNCTION_INFO_V1(relation_accessed_in_transaction_block);
+
+
+/*
+ * relation_accessed_in_transaction_block returns true if the given relation
+ * is accessed in the current transaction block.
+ */
+Datum
+relation_accessed_in_transaction_block(PG_FUNCTION_ARGS)
+{
+	Oid relationId = PG_GETARG_OID(0);
+
+	bool relationAccessed =
+		RelationAccessedInTransactionBlock(list_make1_oid(relationId));
+
+	return BoolGetDatum(relationAccessed);
+}
+
+
+/*
+ * RelationAccessedInTransactionBlock returns true if any element of the
+ * relation id list that is provided is accessed in the current transaction
+ * block.
+ *
+ * Note that the function returns true as soon as any relation is found.
+ */
+bool
+RelationAccessedInTransactionBlock(List *relationIds)
+{
+	int fastPathSlot = 0;
+	int partitionNum = 0;
+	SHM_QUEUE *procLocks = NULL;
+	PROCLOCK *proclock = NULL;
+	LOCK *lock = NULL;
+
+	/* if we're not in a transaction block, no further checks needed */
+	if (!IsTransactionBlock())
+	{
+		return false;
+	}
+
+	/*
+	 * We check relation accesses in two steps. In the first step, we check the
+	 * fast path locks that MyProc holds. Later, we iterate over all the procLoks
+	 * that MyProc holds. With these two iterations, we are able to access all
+	 * the locks that are held by the current backend.
+	 */
+	LWLockAcquire(&MyProc->backendLock, LW_SHARED);
+
+	for (fastPathSlot = 0; fastPathSlot < FP_LOCK_SLOTS_PER_BACKEND; ++fastPathSlot)
+	{
+		uint32 lockbits = FAST_PATH_GET_BITS(MyProc, fastPathSlot);
+		Oid lockedRelationId = InvalidOid;
+
+		/* skip unallocated slots */
+		if (!lockbits)
+		{
+			continue;
+		}
+
+		lockedRelationId = MyProc->fpRelId[fastPathSlot];
+
+		/* we don't need to check catalog tables */
+		if (lockedRelationId > FirstNormalObjectId &&
+			list_member_oid(relationIds, lockedRelationId))
+		{
+			LWLockRelease(&MyProc->backendLock);
+
+			return true;
+		}
+	}
+
+	LWLockRelease(&MyProc->backendLock);
+
+	/* now iterate over the procLocks */
+	for (partitionNum = 0; partitionNum < NUM_LOCK_PARTITIONS; ++partitionNum)
+	{
+		LWLockAcquire(LockHashPartitionLockByIndex(partitionNum), LW_SHARED);
+
+		procLocks = &(MyProc->myProcLocks[partitionNum]);
+
+		proclock = (PROCLOCK *) SHMQueueNext(procLocks, procLocks,
+											 offsetof(PROCLOCK, procLink));
+
+		while (proclock)
+		{
+			Assert(proclock->tag.myProc == MyProc);
+
+			lock = proclock->tag.myLock;
+
+			/* we're only interested in relation locks */
+			if (lock->tag.locktag_type == LOCKTAG_RELATION)
+			{
+				Oid lockedRelationId = lock->tag.locktag_field2;
+
+				/* we don't need to check catalog tables */
+				if (lockedRelationId > FirstNormalObjectId &&
+					list_member_oid(relationIds, lockedRelationId))
+				{
+					LWLockRelease(LockHashPartitionLockByIndex(partitionNum));
+
+					return true;
+				}
+			}
+
+			proclock = (PROCLOCK *)
+					   SHMQueueNext(procLocks, &proclock->procLink,
+									offsetof(PROCLOCK, procLink));
+		}
+
+		LWLockRelease(LockHashPartitionLockByIndex(partitionNum));
+	}
+
+	return false;
+}

--- a/src/include/distributed/access_tracking.h
+++ b/src/include/distributed/access_tracking.h
@@ -1,0 +1,17 @@
+/*
+ * access_tracking.h
+ *
+ * Function declartions for transaction access tracking.
+ *
+ * Copyright (c) 2018, Citus Data, Inc.
+ */
+
+#ifndef ACCESS_TRACKING_H_
+#define ACCESS_TRACKING_H_
+
+#include "nodes/pg_list.h"
+
+extern bool RelationAccessedInTransactionBlock(List *relationIds);
+
+
+#endif /* ACCESS_TRACKING_H_ */

--- a/src/test/regress/expected/access_tracking.out
+++ b/src/test/regress/expected/access_tracking.out
@@ -1,0 +1,237 @@
+---
+--- tests around access tracking within transaction blocks
+---
+CREATE SCHEMA access_tracking;
+SET search_path TO 'access_tracking';
+CREATE FUNCTION relation_accessed_in_transaction_block(relationId Oid)
+    RETURNS boolean
+    LANGUAGE C STABLE STRICT
+    AS 'citus', $$relation_accessed_in_transaction_block$$;
+-- the tests could actually be applied to non-distributed tables as well
+-- however we still prefer to test with distributed tables
+-- but to make the tests run faster, we decrease the shard count
+SET citus.shard_count TO 1;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE table_1 (a int);
+SELECT create_distributed_table('table_1', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table_2 (a int);
+SELECT create_distributed_table('table_2', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table_3 (a int);
+SELECT create_distributed_table('table_3', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table_4 (a int);
+SELECT create_distributed_table('table_4', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE table_5 (a int);
+SELECT create_distributed_table('table_5', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- outisde the transaction blocks, the function always return false
+SELECT count(*) FROM table_1;
+ count 
+-------
+     0
+(1 row)
+
+SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ f
+(1 row)
+
+-- a very simple test that check the fast path locks
+BEGIN;
+	SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ f
+(1 row)
+
+	SELECT count(*) FROM table_1;
+ count 
+-------
+     0
+(1 row)
+
+	SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ f
+(1 row)
+
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+COMMIT;
+-- again fast path locks, with a modify query
+BEGIN;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ f
+(1 row)
+
+	INSERT INTO table_1 VALUES (1);
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+	-- after one more modification, we should still see that
+	DELETE FROM table_1;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+	-- now, lets increment the lock level
+	TRUNCATE table_1;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+COMMIT;
+BEGIN;
+	-- ALTER TABLE should acquire a relation lock
+	ALTER TABLE table_1 ADD COLUMN b INT;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+	-- a join touches multiple tables
+	SELECT 
+		count(*) 
+	FROM 
+		table_1, table_2, table_3, table_4
+	WHERE
+		table_1.a = table_2.a AND table_2.a = table_3.a AND 
+		table_3.a = table_4.a;
+ count 
+-------
+     0
+(1 row)
+
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+	SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+	SELECT relation_accessed_in_transaction_block('table_3'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+	SELECT relation_accessed_in_transaction_block('table_4'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+	-- we haven't accessed this table
+	SELECT relation_accessed_in_transaction_block('table_5'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ f
+(1 row)
+
+ROLLBACK;
+-- this test is slightly different that the others
+-- here we're adding constraints to make sure that
+-- the fast-path slots becomes full and we can still
+-- see all the locks
+BEGIN;
+        -- a join touches multiple tables
+        SELECT 
+                count(*) 
+        FROM 
+                table_1, table_2, table_3, table_4
+        WHERE
+                table_1.a = table_2.a AND table_2.a = table_3.a AND 
+                table_3.a = table_4.a;
+ count 
+-------
+     0
+(1 row)
+
+        ALTER TABLE table_1 ADD CONSTRAINT table_1_u UNIQUE (a);
+        ALTER TABLE table_2 ADD CONSTRAINT table_2_u FOREIGN KEY (a) REFERENCES table_1(a);
+		ALTER TABLE table_3 ADD CONSTRAINT table_3_u FOREIGN KEY (a) REFERENCES table_1(a);
+		ALTER TABLE table_4 ADD CONSTRAINT table_4_u FOREIGN KEY (a) REFERENCES table_1(a);
+		-- pg_dist_node is in the fast path and can be seen via relation_accessed_in_transaction_block
+        SELECT fastpath FROM pg_locks WHERE pid = pg_backend_pid() AND relation = 'pg_dist_node'::regclass;
+ fastpath 
+----------
+ t
+(1 row)
+
+        SELECT relation_accessed_in_transaction_block('pg_dist_node'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+        -- even if table 2 is not in the fast path, we can still see it via relation_accessed_in_transaction_block
+        SELECT fastpath FROM pg_locks WHERE pid = pg_backend_pid() AND relation = 'table_2'::regclass;
+ fastpath 
+----------
+ f
+ f
+ f
+(3 rows)
+
+        SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+ relation_accessed_in_transaction_block 
+----------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+SET search_path TO 'public';
+DROP SCHEMA access_tracking CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to function access_tracking.relation_accessed_in_transaction_block(oid)
+drop cascades to table access_tracking.table_1
+drop cascades to table access_tracking.table_2
+drop cascades to table access_tracking.table_3
+drop cascades to table access_tracking.table_4
+drop cascades to table access_tracking.table_5

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -131,7 +131,7 @@ test: multi_create_schema
 # Tests to check if we inform the user about potential caveats of creating new
 # databases, schemas, and roles.
 # ----------
-test: multi_utility_warnings
+test: multi_utility_warnings access_tracking
 
 # ----------
 # Tests to check the sequential and parallel executions of DDL and modification

--- a/src/test/regress/sql/access_tracking.sql
+++ b/src/test/regress/sql/access_tracking.sql
@@ -1,0 +1,123 @@
+---
+--- tests around access tracking within transaction blocks
+---
+
+
+CREATE SCHEMA access_tracking;
+
+SET search_path TO 'access_tracking';
+
+CREATE FUNCTION relation_accessed_in_transaction_block(relationId Oid)
+    RETURNS boolean
+    LANGUAGE C STABLE STRICT
+    AS 'citus', $$relation_accessed_in_transaction_block$$;
+
+
+-- the tests could actually be applied to non-distributed tables as well
+-- however we still prefer to test with distributed tables
+-- but to make the tests run faster, we decrease the shard count
+SET citus.shard_count TO 1;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE table_1 (a int);
+SELECT create_distributed_table('table_1', 'a');
+CREATE TABLE table_2 (a int);
+SELECT create_distributed_table('table_2', 'a');
+CREATE TABLE table_3 (a int);
+SELECT create_distributed_table('table_3', 'a');
+CREATE TABLE table_4 (a int);
+SELECT create_distributed_table('table_4', 'a');
+CREATE TABLE table_5 (a int);
+SELECT create_distributed_table('table_5', 'a');
+
+
+-- outisde the transaction blocks, the function always return false
+SELECT count(*) FROM table_1;
+SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+
+-- a very simple test that check the fast path locks
+BEGIN;
+
+	SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+
+	SELECT count(*) FROM table_1;
+
+	SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+COMMIT;
+
+
+-- again fast path locks, with a modify query
+BEGIN;
+
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+
+	INSERT INTO table_1 VALUES (1);
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+
+	-- after one more modification, we should still see that
+	DELETE FROM table_1;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+
+	-- now, lets increment the lock level
+	TRUNCATE table_1;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+
+COMMIT;
+
+BEGIN;
+	-- ALTER TABLE should acquire a relation lock
+	ALTER TABLE table_1 ADD COLUMN b INT;
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+ROLLBACK;
+
+BEGIN;
+
+	-- a join touches multiple tables
+	SELECT 
+		count(*) 
+	FROM 
+		table_1, table_2, table_3, table_4
+	WHERE
+		table_1.a = table_2.a AND table_2.a = table_3.a AND 
+		table_3.a = table_4.a;
+
+	SELECT relation_accessed_in_transaction_block('table_1'::regclass);
+	SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+	SELECT relation_accessed_in_transaction_block('table_3'::regclass);
+	SELECT relation_accessed_in_transaction_block('table_4'::regclass);
+
+	-- we haven't accessed this table
+	SELECT relation_accessed_in_transaction_block('table_5'::regclass);
+ROLLBACK;
+
+-- this test is slightly different that the others
+-- here we're adding constraints to make sure that
+-- the fast-path slots becomes full and we can still
+-- see all the locks
+BEGIN;
+        -- a join touches multiple tables
+        SELECT 
+                count(*) 
+        FROM 
+                table_1, table_2, table_3, table_4
+        WHERE
+                table_1.a = table_2.a AND table_2.a = table_3.a AND 
+                table_3.a = table_4.a;
+
+        ALTER TABLE table_1 ADD CONSTRAINT table_1_u UNIQUE (a);
+        ALTER TABLE table_2 ADD CONSTRAINT table_2_u FOREIGN KEY (a) REFERENCES table_1(a);
+		ALTER TABLE table_3 ADD CONSTRAINT table_3_u FOREIGN KEY (a) REFERENCES table_1(a);
+		ALTER TABLE table_4 ADD CONSTRAINT table_4_u FOREIGN KEY (a) REFERENCES table_1(a);
+
+		-- pg_dist_node is in the fast path and can be seen via relation_accessed_in_transaction_block
+        SELECT fastpath FROM pg_locks WHERE pid = pg_backend_pid() AND relation = 'pg_dist_node'::regclass;
+        SELECT relation_accessed_in_transaction_block('pg_dist_node'::regclass);
+
+        -- even if table 2 is not in the fast path, we can still see it via relation_accessed_in_transaction_block
+        SELECT fastpath FROM pg_locks WHERE pid = pg_backend_pid() AND relation = 'table_2'::regclass;
+        SELECT relation_accessed_in_transaction_block('table_2'::regclass);
+
+ROLLBACK;
+
+SET search_path TO 'public';
+DROP SCHEMA access_tracking CASCADE;


### PR DESCRIPTION
This is a pre-requisite for foreign keys from distributed tables to
reference tables (see #968). This should be implemented very efficiently
since we're going to get the list of relations accessed per query execution
within a transaction block.

I've done some benchmarking with the queries in this gist file: https://gist.github.com/onderkalaci/c43d34c590e659df676b021a3babe59a

There are 5 different test cases, and I've run using pgbench
 (` pgbench -j128 -c 128 -T 60  -f test5.sql`). The function is
manually injected in `FinalizePlan()` function, with the following call `RelationAccessedInTransactionBlock(distributedPlan->relationIdList);`. So
basically its a simulation of what we're planning to implement in the executor.

Note that in the current implementation, `RelationAccessedInTransactionBlock()` returns
as soon as a relation is found. **However, in my benchmarks, I've removed those early 
exists and let the function iterate always over all the locks to measure the worst cases.**

Summary of the results: We're not adding any measurable overhead:

```
test1:

	master:
		latency average = 2.747 ms
		tps = 46591.448168 (including connections establishing)
	branch: 
		latency average = 2.737 ms
		tps = 46770.381859 (including connections establishing)

test2:

	master:
		latency average = 1.918 ms
		tps = 66743.596836 (including connections establishing)

	branch:
		latency average = 1.942 ms
		tps = 65925.051692 (including connections establishing)

test3:

	master:
		latency average = 7.598 ms
		tps = 16847.514636 (including connections establishing)

	branch:
		latency average = 7.724 ms
		tps = 16571.969544 (including connections establishing)
		
test4:

	master:
		latency average = 7.741 ms
		tps = 16536.173865 (including connections establishing)

	branch:
		latency average = 7.836 ms
		tps = 16334.710307 (including connections establishing)

test5:

	master:
		latency average = 782.241 ms
		tps = 163.632361 (including connections establishing)

	branch:
		latency average = 798.815 ms
		tps = 160.237282 (including connections establishing)

```

Do you see any other meaningful tests we want to perform?



