### PR TITLE
Prevent overflow of memory accesses during deadlock detection

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -541,9 +541,11 @@ BackendManagementShmemInit(void)
 
 		/*
 		 * We need to init per backend's spinlock before any backend
-		 * starts its execution.
+		 * starts its execution. Note that we initialize TotalProcs (e.g., not
+		 * MaxBackends) since some of the blocking processes could be prepared
+		 * transactions, which aren't covered by MaxBackends.
 		 */
-		for (backendIndex = 0; backendIndex < MaxBackends; ++backendIndex)
+		for (backendIndex = 0; backendIndex < TotalProcs; ++backendIndex)
 		{
 			SpinLockInit(&backendManagementShmemData->backends[backendIndex].mutex);
 		}
@@ -568,7 +570,7 @@ BackendManagementShmemSize(void)
 	Size size = 0;
 
 	size = add_size(size, sizeof(BackendManagementShmemData));
-	size = add_size(size, mul_size(sizeof(BackendData), MaxBackends));
+	size = add_size(size, mul_size(sizeof(BackendData), TotalProcs));
 
 	return size;
 }

--- a/src/backend/distributed/transaction/lock_graph.c
+++ b/src/backend/distributed/transaction/lock_graph.c
@@ -398,12 +398,12 @@ BuildLocalWaitGraph(void)
 	 */
 	waitGraph = (WaitGraph *) palloc0(sizeof(WaitGraph));
 	waitGraph->localNodeId = GetLocalGroupId();
-	waitGraph->allocatedSize = MaxBackends * 3;
+	waitGraph->allocatedSize = TotalProcs * 3;
 	waitGraph->edgeCount = 0;
 	waitGraph->edges = (WaitEdge *) palloc(waitGraph->allocatedSize * sizeof(WaitEdge));
 
-	remaining.procs = (PGPROC **) palloc(sizeof(PGPROC *) * MaxBackends);
-	remaining.procAdded = (bool *) palloc0(sizeof(bool *) * MaxBackends);
+	remaining.procs = (PGPROC **) palloc(sizeof(PGPROC *) * TotalProcs);
+	remaining.procAdded = (bool *) palloc0(sizeof(bool *) * TotalProcs);
 	remaining.procCount = 0;
 
 	LockLockData();
@@ -416,7 +416,7 @@ BuildLocalWaitGraph(void)
 	 */
 
 	/* build list of starting procs */
-	for (curBackend = 0; curBackend < MaxBackends; curBackend++)
+	for (curBackend = 0; curBackend < TotalProcs; curBackend++)
 	{
 		PGPROC *currentProc = &ProcGlobal->allProcs[curBackend];
 		BackendData currentBackendData;
@@ -762,7 +762,7 @@ AddProcToVisit(PROCStack *remaining, PGPROC *proc)
 		return;
 	}
 
-	Assert(remaining->procCount < MaxBackends);
+	Assert(remaining->procCount < TotalProcs);
 
 	remaining->procs[remaining->procCount++] = proc;
 	remaining->procAdded[proc->pgprocno] = true;

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -13,12 +13,16 @@
 #define BACKEND_DATA_H
 
 
+#include "access/twophase.h"
 #include "datatype/timestamp.h"
 #include "distributed/transaction_identifier.h"
 #include "nodes/pg_list.h"
 #include "storage/lwlock.h"
 #include "storage/proc.h"
 #include "storage/s_lock.h"
+
+
+#define TotalProcs (MaxBackends + NUM_AUXILIARY_PROCS + max_prepared_xacts)
 
 
 /*


### PR DESCRIPTION
Fixes #2032  and https://github.com/citusdata/citus-enterprise/issues/276

In the distributed deadlock detection design, we concluded that prepared transactions
cannot be part of a distributed deadlock. The idea is that (a) when the transaction
is prepared it already acquires all the locks, so cannot be part of a deadlock
(b) even if some other processes blocked on the prepared transaction,  prepared transactions
 would eventually be committed (or rollbacked) and the system will continue operating.

With the above in mind, we probably had a mistake in terms of memory allocations. For each
backend initialized, we keep a `BackendData` struct. The bug we've introduced is that, we
assumed there would only be `MaxBackend` number of backends. However, `MaxBackends` doesn't
include the prepared transactions and axuliary processes. When you check Postgres' InitProcGlobal`
you'd see that `TotalProcs = MaxBackends + NUM_AUXILIARY_PROCS + max_prepared_xacts;`

This commit aligns with total procs processed with that.

Note that this commit along with #2376 allows me to run the `tpcb-like` benchmark for hours without any issues.

Final note: We could probably tweak the deadlock detection code to completely ignore the prepared statements and auxiliary procs. However, that seems to require some deeper look and a lot more testing. Instead, with approach ends-up with `104` extra backend space which is really too small to bother about.

