### PR TITLE
Add "direct" node columns to metadata catalogs

### DIFF
--- a/citus.control
+++ b/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.5-5'
+default_version = '7.5-6'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -16,7 +16,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	7.2-1 7.2-2 7.2-3 \
 	7.3-1 7.3-2 7.3-3 \
 	7.4-1 7.4-2 7.4-3 \
-	7.5-1 7.5-2 7.5-3 7.5-4 7.5-5
+	7.5-1 7.5-2 7.5-3 7.5-4 7.5-5 7.5-6
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -209,6 +209,8 @@ $(EXTENSION)--7.5-3.sql: $(EXTENSION)--7.5-2.sql $(EXTENSION)--7.5-2--7.5-3.sql
 $(EXTENSION)--7.5-4.sql: $(EXTENSION)--7.5-3.sql $(EXTENSION)--7.5-3--7.5-4.sql
 	cat $^ > $@
 $(EXTENSION)--7.5-5.sql: $(EXTENSION)--7.5-4.sql $(EXTENSION)--7.5-4--7.5-5.sql
+	cat $^ > $@
+$(EXTENSION)--7.5-6.sql: $(EXTENSION)--7.5-5.sql $(EXTENSION)--7.5-5--7.5-6.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--7.5-5--7.5-6.sql
+++ b/src/backend/distributed/citus--7.5-5--7.5-6.sql
@@ -1,0 +1,91 @@
+/* citus--7.5-5--7.5-6 */
+
+SET search_path = 'pg_catalog';
+
+ALTER TABLE pg_catalog.pg_dist_node
+    ADD COLUMN directname text,
+    ADD COLUMN directport integer,
+    ADD CONSTRAINT direct_complete
+        CHECK ((directname IS NULL) = (directport IS NULL));
+
+DROP FUNCTION master_add_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                groupid integer default 0,
+                                noderole noderole default 'primary',
+                                nodecluster name default 'default',
+                                directname text default NULL,
+                                directport integer default NULL,
+                                OUT nodeid integer,
+                                OUT groupid integer,
+                                OUT nodename text,
+                                OUT nodeport integer,
+                                OUT noderack text,
+                                OUT hasmetadata boolean,
+                                OUT isactive bool,
+                                OUT noderole noderole,
+                                OUT nodecluster name,
+                                OUT directname text,
+                                OUT directport integer)
+  RETURNS record
+  LANGUAGE C
+  AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer,
+                                    groupid integer, noderole noderole, nodecluster name,
+                                    directname text, directport integer)
+  IS 'add node to the cluster';
+
+DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         groupid integer default 0,
+                                         noderole noderole default 'primary',
+                                         nodecluster name default 'default',
+                                         directname text default NULL,
+                                         directport integer default NULL,
+                                         OUT nodeid integer,
+                                         OUT groupid integer,
+                                         OUT nodename text,
+                                         OUT nodeport integer,
+                                         OUT noderack text,
+                                         OUT hasmetadata boolean,
+                                         OUT isactive bool,
+                                         OUT noderole noderole,
+                                         OUT nodecluster name,
+                                         OUT directname text,
+                                         OUT directport integer)
+  RETURNS record
+  LANGUAGE C
+  AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text, nodeport integer,
+                                             groupid integer, noderole noderole,
+                                             nodecluster name, directname text,
+                                             directport integer)
+  IS 'prepare node by adding it to pg_dist_node';
+
+DROP FUNCTION master_activate_node(text, integer);
+CREATE FUNCTION master_activate_node(nodename text,
+                                     nodeport integer,
+                                     OUT nodeid integer,
+                                     OUT groupid integer,
+                                     OUT nodename text,
+                                     OUT nodeport integer,
+                                     OUT noderack text,
+                                     OUT hasmetadata boolean,
+                                     OUT isactive bool,
+                                     OUT noderole noderole,
+                                     OUT nodecluster name,
+                                     OUT directname text,
+                                     OUT directport integer)
+    RETURNS record
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME',$$master_activate_node$$;
+COMMENT ON FUNCTION master_activate_node(nodename text, nodeport integer)
+    IS 'activate a node which is in the cluster';
+
+ALTER TABLE pg_dist_authinfo
+    ADD COLUMN directauthinfo text
+               CONSTRAINT directauthinfo_valid
+						  CHECK (authinfo_valid(directauthinfo));
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '7.5-5'
+default_version = '7.5-6'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -1132,6 +1132,8 @@ GenerateNodeTuple(WorkerNode *workerNode)
 	values[Anum_pg_dist_node_isactive - 1] = BoolGetDatum(workerNode->isActive);
 	values[Anum_pg_dist_node_noderole - 1] = ObjectIdGetDatum(workerNode->nodeRole);
 	values[Anum_pg_dist_node_nodecluster - 1] = nodeClusterNameDatum;
