### PR TITLE
[WIP] Travis test parallelisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@ env:
     - secure: degV+qb2xHiea7E2dGk/WLvmYjq4ZsBn6ZPko+YhRcNm2GRXRaU3FqMBIecPtsEEFYaL5GwCQq/CgBf9aQxgDQ+t2CrmtGTtI9AGAbVBl//amNeJOoLe6QvrDpSQX5pUxwDLCng8cvoQK7ZxGlNCzDKiu4Ep4DUWgQVpauJkQ9nHjtSMZvUqCoI9h1lBy9Mxh7YFfHPW2PAXCqpV4VlNiIYF84UKdX3MXKLy9Yt0JBSNTWLZFp/fFw2qNwzFvN94rF3ZvFSD7Wp6CIhT6R5/6k6Zx8YQIrjWhgm6OVy1osUA8X7W79h2ISPqKqMNVJkjJ+N8S4xuQU0kfejnQ74Ie/uJiHCmbW5W2TjpL1aU3FQpPsGwR8h0rSeHhJAJzd8Ma+z8vvnnQHDyvetPBB0WgA/VMQCu8uEutyfYw2hDmB2+l2dDwkViaI7R95bReAGrpd5uNqklAXuR7yOeArz0ZZpHV0aZHGcNBxznMaZExSVZ5DVPW38UPn7Kgse8BnOWeLgnA1hJVp6CmBCtu+hKYt+atBPgRbM8IUINnKKZf/Sk6HeJIJZs662jD8/X93vFi0ZtyV2jEKJpouWw8j4vrGGsaDzTEUcyJgDqZj7tPJptM2L5B3BcFJmkGj2HO3N+LGDarJrVBBSiEjhTgx4NnLiKZnUbMx547mCRg2akk2w=
     # During push builds (not pull request builds), use custom-built PostgreSQL
     - USE_CUSTOM_PG=$([ -z $TRAVIS_PULL_REQUEST_SHA ] && echo "true")
-matrix:
-  fast_finish: true
-  include:
-    - env: PGVERSION=9.6
-    - env: PGVERSION=10
-    - env: PGVERSION=11
-  allow_failures:
-    - env: PGVERSION=11
 before_install:
   - git clone -b v0.7.6 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
@@ -38,8 +30,28 @@ install:
       apt-get download "postgresql-${PGVERSION}-hll=2.10.2.citus-1"
       sudo dpkg --force-confold --force-confdef --force-all -i *hll*.deb
     fi
-before_script: citus_indent --quiet --check
-script: CFLAGS=-Werror pg_travis_multi_test check
-after_success:
-  - sync_to_enterprise
-  - bash <(curl -s https://codecov.io/bash)
+jobs:
+  include:
+    - stage: PG9_6
+      env: PGVERSION=9.6
+      before_script: citus_indent --quiet --check
+    - script: CFLAGS=-Werror pg_travis_multi_test check-multi
+      env: PGVERSION=9.6
+    - script: CFLAGS=-Werror pg_travis_multi_test check-multi-mx check-multi-task-tracker-extra
+      env: PGVERSION=9.6
+    - script: CFLAGS=-Werror pg_travis_multi_test check-worker check-follower-cluster check-vanilla
+      env: PGVERSION=9.6
+    - script: CFLAGS=-Werror pg_travis_multi_test check-isolation
+      env: PGVERSION=9.6
+    - script: CFLAGS=-Werror pg_travis_multi_test check-multi
+      env: PGVERSION=10
+    - script: CFLAGS=-Werror pg_travis_multi_test check-multi-mx check-multi-task-tracker-extra
+      env: PGVERSION=10
+    - script: CFLAGS=-Werror pg_travis_multi_test check-worker check-follower-cluster check-vanilla
+      env: PGVERSION=10
+    - script: CFLAGS=-Werror pg_travis_multi_test check-isolation
+      env: PGVERSION=10
+    - stage: deploy
+      script: sync_to_enterprise
+    - stage: code_cov
+      script: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR is just created to see if we can benefit from build stages and separate jobs for separate tests.

Just tried to implement what I proposed in #2213 

Obviously, yes, we can. But it does not provide any benefit if we do not use [Build Stages: cache warming](https://docs.travis-ci.com/user/build-stages/warm-cache/) for the initial installation step.

We need to remove [this lines](https://github.com/citusdata/tools/blob/develop/travis/pg_travis_multi_test#L26) so that we do not run vanilla and isolation tests per job. 

We need to make this PR un-ugly. Since I don't know much about travis.yml, I couldn't find a solution to set the environment variable PGVERSION for all, instead I set it again and again. (which is very ugly!).

I don't know how we can benefit allowed failure for upcoming PG version builds as in PG11 builds.

We need to make the test groups more homogenous in terms of run time. check-multi is a huge one anyway...

@jasonmp85 maybe gets your attention :) Feel free to destroy this PR completely. 

