### PR TITLE
{WIP} Add support for foreign tables in MX

### DIFF
--- a/src/backend/distributed/utils/citus_ruleutils.c
+++ b/src/backend/distributed/utils/citus_ruleutils.c
@@ -164,7 +164,8 @@ pg_get_serverdef_string(Oid tableRelationId)
 	StringInfoData buffer = { NULL, 0, 0, 0 };
 	initStringInfo(&buffer);
 
-	appendStringInfo(&buffer, "CREATE SERVER %s", quote_identifier(server->servername));
+	appendStringInfo(&buffer, "CREATE SERVER IF NOT EXISTS %s",
+					 quote_identifier(server->servername));
 	if (server->servertype != NULL)
 	{
 		appendStringInfo(&buffer, " TYPE %s",

--- a/src/backend/distributed/worker/worker_drop_protocol.c
+++ b/src/backend/distributed/worker/worker_drop_protocol.c
@@ -52,7 +52,6 @@ worker_drop_distributed_table(PG_FUNCTION_ARGS)
 	Relation distributedRelation = NULL;
 	List *shardList = NULL;
 	ListCell *shardCell = NULL;
-	char relationKind = '\0';
 
 	CheckCitusVersion(ERROR);
 	EnsureSuperUser();
@@ -61,7 +60,6 @@ worker_drop_distributed_table(PG_FUNCTION_ARGS)
 
 	/* first check the relation type */
 	distributedRelation = relation_open(relationId, AccessShareLock);
-	relationKind = distributedRelation->rd_rel->relkind;
 	EnsureRelationKindSupported(relationId);
 
 	/* close the relation since we do not need anymore */

--- a/src/test/regress/expected/multi_generate_ddl_commands.out
+++ b/src/test/regress/expected/multi_generate_ddl_commands.out
@@ -138,9 +138,9 @@ CREATE FOREIGN TABLE foreign_table (
 ) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true');
 SELECT table_ddl_command_array('foreign_table');
 NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
-                                                                                                             table_ddl_command_array                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"CREATE SERVER fake_fdw_server FOREIGN DATA WRAPPER fake_fdw","CREATE FOREIGN TABLE public.foreign_table (id bigint NOT NULL, full_name text DEFAULT ''::text NOT NULL) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true')"}
+                                                                                                                    table_ddl_command_array                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE SERVER IF NOT EXISTS fake_fdw_server FOREIGN DATA WRAPPER fake_fdw","CREATE FOREIGN TABLE public.foreign_table (id bigint NOT NULL, full_name text DEFAULT ''::text NOT NULL) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true')"}
 (1 row)
 
 -- propagating views is not supported

--- a/src/test/regress/expected/multi_mx_foreign_table.out
+++ b/src/test/regress/expected/multi_mx_foreign_table.out
@@ -1,0 +1,88 @@
+--
+-- multi_mx_foreign_table
+-- test foreign tables can be created and queried in mx mode
+--
+-- create fake fdw for use in tests
+CREATE FUNCTION fake_fdw_handler()
+RETURNS fdw_handler
+AS 'citus'
+LANGUAGE C STRICT;
+CREATE FOREIGN DATA WRAPPER fake_fdw HANDLER fake_fdw_handler;
+CREATE SERVER fake_fdw_server FOREIGN DATA WRAPPER fake_fdw;
+-- create fdw on all workers
+SELECT FROM run_command_on_workers($$CREATE FUNCTION fake_fdw_handler()
+RETURNS fdw_handler
+AS 'citus'
+LANGUAGE C STRICT; $$);
+--
+(2 rows)
+
+SELECT FROM run_command_on_workers($$CREATE FOREIGN DATA WRAPPER fake_fdw HANDLER fake_fdw_handler$$);
+--
+(2 rows)
+
+-- create foreign table
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO 'streaming';
+CREATE FOREIGN TABLE fake_table(a int, b int) SERVER fake_fdw_server;
+SELECT create_distributed_table('fake_table', 'a');
+NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
+NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- verify it can be queried from mx node
+SELECT * FROM fake_table;
+ a | b 
+---+---
+(0 rows)
+
+SELECT * FROM run_command_on_workers('SELECT count(*) FROM fake_table')
+ORDER BY nodeport;
+ nodename  | nodeport | success | result 
+-----------+----------+---------+--------
+ localhost |    57637 | t       | 0
+ localhost |    57638 | t       | 0
+(2 rows)
+
+-- create secont fake table
+CREATE FOREIGN TABLE second_fake_table(a int, b int) SERVER fake_fdw_server;
+SELECT create_distributed_table('second_fake_table', 'a');
+NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
+NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- verify it can be queried from mx nodes
+SELECT * FROM second_fake_table;
+ a | b 
+---+---
+(0 rows)
+
+SELECT * FROM run_command_on_workers('SELECT count(*) FROM second_fake_table')
+ORDER BY nodeport;
+ nodename  | nodeport | success | result 
+-----------+----------+---------+--------
+ localhost |    57637 | t       | 0
+ localhost |    57638 | t       | 0
+(2 rows)
+
+-- cleanup resources
+DROP FUNCTION IF EXISTS fake_fdw_handler() CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to foreign-data wrapper fake_fdw
+drop cascades to server fake_fdw_server
+drop cascades to foreign table fake_table
+drop cascades to foreign table second_fake_table
+SELECT * FROM run_command_on_workers('DROP FUNCTION IF EXISTS fake_fdw_handler() CASCADE')
+ORDER BY nodeport;
+ nodename  | nodeport | success |    result     
+-----------+----------+---------+---------------
+ localhost |    57637 | t       | DROP FUNCTION
+ localhost |    57638 | t       | DROP FUNCTION
+(2 rows)
+

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -33,3 +33,4 @@ test: multi_mx_transaction_recovery
 test: multi_mx_modifying_xacts
 test: multi_mx_explain
 test: multi_mx_reference_table
+test: multi_mx_foreign_table

--- a/src/test/regress/sql/multi_mx_foreign_table.sql
+++ b/src/test/regress/sql/multi_mx_foreign_table.sql
@@ -1,0 +1,46 @@
+--
+-- multi_mx_foreign_table
+-- test foreign tables can be created and queried in mx mode
+--
+
+-- create fake fdw for use in tests
+CREATE FUNCTION fake_fdw_handler()
+RETURNS fdw_handler
+AS 'citus'
+LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER fake_fdw HANDLER fake_fdw_handler;
+CREATE SERVER fake_fdw_server FOREIGN DATA WRAPPER fake_fdw;
+
+-- create fdw on all workers
+SELECT FROM run_command_on_workers($$CREATE FUNCTION fake_fdw_handler()
+RETURNS fdw_handler
+AS 'citus'
+LANGUAGE C STRICT; $$);
+
+SELECT FROM run_command_on_workers($$CREATE FOREIGN DATA WRAPPER fake_fdw HANDLER fake_fdw_handler$$);
+
+-- create foreign table
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO 'streaming';
+CREATE FOREIGN TABLE fake_table(a int, b int) SERVER fake_fdw_server;
+SELECT create_distributed_table('fake_table', 'a');
+
+-- verify it can be queried from mx node
+SELECT * FROM fake_table;
+SELECT * FROM run_command_on_workers('SELECT count(*) FROM fake_table')
+ORDER BY nodeport;
+
+-- create secont fake table
+CREATE FOREIGN TABLE second_fake_table(a int, b int) SERVER fake_fdw_server;
+SELECT create_distributed_table('second_fake_table', 'a');
+
+-- verify it can be queried from mx nodes
+SELECT * FROM second_fake_table;
+SELECT * FROM run_command_on_workers('SELECT count(*) FROM second_fake_table')
+ORDER BY nodeport;
+
+-- cleanup resources
+DROP FUNCTION IF EXISTS fake_fdw_handler() CASCADE;
+SELECT * FROM run_command_on_workers('DROP FUNCTION IF EXISTS fake_fdw_handler() CASCADE')
+ORDER BY nodeport;


### PR DESCRIPTION
DESCRIPTION: Add support for foreign tables in MX

- do not attempt to create truncate triggers for foreign tables anymore
- do not blindly try to create a server, use create if exists
- do not drop server when dropping foreign table

Fixes #2312 
