### PR TITLE
Prototype: INSERT...SELECT via coordinator with ON CONFLICT/RETURNING

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1306,7 +1306,8 @@ CopyLocalDataIntoShards(Oid distributedRelationId)
 		(DestReceiver *) CreateCitusCopyDestReceiver(distributedRelationId,
 													 columnNameList,
 													 partitionColumnIndex,
-													 estate, stopOnFailure);
+													 estate, stopOnFailure,
+													 NULL);
 
 	/* initialise state for writing to shards, we'll open connections on demand */
 	copyDest->rStartup(copyDest, 0, tupleDescriptor);

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2424,3 +2424,31 @@ CitusCopyDestReceiverDestroy(DestReceiver *destReceiver)
 
 	pfree(copyDest);
 }
+
+
+/*
+ * IsCopyResultStmt determines whether the given copy statement is a
+ * COPY "resultkey" FROM STDIN WITH (format result) statement, which is used
+ * to copy query results from the coordinator into workers.
+ */
+bool
+IsCopyResultStmt(CopyStmt *copyStatement)
+{
+	ListCell *optionCell = NULL;
+	bool hasFormatReceive = false;
+
+	/* extract WITH (...) options from the COPY statement */
+	foreach(optionCell, copyStatement->options)
+	{
+		DefElem *defel = (DefElem *) lfirst(optionCell);
+
+		if (strncmp(defel->defname, "format", NAMEDATALEN) == 0 &&
+			strncmp(defGetString(defel), "result", NAMEDATALEN) == 0)
+		{
+			hasFormatReceive = true;
+			break;
+		}
+	}
+
+	return hasFormatReceive;
+}

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -372,7 +372,7 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 
 	/* set up the destination for the COPY */
 	copyDest = CreateCitusCopyDestReceiver(tableId, columnNameList, partitionColumnIndex,
-										   executorState, stopOnFailure);
+										   executorState, stopOnFailure, NULL);
 	dest = (DestReceiver *) copyDest;
 	dest->rStartup(dest, 0, tupleDescriptor);
 
@@ -1133,7 +1133,11 @@ ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId, bool useBinaryCop
 
 	appendStringInfo(command, "FROM STDIN WITH ");
 
-	if (useBinaryCopyFormat)
+	if (IsCopyResultStmt(copyStatement))
+	{
+		appendStringInfoString(command, "(FORMAT RESULT)");
+	}
+	else if (useBinaryCopyFormat)
 	{
 		appendStringInfoString(command, "(FORMAT BINARY)");
 	}
@@ -2031,10 +2035,16 @@ CopyFlushOutput(CopyOutState cstate, char *start, char *pointer)
  * The caller should provide the list of column names to use in the
  * remote COPY statement, and the partition column index in the tuple
  * descriptor (*not* the column name list).
