### PR TITLE
Adds locking reference table utils when a shard has a foreign key to it

### DIFF
--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -165,6 +165,11 @@ extern Datum master_copy_shard_placement(PG_FUNCTION_ARGS);
 extern List * CopyShardCommandList(ShardInterval *shardInterval, char *sourceNodeName,
 								   int32 sourceNodePort);
 extern List * CopyShardForeignConstraintCommandList(ShardInterval *shardInterval);
+extern void CopyShardForeignConstraintCommandListGrouped(ShardInterval *shardInterval,
+														 List **
+														 colocatedShardForeignConstraintCommandList,
+														 List **
+														 referenceTableForeignConstraintList);
 extern ShardPlacement * SearchShardPlacementInList(List *shardPlacementList,
 												   char *nodeName, uint32 nodePort,
 												   bool missingOk);

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -67,6 +67,10 @@ typedef enum AdvisoryLocktagClass
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
 extern bool TryLockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
 
+/* Lock shard/relation metadata of the referenced reference table if exists */
+extern void LockReferencedReferenceShardDistributionMetadata(uint64 shardId, LOCKMODE
+															 lock);
+
 /* Lock shard data, for DML commands or remote fetches */
 extern void LockShardResource(uint64 shardId, LOCKMODE lockmode);
 extern void UnlockShardResource(uint64 shardId, LOCKMODE lockmode);


### PR DESCRIPTION
This PR is added for rebalancer operations on the enterprise but most of the code path should be in the community as well. Check https://github.com/citusdata/citus-enterprise/pull/253/ for details.

