### PR TITLE
create placeholder for policy ddl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ OBJS = src/backend/distributed/shared_library_init.o \
      src/backend/distributed/connection/placement_connection.o \
      src/backend/distributed/connection/remote_commands.o \
      src/backend/distributed/ddl/foreign_constraint.o \
+     src/backend/distributed/ddl/policy.o \
      src/backend/distributed/executor/citus_custom_scan.o \
      src/backend/distributed/executor/insert_select_executor.o \
      src/backend/distributed/executor/intermediate_results.o \

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -46,6 +46,7 @@
 #include "distributed/multi_utility.h"
 #include "distributed/pg_dist_colocation.h"
 #include "distributed/pg_dist_partition.h"
+#include "distributed/policy.h"
 #include "distributed/reference_table_utils.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/remote_commands.h"
@@ -764,6 +765,8 @@ EnsureRelationCanBeDistributed(Oid relationId, Var *distributionColumn,
 	{
 		InvalidateForeignKeyGraph();
 	}
+
+	ErrorIfUnsupportedPolicy(relation);
 
 	relation_close(relation, NoLock);
 }

--- a/src/backend/distributed/ddl/policy.c
+++ b/src/backend/distributed/ddl/policy.c
@@ -1,0 +1,127 @@
+/*-------------------------------------------------------------------------
+ * policy.c
+ *
+ * This file contains functions to create, alter and drop policies on
+ * distributed tables.
+ *
+ * Copyright (c) 2018, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "catalog/namespace.h"
+#include "commands/policy.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/policy.h"
+#include "utils/builtins.h"
+
+
+/* placeholder for CreatePolicyCommands */
+List *
+CreatePolicyCommands(Oid relationId)
+{
+	/* placeholder for future implementation */
+	return NIL;
+}
+
+
+/* placeholder for PlanCreatePolicyStmt */
+List *
+PlanCreatePolicyStmt(CreatePolicyStmt *stmt)
+{
+	Oid relationId = RangeVarGetRelid(stmt->table,
+									  AccessExclusiveLock,
+									  false);
+	if (IsDistributedTable(relationId))
+	{
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("policies on distributed tables are only supported in "
+							   "Citus Enterprise")));
+	}
+
+	/* placeholder for future implementation */
+	return NIL;
+}
+
+
+/* placeholder for PlanAlterPolicyStmt */
+List *
+PlanAlterPolicyStmt(AlterPolicyStmt *stmt)
+{
+	/* placeholder for future implementation */
+	return NIL;
+}
+
+
+/* placeholder for ErrorIfUnsupportedPolicy */
+void
+ErrorIfUnsupportedPolicy(Relation relation)
+{
+	if (relation_has_policies(relation))
+	{
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("policies on distributed tables are only supported in "
+							   "Citus Enterprise"),
+						errhint("Remove any policies on a table before distributing")));
+	}
+}
+
+
+/* placeholder for ErrorIfUnsupportedPolicyExpr */
+void
+ErrorIfUnsupportedPolicyExpr(Node *expr)
+{
+	/* placeholder for future implementation */
+}
+
+
+/* placeholder for PlanDropPolicyStmt */
+List *
+PlanDropPolicyStmt(DropStmt *stmt, const char *queryString)
+{
+	/* placeholder for future implementation */
+	return NIL;
+}
+
+
+/* placeholder for IsPolicyRenameStmt */
+bool
+IsPolicyRenameStmt(RenameStmt *stmt)
+{
+	/* placeholder for future implementation */
+	return false;
+}
+
+
+/* placeholder for CreatePolicyEventExtendNames */
+void
+CreatePolicyEventExtendNames(CreatePolicyStmt *stmt, const char *schemaName, uint64
+							 shardId)
+{
+	/* placeholder for future implementation */
+}
+
+
+/* placeholder for AlterPolicyEventExtendNames */
+void
+AlterPolicyEventExtendNames(AlterPolicyStmt *stmt, const char *schemaName, uint64 shardId)
+{
+	/* placeholder for future implementation */
+}
+
+
+/* placeholder for RenamePolicyEventExtendNames */
+void
+RenamePolicyEventExtendNames(RenameStmt *stmt, const char *schemaName, uint64 shardId)
+{
+	/* placeholder for future implementation */
+}
+
+
+/* placeholder for DropPolicyEventExtendNames */
+void
+DropPolicyEventExtendNames(DropStmt *dropStmt, const char *schemaName, uint64 shardId)
+{
+	/* placeholder for future implementation */
+}

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -46,6 +46,7 @@
 #include "distributed/metadata_cache.h"
 #include "distributed/metadata_sync.h"
 #include "distributed/pg_dist_shard.h"
