### PR TITLE
Don't try to check unopened connection in EXEC_TASK_FAILED state

### DIFF
--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -294,6 +294,14 @@ MultiClientConnectPoll(int32 connectionId)
 MultiConnection *
 MultiClientGetConnection(int32 connectionId)
 {
+	if (connectionId == INVALID_CONNECTION_ID)
+	{
+		return NULL;
+	}
+
+	Assert(connectionId >= 0);
+	Assert(connectionId < MAX_CONNECTION_COUNT);
+
 	return ClientConnectionArray[connectionId];
 }
 


### PR DESCRIPTION
DESCRIPTION: Fix real-time query segfault during online shard moves