### PR TITLE
refactor grantee serialization for reuse

### DIFF
--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -50,5 +50,6 @@ extern void ErrorIfUnsupportedConstraint(Relation relation, char distributionMet
 extern Datum master_drop_all_shards(PG_FUNCTION_ARGS);
 extern Datum master_modify_multiple_shards(PG_FUNCTION_ARGS);
 
+extern const char * RoleSpecString(RoleSpec *spec);
 
 #endif /* MULTI_UTILITY_H */


### PR DESCRIPTION
Its a common pattern to serialize `RoleSpec *` back to its SQL form. By extracting it to its own function we can reuse it.

Also there might be a difference in the value of `SESSION_USER` between the coordinator and a worker when `SET ROLE ...;` has been used on the coordinator. Therefore we resolve `SESSION_USER` and `CURRENT_USER` to its value on during execution on the coordinator to the actual user.