+ *
+ * If intermediateResultIdPrefix is not NULL, the COPY will go into a set
+ * of intermediate results that are co-located with the actual table.
+ * The names of the intermediate results with be of the form:
+ * intermediateResultIdPrefix_<shardid>
  */
 CitusCopyDestReceiver *
 CreateCitusCopyDestReceiver(Oid tableId, List *columnNameList, int partitionColumnIndex,
-							EState *executorState, bool stopOnFailure)
+							EState *executorState, bool stopOnFailure,
+							char *intermediateResultIdPrefix)
 {
 	CitusCopyDestReceiver *copyDest = NULL;
 
@@ -2053,6 +2063,7 @@ CreateCitusCopyDestReceiver(Oid tableId, List *columnNameList, int partitionColu
 	copyDest->partitionColumnIndex = partitionColumnIndex;
 	copyDest->executorState = executorState;
 	copyDest->stopOnFailure = stopOnFailure;
+	copyDest->intermediateResultIdPrefix = intermediateResultIdPrefix;
 	copyDest->memoryContext = CurrentMemoryContext;
 
 	return copyDest;
@@ -2203,13 +2214,27 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 
 	/* define the template for the COPY statement that is sent to workers */
 	copyStatement = makeNode(CopyStmt);
-	copyStatement->relation = makeRangeVar(schemaName, relationName, -1);
+
+	if (copyDest->intermediateResultIdPrefix != NULL)
+	{
+		DefElem *formatResultOption = NULL;
+		copyStatement->relation = makeRangeVar(NULL, copyDest->intermediateResultIdPrefix,
+											   -1);
+
+		formatResultOption = makeDefElem("format", (Node *) makeString("result"), -1);
+		copyStatement->options = list_make1(formatResultOption);
+	}
+	else
+	{
+		copyStatement->relation = makeRangeVar(schemaName, relationName, -1);
+		copyStatement->options = NIL;
+	}
+
 	copyStatement->query = NULL;
 	copyStatement->attlist = quotedColumnNameList;
 	copyStatement->is_from = true;
 	copyStatement->is_program = false;
 	copyStatement->filename = NULL;
-	copyStatement->options = NIL;
 	copyDest->copyStatement = copyStatement;
 
 	copyDest->shardConnectionHash = CreateShardConnectionHash(TopTransactionContext);

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -16,6 +16,7 @@
 #include "distributed/multi_executor.h"
 #include "distributed/multi_partitioning_utils.h"
 #include "distributed/multi_physical_planner.h"
+#include "distributed/multi_router_executor.h"
 #include "distributed/distributed_planner.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/resource_lock.h"
@@ -35,8 +36,9 @@
 #include "utils/snapmgr.h"
 
 
-static void ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
-									  Query *selectQuery, EState *executorState);
+static HTAB * ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
+										Query *selectQuery, EState *executorState,
+										char *intermediateResultIdPrefix);
 
 
 /*
@@ -58,6 +60,8 @@ CoordinatorInsertSelectExecScan(CustomScanState *node)
 		Query *selectQuery = distributedPlan->insertSelectSubquery;
 		List *insertTargetList = distributedPlan->insertTargetList;
 		Oid targetRelationId = distributedPlan->targetRelationId;
+		char *intermediateResultIdPrefix = distributedPlan->intermediateResultIdPrefix;
+		HTAB *shardConnectionsHash = NULL;
 
 		ereport(DEBUG1, (errmsg("Collecting INSERT ... SELECT results on coordinator")));
 
@@ -71,8 +75,52 @@ CoordinatorInsertSelectExecScan(CustomScanState *node)
 			LockPartitionRelations(targetRelationId, RowExclusiveLock);
 		}
 
-		ExecuteSelectIntoRelation(targetRelationId, insertTargetList, selectQuery,
-								  executorState);
+		shardConnectionsHash = ExecuteSelectIntoRelation(targetRelationId,
+														 insertTargetList, selectQuery,
+														 executorState,
+														 intermediateResultIdPrefix);
+
+		if (distributedPlan->workerJob != NULL)
+		{
+			/*
+			 * If we also have a workerJob that means there is a second step
+			 * to the INSERT...SELECT. This happens when there is a RETURNING
+			 * or ON CONFLICT clause which is implemented as a separate
+			 * distributed INSERT...SELECT from a set of intermediate results
+			 * to the target relation.
+			 */
+			Job *workerJob = distributedPlan->workerJob;
+			ListCell *taskCell = NULL;
+			List *taskList = workerJob->taskList;
+			List *prunedTaskList = NIL;
+			bool hasReturning = distributedPlan->hasReturning;
+			bool isModificationQuery = true;
+
+			/*
+			 * We cannot actually execute INSERT...SELECT tasks that read from
+			 * intermediate results that weren't created because no rows were
+			 * written to them. Prune those tasks out by only including tasks
+			 * on shards with connections.
+			 */
+			foreach(taskCell, taskList)
+			{
+				Task *task = (Task *) lfirst(taskCell);
+				uint64 shardId = task->anchorShardId;
+				bool shardModified = false;
+
+				hash_search(shardConnectionsHash, &shardId, HASH_FIND, &shardModified);
+				if (shardModified)
+				{
+					prunedTaskList = lappend(prunedTaskList, task);
+				}
+			}
+
+			if (prunedTaskList != NIL)
+			{
+				ExecuteMultipleTasks(scanState, prunedTaskList, isModificationQuery,
+									 hasReturning);
+			}
+		}
 
 		scanState->finishedRemoteScan = true;
 	}
@@ -87,10 +135,18 @@ CoordinatorInsertSelectExecScan(CustomScanState *node)
  * ExecuteSelectIntoRelation executes given SELECT query and inserts the
  * results into the target relation, which is assumed to be a distributed
  * table.
+ *
+ * If intermediateResultIdPrefix is not NULL, the data is instead written
+ * to a set of intermediate results that are co-located with the table
+ * for further processing (ON CONFLICT).
+ *
+ * ExecuteSelectIntoRelation returns the hash of connections that were
+ * used to insert into the target relation.
  */
-static void
+static HTAB *
 ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
-						  Query *selectQuery, EState *executorState)
+						  Query *selectQuery, EState *executorState,
+						  char *intermediateResultIdPrefix)
 {
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
 
@@ -135,7 +191,7 @@ ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
 	/* set up a DestReceiver that copies into the distributed table */
 	copyDest = CreateCitusCopyDestReceiver(targetRelationId, columnNameList,
 										   partitionColumnIndex, executorState,
-										   stopOnFailure);
+										   stopOnFailure, intermediateResultIdPrefix);
 
 	/*
 	 * Make a copy of the query, since ExecuteQueryIntoDestReceiver may scribble on it
@@ -149,4 +205,6 @@ ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
 	executorState->es_processed = copyDest->tuplesSent;
 
 	XactModificationLevel = XACT_MODIFICATION_DATA;
+
+	return copyDest->shardConnectionHash;
 }

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -89,8 +89,6 @@ static void ExecuteSingleSelectTask(CitusScanState *scanState, Task *task);
 static List * BuildPlacementAccessList(uint32 groupId, List *relationShardList,
 									   ShardPlacementAccessType accessType);
 static List * GetModifyConnections(Task *task, bool markCritical);
-static void ExecuteMultipleTasks(CitusScanState *scanState, List *taskList,
-								 bool isModificationQuery, bool expectResults);
 static int64 ExecuteModifyTasks(List *taskList, bool expectResults,
 								ParamListInfo paramListInfo, CitusScanState *scanState);
 static void AcquireExecutorShardLock(Task *task, CmdType commandType);
@@ -1184,7 +1182,7 @@ GetModifyConnections(Task *task, bool markCritical)
  * Otherwise, the changes are committed using 2PC when the local transaction
  * commits.
  */
