### PR TITLE
Drop sequences on workers as current user in master_drop_sequences

### DIFF
--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -305,8 +305,8 @@ master_drop_sequences(PG_FUNCTION_ARGS)
 	{
 		appendStringInfoString(dropSeqCommand, " CASCADE");
 
-		SendCommandToWorkers(WORKERS_WITH_METADATA, DISABLE_DDL_PROPAGATION);
-		SendCommandToWorkers(WORKERS_WITH_METADATA, dropSeqCommand->data);
+		SendCommandToWorkersAsCurrentUser(WORKERS_WITH_METADATA, DISABLE_DDL_PROPAGATION);
+		SendCommandToWorkersAsCurrentUser(WORKERS_WITH_METADATA, dropSeqCommand->data);
 	}
 
 	PG_RETURN_VOID();

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -268,12 +268,11 @@ master_drop_sequences(PG_FUNCTION_ARGS)
 	Datum sequenceText = 0;
 	bool isNull = false;
 	StringInfo dropSeqCommand = makeStringInfo();
-	bool coordinator = IsCoordinator();
 
 	CheckCitusVersion(ERROR);
 
 	/* do nothing if DDL propagation is switched off or this is not the coordinator */
-	if (!EnableDDLPropagation || !coordinator)
+	if (!EnableDDLPropagation || !IsCoordinator())
 	{
 		PG_RETURN_VOID();
 	}

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -64,7 +64,21 @@ SendCommandToWorker(char *nodeName, int32 nodePort, char *command)
 void
 SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command)
 {
-	SendCommandToWorkersParams(targetWorkerSet, command, 0, NULL, NULL);
+	char *userName = CitusExtensionOwnerName();
+
+	SendCommandToWorkersParams(targetWorkerSet, command, userName, 0, NULL, NULL);
+}
+
+
+/*
+ * SendCommandToWorkers sends a command to all workers in parallel.
+ * Commands are committed on the workers when the local transaction
+ * commits. The connections are made as the current user.
+ */
+void
+SendCommandToWorkersAsCurrentUser(TargetWorkerSet targetWorkerSet, char *command)
+{
+	SendCommandToWorkersParams(targetWorkerSet, command, NULL, 0, NULL, NULL);
 }
 
 
@@ -122,15 +136,14 @@ SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
  * respectively.
  */
 void
-SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
-						   int parameterCount, const Oid *parameterTypes,
-						   const char *const *parameterValues)
+SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command, char *userName,
+						   int parameterCount, const Oid *parameterTypes, const
+						   char *const *parameterValues)
 {
 	List *connectionList = NIL;
 	ListCell *connectionCell = NULL;
 	List *workerNodeList = ActivePrimaryNodeList();
 	ListCell *workerNodeCell = NULL;
-	char *nodeUser = CitusExtensionOwnerName();
 
 	BeginOrContinueCoordinatedTransaction();
 	CoordinatedTransactionUse2PC();
@@ -150,7 +163,7 @@ SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
 		}
 
 		connection = StartNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
-													 nodeUser, NULL);
+													 userName, NULL);
 
 		MarkRemoteTransactionCritical(connection);
 

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -30,11 +30,14 @@ typedef enum TargetWorkerSet
 extern List * GetWorkerTransactions(void);
 extern void SendCommandToWorker(char *nodeName, int32 nodePort, char *command);
 extern void SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command);
+extern void SendCommandToWorkersAsCurrentUser(TargetWorkerSet targetWorkerSet,
+											  char *command);
 extern void SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet,
 										 List *commandList);
 extern void SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
-									   int parameterCount, const Oid *parameterTypes,
-									   const char *const *parameterValues);
+									   char *userName, int parameterCount, const
+									   Oid *parameterTypes, const
+									   char *const *parameterValues);
 extern void SendCommandListToWorkerInSingleTransaction(char *nodeName, int32 nodePort,
 													   char *nodeUser, List *commandList);
 extern void RemoveWorkerTransaction(char *nodeName, int32 nodePort);

--- a/src/test/regress/expected/multi_mx_metadata.out
+++ b/src/test/regress/expected/multi_mx_metadata.out
@@ -296,3 +296,29 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- make sure master_drop_sequences enforces permissions
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO streaming;
+CREATE TABLE drop_seq (no bigserial);
+SELECT create_distributed_table('drop_seq', 'no');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE USER cannot_drop_sequence;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SELECT result FROM run_command_on_workers('CREATE USER cannot_drop_sequence');
+   result    
+-------------
+ CREATE ROLE
+ CREATE ROLE
+(2 rows)
+
+SET ROLE cannot_drop_sequence;
+SELECT master_drop_sequences(ARRAY['drop_seq_no_seq']);
+ERROR:  must be owner of relation drop_seq_no_seq
+CONTEXT:  while executing command on localhost:57638
+RESET ROLE;
+DROP TABLE drop_seq;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug where master_drop_sequences connects as the wrong user

This should only be consequential for MX, since that's the only case in which there are sequences on workers.

We should perhaps consider renaming `SendCommandToWorkers` to `SendCommandToWorkersAsSuperuser` to avoid bugs.

Fixed #2274