### PR TITLE
Bump tools version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   allow_failures:
     - env: PGVERSION=11
 before_install:
-  - git clone -b v0.7.6 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.8 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - curl https://install.citusdata.com/community/deb.sh | sudo bash


### PR DESCRIPTION
To be able to test landlord in travis, we need pg_stat_statements from
contrib packages. New tools version, 0.7.8, installs pg_stat_statements
too, so we are switching to version 0.7.8 in our travis tests.