+	isNulls[Anum_pg_dist_node_directname - 1] = true;
+	isNulls[Anum_pg_dist_node_directport - 1] = true;
 
 	pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
 
@@ -1293,6 +1295,8 @@ InsertNodeRow(int nodeid, char *nodeName, int32 nodePort, uint32 groupId, char *
 	values[Anum_pg_dist_node_isactive - 1] = BoolGetDatum(isActive);
 	values[Anum_pg_dist_node_noderole - 1] = ObjectIdGetDatum(nodeRole);
 	values[Anum_pg_dist_node_nodecluster - 1] = nodeClusterNameDatum;
+	isNulls[Anum_pg_dist_node_directname - 1] = true;
+	isNulls[Anum_pg_dist_node_directport - 1] = true;
 
 	pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
 
@@ -1537,8 +1541,6 @@ TupleToWorkerNode(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 								  tupleDescriptor, &isNull);
 	Datum nodeCluster = heap_getattr(heapTuple, Anum_pg_dist_node_nodecluster,
 									 tupleDescriptor, &isNull);
-
-	Assert(!HeapTupleHasNulls(heapTuple));
 
 	workerNode = (WorkerNode *) palloc0(sizeof(WorkerNode));
 	workerNode->nodeId = DatumGetUInt32(nodeId);

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -20,7 +20,7 @@
  *  in particular their OUT parameters) must be changed whenever the definition of
  *  pg_dist_node changes.
  */
-#define Natts_pg_dist_node 9
+#define Natts_pg_dist_node 11
 #define Anum_pg_dist_node_nodeid 1
 #define Anum_pg_dist_node_groupid 2
 #define Anum_pg_dist_node_nodename 3
@@ -30,6 +30,8 @@
 #define Anum_pg_dist_node_isactive 7
 #define Anum_pg_dist_node_noderole 8
 #define Anum_pg_dist_node_nodecluster 9
+#define Anum_pg_dist_node_directname 10
+#define Anum_pg_dist_node_directport 11
 
 #define GROUPID_SEQUENCE_NAME "pg_dist_groupid_seq"
 #define NODEID_SEQUENCE_NAME "pg_dist_node_nodeid_seq"

--- a/src/test/regress/expected/failure_setup.out
+++ b/src/test/regress/expected/failure_setup.out
@@ -7,13 +7,13 @@ SELECT citus.mitmproxy('conn.allow()');
 -- add the workers
 SELECT master_add_node('localhost', :worker_1_port);  -- the second worker
                   master_add_node                  
----------------------------------------------------
- (1,1,localhost,57637,default,f,t,primary,default)
+-----------------------------------------------------
+ (1,1,localhost,57637,default,f,t,primary,default,,)
 (1 row)
 
 SELECT master_add_node('localhost', :worker_2_port + 2);  -- the first worker, behind a mitmproxy
                   master_add_node                  
----------------------------------------------------
- (2,2,localhost,57640,default,f,t,primary,default)
+-----------------------------------------------------
+ (2,2,localhost,57640,default,f,t,primary,default,,)
 (1 row)
 

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -276,16 +276,16 @@ SELECT count(1) FROM pg_dist_node;
 SELECT
 	master_add_node('localhost', :worker_1_port),
 	master_add_node('localhost', :worker_2_port);
