### PR TITLE
Make master_disable/activate_node runnable when superuser

### DIFF
--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -256,6 +256,9 @@ master_disable_node(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
+	EnsureCoordinator();
+	EnsureSuperUser();
+
 	/* take an exclusive lock on pg_dist_node to serialize pg_dist_node changes */
 	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
 
@@ -300,6 +303,9 @@ master_activate_node(PG_FUNCTION_ARGS)
 	Datum nodeRecord = 0;
 
 	CheckCitusVersion(ERROR);
+
+	EnsureCoordinator();
+	EnsureSuperUser();
 
 	nodeRecord = ActivateNode(nodeNameString, nodePort);
 

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -135,6 +135,21 @@ SELECT master_get_active_worker_nodes();
 -- try to disable a node which does not exist and see that an error is thrown
 SELECT master_disable_node('localhost.noexist', 2345);
 ERROR:  node at "localhost.noexist:2345" does not exist
+-- try to disable a node via non-super user
+CREATE USER non_super_user;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+\c - non_super_user - :master_port
+SELECT master_disable_node('localhost', :worker_1_port);
+ERROR:  operation is not allowed
+HINT:  Run the command with a superuser.
+\c - postgres - :master_port
+SELECT master_get_active_worker_nodes();
+ master_get_active_worker_nodes 
+--------------------------------
+ (localhost,57637)
+(1 row)
+
 -- restore the node for next tests
 SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
  isactive 

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -57,6 +57,13 @@ SELECT master_get_active_worker_nodes();
 -- try to disable a node which does not exist and see that an error is thrown
 SELECT master_disable_node('localhost.noexist', 2345);
 
+-- try to disable a node via non-super user
+CREATE USER non_super_user;
+\c - non_super_user - :master_port
+SELECT master_disable_node('localhost', :worker_1_port);
+\c - postgres - :master_port
+SELECT master_get_active_worker_nodes();
+
 -- restore the node for next tests
 SELECT isactive FROM master_activate_node('localhost', :worker_2_port);
 


### PR DESCRIPTION
This PR fixes an issue with `master_activate_node` and `master_disable_node`. These UDFs should only be runnable under a superuser as we state in our [function comments](https://github.com/citusdata/citus/blob/master/src/backend/distributed/utils/node_metadata.c#L238).

