### PR TITLE
Create pull_request_template.md with DESCRIPTION line

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+DESCRIPTION: PR description that will go into the change log, up to 78 characters


### PR DESCRIPTION
I figured it's easier to remove than to remember the DESCRIPTION line. This change adds "DESCRIPTION:" to the PR description by default.