### PR TITLE
Do not allow unresolved parameters in INSERT...SELECT

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -595,6 +595,16 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 
 		if (InsertSelectIntoDistributedTable(originalQuery))
 		{
+			if (hasUnresolvedParams)
+			{
+				/*
+				 * Unresolved parameters can cause performance regressions in
+				 * INSERT...SELECT when the partition column is a parameter
+				 * because we don't perform any additional pruning in the executor.
+				 */
+				return NULL;
+			}
+
 			distributedPlan =
 				CreateInsertSelectPlan(originalQuery, plannerRestrictionContext);
 		}


### PR DESCRIPTION
DESCRIPTION: Fixes a performance issue in prepared INSERT..SELECT 

Fixes #2394 by generating a high cost plan for any INSERT...SELECT that with unresolved parameters, such that the planner prefers the plan with resolved parameters. This prevents a single shard (prepared) INSERT...SELECT from becoming a multi-shard INSERT...SELECT.