### PR TITLE
Add distributed locking to truncated mx tables

### DIFF
--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -19,8 +19,7 @@
 #include "libpq-fe.h"
 #include "miscadmin.h"
 
-#include "access/xact.h"
-#include "catalog/namespace.h"
+
 #include "catalog/pg_class.h"
 #include "commands/dbcommands.h"
 #include "commands/event_trigger.h"
@@ -57,22 +56,14 @@
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
-#if (PG_VERSION_NUM >= 100000)
-#include "utils/varlena.h"
-#endif
-
-#define LOCK_RELATION_IF_EXISTS "SELECT lock_relation_if_exists('%s', '%s');"
-#define REMOTE_LOCK_MODE_FOR_TRUNCATE "ACCESS EXCLUSIVE"
 
 
 static List * ModifyMultipleShardsTaskList(Query *query, List *shardIntervalList, TaskType
 										   taskType);
 static bool ShouldExecuteTruncateStmtSequential(TruncateStmt *command);
-static LOCKMODE LockModeTextToLockMode(const char *lockModeName);
 
 
 PG_FUNCTION_INFO_V1(master_modify_multiple_shards);
-PG_FUNCTION_INFO_V1(lock_relation_if_exists);
 
 
 /*
@@ -212,26 +203,6 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	taskList =
 		ModifyMultipleShardsTaskList(modifyQuery, prunedShardIntervalList, taskType);
 
-	/*
-	 * We lock the relation we're TRUNCATING on the other worker nodes before
-	 * executing the truncate commands on the shards. This is necessary to prevent
-	 * distributed deadlocks where a concurrent operation on the same table (or a
-	 * cascading table) is executed on the other nodes.
-	 *
-	 * Note that we should skip the current node to prevent a self-deadlock that's why
-	 * we use OTHER_WORKERS tag.
-	 */
-	if (truncateOperation && ShouldSyncTableMetadata(relationId))
-	{
-		char *qualifiedRelationName = generate_qualified_relation_name(relationId);
-		StringInfo lockRelation = makeStringInfo();
-
-		appendStringInfo(lockRelation, LOCK_RELATION_IF_EXISTS, qualifiedRelationName,
-						 REMOTE_LOCK_MODE_FOR_TRUNCATE);
-
-		SendCommandToWorkers(OTHER_WORKERS, lockRelation->data);
-	}
-
 	if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
 	{
 		affectedTupleCount =
@@ -316,106 +287,4 @@ ShouldExecuteTruncateStmtSequential(TruncateStmt *command)
 	}
 
 	return false;
-}
-
-
-/*
- * lock_relation_if_exists gets a relation name and lock mode
- * and returns true if the relation exists and can be locked with
- * the given lock mode. If the relation doesn't exists, the function
- * return false.
- *
- * The relation name should be qualified with the schema name.
- *
- * The function errors out of the lockmode isn't defined in the PostgreSQL's
- * explicit locking table.
- */
-Datum
-lock_relation_if_exists(PG_FUNCTION_ARGS)
-{
-	text *relationName = PG_GETARG_TEXT_P(0);
-	text *lockModeText = PG_GETARG_TEXT_P(1);
-
-	Oid relationId = InvalidOid;
-	char *lockModeCString = text_to_cstring(lockModeText);
-	List *relationNameList = NIL;
-	RangeVar *relation = NULL;
-	LOCKMODE lockMode = NoLock;
-
-	/* ensure that we're in a transaction block */
-	RequireTransactionBlock(true, "lock_relation_if_exists");
-
-	relationId = ResolveRelationId(relationName, true);
-	if (!OidIsValid(relationId))
-	{
-		PG_RETURN_BOOL(false);
-	}
-
-	/* get the lock mode */
-	lockMode = LockModeTextToLockMode(lockModeCString);
-
-	/* resolve relationId from passed in schema and relation name */
-	relationNameList = textToQualifiedNameList(relationName);
-	relation = makeRangeVarFromNameList(relationNameList);
-
-	/* lock the relation with the lock mode */
-	RangeVarGetRelid(relation, lockMode, false);
-
-	PG_RETURN_BOOL(true);
-}
-
-
-/*
- * LockModeTextToLockMode gets a lockMode name and returns its corresponding LOCKMODE.
- * The function errors out if the input lock mode isn't defined in the PostgreSQL's
- * explicit locking table.
- */
-static LOCKMODE
-LockModeTextToLockMode(const char *lockModeName)
-{
-	if (pg_strncasecmp("NoLock", lockModeName, NAMEDATALEN) == 0)
-	{
-		/* there is no explict call for NoLock, but keeping it here for convinience */
-		return NoLock;
-	}
-	else if (pg_strncasecmp("ACCESS SHARE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return AccessShareLock;
-	}
-	else if (pg_strncasecmp("ROW SHARE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return RowShareLock;
-	}
-	else if (pg_strncasecmp("ROW EXCLUSIVE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return RowExclusiveLock;
-	}
-	else if (pg_strncasecmp("SHARE UPDATE EXCLUSIVE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return ShareUpdateExclusiveLock;
-	}
-	else if (pg_strncasecmp("SHARE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return ShareLock;
-	}
-	else if (pg_strncasecmp("SHARE ROW EXCLUSIVE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return ShareRowExclusiveLock;
-	}
-	else if (pg_strncasecmp("EXCLUSIVE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return ExclusiveLock;
-	}
-	else if (pg_strncasecmp("ACCESS EXCLUSIVE", lockModeName, NAMEDATALEN) == 0)
-	{
-		return AccessExclusiveLock;
-	}
-	else
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
-				 errmsg("unknown lock mode: %s", lockModeName)));
-	}
-
-	return NoLock;
 }

--- a/src/backend/distributed/utils/listutils.c
+++ b/src/backend/distributed/utils/listutils.c
@@ -59,6 +59,11 @@ SortList(List *pointerList, int (*comparisonFunction)(const void *, const void *
 
 	pfree(array);
 
+	if (sortedList != NIL)
+	{
+		sortedList->type = pointerList->type;
+	}
+
 	return sortedList;
 }
 

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -97,4 +97,8 @@ extern void LockPartitionRelations(Oid relationId, LOCKMODE lockMode);
 /* Lock parent table's colocated shard resource */
 extern void LockParentShardResourceIfPartition(uint64 shardId, LOCKMODE lockMode);
 
+/* Lock mode translation between text and enum */
+extern LOCKMODE LockModeTextToLockMode(const char *lockModeName);
+extern const char * LockModeToLockModeText(LOCKMODE lockMode);
+
 #endif /* RESOURCE_LOCK_H */


### PR DESCRIPTION
DESCRIPTION: Add distributed locking to truncated mx tables

We acquire distributed lock on all mx nodes for truncated
tables before actually doing truncate operation.

This is needed for distributed serialization of the truncate
command without causing a deadlock.