### PR TITLE
Fix user-facing typos

### DIFF
--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -1092,7 +1092,7 @@ InsertPartitionColumnMatchesSelect(Query *query, RangeTblEntry *insertRte,
 		{
 			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 								 "cannot perform distributed INSERT INTO ... SELECT "
-								 "becuase the partition columns in the source table "
+								 "because the partition columns in the source table "
 								 "and subquery do not match",
 								 "The target table's partition column should correspond "
 								 "to a partition column in the subquery.",

--- a/src/backend/distributed/transaction/distributed_deadlock_detection.c
+++ b/src/backend/distributed/transaction/distributed_deadlock_detection.c
@@ -611,7 +611,7 @@ LogCancellingBackend(TransactionNode *transactionNode)
 
 	appendStringInfo(logMessage, "Cancelling the following backend "
 								 "to resolve distributed deadlock "
-								 "(transaction numner = " UINT64_FORMAT ", pid = %d)",
+								 "(transaction number = " UINT64_FORMAT ", pid = %d)",
 					 transactionNode->transactionId.transactionNumber,
 					 transactionNode->initiatorProc->pid);
 

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -1114,7 +1114,7 @@ INSERT INTO raw_events_second
             (user_id)
 SELECT value_1
 FROM   raw_events_first;
-DEBUG:  cannot perform distributed INSERT INTO ... SELECT becuase the partition columns in the source table and subquery do not match
+DEBUG:  cannot perform distributed INSERT INTO ... SELECT because the partition columns in the source table and subquery do not match
 DETAIL:  The target table's partition column should correspond to a partition column in the subquery.
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
 ERROR:  the partition column of table public.raw_events_second cannot be NULL
@@ -1166,7 +1166,7 @@ SELECT SUM(value_3),
 FROM   raw_events_first
 GROUP  BY user_id,
           value_2;
-DEBUG:  cannot perform distributed INSERT INTO ... SELECT becuase the partition columns in the source table and subquery do not match
+DEBUG:  cannot perform distributed INSERT INTO ... SELECT because the partition columns in the source table and subquery do not match
 DETAIL:  The target table's partition column should correspond to a partition column in the subquery.
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
 ERROR:  the partition column of table public.agg_events cannot be NULL
@@ -1176,7 +1176,7 @@ SELECT
   user_id
 FROM
   reference_table;
-DEBUG:  cannot perform distributed INSERT INTO ... SELECT becuase the partition columns in the source table and subquery do not match
+DEBUG:  cannot perform distributed INSERT INTO ... SELECT because the partition columns in the source table and subquery do not match
 DETAIL:  The target table's partition column should correspond to a partition column in the subquery.
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  Creating router plan

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1173,7 +1173,7 @@ FROM
 	colocated_table_test_2, reference_table_test
 WHERE
 	colocated_table_test_2.value_4 = reference_table_test.value_4;
-DEBUG:  cannot perform distributed INSERT INTO ... SELECT becuase the partition columns in the source table and subquery do not match
+DEBUG:  cannot perform distributed INSERT INTO ... SELECT because the partition columns in the source table and subquery do not match
 DETAIL:  The target table's partition column should correspond to a partition column in the subquery.
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
 RESET client_min_messages;


### PR DESCRIPTION
`lintian` found these (presumably by looking in the text section and running them through e.g. `aspell`).