### PR TITLE
Revert multi_partition test back to being required

### DIFF
--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -37,8 +37,6 @@ test: multi_insert_select_window multi_shard_update_delete window_functions dml_
 # ----------
 # Tests for partitioning support
 # ----------
-# TODO: remove the following ignore when PostgreSQL 11 has a new beta
-ignore: multi_partitioning
 test: multi_partitioning_utils multi_partitioning
 
 


### PR DESCRIPTION
Test was marked as optional (ignore) by previous
commit. Reverting that change to make test required