### PR TITLE
make PG11 builds mandatory again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
     - env: PGVERSION=9.6
     - env: PGVERSION=10
     - env: PGVERSION=11
-  allow_failures:	
-    - env: PGVERSION=11
 before_install:
   - git clone -b v0.7.9 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install

--- a/src/test/regress/specs/isolation_get_distributed_wait_queries.spec
+++ b/src/test/regress/specs/isolation_get_distributed_wait_queries.spec
@@ -19,9 +19,17 @@ setup
 
 	SELECT citus.replace_isolation_tester_func();
 	SELECT citus.refresh_isolation_tester_prepared_statement();
-
-	SELECT start_metadata_sync_to_node('localhost', 57637);
-	SELECT start_metadata_sync_to_node('localhost', 57638);
+	
+	-- start_metadata_sync_to_node can not be run inside a transaction block
+	-- following is a workaround to overcome that
+	-- port numbers are hard coded at the moment
+	SELECT master_run_on_worker(
+		ARRAY['localhost']::text[],
+		ARRAY[57636]::int[],
+		ARRAY[format('SELECT start_metadata_sync_to_node(''%s'', %s)', nodename, nodeport)]::text[],
+		false)
+	FROM pg_dist_node;
+	
 	SET citus.shard_replication_factor TO 1;
 	SET citus.replication_model to streaming;
 

--- a/src/test/regress/specs/isolation_reference_on_mx.spec
+++ b/src/test/regress/specs/isolation_reference_on_mx.spec
@@ -20,8 +20,16 @@ setup
   	SELECT citus.replace_isolation_tester_func();
   	SELECT citus.refresh_isolation_tester_prepared_statement();
 
-	SELECT start_metadata_sync_to_node('localhost', 57637);
-	SELECT start_metadata_sync_to_node('localhost', 57638);
+	-- start_metadata_sync_to_node can not be run inside a transaction block
+	-- following is a workaround to overcome that
+	-- port numbers are hard coded at the moment
+	SELECT master_run_on_worker(
+		ARRAY['localhost']::text[],
+		ARRAY[57636]::int[],
+		ARRAY[format('SELECT start_metadata_sync_to_node(''%s'', %s)', nodename, nodeport)]::text[],
+		false)
+	FROM pg_dist_node;
+
 	SET citus.replication_model to streaming;
 
 	CREATE TABLE ref_table(user_id int, value_1 int);


### PR DESCRIPTION
We made PG11 builds optional when we had an issue with mx isolation test that we could not solve back then.

This PR solves the issue with a workaround by running start_metadats_sync_to_node outside the transaction block.