-static void
+void
 ExecuteMultipleTasks(CitusScanState *scanState, List *taskList,
 					 bool isModificationQuery, bool expectResults)
 {

--- a/src/backend/distributed/executor/multi_utility.c
+++ b/src/backend/distributed/executor/multi_utility.c
@@ -111,7 +111,6 @@ static bool IsCitusExtensionStmt(Node *parsetree);
 /* Local functions forward declarations for Transmit statement */
 static bool IsTransmitStmt(Node *parsetree);
 static void VerifyTransmitStmt(CopyStmt *copyStatement);
-static bool IsCopyResultStmt(CopyStmt *copyStatement);
 
 /* Local functions forward declarations for processing distributed table commands */
 static Node * ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag,
@@ -792,34 +791,6 @@ VerifyTransmitStmt(CopyStmt *copyStatement)
 						errmsg("FORMAT 'transmit' does not accept query, attribute list"
 							   " or PROGRAM parameters ")));
 	}
-}
-
-
-/*
- * IsCopyResultStmt determines whether the given copy statement is a
- * COPY "resultkey" FROM STDIN WITH (format result) statement, which is used
- * to copy query results from the coordinator into workers.
- */
-static bool
-IsCopyResultStmt(CopyStmt *copyStatement)
-{
-	ListCell *optionCell = NULL;
-	bool hasFormatReceive = false;
-
-	/* extract WITH (...) options from the COPY statement */
-	foreach(optionCell, copyStatement->options)
-	{
-		DefElem *defel = (DefElem *) lfirst(optionCell);
-
-		if (strncmp(defel->defname, "format", NAMEDATALEN) == 0 &&
-			strncmp(defGetString(defel), "result", NAMEDATALEN) == 0)
-		{
-			hasFormatReceive = true;
-			break;
-		}
-	}
-
-	return hasFormatReceive;
 }
 
 

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -582,7 +582,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 		if (InsertSelectIntoDistributedTable(originalQuery))
 		{
 			distributedPlan =
-				CreateInsertSelectPlan(originalQuery, plannerRestrictionContext);
+				CreateInsertSelectPlan(planId, originalQuery, plannerRestrictionContext);
 		}
 		else
 		{

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -24,6 +24,7 @@
 #include "distributed/multi_router_planner.h"
 #include "distributed/pg_dist_partition.h"
 #include "distributed/query_pushdown_planning.h"
+#include "distributed/recursive_planning.h"
 #include "distributed/resource_lock.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
@@ -60,10 +61,12 @@ static DeferredErrorMessage * InsertPartitionColumnMatchesSelect(Query *query,
 																 subqueryRte,
 																 Oid *
 																 selectPartitionColumnTableId);
-static DistributedPlan * CreateCoordinatorInsertSelectPlan(Query *parse);
+static DistributedPlan * CreateCoordinatorInsertSelectPlan(uint64 planId, Query *parse);
 static DeferredErrorMessage * CoordinatorInsertSelectSupported(Query *insertSelectQuery);
 static Query * WrapSubquery(Query *subquery);
 static bool CheckInsertSelectQuery(Query *query);
+static List * TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
+										   char *resultIdPrefix);
 
 
 /*
@@ -172,7 +175,7 @@ CheckInsertSelectQuery(Query *query)
  * plan for evaluating the SELECT on the coordinator.
  */
 DistributedPlan *