+#include "distributed/policy.h"
 #include "distributed/worker_manager.h"
 #include "foreign/foreign.h"
 #include "lib/stringinfo.h"
@@ -558,6 +559,7 @@ GetTableDDLEvents(Oid relationId, bool includeSequenceDefaults)
 	List *tableCreationCommandList = NIL;
 	List *indexAndConstraintCommandList = NIL;
 	List *replicaIdentityEvents = NIL;
+	List *policyCommands = NIL;
 
 	tableCreationCommandList = GetTableCreationCommands(relationId,
 														includeSequenceDefaults);
@@ -568,6 +570,9 @@ GetTableDDLEvents(Oid relationId, bool includeSequenceDefaults)
 
 	replicaIdentityEvents = GetTableReplicaIdentityCommand(relationId);
 	tableDDLEventList = list_concat(tableDDLEventList, replicaIdentityEvents);
+
+	policyCommands = CreatePolicyCommands(relationId);
+	tableDDLEventList = list_concat(tableDDLEventList, policyCommands);
 
 	return tableDDLEventList;
 }

--- a/src/include/distributed/multi_utility.h
+++ b/src/include/distributed/multi_utility.h
@@ -51,6 +51,7 @@ extern void ErrorIfUnsupportedConstraint(Relation relation, char distributionMet
 extern Datum master_drop_all_shards(PG_FUNCTION_ARGS);
 extern Datum master_modify_multiple_shards(PG_FUNCTION_ARGS);
 
+extern List * DDLTaskList(Oid relationId, const char *commandString);
 extern const char * RoleSpecString(RoleSpec *spec);
 
 #endif /* MULTI_UTILITY_H */

--- a/src/include/distributed/policy.h
+++ b/src/include/distributed/policy.h
@@ -1,0 +1,32 @@
+/*-------------------------------------------------------------------------
+ * policy.h
+ *
+ * Copyright (c) 2018, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CITUS_POLICY_H
+#define CITUS_POLICY_H
+
+#include "utils/rel.h"
+
+extern List * CreatePolicyCommands(Oid relationId);
+extern void ErrorIfUnsupportedPolicy(Relation relation);
+extern void ErrorIfUnsupportedPolicyExpr(Node *expr);
+
+extern List * PlanCreatePolicyStmt(CreatePolicyStmt *stmt);
+extern List * PlanAlterPolicyStmt(AlterPolicyStmt *stmt);
+extern List * PlanDropPolicyStmt(DropStmt *stmt, const char *queryString);
+extern bool IsPolicyRenameStmt(RenameStmt *stmt);
+
+extern void CreatePolicyEventExtendNames(CreatePolicyStmt *stmt, const char *schemaName,
+										 uint64 shardId);
+extern void AlterPolicyEventExtendNames(AlterPolicyStmt *stmt, const char *schemaName,
+										uint64 shardId);
+extern void RenamePolicyEventExtendNames(RenameStmt *stmt, const char *schemaName, uint64
+										 shardId);
+extern void DropPolicyEventExtendNames(DropStmt *stmt, const char *schemaName, uint64
+									   shardId);
+
+#endif /*CITUS_POLICY_H */

--- a/src/include/distributed/relay_utility.h
+++ b/src/include/distributed/relay_utility.h
@@ -49,4 +49,6 @@ extern void RelayEventExtendNamesForInterShardCommands(Node *parseTree,
 													   char *rightShardSchemaName);
 extern void AppendShardIdToName(char **name, uint64 shardId);
 
+extern void SetSchemaNameIfNotExist(char **schemaName, const char *newSchemaName);
+
 #endif   /* RELAY_UTILITY_H */


### PR DESCRIPTION
DESCRIPTION: Adds infrastructure to implement DDL commands for policies in the future, warn about being unsupported on distributed tables.

There is a small side effect for people that use policies on distributed tables now as it signals when you  execute `CREATE POLICY` that the operation is not supported on distributed tables. Warns in the same way when distributing tables that already have policies defined that those are unsupported and need to be removed from a table before distributing it.

We need to change our [blog post about RLS](https://www.citusdata.com/blog/2018/04/04/raw-sql-access-with-row-level-security/) accordingly by either add more `SET citus.enable_ddl_propagation to off;` statements around the DDL commands. Or better remove them and reword the blogpost to indicate it is a supported feature in Citus Cloud and Enterprise as `Fine-grained access controls`. The current solution provided by the blogpost has problems around shard movement, repairs and splits as the newly createsd shards will not have the policies set on them