### PR TITLE
enable aggregate features (distinct, order by) when group by clause includes partition column

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -3112,6 +3112,8 @@ ErrorIfContainsUnsupportedAggregate(MultiNode *logicalPlanNode)
 {
 	List *opNodeList = FindNodesOfType(logicalPlanNode, T_MultiExtendedOp);
 	MultiExtendedOp *extendedOpNode = (MultiExtendedOp *) linitial(opNodeList);
+	List *tableNodeList = FindNodesOfType(logicalPlanNode, T_MultiTable);
+	bool distinctSupported = TablePartitioningSupportsDistinct(tableNodeList, extendedOpNode, NULL);
 
 	List *targetList = extendedOpNode->targetList;
 
@@ -3131,6 +3133,12 @@ ErrorIfContainsUnsupportedAggregate(MultiNode *logicalPlanNode)
 
 		/* only consider aggregate expressions */
 		if (!IsA(expression, Aggref))
+		{
+			continue;
+		}
+
+		/* only consider aggregates that aren't grouped by the partition column */
+		if (distinctSupported)
 		{
 			continue;
 		}


### PR DESCRIPTION
This PR not currently working

What I'm trying to do here is enable queries like this:

```sql
SELECT partition_column, array_agg(a ORDER BY b) GROUP BY partition_column;
```

TablePartitioningSupportsDistinct seems to always return false and I don't know why. I don't know C, so this is a tricky thing for me to debug. Would love for someone to point me in the right direction.