### PR TITLE
Re-enable JIT in PostgreSQL 11 tests

### DIFF
--- a/src/test/regress/expected/multi_distributed_transaction_id.out
+++ b/src/test/regress/expected/multi_distributed_transaction_id.out
@@ -143,8 +143,8 @@ CREATE UNLOGGED TABLE parallel_id_test AS
 SELECT s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h FROM generate_series(1,150000) s;
 INSERT INTO parallel_id_test VALUES (1234567), (1234567), (1234568), (1234568);
 ANALYSE parallel_id_test;
-SET LOCAL max_parallel_workers_per_gather TO 8;
-SET LOCAL cpu_tuple_cost TO 1000000;
+SET LOCAL max_parallel_workers_per_gather TO 2;
+SET LOCAL parallel_tuple_cost TO 0;
 EXPLAIN (COSTS OFF)
 SELECT a FROM parallel_id_test WHERE a = parallel_worker_transaction_id_test();
                          QUERY PLAN                          

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -313,11 +313,6 @@ push(@pgOptions, '-c', "citus.remote_task_check_interval=1ms");
 push(@pgOptions, '-c', "citus.shard_replication_factor=2");
 push(@pgOptions, '-c', "citus.node_connection_timeout=${connectionTimeout}");
 
-if ($majorversion >= 11)
-{
-    push(@pgOptions, '-c', "jit=off");
-}
-
 if ($useMitmproxy)
 {
   # make tests reproducible by never trying to negotiate ssl

--- a/src/test/regress/sql/multi_distributed_transaction_id.sql
+++ b/src/test/regress/sql/multi_distributed_transaction_id.sql
@@ -96,8 +96,8 @@ SELECT s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h FROM gener
 INSERT INTO parallel_id_test VALUES (1234567), (1234567), (1234568), (1234568);
 ANALYSE parallel_id_test;
 
-SET LOCAL max_parallel_workers_per_gather TO 8;
-SET LOCAL cpu_tuple_cost TO 1000000;
+SET LOCAL max_parallel_workers_per_gather TO 2;
+SET LOCAL parallel_tuple_cost TO 0;
 
 EXPLAIN (COSTS OFF)
 SELECT a FROM parallel_id_test WHERE a = parallel_worker_transaction_id_test();


### PR DESCRIPTION
This test was just pathologically recompiling the function in its WHERE
clause on every row, making execution time seem like an infinite loop.
A small tweak avoids this.