### PR TITLE
Keep track of cached entries in case of interruption.

### DIFF
--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -860,11 +860,21 @@ LookupDistTableCacheEntry(Oid relationId)
 	memset(((char *) cacheEntry) + sizeof(Oid), 0,
 		   sizeof(DistTableCacheEntry) - sizeof(Oid));
 
+	/*
+	 * We disable interrupts while creating the cache entry because loading
+	 * shard metadata can take a while, and if statement_timeout is too low,
+	 * this will get canceled on each call and we won't be able to run any
+	 * queries on the table.
+	 */
+	HOLD_INTERRUPTS();
+
 	/* actually fill out entry */
 	BuildDistTableCacheEntry(cacheEntry);
 
 	/* and finally mark as valid */
 	cacheEntry->isValid = true;
+
+	RESUME_INTERRUPTS();
 
 	return cacheEntry;
 }
@@ -1170,6 +1180,13 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 		}
 	}
 
+	/*
+	 * We set these here, so ResetDistTableCacheEntry() can see what has been
+	 * entered into DistShardCacheHash even if the following loop is interrupted
+	 * by throwing errors, etc.
+	 */
+	cacheEntry->sortedShardIntervalArray = sortedShardIntervalArray;
+	cacheEntry->shardIntervalArrayLength = 0;
 
 	/* maintain shardId->(table,ShardInterval) cache */
 	for (shardIndex = 0; shardIndex < shardIntervalArrayLength; shardIndex++)
@@ -1186,6 +1203,7 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 
 		shardEntry = hash_search(DistShardCacheHash, &shardInterval->shardId, HASH_ENTER,
 								 &foundInCache);
+		cacheEntry->shardIntervalArrayLength++;
 		if (foundInCache)
 		{
 			ereport(ERROR, (errmsg("cached metadata for shard " UINT64_FORMAT
@@ -1222,8 +1240,6 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 		shardInterval->shardIndex = shardIndex;
 	}
 
-	cacheEntry->shardIntervalArrayLength = shardIntervalArrayLength;
-	cacheEntry->sortedShardIntervalArray = sortedShardIntervalArray;
 	cacheEntry->shardColumnCompareFunction = shardColumnCompareFunction;
 	cacheEntry->shardIntervalCompareFunction = shardIntervalCompareFunction;
 }


### PR DESCRIPTION
DESCRIPTION: Fix inconsistent metadata error when shard metadata caching gets interrupted.

Previously we set DistTableCacheEntry->sortedShardIntervalArray
and DistTableCacheEntry->shardIntervalArrayLength after we entered
all related shard entries into DistShardCacheHash. The drawback was
that if populating DistShardCacheHash was interrupted,
ResetDistTableCacheEntry() didn't see the shard hash entries created,
so was unable to clean them up.

This patch fixes that by setting sortedShardIntervalArray earlier,
and incrementing shardIntervalArrayLength as we enter shards into
the cache.

We also don't allow interrupts while making the distributed table shard
entries, so setting `statement_timeout` doesn't result in endless query
cancellation. 