### PR TITLE
Fix permissions checks in UDFs called from the drop table trigger

### DIFF
--- a/src/backend/distributed/commands/drop_distributed_table.c
+++ b/src/backend/distributed/commands/drop_distributed_table.c
@@ -104,6 +104,8 @@ master_remove_distributed_table_metadata_from_workers(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
+	CheckTableSchemaNameForDrop(relationId, &schemaName, &tableName);
+
 	MasterRemoveDistributedTableMetadataFromWorkers(relationId, schemaName, tableName);
 
 	PG_RETURN_VOID();

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -1347,6 +1347,21 @@ EnsureTableOwner(Oid relationId)
 
 
 /*
+ * Check that the current user has owner rights to sequenceRelationId, error out if
+ * not. Superusers are regarded as owners.
+ */
+void
+EnsureSequenceOwner(Oid sequenceOid)
+{
+	if (!pg_class_ownercheck(sequenceOid, GetUserId()))
+	{
+		aclcheck_error(ACLCHECK_NOT_OWNER, ACLCHECK_OBJECT_SEQUENCE,
+					   get_rel_name(sequenceOid));
+	}
+}
+
+
+/*
  * EnsureSuperUser check that the current user is a superuser and errors out if not.
  */
 void

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -155,6 +155,7 @@ extern void CreateTruncateTrigger(Oid relationId);
 extern char * TableOwner(Oid relationId);
 extern void EnsureTablePermissions(Oid relationId, AclMode mode);
 extern void EnsureTableOwner(Oid relationId);
+extern void EnsureSequenceOwner(Oid sequenceOid);
 extern void EnsureSuperUser(void);
 extern void EnsureReplicationSettings(Oid relationId, char replicationModel);
 extern bool RegularTable(Oid relationId);

--- a/src/include/distributed/version_compat.h
+++ b/src/include/distributed/version_compat.h
@@ -67,6 +67,8 @@ struct QueryEnvironment; /* forward-declare to appease compiler */
 #define ACLCHECK_OBJECT_TABLE ACL_KIND_CLASS
 #define ACLCHECK_OBJECT_SCHEMA ACL_KIND_NAMESPACE
 #define ACLCHECK_OBJECT_INDEX ACL_KIND_CLASS
+#define ACLCHECK_OBJECT_SEQUENCE ACL_KIND_CLASS
+
 
 static inline int
 BasicOpenFilePerm(FileName fileName, int fileFlags, int fileMode)
@@ -158,6 +160,8 @@ canonicalize_qual_compat(Expr *qual, bool is_check)
 #define ACLCHECK_OBJECT_TABLE OBJECT_TABLE
 #define ACLCHECK_OBJECT_SCHEMA OBJECT_SCHEMA
 #define ACLCHECK_OBJECT_INDEX OBJECT_INDEX
+#define ACLCHECK_OBJECT_SEQUENCE OBJECT_SEQUENCE
+
 
 #define ConstraintRelidIndexId ConstraintRelidTypidNameIndexId
 

--- a/src/test/regress/expected/multi_mx_metadata.out
+++ b/src/test/regress/expected/multi_mx_metadata.out
@@ -287,8 +287,39 @@ SELECT count(*) FROM pg_tables WHERE tablename = 'should_commit';
      1
 (1 row)
 
--- Resume ordinary recovery
 \c - - - :master_port
+CREATE USER no_access_mx;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SELECT run_command_on_workers($$CREATE USER no_access_mx;$$);
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+SET ROLE no_access_mx;
+DROP TABLE distributed_mx_table;
+ERROR:  must be owner of table distributed_mx_table
+SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ERROR:  must be owner of table distributed_mx_table
+SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ERROR:  must be owner of table distributed_mx_table
+SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ERROR:  must be owner of table distributed_mx_table
+\c - no_access_mx - :worker_1_port
+DROP TABLE distributed_mx_table;
+ERROR:  must be owner of table distributed_mx_table
+SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ERROR:  must be owner of table distributed_mx_table
+SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ERROR:  operation is not allowed on this node
+HINT:  Connect to the coordinator and run it again.
+SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ERROR:  operation is not allowed on this node
+HINT:  Connect to the coordinator and run it again.
+-- Resume ordinary recovery
+\c - postgres - :master_port
 ALTER SYSTEM RESET citus.recover_2pc_interval;
 SELECT pg_reload_conf();
  pg_reload_conf 

--- a/src/test/regress/expected/multi_mx_metadata.out
+++ b/src/test/regress/expected/multi_mx_metadata.out
@@ -7,12 +7,25 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- pg 10 and pg 11 has different error messages for acl checks
+-- so catch them and print only one type of error message to prevent
+-- multiple output test files
+CREATE OR REPLACE FUNCTION raise_failed_aclcheck(query text) RETURNS void AS $$
+BEGIN
+    EXECUTE query;
+    EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'must be owner of%' THEN
+        RAISE 'must be owner of the object';
+    END IF;
+END;
+$$LANGUAGE plpgsql;
 -- get rid of the previously created entries in pg_dist_transaction
 -- for the sake of getting consistent results in this test file
 TRUNCATE pg_dist_transaction;
 CREATE TABLE distributed_mx_table (
     key text primary key,
-    value jsonb
+    value jsonb,
+    some_val bigserial
 );
 CREATE INDEX ON distributed_mx_table USING GIN (value);
 SET citus.shard_replication_factor TO 1;
@@ -47,11 +60,12 @@ SELECT count(*) FROM pg_dist_transaction;
 
 \c - - - :worker_1_port
 SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='distributed_mx_table'::regclass;
- Column | Type  | Modifiers 
---------+-------+-----------
- key    | text  | not null
- value  | jsonb | 
-(2 rows)
+  Column  |  Type  |                                Modifiers                                
+----------+--------+-------------------------------------------------------------------------
+ key      | text   | not null
+ value    | jsonb  | 
+ some_val | bigint | not null default nextval('distributed_mx_table_some_val_seq'::regclass)
+(3 rows)
 
 SELECT "Column", "Type", "Definition" FROM index_attrs WHERE
     relid = 'distributed_mx_table_pkey'::regclass;
@@ -83,11 +97,12 @@ WHERE logicalrelid = 'distributed_mx_table'::regclass;
 
 \c - - - :worker_2_port
 SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='distributed_mx_table'::regclass;
- Column | Type  | Modifiers 
---------+-------+-----------
- key    | text  | not null
- value  | jsonb | 
-(2 rows)
+  Column  |  Type  |                                Modifiers                                
+----------+--------+-------------------------------------------------------------------------
+ key      | text   | not null
+ value    | jsonb  | 
+ some_val | bigint | not null default nextval('distributed_mx_table_some_val_seq'::regclass)
+(3 rows)
 
 SELECT "Column", "Type", "Definition" FROM index_attrs WHERE
     relid = 'distributed_mx_table_pkey'::regclass;
@@ -299,25 +314,120 @@ SELECT run_command_on_workers($$CREATE USER no_access_mx;$$);
 (2 rows)
 
 SET ROLE no_access_mx;
-DROP TABLE distributed_mx_table;
-ERROR:  must be owner of table distributed_mx_table
-SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
-ERROR:  must be owner of table distributed_mx_table
-SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
-ERROR:  must be owner of table distributed_mx_table
-SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
-ERROR:  must be owner of table distributed_mx_table
+SELECT raise_failed_aclcheck($$ 
+    DROP TABLE distributed_mx_table;
+$$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ $$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+$$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+$$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_sequences(ARRAY['public.distributed_mx_table_some_val_seq']);
+$$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_sequences(ARRAY['distributed_mx_table_some_val_seq']);
+$$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT master_drop_sequences(ARRAY['non_existing_schema.distributed_mx_table_some_val_seq']);
+ master_drop_sequences 
+-----------------------
+ 
+(1 row)
+
+SELECT master_drop_sequences(ARRAY['']);
+ERROR:  invalid name syntax
+SELECT master_drop_sequences(ARRAY['public.']);
+ERROR:  invalid name syntax
+SELECT master_drop_sequences(ARRAY['public.distributed_mx_table_some_val_seq_not_existing']);
+ master_drop_sequences 
+-----------------------
+ 
+(1 row)
+
+-- make sure that we can drop unrelated tables/sequences
+CREATE TABLE unrelated_table(key serial);
+DROP TABLE unrelated_table;
+-- doesn't error out but it has no effect, so no need to error out
+SELECT master_drop_sequences(NULL);
+ master_drop_sequences 
+-----------------------
+ 
+(1 row)
+
+\c - postgres - :master_port
+-- finally make sure that the sequence remains
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='distributed_mx_table'::regclass;
+  Column  |  Type  |                                Modifiers                                
+----------+--------+-------------------------------------------------------------------------
+ key      | text   | not null
+ value    | jsonb  | 
+ some_val | bigint | not null default nextval('distributed_mx_table_some_val_seq'::regclass)
+(3 rows)
+
 \c - no_access_mx - :worker_1_port
-DROP TABLE distributed_mx_table;
-ERROR:  must be owner of table distributed_mx_table
-SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
-ERROR:  must be owner of table distributed_mx_table
+-- see the comment in the top of the file
+CREATE OR REPLACE FUNCTION raise_failed_aclcheck(query text) RETURNS void AS $$
+BEGIN
+    EXECUTE query;
+    EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'must be owner of%' THEN
+        RAISE 'must be owner of the object';
+    END IF;
+END;
+$$LANGUAGE plpgsql;
+SELECT raise_failed_aclcheck($$ 
+    DROP TABLE distributed_mx_table;
+$$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ $$);
+ERROR:  must be owner of the object
+CONTEXT:  PL/pgSQL function raise_failed_aclcheck(text) line 6 at RAISE
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_sequences(ARRAY['public.distributed_mx_table_some_val_seq']);
+$$);
+ raise_failed_aclcheck 
+-----------------------
+ 
+(1 row)
+
 SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
 SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
+-- make sure that we can drop unrelated tables/sequences
+CREATE TABLE unrelated_table(key serial);
+DROP TABLE unrelated_table;
+\c - postgres - :worker_1_port
+-- finally make sure that the sequence remains
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='distributed_mx_table'::regclass;
+  Column  |  Type  |                                Modifiers                                
+----------+--------+-------------------------------------------------------------------------
+ key      | text   | not null
+ value    | jsonb  | 
+ some_val | bigint | not null default nextval('distributed_mx_table_some_val_seq'::regclass)
+(3 rows)
+
 -- Resume ordinary recovery
 \c - postgres - :master_port
 ALTER SYSTEM RESET citus.recover_2pc_interval;

--- a/src/test/regress/sql/multi_mx_metadata.sql
+++ b/src/test/regress/sql/multi_mx_metadata.sql
@@ -4,13 +4,27 @@
 ALTER SYSTEM SET citus.recover_2pc_interval TO -1;
 SELECT pg_reload_conf();
 
+-- pg 10 and pg 11 has different error messages for acl checks
+-- so catch them and print only one type of error message to prevent
+-- multiple output test files
+CREATE OR REPLACE FUNCTION raise_failed_aclcheck(query text) RETURNS void AS $$
+BEGIN
+    EXECUTE query;
+    EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'must be owner of%' THEN
+        RAISE 'must be owner of the object';
+    END IF;
+END;
+$$LANGUAGE plpgsql;
+
 -- get rid of the previously created entries in pg_dist_transaction
 -- for the sake of getting consistent results in this test file
 TRUNCATE pg_dist_transaction;
 
 CREATE TABLE distributed_mx_table (
     key text primary key,
-    value jsonb
+    value jsonb,
+    some_val bigserial
 );
 CREATE INDEX ON distributed_mx_table USING GIN (value);
 
@@ -181,16 +195,81 @@ CREATE USER no_access_mx;
 SELECT run_command_on_workers($$CREATE USER no_access_mx;$$);
 
 SET ROLE no_access_mx;
-DROP TABLE distributed_mx_table;
-SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+
+SELECT raise_failed_aclcheck($$ 
+    DROP TABLE distributed_mx_table;
+$$);
+
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ $$);
+
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+$$);
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+$$);
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_sequences(ARRAY['public.distributed_mx_table_some_val_seq']);
+$$);
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_sequences(ARRAY['distributed_mx_table_some_val_seq']);
+$$);
+
+SELECT master_drop_sequences(ARRAY['non_existing_schema.distributed_mx_table_some_val_seq']);
+SELECT master_drop_sequences(ARRAY['']);
+SELECT master_drop_sequences(ARRAY['public.']);
+SELECT master_drop_sequences(ARRAY['public.distributed_mx_table_some_val_seq_not_existing']);
+
+-- make sure that we can drop unrelated tables/sequences
+CREATE TABLE unrelated_table(key serial);
+DROP TABLE unrelated_table;
+
+-- doesn't error out but it has no effect, so no need to error out
+SELECT master_drop_sequences(NULL);
+
+\c - postgres - :master_port
+
+-- finally make sure that the sequence remains
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='distributed_mx_table'::regclass;
+
+\c - no_access_mx - :worker_1_port
+
+-- see the comment in the top of the file
+CREATE OR REPLACE FUNCTION raise_failed_aclcheck(query text) RETURNS void AS $$
+BEGIN
+    EXECUTE query;
+    EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'must be owner of%' THEN
+        RAISE 'must be owner of the object';
+    END IF;
+END;
+$$LANGUAGE plpgsql;
+
+SELECT raise_failed_aclcheck($$ 
+    DROP TABLE distributed_mx_table;
+$$);
+
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+ $$);
+
+SELECT raise_failed_aclcheck($$ 
+    SELECT master_drop_sequences(ARRAY['public.distributed_mx_table_some_val_seq']);
+$$);
+
 SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
 SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
 
-\c - no_access_mx - :worker_1_port
-DROP TABLE distributed_mx_table;
-SELECT master_remove_distributed_table_metadata_from_workers('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
-SELECT master_drop_all_shards('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
-SELECT master_remove_partition_metadata('distributed_mx_table'::regclass, 'public', 'distributed_mx_table');
+-- make sure that we can drop unrelated tables/sequences
+CREATE TABLE unrelated_table(key serial);
+DROP TABLE unrelated_table;
+
+\c - postgres - :worker_1_port
+
+-- finally make sure that the sequence remains
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='distributed_mx_table'::regclass;
 
 -- Resume ordinary recovery
 \c - postgres - :master_port


### PR DESCRIPTION
Not fixes #2274 as described in the issue, but addresses in another way, similar to how drop table is handled.

In MX, we allow unauthorized users to drop (or at least mess up) tables/sequences. This PR prevents that.

I'm assigning @marcocitus since he asked for the change. But, feel to re-assign to @metdos if you're not avaliable.