### PR TITLE
Relax assertion on transaction abort on PREPARE step

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -528,8 +528,20 @@ FinishRemoteTransactionPrepare(struct MultiConnection *connection)
 		transaction->transactionState = REMOTE_TRANS_PREPARED;
 	}
 
-	result = GetRemoteCommandResult(connection, raiseErrors);
-	Assert(!result);
+	/*
+	 * Try to consume results of PREPARE TRANSACTION command. If we don't
+	 * succeed, rollback the transaction. Note that we've not committed on
+	 * any node yet, and we're not sure about the state of the worker node.
+	 * So rollbacking seems to be the safest action if the worker is
+	 * in a state where it can actually rollback.
+	 */
+	if (!ClearResults(connection, raiseErrors))
+	{
+		ereport(ERROR, (errmsg("failed to prepare transaction '%s' on host %s:%d",
+							   transaction->preparedName, connection->hostname,
+							   connection->port),
+						errhint("Try re-running the command.")));
+	}
 }
 
 


### PR DESCRIPTION
Fixes #1966, and actually very similar to #2031. We should probably
fixed them both at that time.

If you look closely, you'll see that the change doesn't effect 
non-assert builds.

In case a failure happens when a transaction is failed on PREPARE,
we used to hit an assertion for ensuring there is no pending
activity on the connection. However, that's not true after the
changes in #2031. Thus, we've replaced the assertion with a more
generic function call to consume any pending activity, if exists.