-CreateInsertSelectPlan(Query *originalQuery,
+CreateInsertSelectPlan(uint64 planId, Query *originalQuery,
 					   PlannerRestrictionContext *plannerRestrictionContext)
 {
 	DistributedPlan *distributedPlan = NULL;
@@ -185,7 +188,7 @@ CreateInsertSelectPlan(Query *originalQuery,
 		RaiseDeferredError(distributedPlan->planningError, DEBUG1);
 
 		/* if INSERT..SELECT cannot be distributed, pull to coordinator */
-		distributedPlan = CreateCoordinatorInsertSelectPlan(originalQuery);
+		distributedPlan = CreateCoordinatorInsertSelectPlan(planId, originalQuery);
 	}
 
 	return distributedPlan;
@@ -1117,7 +1120,7 @@ InsertPartitionColumnMatchesSelect(Query *query, RangeTblEntry *insertRte,
  * distributed table. The query plan can also be executed on a worker in MX.
  */
 static DistributedPlan *
-CreateCoordinatorInsertSelectPlan(Query *parse)
+CreateCoordinatorInsertSelectPlan(uint64 planId, Query *parse)
 {
 	Query *insertSelectQuery = copyObject(parse);
 	Query *selectQuery = NULL;
@@ -1166,6 +1169,40 @@ CreateCoordinatorInsertSelectPlan(Query *parse)
 
 	ReorderInsertSelectTargetLists(insertSelectQuery, insertRte, selectRte);
 
+	if (insertSelectQuery->onConflict || insertSelectQuery->returningList != NIL)
+	{
+		/*
+		 * We cannot perform a COPY operation with RETURNING or ON CONFLICT.
+		 * We therefore perform the INSERT...SELECT in two phases. First we
+		 * copy the result of the SELECT query in a set of intermediate
+		 * results, one for each shard placement in the destination table.
+		 * Second, we perform an INSERT..SELECT..ON CONFLICT/RETURNING from
+		 * the intermediate results into the destination table. This is
+		 * represented in the plan by simply having both an
+		 * insertSelectSubuery and a workerJob to execute afterwards.
+		 */
+		uint64 jobId = INVALID_JOB_ID;
+		Job *workerJob = NULL;
+		List *taskList = NIL;
+		char *resultIdPrefix = InsertSelectResultIdPrefix(planId);
+
+		/* generate tasks for the INSERT..SELECT phase */
+		taskList = TwoPhaseInsertSelectTaskList(targetRelationId, insertSelectQuery,
+												resultIdPrefix);
+
+		workerJob = CitusMakeNode(Job);
+		workerJob->taskList = taskList;
+		workerJob->subqueryPushdown = false;
+		workerJob->dependedJobList = NIL;
+		workerJob->jobId = jobId;
+		workerJob->jobQuery = insertSelectQuery;
+		workerJob->requiresMasterEvaluation = false;
+
+		distributedPlan->workerJob = workerJob;
+		distributedPlan->hasReturning = insertSelectQuery->returningList != NIL;
+		distributedPlan->intermediateResultIdPrefix = resultIdPrefix;
+	}
+
 	distributedPlan->insertSelectSubquery = selectQuery;
 	distributedPlan->insertTargetList = insertSelectQuery->targetList;
 	distributedPlan->targetRelationId = targetRelationId;
@@ -1186,19 +1223,12 @@ CoordinatorInsertSelectSupported(Query *insertSelectQuery)
 	RangeTblEntry *insertRte = NULL;
 	RangeTblEntry *subqueryRte = NULL;
 	Query *subquery = NULL;
+	DeferredErrorMessage *deferredError = NULL;
 
-	if (list_length(insertSelectQuery->returningList) > 0)
+	deferredError = ErrorIfOnConflictNotSupported(insertSelectQuery);
+	if (deferredError)
 	{
-		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "RETURNING is not supported in INSERT ... SELECT via "
-							 "coordinator", NULL, NULL);
-	}
-
-	if (insertSelectQuery->onConflict)
-	{
-		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "ON CONFLICT is not supported in INSERT ... SELECT via "
-							 "coordinator", NULL, NULL);
+		return deferredError;
 	}
 
 	insertRte = ExtractInsertRangeTableEntry(insertSelectQuery);
@@ -1285,4 +1315,130 @@ WrapSubquery(Query *subquery)
 	outerQuery->targetList = newTargetList;
 
 	return outerQuery;
+}
+
+
+/*
+ * TwoPhaseInsertSelectTaskList generates a list of task for a query that
+ * inserts into a target relation and selects from a set of co-located
+ * intermediate results.
+ */
+static List *
+TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
+							 char *resultIdPrefix)
+{
+	List *taskList = NIL;
+
+	/*
+	 * Make a copy of the INSERT ... SELECT. We'll repeatedly replace the
+	 * subquery of insertResultQuery for different intermediate results and
+	 * then deparse it.
+	 */
+	Query *insertResultQuery = copyObject(insertSelectQuery);
+	RangeTblEntry *insertRte = ExtractInsertRangeTableEntry(insertResultQuery);
+	RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertResultQuery);
+
+	DistTableCacheEntry *targetCacheEntry = DistributedTableCacheEntry(targetRelationId);
+	int shardCount = targetCacheEntry->shardIntervalArrayLength;
+	int shardOffset = 0;
+	uint32 taskIdIndex = 1;
+	uint64 jobId = INVALID_JOB_ID;
+
+	ListCell *targetEntryCell = NULL;
+	Relation distributedRelation = NULL;
+	TupleDesc destTupleDescriptor = NULL;
+
+	distributedRelation = heap_open(targetRelationId, RowExclusiveLock);
+	destTupleDescriptor = RelationGetDescr(distributedRelation);
+
+	/*
+	 * Hacky: adjust types since they will be coerced to match the table columns
+	 * by copy logic.
+	 */
+	foreach(targetEntryCell, insertSelectQuery->targetList)
+	{
+		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
+		Var *insertColumn = (Var *) targetEntry->expr;
+		Form_pg_attribute attr = TupleDescAttr(destTupleDescriptor, targetEntry->resno -
+											   1);
+
+		insertColumn->vartype = attr->atttypid;
+	}
+
+	for (shardOffset = 0; shardOffset < shardCount; shardOffset++)
+	{
+		ShardInterval *targetShardInterval =
+			targetCacheEntry->sortedShardIntervalArray[shardOffset];
+		uint64 shardId = targetShardInterval->shardId;
+		List *columnAliasList = NIL;
+		List *insertShardPlacementList = NIL;
+		Query *resultSelectQuery = NULL;
+		StringInfo queryString = makeStringInfo();
+		RelationShard *relationShard = NULL;
+		Task *modifyTask = NULL;
+		StringInfo resultId = makeStringInfo();
+
+		/* during COPY, the shard ID is appended to the result name */
+		appendStringInfo(resultId, "%s_" UINT64_FORMAT, resultIdPrefix, shardId);
+
+		/* generate the query on the intermediate result */
+		resultSelectQuery = BuildSubPlanResultQuery(insertSelectQuery->targetList,
+													columnAliasList, resultId->data);
+
+		/* put the intermediate result query in the INSERT..SELECT */
+		selectRte->subquery = resultSelectQuery;
+
+		/* setting an alias simplifies deparsing of RETURNING */
+		if (insertRte->alias == NULL)
+		{
+			Alias *alias = makeAlias(CITUS_TABLE_ALIAS, NIL);
+			insertRte->alias = alias;
+		}
+
+		/*
+		 * Generate a query string for the query that inserts into a shard and reads
+		 * from an intermediate result.
+		 */
+		deparse_shard_query(insertResultQuery, targetRelationId, shardId, queryString);
+		ereport(DEBUG2, (errmsg("distributed statement: %s", queryString->data)));
+
+		LockShardDistributionMetadata(shardId, ShareLock);
+		insertShardPlacementList = FinalizedShardPlacementList(shardId);
+
+		relationShard = CitusMakeNode(RelationShard);
+		relationShard->relationId = targetShardInterval->relationId;
+		relationShard->shardId = targetShardInterval->shardId;
+
+		modifyTask = CreateBasicTask(jobId, taskIdIndex, MODIFY_TASK, queryString->data);
+		modifyTask->dependedTaskList = NULL;
+		modifyTask->anchorShardId = shardId;
+		modifyTask->taskPlacementList = insertShardPlacementList;
+		modifyTask->upsertQuery = insertResultQuery->onConflict != NULL;
+		modifyTask->relationShardList = list_make1(relationShard);
+		modifyTask->replicationModel = targetCacheEntry->replicationModel;
+
+		taskList = lappend(taskList, modifyTask);
+
+		taskIdIndex++;
+	}
+
+	heap_close(distributedRelation, NoLock);
+
+	return taskList;
+}
+
+
+/*
+ * InsertSelectResultPrefix returns the prefix to use for intermediate
+ * results of an INSERT ... SELECT via the coordinator that runs in two
+ * phases in order to do RETURNING or ON CONFLICT.
+ */
+char *
+InsertSelectResultIdPrefix(uint64 planId)
+{
+	StringInfo resultIdPrefix = makeStringInfo();
+
+	appendStringInfo(resultIdPrefix, "insert_select_" UINT64_FORMAT, planId);
+
+	return resultIdPrefix->data;
 }

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -523,6 +523,7 @@ DeferredErrorMessage *
 ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuery,
 					 PlannerRestrictionContext *plannerRestrictionContext)
 {
+	DeferredErrorMessage *deferredError = NULL;
 	Oid distributedTableId = ExtractFirstDistributedTableId(queryTree);
 	uint32 rangeTableId = 1;
 	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
@@ -530,11 +531,6 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 	List *rangeTableList = NIL;
 	ListCell *rangeTableCell = NULL;
 	uint32 queryTableCount = 0;
-	bool specifiesPartitionValue = false;
-	ListCell *setTargetCell = NULL;
-	List *onConflictSet = NIL;
-	Node *arbiterWhere = NULL;
-	Node *onConflictWhere = NULL;
 	CmdType commandType = queryTree->commandType;
 
 	/*
@@ -769,7 +765,10 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 				TargetEntryChangesValue(targetEntry, partitionColumn,
 										queryTree->jointree))
 			{
-				specifiesPartitionValue = true;
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "modifying the partition value of rows is not "
+									 "allowed",
+									 NULL, NULL);
 			}
 
 			if (commandType == CMD_UPDATE &&
@@ -829,12 +828,45 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 		}
 	}
 
-	if (commandType == CMD_INSERT && queryTree->onConflict != NULL)
+	deferredError = ErrorIfOnConflictNotSupported(queryTree);
+	if (deferredError != NULL)
 	{
-		onConflictSet = queryTree->onConflict->onConflictSet;
-		arbiterWhere = queryTree->onConflict->arbiterWhere;
-		onConflictWhere = queryTree->onConflict->onConflictWhere;
+		return deferredError;
 	}
+
+	return NULL;
+}
+
+
+/*
+ * ErrorIfOnConflictNotSupprted returns an error if an INSERT query has an
+ * unsupported ON CONFLICT clause. In particular, changing the partition
+ * column value or using volatile functions is not allowed.
+ */
+DeferredErrorMessage *
+ErrorIfOnConflictNotSupported(Query *queryTree)
+{
+	Oid distributedTableId = InvalidOid;
+	uint32 rangeTableId = 1;
+	Var *partitionColumn = NULL;
+	List *onConflictSet = NIL;
+	Node *arbiterWhere = NULL;
+	Node *onConflictWhere = NULL;
+	ListCell *setTargetCell = NULL;
+	bool specifiesPartitionValue = false;
+
+	CmdType commandType = queryTree->commandType;
+	if (commandType != CMD_INSERT || queryTree->onConflict == NULL)
+	{
+		return NULL;
+	}
+
+	distributedTableId = ExtractFirstDistributedTableId(queryTree);
+	partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
+
+	onConflictSet = queryTree->onConflict->onConflictSet;
+	arbiterWhere = queryTree->onConflict->arbiterWhere;
+	onConflictWhere = queryTree->onConflict->onConflictWhere;
 
 	/*
 	 * onConflictSet is expanded via expand_targetlist() on the standard planner.

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -162,8 +162,6 @@ static bool CteReferenceListWalker(Node *node, CteReferenceWalkerContext *contex
 static bool ContainsReferencesToOuterQuery(Query *query);
 static bool ContainsReferencesToOuterQueryWalker(Node *node,
 												 VarLevelsUpWalkerContext *context);
-static Query * BuildSubPlanResultQuery(Query *subquery, List *columnAliasList,
-									   uint64 planId, uint32 subPlanId);
 
 
 /*
@@ -686,6 +684,8 @@ RecursivelyPlanCTEs(Query *query, RecursivePlanningContext *planningContext)
 		Query *subquery = (Query *) cte->ctequery;
 		uint64 planId = planningContext->planId;
 		uint32 subPlanId = 0;
+		char *resultId = NULL;
+		List *cteTargetList = NIL;
 		Query *resultQuery = NULL;
 		DistributedSubPlan *subPlan = NULL;
 		ListCell *rteCell = NULL;
@@ -724,9 +724,23 @@ RecursivelyPlanCTEs(Query *query, RecursivePlanningContext *planningContext)
 		subPlan = CreateDistributedSubPlan(subPlanId, subquery);
 		planningContext->subPlanList = lappend(planningContext->subPlanList, subPlan);
 
+		/* build the result_id parameter for the call to read_intermediate_result */
+		resultId = GenerateResultId(planId, subPlanId);
+
+		if (subquery->returningList)
+		{
+			/* modifying CTE with returning */
+			cteTargetList = subquery->returningList;
+		}
+		else
+		{
+			/* regular SELECT CTE */
+			cteTargetList = subquery->targetList;
+		}
+
 		/* replace references to the CTE with a subquery that reads results */
-		resultQuery = BuildSubPlanResultQuery(subquery, cte->aliascolnames, planId,
-											  subPlanId);
+		resultQuery = BuildSubPlanResultQuery(cteTargetList, cte->aliascolnames,
+											  resultId);
 
 		foreach(rteCell, context.cteReferenceList)
 		{
@@ -1079,7 +1093,7 @@ RecursivelyPlanSubquery(Query *subquery, RecursivePlanningContext *planningConte
 	DistributedSubPlan *subPlan = NULL;
 	uint64 planId = planningContext->planId;
 	int subPlanId = 0;
-
+	char *resultId = NULL;
 	Query *resultQuery = NULL;
 	Query *debugQuery = NULL;
 
@@ -1108,11 +1122,14 @@ RecursivelyPlanSubquery(Query *subquery, RecursivePlanningContext *planningConte
 	subPlan = CreateDistributedSubPlan(subPlanId, subquery);
 	planningContext->subPlanList = lappend(planningContext->subPlanList, subPlan);
 
+	/* build the result_id parameter for the call to read_intermediate_result */
+	resultId = GenerateResultId(planId, subPlanId);
+
 	/*
 	 * BuildSubPlanResultQuery() can optionally use provided column aliases.
 	 * We do not need to send additional alias list for subqueries.
 	 */
-	resultQuery = BuildSubPlanResultQuery(subquery, NIL, planId, subPlanId);
+	resultQuery = BuildSubPlanResultQuery(subquery->targetList, NIL, resultId);
 
 	if (log_min_messages <= DEBUG1 || client_min_messages <= DEBUG1)
 	{
@@ -1293,21 +1310,19 @@ ContainsReferencesToOuterQueryWalker(Node *node, VarLevelsUpWalkerContext *conte
  * SELECT
  *   <target list>
  * FROM
- *   read_intermediate_result('<planId>_<subPlanId>', '<copy format'>)
+ *   read_intermediate_result('<resultId>', '<copy format'>)
  *   AS res (<column definition list>);
  *
- * The target list and column definition list are derived from the given subquery
- * and columm name alias list.
+ * The caller can optionally supply a columnAliasList, which is useful for
+ * CTEs that have column aliases.
  *
  * If any of the types in the target list cannot be used in the binary copy format,
  * then the copy format 'text' is used, otherwise 'binary' is used.
  */
-static Query *
-BuildSubPlanResultQuery(Query *subquery, List *columnAliasList, uint64 planId,
-						uint32 subPlanId)
+Query *
+BuildSubPlanResultQuery(List *targetEntryList, List *columnAliasList, char *resultId)
 {
 	Query *resultQuery = NULL;
-	char *resultIdString = NULL;
 	Const *resultIdConst = NULL;
 	Const *resultFormatConst = NULL;
 	FuncExpr *funcExpr = NULL;
@@ -1326,16 +1341,6 @@ BuildSubPlanResultQuery(Query *subquery, List *columnAliasList, uint64 planId,
 	bool useBinaryCopyFormat = true;
 	Oid copyFormatId = BinaryCopyFormatId();
 	int columnAliasCount = list_length(columnAliasList);
-
-	List *targetEntryList = NIL;
-	if (subquery->returningList)
-	{
-		targetEntryList = subquery->returningList;
-	}
-	else
-	{
-		targetEntryList = subquery->targetList;
-	}
 
 	/* build the target list and column definition list */
 	foreach(targetEntryCell, targetEntryList)
@@ -1402,14 +1407,11 @@ BuildSubPlanResultQuery(Query *subquery, List *columnAliasList, uint64 planId,
 		columnNumber++;
 	}
 
-	/* build the result_id parameter for the call to read_intermediate_result */
-	resultIdString = GenerateResultId(planId, subPlanId);
-
 	resultIdConst = makeNode(Const);
 	resultIdConst->consttype = TEXTOID;
 	resultIdConst->consttypmod = -1;
 	resultIdConst->constlen = -1;
-	resultIdConst->constvalue = CStringGetTextDatum(resultIdString);
+	resultIdConst->constvalue = CStringGetTextDatum(resultId);
 	resultIdConst->constbyval = false;
 	resultIdConst->constisnull = false;
 	resultIdConst->location = -1;

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -115,6 +115,7 @@ CopyNodeDistributedPlan(COPYFUNC_ARGS)
 	COPY_NODE_FIELD(insertSelectSubquery);
 	COPY_NODE_FIELD(insertTargetList);
 	COPY_SCALAR_FIELD(targetRelationId);
+	COPY_STRING_FIELD(intermediateResultIdPrefix);
 
 	COPY_NODE_FIELD(subPlanList);
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -188,6 +188,7 @@ OutDistributedPlan(OUTFUNC_ARGS)
 	WRITE_NODE_FIELD(insertSelectSubquery);
 	WRITE_NODE_FIELD(insertTargetList);
 	WRITE_OID_FIELD(targetRelationId);
+	WRITE_STRING_FIELD(intermediateResultIdPrefix);
 
 	WRITE_NODE_FIELD(subPlanList);
 

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -214,6 +214,7 @@ ReadDistributedPlan(READFUNC_ARGS)
 	READ_NODE_FIELD(insertSelectSubquery);
 	READ_NODE_FIELD(insertTargetList);
 	READ_OID_FIELD(targetRelationId);
+	READ_STRING_FIELD(intermediateResultIdPrefix);
 
 	READ_NODE_FIELD(subPlanList);
 

--- a/src/include/distributed/insert_select_planner.h
+++ b/src/include/distributed/insert_select_planner.h
@@ -30,9 +30,10 @@ extern Query * ReorderInsertSelectTargetLists(Query *originalQuery,
 											  RangeTblEntry *subqueryRte);
 extern void CoordinatorInsertSelectExplainScan(CustomScanState *node, List *ancestors,
 											   struct ExplainState *es);
-extern DistributedPlan * CreateInsertSelectPlan(Query *originalQuery,
+extern DistributedPlan * CreateInsertSelectPlan(uint64 planId, Query *originalQuery,
 												PlannerRestrictionContext *
 												plannerRestrictionContext);
+extern char * InsertSelectResultIdPrefix(uint64 planId);
 
 
 #endif /* INSERT_SELECT_PLANNER_H */

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -131,6 +131,7 @@ extern void EndRemoteCopy(int64 shardId, List *connectionList, bool stopOnFailur
 extern void CitusCopyFrom(CopyStmt *copyStatement, char *completionTag);
 extern bool IsCopyFromWorker(CopyStmt *copyStatement);
 extern NodeAddress * MasterNodeAddress(CopyStmt *copyStatement);
+extern bool IsCopyResultStmt(CopyStmt *copyStatement);
 
 
 #endif /* MULTI_COPY_H */

--- a/src/include/distributed/multi_copy.h
+++ b/src/include/distributed/multi_copy.h
@@ -108,6 +108,9 @@ typedef struct CitusCopyDestReceiver
 
 	/* useful for tracking multi shard accesses */
 	bool multiShardCopy;
+
+	/* copy into intermediate result */
+	char *intermediateResultIdPrefix;
 } CitusCopyDestReceiver;
 
 
@@ -116,7 +119,8 @@ extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   List *columnNameList,
 														   int partitionColumnIndex,
 														   EState *executorState,
-														   bool stopOnFailure);
+														   bool stopOnFailure,
+														   char *intermediateResultPrefix);
 extern FmgrInfo * ColumnOutputFunctions(TupleDesc rowDescriptor, bool binaryFormat);
 extern bool CanUseBinaryCopyFormat(TupleDesc tupleDescription);
 extern bool CanUseBinaryCopyFormatForType(Oid typeId);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -259,6 +259,16 @@ typedef struct DistributedPlan
 	/* target relation of an INSERT ... SELECT via the coordinator */
 	Oid targetRelationId;
 
+	/*
+	 * If intermediateResultIdPrefix is non-null, an INSERT ... SELECT
+	 * via the coordinator is written to a set of intermediate results
+	 * named according to <intermediateResultIdPrefix>_<anchorShardId>.
+	 * That way we can run a distributed INSERT ... SELECT with
+	 * RETURNING or ON CONFLICT from the intermediate results to the
+	 * target relation.
+	 */
+	char *intermediateResultIdPrefix;
+
 	/* list of subplans to execute before the distributed query */
 	List *subPlanList;
 

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -40,6 +40,8 @@ extern void CitusModifyBeginScan(CustomScanState *node, EState *estate, int efla
 extern TupleTableSlot * RouterSequentialModifyExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterSelectExecScan(CustomScanState *node);
 extern TupleTableSlot * RouterMultiModifyExecScan(CustomScanState *node);
+extern void ExecuteMultipleTasks(CitusScanState *scanState, List *taskList,
+								 bool isModificationQuery, bool expectResults);
 
 extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
 extern int64 ExecuteModifyTasksSequentiallyWithoutResults(List *taskList,

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -52,6 +52,7 @@ extern DeferredErrorMessage * ModifyQuerySupported(Query *queryTree, Query *orig
 												   bool multiShardQuery,
 												   PlannerRestrictionContext *
 												   plannerRestrictionContext);
+extern DeferredErrorMessage * ErrorIfOnConflictNotSupported(Query *queryTree);
 extern List * ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex);
 extern RelationRestrictionContext * CopyRelationRestrictionContext(
 	RelationRestrictionContext *oldContext);

--- a/src/include/distributed/recursive_planning.h
+++ b/src/include/distributed/recursive_planning.h
@@ -22,6 +22,8 @@ extern List * GenerateSubplansForSubqueriesAndCTEs(uint64 planId, Query *origina
 												   PlannerRestrictionContext *
 												   plannerRestrictionContext);
 extern char * GenerateResultId(uint64 planId, uint32 subPlanId);
+extern Query * BuildSubPlanResultQuery(List *targetEntryList, List *columnAliasList,
+									   char *resultId);
 
 
 #endif /* RECURSIVE_PLANNING_H */


### PR DESCRIPTION
This PR implements ON CONFLICT and RETURNING support for INSERT..SELECT commands which cannot be pushed down. For those INSERT...SELECT commands the coordinator plans and executes the SELECT separately and writes the results a distributed table through by doing a distributed COPY.

Because COPY does not have ON CONFLICT or RETURNING semantics, these features were so far unavailable. However, this PR works around that by reusing the intermediate result infrastructure from https://github.com/citusdata/citus/pull/1829  . It first copies into a set of intermediate results that are partitioned in the same way as the destination table, and then performs a distributed INSERT..SELECT from intermediate result in the corresponding shard.

As it turns out, this only requires minimal changes to the COPY logic. Instead of sending `COPY distributed_table_<shardid> FROM STDIN WITH (format binary)` commands to workers, we simply send  `COPY insert_select_<planid>_<shardid> FROM STDIN WITH (format result)` commands, which has the effect that the rows are not written to the table, but instead written to a set of intermediate results that are named according to the shard into which they should be inserted. 

To construct the INSERT..SELECT queries, we can reuse the infrastructure for replacing CTEs/subqueries with `read_intermediate_result` calls. The bulk of the logic in this PR is in constructing a custom task list for the final INSERT..SELECT. We currently put this task list in a `workerJob` in the `DistributedPlan`, which is otherwise unused for INSERT...SELECT via the coordinator. 

Remaining items:
[ ] Find a clean approach for the hack in `TwoPhaseInsertSelectTaskList` to set the column types in the `read_intermediate_result` call, consider collation etc.
[ ] Consider making the first step a subplan of the second step (optional)
[ ] Careful testing with CTEs/recursively planned subqueries
[ ] Regression tests