### PR TITLE
Do not recover wrong distributed transactions in MX

### DIFF
--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -420,7 +420,7 @@ PendingWorkerTransactionList(MultiConnection *connection)
 	int coordinatorId = GetLocalGroupId();
 
 	appendStringInfo(command, "SELECT gid FROM pg_prepared_xacts "
-							  "WHERE gid LIKE 'citus_%d_%%'",
+							  "WHERE gid LIKE 'citus\\_%d\\_%%'",
 					 coordinatorId);
 
 	querySent = SendRemoteCommand(connection, command->data);

--- a/src/test/regress/expected/multi_mx_transaction_recovery.out
+++ b/src/test/regress/expected/multi_mx_transaction_recovery.out
@@ -50,15 +50,29 @@ PREPARE TRANSACTION 'citus_12_should_commit';
 BEGIN;
 CREATE TABLE should_be_sorted_into_middle (value int);
 PREPARE TRANSACTION 'citus_12_should_be_sorted_into_middle';
+-- this node (e.g., node id 12) should not touch
+-- transactions with different nodeIds in the gid
+BEGIN;
+CREATE TABLE table_should_do_nothing (value int);
+PREPARE TRANSACTION 'citus_122_should_do_nothing';
 -- Add "fake" pg_dist_transaction records and run recovery
 INSERT INTO pg_dist_transaction VALUES (12, 'citus_12_should_commit');
 INSERT INTO pg_dist_transaction VALUES (12, 'citus_12_should_be_forgotten');
+INSERT INTO pg_dist_transaction VALUES (122, 'citus_122_should_do_nothing');
 SELECT recover_prepared_transactions();
  recover_prepared_transactions 
 -------------------------------
                              3
 (1 row)
 
+-- delete the citus_122_should_do_nothing transaction
+DELETE FROM pg_dist_transaction WHERE gid = 'citus_122_should_do_nothing' RETURNING *;
+ groupid |             gid             
+---------+-----------------------------
+     122 | citus_122_should_do_nothing
+(1 row)
+
+ROLLBACK PREPARED 'citus_122_should_do_nothing';
 SELECT count(*) FROM pg_dist_transaction;
  count 
 -------


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that prevents recovering wrong transactions in MX

Fixes #2095 see the details in that issue.