### PR TITLE
Update topn and hll versions used in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ install:
   # download and install HLL and TopN manually, as custom builds won't satisfy deps
   # only install if performing non-11 build
   - |
-    if [ "${PGVERSION}" != "11" ]; then
-      apt-get download "postgresql-${PGVERSION}-hll=2.10.2.citus-1"
+    if [ "${PGVERSION}" != "12" ]; then
+      apt-get download "postgresql-${PGVERSION}-hll=2.12.citus-1"
       sudo dpkg --force-confold --force-confdef --force-all -i *hll*.deb
     fi
   - |
-    if [ "${PGVERSION}" != "11" ]; then
-      apt-get download "postgresql-${PGVERSION}-topn=2.1.0"
+    if [ "${PGVERSION}" != "12" ]; then
+      apt-get download "postgresql-${PGVERSION}-topn=2.2.0"
       sudo dpkg --force-confold --force-confdef --force-all -i *topn*.deb
     fi
 before_script: citus_indent --quiet --check


### PR DESCRIPTION
- changed hll  version 2.12 from 2.10.2
- changed topn version to 2.2.0 from 2.1.0
- both topn and hll were not installed for PG11, now they are installed in travis builds
