### PR TITLE
Improve query pushdown planning for very large number of shards and queries with many tables

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -2080,12 +2080,6 @@ ExtractRangeTableRelationWalker(Node *node, List **rangeTableRelationList)
 
 			walkIsComplete = false;
 		}
-		else
-		{
-			walkIsComplete = range_table_walker(list_make1(rangeTable),
-												ExtractRangeTableRelationWalker,
-												rangeTableRelationList, 0);
-		}
 	}
 	else if (IsA(node, Query))
 	{

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2545,6 +2545,12 @@ IntersectPlacementList(List *lhsPlacementList, List *rhsPlacementList)
 						WORKER_LENGTH) == 0)
 			{
 				placementList = lappend(placementList, rhsPlacement);
+
+				/*
+				 * We don't need to add the same placement over and over again. This
+				 * could happen if both placements of a shard appear on the same node.
+				 */
+				break;
 			}
 		}
 	}

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -1825,8 +1825,21 @@ RangeTableArrayContainsAnyRTEIdentities(RangeTblEntry **rangeTableEntries, int
 		 * (i.e.,rangeTableEntry could be a subquery where we're interested
 		 * in relations).
 		 */
-		ExtractRangeTableRelationWalker((Node *) rangeTableEntry,
-										&rangeTableRelationList);
+		if (rangeTableEntry->rtekind == RTE_SUBQUERY)
+		{
+			ExtractRangeTableRelationWalker((Node *) rangeTableEntry->subquery,
+											&rangeTableRelationList);
+		}
+		else if (rangeTableEntry->rtekind == RTE_RELATION)
+		{
+			ExtractRangeTableRelationWalker((Node *) rangeTableEntry,
+											&rangeTableRelationList);
+		}
+		else
+		{
+			/* we currently do not accept any other RTE types here */
+			continue;
+		}
 
 		foreach(rteRelationCell, rangeTableRelationList)
 		{

--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -38,6 +38,10 @@ CREATE FUNCTION acquire_shared_shard_lock(bigint)
 	RETURNS void
 	AS 'citus'
 	LANGUAGE C STRICT;
+CREATE FUNCTION relation_count_in_query(text)
+	RETURNS int
+	AS 'citus'
+	LANGUAGE C STRICT;
 -- ===================================================================
 -- test distribution metadata functionality
 -- ===================================================================
@@ -464,5 +468,96 @@ SELECT get_shard_id_for_distribution_column('get_shardid_test_table5', -999);
                                     0
 (1 row)
 
+SET citus.shard_count TO 2;
+CREATE TABLE events_table_count (user_id int, time timestamp, event_type int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('events_table_count', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE TABLE users_table_count (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_distributed_table('users_table_count', 'user_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT relation_count_in_query($$-- we can support arbitrary subqueries within UNIONs
+SELECT ("final_query"."event_types") as types, count(*) AS sumOfEventType
+FROM
+  ( SELECT 
+      *, random()
+    FROM
+     (SELECT 
+        "t"."user_id", "t"."time", unnest("t"."collected_events") AS "event_types"
+      FROM
+        ( SELECT 
+            "t1"."user_id", min("t1"."time") AS "time", array_agg(("t1"."event") ORDER BY TIME ASC, event DESC) AS collected_events
+          FROM (
+                (SELECT 
+                    *
+                 FROM
+                   (SELECT 
+                          events_table."time", 0 AS event, events_table."user_id"
+                    FROM 
+                       "events_table_count" as events_table
+                    WHERE 
+                      events_table.event_type IN (1, 2) ) events_subquery_1) 
+                UNION 
+                 (SELECT *
+                  FROM
+                    (
+                          SELECT * FROM
+                          (
+                              SELECT 
+                                max("events_table_count"."time"),
+                                0 AS event,
+                                "events_table_count"."user_id"
+                              FROM 
+                                "events_table_count", users_table_count as "users"
+                              WHERE 
+                                 "events_table_count".user_id = users.user_id AND
+                                "events_table_count".event_type IN (1, 2)
+                                GROUP BY   "events_table_count"."user_id"
+                          ) as events_subquery_5
+                     ) events_subquery_2)
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT 
+                        "events_table_count"."time", 2 AS event, "events_table_count"."user_id"
+                     FROM 
+                       "events_table_count"
+                     WHERE 
+                      event_type IN (3, 4) ) events_subquery_3)
+               UNION 
+                 (SELECT *
+                  FROM
+                    (SELECT
+                       "events_table_count"."time", 3 AS event, "events_table_count"."user_id"
+                     FROM 
+                       "events_table_count"
+                     WHERE 
+                      event_type IN (5, 6)) events_subquery_4)
+                 ) t1
+         GROUP BY "t1"."user_id") AS t) "q" 
+INNER JOIN
+     (SELECT 
+        "events_table_count"."user_id"
+      FROM 
+        users_table_count as "events_table_count"
+      WHERE 
+        value_1 > 0 and value_1 < 4) AS t 
+     ON (t.user_id = q.user_id)) as final_query
+GROUP BY 
+  types
+ORDER BY 
+  types;$$);
+ relation_count_in_query 
+-------------------------
+                       6
+(1 row)
+
 -- clear unnecessary tables;
-DROP TABLE get_shardid_test_table1, get_shardid_test_table2, get_shardid_test_table3, get_shardid_test_table4, get_shardid_test_table5;
+DROP TABLE get_shardid_test_table1, get_shardid_test_table2, get_shardid_test_table3, get_shardid_test_table4, get_shardid_test_table5, events_table_count;


### PR DESCRIPTION
This PR consists of two commits.

The first commit is a performance improvement for queries with many tables. Previously, due to a bug in the `ExtractRangeTableRelationWalker `, Citus pulled too returned unnecessary range table entries. Though doesn't change the correctness, that leads to CPU/memory overhead.

The second commit is a performance improvement for an edge case when a query hits too many shards and the placements of all shards reside on a single node. This case is not a realistic one. However, still fixing it for completeness.