### PR TITLE
Fix memory leak in FinishRemoteTransactionPrepare

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -528,6 +528,8 @@ FinishRemoteTransactionPrepare(struct MultiConnection *connection)
 		transaction->transactionState = REMOTE_TRANS_PREPARED;
 	}
 
+	PQclear(result);
+
 	/*
 	 * Try to consume results of PREPARE TRANSACTION command. If we don't
 	 * succeed, rollback the transaction. Note that we've not committed on


### PR DESCRIPTION
We seem to be leaking some memory in remote transaction preparation. This works reclaims memory kept in PGresult structure.

We should do more extensive review and testing for similar usages in the codebase.

Fixes #2405 