### PR TITLE
Fix citus_stat_statements view

### DIFF
--- a/citus.control
+++ b/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '8.0-11'
+default_version = '8.0-12'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -17,7 +17,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	7.3-1 7.3-2 7.3-3 \
 	7.4-1 7.4-2 7.4-3 \
 	7.5-1 7.5-2 7.5-3 7.5-4 7.5-5 7.5-6 7.5-7 \
-	8.0-1 8.0-2 8.0-3 8.0-4 8.0-5 8.0-6 8.0-7 8.0-8 8.0-9 8.0-10 8.0-11
+	8.0-1 8.0-2 8.0-3 8.0-4 8.0-5 8.0-6 8.0-7 8.0-8 8.0-9 8.0-10 8.0-11 8.0-12
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -236,6 +236,8 @@ $(EXTENSION)--8.0-9.sql: $(EXTENSION)--8.0-8.sql $(EXTENSION)--8.0-8--8.0-9.sql
 $(EXTENSION)--8.0-10.sql: $(EXTENSION)--8.0-9.sql $(EXTENSION)--8.0-9--8.0-10.sql
 	cat $^ > $@
 $(EXTENSION)--8.0-11.sql: $(EXTENSION)--8.0-10.sql $(EXTENSION)--8.0-10--8.0-11.sql
+	cat $^ > $@
+$(EXTENSION)--8.0-12.sql: $(EXTENSION)--8.0-11.sql $(EXTENSION)--8.0-11--8.0-12.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--8.0-11--8.0-12.sql
+++ b/src/backend/distributed/citus--8.0-11--8.0-12.sql
@@ -1,0 +1,31 @@
+/* citus--8.0-11--8.0-12 */
+SET search_path = 'pg_catalog';
+
+CREATE OR REPLACE FUNCTION pg_catalog.citus_stat_statements(OUT queryid bigint,
+												 OUT userid oid,
+												 OUT dbid oid,
+												 OUT query text,
+												 OUT executor bigint,
+												 OUT partition_key text,
+												 OUT calls bigint)
+RETURNS SETOF record
+LANGUAGE plpgsql
+AS $citus_stat_statements$
+BEGIN
+ IF EXISTS (
+ 	SELECT extname FROM pg_extension
+ 	WHERE extname = 'pg_stat_statements')
+ THEN
+ 	RETURN QUERY SELECT pss.queryid, pss.userid, pss.dbid, pss.query, cqs.executor,
+ 						cqs.partition_key, cqs.calls
+ 				 FROM pg_stat_statements(true) pss
+ 				 	JOIN citus_query_stats() cqs
+ 				 	USING (queryid, userid, dbid);
+ ELSE
+    RAISE EXCEPTION 'pg_stat_statements is not installed'
+    	USING HINT = 'install pg_stat_statements extension and try again';
+ END IF;
+END;
+$citus_stat_statements$;
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '8.0-11'
+default_version = '8.0-12'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -154,6 +154,7 @@ ALTER EXTENSION citus UPDATE TO '8.0-8';
 ALTER EXTENSION citus UPDATE TO '8.0-9';
 ALTER EXTENSION citus UPDATE TO '8.0-10';
 ALTER EXTENSION citus UPDATE TO '8.0-11';
+ALTER EXTENSION citus UPDATE TO '8.0-12';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -154,6 +154,7 @@ ALTER EXTENSION citus UPDATE TO '8.0-8';
 ALTER EXTENSION citus UPDATE TO '8.0-9';
 ALTER EXTENSION citus UPDATE TO '8.0-10';
 ALTER EXTENSION citus UPDATE TO '8.0-11';
+ALTER EXTENSION citus UPDATE TO '8.0-12';
 
 -- show running version
 SHOW citus.version;


### PR DESCRIPTION
Join between pg_stat_statements and citus_query_stats should include queryid, dbid, userid instead of just queryid.

Otherwise citus_stat_statements may have additional entries if the same query is executed in different databases, or by different users.
