### PR TITLE
Round robin queries to reference tables with task_assignment_policy set to `round-robin`

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -178,7 +178,6 @@ static List * ReorderAndAssignTaskList(List *taskList,
 static int CompareTasksByShardId(const void *leftElement, const void *rightElement);
 static List * ActiveShardPlacementLists(List *taskList);
 static List * ActivePlacementList(List *placementList);
-static List * LeftRotateList(List *list, uint32 rotateCount);
 static List * FindDependedMergeTaskList(Task *sqlTask);
 static List * AssignDualHashTaskList(List *taskList);
 static int CompareTasksByTaskId(const void *leftElement, const void *rightElement);
@@ -5311,7 +5310,7 @@ ActivePlacementList(List *placementList)
  * repeatedly moves the list's first element to the end of the list, and
  * then returns the newly rotated list.
  */
-static List *
+List *
 LeftRotateList(List *list, uint32 rotateCount)
 {
 	List *rotatedList = list_copy(list);

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -171,13 +171,13 @@ static bool HasMergeTaskDependencies(List *sqlTaskList);
 static List * GreedyAssignTaskList(List *taskList);
 static Task * GreedyAssignTask(WorkerNode *workerNode, List *taskList,
 							   List *activeShardPlacementLists);
-static List * RoundRobinAssignTaskList(List *taskList);
 static List * RoundRobinReorder(Task *task, List *placementList);
 static List * ReorderAndAssignTaskList(List *taskList,
 									   List * (*reorderFunction)(Task *, List *));
 static int CompareTasksByShardId(const void *leftElement, const void *rightElement);
 static List * ActiveShardPlacementLists(List *taskList);
 static List * ActivePlacementList(List *placementList);
+static List * LeftRotateList(List *list, uint32 rotateCount);
 static List * FindDependedMergeTaskList(Task *sqlTask);
 static List * AssignDualHashTaskList(List *taskList);
 static int CompareTasksByTaskId(const void *leftElement, const void *rightElement);
@@ -5097,7 +5097,7 @@ FirstReplicaAssignTaskList(List *taskList)
  * by the number of active shard placements, and ensure that we rotate between
  * these placements across subsequent queries.
  */
-static List *
+List *
 RoundRobinAssignTaskList(List *taskList)
 {
 	taskList = ReorderAndAssignTaskList(taskList, RoundRobinReorder);
@@ -5310,7 +5310,7 @@ ActivePlacementList(List *placementList)
  * repeatedly moves the list's first element to the end of the list, and
  * then returns the newly rotated list.
  */
-List *
+static List *
 LeftRotateList(List *list, uint32 rotateCount)
 {
 	List *rotatedList = list_copy(list);

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -114,7 +114,6 @@ static AttrNumber NewColumnId(Index originalTableId, AttrNumber originalColumnId
 static Job * JobForRangeTable(List *jobList, RangeTblEntry *rangeTableEntry);
 static Job * JobForTableIdList(List *jobList, List *searchedTableIdList);
 static List * ChildNodeList(MultiNode *multiNode);
-static uint64 UniqueJobId(void);
 static Job * BuildJob(Query *jobQuery, List *dependedJobList);
 static MapMergeJob * BuildMapMergeJob(Query *jobQuery, List *dependedJobList,
 									  Var *partitionKey, PartitionType partitionType,
@@ -1757,7 +1756,7 @@ ChildNodeList(MultiNode *multiNode)
  * When citus.enable_unique_job_ids is off then only the local counter is
  * included to get repeatable results.
  */
-static uint64
+uint64
 UniqueJobId(void)
 {
 	static uint32 jobIdCounter = 0;

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1658,11 +1658,19 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 	}
 
 	job->requiresMasterEvaluation = requiresMasterEvaluation;
-
 	return job;
 }
 
 
+/*
+ * ReorderTaskPlacementsByTaskAssignmentPolicy applies selective reordering for supported
+ * TaskAssignmentPolicyTypes.
+ *
+ * Supported Types
+ * - TASK_ASSIGNMENT_ROUND_ROBIN round robin schedule queries among placements
+ *
+ * By default it does not reorder the task list, implying a first-replica strategy.
+ */
 static void
 ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job, TaskAssignmentPolicyType
 											taskAssignmentPolicy)

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -340,6 +340,7 @@ extern bool TaskListMember(const List *taskList, const Task *task);
 extern List * TaskListDifference(const List *list1, const List *list2);
 extern List * AssignAnchorShardTaskList(List *taskList);
 extern List * FirstReplicaAssignTaskList(List *taskList);
+extern List * RoundRobinAssignTaskList(List *taskList);
 
 /* function declaration for creating Task */
 extern List * QueryPushdownSqlTaskList(Query *query, uint64 jobId,
@@ -350,7 +351,6 @@ extern List * QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 
 /* function declarations for managing jobs */
 extern uint64 UniqueJobId(void);
-extern List * LeftRotateList(List *list, uint32 rotateCount);
 
 
 #endif   /* MULTI_PHYSICAL_PLANNER_H */

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -348,5 +348,8 @@ extern List * QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 									   List *prunedRelationShardList, TaskType taskType,
 									   bool modifyRequiresMasterEvaluation);
 
+/* function declarations for managing jobs */
+extern uint64 UniqueJobId(void);
+
 
 #endif   /* MULTI_PHYSICAL_PLANNER_H */

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -350,6 +350,7 @@ extern List * QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 
 /* function declarations for managing jobs */
 extern uint64 UniqueJobId(void);
+extern List * LeftRotateList(List *list, uint32 rotateCount);
 
 
 #endif   /* MULTI_PHYSICAL_PLANNER_H */

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -140,3 +140,84 @@ DEBUG:  assigned task 1 to node localhost:57637
 RESET citus.task_assignment_policy;
 RESET client_min_messages;
 COMMIT;
+-- Check how task_assignment_policy impact planning decisions for reference tables
+-- We rely on the node:ports displayed in the explain plan
+RESET citus.explain_distributed_queries;
+CREATE TABLE task_assignment_reference_table (test_id  integer);
+SELECT create_reference_table('task_assignment_reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SET citus.task_assignment_policy TO 'greedy';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+SET citus.task_assignment_policy TO 'first-replica';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+SET citus.task_assignment_policy TO 'round-robin';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+RESET citus.task_assignment_policy;
+DROP TABLE task_assignment_reference_table;

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -204,7 +204,7 @@ EXPLAIN SELECT * FROM task_assignment_reference_table;
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Node: host=localhost port=57638 dbname=regression
+         Node: host=localhost port=57637 dbname=regression
          ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
 (6 rows)
 
@@ -215,7 +215,7 @@ EXPLAIN SELECT * FROM task_assignment_reference_table;
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Node: host=localhost port=57637 dbname=regression
+         Node: host=localhost port=57638 dbname=regression
          ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
 (6 rows)
 

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -140,9 +140,10 @@ DEBUG:  assigned task 1 to node localhost:57637
 RESET citus.task_assignment_policy;
 RESET client_min_messages;
 COMMIT;
+BEGIN;
+SET LOCAL client_min_messages TO DEBUG3;
+SET LOCAL citus.explain_distributed_queries TO off;
 -- Check how task_assignment_policy impact planning decisions for reference tables
--- We rely on the node:ports displayed in the explain plan
-RESET citus.explain_distributed_queries;
 CREATE TABLE task_assignment_reference_table (test_id  integer);
 SELECT create_reference_table('task_assignment_reference_table');
  create_reference_table 
@@ -150,74 +151,64 @@ SELECT create_reference_table('task_assignment_reference_table');
  
 (1 row)
 
-SET citus.task_assignment_policy TO 'greedy';
+SET LOCAL citus.task_assignment_policy TO 'greedy';
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
-SET citus.task_assignment_policy TO 'first-replica';
+SET LOCAL citus.task_assignment_policy TO 'first-replica';
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
-SET citus.task_assignment_policy TO 'round-robin';
+-- here we expect debug output showing two different hosts for subsequent queries
+SET LOCAL citus.task_assignment_policy TO 'round-robin';
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  assigned task 0 to node localhost:57637
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57637 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  assigned task 0 to node localhost:57638
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
-RESET citus.task_assignment_policy;
-DROP TABLE task_assignment_reference_table;
+ROLLBACK;

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -151,72 +151,72 @@ SELECT create_reference_table('task_assignment_reference_table');
 (1 row)
 
 SET citus.task_assignment_policy TO 'greedy';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
 SET citus.task_assignment_policy TO 'first-replica';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
 SET citus.task_assignment_policy TO 'round-robin';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57637 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
 RESET citus.task_assignment_policy;

--- a/src/test/regress/expected/multi_task_assignment_policy_0.out
+++ b/src/test/regress/expected/multi_task_assignment_policy_0.out
@@ -176,3 +176,84 @@ RESET client_min_messages;
 DEBUG:  StartTransactionCommand
 DEBUG:  ProcessUtility
 COMMIT;
+-- Check how task_assignment_policy impact planning decisions for reference tables
+-- We rely on the node:ports displayed in the explain plan
+RESET citus.explain_distributed_queries;
+CREATE TABLE task_assignment_reference_table (test_id  integer);
+SELECT create_reference_table('task_assignment_reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SET citus.task_assignment_policy TO 'greedy';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+SET citus.task_assignment_policy TO 'first-replica';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+SET citus.task_assignment_policy TO 'round-robin';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57638 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+(6 rows)
+
+RESET citus.task_assignment_policy;
+DROP TABLE task_assignment_reference_table;

--- a/src/test/regress/expected/multi_task_assignment_policy_0.out
+++ b/src/test/regress/expected/multi_task_assignment_policy_0.out
@@ -240,7 +240,7 @@ EXPLAIN SELECT * FROM task_assignment_reference_table;
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Node: host=localhost port=57638 dbname=regression
+         Node: host=localhost port=57637 dbname=regression
          ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
 (6 rows)
 
@@ -251,7 +251,7 @@ EXPLAIN SELECT * FROM task_assignment_reference_table;
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Node: host=localhost port=57637 dbname=regression
+         Node: host=localhost port=57638 dbname=regression
          ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
 (6 rows)
 

--- a/src/test/regress/expected/multi_task_assignment_policy_0.out
+++ b/src/test/regress/expected/multi_task_assignment_policy_0.out
@@ -187,72 +187,72 @@ SELECT create_reference_table('task_assignment_reference_table');
 (1 row)
 
 SET citus.task_assignment_policy TO 'greedy';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
 SET citus.task_assignment_policy TO 'first-replica';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
 SET citus.task_assignment_policy TO 'round-robin';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57637 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Custom Scan (Citus Router)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table  (cost=0.00..35.50 rows=2550 width=4)
+         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
 (6 rows)
 
 RESET citus.task_assignment_policy;

--- a/src/test/regress/expected/multi_task_assignment_policy_0.out
+++ b/src/test/regress/expected/multi_task_assignment_policy_0.out
@@ -176,84 +176,114 @@ RESET client_min_messages;
 DEBUG:  StartTransactionCommand
 DEBUG:  ProcessUtility
 COMMIT;
+BEGIN;
+SET LOCAL client_min_messages TO DEBUG3;
+DEBUG:  CommitTransactionCommand
+SET LOCAL citus.explain_distributed_queries TO off;
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  CommitTransactionCommand
 -- Check how task_assignment_policy impact planning decisions for reference tables
--- We rely on the node:ports displayed in the explain plan
-RESET citus.explain_distributed_queries;
 CREATE TABLE task_assignment_reference_table (test_id  integer);
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  CommitTransactionCommand
 SELECT create_reference_table('task_assignment_reference_table');
+DEBUG:  StartTransactionCommand
+DEBUG:  CommitTransactionCommand
  create_reference_table 
 ------------------------
  
 (1 row)
 
-SET citus.task_assignment_policy TO 'greedy';
+SET LOCAL citus.task_assignment_policy TO 'greedy';
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  CommitTransactionCommand
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  CommitTransactionCommand
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  CommitTransactionCommand
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
-SET citus.task_assignment_policy TO 'first-replica';
+SET LOCAL citus.task_assignment_policy TO 'first-replica';
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  CommitTransactionCommand
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  CommitTransactionCommand
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
-
-EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
-
-SET citus.task_assignment_policy TO 'round-robin';
-EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57637 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  CommitTransactionCommand
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Custom Scan (Citus Router)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=57638 dbname=regression
-         ->  Seq Scan on task_assignment_reference_table_880000 task_assignment_reference_table
-(6 rows)
+   explain statements for distributed queries are not enabled
+(2 rows)
 
-RESET citus.task_assignment_policy;
-DROP TABLE task_assignment_reference_table;
+-- here we expect debug output showing two different hosts for subsequent queries
+SET LOCAL citus.task_assignment_policy TO 'round-robin';
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  CommitTransactionCommand
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  assigned task 0 to node localhost:57637
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  CommitTransactionCommand
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Custom Scan (Citus Router)
+   explain statements for distributed queries are not enabled
+(2 rows)
+
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  assigned task 0 to node localhost:57638
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  CommitTransactionCommand
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Custom Scan (Citus Router)
+   explain statements for distributed queries are not enabled
+(2 rows)
+
+ROLLBACK;
+DEBUG:  StartTransactionCommand
+DEBUG:  ProcessUtility
+DEBUG:  CommitTransactionCommand

--- a/src/test/regress/sql/multi_task_assignment_policy.sql
+++ b/src/test/regress/sql/multi_task_assignment_policy.sql
@@ -103,16 +103,16 @@ CREATE TABLE task_assignment_reference_table (test_id  integer);
 SELECT create_reference_table('task_assignment_reference_table');
 
 SET citus.task_assignment_policy TO 'greedy';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-EXPLAIN SELECT * FROM task_assignment_reference_table;
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
 
 SET citus.task_assignment_policy TO 'first-replica';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-EXPLAIN SELECT * FROM task_assignment_reference_table;
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
 
 SET citus.task_assignment_policy TO 'round-robin';
-EXPLAIN SELECT * FROM task_assignment_reference_table;
-EXPLAIN SELECT * FROM task_assignment_reference_table;
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
+EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
 
 RESET citus.task_assignment_policy;
 

--- a/src/test/regress/sql/multi_task_assignment_policy.sql
+++ b/src/test/regress/sql/multi_task_assignment_policy.sql
@@ -94,3 +94,26 @@ RESET citus.task_assignment_policy;
 RESET client_min_messages;
 
 COMMIT;
+
+-- Check how task_assignment_policy impact planning decisions for reference tables
+-- We rely on the node:ports displayed in the explain plan
+RESET citus.explain_distributed_queries;
+
+CREATE TABLE task_assignment_reference_table (test_id  integer);
+SELECT create_reference_table('task_assignment_reference_table');
+
+SET citus.task_assignment_policy TO 'greedy';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+
+SET citus.task_assignment_policy TO 'first-replica';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+
+SET citus.task_assignment_policy TO 'round-robin';
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+EXPLAIN SELECT * FROM task_assignment_reference_table;
+
+RESET citus.task_assignment_policy;
+
+DROP TABLE task_assignment_reference_table;


### PR DESCRIPTION
Description: Support round-robin `task_assignment_policy` for queries to reference tables.

This PR allows users to query multiple placements of shards in a round robin fashion. When `citus.task_assignment_policy` is set to `'round-robin'` the planner will use a round robin scheduling feature when multiple shard placements are available.

The primary use-case is spreading the load of reference table queries to all the nodes in the cluster instead of hammering only the first placement of the reference table. Since reference tables share the same path for selecting the shards with single shard queries that have multiple placements (`citus.shard_replication_factor > 1`) this setting also allows users to spread the query load on these shards.

For modifying queries we do not apply a round-robin strategy. This would be negated by an extra reordering step in the executor for such queries where a `first-replica` strategy is enforced.