-                  master_add_node                  |                  master_add_node                  
----------------------------------------------------+---------------------------------------------------
- (8,7,localhost,57637,default,f,t,primary,default) | (9,8,localhost,57638,default,f,t,primary,default)
+                   master_add_node                   |                   master_add_node                   
+-----------------------------------------------------+-----------------------------------------------------
+ (8,7,localhost,57637,default,f,t,primary,default,,) | (9,8,localhost,57638,default,f,t,primary,default,,)
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-      8 |       7 | localhost |    57637 | default  | f           | t        | primary  | default
-      9 |       8 | localhost |    57638 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | directname | directport 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------+------------+------------
+      8 |       7 | localhost |    57637 | default  | f           | t        | primary  | default     |            |           
+      9 |       8 | localhost |    57638 | default  | f           | t        | primary  | default     |            |           
 (2 rows)
 
 -- check that mixed add/remove node commands work fine inside transaction
@@ -463,15 +463,15 @@ SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_g
 
 -- check that you can add a seconary to a non-default cluster, and activate it, and remove it
 SELECT master_add_inactive_node('localhost', 9999, groupid => :worker_2_group, nodecluster => 'olap', noderole => 'secondary');
-             master_add_inactive_node              
----------------------------------------------------
- (19,14,localhost,9999,default,f,f,secondary,olap)
+              master_add_inactive_node               
+-----------------------------------------------------
+ (19,14,localhost,9999,default,f,f,secondary,olap,,)
 (1 row)
 
 SELECT master_activate_node('localhost', 9999);
-               master_activate_node                
----------------------------------------------------
- (19,14,localhost,9999,default,f,t,secondary,olap)
+                master_activate_node                 
+-----------------------------------------------------
+ (19,14,localhost,9999,default,f,t,secondary,olap,,)
 (1 row)
 
 SELECT master_disable_node('localhost', 9999);
@@ -499,17 +499,17 @@ CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 18 at RAISE
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole, nodecluster)
   VALUES ('localhost', 5000, 1000, 'primary', 'olap');
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
-DETAIL:  Failing row contains (17, 1000, localhost, 5000, default, f, t, primary, olap).
+DETAIL:  Failing row contains (17, 1000, localhost, 5000, default, f, t, primary, olap, null, null).
 UPDATE pg_dist_node SET nodecluster = 'olap'
   WHERE nodeport = :worker_1_port;
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
-DETAIL:  Failing row contains (13, 12, localhost, 57637, default, f, t, primary, olap).
+DETAIL:  Failing row contains (13, 12, localhost, 57637, default, f, t, primary, olap, null, null).
 -- check that you /can/ add a secondary node to a non-default cluster
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
 SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary', nodecluster=> 'olap');
-                  master_add_node                  
----------------------------------------------------
- (20,12,localhost,8888,default,f,t,secondary,olap)
+                   master_add_node                   
+-----------------------------------------------------
+ (20,12,localhost,8888,default,f,t,secondary,olap,,)
 (1 row)
 
 -- check that super-long cluster names are truncated
@@ -520,38 +520,38 @@ SELECT master_add_node('localhost', 8887, groupid => :worker_1_group, noderole =
 	'thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.'
 	'overflow'
 );
-                                               master_add_node                                                
---------------------------------------------------------------------------------------------------------------
- (21,12,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.)
+                                                master_add_node                                                 
+----------------------------------------------------------------------------------------------------------------
+ (21,12,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.,,)
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeport=8887;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           
---------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------
-     21 |      12 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           | directname | directport 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------+------------+------------
+     21 |      12 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars. |            |           
 (1 row)
 
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
 -- them in any of the remaining tests
 -- master_add_secondary_node lets you skip looking up the groupid
 SELECT master_add_secondary_node('localhost', 9995, 'localhost', :worker_1_port);
