### PR TITLE
fix missing space for tablein in error

### DIFF
--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -4086,7 +4086,7 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 		char *relationName = get_rel_name(relationId);
 
 		ereport(ERROR, (errmsg("cannot modify table \"%s\" because there "
-							   "was a parallel operation on a distributed table"
+							   "was a parallel operation on a distributed table "
 							   "in the transaction", relationName),
 						errdetail("When there is a foreign key to a reference "
 								  "table, Citus needs to perform all operations "

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -161,7 +161,7 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE on_update_fkey_table DROP COLUMN value_1 CASCADE;
-ERROR:  cannot modify table "on_update_fkey_table" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "on_update_fkey_table" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
@@ -549,7 +549,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE smallint;
-ERROR:  cannot modify table "on_update_fkey_table" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "on_update_fkey_table" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
@@ -796,7 +796,7 @@ DETAIL:  NOTICE from localhost:57638
 (1 row)
 
 	ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 	-- make sure that the output isn't too verbose
@@ -895,7 +895,7 @@ DETAIL:  NOTICE from localhost:57638
 (1 row)
 
 	ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 	-- make sure that the output isn't too verbose

--- a/src/test/regress/expected/foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table.out
@@ -1283,7 +1283,7 @@ BEGIN;
 (1 row)
 
   ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
   DROP TABLE test_table_1, test_table_2;
@@ -1306,7 +1306,7 @@ BEGIN;
 (1 row)
 
   ALTER TABLE test_table_1 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_2(id);
-ERROR:  cannot modify table "test_table_1" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_1" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
   DROP TABLE test_table_2 CASCADE;
@@ -1399,7 +1399,7 @@ BEGIN;
 (1 row)
 
   ALTER TABLE test_table_2 ADD CONSTRAINT foreign_key FOREIGN KEY(value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
   ALTER TABLE test_table_2 DROP CONSTRAINT test_table_2_value_1_fkey;

--- a/src/test/regress/expected/foreign_key_to_reference_table_0.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table_0.out
@@ -1283,7 +1283,7 @@ BEGIN;
 (1 row)
 
   ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
   DROP TABLE test_table_1, test_table_2;
@@ -1306,7 +1306,7 @@ BEGIN;
 (1 row)
 
   ALTER TABLE test_table_1 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_2(id);
-ERROR:  cannot modify table "test_table_1" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_1" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
   DROP TABLE test_table_2 CASCADE;
@@ -1399,7 +1399,7 @@ BEGIN;
 (1 row)
 
   ALTER TABLE test_table_2 ADD CONSTRAINT foreign_key FOREIGN KEY(value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed tablein the transaction
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
   ALTER TABLE test_table_2 DROP CONSTRAINT test_table_2_value_1_fkey;


### PR DESCRIPTION
During testing I ran into this error message that looked funky due to a missing space in the console.