### PR TITLE
Reflect changed index for constraint scans in PG11

### DIFF
--- a/src/backend/distributed/ddl/foreign_constraint.c
+++ b/src/backend/distributed/ddl/foreign_constraint.c
@@ -142,8 +142,10 @@ ErrorIfUnsupportedForeignConstraint(Relation relation, char distributionMethod,
 	pgConstraint = heap_open(ConstraintRelationId, AccessShareLock);
 	ScanKeyInit(&scanKey[0], Anum_pg_constraint_conrelid, BTEqualStrategyNumber, F_OIDEQ,
 				relation->rd_id);
-	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidIndexId, true, NULL,
-										scanKeyCount, scanKey);
+
+
+	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidTypidNameIndexId,
+										true, NULL, scanKeyCount, scanKey);
 
 	heapTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(heapTuple))
@@ -485,8 +487,8 @@ GetTableForeignConstraintCommands(Oid relationId)
 	pgConstraint = heap_open(ConstraintRelationId, AccessShareLock);
 	ScanKeyInit(&scanKey[0], Anum_pg_constraint_conrelid, BTEqualStrategyNumber, F_OIDEQ,
 				relationId);
-	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidIndexId, true, NULL,
-										scanKeyCount, scanKey);
+	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidTypidNameIndexId,
+										true, NULL, scanKeyCount, scanKey);
 
 	heapTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(heapTuple))
@@ -535,8 +537,8 @@ HasForeignKeyToReferenceTable(Oid relationId)
 	pgConstraint = heap_open(ConstraintRelationId, AccessShareLock);
 	ScanKeyInit(&scanKey[0], Anum_pg_constraint_conrelid, BTEqualStrategyNumber, F_OIDEQ,
 				relationId);
-	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidIndexId, true, NULL,
-										scanKeyCount, scanKey);
+	scanDescriptor = systable_beginscan(pgConstraint, ConstraintRelidTypidNameIndexId,
+										true, NULL, scanKeyCount, scanKey);
 
 	heapTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(heapTuple))

--- a/src/include/distributed/version_compat.h
+++ b/src/include/distributed/version_compat.h
@@ -38,6 +38,9 @@
 #define PreventInTransactionBlock PreventTransactionChain
 #define DatumGetJsonbP(d) DatumGetJsonb(d)
 
+/* following is introduced in PG11 */
+#define ConstraintRelidTypidNameIndexId ConstraintRelidIndexId
+
 /* following defines also exist for PG11 */
 #define RELATION_OBJECT_TYPE ACL_OBJECT_RELATION
 #define IndexInfoAttributeNumberArray(indexinfo) (indexinfo->ii_KeyAttrNumbers)


### PR DESCRIPTION
PG11 removed index `pg_constraint_conrelid_index` and created `pg_constraint_conrelid_contypid_conname_index` on pg_constraint. 

With this change we use the new index in PG11, and the old one in pre-11.
