### PR TITLE
DDLs affecting foreign keys to reference tables are serialized

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -310,8 +310,6 @@ ExecutePlanIntoDestReceiver(PlannedStmt *queryPlan, ParamListInfo params,
 void
 SetLocalMultiShardModifyModeToSequential()
 {
-	WarnNoTransactionChain(true, "SET LOCAL");
-
 	set_config_option("citus.multi_shard_modify_mode", "sequential",
 					  (superuser() ? PGC_SUSET : PGC_USERSET), PGC_S_SESSION,
 					  GUC_ACTION_LOCAL, true, 0, false);

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -26,6 +26,7 @@
 #include "commands/event_trigger.h"
 #include "distributed/citus_clauses.h"
 #include "distributed/citus_ruleutils.h"
+#include "distributed/foreign_constraint.h"
 #include "distributed/listutils.h"
 #include "distributed/master_metadata_utility.h"
 #include "distributed/master_protocol.h"
@@ -56,6 +57,7 @@
 
 
 static List * ModifyMultipleShardsTaskList(Query *query, List *shardIntervalList);
+static bool ShouldExecuteTruncateStmtSequential(TruncateStmt *command);
 
 
 PG_FUNCTION_INFO_V1(master_modify_multiple_shards);
@@ -132,6 +134,11 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 		}
 
 		EnsureTablePermissions(relationId, ACL_TRUNCATE);
+
+		if (ShouldExecuteTruncateStmtSequential(truncateStatement))
+		{
+			SetLocalMultiShardModifyModeToSequential();
+		}
 	}
 	else
 	{
@@ -234,4 +241,35 @@ ModifyMultipleShardsTaskList(Query *query, List *shardIntervalList)
 	}
 
 	return taskList;