-              master_add_secondary_node               
-------------------------------------------------------
- (22,12,localhost,9995,default,f,t,secondary,default)
+               master_add_secondary_node                
+--------------------------------------------------------
+ (22,12,localhost,9995,default,f,t,secondary,default,,)
 (1 row)
 
 SELECT master_add_secondary_node('localhost', 9994, primaryname => 'localhost', primaryport => :worker_2_port);
-              master_add_secondary_node               
-------------------------------------------------------
- (23,14,localhost,9994,default,f,t,secondary,default)
+               master_add_secondary_node                
+--------------------------------------------------------
+ (23,14,localhost,9994,default,f,t,secondary,default,,)
 (1 row)
 
 SELECT master_add_secondary_node('localhost', 9993, 'localhost', 2000);
 ERROR:  node at "localhost:2000" does not exist
 SELECT master_add_secondary_node('localhost', 9992, 'localhost', :worker_1_port, nodecluster => 'second-cluster');
-                  master_add_secondary_node                  
--------------------------------------------------------------
- (24,12,localhost,9992,default,f,t,secondary,second-cluster)
+                   master_add_secondary_node                   
+---------------------------------------------------------------
+ (24,12,localhost,9992,default,f,t,secondary,second-cluster,,)
 (1 row)
 
 SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset
@@ -569,9 +569,9 @@ SELECT master_update_node(:worker_1_node, 'somehost', 9000);
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+----------+----------+----------+-------------+----------+----------+-------------
-     13 |      12 | somehost |     9000 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | directname | directport 
+--------+---------+----------+----------+----------+-------------+----------+----------+-------------+------------+------------
+     13 |      12 | somehost |     9000 | default  | f           | t        | primary  | default     |            |           
 (1 row)
 
 -- cleanup
@@ -582,8 +582,8 @@ SELECT master_update_node(:worker_1_node, 'localhost', :worker_1_port);
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-     13 |      12 | localhost |    57637 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | directname | directport 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------+------------+------------
+     13 |      12 | localhost |    57637 | default  | f           | t        | primary  | default     |            |           
 (1 row)
 

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -141,6 +141,7 @@ ALTER EXTENSION citus UPDATE TO '7.5-2';
 ALTER EXTENSION citus UPDATE TO '7.5-3';
 ALTER EXTENSION citus UPDATE TO '7.5-4';
 ALTER EXTENSION citus UPDATE TO '7.5-5';
+ALTER EXTENSION citus UPDATE TO '7.5-6';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -176,9 +176,9 @@ SELECT count(*) FROM pg_dist_node WHERE hasmetadata=true;
 -- Ensure it works when run on a secondary node
 SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
 SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary');
-                  master_add_node                   
-----------------------------------------------------
- (4,1,localhost,8888,default,f,t,secondary,default)
+                   master_add_node                    
+------------------------------------------------------
+ (4,1,localhost,8888,default,f,t,secondary,default,,)
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', 8888);
@@ -207,9 +207,9 @@ SELECT hasmetadata FROM pg_dist_node WHERE nodeport = 8888;
 
 -- Add a node to another cluster to make sure it's also synced
 SELECT master_add_secondary_node('localhost', 8889, 'localhost', :worker_1_port, nodecluster => 'second-cluster');
-                 master_add_secondary_node                 
------------------------------------------------------------
- (5,1,localhost,8889,default,f,t,secondary,second-cluster)
+                  master_add_secondary_node                  
+-------------------------------------------------------------
+ (5,1,localhost,8889,default,f,t,secondary,second-cluster,,)
 (1 row)
 
 -- Run start_metadata_sync_to_node and check that it marked hasmetadata for that worker
@@ -234,12 +234,12 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   
---------+---------+-----------+----------+----------+-------------+----------+-----------+----------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default
-      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default
-      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | directname | directport 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+----------------+------------+------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        |            |           
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        |            |           
+      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        |            |           
+      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster |            |           
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -373,12 +373,12 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   
---------+---------+-----------+----------+----------+-------------+----------+-----------+----------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default
-      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default
-      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | directname | directport 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+----------------+------------+------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        |            |           
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        |            |           
+      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        |            |           
+      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster |            |           
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -1163,9 +1163,9 @@ SELECT create_distributed_table('mx_table', 'a');
 
 \c - postgres - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
