### PR TITLE
Expand recursive planning for distributed tables and recurring outer/semi joins

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -61,7 +61,8 @@ static DistributedPlan * CreateDistributedPlan(uint64 planId, Query *originalQue
 											   Query *query, ParamListInfo boundParams,
 											   bool hasUnresolvedParams,
 											   PlannerRestrictionContext *
-											   plannerRestrictionContext);
+											   plannerRestrictionContext,
+											   List *previousSubPlanList);
 static DeferredErrorMessage * DeferErrorIfPartitionTableNotSingleReplicated(Oid
 																			relationId);
 static Node * ResolveExternalParams(Node *inputNode, ParamListInfo boundParams);
@@ -497,7 +498,8 @@ CreateDistributedPlannedStmt(uint64 planId, PlannedStmt *localPlan, Query *origi
 
 	distributedPlan =
 		CreateDistributedPlan(planId, originalQuery, query, boundParams,
-							  hasUnresolvedParams, plannerRestrictionContext);
+							  hasUnresolvedParams, plannerRestrictionContext,
+							  NIL);
 
 	/*
 	 * If no plan was generated, prepare a generic error to be emitted.
@@ -575,7 +577,8 @@ CreateDistributedPlannedStmt(uint64 planId, PlannedStmt *localPlan, Query *origi
 static DistributedPlan *
 CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamListInfo
 					  boundParams, bool hasUnresolvedParams,
-					  PlannerRestrictionContext *plannerRestrictionContext)
+					  PlannerRestrictionContext *plannerRestrictionContext,
+					  List *previousSubPlanList)
 {
 	DistributedPlan *distributedPlan = NULL;
 	MultiTreeRoot *logicalPlan = NULL;
@@ -683,7 +686,8 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 	 * calling the planner and return the resulting plans to subPlanList.
 	 */
 	subPlanList = GenerateSubplansForSubqueriesAndCTEs(planId, originalQuery,
-													   plannerRestrictionContext);
+													   plannerRestrictionContext,
+													   previousSubPlanList);
 
 	/*
 	 * If subqueries were recursively planned then we need to replan the query
@@ -698,7 +702,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 	 * the CTEs are referenced then there are no subplans, but we still want
 	 * to retry the router planner.
 	 */
-	if (list_length(subPlanList) > 0 || hasCtes)
+	if (list_length(subPlanList) > list_length(previousSubPlanList) || hasCtes)
 	{
 		Query *newQuery = copyObject(originalQuery);
 		bool setPartitionedTablesInherited = false;
@@ -730,7 +734,8 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 
 		/* recurse into CreateDistributedPlan with subqueries/CTEs replaced */
 		distributedPlan = CreateDistributedPlan(planId, originalQuery, query, NULL, false,
-												plannerRestrictionContext);
+												plannerRestrictionContext, subPlanList);
+
 		distributedPlan->subPlanList = subPlanList;
 
 		return distributedPlan;

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -77,6 +77,7 @@
 #include "nodes/primnodes.h"
 #include "nodes/relation.h"
 #include "optimizer/clauses.h"