+}
+
+
+/*
+ * ShouldExecuteTruncateStmtSequential decides if the TRUNCATE stmt needs
+ * to run sequential. If so, it calls SetLocalMultiShardModifyModeToSequential().
+ *
+ * If a reference table which has a foreign key from a distributed table is truncated
+ * we need to execute the command sequentially to avoid self-deadlock.
+ */
+static bool
+ShouldExecuteTruncateStmtSequential(TruncateStmt *command)
+{
+	List *relationList = command->relations;
+	ListCell *relationCell = NULL;
+	bool failOK = false;
+
+	foreach(relationCell, relationList)
+	{
+		RangeVar *rangeVar = (RangeVar *) lfirst(relationCell);
+		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
+
+		if (IsDistributedTable(relationId) &&
+			PartitionMethod(relationId) == DISTRIBUTE_BY_NONE &&
+			TableReferenced(relationId))
+		{
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/include/distributed/foreign_constraint.h
+++ b/src/include/distributed/foreign_constraint.h
@@ -14,10 +14,14 @@
 #include "utils/relcache.h"
 #include "nodes/primnodes.h"
 
+extern bool ConstraintIsAForeignKeyToReferenceTable(char *constraintName,
+													Oid leftRelationId);
 extern void ErrorIfUnsupportedForeignConstraint(Relation relation, char
 												distributionMethod,
 												Var *distributionColumn, uint32
 												colocationId);
+extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
+													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);
 extern bool HasForeignKeyToReferenceTable(Oid relationId);
 extern bool TableReferenced(Oid relationId);

--- a/src/test/regress/expected/foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table.out
@@ -436,14 +436,12 @@ CONTEXT:  while executing command on localhost:57637
 -- test delete from referenced table while there is NO corresponding value in referencing table
 DELETE FROM referenced_table WHERE id = 501;
 -- test cascading truncate
--- will fail for now
 TRUNCATE referenced_table CASCADE;
 NOTICE:  truncate cascades to table "referencing_table"
-ERROR:  canceling the transaction since it was involved in a distributed deadlock
 SELECT count(*) FROM referencing_table;
  count 
 -------
-   500
+     0
 (1 row)
 
 -- drop table for next tests
@@ -1357,6 +1355,456 @@ ERROR:  cannot establish a new connection for placement 7000388, since DDL has b
   DROP TABLE test_table_2, test_table_1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
+-- The following tests check if the DDLs affecting foreign keys work as expected
+-- check if we can drop the foreign constraint
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     8
+(1 row)
+
+ALTER TABLE test_table_2 DROP CONSTRAINT test_table_2_value_1_fkey;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can drop the foreign constraint in a transaction right after ADD CONSTRAINT
+-- FIXME: fails for now
+BEGIN;
+  CREATE TABLE test_table_1(id int PRIMARY KEY);
+  CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
+  SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+  SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+  ALTER TABLE test_table_2 ADD CONSTRAINT foreign_key FOREIGN KEY(value_1) REFERENCES test_table_1(id);
+ERROR:  relation "fkey_reference_table.test_table_1_7000362" does not exist
+CONTEXT:  while executing command on localhost:57637
+  ALTER TABLE test_table_2 DROP CONSTRAINT test_table_2_value_1_fkey;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+ERROR:  table "test_table_1" does not exist
+-- check if we can drop the primary key which cascades to the foreign key
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE test_table_1 DROP CONSTRAINT test_table_1_pkey CASCADE;
+NOTICE:  drop cascades to constraint test_table_2_value_1_fkey on table test_table_2
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can drop the primary key which cascades to the foreign key in a transaction block
+BEGIN;
+  CREATE TABLE test_table_1(id int PRIMARY KEY);
+  CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+  SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+  SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+  ALTER TABLE test_table_1 DROP CONSTRAINT test_table_1_pkey CASCADE;
+NOTICE:  drop cascades to constraint test_table_2_value_1_fkey on table test_table_2
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can drop the column which foreign key is referencing from
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE test_table_2 DROP COLUMN value_1;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can drop the column which foreign key is referencing from in a transaction block
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+  SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+  ALTER TABLE test_table_2 DROP COLUMN value_1;
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can drop the column which foreign key is referencing to
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+NOTICE:  drop cascades to constraint test_table_2_value_1_fkey on table test_table_2
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can drop the column which foreign key is referencing from in a transaction block
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+  SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+  ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+NOTICE:  drop cascades to constraint test_table_2_value_1_fkey on table test_table_2
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can alter the column type which foreign key is referencing to
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_1 VALUES (1,1), (2,2), (3,3);
+INSERT INTO test_table_2 VALUES (1,1), (2,2), (3,3);
+-- should succeed
+ALTER TABLE test_table_2 ALTER COLUMN value_1 SET DATA TYPE bigint;
+ALTER TABLE test_table_1 ALTER COLUMN id SET DATA TYPE bigint;
+-- should fail since there is a bigint out of integer range > (2^32 - 1)
+INSERT INTO test_table_1 VALUES (2147483648,4);
+INSERT INTO test_table_2 VALUES (4,2147483648);
+ALTER TABLE test_table_2 ALTER COLUMN value_1 SET DATA TYPE int;
+ERROR:  integer out of range
+CONTEXT:  while executing command on localhost:57637
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     8
+(1 row)
+
+DROP TABLE test_table_1 CASCADE;
+NOTICE:  drop cascades to constraint test_table_2_value_1_fkey on table test_table_2
+DROP TABLE test_table_2;
+-- check if we can alter the column type and drop it which foreign key is referencing to in a transaction block
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+  SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+  ALTER TABLE test_table_2 ALTER COLUMN value_1 SET DATA TYPE bigint;
+  ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+NOTICE:  drop cascades to constraint test_table_2_value_1_fkey on table test_table_2
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can TRUNCATE the referenced table
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+TRUNCATE test_table_1 CASCADE;
+NOTICE:  truncate cascades to table "test_table_2"
+SELECT * FROM test_table_2;
+ id | value_1 
+----+---------
+(0 rows)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can TRUNCATE the referenced table in a transaction
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+BEGIN;
+  TRUNCATE test_table_1 CASCADE;
+NOTICE:  truncate cascades to table "test_table_2"
+COMMIT;
+SELECT * FROM test_table_2;
+ id | value_1 
+----+---------
+(0 rows)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can TRUNCATE the referenced table in a transaction after inserts
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+  SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+  INSERT INTO test_table_1 VALUES (1),(2),(3);
+  INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3);
+  TRUNCATE test_table_1 CASCADE;
+NOTICE:  truncate cascades to table "test_table_2"
+COMMIT;
+SELECT * FROM test_table_2;
+ id | value_1 
+----+---------
+(0 rows)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can TRUNCATE the referencing table
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+TRUNCATE test_table_2 CASCADE;
+SELECT * FROM test_table_2;
+ id | value_1 
+----+---------
+(0 rows)
+
+SELECT * FROM test_table_1;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we can TRUNCATE the referencing table in a transaction
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+BEGIN;
+  TRUNCATE test_table_2 CASCADE;
+COMMIT;
+SELECT * FROM test_table_2;
+ id | value_1 
+----+---------
+(0 rows)
+
+SELECT * FROM test_table_1;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+DROP TABLE test_table_1, test_table_2;
+-- check if we successfuly set multi_shard_modify_mode to sequential after sequentially running DDLs
+-- in transaction since the upcoming DDLs need to run sequentially. 
+-- FIXME: fails for now
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
+CREATE TABLE test_table_3(id int PRIMARY KEY, value_1 int);
+SELECT create_reference_table('test_table_1');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('test_table_3', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+BEGIN;
+  ALTER TABLE test_table_2 ADD CONSTRAINT fkey FOREIGN KEY (value_1) REFERENCES test_table_1(id);
+  ALTER TABLE test_table_3 ADD COLUMN test_column int;
+ERROR:  cannot establish a new connection for placement 7000556, since DDL has been executed on a connection that is in use
+  ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+  ALTER TABLE test_table_1 ADD COLUMN id int;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+DROP TABLE test_table_1, test_table_2, test_table_3;
 DROP SCHEMA fkey_reference_table CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to type foreign_details

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -919,7 +919,8 @@ SELECT create_reference_table('reference_table');
 (1 row)
 
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_local_table(id);
-ERROR:  relation referenced_local_table is not distributed
+ERROR:  cannot create foreign key constraint because reference tables are not supported as the referencing table of a foreign constraint
+DETAIL:  Reference tables are only supported as the referenced table of a foreign key when the referencing table is a hash distributed table
 -- test foreign key creation on ALTER TABLE on self referencing reference table
 DROP TABLE self_referencing_reference_table;
 CREATE TABLE self_referencing_reference_table(

--- a/src/test/regress/expected/sequential_modifications.out
+++ b/src/test/regress/expected/sequential_modifications.out
@@ -74,7 +74,6 @@ SELECT create_distributed_table('test_table', 'a');
 
 -- not useful if not in transaction
 SELECT set_local_multi_shard_modify_mode_to_sequential();
-WARNING:  SET LOCAL can only be used in transaction blocks
  set_local_multi_shard_modify_mode_to_sequential 
 -------------------------------------------------
  

--- a/src/test/regress/sql/foreign_key_to_reference_table.sql
+++ b/src/test/regress/sql/foreign_key_to_reference_table.sql
@@ -198,7 +198,6 @@ DELETE FROM referenced_table WHERE id > 3;
 DELETE FROM referenced_table WHERE id = 501;
 
 -- test cascading truncate
--- will fail for now
 TRUNCATE referenced_table CASCADE;
 SELECT count(*) FROM referencing_table;
 
@@ -679,6 +678,237 @@ BEGIN;
 
   DROP TABLE test_table_2, test_table_1;
 COMMIT;
+
+-- The following tests check if the DDLs affecting foreign keys work as expected
+-- check if we can drop the foreign constraint
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+
+ALTER TABLE test_table_2 DROP CONSTRAINT test_table_2_value_1_fkey;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the foreign constraint in a transaction right after ADD CONSTRAINT
+-- FIXME: fails for now
+BEGIN;
+  CREATE TABLE test_table_1(id int PRIMARY KEY);
+  CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
+
+  SELECT create_reference_table('test_table_1');
+  SELECT create_distributed_table('test_table_2', 'id');
+
+  ALTER TABLE test_table_2 ADD CONSTRAINT foreign_key FOREIGN KEY(value_1) REFERENCES test_table_1(id);
+  ALTER TABLE test_table_2 DROP CONSTRAINT test_table_2_value_1_fkey;
+COMMIT;
+
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the primary key which cascades to the foreign key
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+ALTER TABLE test_table_1 DROP CONSTRAINT test_table_1_pkey CASCADE;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the primary key which cascades to the foreign key in a transaction block
+BEGIN;
+  CREATE TABLE test_table_1(id int PRIMARY KEY);
+  CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+  SELECT create_reference_table('test_table_1');
+  SELECT create_distributed_table('test_table_2', 'id');
+
+  ALTER TABLE test_table_1 DROP CONSTRAINT test_table_1_pkey CASCADE;
+COMMIT;
+
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the column which foreign key is referencing from
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+ALTER TABLE test_table_2 DROP COLUMN value_1;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the column which foreign key is referencing from in a transaction block
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+  SELECT create_distributed_table('test_table_2', 'id');
+
+  ALTER TABLE test_table_2 DROP COLUMN value_1;
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the column which foreign key is referencing to
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can drop the column which foreign key is referencing from in a transaction block
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+  SELECT create_distributed_table('test_table_2', 'id');
+
+  ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+COMMIT;
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can alter the column type which foreign key is referencing to
+CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+INSERT INTO test_table_1 VALUES (1,1), (2,2), (3,3);
+INSERT INTO test_table_2 VALUES (1,1), (2,2), (3,3);
+
+-- should succeed
+ALTER TABLE test_table_2 ALTER COLUMN value_1 SET DATA TYPE bigint;
+ALTER TABLE test_table_1 ALTER COLUMN id SET DATA TYPE bigint;
+
+-- should fail since there is a bigint out of integer range > (2^32 - 1)
+INSERT INTO test_table_1 VALUES (2147483648,4);
+INSERT INTO test_table_2 VALUES (4,2147483648);
+ALTER TABLE test_table_2 ALTER COLUMN value_1 SET DATA TYPE int;
+
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1 CASCADE;
+DROP TABLE test_table_2;
+
+-- check if we can alter the column type and drop it which foreign key is referencing to in a transaction block
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+  SELECT create_distributed_table('test_table_2', 'id');
+
+  ALTER TABLE test_table_2 ALTER COLUMN value_1 SET DATA TYPE bigint;
+  ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+COMMIT;
+
+SELECT count(*) FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%';
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can TRUNCATE the referenced table
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+TRUNCATE test_table_1 CASCADE;
+
+SELECT * FROM test_table_2;
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can TRUNCATE the referenced table in a transaction
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+
+BEGIN;
+  TRUNCATE test_table_1 CASCADE;
+COMMIT;
+SELECT * FROM test_table_2;
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can TRUNCATE the referenced table in a transaction after inserts
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+
+BEGIN;
+  SELECT create_reference_table('test_table_1');
+  SELECT create_distributed_table('test_table_2', 'id');
+
+  INSERT INTO test_table_1 VALUES (1),(2),(3);
+  INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3);
+  TRUNCATE test_table_1 CASCADE;
+COMMIT;
+
+SELECT * FROM test_table_2;
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can TRUNCATE the referencing table
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+TRUNCATE test_table_2 CASCADE;
+
+SELECT * FROM test_table_2;
+SELECT * FROM test_table_1;
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we can TRUNCATE the referencing table in a transaction
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+
+INSERT INTO test_table_1 VALUES (1),(2),(3);
+INSERT INTO test_table_2 VALUES (1,1),(2,2),(3,3); 
+BEGIN;
+  TRUNCATE test_table_2 CASCADE;
+COMMIT;
+
+SELECT * FROM test_table_2;
+SELECT * FROM test_table_1;
+DROP TABLE test_table_1, test_table_2;
+
+-- check if we successfuly set multi_shard_modify_mode to sequential after sequentially running DDLs
+-- in transaction since the upcoming DDLs need to run sequentially. 
+-- FIXME: fails for now
+CREATE TABLE test_table_1(id int PRIMARY KEY);
+CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
+CREATE TABLE test_table_3(id int PRIMARY KEY, value_1 int);
+SELECT create_reference_table('test_table_1');
+SELECT create_distributed_table('test_table_2', 'id');
+SELECT create_distributed_table('test_table_3', 'id');
+BEGIN;
+  ALTER TABLE test_table_2 ADD CONSTRAINT fkey FOREIGN KEY (value_1) REFERENCES test_table_1(id);
+  ALTER TABLE test_table_3 ADD COLUMN test_column int;
+  ALTER TABLE test_table_1 DROP COLUMN id CASCADE;
+  ALTER TABLE test_table_1 ADD COLUMN id int;
+COMMIT;
+DROP TABLE test_table_1, test_table_2, test_table_3;
 
 DROP SCHEMA fkey_reference_table CASCADE;
 SET search_path TO DEFAULT;


### PR DESCRIPTION
This PR serializes some of the DDL operations related to foreign keys from hash distributed to reference tables.

- [x] `DROP CONSTRAINT`
- [x] `DROP COLUMN`
- [x] `ALTER COLUMN id SET DATA TYPE `
- [x] `TRUNCATE ... CASCADE`

We need to serialize these operations because they either `CASCADE` to the distributed table or executes a parallel `SELECT` on the distributed table to do some checks before adding the foreign keys.