-                  master_add_node                  
----------------------------------------------------
- (6,4,localhost,57638,default,f,t,primary,default)
+                   master_add_node                   
+-----------------------------------------------------
+ (6,4,localhost,57638,default,f,t,primary,default,,)
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
@@ -1374,9 +1374,9 @@ WHERE logicalrelid='mx_ref'::regclass;
 \c - - - :master_port
 SELECT master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "mx_ref" to the node localhost:57638
-                  master_add_node                  
----------------------------------------------------
- (7,5,localhost,57638,default,f,t,primary,default)
+                   master_add_node                   
+-----------------------------------------------------
+ (7,5,localhost,57638,default,f,t,primary,default,,)
 (1 row)
 
 SELECT shardid, nodename, nodeport 

--- a/src/test/regress/expected/multi_read_from_secondaries.out
+++ b/src/test/regress/expected/multi_read_from_secondaries.out
@@ -24,10 +24,10 @@ INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (10, 10);
 -- simluate actually having secondary nodes
 SELECT * FROM pg_dist_node;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-      1 |       1 | localhost |    57637 | default  | f           | t        | primary  | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | directname | directport 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------+------------+------------
+      1 |       1 | localhost |    57637 | default  | f           | t        | primary  | default     |            |           
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default     |            |           
 (2 rows)
 
 UPDATE pg_dist_node SET noderole = 'secondary';

--- a/src/test/regress/expected/multi_transactional_drop_shards.out
+++ b/src/test/regress/expected/multi_transactional_drop_shards.out
@@ -656,9 +656,9 @@ ORDER BY
 -- try using the coordinator as a worker and then dropping the table
 SELECT master_add_node('localhost', :master_port);
 NOTICE:  Replicating reference table "transactional_drop_reference" to the node localhost:57636
-                        master_add_node                        
----------------------------------------------------------------
- (1380010,1380008,localhost,57636,default,f,t,primary,default)
+                         master_add_node                         
+-----------------------------------------------------------------
+ (1380010,1380008,localhost,57636,default,f,t,primary,default,,)
 (1 row)
 
 CREATE TABLE citus_local (id serial, k int);

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -141,6 +141,7 @@ ALTER EXTENSION citus UPDATE TO '7.5-2';
 ALTER EXTENSION citus UPDATE TO '7.5-3';
 ALTER EXTENSION citus UPDATE TO '7.5-4';
 ALTER EXTENSION citus UPDATE TO '7.5-5';
+ALTER EXTENSION citus UPDATE TO '7.5-6';
 
 -- show running version
 SHOW citus.version;

--- a/windows/include/citus_version.h
+++ b/windows/include/citus_version.h
@@ -5,7 +5,7 @@
 #define CITUS_EDITION "community"
 
 /* Extension version expected by this Citus build */
-#define CITUS_EXTENSIONVERSION "7.5-3"
+#define CITUS_EXTENSIONVERSION "7.5-6"
 
 /* Citus major version as a string */
 #define CITUS_MAJORVERSION "7.5"


### PR DESCRIPTION
When Citus is used in an advanced setup, e.g. with pgbouncer between the coordinator and workers for most queries, it is still the case that certain operations (e.g. logical shard rebalancing) should use "direct" connections.

Because (when both pgbouncer and direct connections are in use) non-direct connections are the "common case", it makes sense to leave the existing nodename and nodeport fields in use for typical queries and to add special-case directname/directport columns for use by operations requiring direct connections. The alternative (changing nodename/port semantics to mean "direct" and adding e.g. poolname/poolport columns to specify the pgbouncer pool) is more complex behaviorally and more surprising to those who upgrade and expect nodename to continue being the name used for typical operations.

As a typical installation may not use pgbouncer, I've allowed these columns to be nullable.

Additionally, pg_dist_authinfo gets an extra column to specify direct-connection–specific authentication information, to extend to this new functionality the same authentication improvements we previously added.