+#include "optimizer/var.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
@@ -158,6 +159,8 @@ static void RecursivelyPlanSetOperations(Query *query, Node *node,
 static bool IsLocalTableRTE(Node *node);
 static void RecursivelyPlanRTERelation(RangeTblEntry *relationRte,
 									   RecursivePlanningContext *planningContext);
+static List * RequiredAttrNumbersForRelation(RangeTblEntry *relationRte,
+											 RecursivePlanningContext *planningContext);
 static void RecursivelyPlanSubquery(Query *subquery,
 									RecursivePlanningContext *planningContext);
 static DistributedSubPlan * CreateDistributedSubPlan(uint32 subPlanId,
@@ -480,7 +483,7 @@ RecursivelyPlanNonColocatedJoinWalker(Node *joinNode,
 
 		if (rte->rtekind == RTE_RELATION)
 		{
-			subquery = WrapRteRelationIntoSubquery(rte);
+			subquery = WrapRteRelationIntoSubquery(rte, NIL);
 
 			if (!SubqueryColocated(subquery, colocatedJoinChecker))
 			{
@@ -1091,15 +1094,18 @@ RecursivelyPlanRTERelation(RangeTblEntry *relationRte,
 		planningContext->plannerRestrictionContext;
 	List *restrictionExprListOnTable =
 		GetRestrictInfoListForRelation(relationRte, plannerRestrictionContext);
+	List *requiredAttrNumbersForRelation =
+		RequiredAttrNumbersForRelation(relationRte, planningContext);
 
-	Query *subquery = WrapRteRelationIntoSubquery(relationRte);
+	Query *subquery =
+		WrapRteRelationIntoSubquery(relationRte, requiredAttrNumbersForRelation);
 	RangeTblEntry *wrappedSubqueryEntry = makeNode(RangeTblEntry);
 	ListCell *columnListCell = NULL;
 	List *columnNames = NIL;
 	char *relationName = get_rel_name(relationRte->relid);
 
 	wrappedSubqueryEntry->rtekind = RTE_SUBQUERY;
-	wrappedSubqueryEntry->subquery = copyObject(subquery);
+	wrappedSubqueryEntry->subquery = subquery;
 
 	foreach(columnListCell, subquery->targetList)
 	{
@@ -1123,6 +1129,54 @@ RecursivelyPlanRTERelation(RangeTblEntry *relationRte,
 
 	/* simply call the main logic for recursive query planning */
 	RecursivelyPlanSubquery(wrappedSubqueryEntry->subquery, planningContext);
+}
+
+
+/*
+ * RequiredAttrNumbersForRelation returns the required attribute numbers for
+ * the input RTE relation in order for the planning to succeed.
+ *
+ * The function could be optimized by not adding the columns that only appear
+ * WHERE clause as a filter (e.g., not a join clause).
+ */
+static List *
+RequiredAttrNumbersForRelation(RangeTblEntry *relationRte,
+							   RecursivePlanningContext *planningContext)
+{
+	PlannerRestrictionContext *plannerRestrictionContext =
+		planningContext->plannerRestrictionContext;
+	PlannerRestrictionContext *filteredPlannerRestrictionContext =
+		FilterPlannerRestrictionForQuery(plannerRestrictionContext,
+										 WrapRteRelationIntoSubquery(relationRte, NIL));
+
+	RelationRestrictionContext *relationRestrictionContext =
+		filteredPlannerRestrictionContext->relationRestrictionContext;
+	List *filteredRelationRestrictionList =
+		relationRestrictionContext->relationRestrictionList;
+	RelationRestriction *relationRestriction =
+		(RelationRestriction *) linitial(filteredRelationRestrictionList);
+
+	PlannerInfo *plannerInfo = relationRestriction->plannerInfo;
+	Query *queryToProcess = plannerInfo->parse;
+	int rteIndex = relationRestriction->index;
+
+	List *allVarsInQuery = pull_vars_of_level((Node *) queryToProcess, 0);
+	ListCell *varCell = NULL;
+
+	List *requiredAttrNumbers = NIL;
+
+	foreach(varCell, allVarsInQuery)
+	{
+		Var *var = (Var *) lfirst(varCell);
+
+		if (var->varno == rteIndex)
+		{
+			requiredAttrNumbers = list_append_unique_int(requiredAttrNumbers,
+														 var->varattno);
+		}
+	}
+
+	return requiredAttrNumbers;
 }
 
 

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -76,6 +76,7 @@
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
 #include "nodes/relation.h"
+#include "optimizer/clauses.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
@@ -480,6 +481,7 @@ RecursivelyPlanNonColocatedJoinWalker(Node *joinNode,
 		if (rte->rtekind == RTE_RELATION)
 		{
 			subquery = WrapRteRelationIntoSubquery(rte);
+
 			if (!SubqueryColocated(subquery, colocatedJoinChecker))
 			{
 				RecursivelyPlanRTERelation(rte, recursivePlanningContext);
@@ -1076,15 +1078,24 @@ IsLocalTableRTE(Node *node)
  * (e.g., users_table becomes (SELECT * FROM users_table) as users_table).
  *
  * Later, the subquery is recursively planned via RecursivelyPlanSubquery().
+ *
+ * The function pushes down all the restriction appering on the table to the
+ * subquery in order to restrict the total amount of data that'd be pulled and
+ * pushed back.
  */
 static void
 RecursivelyPlanRTERelation(RangeTblEntry *relationRte,
 						   RecursivePlanningContext *planningContext)
 {
+	PlannerRestrictionContext *plannerRestrictionContext =
+		planningContext->plannerRestrictionContext;
+	List *restrictionExprListOnTable =
+		GetRestrictInfoListForRelation(relationRte, plannerRestrictionContext);
+
 	Query *subquery = WrapRteRelationIntoSubquery(relationRte);
 	RangeTblEntry *wrappedSubqueryEntry = makeNode(RangeTblEntry);
 	ListCell *columnListCell = NULL;
-	List *colNames = NIL;
+	List *columnNames = NIL;
 	char *relationName = get_rel_name(relationRte->relid);
 
 	wrappedSubqueryEntry->rtekind = RTE_SUBQUERY;
@@ -1094,17 +1105,23 @@ RecursivelyPlanRTERelation(RangeTblEntry *relationRte,
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(columnListCell);
 
-		colNames =
-			lappend(colNames, makeString(pstrdup(tle->resname)));
+		columnNames = lappend(columnNames, makeString(pstrdup(tle->resname)));
 	}
 
-	wrappedSubqueryEntry->eref = makeAlias(pstrdup(relationName), copyObject(colNames));
-	wrappedSubqueryEntry->alias = makeAlias(pstrdup(relationName), copyObject(colNames));
+	wrappedSubqueryEntry->eref =
+		makeAlias(pstrdup(relationName), copyObject(columnNames));
+	wrappedSubqueryEntry->alias =
+		makeAlias(pstrdup(relationName), copyObject(columnNames));
 
 	wrappedSubqueryEntry->inFromCl = true;
 
+	wrappedSubqueryEntry->subquery->jointree->quals =
+		(Node *) make_ands_explicit(restrictionExprListOnTable);
+
+	/* replace RTE_RELATION with the corresponding RTE_SUBQUERY */
 	memcpy(relationRte, wrappedSubqueryEntry, sizeof(RangeTblEntry));
 
+	/* simply call the main logic for recursive query planning */
 	RecursivelyPlanSubquery(wrappedSubqueryEntry->subquery, planningContext);
 }
 

--- a/src/include/distributed/query_colocation_checker.h
+++ b/src/include/distributed/query_colocation_checker.h
@@ -34,6 +34,7 @@ extern ColocatedJoinChecker CreateColocatedJoinChecker(Query *subquery,
 													   PlannerRestrictionContext *
 													   restrictionContext);
 extern bool SubqueryColocated(Query *subquery, ColocatedJoinChecker *context);
+extern Query * WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation);
 
 
 #endif /* QUERY_COLOCATION_CHECKER_H */

--- a/src/include/distributed/query_colocation_checker.h
+++ b/src/include/distributed/query_colocation_checker.h
@@ -34,7 +34,8 @@ extern ColocatedJoinChecker CreateColocatedJoinChecker(Query *subquery,
 													   PlannerRestrictionContext *
 													   restrictionContext);
 extern bool SubqueryColocated(Query *subquery, ColocatedJoinChecker *context);
-extern Query * WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation);
+extern Query * WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation,
+										   List *requiredAttrNumbersForRelation);
 
 
 #endif /* QUERY_COLOCATION_CHECKER_H */

--- a/src/include/distributed/query_pushdown_planning.h
+++ b/src/include/distributed/query_pushdown_planning.h
@@ -39,6 +39,8 @@ extern DeferredErrorMessage * DeferErrorIfCannotPushdownSubquery(Query *subquery
 																 bool
 																 outerMostQueryHasLimit);
 extern DeferredErrorMessage * DeferErrorIfUnsupportedUnionQuery(Query *queryTree);
+extern DeferredErrorMessage * DeferredErrorIfUnsupportedRecurringTuplesJoin(
+	PlannerRestrictionContext *plannerRestrictionContext, List **innerRteIdentities);
 
 
 #endif /* QUERY_PUSHDOWN_PLANNING_H */

--- a/src/include/distributed/recursive_planning.h
+++ b/src/include/distributed/recursive_planning.h
@@ -20,7 +20,8 @@
 
 extern List * GenerateSubplansForSubqueriesAndCTEs(uint64 planId, Query *originalQuery,
 												   PlannerRestrictionContext *
-												   plannerRestrictionContext);
+												   plannerRestrictionContext,
+												   List *previousSubPlanList);
 extern char * GenerateResultId(uint64 planId, uint32 subPlanId);
 
 

--- a/src/include/distributed/relation_restriction_equivalence.h
+++ b/src/include/distributed/relation_restriction_equivalence.h
@@ -42,4 +42,7 @@ extern bool EquivalenceListContainsRelationsEquality(List *attributeEquivalenceL
 													 RelationRestrictionContext *
 													 restrictionContext);
 
+List * GetRestrictInfoListForRelation(RangeTblEntry *rte,
+									  PlannerRestrictionContext *plannerRestrictionContext);
+
 #endif /* RELATION_RESTRICTION_EQUIVALENCE_H */

--- a/src/test/regress/expected/multi_dropped_column_aliases.out
+++ b/src/test/regress/expected/multi_dropped_column_aliases.out
@@ -59,5 +59,5 @@ FROM   (customer LEFT OUTER JOIN orders ON (c_custkey = o_custkey)) AS
        test(c_custkey, c_nationkey)
        INNER JOIN lineitem ON (test.c_custkey = l_orderkey)
 LIMIT 10;
-ERROR:  cannot run outer join query if join is not on the partition column
-DETAIL:  Outer joins requiring repartitioning are not supported.
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a reference table in the outer part of the outer join

--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -1252,7 +1252,15 @@ WHERE
 GROUP BY 1
 ORDER BY 2 DESC, 1 DESC
 LIMIT 5;
-ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+ user_id | count 
+---------+-------
+       5 |   936
+       4 |   644
+       6 |   390
+       3 |   289
+       2 |   144
+(5 rows)
+
 SELECT foo.user_id FROM
 (
   SELECT m.user_id, random() FROM users_table m JOIN events_reference_table r ON int4eq(m.user_id, r.user_id)

--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -77,12 +77,27 @@ ORDER BY 1;
        7
 (10 rows)
 
--- Shouldn't work, reference table at the outer side is not allowed
+SET client_min_messages TO DEBUG;
+-- Should work because we can recursively plan the distributed relation on the
+-- inner part of the outer join
 SELECT * FROM
-  (SELECT random() FROM users_ref_test_table LEFT JOIN user_buy_test_table
-  ON users_ref_test_table.id = user_buy_test_table.user_id) subquery_1;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a reference table in the outer part of the outer join
+  (SELECT users_ref_test_table.id FROM users_ref_test_table LEFT JOIN user_buy_test_table
+  ON users_ref_test_table.id = user_buy_test_table.user_id) subquery_1 ORDER BY 1 DESC;
+DEBUG:  generating subplan 12_1 for subquery SELECT user_id, NULL::integer AS item_id, NULL::integer AS buy_count FROM public.user_buy_test_table WHERE true
+DEBUG:  Plan 12 query after replacing subqueries and CTEs: SELECT id FROM (SELECT users_ref_test_table.id FROM (public.users_ref_test_table LEFT JOIN (SELECT intermediate_result.user_id, intermediate_result.item_id, intermediate_result.buy_count FROM read_intermediate_result('12_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, item_id integer, buy_count integer)) user_buy_test_table(user_id, item_id, buy_count) ON ((users_ref_test_table.id OPERATOR(pg_catalog.=) user_buy_test_table.user_id)))) subquery_1 ORDER BY id DESC
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ id 
+----
+  6
+  5
+  4
+  3
+  2
+  1
+(6 rows)
+
+RESET client_min_messages;
 -- Should work, reference table at the inner side is allowed
 SELECT count(*) FROM
   (SELECT random() FROM users_ref_test_table RIGHT JOIN user_buy_test_table
@@ -92,12 +107,22 @@ SELECT count(*) FROM
      4
 (1 row)
 
--- Shouldn't work, reference table at the outer side is not allowed
-SELECT * FROM
+SET client_min_messages TO DEBUG;
+-- Should work because we can recursively plan the distributed relation on the
+-- inner part of the outer join
+SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table RIGHT JOIN users_ref_test_table
   ON user_buy_test_table.user_id = users_ref_test_table.id) subquery_1;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a reference table in the outer part of the outer join
+DEBUG:  generating subplan 15_1 for subquery SELECT user_id, NULL::integer AS item_id, NULL::integer AS buy_count FROM public.user_buy_test_table WHERE true
+DEBUG:  Plan 15 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT random() AS random FROM ((SELECT intermediate_result.user_id, intermediate_result.item_id, intermediate_result.buy_count FROM read_intermediate_result('15_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, item_id integer, buy_count integer)) user_buy_test_table(user_id, item_id, buy_count) RIGHT JOIN public.users_ref_test_table ON ((user_buy_test_table.user_id OPERATOR(pg_catalog.=) users_ref_test_table.id)))) subquery_1
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count 
+-------
+     6
+(1 row)
+
+RESET client_min_messages;
 -- Equi join test with reference table on non-partition keys
 SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table JOIN users_ref_test_table
@@ -250,23 +275,40 @@ ON user_buy_test_table.item_id = users_ref_test_table.id;
      4
 (1 row)
 
--- table function cannot be the outer relationship in an outer join
+SET client_min_messages TO DEBUG;
+-- table function can be the outer relationship in an outer join
+-- since the inner side is recursively planned
 SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table RIGHT JOIN generate_series(1,10) AS users_ref_test_table(id)
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a table function in the outer part of the outer join
+DEBUG:  generating subplan 30_1 for subquery SELECT NULL::integer AS user_id, item_id, NULL::integer AS buy_count FROM public.user_buy_test_table WHERE true
+DEBUG:  Plan 30 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT random() AS random FROM ((SELECT intermediate_result.user_id, intermediate_result.item_id, intermediate_result.buy_count FROM read_intermediate_result('30_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, item_id integer, buy_count integer)) user_buy_test_table(user_id, item_id, buy_count) RIGHT JOIN generate_series(1, 10) users_ref_test_table(id) ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))) subquery_1
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count 
+-------
+    16
+(1 row)
+
 SELECT count(*) FROM user_buy_test_table RIGHT JOIN (SELECT * FROM generate_series(1,10) id) users_ref_test_table
 ON user_buy_test_table.item_id = users_ref_test_table.id;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a table function in the outer part of the outer join
+DEBUG:  generating subplan 32_1 for subquery SELECT NULL::integer AS user_id, item_id, NULL::integer AS buy_count FROM public.user_buy_test_table WHERE true
+DEBUG:  Plan 32 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.user_id, intermediate_result.item_id, intermediate_result.buy_count FROM read_intermediate_result('32_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, item_id integer, buy_count integer)) user_buy_test_table(user_id, item_id, buy_count) RIGHT JOIN (SELECT id.id FROM generate_series(1, 10) id(id)) users_ref_test_table ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.=) users_ref_test_table.id)))
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count 
+-------
+    10
+(1 row)
+
+RESET client_min_messages;
 -- volatile functions can be used as table expressions through recursive planning
 SET client_min_messages TO DEBUG;
 SELECT count(*) FROM
   (SELECT random() FROM user_buy_test_table JOIN random() AS users_ref_test_table(id)
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
-DEBUG:  generating subplan 30_1 for subquery SELECT random() AS random FROM (public.user_buy_test_table JOIN random() users_ref_test_table(id) ON (((user_buy_test_table.item_id)::double precision OPERATOR(pg_catalog.>) users_ref_test_table.id)))
-DEBUG:  Plan 30 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.random FROM read_intermediate_result('30_1'::text, 'binary'::citus_copy_format) intermediate_result(random double precision)) subquery_1
+DEBUG:  generating subplan 34_1 for subquery SELECT random() AS random FROM (public.user_buy_test_table JOIN random() users_ref_test_table(id) ON (((user_buy_test_table.item_id)::double precision OPERATOR(pg_catalog.>) users_ref_test_table.id)))
+DEBUG:  Plan 34 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.random FROM read_intermediate_result('34_1'::text, 'binary'::citus_copy_format) intermediate_result(random double precision)) subquery_1
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -279,8 +321,8 @@ SELECT count(*) FROM
   (SELECT item_id FROM user_buy_test_table JOIN generate_series(random()::int,10) AS users_ref_test_table(id)
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1
 WHERE item_id = 6;
-DEBUG:  generating subplan 32_1 for subquery SELECT user_buy_test_table.item_id FROM (public.user_buy_test_table JOIN generate_series((random())::integer, 10) users_ref_test_table(id) ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))
-DEBUG:  Plan 32 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.item_id FROM read_intermediate_result('32_1'::text, 'binary'::citus_copy_format) intermediate_result(item_id integer)) subquery_1 WHERE (item_id OPERATOR(pg_catalog.=) 6)
+DEBUG:  generating subplan 36_1 for subquery SELECT user_buy_test_table.item_id FROM (public.user_buy_test_table JOIN generate_series((random())::integer, 10) users_ref_test_table(id) ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))
+DEBUG:  Plan 36 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.item_id FROM read_intermediate_result('36_1'::text, 'binary'::citus_copy_format) intermediate_result(item_id integer)) subquery_1 WHERE (item_id OPERATOR(pg_catalog.=) 6)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -293,11 +335,11 @@ SELECT count(*) FROM
   (SELECT user_id FROM user_buy_test_table
    UNION ALL
    SELECT id FROM generate_series(1,10) AS users_ref_test_table(id)) subquery_1;
-DEBUG:  generating subplan 34_1 for subquery SELECT user_id FROM public.user_buy_test_table
+DEBUG:  generating subplan 38_1 for subquery SELECT user_id FROM public.user_buy_test_table
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 34_2 for subquery SELECT intermediate_result.user_id FROM read_intermediate_result('34_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION ALL SELECT users_ref_test_table.id FROM generate_series(1, 10) users_ref_test_table(id)
-DEBUG:  Plan 34 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('34_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) subquery_1
+DEBUG:  generating subplan 38_2 for subquery SELECT intermediate_result.user_id FROM read_intermediate_result('38_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION ALL SELECT users_ref_test_table.id FROM generate_series(1, 10) users_ref_test_table(id)
+DEBUG:  Plan 38 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('38_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) subquery_1
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -331,11 +373,19 @@ ON user_buy_test_table.item_id = users_ref_test_table.id;
      4
 (1 row)
 
--- subquery without FROM cannot be the outer relationship in an outer join
+SET client_min_messages TO DEBUG1;
+-- subquery without FROM can be the outer relationship in an outer join
+-- since the inner part can be recursively planned
 SELECT count(*) FROM user_buy_test_table RIGHT JOIN (SELECT 5 AS id) users_ref_test_table
 ON user_buy_test_table.item_id = users_ref_test_table.id;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a subquery without FROM in the outer part of the outer join
+DEBUG:  generating subplan 44_1 for subquery SELECT NULL::integer AS user_id, item_id, NULL::integer AS buy_count FROM public.user_buy_test_table WHERE true
+DEBUG:  Plan 44 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.user_id, intermediate_result.item_id, intermediate_result.buy_count FROM read_intermediate_result('44_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, item_id integer, buy_count integer)) user_buy_test_table(user_id, item_id, buy_count) RIGHT JOIN (SELECT 5 AS id) users_ref_test_table ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.=) users_ref_test_table.id)))
+ count 
+-------
+     1
+(1 row)
+
+RESET client_min_messages;
 -- can perform a union with subquery without FROM
 SELECT count(*) FROM
   (SELECT user_id FROM user_buy_test_table
@@ -368,8 +418,10 @@ FROM
        6 |   210
 (6 rows)
 
--- should not be able to pushdown since reference table is in the
--- direct outer part of the left join
+SET client_min_messages TO DEBUG1;
+-- although the inner part of an outer join with reference table is 
+-- recursively planned, we still hit the agressive outer join checks 
+-- (recurring tuple Left Join recurring tuple) errors
 SELECT
   user_id, sum(value_1)
 FROM
@@ -380,17 +432,32 @@ FROM
       LEFT JOIN events_table ON (events_table.user_id = users_table.user_id)
   ) as foo
   GROUP BY user_id ORDER BY 2 DESC LIMIT 10;
+DEBUG:  generating subplan 50_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table WHERE true
+DEBUG:  Plan 50 query after replacing subqueries and CTEs: SELECT user_id, sum(value_1) AS sum FROM (SELECT users_table.user_id, users_table.value_1, random() AS random FROM ((public.events_reference_table LEFT JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('50_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) ON ((users_table.user_id OPERATOR(pg_catalog.=) events_reference_table.value_2))) LEFT JOIN public.events_table ON ((events_table.user_id OPERATOR(pg_catalog.=) users_table.user_id)))) foo GROUP BY user_id ORDER BY (sum(value_1)) DESC LIMIT 10
 ERROR:  cannot pushdown the subquery
 DETAIL:  There exist a reference table in the outer part of the outer join
--- should not be able to pushdown since reference table is in the
--- direct outer part of the left join wrapped into a subquery
+-- should be able to pushdown since reference table is in the
+-- direct outer part of the left join is recursively planned
+-- and the final query becomes a router query
 SELECT
-    *
+   users_table.time, users_table.value_2
 FROM
     (SELECT *, random() FROM events_reference_table) as ref_all LEFT JOIN users_table
-    ON (users_table.user_id = ref_all.value_2);
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a reference table in the outer part of the outer join
+    ON (users_table.user_id = ref_all.value_2)
+ORDER BY 1, 2 DESC LIMIT 6;
+DEBUG:  generating subplan 52_1 for subquery SELECT user_id, "time", NULL::integer AS value_1, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table WHERE true
+DEBUG:  Plan 52 query after replacing subqueries and CTEs: SELECT users_table."time", users_table.value_2 FROM ((SELECT events_reference_table.user_id, events_reference_table."time", events_reference_table.event_type, events_reference_table.value_2, events_reference_table.value_3, events_reference_table.value_4, random() AS random FROM public.events_reference_table) ref_all LEFT JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('52_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) ON ((users_table.user_id OPERATOR(pg_catalog.=) ref_all.value_2))) ORDER BY users_table."time", users_table.value_2 DESC LIMIT 6
+              time               | value_2 
+---------------------------------+---------
+ Wed Nov 22 18:19:49.944985 2017 |       5
+ Wed Nov 22 18:19:49.944985 2017 |       5
+ Wed Nov 22 18:19:49.944985 2017 |       5
+ Wed Nov 22 18:19:49.944985 2017 |       5
+ Wed Nov 22 18:19:49.944985 2017 |       5
+ Wed Nov 22 18:19:49.944985 2017 |       5
+(6 rows)
+
+RESET client_min_messages;
 -- should not be able to pushdown since reference table is in the
 -- outer part of the left join
 SELECT
@@ -762,8 +829,9 @@ count(*) AS cnt, "generated_group_field"
   84 |                     0
 (6 rows)
 
-  -- RIGHT JOINs used with INNER JOINs should error out since reference table exist in the
--- right side of the RIGHT JOIN.
+  -- RIGHT JOINs used with INNER JOINs should work out since reference table exist in the
+-- right side of the RIGHT JOIN and the inner subquery is recursively planned
+SET client_min_messages TO DEBUG1;
 SELECT
 count(*) AS cnt, "generated_group_field"
  FROM
@@ -800,8 +868,19 @@ count(*) AS cnt, "generated_group_field"
   ORDER BY
     cnt DESC, generated_group_field ASC
   LIMIT 10;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a reference table in the outer part of the outer join
+DEBUG:  generating subplan 68_1 for subquery SELECT temp_data_queries."time", temp_data_queries.event_user_id, user_filters_1.user_id FROM ((SELECT events."time", events.user_id AS event_user_id FROM public.events_table events WHERE (events.user_id OPERATOR(pg_catalog.>) 2)) temp_data_queries JOIN (SELECT users.user_id FROM public.users_table users WHERE ((users.user_id OPERATOR(pg_catalog.>) 2) AND (users.value_2 OPERATOR(pg_catalog.=) 5))) user_filters_1 ON ((temp_data_queries.event_user_id OPERATOR(pg_catalog.=) user_filters_1.user_id)))
+DEBUG:  Plan 68 query after replacing subqueries and CTEs: SELECT count(*) AS cnt, generated_group_field FROM (SELECT "eventQuery".user_id, random() AS random, "eventQuery".generated_group_field FROM (SELECT multi_group_wrapper_1."time", multi_group_wrapper_1.event_user_id, multi_group_wrapper_1.user_id, right_group_by_1.generated_group_field, random() AS random FROM ((SELECT intermediate_result."time", intermediate_result.event_user_id, intermediate_result.user_id FROM read_intermediate_result('68_1'::text, 'binary'::citus_copy_format) intermediate_result("time" timestamp without time zone, event_user_id integer, user_id integer)) multi_group_wrapper_1 RIGHT JOIN (SELECT users.user_id, users.value_2 AS generated_group_field FROM public.users_reference_table users) right_group_by_1 ON ((right_group_by_1.user_id OPERATOR(pg_catalog.=) multi_group_wrapper_1.event_user_id)))) "eventQuery") "pushedDownQuery" GROUP BY generated_group_field ORDER BY (count(*)) DESC, generated_group_field LIMIT 10
+ cnt  | generated_group_field 
+------+-----------------------
+ 1007 |                     2
+  952 |                     5
+  773 |                     1
+  696 |                     3
+  433 |                     4
+  190 |                     0
+(6 rows)
+
+RESET client_min_messages;
 -- right join where the inner part of the join includes a reference table
 -- joined with hash partitioned table using non-equi join
 SELECT user_id, sum(array_length(events_table, 1)), length(hasdone_event), hasdone_event
@@ -1164,23 +1243,28 @@ ORDER BY types;
      3 |            120
 (4 rows)
 
+SET client_min_messages TO DEBUG1;
 -- just a sanity check that we don't allow this if the reference table is on the
--- left part of the left join
+-- left part of the left join, we can still recursively plan the inner side
 SELECT count(*) FROM
   (SELECT random() FROM users_ref_test_table LEFT JOIN user_buy_test_table
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1;
-ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a reference table in the outer part of the outer join
+DEBUG:  generating subplan 90_1 for subquery SELECT NULL::integer AS user_id, item_id, NULL::integer AS buy_count FROM public.user_buy_test_table WHERE true
+DEBUG:  Plan 90 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT random() AS random FROM (public.users_ref_test_table LEFT JOIN (SELECT intermediate_result.user_id, intermediate_result.item_id, intermediate_result.buy_count FROM read_intermediate_result('90_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, item_id integer, buy_count integer)) user_buy_test_table(user_id, item_id, buy_count) ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))) subquery_1
+ count 
+-------
+    12
+(1 row)
+
 -- we do allow non equi join among subqueries via recursive planning
-SET client_min_messages TO DEBUG1;
 SELECT count(*) FROM
   (SELECT user_buy_test_table.user_id, random() FROM user_buy_test_table LEFT JOIN users_ref_test_table
   ON user_buy_test_table.item_id > users_ref_test_table.id) subquery_1,
 (SELECT user_buy_test_table.user_id, random() FROM user_buy_test_table LEFT JOIN users_ref_test_table
   ON user_buy_test_table.user_id > users_ref_test_table.id) subquery_2
 WHERE subquery_1.user_id != subquery_2.user_id ;
-DEBUG:  generating subplan 79_1 for subquery SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.user_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))
-DEBUG:  Plan 79 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))) subquery_1, (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('79_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) subquery_2 WHERE (subquery_1.user_id OPERATOR(pg_catalog.<>) subquery_2.user_id)
+DEBUG:  generating subplan 92_1 for subquery SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.user_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))
+DEBUG:  Plan 92 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))) subquery_1, (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('92_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) subquery_2 WHERE (subquery_1.user_id OPERATOR(pg_catalog.<>) subquery_2.user_id)
  count 
 -------
     67
@@ -1225,8 +1309,10 @@ count(*) AS cnt, "generated_group_field"
   ORDER BY
     cnt DESC, generated_group_field ASC
   LIMIT 10;
-DEBUG:  generating subplan 81_1 for subquery SELECT user_id, value_2 AS generated_group_field FROM public.users_table users
-DEBUG:  Plan 81 query after replacing subqueries and CTEs: SELECT count(*) AS cnt, generated_group_field FROM (SELECT "eventQuery".user_id, random() AS random, "eventQuery".generated_group_field FROM (SELECT multi_group_wrapper_1."time", multi_group_wrapper_1.event_user_id, multi_group_wrapper_1.user_id, left_group_by_1.generated_group_field, random() AS random FROM ((SELECT temp_data_queries."time", temp_data_queries.event_user_id, user_filters_1.user_id FROM ((SELECT events."time", events.user_id AS event_user_id FROM public.events_table events WHERE (events.user_id OPERATOR(pg_catalog.>) 2)) temp_data_queries JOIN (SELECT users.user_id FROM public.users_reference_table users WHERE ((users.user_id OPERATOR(pg_catalog.>) 2) AND (users.value_2 OPERATOR(pg_catalog.=) 5))) user_filters_1 ON ((temp_data_queries.event_user_id OPERATOR(pg_catalog.<) user_filters_1.user_id)))) multi_group_wrapper_1 RIGHT JOIN (SELECT intermediate_result.user_id, intermediate_result.generated_group_field FROM read_intermediate_result('81_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, generated_group_field integer)) left_group_by_1 ON ((left_group_by_1.user_id OPERATOR(pg_catalog.>) multi_group_wrapper_1.event_user_id)))) "eventQuery") "pushedDownQuery" GROUP BY generated_group_field ORDER BY (count(*)) DESC, generated_group_field LIMIT 10
+DEBUG:  generating subplan 94_1 for subquery SELECT user_id, value_2 AS generated_group_field FROM public.users_table users
+DEBUG:  Plan 94 query after replacing subqueries and CTEs: SELECT count(*) AS cnt, generated_group_field FROM (SELECT "eventQuery".user_id, random() AS random, "eventQuery".generated_group_field FROM (SELECT multi_group_wrapper_1."time", multi_group_wrapper_1.event_user_id, multi_group_wrapper_1.user_id, left_group_by_1.generated_group_field, random() AS random FROM ((SELECT temp_data_queries."time", temp_data_queries.event_user_id, user_filters_1.user_id FROM ((SELECT events."time", events.user_id AS event_user_id FROM public.events_table events WHERE (events.user_id OPERATOR(pg_catalog.>) 2)) temp_data_queries JOIN (SELECT users.user_id FROM public.users_reference_table users WHERE ((users.user_id OPERATOR(pg_catalog.>) 2) AND (users.value_2 OPERATOR(pg_catalog.=) 5))) user_filters_1 ON ((temp_data_queries.event_user_id OPERATOR(pg_catalog.<) user_filters_1.user_id)))) multi_group_wrapper_1 RIGHT JOIN (SELECT intermediate_result.user_id, intermediate_result.generated_group_field FROM read_intermediate_result('94_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, generated_group_field integer)) left_group_by_1 ON ((left_group_by_1.user_id OPERATOR(pg_catalog.>) multi_group_wrapper_1.event_user_id)))) "eventQuery") "pushedDownQuery" GROUP BY generated_group_field ORDER BY (count(*)) DESC, generated_group_field LIMIT 10
+DEBUG:  generating subplan 94_2 for subquery SELECT temp_data_queries."time", temp_data_queries.event_user_id, user_filters_1.user_id FROM ((SELECT events."time", events.user_id AS event_user_id FROM public.events_table events WHERE (events.user_id OPERATOR(pg_catalog.>) 2)) temp_data_queries JOIN (SELECT users.user_id FROM public.users_reference_table users WHERE ((users.user_id OPERATOR(pg_catalog.>) 2) AND (users.value_2 OPERATOR(pg_catalog.=) 5))) user_filters_1 ON ((temp_data_queries.event_user_id OPERATOR(pg_catalog.<) user_filters_1.user_id)))
+DEBUG:  Plan 94 query after replacing subqueries and CTEs: SELECT count(*) AS cnt, generated_group_field FROM (SELECT "eventQuery".user_id, random() AS random, "eventQuery".generated_group_field FROM (SELECT multi_group_wrapper_1."time", multi_group_wrapper_1.event_user_id, multi_group_wrapper_1.user_id, left_group_by_1.generated_group_field, random() AS random FROM ((SELECT intermediate_result."time", intermediate_result.event_user_id, intermediate_result.user_id FROM read_intermediate_result('94_2'::text, 'binary'::citus_copy_format) intermediate_result("time" timestamp without time zone, event_user_id integer, user_id integer)) multi_group_wrapper_1 RIGHT JOIN (SELECT intermediate_result.user_id, intermediate_result.generated_group_field FROM read_intermediate_result('94_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, generated_group_field integer)) left_group_by_1 ON ((left_group_by_1.user_id OPERATOR(pg_catalog.>) multi_group_wrapper_1.event_user_id)))) "eventQuery") "pushedDownQuery" GROUP BY generated_group_field ORDER BY (count(*)) DESC, generated_group_field LIMIT 10
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 RESET client_min_messages;

--- a/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_in_where_reference_clause.out
@@ -46,8 +46,10 @@ LIMIT 3;
 ---------
 (0 rows)
 
--- subqueries in WHERE with NOT EXISTS operator, should not work since 
--- there is a correlated subquery in WHERE clause
+SET client_min_messages TO DEBUG1;
+-- although the subquery in WHERE with NOT EXISTS operator (e.g., semi-join)
+-- is correlated with the reference table, since events_table can be 
+-- recursively planned the whole query becomes a router query
 SELECT 
   user_id
 FROM 
@@ -62,10 +64,16 @@ WHERE
           users_reference_table.user_id = events_table.user_id
       )
 LIMIT 3;
-ERROR:  cannot pushdown the subquery
-DETAIL:  Reference tables are not allowed in FROM clause when the query has subqueries in WHERE clause and it references a column from another query
--- immutable functions are also treated as reference tables, query should not
--- work since there is a correlated subquery in the WHERE clause
+DEBUG:  generating subplan 3_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", NULL::integer AS event_type, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.events_table WHERE true
+DEBUG:  Plan 3 query after replacing subqueries and CTEs: SELECT user_id FROM public.users_reference_table WHERE (NOT (EXISTS (SELECT events_table.value_2 FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.event_type, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('3_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, event_type integer, value_2 integer, value_3 double precision, value_4 bigint)) events_table(user_id, "time", event_type, value_2, value_3, value_4) WHERE (users_reference_table.user_id OPERATOR(pg_catalog.=) events_table.user_id)))) LIMIT 3
+ user_id 
+---------
+(0 rows)
+
+-- immutable functions are also treated as reference tables thus
+-- although the subquery in WHERE with NOT EXISTS operator (e.g., semi-join)
+-- is correlated with the immutable function, since events_table can be 
+-- recursively planned the whole query becomes a router query
 SELECT
   user_id
 FROM
@@ -79,11 +87,21 @@ WHERE
        WHERE
           users_reference_table.user_id = events_table.user_id
       )
+ORDER BY 1
 LIMIT 3;
-ERROR:  cannot pushdown the subquery
-DETAIL:  Functions are not allowed in FROM clause when the query has subqueries in WHERE clause and it references a column from another query
--- subqueries without FROM are also treated as reference tables, query should not
--- work since there is a correlated subquery in the WHERE clause
+DEBUG:  generating subplan 5_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", NULL::integer AS event_type, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.events_table WHERE true
+DEBUG:  Plan 5 query after replacing subqueries and CTEs: SELECT user_id FROM (SELECT series.user_id FROM generate_series(1, 10) series(user_id)) users_reference_table WHERE (NOT (EXISTS (SELECT events_table.value_2 FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.event_type, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('5_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, event_type integer, value_2 integer, value_3 double precision, value_4 bigint)) events_table(user_id, "time", event_type, value_2, value_3, value_4) WHERE (users_reference_table.user_id OPERATOR(pg_catalog.=) events_table.user_id)))) ORDER BY user_id LIMIT 3
+ user_id 
+---------
+       7
+       8
+       9
+(3 rows)
+
+-- subqueries without FROM are also treated as reference tables thus
+-- although the subquery in WHERE with NOT EXISTS operator (e.g., semi-join)
+-- is correlated with the subquery, since events_table can be 
+-- recursively planned the whole query becomes a router query
 SELECT
   user_id
 FROM
@@ -98,8 +116,13 @@ WHERE
           users_reference_table.user_id = events_table.user_id
       )
 LIMIT 3;
-ERROR:  cannot pushdown the subquery
-DETAIL:  Subqueries without FROM are not allowed in FROM clause when the outer query has subqueries in WHERE clause and it references a column from another query
+DEBUG:  generating subplan 7_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", NULL::integer AS event_type, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.events_table WHERE true
+DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT user_id FROM (SELECT 5 AS user_id) users_reference_table WHERE (NOT (EXISTS (SELECT events_table.value_2 FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.event_type, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, event_type integer, value_2 integer, value_3 double precision, value_4 bigint)) events_table(user_id, "time", event_type, value_2, value_3, value_4) WHERE (users_reference_table.user_id OPERATOR(pg_catalog.=) events_table.user_id)))) LIMIT 3
+ user_id 
+---------
+(0 rows)
+
+RESET client_min_messages;
 -- join with distributed table prevents FROM from recurring
 SELECT
   DISTINCT user_id
@@ -166,7 +189,7 @@ WHERE
 ORDER BY user_id
 LIMIT 3;
 ERROR:  cannot pushdown the subquery
-DETAIL:  There exist a reference table in the outer part of the outer join
+DETAIL:  Complex subqueries and CTEs are not allowed in the FROM clause when the query has subqueries in the WHERE clause and it references a column from another query
 -- subqueries in WHERE with IN operator without equality
 SELECT 
   users_table.user_id, count(*)
@@ -425,8 +448,8 @@ FROM
 WHERE user_id 
   NOT IN
 (SELECT users_table.value_2 FROM users_table JOIN users_reference_table as u2 ON users_table.value_2 = u2.value_2);
-DEBUG:  generating subplan 16_1 for subquery SELECT users_table.value_2 FROM (public.users_table JOIN public.users_reference_table u2 ON ((users_table.value_2 OPERATOR(pg_catalog.=) u2.value_2)))
-DEBUG:  Plan 16 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.users_reference_table WHERE (NOT (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('16_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))))
+DEBUG:  generating subplan 20_1 for subquery SELECT users_table.value_2 FROM (public.users_table JOIN public.users_reference_table u2 ON ((users_table.value_2 OPERATOR(pg_catalog.=) u2.value_2)))
+DEBUG:  Plan 20 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.users_reference_table WHERE (NOT (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('20_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))))
  count 
 -------
     10
@@ -441,8 +464,8 @@ FROM
     (SELECT users_table.value_2
      FROM users_table
      JOIN users_reference_table AS u2 ON users_table.value_2 = u2.value_2);
-DEBUG:  generating subplan 18_1 for subquery SELECT users_table.value_2 FROM (public.users_table JOIN public.users_reference_table u2 ON ((users_table.value_2 OPERATOR(pg_catalog.=) u2.value_2)))
-DEBUG:  Plan 18 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT users_reference_table.user_id, random() AS random FROM public.users_reference_table) vals WHERE (NOT (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('18_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))))
+DEBUG:  generating subplan 22_1 for subquery SELECT users_table.value_2 FROM (public.users_table JOIN public.users_reference_table u2 ON ((users_table.value_2 OPERATOR(pg_catalog.=) u2.value_2)))
+DEBUG:  Plan 22 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT users_reference_table.user_id, random() AS random FROM public.users_reference_table) vals WHERE (NOT (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))))
  count 
 -------
     10

--- a/src/test/regress/expected/non_colocated_subquery_joins.out
+++ b/src/test/regress/expected/non_colocated_subquery_joins.out
@@ -638,9 +638,14 @@ SELECT true AS valid FROM explain_json_2($$
     FROM
         (users_table u1 JOIN users_table u2 using(value_1)) a JOIN (SELECT value_1, random() FROM users_table) as u3 USING (value_1); 
 $$);
-DEBUG:  generating subplan 66_1 for subquery SELECT value_1, random() AS random FROM public.users_table
-DEBUG:  Plan 66 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN public.users_table u2 USING (value_1)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('66_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
-ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+DEBUG:  generating subplan 66_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2
+DEBUG:  generating subplan 66_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 66 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('66_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('66_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
+ valid 
+-------
+ t
+(1 row)
+
 -- a very similar query to the above
 -- however, this time we users a subquery instead of join alias, and it works
 SELECT true AS valid FROM explain_json_2($$
@@ -651,8 +656,8 @@ SELECT true AS valid FROM explain_json_2($$
         (SELECT * FROM users_table u1 JOIN users_table u2 using(value_1)) a JOIN (SELECT value_1, random() FROM users_table) as u3 USING (value_1); 
 $$);
 DEBUG:  cannot use real time executor with repartition jobs
-DEBUG:  generating subplan 68_1 for subquery SELECT u1.value_1, u1.user_id, u1."time", u1.value_2, u1.value_3, u1.value_4, u2.user_id, u2."time", u2.value_2, u2.value_3, u2.value_4 FROM (public.users_table u1 JOIN public.users_table u2 USING (value_1))
-DEBUG:  Plan 68 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.value_1, intermediate_result.user_id, intermediate_result."time", intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4, intermediate_result.user_id_1 AS user_id, intermediate_result.time_1 AS "time", intermediate_result.value_2_1 AS value_2, intermediate_result.value_3_1 AS value_3, intermediate_result.value_4_1 AS value_4 FROM read_intermediate_result('68_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, user_id integer, "time" timestamp without time zone, value_2 integer, value_3 double precision, value_4 bigint, user_id_1 integer, time_1 timestamp without time zone, value_2_1 integer, value_3_1 double precision, value_4_1 bigint)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT users_table.value_1, random() AS random FROM public.users_table) u3 USING (value_1))
+DEBUG:  generating subplan 69_1 for subquery SELECT u1.value_1, u1.user_id, u1."time", u1.value_2, u1.value_3, u1.value_4, u2.user_id, u2."time", u2.value_2, u2.value_3, u2.value_4 FROM (public.users_table u1 JOIN public.users_table u2 USING (value_1))
+DEBUG:  Plan 69 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.value_1, intermediate_result.user_id, intermediate_result."time", intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4, intermediate_result.user_id_1 AS user_id, intermediate_result.time_1 AS "time", intermediate_result.value_2_1 AS value_2, intermediate_result.value_3_1 AS value_3, intermediate_result.value_4_1 AS value_4 FROM read_intermediate_result('69_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, user_id integer, "time" timestamp without time zone, value_2 integer, value_3 double precision, value_4 bigint, user_id_1 integer, time_1 timestamp without time zone, value_2_1 integer, value_3_1 double precision, value_4_1 bigint)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT users_table.value_1, random() AS random FROM public.users_table) u3 USING (value_1))
  valid 
 -------
  t
@@ -670,8 +675,8 @@ SELECT true AS valid FROM explain_json_2($$
         events_table
             using (value_2);
 $$);
-DEBUG:  generating subplan 70_1 for subquery SELECT value_2, random() AS random FROM public.users_table
-DEBUG:  Plan 70 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('70_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u1 JOIN public.events_table USING (value_2))
+DEBUG:  generating subplan 71_1 for subquery SELECT value_2, random() AS random FROM public.users_table
+DEBUG:  Plan 71 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('71_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u1 JOIN public.events_table USING (value_2))
  valid 
 -------
  t
@@ -688,8 +693,8 @@ SELECT true AS valid FROM explain_json_2($$
         (SELECT value_2, random() FROM users_table) as u2
             USING(value_2);
 $$);
-DEBUG:  generating subplan 72_1 for subquery SELECT value_2, random() AS random FROM public.users_table
-DEBUG:  Plan 72 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT users_table.value_2, random() AS random FROM public.users_table) u1 LEFT JOIN (SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('72_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u2 USING (value_2))
+DEBUG:  generating subplan 73_1 for subquery SELECT value_2, random() AS random FROM public.users_table
+DEBUG:  Plan 73 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT users_table.value_2, random() AS random FROM public.users_table) u1 LEFT JOIN (SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('73_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u2 USING (value_2))
  valid 
 -------
  t
@@ -708,8 +713,8 @@ SELECT true AS valid FROM explain_json_2($$
         (SELECT value_2, random() FROM users_table) as u2
             USING(value_2);
 $$);
-DEBUG:  generating subplan 74_1 for subquery SELECT value_2, random() AS random FROM public.users_table
-DEBUG:  Plan 74 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT users_table.value_2, random() AS random FROM public.users_table) u1 RIGHT JOIN (SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('74_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u2 USING (value_2))
+DEBUG:  generating subplan 75_1 for subquery SELECT value_2, random() AS random FROM public.users_table
+DEBUG:  Plan 75 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT users_table.value_2, random() AS random FROM public.users_table) u1 RIGHT JOIN (SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('75_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u2 USING (value_2))
 ERROR:  cannot pushdown the subquery
 -- set operations may produce not very efficient plans
 -- although we could have picked a as our anchor subquery,
@@ -727,11 +732,11 @@ SELECT true AS valid FROM explain_json_2($$
         (SELECT value_1 FROM users_table) as foo ON (a.user_id = foo.value_1) 
     );
 $$);
-DEBUG:  generating subplan 77_1 for subquery SELECT user_id FROM public.users_table
-DEBUG:  generating subplan 77_2 for subquery SELECT user_id FROM public.users_table
-DEBUG:  Plan 77 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('77_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('77_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
-DEBUG:  generating subplan 76_1 for subquery SELECT users_table.user_id FROM public.users_table UNION SELECT users_table.user_id FROM public.users_table
-DEBUG:  Plan 76 query after replacing subqueries and CTEs: SELECT a.user_id, foo.value_1 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('76_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a JOIN (SELECT users_table.value_1 FROM public.users_table) foo ON ((a.user_id OPERATOR(pg_catalog.=) foo.value_1)))
+DEBUG:  generating subplan 78_1 for subquery SELECT user_id FROM public.users_table
+DEBUG:  generating subplan 78_2 for subquery SELECT user_id FROM public.users_table
+DEBUG:  Plan 78 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('78_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('78_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
+DEBUG:  generating subplan 77_1 for subquery SELECT users_table.user_id FROM public.users_table UNION SELECT users_table.user_id FROM public.users_table
+DEBUG:  Plan 77 query after replacing subqueries and CTEs: SELECT a.user_id, foo.value_1 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('77_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a JOIN (SELECT users_table.value_1 FROM public.users_table) foo ON ((a.user_id OPERATOR(pg_catalog.=) foo.value_1)))
  valid 
 -------
  t
@@ -751,11 +756,11 @@ SELECT true AS valid FROM explain_json_2($$
         users_table as foo ON (a.user_id = foo.value_1) 
     );
 $$);
-DEBUG:  generating subplan 81_1 for subquery SELECT user_id FROM public.users_table
-DEBUG:  generating subplan 81_2 for subquery SELECT user_id FROM public.users_table
-DEBUG:  Plan 81 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('81_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('81_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
-DEBUG:  generating subplan 80_1 for subquery SELECT users_table.user_id FROM public.users_table UNION SELECT users_table.user_id FROM public.users_table
-DEBUG:  Plan 80 query after replacing subqueries and CTEs: SELECT a.user_id, foo.user_id, foo."time", foo.value_1, foo.value_2, foo.value_3, foo.value_4 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('80_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a JOIN public.users_table foo ON ((a.user_id OPERATOR(pg_catalog.=) foo.value_1)))
+DEBUG:  generating subplan 82_1 for subquery SELECT user_id FROM public.users_table
+DEBUG:  generating subplan 82_2 for subquery SELECT user_id FROM public.users_table
+DEBUG:  Plan 82 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('82_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('82_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
+DEBUG:  generating subplan 81_1 for subquery SELECT users_table.user_id FROM public.users_table UNION SELECT users_table.user_id FROM public.users_table
+DEBUG:  Plan 81 query after replacing subqueries and CTEs: SELECT a.user_id, foo.user_id, foo."time", foo.value_1, foo.value_2, foo.value_3, foo.value_4 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('81_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a JOIN public.users_table foo ON ((a.user_id OPERATOR(pg_catalog.=) foo.value_1)))
  valid 
 -------
  t
@@ -784,8 +789,8 @@ SELECT true AS valid FROM explain_json_2($$
          ON(foo.user_id = bar.value_1) 
     );
 $$);
-DEBUG:  generating subplan 84_1 for subquery SELECT value_1 FROM public.users_table
-DEBUG:  Plan 84 query after replacing subqueries and CTEs: SELECT foo.user_id, a.user_id, bar.value_1 FROM (((SELECT users_table.user_id FROM public.users_table) foo JOIN (SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])) UNION SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8]))) a ON ((a.user_id OPERATOR(pg_catalog.=) foo.user_id))) JOIN (SELECT intermediate_result.value_1 FROM read_intermediate_result('84_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer)) bar ON ((foo.user_id OPERATOR(pg_catalog.=) bar.value_1)))
+DEBUG:  generating subplan 85_1 for subquery SELECT value_1 FROM public.users_table
+DEBUG:  Plan 85 query after replacing subqueries and CTEs: SELECT foo.user_id, a.user_id, bar.value_1 FROM (((SELECT users_table.user_id FROM public.users_table) foo JOIN (SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])) UNION SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8]))) a ON ((a.user_id OPERATOR(pg_catalog.=) foo.user_id))) JOIN (SELECT intermediate_result.value_1 FROM read_intermediate_result('85_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer)) bar ON ((foo.user_id OPERATOR(pg_catalog.=) bar.value_1)))
  valid 
 -------
  t
@@ -823,13 +828,13 @@ SELECT true AS valid FROM explain_json_2($$
     WHERE 
         non_colocated_subquery.value_2 != non_colocated_subquery_2.cnt
 $$);
-DEBUG:  generating subplan 86_1 for CTE non_colocated_subquery: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
-DEBUG:  generating subplan 87_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
-DEBUG:  Plan 87 query after replacing subqueries and CTEs: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('87_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
-DEBUG:  generating subplan 86_2 for CTE non_colocated_subquery_2: SELECT count(*) AS cnt FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT events_table_1.event_type FROM public.events_table events_table_1 WHERE (events_table_1.user_id OPERATOR(pg_catalog.<) 4)))
-DEBUG:  generating subplan 89_1 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 4)
-DEBUG:  Plan 89 query after replacing subqueries and CTEs: SELECT count(*) AS cnt FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('89_1'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer)))
-DEBUG:  Plan 86 query after replacing subqueries and CTEs: SELECT non_colocated_subquery.value_2, non_colocated_subquery_2.cnt FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('86_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) non_colocated_subquery, (SELECT intermediate_result.cnt FROM read_intermediate_result('86_2'::text, 'binary'::citus_copy_format) intermediate_result(cnt bigint)) non_colocated_subquery_2 WHERE (non_colocated_subquery.value_2 OPERATOR(pg_catalog.<>) non_colocated_subquery_2.cnt)
+DEBUG:  generating subplan 87_1 for CTE non_colocated_subquery: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
+DEBUG:  generating subplan 88_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  Plan 88 query after replacing subqueries and CTEs: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('88_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
+DEBUG:  generating subplan 87_2 for CTE non_colocated_subquery_2: SELECT count(*) AS cnt FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT events_table_1.event_type FROM public.events_table events_table_1 WHERE (events_table_1.user_id OPERATOR(pg_catalog.<) 4)))
+DEBUG:  generating subplan 90_1 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 4)
+DEBUG:  Plan 90 query after replacing subqueries and CTEs: SELECT count(*) AS cnt FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('90_1'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer)))
+DEBUG:  Plan 87 query after replacing subqueries and CTEs: SELECT non_colocated_subquery.value_2, non_colocated_subquery_2.cnt FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('87_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) non_colocated_subquery, (SELECT intermediate_result.cnt FROM read_intermediate_result('87_2'::text, 'binary'::citus_copy_format) intermediate_result(cnt bigint)) non_colocated_subquery_2 WHERE (non_colocated_subquery.value_2 OPERATOR(pg_catalog.<>) non_colocated_subquery_2.cnt)
  valid 
 -------
  t
@@ -848,9 +853,9 @@ SELECT true AS valid FROM explain_json_2($$
         AND 
         foo.value_2 = baz.value_2
 $$);
-DEBUG:  generating subplan 91_1 for subquery SELECT users_table_local.value_2 FROM non_colocated_subquery.users_table_local, non_colocated_subquery.events_table_local WHERE ((users_table_local.user_id OPERATOR(pg_catalog.=) events_table_local.user_id) AND (events_table_local.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
-DEBUG:  generating subplan 91_2 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))
-DEBUG:  Plan 91 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('91_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar, (SELECT intermediate_result.value_2 FROM read_intermediate_result('91_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) baz WHERE ((foo.value_2 OPERATOR(pg_catalog.=) bar.value_2) AND (foo.value_2 OPERATOR(pg_catalog.=) baz.value_2))
+DEBUG:  generating subplan 92_1 for subquery SELECT users_table_local.value_2 FROM non_colocated_subquery.users_table_local, non_colocated_subquery.events_table_local WHERE ((users_table_local.user_id OPERATOR(pg_catalog.=) events_table_local.user_id) AND (events_table_local.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 92_2 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))
+DEBUG:  Plan 92 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('92_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar, (SELECT intermediate_result.value_2 FROM read_intermediate_result('92_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) baz WHERE ((foo.value_2 OPERATOR(pg_catalog.=) bar.value_2) AND (foo.value_2 OPERATOR(pg_catalog.=) baz.value_2))
  valid 
 -------
  t
@@ -885,10 +890,10 @@ SELECT true AS valid FROM explain_json_2($$
             AND
         foo.user_id IN (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2))
 $$);
-DEBUG:  generating subplan 93_1 for subquery SELECT value_1, value_2 FROM public.users_table
-DEBUG:  generating subplan 93_2 for subquery SELECT value_1 FROM public.users_table WHERE (value_2 OPERATOR(pg_catalog.<) 1)
-DEBUG:  generating subplan 93_3 for subquery SELECT value_2 FROM public.users_table WHERE (value_1 OPERATOR(pg_catalog.<) 2)
-DEBUG:  Plan 93 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (((SELECT users_table.user_id FROM public.users_table) foo JOIN (SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])) UNION SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8]))) a ON ((a.user_id OPERATOR(pg_catalog.=) foo.user_id))) JOIN (SELECT intermediate_result.value_1, intermediate_result.value_2 FROM read_intermediate_result('93_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, value_2 integer)) bar ON ((foo.user_id OPERATOR(pg_catalog.=) bar.value_1))) WHERE ((bar.value_2 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_1 FROM read_intermediate_result('93_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))) AND (bar.value_1 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('93_3'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))) AND (foo.user_id OPERATOR(pg_catalog.=) ANY (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2]))))))
+DEBUG:  generating subplan 94_1 for subquery SELECT value_1, value_2 FROM public.users_table
+DEBUG:  generating subplan 94_2 for subquery SELECT value_1 FROM public.users_table WHERE (value_2 OPERATOR(pg_catalog.<) 1)
+DEBUG:  generating subplan 94_3 for subquery SELECT value_2 FROM public.users_table WHERE (value_1 OPERATOR(pg_catalog.<) 2)
+DEBUG:  Plan 94 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (((SELECT users_table.user_id FROM public.users_table) foo JOIN (SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])) UNION SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8]))) a ON ((a.user_id OPERATOR(pg_catalog.=) foo.user_id))) JOIN (SELECT intermediate_result.value_1, intermediate_result.value_2 FROM read_intermediate_result('94_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, value_2 integer)) bar ON ((foo.user_id OPERATOR(pg_catalog.=) bar.value_1))) WHERE ((bar.value_2 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_1 FROM read_intermediate_result('94_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))) AND (bar.value_1 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('94_3'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))) AND (foo.user_id OPERATOR(pg_catalog.=) ANY (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2]))))))
 ERROR:  cannot pushdown the subquery
 -- make sure that we don't pick the refeence table as 
 -- the anchor
@@ -903,8 +908,8 @@ SELECT true AS valid FROM explain_json_2($$
       users_table_ref.user_id = foo.user_id
       AND foo.user_id = bar.value_2;
 $$);
-DEBUG:  generating subplan 97_1 for subquery SELECT user_id, value_2 FROM public.events_table
-DEBUG:  Plan 97 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.users_reference_table users_table_ref, (SELECT users_table.user_id FROM public.users_table) foo, (SELECT intermediate_result.user_id, intermediate_result.value_2 FROM read_intermediate_result('97_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_2 integer)) bar WHERE ((users_table_ref.user_id OPERATOR(pg_catalog.=) foo.user_id) AND (foo.user_id OPERATOR(pg_catalog.=) bar.value_2))
+DEBUG:  generating subplan 98_1 for subquery SELECT user_id, value_2 FROM public.events_table
+DEBUG:  Plan 98 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.users_reference_table users_table_ref, (SELECT users_table.user_id FROM public.users_table) foo, (SELECT intermediate_result.user_id, intermediate_result.value_2 FROM read_intermediate_result('98_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_2 integer)) bar WHERE ((users_table_ref.user_id OPERATOR(pg_catalog.=) foo.user_id) AND (foo.user_id OPERATOR(pg_catalog.=) bar.value_2))
  valid 
 -------
  t

--- a/src/test/regress/expected/non_colocated_subquery_joins.out
+++ b/src/test/regress/expected/non_colocated_subquery_joins.out
@@ -638,7 +638,7 @@ SELECT true AS valid FROM explain_json_2($$
     FROM
         (users_table u1 JOIN users_table u2 using(value_1)) a JOIN (SELECT value_1, random() FROM users_table) as u3 USING (value_1); 
 $$);
-DEBUG:  generating subplan 66_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 66_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 66_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 66 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('66_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('66_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
  valid 

--- a/src/test/regress/expected/non_colocated_subquery_joins.out
+++ b/src/test/regress/expected/non_colocated_subquery_joins.out
@@ -638,7 +638,7 @@ SELECT true AS valid FROM explain_json_2($$
     FROM
         (users_table u1 JOIN users_table u2 using(value_1)) a JOIN (SELECT value_1, random() FROM users_table) as u3 USING (value_1); 
 $$);
-DEBUG:  generating subplan 66_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2
+DEBUG:  generating subplan 66_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 66_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 66 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('66_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('66_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
  valid 

--- a/src/test/regress/expected/non_colocated_subquery_joins_0.out
+++ b/src/test/regress/expected/non_colocated_subquery_joins_0.out
@@ -1,0 +1,922 @@
+-- ===================================================================
+-- test recursive planning functionality for non-colocated subqueries
+-- We prefered to use EXPLAIN almost all the queries here,
+-- otherwise the execution time of so many repartition queries would
+-- be too high for the regression tests. Also, note that we're mostly
+-- interested in recurive planning side of the things, thus supressing
+-- the actual explain output.
+-- ===================================================================
+SET client_min_messages TO DEBUG1;
+CREATE SCHEMA non_colocated_subquery;
+SET search_path TO non_colocated_subquery, public;
+-- we don't use the data anyway
+CREATE TABLE users_table_local AS SELECT * FROM users_table LIMIT 0;
+DEBUG:  push down of limit count: 0
+CREATE TABLE events_table_local AS SELECT * FROM events_table LIMIT 0;
+DEBUG:  push down of limit count: 0
+SET citus.enable_repartition_joins TO ON;
+\set VERBOSITY terse
+-- Function that parses explain output as JSON
+-- copied from multi_explain.sql and had to give
+-- a different name via postfix to prevent concurrent
+-- create/drop etc.
+CREATE OR REPLACE FUNCTION explain_json_2(query text)
+RETURNS jsonb
+AS $BODY$
+DECLARE
+  result jsonb;
+BEGIN
+  EXECUTE format('EXPLAIN (FORMAT JSON) %s', query) INTO result;
+  RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;
+-- leaf queries contain colocated joins
+-- but not the subquery
+SELECT true AS valid FROM explain_json_2($$
+    SELECT
+        foo.value_2
+    FROM
+        (SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.value_2 = bar.value_2;
+$$);
+DEBUG:  generating subplan 3_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  Plan 3 query after replacing subqueries and CTEs: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('3_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
+ valid 
+-------
+ t
+(1 row)
+
+-- simple non colocated join with subqueries in WHERE clause
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        count(*)
+    FROM
+        events_table
+    WHERE
+        event_type
+    IN
+        (SELECT event_type FROM events_table WHERE user_id < 100);
+
+$$);
+DEBUG:  generating subplan 5_1 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 100)
+DEBUG:  Plan 5 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('5_1'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer)))
+ valid 
+-------
+ t
+(1 row)
+
+-- simple non colocated join with subqueries in WHERE clause with NOT IN
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        count(*)
+    FROM
+        events_table
+    WHERE
+        user_id
+    NOT IN
+        (SELECT user_id FROM events_table WHERE event_type = 2);
+$$);
+DEBUG:  generating subplan 7_1 for subquery SELECT user_id FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) 2)
+DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.events_table WHERE (NOT (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer))))
+ valid 
+-------
+ t
+(1 row)
+
+-- Subqueries in WHERE and FROM are mixed
+-- In this query, only subquery in WHERE is not a colocated join
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        foo.user_id
+    FROM
+        (SELECT users_table.user_id, event_type FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id AND
+        foo.event_type IN (SELECT event_type FROM events_table WHERE user_id < 3);
+
+$$);
+DEBUG:  generating subplan 9_1 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 3)
+DEBUG:  Plan 9 query after replacing subqueries and CTEs: SELECT foo.user_id FROM (SELECT users_table.user_id, events_table.event_type FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE ((foo.user_id OPERATOR(pg_catalog.=) bar.user_id) AND (foo.event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('9_1'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer))))
+ valid 
+-------
+ t
+(1 row)
+
+-- Subqueries in WHERE and FROM are mixed
+-- In this query, one of the joins in the FROM clause is not colocated
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        foo.user_id
+    FROM
+        (SELECT users_table.user_id, event_type FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT (users_table.user_id / 2) as user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id AND
+        foo.user_id IN (SELECT user_id FROM events_table WHERE user_id < 10);
+$$);
+DEBUG:  generating subplan 11_1 for subquery SELECT (users_table.user_id OPERATOR(pg_catalog./) 2) AS user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  Plan 11 query after replacing subqueries and CTEs: SELECT foo.user_id FROM (SELECT users_table.user_id, events_table.event_type FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.user_id FROM read_intermediate_result('11_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar WHERE ((foo.user_id OPERATOR(pg_catalog.=) bar.user_id) AND (foo.user_id OPERATOR(pg_catalog.=) ANY (SELECT events_table.user_id FROM public.events_table WHERE (events_table.user_id OPERATOR(pg_catalog.<) 10))))
+ valid 
+-------
+ t
+(1 row)
+
+-- Subqueries in WHERE and FROM are mixed
+-- In this query, both the joins in the FROM clause is not colocated
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        foo.user_id
+    FROM
+        (SELECT users_table.user_id, event_type FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT (users_table.user_id / 2) as user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id AND
+        foo.user_id NOT IN (SELECT user_id FROM events_table WHERE user_id < 10);
+$$);
+DEBUG:  generating subplan 13_1 for subquery SELECT (users_table.user_id OPERATOR(pg_catalog./) 2) AS user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 13_2 for subquery SELECT user_id FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 10)
+DEBUG:  Plan 13 query after replacing subqueries and CTEs: SELECT foo.user_id FROM (SELECT users_table.user_id, events_table.event_type FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.user_id FROM read_intermediate_result('13_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar WHERE ((foo.user_id OPERATOR(pg_catalog.=) bar.user_id) AND (NOT (foo.user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('13_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))))
+ valid 
+-------
+ t
+(1 row)
+
+-- Subqueries in WHERE and FROM are mixed
+-- In this query, one of the joins in the FROM clause is not colocated and subquery in WHERE clause is not colocated
+-- similar to the above, but, this time bar is the anchor subquery
+SELECT true AS valid FROM explain_json_2($$
+    SELECT
+        foo.user_id
+    FROM
+        (SELECT users_table.user_id, event_type FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4)) as foo,
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id AND
+        foo.event_type IN (SELECT event_type FROM events_table WHERE user_id < 4);
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 16_1 for subquery SELECT users_table.user_id, events_table.event_type FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 16_2 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 4)
+DEBUG:  Plan 16 query after replacing subqueries and CTEs: SELECT foo.user_id FROM (SELECT intermediate_result.user_id, intermediate_result.event_type FROM read_intermediate_result('16_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, event_type integer)) foo, (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE ((foo.user_id OPERATOR(pg_catalog.=) bar.user_id) AND (foo.event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('16_2'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer))))
+ERROR:  cannot pushdown the subquery
+-- The inner subqueries and the subquery in WHERE are non-located joins
+SELECT true AS valid FROM explain_json_2($$
+    SELECT foo_top.*, events_table.user_id FROM
+    (
+
+            SELECT
+            foo.user_id, random()
+        FROM
+            (SELECT users_table.user_id, event_type FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4)) as foo,
+            (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.event_type AND event_type IN (5,6,7,8)) as bar
+        WHERE
+            foo.user_id = bar.user_id AND
+            foo.event_type IN (SELECT event_type FROM events_table WHERE user_id = 5)
+
+    ) as foo_top, events_table WHERE events_table.user_id = foo_top.user_id;
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 19_1 for subquery SELECT users_table.user_id, events_table.event_type FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 19_2 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.event_type) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 19_3 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.=) 5)
+DEBUG:  generating subplan 19_4 for subquery SELECT foo.user_id, random() AS random FROM (SELECT intermediate_result.user_id, intermediate_result.event_type FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, event_type integer)) foo, (SELECT intermediate_result.user_id FROM read_intermediate_result('19_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar WHERE ((foo.user_id OPERATOR(pg_catalog.=) bar.user_id) AND (foo.event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('19_3'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer))))
+DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT foo_top.user_id, foo_top.random, events_table.user_id FROM (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('19_4'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) foo_top, public.events_table WHERE (events_table.user_id OPERATOR(pg_catalog.=) foo_top.user_id)
+ valid 
+-------
+ t
+(1 row)
+
+-- Slightly more complex query where there are 5 joins, 1 of them is non-colocated
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    (
+      SELECT
+        foo1.user_id, random()
+    FROM
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo1,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as foo2,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as foo3,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (13,14,15,16)) as foo4,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (17,18,19,20)) as foo5
+       
+    WHERE
+
+        foo1.user_id = foo4.user_id AND
+        foo1.user_id = foo2.user_id AND
+        foo1.user_id = foo3.user_id AND
+        foo1.user_id = foo4.user_id AND
+        foo1.user_id = foo5.value_1
+    ) as foo_top;
+
+$$);
+DEBUG:  generating subplan 24_1 for subquery SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[17, 18, 19, 20])))
+DEBUG:  Plan 24 query after replacing subqueries and CTEs: SELECT user_id, random FROM (SELECT foo1.user_id, random() AS random FROM (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo1, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) foo2, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))) foo3, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[13, 14, 15, 16])))) foo4, (SELECT intermediate_result.user_id, intermediate_result.value_1 FROM read_intermediate_result('24_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer)) foo5 WHERE ((foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo2.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo3.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo5.value_1))) foo_top
+ valid 
+-------
+ t
+(1 row)
+
+-- Very similar to the above query
+-- One of the queries is not joined on partition key, but this time subquery itself
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    (
+      SELECT
+        foo1.user_id, random()
+    FROM
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo1,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as foo2,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as foo3,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (13,14,15,16)) as foo4,
+        (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (17,18,19,20)) as foo5
+       
+        WHERE
+
+        foo1.user_id = foo4.user_id AND
+        foo1.user_id = foo2.user_id AND
+        foo1.user_id = foo3.user_id AND
+        foo1.user_id = foo4.user_id AND
+        foo1.user_id = foo5.user_id
+    ) as foo_top;
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 26_1 for subquery SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[17, 18, 19, 20])))
+DEBUG:  Plan 26 query after replacing subqueries and CTEs: SELECT user_id, random FROM (SELECT foo1.user_id, random() AS random FROM (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo1, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) foo2, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))) foo3, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[13, 14, 15, 16])))) foo4, (SELECT intermediate_result.user_id, intermediate_result.value_1 FROM read_intermediate_result('26_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer)) foo5 WHERE ((foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo2.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo3.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo5.user_id))) foo_top
+ valid 
+-------
+ t
+(1 row)
+
+--  There are two non colocated joins, one is in the one of the leaf queries, 
+-- the other is on the top-level subquery
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    (
+      SELECT
+        foo1.user_id, random()
+    FROM
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo1,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (5,6,7,8)) as foo2,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as foo3,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (13,14,15,16)) as foo4,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (17,18,19,20)) as foo5   
+        WHERE
+            foo1.user_id = foo4.user_id AND
+            foo1.user_id = foo2.user_id AND
+            foo1.user_id = foo3.user_id AND
+            foo1.user_id = foo4.user_id AND
+            foo1.user_id = foo5.value_1
+    ) as foo_top;
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 28_1 for subquery SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 28_2 for subquery SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[17, 18, 19, 20])))
+DEBUG:  Plan 28 query after replacing subqueries and CTEs: SELECT user_id, random FROM (SELECT foo1.user_id, random() AS random FROM (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo1, (SELECT intermediate_result.user_id, intermediate_result.value_1 FROM read_intermediate_result('28_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer)) foo2, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))) foo3, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[13, 14, 15, 16])))) foo4, (SELECT intermediate_result.user_id, intermediate_result.value_1 FROM read_intermediate_result('28_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer)) foo5 WHERE ((foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo2.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo3.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo5.value_1))) foo_top
+ valid 
+-------
+ t
+(1 row)
+
+-- a similar query to the above, but, this sime the second
+-- non colocated join is on the already recursively planned subquery
+-- the results should be the same
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    (
+      SELECT
+        foo1.user_id, random()
+    FROM
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo1,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (5,6,7,8)) as foo2,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as foo3,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (13,14,15,16)) as foo4,
+            (SELECT users_table.user_id, users_table.value_1 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (17,18,19,20)) as foo5   
+        WHERE
+            foo1.user_id = foo4.user_id AND
+            foo1.user_id = foo2.user_id AND
+            foo1.user_id = foo3.user_id AND
+            foo1.user_id = foo4.user_id AND
+            foo2.user_id = foo5.value_1
+    ) as foo_top;
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 31_1 for subquery SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 31_2 for subquery SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[17, 18, 19, 20])))
+DEBUG:  Plan 31 query after replacing subqueries and CTEs: SELECT user_id, random FROM (SELECT foo1.user_id, random() AS random FROM (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo1, (SELECT intermediate_result.user_id, intermediate_result.value_1 FROM read_intermediate_result('31_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer)) foo2, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))) foo3, (SELECT users_table.user_id, users_table.value_1 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[13, 14, 15, 16])))) foo4, (SELECT intermediate_result.user_id, intermediate_result.value_1 FROM read_intermediate_result('31_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer)) foo5 WHERE ((foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo2.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo3.user_id) AND (foo1.user_id OPERATOR(pg_catalog.=) foo4.user_id) AND (foo2.user_id OPERATOR(pg_catalog.=) foo5.value_1))) foo_top
+ valid 
+-------
+ t
+(1 row)
+
+--  Deeper subqueries are non-colocated
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*) 
+    FROM
+    (
+        SELECT
+        foo.user_id
+    FROM
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4)) as foo,
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id) as foo_top JOIN 
+
+    (
+        SELECT
+        foo.user_id
+    FROM
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4)) as foo,
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id) as bar_top 
+        ON (foo_top.user_id = bar_top.user_id);
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 34_1 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 34_2 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  Plan 34 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT foo.user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('34_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo, (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.user_id OPERATOR(pg_catalog.=) bar.user_id)) foo_top JOIN (SELECT foo.user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('34_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) foo, (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.user_id OPERATOR(pg_catalog.=) bar.user_id)) bar_top ON ((foo_top.user_id OPERATOR(pg_catalog.=) bar_top.user_id)))
+ valid 
+-------
+ t
+(1 row)
+
+--  Top level Subquery is not colocated
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*) 
+    FROM
+    (
+        SELECT
+        foo.user_id, foo.value_2
+    FROM
+        (SELECT DISTINCT users_table.user_id, users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT DISTINCT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id) as foo_top JOIN 
+
+    (
+        SELECT
+        foo.user_id
+    FROM
+        (SELECT DISTINCT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as foo,
+        (SELECT DISTINCT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (13,14,15,16)) as bar
+    WHERE
+        foo.user_id = bar.user_id) as bar_top 
+        ON (foo_top.value_2 = bar_top.user_id);  
+
+$$);
+DEBUG:  generating subplan 37_1 for subquery SELECT foo.user_id FROM (SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))) foo, (SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[13, 14, 15, 16])))) bar WHERE (foo.user_id OPERATOR(pg_catalog.=) bar.user_id)
+DEBUG:  Plan 37 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT foo.user_id, foo.value_2 FROM (SELECT DISTINCT users_table.user_id, users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.user_id OPERATOR(pg_catalog.=) bar.user_id)) foo_top JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('37_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar_top ON ((foo_top.value_2 OPERATOR(pg_catalog.=) bar_top.user_id)))
+ valid 
+-------
+ t
+(1 row)
+
+--  Top level Subquery is not colocated as the above
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*) 
+    FROM
+    (
+        SELECT
+        foo.user_id, foo.value_2
+    FROM
+        (SELECT DISTINCT users_table.user_id, users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT DISTINCT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+    WHERE
+        foo.user_id = bar.user_id) as foo_top JOIN 
+    (
+        SELECT
+        foo.user_id
+    FROM
+        (SELECT DISTINCT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as foo,
+        (SELECT DISTINCT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (13,14,15,16)) as bar
+    WHERE
+        foo.user_id = bar.user_id) as bar_top 
+    ON (foo_top.value_2 = bar_top.user_id);
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 39_1 for subquery SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[13, 14, 15, 16])))
+DEBUG:  generating subplan 39_2 for subquery SELECT foo.user_id FROM (SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))) foo, (SELECT intermediate_result.user_id FROM read_intermediate_result('39_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar WHERE (foo.user_id OPERATOR(pg_catalog.=) bar.user_id)
+DEBUG:  Plan 39 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT foo.user_id, foo.value_2 FROM (SELECT DISTINCT users_table.user_id, users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT DISTINCT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.user_id OPERATOR(pg_catalog.=) bar.user_id)) foo_top JOIN (SELECT intermediate_result.user_id FROM read_intermediate_result('39_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar_top ON ((foo_top.value_2 OPERATOR(pg_catalog.=) bar_top.user_id)))
+ valid 
+-------
+ t
+(1 row)
+
+--  non colocated joins are deep inside the query
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*)
+    FROM
+        (
+            SELECT *  FROM 
+                (SELECT DISTINCT users_table.user_id FROM users_table, 
+                (SELECT events_table.user_id as my_users FROM events_table, users_table WHERE events_table.event_type = users_table.user_id) as foo 
+                WHERE foo.my_users = users_table.user_id) as mid_level_query
+        ) as bar;
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 42_1 for subquery SELECT events_table.user_id AS my_users FROM public.events_table, public.users_table WHERE (events_table.event_type OPERATOR(pg_catalog.=) users_table.user_id)
+DEBUG:  Plan 42 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT mid_level_query.user_id FROM (SELECT DISTINCT users_table.user_id FROM public.users_table, (SELECT intermediate_result.my_users FROM read_intermediate_result('42_1'::text, 'binary'::citus_copy_format) intermediate_result(my_users integer)) foo WHERE (foo.my_users OPERATOR(pg_catalog.=) users_table.user_id)) mid_level_query) bar
+ valid 
+-------
+ t
+(1 row)
+
+-- similar to the above, with relation rtes
+-- we're able to recursively plan foo
+-- note that if we haven't added random() to the subquery, we'd be able run the query
+-- via regular repartitioning since PostgreSQL would pull the query up
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT count(*) FROM ( SELECT * FROM 
+        (SELECT DISTINCT users_table.user_id FROM users_table, 
+        (SELECT events_table.event_type as my_users, random() FROM events_table, users_table WHERE events_table.user_id = users_table.user_id) as foo 
+        WHERE foo.my_users = users_table.user_id) as mid_level_query   ) as bar;
+
+$$);
+DEBUG:  generating subplan 44_1 for subquery SELECT events_table.event_type AS my_users, random() AS random FROM public.events_table, public.users_table WHERE (events_table.user_id OPERATOR(pg_catalog.=) users_table.user_id)
+DEBUG:  Plan 44 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT mid_level_query.user_id FROM (SELECT DISTINCT users_table.user_id FROM public.users_table, (SELECT intermediate_result.my_users, intermediate_result.random FROM read_intermediate_result('44_1'::text, 'binary'::citus_copy_format) intermediate_result(my_users integer, random double precision)) foo WHERE (foo.my_users OPERATOR(pg_catalog.=) users_table.user_id)) mid_level_query) bar
+ valid 
+-------
+ t
+(1 row)
+
+-- same as the above query, but, one level deeper subquery
+ SELECT true AS valid FROM explain_json_2($$
+ 
+     SELECT 
+         count(*)
+     FROM
+         (
+             SELECT *  FROM 
+                 (SELECT DISTINCT users_table.user_id FROM users_table, 
+                     (SELECT events_table.user_id as my_users FROM events_table, 
+                     (SELECT events_table.user_id, random() FROM users_table, events_table WHERE users_table.user_id = events_table.user_id) as selected_users
+                     WHERE events_table.event_type = selected_users.user_id) as foo 
+ 
+                 WHERE foo.my_users = users_table.user_id) as mid_level_query
+         ) as bar;
+ $$);
+DEBUG:  generating subplan 46_1 for subquery SELECT events_table.user_id, random() AS random FROM public.users_table, public.events_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id)
+DEBUG:  Plan 46 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT mid_level_query.user_id FROM (SELECT DISTINCT users_table.user_id FROM public.users_table, (SELECT events_table.user_id AS my_users FROM public.events_table, (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('46_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) selected_users WHERE (events_table.event_type OPERATOR(pg_catalog.=) selected_users.user_id)) foo WHERE (foo.my_users OPERATOR(pg_catalog.=) users_table.user_id)) mid_level_query) bar
+ valid 
+-------
+ t
+(1 row)
+
+-- deeper query, subquery in WHERE clause
+-- this time successfull plan the query since the join on the relation and
+-- the subquery on the distribution key
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*)
+    FROM
+        (
+            SELECT *  FROM 
+                (SELECT DISTINCT users_table.user_id FROM users_table, 
+                
+
+                    (SELECT events_table.user_id as my_users FROM events_table, 
+                    (SELECT events_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND 
+
+                            users_table.user_id IN (SELECT value_2 FROM events_table)
+
+                        ) as selected_users
+                    WHERE events_table.user_id = selected_users.user_id) as foo 
+
+                WHERE foo.my_users = users_table.user_id) as mid_level_query
+
+    ) as bar;
+
+$$);
+DEBUG:  generating subplan 48_1 for subquery SELECT value_2 FROM public.events_table
+DEBUG:  Plan 48 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT mid_level_query.user_id FROM (SELECT DISTINCT users_table.user_id FROM public.users_table, (SELECT events_table.user_id AS my_users FROM public.events_table, (SELECT events_table_1.user_id FROM public.users_table users_table_1, public.events_table events_table_1 WHERE ((users_table_1.user_id OPERATOR(pg_catalog.=) events_table_1.user_id) AND (users_table_1.user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('48_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))))) selected_users WHERE (events_table.user_id OPERATOR(pg_catalog.=) selected_users.user_id)) foo WHERE (foo.my_users OPERATOR(pg_catalog.=) users_table.user_id)) mid_level_query) bar
+ valid 
+-------
+ t
+(1 row)
+
+-- should recursively plan the subquery in WHERE clause
+SELECT true AS valid FROM explain_json_2($$SELECT
+	count(*)
+FROM
+	users_table
+WHERE
+	value_1 
+		IN
+	(SELECT 
+		users_table.user_id 
+	 FROM 
+	 	users_table, events_table 
+	 WHERE 
+	 	users_table.user_id = events_table.value_2 AND event_type IN (5,6));$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 50_1 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6])))
+DEBUG:  Plan 50 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.users_table WHERE (value_1 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('50_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))
+ valid 
+-------
+ t
+(1 row)
+
+-- leaf subquery repartitioning should work fine when used with CTEs
+SELECT true AS valid FROM explain_json_2($$
+	WITH q1 AS (SELECT user_id FROM users_table) 
+SELECT count(*) FROM q1, (SELECT 
+					users_table.user_id, random() 
+				FROM 
+					users_table, events_table 
+				WHERE 
+					users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4)) as bar WHERE bar.user_id = q1.user_id ;$$);
+DEBUG:  generating subplan 52_1 for CTE q1: SELECT user_id FROM public.users_table
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 52_2 for subquery SELECT users_table.user_id, random() AS random FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  Plan 52 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('52_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) q1, (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('52_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) bar WHERE (bar.user_id OPERATOR(pg_catalog.=) q1.user_id)
+ valid 
+-------
+ t
+(1 row)
+
+-- subquery joins should work fine when used with CTEs
+SELECT true AS valid FROM explain_json_2($$
+    WITH q1 AS (SELECT user_id FROM users_table) 
+ SELECT count(*) FROM q1, (SELECT 
+                    users_table.user_id, random() 
+                FROM 
+                    users_table, events_table 
+                WHERE 
+                    users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as bar WHERE bar.user_id = q1.user_id ;$$);
+DEBUG:  generating subplan 55_1 for CTE q1: SELECT user_id FROM public.users_table
+DEBUG:  Plan 55 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('55_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) q1, (SELECT users_table.user_id, random() AS random FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) bar WHERE (bar.user_id OPERATOR(pg_catalog.=) q1.user_id)
+ valid 
+-------
+ t
+(1 row)
+
+-- should work fine within UNIONs
+SELECT true AS valid FROM explain_json_2($$
+    (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4)) UNION
+    (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8));$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 57_1 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  generating subplan 57_2 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  Plan 57 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('57_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('57_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
+ valid 
+-------
+ t
+(1 row)
+
+-- should work fine within leaf queries of deeper subqueries
+SELECT true AS valid FROM explain_json_2($$
+SELECT event, array_length(events_table, 1)
+FROM (
+  SELECT event, array_agg(t.user_id) AS events_table
+  FROM (
+    SELECT 
+    	DISTINCT ON(e.event_type::text) e.event_type::text as event, e.time, e.user_id
+    FROM 
+    	users_table AS u,
+        events_table AS e,
+        (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (5,6,7,8)) as bar
+    WHERE u.user_id = e.user_id AND 
+    		u.user_id IN 
+    		(
+    			SELECT 
+    				user_id 
+    			FROM 
+    				users_table 
+    			WHERE value_2 >= 5
+			    AND  EXISTS (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.value_2 AND event_type IN (1,2,3,4))
+				LIMIT 5
+    		)
+  ) t, users_table WHERE users_table.value_1 = t.event::int
+  GROUP BY event
+) q
+ORDER BY 2 DESC, 1;
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 60_1 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
+DEBUG:  push down of limit count: 5
+DEBUG:  generating subplan 60_2 for subquery SELECT user_id FROM public.users_table WHERE ((value_2 OPERATOR(pg_catalog.>=) 5) AND (EXISTS (SELECT intermediate_result.user_id FROM read_intermediate_result('60_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))) LIMIT 5
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 60_3 for subquery SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.value_2) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 60_4 for subquery SELECT DISTINCT ON ((e.event_type)::text) (e.event_type)::text AS event, e."time", e.user_id FROM public.users_table u, public.events_table e, (SELECT intermediate_result.user_id FROM read_intermediate_result('60_3'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) bar WHERE ((u.user_id OPERATOR(pg_catalog.=) e.user_id) AND (u.user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('60_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer))))
+DEBUG:  generating subplan 60_5 for subquery SELECT t.event, array_agg(t.user_id) AS events_table FROM (SELECT intermediate_result.event, intermediate_result."time", intermediate_result.user_id FROM read_intermediate_result('60_4'::text, 'binary'::citus_copy_format) intermediate_result(event text, "time" timestamp without time zone, user_id integer)) t, public.users_table WHERE (users_table.value_1 OPERATOR(pg_catalog.=) (t.event)::integer) GROUP BY t.event
+DEBUG:  Plan 60 query after replacing subqueries and CTEs: SELECT event, array_length(events_table, 1) AS array_length FROM (SELECT intermediate_result.event, intermediate_result.events_table FROM read_intermediate_result('60_5'::text, 'binary'::citus_copy_format) intermediate_result(event text, events_table integer[])) q ORDER BY (array_length(events_table, 1)) DESC, event
+ valid 
+-------
+ t
+(1 row)
+
+-- this is also supported since we can recursively plan relations as well
+-- the relations are joined under a join tree with an alias
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*) 
+    FROM
+        (users_table u1 JOIN users_table u2 using(value_1)) a JOIN (SELECT value_1, random() FROM users_table) as u3 USING (value_1); 
+$$);
+DEBUG:  generating subplan 66_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 66_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 66 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('66_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('66_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
+ valid 
+-------
+ t
+(1 row)
+
+-- a very similar query to the above
+-- however, this time we users a subquery instead of join alias, and it works
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT 
+        count(*) 
+    FROM
+        (SELECT * FROM users_table u1 JOIN users_table u2 using(value_1)) a JOIN (SELECT value_1, random() FROM users_table) as u3 USING (value_1); 
+$$);
+DEBUG:  cannot use real time executor with repartition jobs
+DEBUG:  generating subplan 69_1 for subquery SELECT u1.value_1, u1.user_id, u1."time", u1.value_2, u1.value_3, u1.value_4, u2.user_id, u2."time", u2.value_2, u2.value_3, u2.value_4 FROM (public.users_table u1 JOIN public.users_table u2 USING (value_1))
+DEBUG:  Plan 69 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.value_1, intermediate_result.user_id, intermediate_result."time", intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4, intermediate_result.user_id_1 AS user_id, intermediate_result.time_1 AS "time", intermediate_result.value_2_1 AS value_2, intermediate_result.value_3_1 AS value_3, intermediate_result.value_4_1 AS value_4 FROM read_intermediate_result('69_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, user_id integer, "time" timestamp without time zone, value_2 integer, value_3 double precision, value_4 bigint, user_id_1 integer, time_1 timestamp without time zone, value_2_1 integer, value_3_1 double precision, value_4_1 bigint)) a(value_1, user_id, "time", value_2, value_3, value_4, user_id_1, time_1, value_2_1, value_3_1, value_4_1) JOIN (SELECT users_table.value_1, random() AS random FROM public.users_table) u3 USING (value_1))
+ valid 
+-------
+ t
+(1 row)
+
+-- a similar query to the above, this time subquery is on the left
+-- and the relation is on the right of the join tree
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        count(*)
+    FROM
+        (SELECT value_2, random() FROM users_table) as u1
+            JOIN
+        events_table
+            using (value_2);
+$$);
+DEBUG:  generating subplan 71_1 for subquery SELECT value_2, random() AS random FROM public.users_table
+DEBUG:  Plan 71 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('71_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u1 JOIN public.events_table USING (value_2))
+ valid 
+-------
+ t
+(1 row)
+
+-- recursive planning should kick in for outer joins as well
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        count(*)
+    FROM
+        (SELECT value_2, random() FROM users_table) as u1
+            LEFT JOIN
+        (SELECT value_2, random() FROM users_table) as u2
+            USING(value_2);
+$$);
+DEBUG:  generating subplan 73_1 for subquery SELECT value_2, random() AS random FROM public.users_table
+DEBUG:  Plan 73 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT users_table.value_2, random() AS random FROM public.users_table) u1 LEFT JOIN (SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('73_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u2 USING (value_2))
+ valid 
+-------
+ t
+(1 row)
+
+-- recursive planning should kick in for outer joins as well
+-- but this time recursive planning might convert the query
+-- into a not supported join
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        count(*)
+    FROM
+        (SELECT value_2, random() FROM users_table) as u1
+            RIGHT JOIN
+        (SELECT value_2, random() FROM users_table) as u2
+            USING(value_2);
+$$);
+DEBUG:  generating subplan 75_1 for subquery SELECT value_2, random() AS random FROM public.users_table
+DEBUG:  Plan 75 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT users_table.value_2, random() AS random FROM public.users_table) u1 RIGHT JOIN (SELECT intermediate_result.value_2, intermediate_result.random FROM read_intermediate_result('75_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer, random double precision)) u2 USING (value_2))
+ERROR:  cannot pushdown the subquery
+-- set operations may produce not very efficient plans
+-- although we could have picked a as our anchor subquery,
+-- we pick foo in this case and recursively plan a
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    (
+        (
+         SELECT user_id FROM users_table
+            UNION
+         SELECT user_id FROM users_table
+        ) a 
+            JOIN
+        (SELECT value_1 FROM users_table) as foo ON (a.user_id = foo.value_1) 
+    );
+$$);
+DEBUG:  generating subplan 78_1 for subquery SELECT user_id FROM public.users_table
+DEBUG:  generating subplan 78_2 for subquery SELECT user_id FROM public.users_table
+DEBUG:  Plan 78 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('78_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('78_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
+DEBUG:  generating subplan 77_1 for subquery SELECT users_table.user_id FROM public.users_table UNION SELECT users_table.user_id FROM public.users_table
+DEBUG:  Plan 77 query after replacing subqueries and CTEs: SELECT a.user_id, foo.value_1 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('77_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a JOIN (SELECT users_table.value_1 FROM public.users_table) foo ON ((a.user_id OPERATOR(pg_catalog.=) foo.value_1)))
+ valid 
+-------
+ t
+(1 row)
+
+-- we could do the same with regular tables as well
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    (
+        (
+         SELECT user_id FROM users_table
+            UNION
+         SELECT user_id FROM users_table
+        ) a 
+            JOIN
+        users_table as foo ON (a.user_id = foo.value_1) 
+    );
+$$);
+DEBUG:  generating subplan 82_1 for subquery SELECT user_id FROM public.users_table
+DEBUG:  generating subplan 82_2 for subquery SELECT user_id FROM public.users_table
+DEBUG:  Plan 82 query after replacing subqueries and CTEs: SELECT intermediate_result.user_id FROM read_intermediate_result('82_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('82_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
+DEBUG:  generating subplan 81_1 for subquery SELECT users_table.user_id FROM public.users_table UNION SELECT users_table.user_id FROM public.users_table
+DEBUG:  Plan 81 query after replacing subqueries and CTEs: SELECT a.user_id, foo.user_id, foo."time", foo.value_1, foo.value_2, foo.value_3, foo.value_4 FROM ((SELECT intermediate_result.user_id FROM read_intermediate_result('81_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a JOIN public.users_table foo ON ((a.user_id OPERATOR(pg_catalog.=) foo.value_1)))
+ valid 
+-------
+ t
+(1 row)
+
+-- this time the the plan is optimial, we are
+-- able to keep the UNION query given that foo
+-- is the anchor
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT * FROM
+    ( 
+        (SELECT user_id FROM users_table) as foo 
+            JOIN
+        (
+         SELECT user_id FROM users_table WHERE user_id IN (1,2,3,4)
+            UNION
+         SELECT user_id FROM users_table WHERE user_id IN (5,6,7,8)
+        ) a 
+
+        ON (a.user_id = foo.user_id) 
+        JOIN
+
+         (SELECT value_1 FROM users_table) as bar
+        
+         ON(foo.user_id = bar.value_1) 
+    );
+$$);
+DEBUG:  generating subplan 85_1 for subquery SELECT value_1 FROM public.users_table
+DEBUG:  Plan 85 query after replacing subqueries and CTEs: SELECT foo.user_id, a.user_id, bar.value_1 FROM (((SELECT users_table.user_id FROM public.users_table) foo JOIN (SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])) UNION SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8]))) a ON ((a.user_id OPERATOR(pg_catalog.=) foo.user_id))) JOIN (SELECT intermediate_result.value_1 FROM read_intermediate_result('85_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer)) bar ON ((foo.user_id OPERATOR(pg_catalog.=) bar.value_1)))
+ valid 
+-------
+ t
+(1 row)
+
+-- it should be safe to recursively plan non colocated subqueries
+-- inside a CTE
+SELECT true AS valid FROM explain_json_2($$
+
+    WITH non_colocated_subquery AS 
+    (
+         SELECT
+            foo.value_2
+        FROM
+            (SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+            (SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (5,6,7,8)) as bar
+        WHERE
+            foo.value_2 = bar.value_2
+    ),
+    non_colocated_subquery_2 AS 
+    (
+        SELECT
+            count(*) as cnt
+        FROM
+            events_table
+        WHERE
+            event_type
+        IN
+            (SELECT event_type FROM events_table WHERE user_id < 4)
+    )
+    SELECT 
+        * 
+    FROM 
+        non_colocated_subquery, non_colocated_subquery_2 
+    WHERE 
+        non_colocated_subquery.value_2 != non_colocated_subquery_2.cnt
+$$);
+DEBUG:  generating subplan 87_1 for CTE non_colocated_subquery: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
+DEBUG:  generating subplan 88_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  Plan 88 query after replacing subqueries and CTEs: SELECT foo.value_2 FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('88_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar WHERE (foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)
+DEBUG:  generating subplan 87_2 for CTE non_colocated_subquery_2: SELECT count(*) AS cnt FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT events_table_1.event_type FROM public.events_table events_table_1 WHERE (events_table_1.user_id OPERATOR(pg_catalog.<) 4)))
+DEBUG:  generating subplan 90_1 for subquery SELECT event_type FROM public.events_table WHERE (user_id OPERATOR(pg_catalog.<) 4)
+DEBUG:  Plan 90 query after replacing subqueries and CTEs: SELECT count(*) AS cnt FROM public.events_table WHERE (event_type OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.event_type FROM read_intermediate_result('90_1'::text, 'binary'::citus_copy_format) intermediate_result(event_type integer)))
+DEBUG:  Plan 87 query after replacing subqueries and CTEs: SELECT non_colocated_subquery.value_2, non_colocated_subquery_2.cnt FROM (SELECT intermediate_result.value_2 FROM read_intermediate_result('87_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) non_colocated_subquery, (SELECT intermediate_result.cnt FROM read_intermediate_result('87_2'::text, 'binary'::citus_copy_format) intermediate_result(cnt bigint)) non_colocated_subquery_2 WHERE (non_colocated_subquery.value_2 OPERATOR(pg_catalog.<>) non_colocated_subquery_2.cnt)
+ valid 
+-------
+ t
+(1 row)
+
+-- non colocated subquery joins should work fine along with local tables
+SELECT true AS valid FROM explain_json_2($$
+     SELECT
+        count(*)
+    FROM
+        (SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2,3,4)) as foo,
+        (SELECT users_table_local.value_2 FROM users_table_local, events_table_local WHERE users_table_local.user_id = events_table_local.user_id AND event_type IN (5,6,7,8)) as bar,
+         (SELECT users_table.value_2 FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (9,10,11,12)) as baz
+    WHERE
+        foo.value_2 = bar.value_2 
+        AND 
+        foo.value_2 = baz.value_2
+$$);
+DEBUG:  generating subplan 92_1 for subquery SELECT users_table_local.value_2 FROM non_colocated_subquery.users_table_local, non_colocated_subquery.events_table_local WHERE ((users_table_local.user_id OPERATOR(pg_catalog.=) events_table_local.user_id) AND (events_table_local.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  generating subplan 92_2 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[9, 10, 11, 12])))
+DEBUG:  Plan 92 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))) foo, (SELECT intermediate_result.value_2 FROM read_intermediate_result('92_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar, (SELECT intermediate_result.value_2 FROM read_intermediate_result('92_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) baz WHERE ((foo.value_2 OPERATOR(pg_catalog.=) bar.value_2) AND (foo.value_2 OPERATOR(pg_catalog.=) baz.value_2))
+ valid 
+-------
+ t
+(1 row)
+
+-- a combination of subqueries in FROM and WHERE clauses
+-- we actually recursively plan non colocated subqueries
+-- pretty accurate, however, we hit our join checks, which seems too restrictive
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT
+        count(*)
+    FROM
+            (SELECT user_id FROM users_table) as foo 
+                JOIN
+            (
+             SELECT user_id FROM users_table WHERE user_id IN (1,2,3,4)
+                UNION
+             SELECT user_id FROM users_table WHERE user_id IN (5,6,7,8)
+            ) a 
+
+            ON (a.user_id = foo.user_id) 
+            JOIN
+
+             (SELECT value_1, value_2 FROM users_table) as bar
+
+             ON(foo.user_id = bar.value_1) 
+    WHERE
+        value_2 IN (SELECT value_1 FROM users_table WHERE value_2 < 1)
+            AND
+        value_1 IN (SELECT value_2 FROM users_table WHERE value_1 < 2)
+            AND
+        foo.user_id IN (SELECT users_table.user_id FROM users_table, events_table WHERE users_table.user_id = events_table.user_id AND event_type IN (1,2))
+$$);
+DEBUG:  generating subplan 94_1 for subquery SELECT value_1, value_2 FROM public.users_table
+DEBUG:  generating subplan 94_2 for subquery SELECT value_1 FROM public.users_table WHERE (value_2 OPERATOR(pg_catalog.<) 1)
+DEBUG:  generating subplan 94_3 for subquery SELECT value_2 FROM public.users_table WHERE (value_1 OPERATOR(pg_catalog.<) 2)
+DEBUG:  Plan 94 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (((SELECT users_table.user_id FROM public.users_table) foo JOIN (SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])) UNION SELECT users_table.user_id FROM public.users_table WHERE (users_table.user_id OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8]))) a ON ((a.user_id OPERATOR(pg_catalog.=) foo.user_id))) JOIN (SELECT intermediate_result.value_1, intermediate_result.value_2 FROM read_intermediate_result('94_1'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, value_2 integer)) bar ON ((foo.user_id OPERATOR(pg_catalog.=) bar.value_1))) WHERE ((bar.value_2 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_1 FROM read_intermediate_result('94_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer))) AND (bar.value_1 OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('94_3'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))) AND (foo.user_id OPERATOR(pg_catalog.=) ANY (SELECT users_table.user_id FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2]))))))
+ERROR:  cannot pushdown the subquery
+-- make sure that we don't pick the refeence table as 
+-- the anchor
+SELECT true AS valid FROM explain_json_2($$
+
+    SELECT count(*)
+    FROM 
+      users_reference_table AS users_table_ref,
+      (SELECT user_id FROM users_Table) AS foo,
+      (SELECT user_id, value_2 FROM events_Table) AS bar
+    WHERE 
+      users_table_ref.user_id = foo.user_id
+      AND foo.user_id = bar.value_2;
+$$);
+DEBUG:  generating subplan 98_1 for subquery SELECT user_id, value_2 FROM public.events_table
+DEBUG:  Plan 98 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM public.users_reference_table users_table_ref, (SELECT users_table.user_id FROM public.users_table) foo, (SELECT intermediate_result.user_id, intermediate_result.value_2 FROM read_intermediate_result('98_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_2 integer)) bar WHERE ((users_table_ref.user_id OPERATOR(pg_catalog.=) foo.user_id) AND (foo.user_id OPERATOR(pg_catalog.=) bar.value_2))
+ valid 
+-------
+ t
+(1 row)
+
+RESET client_min_messages;
+DROP FUNCTION explain_json_2(text);
+SET search_path TO 'public';
+DROP SCHEMA non_colocated_subquery CASCADE;
+NOTICE:  drop cascades to 2 other objects

--- a/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
+++ b/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
@@ -20,7 +20,7 @@ JOIN
   (SELECT value_1,
           random()
    FROM users_table) AS u3 USING (value_1);
-DEBUG:  generating subplan 1_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 1_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 1_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 1 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('1_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('1_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
  count 
@@ -37,7 +37,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE u2.value_1 > ANY(ARRAY[2, 1, 6]);
-DEBUG:  generating subplan 4_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.>) ANY ('{2,1,6}'::integer[]))
+DEBUG:  generating subplan 4_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.>) ANY ('{2,1,6}'::integer[]))
 DEBUG:  generating subplan 4_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 4 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('4_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('4_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_1 OPERATOR(pg_catalog.>) ANY (ARRAY[2, 1, 6]))
  count 
@@ -54,7 +54,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE  ARRAY[u2.value_1, u2.value_2] @> (ARRAY[2, 3]);
-DEBUG:  generating subplan 7_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (ARRAY[value_1, value_2] OPERATOR(pg_catalog.@>) '{2,3}'::integer[])
+DEBUG:  generating subplan 7_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (ARRAY[value_1, value_2] OPERATOR(pg_catalog.@>) '{2,3}'::integer[])
 DEBUG:  generating subplan 7_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('7_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ARRAY[users_table.value_1, users_table.value_2] OPERATOR(pg_catalog.@>) ARRAY[2, 3])
  count 
@@ -71,7 +71,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE  ARRAY[u2.value_1, u1.user_id] @> (ARRAY[2, 3]);
-DEBUG:  generating subplan 10_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 10_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 10_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('10_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ARRAY[users_table.value_1, u1.user_id] OPERATOR(pg_catalog.@>) ARRAY[2, 3])
  count 
@@ -88,7 +88,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1/2.0 > 2)::int::bool::text::bool;
-DEBUG:  generating subplan 13_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (((((((value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) '2'::numeric))::integer)::boolean)::text)::boolean
+DEBUG:  generating subplan 13_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (((((((value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) '2'::numeric))::integer)::boolean)::text)::boolean
 DEBUG:  generating subplan 13_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 13 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('13_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('13_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((((((users_table.value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) (2)::numeric))::integer)::boolean)::text)::boolean
  count 
@@ -105,7 +105,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (CASE WHEN u2.value_1 > 3 THEN u2.value_1 > 2 ELSE false END);
-DEBUG:  generating subplan 16_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE CASE WHEN (value_1 OPERATOR(pg_catalog.>) 3) THEN (value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
+DEBUG:  generating subplan 16_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE CASE WHEN (value_1 OPERATOR(pg_catalog.>) 3) THEN (value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
 DEBUG:  generating subplan 16_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 16 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('16_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('16_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE CASE WHEN (users_table.value_1 OPERATOR(pg_catalog.>) 3) THEN (users_table.value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
  count 
@@ -122,7 +122,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (CASE WHEN u1.value_1 > 4000 THEN u2.value_1 / 100 > 1 ELSE false END);
-DEBUG:  generating subplan 19_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 19_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 19_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('19_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE CASE WHEN (u1.value_1 OPERATOR(pg_catalog.>) 4000) THEN ((users_table.value_1 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END
  count 
@@ -139,7 +139,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE COALESCE((u2.user_id/5.0)::int::bool, false);
-DEBUG:  generating subplan 22_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE COALESCE(((((user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+DEBUG:  generating subplan 22_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE COALESCE(((((user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
 DEBUG:  generating subplan 22_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 22 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('22_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE COALESCE(((((users_table.user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
  count 
@@ -156,7 +156,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE NULLIF((u2.value_2/5.0)::int::bool, false);
-DEBUG:  generating subplan 25_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE NULLIF(((((value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+DEBUG:  generating subplan 25_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE NULLIF(((((value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
 DEBUG:  generating subplan 25_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('25_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE NULLIF(((((users_table.value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
  count 
@@ -173,7 +173,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE u2.value_3 IS NOT NULL;
-DEBUG:  generating subplan 28_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_3 IS NOT NULL)
+DEBUG:  generating subplan 28_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (value_3 IS NOT NULL)
 DEBUG:  generating subplan 28_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 28 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('28_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('28_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_3 IS NOT NULL)
  count 
@@ -190,7 +190,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE isfinite(u2.time);
-DEBUG:  generating subplan 31_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE isfinite("time")
+DEBUG:  generating subplan 31_1 for subquery SELECT NULL::integer AS user_id, "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE isfinite("time")
 DEBUG:  generating subplan 31_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 31 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('31_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('31_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE isfinite(users_table."time")
  count 
@@ -207,7 +207,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE int4smaller(u2.value_1, u1.value_1) = 55;
-DEBUG:  generating subplan 34_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 34_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 34_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 34 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('34_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('34_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (int4smaller(users_table.value_1, u1.value_1) OPERATOR(pg_catalog.=) 55)
  count 
@@ -224,7 +224,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE int4smaller(u2.value_1, u2.value_2) = u2.value_1;
-DEBUG:  generating subplan 37_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) int4smaller(value_1, value_2))
+DEBUG:  generating subplan 37_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) int4smaller(value_1, value_2))
 DEBUG:  generating subplan 37_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 37 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('37_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('37_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (int4smaller(users_table.value_1, users_table.value_2) OPERATOR(pg_catalog.=) users_table.value_1)
  count 
@@ -241,7 +241,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE row(u2.value_1, 2, 3) > row(u2.value_2, 2, 3);
-DEBUG:  generating subplan 40_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (ROW(value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(value_2, 2, 3))
+DEBUG:  generating subplan 40_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (ROW(value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(value_2, 2, 3))
 DEBUG:  generating subplan 40_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 40 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('40_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('40_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ROW(users_table.value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(users_table.value_2, 2, 3))
  count 
@@ -285,7 +285,7 @@ WHERE u2.value_1 >
     (SELECT avg(user_id)
      FROM events_table);
 DEBUG:  generating subplan 46_1 for subquery SELECT avg(user_id) AS avg FROM public.events_table
-DEBUG:  generating subplan 46_2 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 46_2 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 46_3 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 46 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('46_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('46_3'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1)::numeric OPERATOR(pg_catalog.>) (SELECT intermediate_result.avg FROM read_intermediate_result('46_1'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)))
  count 
@@ -303,7 +303,7 @@ JOIN
    FROM users_table) AS u3 USING (value_1)
 WHERE u2.value_1 >
     (SELECT 5);
-DEBUG:  generating subplan 50_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 50_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 50_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 50 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('50_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('50_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_1 OPERATOR(pg_catalog.>) (SELECT 5))
  count 
@@ -320,7 +320,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE  u2.value_1 *  u1.user_id > 25;
-DEBUG:  generating subplan 53_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 53_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 53_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 53 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('53_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('53_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.*) u1.user_id) OPERATOR(pg_catalog.>) 25)
  count 
@@ -339,7 +339,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE  u1.value_1 = 3;
-DEBUG:  generating subplan 56_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) 3)
+DEBUG:  generating subplan 56_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) 3)
 DEBUG:  generating subplan 56_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 56 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('56_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('56_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_1 OPERATOR(pg_catalog.=) 3)
  count 
@@ -356,7 +356,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE  u1.value_1 > 3;
-DEBUG:  generating subplan 59_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 59_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 59_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 59 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('59_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('59_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_1 OPERATOR(pg_catalog.>) 3)
  count 
@@ -374,7 +374,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE  u1.value_2 = 3;
-DEBUG:  generating subplan 62_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 62_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 62_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 62 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('62_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('62_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_2 OPERATOR(pg_catalog.=) 3)
  count 
@@ -391,7 +391,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE u2.value_1 > 4 OR u2.value_4 = 4;
-DEBUG:  generating subplan 65_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 4) OR (value_4 OPERATOR(pg_catalog.=) 4))
+DEBUG:  generating subplan 65_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 4) OR (value_4 OPERATOR(pg_catalog.=) 4))
 DEBUG:  generating subplan 65_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 65 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('65_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('65_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 4) OR (users_table.value_4 OPERATOR(pg_catalog.=) 4))
  count 
@@ -408,7 +408,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE u2.value_1 > 2 and u2.value_4 IS NULL;
-DEBUG:  generating subplan 68_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) AND (value_4 IS NULL))
+DEBUG:  generating subplan 68_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) AND (value_4 IS NULL))
 DEBUG:  generating subplan 68_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 68 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('68_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('68_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND (users_table.value_4 IS NULL))
  count 
@@ -426,7 +426,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
-DEBUG:  generating subplan 71_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL))
+DEBUG:  generating subplan 71_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL))
 DEBUG:  generating subplan 71_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 71 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('71_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('71_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (users_table.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
  count 
@@ -443,7 +443,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) OR (u2.user_id > 4 AND u1.user_id > 3);
-DEBUG:  generating subplan 74_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL) OR (user_id OPERATOR(pg_catalog.>) 4))
+DEBUG:  generating subplan 74_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL) OR (user_id OPERATOR(pg_catalog.>) 4))
 DEBUG:  generating subplan 74_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 74 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('74_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('74_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (users_table.value_4 IS NULL) OR ((users_table.user_id OPERATOR(pg_catalog.>) 4) AND (u1.user_id OPERATOR(pg_catalog.>) 3)))
  count 
@@ -460,7 +460,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 AND u1.user_id > 3);
-DEBUG:  generating subplan 77_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (user_id OPERATOR(pg_catalog.>) 4)
+DEBUG:  generating subplan 77_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE (user_id OPERATOR(pg_catalog.>) 4)
 DEBUG:  generating subplan 77_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 77 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('77_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('77_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) AND (u1.user_id OPERATOR(pg_catalog.>) 3)))
  count 
@@ -477,7 +477,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
-DEBUG:  generating subplan 80_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 80_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 80_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 80 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('80_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('80_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
  count 
@@ -495,7 +495,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id = 10000 * random() OR u1.user_id > 3);
-DEBUG:  generating subplan 83_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 83_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 83_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 83 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('83_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('83_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND (((users_table.user_id)::double precision OPERATOR(pg_catalog.=) ((10000)::double precision OPERATOR(pg_catalog.*) random())) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
  count 
@@ -512,7 +512,7 @@ JOIN
           random()
    FROM users_table) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2 AND false);
-DEBUG:  generating subplan 86_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 86_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  generating subplan 86_2 for subquery SELECT value_1, random() AS random FROM public.users_table
 DEBUG:  Plan 86 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('86_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('86_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND false)
  count 
@@ -531,6 +531,6 @@ JOIN LATERAL
    WHERE u2.value_2 = 15) AS u3 USING (value_1)
 WHERE (u2.value_1 > 2
        AND FALSE);
-DEBUG:  generating subplan 89_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 89_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", value_1, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table u2 WHERE true
 DEBUG:  Plan 89 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('89_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN LATERAL (SELECT users_table_1.value_1, random() AS random FROM public.users_table users_table_1 WHERE (users_table.value_2 OPERATOR(pg_catalog.=) 15)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND false)
 ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator

--- a/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
+++ b/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
@@ -1,0 +1,536 @@
+----------------------------------------------------
+-- recursive_relation_planning_restirction_pushdown
+-- In this test file, we mosly test whether Citus
+-- can successfully pushdown filters to the subquery
+-- that is 
+----------------------------------------------------
+-- all the queries in this file have the 
+-- same tables/subqueries combination as below
+-- because this test aims to hold the query planning 
+-- steady, but mostly ensure that filters are handled
+-- properly. Note that u2 is the relation that is 
+-- recursively planned
+-- Setting the debug level so that filters can be observed
+SET client_min_messages TO DEBUG1;
+-- no filters on u2
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1);
+DEBUG:  generating subplan 1_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 1_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 1 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('1_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('1_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
+ count 
+-------
+ 38501
+(1 row)
+
+-- scalar array expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > ANY(ARRAY[2, 1, 6]);
+DEBUG:  generating subplan 4_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.>) ANY ('{2,1,6}'::integer[]))
+DEBUG:  generating subplan 4_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 4 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('4_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('4_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_1 OPERATOR(pg_catalog.>) ANY (ARRAY[2, 1, 6]))
+ count 
+-------
+ 33398
+(1 row)
+
+-- array operators on the table can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  ARRAY[u2.value_1, u2.value_2] @> (ARRAY[2, 3]);
+DEBUG:  generating subplan 7_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (ARRAY[value_1, value_2] OPERATOR(pg_catalog.@>) '{2,3}'::integer[])
+DEBUG:  generating subplan 7_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('7_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ARRAY[users_table.value_1, users_table.value_2] OPERATOR(pg_catalog.@>) ARRAY[2, 3])
+ count 
+-------
+  4704
+(1 row)
+
+-- array operators on different tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  ARRAY[u2.value_1, u1.user_id] @> (ARRAY[2, 3]);
+DEBUG:  generating subplan 10_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 10_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('10_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ARRAY[users_table.value_1, u1.user_id] OPERATOR(pg_catalog.@>) ARRAY[2, 3])
+ count 
+-------
+  3352
+(1 row)
+
+-- coerced expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1/2.0 > 2)::int::bool::text::bool;
+DEBUG:  generating subplan 13_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (((((((value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) '2'::numeric))::integer)::boolean)::text)::boolean
+DEBUG:  generating subplan 13_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 13 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('13_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('13_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((((((users_table.value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) (2)::numeric))::integer)::boolean)::text)::boolean
+ count 
+-------
+   729
+(1 row)
+
+-- case expression on a single table can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (CASE WHEN u2.value_1 > 3 THEN u2.value_1 > 2 ELSE false END);
+DEBUG:  generating subplan 16_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE CASE WHEN (value_1 OPERATOR(pg_catalog.>) 3) THEN (value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
+DEBUG:  generating subplan 16_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 16 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('16_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('16_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE CASE WHEN (users_table.value_1 OPERATOR(pg_catalog.>) 3) THEN (users_table.value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
+ count 
+-------
+  9990
+(1 row)
+
+-- case expression multiple tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (CASE WHEN u1.value_1 > 4000 THEN u2.value_1 / 100 > 1 ELSE false END);
+DEBUG:  generating subplan 19_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 19_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('19_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE CASE WHEN (u1.value_1 OPERATOR(pg_catalog.>) 4000) THEN ((users_table.value_1 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END
+ count 
+-------
+     0
+(1 row)
+
+-- coalesce expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE COALESCE((u2.user_id/5.0)::int::bool, false);
+DEBUG:  generating subplan 22_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE COALESCE(((((user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+DEBUG:  generating subplan 22_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 22 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('22_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE COALESCE(((((users_table.user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+ count 
+-------
+ 28198
+(1 row)
+
+-- nullif expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE NULLIF((u2.value_2/5.0)::int::bool, false);
+DEBUG:  generating subplan 25_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE NULLIF(((((value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+DEBUG:  generating subplan 25_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('25_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE NULLIF(((((users_table.value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+ count 
+-------
+ 18895
+(1 row)
+
+-- null test can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_3 IS NOT NULL;
+DEBUG:  generating subplan 28_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_3 IS NOT NULL)
+DEBUG:  generating subplan 28_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 28 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('28_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('28_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_3 IS NOT NULL)
+ count 
+-------
+ 38501
+(1 row)
+
+-- functions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE isfinite(u2.time);
+DEBUG:  generating subplan 31_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE isfinite("time")
+DEBUG:  generating subplan 31_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 31 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('31_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('31_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE isfinite(users_table."time")
+ count 
+-------
+ 38501
+(1 row)
+
+-- functions with multiple tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE int4smaller(u2.value_1, u1.value_1) = 55;
+DEBUG:  generating subplan 34_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 34_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 34 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('34_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('34_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (int4smaller(users_table.value_1, u1.value_1) OPERATOR(pg_catalog.=) 55)
+ count 
+-------
+     0
+(1 row)
+
+-- functions with multiple columns from the same tables can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE int4smaller(u2.value_1, u2.value_2) = u2.value_1;
+DEBUG:  generating subplan 37_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) int4smaller(value_1, value_2))
+DEBUG:  generating subplan 37_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 37 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('37_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('37_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (int4smaller(users_table.value_1, users_table.value_2) OPERATOR(pg_catalog.=) users_table.value_1)
+ count 
+-------
+ 20686
+(1 row)
+
+-- row expressions can be pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE row(u2.value_1, 2, 3) > row(u2.value_2, 2, 3);
+DEBUG:  generating subplan 40_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (ROW(value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(value_2, 2, 3))
+DEBUG:  generating subplan 40_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 40 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('40_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('40_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ROW(users_table.value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(users_table.value_2, 2, 3))
+ count 
+-------
+ 17815
+(1 row)
+
+-- multiple expression from the same table can be pushed down together
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+	WHERE
+		  (u2.user_id/1.0)::int::bool::text::bool AND
+		  CASE WHEN u2.value_1 > 4000 THEN u2.value_2 / 100 > 1 ELSE false END AND
+		  COALESCE((u2.user_id/50000)::bool, false) AND
+		  NULLIF((u2.value_3/50000)::int::bool, false) AND
+		  isfinite(u2.time) AND
+		  u2.value_4 IS DISTINCT FROM 50040 AND
+		  row(u2.value_4, 2, 3) > row(2000, 2, 3);
+DEBUG:  generating subplan 43_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (((((((user_id)::numeric OPERATOR(pg_catalog./) 1.0))::integer)::boolean)::text)::boolean AND CASE WHEN (value_1 OPERATOR(pg_catalog.>) 4000) THEN ((value_2 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END AND COALESCE(((user_id OPERATOR(pg_catalog./) 50000))::boolean, false) AND NULLIF((((value_3 OPERATOR(pg_catalog./) '50000'::double precision))::integer)::boolean, false) AND isfinite("time") AND (value_4 IS DISTINCT FROM 50040) AND (ROW(value_4, 2, 3) OPERATOR(pg_catalog.>) ROW(2000, 2, 3)))
+DEBUG:  generating subplan 43_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 43 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('43_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('43_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((((((users_table.user_id)::numeric OPERATOR(pg_catalog./) 1.0))::integer)::boolean)::text)::boolean AND CASE WHEN (users_table.value_1 OPERATOR(pg_catalog.>) 4000) THEN ((users_table.value_2 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END AND COALESCE(((users_table.user_id OPERATOR(pg_catalog./) 50000))::boolean, false) AND NULLIF((((users_table.value_3 OPERATOR(pg_catalog./) (50000)::double precision))::integer)::boolean, false) AND isfinite(users_table."time") AND (users_table.value_4 IS DISTINCT FROM 50040) AND (ROW(users_table.value_4, 2, 3) OPERATOR(pg_catalog.>) ROW(2000, 2, 3)))
+ count 
+-------
+     0
+(1 row)
+
+-- subqueries are not pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 >
+    (SELECT avg(user_id)
+     FROM events_table);
+DEBUG:  generating subplan 46_1 for subquery SELECT avg(user_id) AS avg FROM public.events_table
+DEBUG:  generating subplan 46_2 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 46_3 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 46 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('46_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('46_3'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1)::numeric OPERATOR(pg_catalog.>) (SELECT intermediate_result.avg FROM read_intermediate_result('46_1'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)))
+ count 
+-------
+  9990
+(1 row)
+
+-- even subqueries with constant values are not pushdowned
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 >
+    (SELECT 5);
+DEBUG:  generating subplan 50_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 50_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 50 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('50_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('50_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_1 OPERATOR(pg_catalog.>) (SELECT 5))
+ count 
+-------
+     0
+(1 row)
+
+-- filters involving multiple tables aren't pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u2.value_1 *  u1.user_id > 25;
+DEBUG:  generating subplan 53_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 53_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 53 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('53_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('53_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.*) u1.user_id) OPERATOR(pg_catalog.>) 25)
+ count 
+-------
+   162
+(1 row)
+
+-- filter on other tables can only be pushdown 
+-- as long as they are equality filters on the
+-- joining column
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_1 = 3;
+DEBUG:  generating subplan 56_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) 3)
+DEBUG:  generating subplan 56_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 56 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('56_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('56_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_1 OPERATOR(pg_catalog.=) 3)
+ count 
+-------
+ 17576
+(1 row)
+
+-- but not when the filter is gt, lt or any other thing
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_1 > 3;
+DEBUG:  generating subplan 59_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 59_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 59 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('59_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('59_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_1 OPERATOR(pg_catalog.>) 3)
+ count 
+-------
+  9990
+(1 row)
+
+-- when the filter is on another column than the 
+-- join column, that's obviously not pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_2 = 3;
+DEBUG:  generating subplan 62_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 62_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 62 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('62_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('62_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_2 OPERATOR(pg_catalog.=) 3)
+ count 
+-------
+  5618
+(1 row)
+
+-- or filters on the same table is pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > 4 OR u2.value_4 = 4;
+DEBUG:  generating subplan 65_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 4) OR (value_4 OPERATOR(pg_catalog.=) 4))
+DEBUG:  generating subplan 65_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 65 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('65_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('65_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 4) OR (users_table.value_4 OPERATOR(pg_catalog.=) 4))
+ count 
+-------
+   729
+(1 row)
+
+-- and filters on the same table is pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > 2 and u2.value_4 IS NULL;
+DEBUG:  generating subplan 68_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) AND (value_4 IS NULL))
+DEBUG:  generating subplan 68_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 68 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('68_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('68_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND (users_table.value_4 IS NULL))
+ count 
+-------
+ 27566
+(1 row)
+
+-- filters on different tables are pushdown
+-- only the ones that are not ANDed
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
+DEBUG:  generating subplan 71_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL))
+DEBUG:  generating subplan 71_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 71 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('71_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('71_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (users_table.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 27405
+(1 row)
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) OR (u2.user_id > 4 AND u1.user_id > 3);
+DEBUG:  generating subplan 74_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL) OR (user_id OPERATOR(pg_catalog.>) 4))
+DEBUG:  generating subplan 74_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 74 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('74_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('74_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (users_table.value_4 IS NULL) OR ((users_table.user_id OPERATOR(pg_catalog.>) 4) AND (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 38501
+(1 row)
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 AND u1.user_id > 3);
+DEBUG:  generating subplan 77_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (user_id OPERATOR(pg_catalog.>) 4)
+DEBUG:  generating subplan 77_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 77 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('77_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('77_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) AND (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+  7883
+(1 row)
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
+DEBUG:  generating subplan 80_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 80_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 80 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('80_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('80_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 27405
+(1 row)
+
+-- see the comment above
+-- but volatile functions are not pushed down 
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id = 10000 * random() OR u1.user_id > 3);
+DEBUG:  generating subplan 83_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 83_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 83 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('83_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('83_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND (((users_table.user_id)::double precision OPERATOR(pg_catalog.=) ((10000)::double precision OPERATOR(pg_catalog.*) random())) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 22183
+(1 row)
+
+-- TODO: constant results should be pushed down, but not supported yet
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 AND false);
+DEBUG:  generating subplan 86_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 86_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 86 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('86_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('86_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND false)
+ count 
+-------
+     0
+(1 row)
+
+-- TODO: what should the behaviour be?
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN LATERAL
+  (SELECT value_1,
+          random()
+   FROM users_table
+   WHERE u2.value_2 = 15) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2
+       AND FALSE);
+DEBUG:  generating subplan 89_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  Plan 89 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('89_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN LATERAL (SELECT users_table_1.value_1, random() AS random FROM public.users_table users_table_1 WHERE (users_table.value_2 OPERATOR(pg_catalog.=) 15)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND false)
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator

--- a/src/test/regress/expected/recursive_relation_planning_restriction_pushdown_0.out
+++ b/src/test/regress/expected/recursive_relation_planning_restriction_pushdown_0.out
@@ -1,0 +1,536 @@
+----------------------------------------------------
+-- recursive_relation_planning_restirction_pushdown
+-- In this test file, we mosly test whether Citus
+-- can successfully pushdown filters to the subquery
+-- that is 
+----------------------------------------------------
+-- all the queries in this file have the 
+-- same tables/subqueries combination as below
+-- because this test aims to hold the query planning 
+-- steady, but mostly ensure that filters are handled
+-- properly. Note that u2 is the relation that is 
+-- recursively planned
+-- Setting the debug level so that filters can be observed
+SET client_min_messages TO DEBUG1;
+-- no filters on u2
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1);
+DEBUG:  generating subplan 1_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 1_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 1 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('1_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('1_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1))
+ count 
+-------
+ 38501
+(1 row)
+
+-- scalar array expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > ANY(ARRAY[2, 1, 6]);
+DEBUG:  generating subplan 4_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.>) ANY ('{2,1,6}'::integer[]))
+DEBUG:  generating subplan 4_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 4 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('4_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('4_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_1 OPERATOR(pg_catalog.>) ANY (ARRAY[2, 1, 6]))
+ count 
+-------
+ 33398
+(1 row)
+
+-- array operators on the table can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  ARRAY[u2.value_1, u2.value_2] @> (ARRAY[2, 3]);
+DEBUG:  generating subplan 7_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (ARRAY[value_1, value_2] OPERATOR(pg_catalog.@>) '{2,3}'::integer[])
+DEBUG:  generating subplan 7_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('7_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ARRAY[users_table.value_1, users_table.value_2] OPERATOR(pg_catalog.@>) ARRAY[2, 3])
+ count 
+-------
+  4704
+(1 row)
+
+-- array operators on different tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  ARRAY[u2.value_1, u1.user_id] @> (ARRAY[2, 3]);
+DEBUG:  generating subplan 10_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 10_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('10_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ARRAY[users_table.value_1, u1.user_id] OPERATOR(pg_catalog.@>) ARRAY[2, 3])
+ count 
+-------
+  3352
+(1 row)
+
+-- coerced expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1/2.0 > 2)::int::bool::text::bool;
+DEBUG:  generating subplan 13_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (((((((value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) '2'::numeric))::integer)::boolean)::text)::boolean
+DEBUG:  generating subplan 13_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 13 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('13_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('13_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((((((users_table.value_1)::numeric OPERATOR(pg_catalog./) 2.0) OPERATOR(pg_catalog.>) (2)::numeric))::integer)::boolean)::text)::boolean
+ count 
+-------
+   729
+(1 row)
+
+-- case expression on a single table can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (CASE WHEN u2.value_1 > 3 THEN u2.value_1 > 2 ELSE false END);
+DEBUG:  generating subplan 16_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE CASE WHEN (value_1 OPERATOR(pg_catalog.>) 3) THEN (value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
+DEBUG:  generating subplan 16_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 16 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('16_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('16_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE CASE WHEN (users_table.value_1 OPERATOR(pg_catalog.>) 3) THEN (users_table.value_1 OPERATOR(pg_catalog.>) 2) ELSE false END
+ count 
+-------
+  9990
+(1 row)
+
+-- case expression multiple tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (CASE WHEN u1.value_1 > 4000 THEN u2.value_1 / 100 > 1 ELSE false END);
+DEBUG:  generating subplan 19_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 19_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('19_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE CASE WHEN (u1.value_1 OPERATOR(pg_catalog.>) 4000) THEN ((users_table.value_1 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END
+ count 
+-------
+     0
+(1 row)
+
+-- coalesce expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE COALESCE((u2.user_id/5.0)::int::bool, false);
+DEBUG:  generating subplan 22_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE COALESCE(((((user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+DEBUG:  generating subplan 22_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 22 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('22_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE COALESCE(((((users_table.user_id)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+ count 
+-------
+ 28198
+(1 row)
+
+-- nullif expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE NULLIF((u2.value_2/5.0)::int::bool, false);
+DEBUG:  generating subplan 25_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE NULLIF(((((value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+DEBUG:  generating subplan 25_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('25_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE NULLIF(((((users_table.value_2)::numeric OPERATOR(pg_catalog./) 5.0))::integer)::boolean, false)
+ count 
+-------
+ 18895
+(1 row)
+
+-- null test can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_3 IS NOT NULL;
+DEBUG:  generating subplan 28_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_3 IS NOT NULL)
+DEBUG:  generating subplan 28_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 28 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('28_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('28_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_3 IS NOT NULL)
+ count 
+-------
+ 38501
+(1 row)
+
+-- functions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE isfinite(u2.time);
+DEBUG:  generating subplan 31_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE isfinite("time")
+DEBUG:  generating subplan 31_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 31 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('31_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('31_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE isfinite(users_table."time")
+ count 
+-------
+ 38501
+(1 row)
+
+-- functions with multiple tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE int4smaller(u2.value_1, u1.value_1) = 55;
+DEBUG:  generating subplan 34_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 34_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 34 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('34_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('34_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (int4smaller(users_table.value_1, u1.value_1) OPERATOR(pg_catalog.=) 55)
+ count 
+-------
+     0
+(1 row)
+
+-- functions with multiple columns from the same tables can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE int4smaller(u2.value_1, u2.value_2) = u2.value_1;
+DEBUG:  generating subplan 37_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) int4smaller(value_1, value_2))
+DEBUG:  generating subplan 37_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 37 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('37_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('37_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (int4smaller(users_table.value_1, users_table.value_2) OPERATOR(pg_catalog.=) users_table.value_1)
+ count 
+-------
+ 20686
+(1 row)
+
+-- row expressions can be pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE row(u2.value_1, 2, 3) > row(u2.value_2, 2, 3);
+DEBUG:  generating subplan 40_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (ROW(value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(value_2, 2, 3))
+DEBUG:  generating subplan 40_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 40 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('40_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('40_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (ROW(users_table.value_1, 2, 3) OPERATOR(pg_catalog.>) ROW(users_table.value_2, 2, 3))
+ count 
+-------
+ 17815
+(1 row)
+
+-- multiple expression from the same table can be pushed down together
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+	WHERE
+		  (u2.user_id/1.0)::int::bool::text::bool AND
+		  CASE WHEN u2.value_1 > 4000 THEN u2.value_2 / 100 > 1 ELSE false END AND
+		  COALESCE((u2.user_id/50000)::bool, false) AND
+		  NULLIF((u2.value_3/50000)::int::bool, false) AND
+		  isfinite(u2.time) AND
+		  u2.value_4 IS DISTINCT FROM 50040 AND
+		  row(u2.value_4, 2, 3) > row(2000, 2, 3);
+DEBUG:  generating subplan 43_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (((((((user_id)::numeric OPERATOR(pg_catalog./) 1.0))::integer)::boolean)::text)::boolean AND CASE WHEN (value_1 OPERATOR(pg_catalog.>) 4000) THEN ((value_2 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END AND COALESCE(((user_id OPERATOR(pg_catalog./) 50000))::boolean, false) AND NULLIF((((value_3 OPERATOR(pg_catalog./) '50000'::double precision))::integer)::boolean, false) AND isfinite("time") AND (value_4 IS DISTINCT FROM 50040) AND (ROW(value_4, 2, 3) OPERATOR(pg_catalog.>) ROW(2000, 2, 3)))
+DEBUG:  generating subplan 43_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 43 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('43_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('43_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((((((users_table.user_id)::numeric OPERATOR(pg_catalog./) 1.0))::integer)::boolean)::text)::boolean AND CASE WHEN (users_table.value_1 OPERATOR(pg_catalog.>) 4000) THEN ((users_table.value_2 OPERATOR(pg_catalog./) 100) OPERATOR(pg_catalog.>) 1) ELSE false END AND COALESCE(((users_table.user_id OPERATOR(pg_catalog./) 50000))::boolean, false) AND NULLIF((((users_table.value_3 OPERATOR(pg_catalog./) (50000)::double precision))::integer)::boolean, false) AND isfinite(users_table."time") AND (users_table.value_4 IS DISTINCT FROM 50040) AND (ROW(users_table.value_4, 2, 3) OPERATOR(pg_catalog.>) ROW(2000, 2, 3)))
+ count 
+-------
+     0
+(1 row)
+
+-- subqueries are not pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 >
+    (SELECT avg(user_id)
+     FROM events_table);
+DEBUG:  generating subplan 46_1 for subquery SELECT avg(user_id) AS avg FROM public.events_table
+DEBUG:  generating subplan 46_2 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 46_3 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 46 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('46_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('46_3'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1)::numeric OPERATOR(pg_catalog.>) (SELECT intermediate_result.avg FROM read_intermediate_result('46_1'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)))
+ count 
+-------
+  9990
+(1 row)
+
+-- even subqueries with constant values are not pushdowned
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 >
+    (SELECT 5);
+DEBUG:  generating subplan 50_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 50_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 50 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('50_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('50_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (users_table.value_1 OPERATOR(pg_catalog.>) (SELECT 5))
+ count 
+-------
+     0
+(1 row)
+
+-- filters involving multiple tables aren't pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u2.value_1 *  u1.user_id > 25;
+DEBUG:  generating subplan 53_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 53_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 53 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('53_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('53_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.*) u1.user_id) OPERATOR(pg_catalog.>) 25)
+ count 
+-------
+   162
+(1 row)
+
+-- filter on other tables can only be pushdown 
+-- as long as they are equality filters on the
+-- joining column
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_1 = 3;
+DEBUG:  generating subplan 56_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (value_1 OPERATOR(pg_catalog.=) 3)
+DEBUG:  generating subplan 56_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 56 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('56_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('56_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_1 OPERATOR(pg_catalog.=) 3)
+ count 
+-------
+ 17576
+(1 row)
+
+-- but not when the filter is gt, lt or any other thing
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_1 > 3;
+DEBUG:  generating subplan 59_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 59_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 59 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('59_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('59_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_1 OPERATOR(pg_catalog.>) 3)
+ count 
+-------
+  9990
+(1 row)
+
+-- when the filter is on another column than the 
+-- join column, that's obviously not pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_2 = 3;
+DEBUG:  generating subplan 62_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 62_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 62 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('62_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('62_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (u1.value_2 OPERATOR(pg_catalog.=) 3)
+ count 
+-------
+  5618
+(1 row)
+
+-- or filters on the same table is pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > 4 OR u2.value_4 = 4;
+DEBUG:  generating subplan 65_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 4) OR (value_4 OPERATOR(pg_catalog.=) 4))
+DEBUG:  generating subplan 65_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 65 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('65_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('65_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 4) OR (users_table.value_4 OPERATOR(pg_catalog.=) 4))
+ count 
+-------
+   729
+(1 row)
+
+-- and filters on the same table is pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > 2 and u2.value_4 IS NULL;
+DEBUG:  generating subplan 68_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) AND (value_4 IS NULL))
+DEBUG:  generating subplan 68_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 68 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('68_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('68_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND (users_table.value_4 IS NULL))
+ count 
+-------
+ 27566
+(1 row)
+
+-- filters on different tables are pushdown
+-- only the ones that are not ANDed
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
+DEBUG:  generating subplan 71_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL))
+DEBUG:  generating subplan 71_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 71 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('71_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('71_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (users_table.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 27405
+(1 row)
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) OR (u2.user_id > 4 AND u1.user_id > 3);
+DEBUG:  generating subplan 74_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE ((value_1 OPERATOR(pg_catalog.>) 2) OR (value_4 IS NULL) OR (user_id OPERATOR(pg_catalog.>) 4))
+DEBUG:  generating subplan 74_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 74 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('74_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('74_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (users_table.value_4 IS NULL) OR ((users_table.user_id OPERATOR(pg_catalog.>) 4) AND (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 38501
+(1 row)
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 AND u1.user_id > 3);
+DEBUG:  generating subplan 77_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE (user_id OPERATOR(pg_catalog.>) 4)
+DEBUG:  generating subplan 77_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 77 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('77_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('77_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) AND (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+  7883
+(1 row)
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
+DEBUG:  generating subplan 80_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 80_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 80 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('80_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('80_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND ((users_table.user_id OPERATOR(pg_catalog.>) 4) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 27405
+(1 row)
+
+-- see the comment above
+-- but volatile functions are not pushed down 
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id = 10000 * random() OR u1.user_id > 3);
+DEBUG:  generating subplan 83_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 83_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 83 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('83_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('83_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE (((users_table.value_1 OPERATOR(pg_catalog.>) 2) OR (u1.value_4 IS NULL)) AND (((users_table.user_id)::double precision OPERATOR(pg_catalog.=) ((10000)::double precision OPERATOR(pg_catalog.*) random())) OR (u1.user_id OPERATOR(pg_catalog.>) 3)))
+ count 
+-------
+ 22183
+(1 row)
+
+-- TODO: constant results should be pushed down, but not supported yet
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 AND false);
+DEBUG:  generating subplan 86_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  generating subplan 86_2 for subquery SELECT value_1, random() AS random FROM public.users_table
+DEBUG:  Plan 86 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('86_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN (SELECT intermediate_result.value_1, intermediate_result.random FROM read_intermediate_result('86_2'::text, 'binary'::citus_copy_format) intermediate_result(value_1 integer, random double precision)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND false)
+ count 
+-------
+     0
+(1 row)
+
+-- TODO: what should the behaviour be?
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN LATERAL
+  (SELECT value_1,
+          random()
+   FROM users_table
+   WHERE u2.value_2 = 15) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2
+       AND FALSE);
+DEBUG:  generating subplan 89_1 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table u2 WHERE true
+DEBUG:  Plan 89 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((public.users_table u1 JOIN (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('89_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) USING (value_1)) JOIN LATERAL (SELECT users_table_1.value_1, random() AS random FROM public.users_table users_table_1 WHERE (users_table.value_2 OPERATOR(pg_catalog.=) 15)) u3 USING (value_1)) WHERE ((users_table.value_1 OPERATOR(pg_catalog.>) 2) AND false)
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator

--- a/src/test/regress/expected/set_operation_and_local_tables.out
+++ b/src/test/regress/expected/set_operation_and_local_tables.out
@@ -229,17 +229,19 @@ DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 DEBUG:  generating subplan 39_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('39_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('39_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
 DEBUG:  Plan 39 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('39_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN recursive_set_local.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 39_4 for subquery SELECT x, y FROM recursive_set_local.test WHERE true
+DEBUG:  Plan 39 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('39_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('39_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) test(x, y) USING (x)) ORDER BY u.x, u.y
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 -- we replace some queries including the local query, the intermediate result is on the inner part of an outer join 
 SELECT * FROM ((SELECT * FROM local_test) INTERSECT (SELECT * FROM test ORDER BY x LIMIT 1)) u RIGHT JOIN test USING (x) ORDER BY 1,2;
-DEBUG:  generating subplan 42_1 for subquery SELECT x, y FROM recursive_set_local.local_test
+DEBUG:  generating subplan 43_1 for subquery SELECT x, y FROM recursive_set_local.local_test
 DEBUG:  push down of limit count: 1
-DEBUG:  generating subplan 42_2 for subquery SELECT x, y FROM recursive_set_local.test ORDER BY x LIMIT 1
+DEBUG:  generating subplan 43_2 for subquery SELECT x, y FROM recursive_set_local.test ORDER BY x LIMIT 1
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 42_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('42_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('42_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
-DEBUG:  Plan 42 query after replacing subqueries and CTEs: SELECT test.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('42_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u RIGHT JOIN recursive_set_local.test USING (x)) ORDER BY test.x, u.y
+DEBUG:  generating subplan 43_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('43_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('43_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
+DEBUG:  Plan 43 query after replacing subqueries and CTEs: SELECT test.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('43_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u RIGHT JOIN recursive_set_local.test USING (x)) ORDER BY test.x, u.y
  x | y | y 
 ---+---+---
  1 |   | 1
@@ -248,29 +250,29 @@ DEBUG:  Plan 42 query after replacing subqueries and CTEs: SELECT test.x, u.y, t
 
 -- recurively plan left part of the join, and run a final real-time query
 SELECT * FROM ((SELECT * FROM local_test) INTERSECT (SELECT * FROM test ORDER BY x LIMIT 1)) u INNER JOIN test USING (x) ORDER BY 1,2;
-DEBUG:  generating subplan 45_1 for subquery SELECT x, y FROM recursive_set_local.local_test
+DEBUG:  generating subplan 46_1 for subquery SELECT x, y FROM recursive_set_local.local_test
 DEBUG:  push down of limit count: 1
-DEBUG:  generating subplan 45_2 for subquery SELECT x, y FROM recursive_set_local.test ORDER BY x LIMIT 1
+DEBUG:  generating subplan 46_2 for subquery SELECT x, y FROM recursive_set_local.test ORDER BY x LIMIT 1
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 45_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('45_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('45_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
-DEBUG:  Plan 45 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('45_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_set_local.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 46_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('46_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('46_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
+DEBUG:  Plan 46 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('46_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_set_local.test USING (x)) ORDER BY u.x, u.y
  x | y | y 
 ---+---+---
 (0 rows)
 
 -- set operations and the sublink can be recursively planned
 SELECT * FROM ((SELECT x FROM test) UNION (SELECT x FROM (SELECT x FROM local_test) as foo WHERE x IN (SELECT x FROM test))) u ORDER BY 1;
-DEBUG:  generating subplan 48_1 for subquery SELECT x FROM recursive_set_local.local_test
-DEBUG:  generating subplan 48_2 for subquery SELECT x FROM recursive_set_local.test
+DEBUG:  generating subplan 49_1 for subquery SELECT x FROM recursive_set_local.local_test
+DEBUG:  generating subplan 49_2 for subquery SELECT x FROM recursive_set_local.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 48_3 for subquery SELECT x FROM (SELECT intermediate_result.x FROM read_intermediate_result('48_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('48_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer)))
-DEBUG:  generating subplan 48_4 for subquery SELECT x FROM recursive_set_local.test
+DEBUG:  generating subplan 49_3 for subquery SELECT x FROM (SELECT intermediate_result.x FROM read_intermediate_result('49_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('49_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer)))
+DEBUG:  generating subplan 49_4 for subquery SELECT x FROM recursive_set_local.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 48_5 for subquery SELECT intermediate_result.x FROM read_intermediate_result('48_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.x FROM read_intermediate_result('48_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
-DEBUG:  Plan 48 query after replacing subqueries and CTEs: SELECT x FROM (SELECT intermediate_result.x FROM read_intermediate_result('48_5'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) u ORDER BY x
+DEBUG:  generating subplan 49_5 for subquery SELECT intermediate_result.x FROM read_intermediate_result('49_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.x FROM read_intermediate_result('49_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
+DEBUG:  Plan 49 query after replacing subqueries and CTEs: SELECT x FROM (SELECT intermediate_result.x FROM read_intermediate_result('49_5'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) u ORDER BY x
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x 
@@ -313,11 +315,11 @@ DEBUG:  pruning merge fetch taskId 11
 DETAIL:  Creating dependency on merge taskId 20
 DEBUG:  cannot use real time executor with repartition jobs
 HINT:  Since you enabled citus.enable_repartition_joins Citus chose to use task-tracker.
-DEBUG:  generating subplan 53_1 for subquery SELECT t1.x FROM recursive_set_local.test t1, recursive_set_local.test t2 WHERE (t1.x OPERATOR(pg_catalog.=) t2.y) LIMIT 2
-DEBUG:  generating subplan 53_2 for subquery SELECT x FROM recursive_set_local.local_test
-DEBUG:  generating subplan 53_3 for subquery SELECT x FROM recursive_set_local.test
-DEBUG:  generating subplan 53_4 for subquery SELECT x FROM recursive_set_local.test
-DEBUG:  Plan 53 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('53_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT intermediate_result.x FROM read_intermediate_result('53_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT ((SELECT intermediate_result.x FROM read_intermediate_result('53_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION ALL SELECT intermediate_result.x FROM read_intermediate_result('53_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) INTERSECT SELECT i.i FROM generate_series(0, 100) i(i)) ORDER BY 1 DESC
+DEBUG:  generating subplan 54_1 for subquery SELECT t1.x FROM recursive_set_local.test t1, recursive_set_local.test t2 WHERE (t1.x OPERATOR(pg_catalog.=) t2.y) LIMIT 2
+DEBUG:  generating subplan 54_2 for subquery SELECT x FROM recursive_set_local.local_test
+DEBUG:  generating subplan 54_3 for subquery SELECT x FROM recursive_set_local.test
+DEBUG:  generating subplan 54_4 for subquery SELECT x FROM recursive_set_local.test
+DEBUG:  Plan 54 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('54_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT intermediate_result.x FROM read_intermediate_result('54_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT ((SELECT intermediate_result.x FROM read_intermediate_result('54_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION ALL SELECT intermediate_result.x FROM read_intermediate_result('54_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) INTERSECT SELECT i.i FROM generate_series(0, 100) i(i)) ORDER BY 1 DESC
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x 

--- a/src/test/regress/expected/set_operations.out
+++ b/src/test/regress/expected/set_operations.out
@@ -465,16 +465,18 @@ DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 DEBUG:  generating subplan 87_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('87_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION ALL SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('87_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
 DEBUG:  Plan 87 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('87_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 87_4 for subquery SELECT x, y FROM recursive_union.test WHERE true
+DEBUG:  Plan 87 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('87_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('87_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) test(x, y) USING (x)) ORDER BY u.x, u.y
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 -- unions in a join without partition column equality (column names from first query are used for join)
 SELECT * FROM ((SELECT x, y FROM test) UNION (SELECT y, x FROM test)) u JOIN test USING (x) ORDER BY 1,2;
-DEBUG:  generating subplan 91_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 91_2 for subquery SELECT y, x FROM recursive_union.test
+DEBUG:  generating subplan 92_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 92_2 for subquery SELECT y, x FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 91_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('91_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.y, intermediate_result.x FROM read_intermediate_result('91_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer, x integer)
-DEBUG:  Plan 91 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('91_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 92_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('92_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.y, intermediate_result.x FROM read_intermediate_result('92_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer, x integer)
+DEBUG:  Plan 92 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('92_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
  x | y | y 
 ---+---+---
  1 | 1 | 1
@@ -482,12 +484,12 @@ DEBUG:  Plan 91 query after replacing subqueries and CTEs: SELECT u.x, u.y, test
 (2 rows)
 
 SELECT * FROM ((SELECT x, y FROM test) UNION (SELECT 1, 1 FROM test)) u JOIN test USING (x) ORDER BY 1,2;
-DEBUG:  generating subplan 95_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 95_2 for subquery SELECT 1, 1 FROM recursive_union.test
+DEBUG:  generating subplan 96_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 96_2 for subquery SELECT 1, 1 FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 95_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('95_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result."?column?", intermediate_result."?column?_1" AS "?column?" FROM read_intermediate_result('95_2'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer, "?column?_1" integer)
-DEBUG:  Plan 95 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('95_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 96_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('96_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result."?column?", intermediate_result."?column?_1" AS "?column?" FROM read_intermediate_result('96_2'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer, "?column?_1" integer)
+DEBUG:  Plan 96 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('96_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
  x | y | y 
 ---+---+---
  1 | 1 | 1
@@ -504,12 +506,12 @@ DEBUG:  Plan 95 query after replacing subqueries and CTEs: SELECT u.x, u.y, test
 
 -- a join between a set operation and a generate_series which is not pushdownable due to EXCEPT
  SELECT * FROM ((SELECT * FROM test) EXCEPT (SELECT * FROM test ORDER BY x)) u JOIN generate_series(1,10) x USING (x) ORDER BY 1,2;
-DEBUG:  generating subplan 100_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 100_2 for subquery SELECT x, y FROM recursive_union.test ORDER BY x
+DEBUG:  generating subplan 101_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 101_2 for subquery SELECT x, y FROM recursive_union.test ORDER BY x
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 100_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('100_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) EXCEPT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('100_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
-DEBUG:  Plan 100 query after replacing subqueries and CTEs: SELECT u.x, u.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('100_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN generate_series(1, 10) x(x) USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 101_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('101_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) EXCEPT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('101_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
+DEBUG:  Plan 101 query after replacing subqueries and CTEs: SELECT u.x, u.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('101_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN generate_series(1, 10) x(x) USING (x)) ORDER BY u.x, u.y
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x | y 
@@ -523,8 +525,8 @@ DETAIL:  Each leaf query of the UNION should return the partition column in the 
 -- subqueries in WHERE clause forced to be recursively planned
 SELECT * FROM ((SELECT * FROM test) UNION (SELECT * FROM test)) foo WHERE x IN (SELECT y FROM test ORDER BY 1 LIMIT 4) ORDER BY 1;
 DEBUG:  push down of limit count: 4
-DEBUG:  generating subplan 105_1 for subquery SELECT y FROM recursive_union.test ORDER BY y LIMIT 4
-DEBUG:  Plan 105 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT test.x, test.y FROM recursive_union.test UNION SELECT test.x, test.y FROM recursive_union.test) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.y FROM read_intermediate_result('105_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer))) ORDER BY x
+DEBUG:  generating subplan 106_1 for subquery SELECT y FROM recursive_union.test ORDER BY y LIMIT 4
+DEBUG:  Plan 106 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT test.x, test.y FROM recursive_union.test UNION SELECT test.x, test.y FROM recursive_union.test) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.y FROM read_intermediate_result('106_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer))) ORDER BY x
  x | y 
 ---+---
  1 | 1
@@ -534,13 +536,13 @@ DEBUG:  Plan 105 query after replacing subqueries and CTEs: SELECT x, y FROM (SE
 -- now both the set operations and the sublink is recursively planned
 SELECT * FROM ((SELECT x,y FROM test) UNION (SELECT y,x FROM test)) foo WHERE x IN (SELECT y FROM test ORDER BY 1 LIMIT 4) ORDER BY 1;
 DEBUG:  push down of limit count: 4
-DEBUG:  generating subplan 107_1 for subquery SELECT y FROM recursive_union.test ORDER BY y LIMIT 4
-DEBUG:  generating subplan 107_2 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 107_3 for subquery SELECT y, x FROM recursive_union.test
+DEBUG:  generating subplan 108_1 for subquery SELECT y FROM recursive_union.test ORDER BY y LIMIT 4
+DEBUG:  generating subplan 108_2 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 108_3 for subquery SELECT y, x FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 107_4 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('107_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.y, intermediate_result.x FROM read_intermediate_result('107_3'::text, 'binary'::citus_copy_format) intermediate_result(y integer, x integer)
-DEBUG:  Plan 107 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('107_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.y FROM read_intermediate_result('107_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer))) ORDER BY x
+DEBUG:  generating subplan 108_4 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('108_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.y, intermediate_result.x FROM read_intermediate_result('108_3'::text, 'binary'::citus_copy_format) intermediate_result(y integer, x integer)
+DEBUG:  Plan 108 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('108_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.y FROM read_intermediate_result('108_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer))) ORDER BY x
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x | y 
@@ -551,13 +553,13 @@ DEBUG:  Plan is router executable
 
 -- set operations and the sublink can be recursively planned
 SELECT * FROM ((SELECT x,y FROM test) UNION (SELECT y,x FROM test)) foo WHERE x IN (SELECT y FROM test) ORDER BY 1;
-DEBUG:  generating subplan 112_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 112_2 for subquery SELECT y, x FROM recursive_union.test
+DEBUG:  generating subplan 113_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 113_2 for subquery SELECT y, x FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 112_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('112_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.y, intermediate_result.x FROM read_intermediate_result('112_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer, x integer)
-DEBUG:  generating subplan 112_4 for subquery SELECT y FROM recursive_union.test
-DEBUG:  Plan 112 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('112_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.y FROM read_intermediate_result('112_4'::text, 'binary'::citus_copy_format) intermediate_result(y integer))) ORDER BY x
+DEBUG:  generating subplan 113_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('113_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.y, intermediate_result.x FROM read_intermediate_result('113_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer, x integer)
+DEBUG:  generating subplan 113_4 for subquery SELECT y FROM recursive_union.test
+DEBUG:  Plan 113 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('113_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) foo WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.y FROM read_intermediate_result('113_4'::text, 'binary'::citus_copy_format) intermediate_result(y integer))) ORDER BY x
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x | y 
@@ -571,9 +573,9 @@ SELECT x, y, rnk FROM (SELECT *, rank() OVER my_win as rnk FROM test WINDOW my_w
 UNION
 SELECT x, y, rnk FROM (SELECT *, rank() OVER my_win as rnk FROM test WINDOW my_win AS (PARTITION BY x ORDER BY y DESC)) as bar
 ORDER BY 1 DESC, 2 DESC, 3 DESC;
-DEBUG:  generating subplan 117_1 for subquery SELECT x, y, rnk FROM (SELECT test.x, test.y, rank() OVER my_win AS rnk FROM recursive_union.test WINDOW my_win AS (PARTITION BY test.x ORDER BY test.y DESC)) foo
-DEBUG:  generating subplan 117_2 for subquery SELECT x, y, rnk FROM (SELECT test.x, test.y, rank() OVER my_win AS rnk FROM recursive_union.test WINDOW my_win AS (PARTITION BY test.x ORDER BY test.y DESC)) bar
-DEBUG:  Plan 117 query after replacing subqueries and CTEs: SELECT intermediate_result.x, intermediate_result.y, intermediate_result.rnk FROM read_intermediate_result('117_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer, rnk bigint) UNION SELECT intermediate_result.x, intermediate_result.y, intermediate_result.rnk FROM read_intermediate_result('117_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer, rnk bigint) ORDER BY 1 DESC, 2 DESC, 3 DESC
+DEBUG:  generating subplan 118_1 for subquery SELECT x, y, rnk FROM (SELECT test.x, test.y, rank() OVER my_win AS rnk FROM recursive_union.test WINDOW my_win AS (PARTITION BY test.x ORDER BY test.y DESC)) foo
+DEBUG:  generating subplan 118_2 for subquery SELECT x, y, rnk FROM (SELECT test.x, test.y, rank() OVER my_win AS rnk FROM recursive_union.test WINDOW my_win AS (PARTITION BY test.x ORDER BY test.y DESC)) bar
+DEBUG:  Plan 118 query after replacing subqueries and CTEs: SELECT intermediate_result.x, intermediate_result.y, intermediate_result.rnk FROM read_intermediate_result('118_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer, rnk bigint) UNION SELECT intermediate_result.x, intermediate_result.y, intermediate_result.rnk FROM read_intermediate_result('118_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer, rnk bigint) ORDER BY 1 DESC, 2 DESC, 3 DESC
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x | y | rnk 
@@ -591,12 +593,12 @@ HINT:  Window functions are supported in two ways. Either add an equality filter
 -- other set operations in joins also cannot be pushed down
 SELECT * FROM ((SELECT * FROM test) EXCEPT (SELECT * FROM test ORDER BY x LIMIT 1)) u JOIN test USING (x) ORDER BY 1,2;
 DEBUG:  push down of limit count: 1
-DEBUG:  generating subplan 122_1 for subquery SELECT x, y FROM recursive_union.test ORDER BY x LIMIT 1
-DEBUG:  generating subplan 122_2 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 123_1 for subquery SELECT x, y FROM recursive_union.test ORDER BY x LIMIT 1
+DEBUG:  generating subplan 123_2 for subquery SELECT x, y FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 122_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('122_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) EXCEPT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('122_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
-DEBUG:  Plan 122 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('122_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 123_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('123_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) EXCEPT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('123_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
+DEBUG:  Plan 123 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('123_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
  x | y | y 
 ---+---+---
  2 | 2 | 2
@@ -604,25 +606,27 @@ DEBUG:  Plan 122 query after replacing subqueries and CTEs: SELECT u.x, u.y, tes
 
 SELECT * FROM ((SELECT * FROM test) INTERSECT (SELECT * FROM test ORDER BY x LIMIT 1)) u LEFT JOIN test USING (x) ORDER BY 1,2;
 DEBUG:  push down of limit count: 1
-DEBUG:  generating subplan 126_1 for subquery SELECT x, y FROM recursive_union.test ORDER BY x LIMIT 1
-DEBUG:  generating subplan 126_2 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 127_1 for subquery SELECT x, y FROM recursive_union.test ORDER BY x LIMIT 1
+DEBUG:  generating subplan 127_2 for subquery SELECT x, y FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 126_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('126_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('126_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
-DEBUG:  Plan 126 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('126_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 127_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('127_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) INTERSECT SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('127_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)
+DEBUG:  Plan 127 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('127_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN recursive_union.test USING (x)) ORDER BY u.x, u.y
+DEBUG:  generating subplan 127_4 for subquery SELECT x, y FROM recursive_union.test WHERE true
+DEBUG:  Plan 127 query after replacing subqueries and CTEs: SELECT u.x, u.y, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('127_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u LEFT JOIN (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('127_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) test(x, y) USING (x)) ORDER BY u.x, u.y
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 -- distributed table in WHERE clause is recursively planned 
 SELECT * FROM ((SELECT * FROM test) UNION (SELECT * FROM ref WHERE a IN (SELECT x FROM test))) u ORDER BY 1,2;
-DEBUG:  generating subplan 130_1 for subquery SELECT x FROM recursive_union.test
+DEBUG:  generating subplan 132_1 for subquery SELECT x, NULL::integer AS y FROM recursive_union.test WHERE true
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 130_2 for subquery SELECT a, b FROM recursive_union.ref WHERE (a OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('130_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer)))
-DEBUG:  generating subplan 130_3 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 132_2 for subquery SELECT a, b FROM recursive_union.ref WHERE (a OPERATOR(pg_catalog.=) ANY (SELECT test.x FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('132_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) test(x, y)))
+DEBUG:  generating subplan 132_3 for subquery SELECT x, y FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 130_4 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('130_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.a, intermediate_result.b FROM read_intermediate_result('130_2'::text, 'binary'::citus_copy_format) intermediate_result(a integer, b integer)
-DEBUG:  Plan 130 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('130_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u ORDER BY x, y
+DEBUG:  generating subplan 132_4 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('132_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.a, intermediate_result.b FROM read_intermediate_result('132_2'::text, 'binary'::citus_copy_format) intermediate_result(a integer, b integer)
+DEBUG:  Plan 132 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('132_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u ORDER BY x, y
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x | y 
@@ -641,25 +645,25 @@ SELECT * FROM test a WHERE x IN (SELECT x FROM test b WHERE y = 1 UNION SELECT x
 
 -- subquery union in WHERE clause with partition column equality, without implicit join on partition column is recursively planned
 SELECT * FROM test a WHERE x NOT IN (SELECT x FROM test b WHERE y = 1 UNION SELECT x FROM test c WHERE y = 2) ORDER BY 1,2;
-DEBUG:  generating subplan 137_1 for subquery SELECT x FROM recursive_union.test b WHERE (y OPERATOR(pg_catalog.=) 1)
-DEBUG:  generating subplan 137_2 for subquery SELECT x FROM recursive_union.test c WHERE (y OPERATOR(pg_catalog.=) 2)
-DEBUG:  Plan 137 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('137_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.x FROM read_intermediate_result('137_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
+DEBUG:  generating subplan 139_1 for subquery SELECT x FROM recursive_union.test b WHERE (y OPERATOR(pg_catalog.=) 1)
+DEBUG:  generating subplan 139_2 for subquery SELECT x FROM recursive_union.test c WHERE (y OPERATOR(pg_catalog.=) 2)
+DEBUG:  Plan 139 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('139_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.x FROM read_intermediate_result('139_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 136_1 for subquery SELECT b.x FROM recursive_union.test b WHERE (b.y OPERATOR(pg_catalog.=) 1) UNION SELECT c.x FROM recursive_union.test c WHERE (c.y OPERATOR(pg_catalog.=) 2)
-DEBUG:  Plan 136 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (NOT (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('136_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer)))) ORDER BY x, y
+DEBUG:  generating subplan 138_1 for subquery SELECT b.x FROM recursive_union.test b WHERE (b.y OPERATOR(pg_catalog.=) 1) UNION SELECT c.x FROM recursive_union.test c WHERE (c.y OPERATOR(pg_catalog.=) 2)
+DEBUG:  Plan 138 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (NOT (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('138_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer)))) ORDER BY x, y
  x | y 
 ---+---
 (0 rows)
 
 -- subquery union in WHERE clause without parition column equality is recursively planned
 SELECT * FROM test a WHERE x IN (SELECT x FROM test b UNION SELECT y FROM test c) ORDER BY 1,2;
-DEBUG:  generating subplan 140_1 for subquery SELECT x FROM recursive_union.test b
-DEBUG:  generating subplan 140_2 for subquery SELECT y FROM recursive_union.test c
+DEBUG:  generating subplan 142_1 for subquery SELECT x FROM recursive_union.test b
+DEBUG:  generating subplan 142_2 for subquery SELECT y FROM recursive_union.test c
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 140_3 for subquery SELECT intermediate_result.x FROM read_intermediate_result('140_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('140_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
-DEBUG:  Plan 140 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('140_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer))) ORDER BY x, y
+DEBUG:  generating subplan 142_3 for subquery SELECT intermediate_result.x FROM read_intermediate_result('142_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('142_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
+DEBUG:  Plan 142 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('142_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer))) ORDER BY x, y
  x | y 
 ---+---
  1 | 1
@@ -668,24 +672,24 @@ DEBUG:  Plan 140 query after replacing subqueries and CTEs: SELECT x, y FROM rec
 
 -- correlated subquery with union in WHERE clause
 SELECT * FROM test a WHERE x IN (SELECT x FROM test b UNION SELECT y FROM test c WHERE a.x = c.x) ORDER BY 1,2;
-DEBUG:  generating subplan 144_1 for subquery SELECT x FROM recursive_union.test b
+DEBUG:  generating subplan 146_1 for subquery SELECT x FROM recursive_union.test b
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
-DEBUG:  Plan 144 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('144_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT c.y FROM recursive_union.test c WHERE (a.x OPERATOR(pg_catalog.=) c.x))) ORDER BY x, y
+DEBUG:  Plan 146 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('146_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT c.y FROM recursive_union.test c WHERE (a.x OPERATOR(pg_catalog.=) c.x))) ORDER BY x, y
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 -- force unions to be planned while subqueries are being planned
 SELECT * FROM ((SELECT * FROM test) UNION (SELECT * FROM test) ORDER BY 1,2 LIMIT 5) as foo ORDER BY 1 DESC LIMIT 3;
-DEBUG:  generating subplan 147_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 147_2 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  Plan 147 query after replacing subqueries and CTEs: SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('147_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('147_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) ORDER BY 1, 2 LIMIT 5
+DEBUG:  generating subplan 149_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 149_2 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  Plan 149 query after replacing subqueries and CTEs: SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('149_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('149_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) ORDER BY 1, 2 LIMIT 5
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 146_1 for subquery SELECT test.x, test.y FROM recursive_union.test UNION SELECT test.x, test.y FROM recursive_union.test ORDER BY 1, 2 LIMIT 5
-DEBUG:  Plan 146 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('146_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) foo ORDER BY x DESC LIMIT 3
+DEBUG:  generating subplan 148_1 for subquery SELECT test.x, test.y FROM recursive_union.test UNION SELECT test.x, test.y FROM recursive_union.test ORDER BY 1, 2 LIMIT 5
+DEBUG:  Plan 148 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('148_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) foo ORDER BY x DESC LIMIT 3
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x | y 
@@ -696,12 +700,12 @@ DEBUG:  Plan is router executable
 
 -- distinct and count distinct should work without any problems
 select count(DISTINCT t.x) FROM ((SELECT DISTINCT x FROM test) UNION (SELECT DISTINCT y FROM test)) as t(x) ORDER BY 1;
-DEBUG:  generating subplan 150_1 for subquery SELECT DISTINCT y FROM recursive_union.test
-DEBUG:  generating subplan 150_2 for subquery SELECT DISTINCT x FROM recursive_union.test
+DEBUG:  generating subplan 152_1 for subquery SELECT DISTINCT y FROM recursive_union.test
+DEBUG:  generating subplan 152_2 for subquery SELECT DISTINCT x FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 150_3 for subquery SELECT intermediate_result.x FROM read_intermediate_result('150_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('150_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
-DEBUG:  Plan 150 query after replacing subqueries and CTEs: SELECT count(DISTINCT x) AS count FROM (SELECT intermediate_result.x FROM read_intermediate_result('150_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) t(x) ORDER BY (count(DISTINCT x))
+DEBUG:  generating subplan 152_3 for subquery SELECT intermediate_result.x FROM read_intermediate_result('152_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('152_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
+DEBUG:  Plan 152 query after replacing subqueries and CTEs: SELECT count(DISTINCT x) AS count FROM (SELECT intermediate_result.x FROM read_intermediate_result('152_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) t(x) ORDER BY (count(DISTINCT x))
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -710,12 +714,12 @@ DEBUG:  Plan is router executable
 (1 row)
 
 select count(DISTINCT t.x) FROM ((SELECT count(DISTINCT x) FROM test) UNION (SELECT count(DISTINCT y) FROM test)) as t(x) ORDER BY 1;
-DEBUG:  generating subplan 154_1 for subquery SELECT count(DISTINCT x) AS count FROM recursive_union.test
-DEBUG:  generating subplan 154_2 for subquery SELECT count(DISTINCT y) AS count FROM recursive_union.test
+DEBUG:  generating subplan 156_1 for subquery SELECT count(DISTINCT x) AS count FROM recursive_union.test
+DEBUG:  generating subplan 156_2 for subquery SELECT count(DISTINCT y) AS count FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 154_3 for subquery SELECT intermediate_result.count FROM read_intermediate_result('154_1'::text, 'binary'::citus_copy_format) intermediate_result(count bigint) UNION SELECT intermediate_result.count FROM read_intermediate_result('154_2'::text, 'binary'::citus_copy_format) intermediate_result(count bigint)
-DEBUG:  Plan 154 query after replacing subqueries and CTEs: SELECT count(DISTINCT x) AS count FROM (SELECT intermediate_result.count FROM read_intermediate_result('154_3'::text, 'binary'::citus_copy_format) intermediate_result(count bigint)) t(x) ORDER BY (count(DISTINCT x))
+DEBUG:  generating subplan 156_3 for subquery SELECT intermediate_result.count FROM read_intermediate_result('156_1'::text, 'binary'::citus_copy_format) intermediate_result(count bigint) UNION SELECT intermediate_result.count FROM read_intermediate_result('156_2'::text, 'binary'::citus_copy_format) intermediate_result(count bigint)
+DEBUG:  Plan 156 query after replacing subqueries and CTEs: SELECT count(DISTINCT x) AS count FROM (SELECT intermediate_result.count FROM read_intermediate_result('156_3'::text, 'binary'::citus_copy_format) intermediate_result(count bigint)) t(x) ORDER BY (count(DISTINCT x))
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  count 
@@ -725,12 +729,12 @@ DEBUG:  Plan is router executable
 
 -- other agg. distincts are also supported when group by includes partition key 
 select avg(DISTINCT t.x) FROM ((SELECT avg(DISTINCT y) FROM test GROUP BY x) UNION (SELECT avg(DISTINCT y) FROM test GROUP BY x)) as t(x) ORDER BY 1;
-DEBUG:  generating subplan 158_1 for subquery SELECT avg(DISTINCT y) AS avg FROM recursive_union.test GROUP BY x
-DEBUG:  generating subplan 158_2 for subquery SELECT avg(DISTINCT y) AS avg FROM recursive_union.test GROUP BY x
+DEBUG:  generating subplan 160_1 for subquery SELECT avg(DISTINCT y) AS avg FROM recursive_union.test GROUP BY x
+DEBUG:  generating subplan 160_2 for subquery SELECT avg(DISTINCT y) AS avg FROM recursive_union.test GROUP BY x
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 158_3 for subquery SELECT intermediate_result.avg FROM read_intermediate_result('158_1'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric) UNION SELECT intermediate_result.avg FROM read_intermediate_result('158_2'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)
-DEBUG:  Plan 158 query after replacing subqueries and CTEs: SELECT avg(DISTINCT x) AS avg FROM (SELECT intermediate_result.avg FROM read_intermediate_result('158_3'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)) t(x) ORDER BY (avg(DISTINCT x))
+DEBUG:  generating subplan 160_3 for subquery SELECT intermediate_result.avg FROM read_intermediate_result('160_1'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric) UNION SELECT intermediate_result.avg FROM read_intermediate_result('160_2'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)
+DEBUG:  Plan 160 query after replacing subqueries and CTEs: SELECT avg(DISTINCT x) AS avg FROM (SELECT intermediate_result.avg FROM read_intermediate_result('160_3'::text, 'binary'::citus_copy_format) intermediate_result(avg numeric)) t(x) ORDER BY (avg(DISTINCT x))
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
           avg           
@@ -777,9 +781,9 @@ DEBUG:  pruning merge fetch taskId 11
 DETAIL:  Creating dependency on merge taskId 20
 DEBUG:  cannot use real time executor with repartition jobs
 HINT:  Since you enabled citus.enable_repartition_joins Citus chose to use task-tracker.
-DEBUG:  generating subplan 164_1 for subquery SELECT t1.x FROM recursive_union.test t1, recursive_union.test t2 WHERE (t1.x OPERATOR(pg_catalog.=) t2.y) LIMIT 0
-DEBUG:  generating subplan 164_2 for subquery SELECT x FROM recursive_union.test
-DEBUG:  Plan 164 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('164_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT intermediate_result.x FROM read_intermediate_result('164_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) ORDER BY 1 DESC
+DEBUG:  generating subplan 166_1 for subquery SELECT t1.x FROM recursive_union.test t1, recursive_union.test t2 WHERE (t1.x OPERATOR(pg_catalog.=) t2.y) LIMIT 0
+DEBUG:  generating subplan 166_2 for subquery SELECT x FROM recursive_union.test
+DEBUG:  Plan 166 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('166_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT intermediate_result.x FROM read_intermediate_result('166_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) ORDER BY 1 DESC
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x 
@@ -818,9 +822,9 @@ DEBUG:  pruning merge fetch taskId 11
 DETAIL:  Creating dependency on merge taskId 20
 DEBUG:  cannot use real time executor with repartition jobs
 HINT:  Since you enabled citus.enable_repartition_joins Citus chose to use task-tracker.
-DEBUG:  generating subplan 167_1 for subquery SELECT t1.x FROM recursive_union.test t1, recursive_union.test t2 WHERE (t1.x OPERATOR(pg_catalog.=) t2.y)
-DEBUG:  generating subplan 167_2 for subquery SELECT x FROM recursive_union.test
-DEBUG:  Plan 167 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('167_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT intermediate_result.x FROM read_intermediate_result('167_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) ORDER BY 1 DESC
+DEBUG:  generating subplan 169_1 for subquery SELECT t1.x FROM recursive_union.test t1, recursive_union.test t2 WHERE (t1.x OPERATOR(pg_catalog.=) t2.y)
+DEBUG:  generating subplan 169_2 for subquery SELECT x FROM recursive_union.test
+DEBUG:  Plan 169 query after replacing subqueries and CTEs: SELECT intermediate_result.x FROM read_intermediate_result('169_2'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT intermediate_result.x FROM read_intermediate_result('169_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) ORDER BY 1 DESC
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x 
@@ -833,12 +837,12 @@ SET citus.enable_repartition_joins TO OFF;
 -- this should be recursively planned
 CREATE VIEW set_view_recursive AS (SELECT y FROM test) UNION (SELECT y FROM test);
 SELECT * FROM set_view_recursive ORDER BY 1 DESC;
-DEBUG:  generating subplan 170_1 for subquery SELECT y FROM recursive_union.test
-DEBUG:  generating subplan 170_2 for subquery SELECT y FROM recursive_union.test
+DEBUG:  generating subplan 172_1 for subquery SELECT y FROM recursive_union.test
+DEBUG:  generating subplan 172_2 for subquery SELECT y FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 170_3 for subquery SELECT intermediate_result.y FROM read_intermediate_result('170_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('170_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
-DEBUG:  Plan 170 query after replacing subqueries and CTEs: SELECT y FROM (SELECT intermediate_result.y FROM read_intermediate_result('170_3'::text, 'binary'::citus_copy_format) intermediate_result(y integer)) set_view_recursive ORDER BY y DESC
+DEBUG:  generating subplan 172_3 for subquery SELECT intermediate_result.y FROM read_intermediate_result('172_1'::text, 'binary'::citus_copy_format) intermediate_result(y integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('172_2'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
+DEBUG:  Plan 172 query after replacing subqueries and CTEs: SELECT y FROM (SELECT intermediate_result.y FROM read_intermediate_result('172_3'::text, 'binary'::citus_copy_format) intermediate_result(y integer)) set_view_recursive ORDER BY y DESC
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  y 
@@ -859,12 +863,12 @@ SELECT * FROM set_view_pushdown ORDER BY 1 DESC;
 -- this should be recursively planned
 CREATE VIEW set_view_recursive_second AS SELECT u.x, test.y FROM ((SELECT x, y FROM test) UNION (SELECT 1, 1 FROM test)) u JOIN test USING (x) ORDER BY 1,2;
 SELECT * FROM set_view_recursive_second;
-DEBUG:  generating subplan 175_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 175_2 for subquery SELECT 1, 1 FROM recursive_union.test
+DEBUG:  generating subplan 177_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 177_2 for subquery SELECT 1, 1 FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 175_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('175_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result."?column?", intermediate_result."?column?_1" AS "?column?" FROM read_intermediate_result('175_2'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer, "?column?_1" integer)
-DEBUG:  Plan 175 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT u.x, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('175_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, test.y) set_view_recursive_second
+DEBUG:  generating subplan 177_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('177_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result."?column?", intermediate_result."?column?_1" AS "?column?" FROM read_intermediate_result('177_2'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer, "?column?_1" integer)
+DEBUG:  Plan 177 query after replacing subqueries and CTEs: SELECT x, y FROM (SELECT u.x, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('177_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, test.y) set_view_recursive_second
  x | y 
 ---+---
  1 | 1
@@ -873,19 +877,19 @@ DEBUG:  Plan 175 query after replacing subqueries and CTEs: SELECT x, y FROM (SE
 
 -- this should create lots of recursive calls since both views and set operations lead to recursive plans :) 
 ((SELECT x FROM set_view_recursive_second) INTERSECT (SELECT * FROM set_view_recursive)) EXCEPT (SELECT * FROM set_view_pushdown);
-DEBUG:  generating subplan 179_1 for subquery SELECT x, y FROM recursive_union.test
-DEBUG:  generating subplan 179_2 for subquery SELECT 1, 1 FROM recursive_union.test
+DEBUG:  generating subplan 181_1 for subquery SELECT x, y FROM recursive_union.test
+DEBUG:  generating subplan 181_2 for subquery SELECT 1, 1 FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 179_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('179_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result."?column?", intermediate_result."?column?_1" AS "?column?" FROM read_intermediate_result('179_2'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer, "?column?_1" integer)
-DEBUG:  generating subplan 179_4 for subquery SELECT y FROM recursive_union.test
-DEBUG:  generating subplan 179_5 for subquery SELECT y FROM recursive_union.test
+DEBUG:  generating subplan 181_3 for subquery SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('181_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer) UNION SELECT intermediate_result."?column?", intermediate_result."?column?_1" AS "?column?" FROM read_intermediate_result('181_2'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer, "?column?_1" integer)
+DEBUG:  generating subplan 181_4 for subquery SELECT y FROM recursive_union.test
+DEBUG:  generating subplan 181_5 for subquery SELECT y FROM recursive_union.test
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-DEBUG:  generating subplan 179_6 for subquery SELECT intermediate_result.y FROM read_intermediate_result('179_4'::text, 'binary'::citus_copy_format) intermediate_result(y integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('179_5'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
-DEBUG:  generating subplan 179_7 for subquery SELECT x FROM (SELECT u.x, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('179_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, test.y) set_view_recursive_second
-DEBUG:  generating subplan 179_8 for subquery SELECT x FROM (SELECT test.x FROM recursive_union.test UNION SELECT test.x FROM recursive_union.test) set_view_pushdown
-DEBUG:  Plan 179 query after replacing subqueries and CTEs: (SELECT intermediate_result.x FROM read_intermediate_result('179_7'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT set_view_recursive.y FROM (SELECT intermediate_result.y FROM read_intermediate_result('179_6'::text, 'binary'::citus_copy_format) intermediate_result(y integer)) set_view_recursive) EXCEPT SELECT intermediate_result.x FROM read_intermediate_result('179_8'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
+DEBUG:  generating subplan 181_6 for subquery SELECT intermediate_result.y FROM read_intermediate_result('181_4'::text, 'binary'::citus_copy_format) intermediate_result(y integer) UNION SELECT intermediate_result.y FROM read_intermediate_result('181_5'::text, 'binary'::citus_copy_format) intermediate_result(y integer)
+DEBUG:  generating subplan 181_7 for subquery SELECT x FROM (SELECT u.x, test.y FROM ((SELECT intermediate_result.x, intermediate_result.y FROM read_intermediate_result('181_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer, y integer)) u JOIN recursive_union.test USING (x)) ORDER BY u.x, test.y) set_view_recursive_second
+DEBUG:  generating subplan 181_8 for subquery SELECT x FROM (SELECT test.x FROM recursive_union.test UNION SELECT test.x FROM recursive_union.test) set_view_pushdown
+DEBUG:  Plan 181 query after replacing subqueries and CTEs: (SELECT intermediate_result.x FROM read_intermediate_result('181_7'::text, 'binary'::citus_copy_format) intermediate_result(x integer) INTERSECT SELECT set_view_recursive.y FROM (SELECT intermediate_result.y FROM read_intermediate_result('181_6'::text, 'binary'::citus_copy_format) intermediate_result(y integer)) set_view_recursive) EXCEPT SELECT intermediate_result.x FROM read_intermediate_result('181_8'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  x 

--- a/src/test/regress/expected/subqueries_not_supported.out
+++ b/src/test/regress/expected/subqueries_not_supported.out
@@ -115,6 +115,8 @@ FROM
 DEBUG:  push down of limit count: 5
 DEBUG:  generating subplan 14_1 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4]))) LIMIT 5
 DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT foo.value_2 FROM ((SELECT intermediate_result.value_2 FROM read_intermediate_result('14_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) foo LEFT JOIN (SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))) bar ON ((foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)))
+DEBUG:  generating subplan 14_2 for subquery SELECT users_table.value_2 FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[5, 6, 7, 8])))
+DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT foo.value_2 FROM ((SELECT intermediate_result.value_2 FROM read_intermediate_result('14_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) foo LEFT JOIN (SELECT intermediate_result.value_2 FROM read_intermediate_result('14_2'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer)) bar ON ((foo.value_2 OPERATOR(pg_catalog.=) bar.value_2)))
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 -- Aggregates in subquery without partition column can be planned recursively

--- a/src/test/regress/expected/subquery_in_where.out
+++ b/src/test/regress/expected/subquery_in_where.out
@@ -44,8 +44,8 @@ FROM   (SELECT 1 AS id,
                3 AS value_3) AS tt1 
 WHERE  id IN (SELECT user_id 
               FROM   events_table); 
-DEBUG:  generating subplan 6_1 for subquery SELECT user_id FROM public.events_table
-DEBUG:  Plan 6 query after replacing subqueries and CTEs: SELECT id, value_1, value_3 FROM (SELECT 1 AS id, 2 AS value_1, 3 AS value_3) tt1 WHERE (id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('6_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))
+DEBUG:  generating subplan 6_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", NULL::integer AS event_type, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.events_table WHERE true
+DEBUG:  Plan 6 query after replacing subqueries and CTEs: SELECT id, value_1, value_3 FROM (SELECT 1 AS id, 2 AS value_1, 3 AS value_3) tt1 WHERE (id OPERATOR(pg_catalog.=) ANY (SELECT events_table.user_id FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.event_type, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('6_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, event_type integer, value_2 integer, value_3 double precision, value_4 bigint)) events_table(user_id, "time", event_type, value_2, value_3, value_4)))
  id | value_1 | value_3 
 ----+---------+---------
   1 |       2 |       3
@@ -580,8 +580,8 @@ IN
 	)
 ORDER BY
 	generate_series ASC;
-DEBUG:  generating subplan 63_1 for subquery SELECT value_2 FROM public.events_table
-DEBUG:  Plan 63 query after replacing subqueries and CTEs: SELECT generate_series FROM (SELECT generate_series.generate_series FROM generate_series(1, 10) generate_series(generate_series)) gst WHERE (generate_series OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value_2 FROM read_intermediate_result('63_1'::text, 'binary'::citus_copy_format) intermediate_result(value_2 integer))) ORDER BY generate_series
+DEBUG:  generating subplan 63_1 for subquery SELECT NULL::integer AS user_id, NULL::timestamp without time zone AS "time", NULL::integer AS event_type, value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.events_table WHERE true
+DEBUG:  Plan 63 query after replacing subqueries and CTEs: SELECT generate_series FROM (SELECT generate_series.generate_series FROM generate_series(1, 10) generate_series(generate_series)) gst WHERE (generate_series OPERATOR(pg_catalog.=) ANY (SELECT events_table.value_2 FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.event_type, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('63_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, event_type integer, value_2 integer, value_3 double precision, value_4 bigint)) events_table(user_id, "time", event_type, value_2, value_3, value_4))) ORDER BY generate_series
  generate_series 
 -----------------
                1
@@ -618,8 +618,9 @@ IN
 	)
 ORDER BY
 	generate_series ASC;
-DEBUG:  generating subplan 65_1 for subquery SELECT user_id FROM public.users_table WHERE (user_id OPERATOR(pg_catalog.=) ANY (SELECT generate_series.generate_series FROM generate_series(1, 3) generate_series(generate_series)))
-DEBUG:  Plan 65 query after replacing subqueries and CTEs: SELECT generate_series FROM (SELECT generate_series.generate_series FROM generate_series(1, 10) generate_series(generate_series)) gst WHERE (generate_series OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('65_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer))) ORDER BY generate_series
+DEBUG:  generating subplan 65_1 for subquery SELECT user_id, NULL::timestamp without time zone AS "time", NULL::integer AS value_1, NULL::integer AS value_2, NULL::double precision AS value_3, NULL::bigint AS value_4 FROM public.users_table WHERE true
+DEBUG:  generating subplan 65_2 for subquery SELECT user_id FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('65_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) users_table(user_id, "time", value_1, value_2, value_3, value_4) WHERE (user_id OPERATOR(pg_catalog.=) ANY (SELECT generate_series.generate_series FROM generate_series(1, 3) generate_series(generate_series)))
+DEBUG:  Plan 65 query after replacing subqueries and CTEs: SELECT generate_series FROM (SELECT generate_series.generate_series FROM generate_series(1, 10) generate_series(generate_series)) gst WHERE (generate_series OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('65_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer))) ORDER BY generate_series
  generate_series 
 -----------------
                1
@@ -646,9 +647,9 @@ IN
 		user_id
 	FROM
 		users_table);
-DEBUG:  generating subplan 67_1 for subquery SELECT id, value_1 FROM subquery_in_where.local_table
-DEBUG:  generating subplan 67_2 for subquery SELECT user_id FROM public.users_table
-DEBUG:  Plan 67 query after replacing subqueries and CTEs: SELECT id, value_1 FROM (SELECT intermediate_result.id, intermediate_result.value_1 FROM read_intermediate_result('67_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, value_1 integer)) sub_table WHERE (id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('67_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))
+DEBUG:  generating subplan 68_1 for subquery SELECT id, value_1 FROM subquery_in_where.local_table
+DEBUG:  generating subplan 68_2 for subquery SELECT user_id FROM public.users_table
+DEBUG:  Plan 68 query after replacing subqueries and CTEs: SELECT id, value_1 FROM (SELECT intermediate_result.id, intermediate_result.value_1 FROM read_intermediate_result('68_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, value_1 integer)) sub_table WHERE (id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('68_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))
  id | value_1 
 ----+---------
   1 |       1
@@ -675,10 +676,10 @@ IN
 		id
 	FROM
 		local_table);
-DEBUG:  generating subplan 69_1 for subquery SELECT id FROM subquery_in_where.local_table
+DEBUG:  generating subplan 70_1 for subquery SELECT id FROM subquery_in_where.local_table
 DEBUG:  push down of limit count: 10
-DEBUG:  generating subplan 69_2 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table ORDER BY user_id LIMIT 10
-DEBUG:  Plan 69 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('69_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) sub_table WHERE (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.id FROM read_intermediate_result('69_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer)))
+DEBUG:  generating subplan 70_2 for subquery SELECT user_id, "time", value_1, value_2, value_3, value_4 FROM public.users_table ORDER BY user_id LIMIT 10
+DEBUG:  Plan 70 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.user_id, intermediate_result."time", intermediate_result.value_1, intermediate_result.value_2, intermediate_result.value_3, intermediate_result.value_4 FROM read_intermediate_result('70_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, "time" timestamp without time zone, value_1 integer, value_2 integer, value_3 double precision, value_4 bigint)) sub_table WHERE (user_id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.id FROM read_intermediate_result('70_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer)))
  count 
 -------
     10

--- a/src/test/regress/input/multi_outer_join_reference.source
+++ b/src/test/regress/input/multi_outer_join_reference.source
@@ -149,12 +149,15 @@ FROM
 	multi_outer_join_left_hash a LEFT JOIN multi_outer_join_right_reference b
 	ON (l_custkey = r_custkey AND l_custkey = -1 /* nonexistant */);
 
--- Right join should be disallowed in this case
+SET client_min_messages TO DEBUG1;
+-- Right join should be allowed in this case
+-- since the table in the inner part can be recursively
+-- planned
 SELECT
 	min(r_custkey), max(r_custkey)
 FROM
 	multi_outer_join_left_hash a RIGHT JOIN multi_outer_join_right_reference b ON (l_custkey = r_custkey);
-
+SET client_min_messages TO LOG;
 
 -- Reverse right join should be same as left join
 SELECT
@@ -243,13 +246,15 @@ FROM
 	multi_outer_join_left_hash a LEFT JOIN multi_outer_join_right_reference b
 	ON (l_custkey = r_custkey AND r_custkey = 21);
 
-
--- Right join should not be allowed in this case
+SET client_min_messages TO DEBUG;
+-- Right join should be allowed in this case
+-- since the table in the inner part can be recursively
+-- planned
 SELECT
 	min(r_custkey), max(r_custkey)
 FROM
 	multi_outer_join_left_hash a RIGHT JOIN multi_outer_join_right_reference b ON (l_custkey = r_custkey);
-
+SET client_min_messages TO LOG;
 
 -- Reverse right join should be same as left join
 SELECT
@@ -279,6 +284,8 @@ WHERE
 	r1.r_custkey is NULL;
 
 -- Three way join 2-1-1 (broadcast + broadcast join) should work
+-- after #2481 since we're hitting aggressive outer join checks
+SET client_min_messages TO DEBUG;
 SELECT
 	l_custkey, r_custkey, t_custkey
 FROM
@@ -286,6 +293,7 @@ FROM
 	LEFT JOIN multi_outer_join_right_reference r1 ON (l1.l_custkey = r1.r_custkey)
 	LEFT JOIN multi_outer_join_third_reference t1 ON (r1.r_custkey  = t1.t_custkey)
 ORDER BY 1;
+SET client_min_messages TO LOG;
 
 -- Right join with single shard right most table should error out
 SELECT

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -54,7 +54,7 @@ test: multi_partitioning_utils multi_partitioning replicated_partitioned_table
 test: subquery_basics subquery_local_tables subquery_executors subquery_and_cte set_operations set_operation_and_local_tables
 test: subqueries_deep subquery_view subquery_partitioning subquery_complex_target_list subqueries_not_supported subquery_in_where 
 test: non_colocated_leaf_subquery_joins non_colocated_subquery_joins non_colocated_join_order
-test: subquery_prepared_statements 
+test: subquery_prepared_statements recursive_relation_planning_restriction_pushdown
 
 # ----------
 # Miscellaneous tests to check our query planning behavior

--- a/src/test/regress/output/multi_outer_join_reference.source
+++ b/src/test/regress/output/multi_outer_join_reference.source
@@ -208,13 +208,23 @@ LOG:  join order: [ "multi_outer_join_left_hash" ][ reference join "multi_outer_
     20 |     0
 (1 row)
 
--- Right join should be disallowed in this case
+SET client_min_messages TO DEBUG1;
+-- Right join should be allowed in this case
+-- since the table in the inner part can be recursively
+-- planned
 SELECT
 	min(r_custkey), max(r_custkey)
 FROM
 	multi_outer_join_left_hash a RIGHT JOIN multi_outer_join_right_reference b ON (l_custkey = r_custkey);
-ERROR:  cannot run outer join query if join is not on the partition column
-DETAIL:  Outer joins requiring repartitioning are not supported.
+LOG:  join order: [ "multi_outer_join_left_hash" ]
+DEBUG:  generating subplan 12_1 for subquery SELECT l_custkey, NULL::character varying(25) AS l_name, NULL::character varying(40) AS l_address, NULL::integer AS l_nationkey, NULL::character(15) AS l_phone, NULL::numeric(15,2) AS l_acctbal, NULL::character(10) AS l_mktsegment, NULL::character varying(117) AS l_comment FROM public.multi_outer_join_left_hash a WHERE true
+DEBUG:  Plan 12 query after replacing subqueries and CTEs: SELECT min(b.r_custkey) AS min, max(b.r_custkey) AS max FROM ((SELECT intermediate_result.l_custkey, intermediate_result.l_name, intermediate_result.l_address, intermediate_result.l_nationkey, intermediate_result.l_phone, intermediate_result.l_acctbal, intermediate_result.l_mktsegment, intermediate_result.l_comment FROM read_intermediate_result('12_1'::text, 'binary'::citus_copy_format) intermediate_result(l_custkey integer, l_name character varying(25), l_address character varying(40), l_nationkey integer, l_phone character(15), l_acctbal numeric(15,2), l_mktsegment character(10), l_comment character varying(117))) multi_outer_join_left_hash(l_custkey, l_name, l_address, l_nationkey, l_phone, l_acctbal, l_mktsegment, l_comment) RIGHT JOIN public.multi_outer_join_right_reference b ON ((multi_outer_join_left_hash.l_custkey OPERATOR(pg_catalog.=) b.r_custkey)))
+ min | max 
+-----+-----
+   1 |  15
+(1 row)
+
+SET client_min_messages TO LOG;
 -- Reverse right join should be same as left join
 SELECT
 	min(l_custkey), max(l_custkey)
@@ -330,13 +340,25 @@ LOG:  join order: [ "multi_outer_join_left_hash" ][ reference join "multi_outer_
     25 |     1
 (1 row)
 
--- Right join should not be allowed in this case
+SET client_min_messages TO DEBUG;
+-- Right join should be allowed in this case
+-- since the table in the inner part can be recursively
+-- planned
 SELECT
 	min(r_custkey), max(r_custkey)
 FROM
 	multi_outer_join_left_hash a RIGHT JOIN multi_outer_join_right_reference b ON (l_custkey = r_custkey);
-ERROR:  cannot run outer join query if join is not on the partition column
-DETAIL:  Outer joins requiring repartitioning are not supported.
+LOG:  join order: [ "multi_outer_join_left_hash" ]
+DEBUG:  generating subplan 22_1 for subquery SELECT l_custkey, NULL::character varying(25) AS l_name, NULL::character varying(40) AS l_address, NULL::integer AS l_nationkey, NULL::character(15) AS l_phone, NULL::numeric(15,2) AS l_acctbal, NULL::character(10) AS l_mktsegment, NULL::character varying(117) AS l_comment FROM public.multi_outer_join_left_hash a WHERE true
+DEBUG:  Plan 22 query after replacing subqueries and CTEs: SELECT min(b.r_custkey) AS min, max(b.r_custkey) AS max FROM ((SELECT intermediate_result.l_custkey, intermediate_result.l_name, intermediate_result.l_address, intermediate_result.l_nationkey, intermediate_result.l_phone, intermediate_result.l_acctbal, intermediate_result.l_mktsegment, intermediate_result.l_comment FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(l_custkey integer, l_name character varying(25), l_address character varying(40), l_nationkey integer, l_phone character(15), l_acctbal numeric(15,2), l_mktsegment character(10), l_comment character varying(117))) multi_outer_join_left_hash(l_custkey, l_name, l_address, l_nationkey, l_phone, l_acctbal, l_mktsegment, l_comment) RIGHT JOIN public.multi_outer_join_right_reference b ON ((multi_outer_join_left_hash.l_custkey OPERATOR(pg_catalog.=) b.r_custkey)))
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ min | max 
+-----+-----
+  11 |  30
+(1 row)
+
+SET client_min_messages TO LOG;
 -- Reverse right join should be same as left join
 SELECT
 	min(l_custkey), max(l_custkey)
@@ -371,6 +393,8 @@ WHERE
 ERROR:  could not run distributed query with complex join orders
 HINT:  Consider joining tables on partition column and have equal filter on joining columns.
 -- Three way join 2-1-1 (broadcast + broadcast join) should work
+-- after #2481 since we're hitting aggressive outer join checks
+SET client_min_messages TO DEBUG;
 SELECT
 	l_custkey, r_custkey, t_custkey
 FROM
@@ -378,36 +402,13 @@ FROM
 	LEFT JOIN multi_outer_join_right_reference r1 ON (l1.l_custkey = r1.r_custkey)
 	LEFT JOIN multi_outer_join_third_reference t1 ON (r1.r_custkey  = t1.t_custkey)
 ORDER BY 1;
-LOG:  join order: [ "multi_outer_join_left_hash" ][ reference join "multi_outer_join_right_reference" ][ reference join "multi_outer_join_third_reference" ]
- l_custkey | r_custkey | t_custkey 
------------+-----------+-----------
-         1 |           |          
-         2 |           |          
-         3 |           |          
-         4 |           |          
-         5 |           |          
-         6 |           |          
-         7 |           |          
-         8 |           |          
-         9 |           |          
-        10 |           |          
-        11 |        11 |        11
-        12 |        12 |        12
-        13 |        13 |        13
-        14 |        14 |        14
-        15 |        15 |        15
-        21 |        21 |        21
-        22 |        22 |        22
-        23 |        23 |        23
-        24 |        24 |        24
-        25 |        25 |        25
-        26 |        26 |        26
-        27 |        27 |        27
-        28 |        28 |        28
-        29 |        29 |        29
-        30 |        30 |        30
-(25 rows)
-
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan 27_1 for subquery SELECT t_custkey, NULL::character varying(25) AS t_name, NULL::character varying(40) AS t_address, NULL::integer AS t_nationkey, NULL::character(15) AS t_phone, NULL::numeric(15,2) AS t_acctbal, NULL::character(10) AS t_mktsegment, NULL::character varying(117) AS t_comment FROM public.multi_outer_join_third_reference t1 WHERE true
+DEBUG:  Plan 27 query after replacing subqueries and CTEs: SELECT l1.l_custkey, r1.r_custkey, multi_outer_join_third_reference.t_custkey FROM ((public.multi_outer_join_left_hash l1 LEFT JOIN public.multi_outer_join_right_reference r1 ON ((l1.l_custkey OPERATOR(pg_catalog.=) r1.r_custkey))) LEFT JOIN (SELECT intermediate_result.t_custkey, intermediate_result.t_name, intermediate_result.t_address, intermediate_result.t_nationkey, intermediate_result.t_phone, intermediate_result.t_acctbal, intermediate_result.t_mktsegment, intermediate_result.t_comment FROM read_intermediate_result('27_1'::text, 'binary'::citus_copy_format) intermediate_result(t_custkey integer, t_name character varying(25), t_address character varying(40), t_nationkey integer, t_phone character(15), t_acctbal numeric(15,2), t_mktsegment character(10), t_comment character varying(117))) multi_outer_join_third_reference(t_custkey, t_name, t_address, t_nationkey, t_phone, t_acctbal, t_mktsegment, t_comment) ON ((r1.r_custkey OPERATOR(pg_catalog.=) multi_outer_join_third_reference.t_custkey))) ORDER BY l1.l_custkey
+ERROR:  cannot pushdown the subquery
+DETAIL:  There exist a reference table in the outer part of the outer join
+SET client_min_messages TO LOG;
 -- Right join with single shard right most table should error out
 SELECT
 	l_custkey, r_custkey, t_custkey

--- a/src/test/regress/sql/recursive_relation_planning_restriction_pushdown.sql
+++ b/src/test/regress/sql/recursive_relation_planning_restriction_pushdown.sql
@@ -1,0 +1,349 @@
+----------------------------------------------------
+-- recursive_relation_planning_restirction_pushdown
+-- In this test file, we mosly test whether Citus
+-- can successfully pushdown filters to the subquery
+-- that is 
+----------------------------------------------------
+
+-- all the queries in this file have the 
+-- same tables/subqueries combination as below
+-- because this test aims to hold the query planning 
+-- steady, but mostly ensure that filters are handled
+-- properly. Note that u2 is the relation that is 
+-- recursively planned
+
+-- Setting the debug level so that filters can be observed
+SET client_min_messages TO DEBUG1;
+
+-- no filters on u2
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1);
+
+
+-- scalar array expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > ANY(ARRAY[2, 1, 6]);
+
+
+-- array operators on the table can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  ARRAY[u2.value_1, u2.value_2] @> (ARRAY[2, 3]);
+
+-- array operators on different tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  ARRAY[u2.value_1, u1.user_id] @> (ARRAY[2, 3]);
+
+
+-- coerced expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1/2.0 > 2)::int::bool::text::bool;
+
+
+-- case expression on a single table can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (CASE WHEN u2.value_1 > 3 THEN u2.value_1 > 2 ELSE false END);
+
+
+-- case expression multiple tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (CASE WHEN u1.value_1 > 4000 THEN u2.value_1 / 100 > 1 ELSE false END);
+
+
+-- coalesce expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE COALESCE((u2.user_id/5.0)::int::bool, false);
+
+
+-- nullif expressions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE NULLIF((u2.value_2/5.0)::int::bool, false);
+
+
+-- null test can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_3 IS NOT NULL;
+
+
+-- functions can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE isfinite(u2.time);
+
+-- functions with multiple tables cannot be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE int4smaller(u2.value_1, u1.value_1) = 55;
+
+-- functions with multiple columns from the same tables can be pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE int4smaller(u2.value_1, u2.value_2) = u2.value_1;
+
+-- row expressions can be pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE row(u2.value_1, 2, 3) > row(u2.value_2, 2, 3);
+
+-- multiple expression from the same table can be pushed down together
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+	WHERE
+		  (u2.user_id/1.0)::int::bool::text::bool AND
+		  CASE WHEN u2.value_1 > 4000 THEN u2.value_2 / 100 > 1 ELSE false END AND
+		  COALESCE((u2.user_id/50000)::bool, false) AND
+		  NULLIF((u2.value_3/50000)::int::bool, false) AND
+		  isfinite(u2.time) AND
+		  u2.value_4 IS DISTINCT FROM 50040 AND
+		  row(u2.value_4, 2, 3) > row(2000, 2, 3);
+
+
+-- subqueries are not pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 >
+    (SELECT avg(user_id)
+     FROM events_table);
+
+-- even subqueries with constant values are not pushdowned
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 >
+    (SELECT 5);
+
+-- filters involving multiple tables aren't pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u2.value_1 *  u1.user_id > 25;
+
+
+-- filter on other tables can only be pushdown 
+-- as long as they are equality filters on the
+-- joining column
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_1 = 3;
+
+-- but not when the filter is gt, lt or any other thing
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_1 > 3;
+
+-- when the filter is on another column than the 
+-- join column, that's obviously not pushed down
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE  u1.value_2 = 3;
+
+
+-- or filters on the same table is pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > 4 OR u2.value_4 = 4;
+
+-- and filters on the same table is pushdown
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE u2.value_1 > 2 and u2.value_4 IS NULL;
+
+
+-- filters on different tables are pushdown
+-- only the ones that are not ANDed
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u2.value_4 IS NULL) OR (u2.user_id > 4 AND u1.user_id > 3);
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 AND u1.user_id > 3);
+
+-- see the comment above
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id > 4 OR u1.user_id > 3);
+
+-- see the comment above
+-- but volatile functions are not pushed down 
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 OR u1.value_4 IS NULL) AND (u2.user_id = 10000 * random() OR u1.user_id > 3);
+
+-- TODO: constant results should be pushed down, but not supported yet
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN
+  (SELECT value_1,
+          random()
+   FROM users_table) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2 AND false);
+
+-- TODO: what should the behaviour be?
+SELECT count(*)
+FROM users_table u1
+JOIN users_table u2 USING(value_1)
+JOIN LATERAL
+  (SELECT value_1,
+          random()
+   FROM users_table
+   WHERE u2.value_2 = 15) AS u3 USING (value_1)
+WHERE (u2.value_1 > 2
+       AND FALSE);
+
+
+
+


### PR DESCRIPTION
This PR is a prototype, and requires several improvements before merging. 

It enables good chunk of complex SQL queries that used be not supported. The improvements are mostly around subquery/cte joins with tables and outer joins with recurring tuples (e.g., reference table or intermediate results).

Though I started with a single improvement in my mind, I ended up implementing the second one as well to complement the first one which is by itself a useful feature.

- Expand recursive planning for tables
- Expand recursive planning for recursively planning inner parts of recurring tuple joins


The PR itself may not be performant for many cases where all the distributed table (or even some of the columns) needs to pulled to the coordinator** and pushed back. However, this can be considered a step towards future improvements. This PR, in combination with #2481 and an enhanced version of the implementation in #2305 could enable `Repartition via Coordinator`. Coupled with Citus MX, we might become closer to replace the existing repartitioning support. Though, we should find a way to execute `push` part of `pull & push` in parallel to compete with the current repartitioning implementation. Can we implement `Parallel COPY` in Postgres and use it?

 The coverage of this PR is tightly coupled with #2481, which enables (recurring tuple OUTER JOIN recurring tuple). And, this PR could yield lots of those joins.

 Basic algorithm to implement the changes:

 - Expand recursive planning for tables 

    - Simply convert "table" into `(SELECT required_columns FROM table)`
    - required_columns: The columns that the query refers
    - push all the filters that exists on the table in to the subquery, so actually: `(SELECT required_columns FROM table WHERE filters)`
    - Postgres pushes as much filters as possible, and we use those information to generate the wrapper subquery
    - Finally, call `RecursivelyPlanSubquery()` on the newly created subquery
    - Do this for failed non-colocated joins and failed recurrig tuple checks due to the table

 - Expand recursive planning for recursively planning inner parts of recurring tuple joins
    - During recursive planning, call `DeferredErrorIfUnsupportedRecurringTuplesJoin()`. If the function returns error, we know that there is no other way of executing this query.
    - Thus, get the inner part of the join that led to the error
    - If it is a relation, follow the above algorithm. If it is a subquery, we already know what to do via `RecursivelyPlanSubquery()`.



TODOs:
- [ ] Fix 9.6 regression tests
- [ ] Add more specific tests
- [ ] Probably merge it via two different PRs
- [ ] Improve the algorithm for calculating required_columns. For example, if a column appears only as a filter, we shouldn't pull it, but we do it now.
- [ ] Even though we don't need a column at all, we're currently adding it to the target list like `NULL::int as user_id`. Instead, we could only add the required columns and travers the remaining of query tree to update the references to those columns.
- [ ] We currently ignore FULL OUTER JOINS, which should be simple to add
- [ ] There are two regressions in the tests. Make sure that those are fixed with #2481
- [ ] Improve logging. We currently do not mention about recursive relation planning, which should be mentioned. Otherwirse, it'd be pretty confusing for the users.
- [ ] Restriction eq. codes rely on RTE to be `RTE_SUBQUERY`. However, we've now enough references to `RTE_RELATION`, so make those functions operate on `RTE_RELATION` as well
- [ ] Test with edge cases such as dropped columns, prepared statements, insert..select via coordinator etc.
- [ ] Consider LATERAL or any other correlated query cases some more


Any feedback is welcome!

** luckily we already have 1GB max limit of intermediate results