### PR TITLE
Fix use-after-free that may occur for INSERT..SELECT in prepared statements

### DIFF
--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2722,6 +2722,19 @@ SELECT * FROM coerce_agg;
        2 | {2,2,2}
 (2 rows)
 
+-- INSERT..SELECT + prepared statements + recursive planning
+BEGIN;
+PREPARE prepared_recursive_insert_select AS 
+INSERT INTO users_table 
+SELECT * FROM users_table 
+WHERE value_1 IN (SELECT value_2 FROM events_table OFFSET 0);
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+ROLLBACK;
 -- wrap in a transaction to improve performance
 BEGIN;
 DROP TABLE coerce_events;

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -2090,6 +2090,20 @@ LIMIT 5;
 
 SELECT * FROM coerce_agg;
 
+-- INSERT..SELECT + prepared statements + recursive planning
+BEGIN;
+PREPARE prepared_recursive_insert_select AS 
+INSERT INTO users_table 
+SELECT * FROM users_table 
+WHERE value_1 IN (SELECT value_2 FROM events_table OFFSET 0);
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+EXECUTE prepared_recursive_insert_select;
+ROLLBACK;
+
 -- wrap in a transaction to improve performance
 BEGIN;
 DROP TABLE coerce_events;


### PR DESCRIPTION
Fixes #2217 

Basically, we're currently allowing the planner to scribble on the parse tree of the SELECT query (e.g. Citus does this when there are recursively planned subqueries) when executing INSERT..SELECT via the coordinator, but the parse tree may be stored in a prepared plan. The changes to the parse tree will not be in a persistent memory context, hence this may cause crashes or undefined behaviour.

Note: I know I could have added more tests, but I don't have a lot of time.