### PR TITLE
Fix explain outputs on some tests

### DIFF
--- a/src/test/regress/expected/dml_recursive.out
+++ b/src/test/regress/expected/dml_recursive.out
@@ -275,6 +275,9 @@ DEBUG:  subqueries are not supported within INSERT queries
 HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
 ERROR:  subqueries are not supported within INSERT queries
 HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE distributed_table;
+VACUUM ANALYZE second_distributed_table;
 -- DML with an unreferenced SELECT CTE
 WITH cte_1 AS (
     WITH cte_2 AS (
@@ -295,6 +298,9 @@ DEBUG:  common table expressions are not supported in distributed modifications
 DEBUG:  generating subplan 20_1 for CTE cte_1: WITH cte_2 AS (SELECT second_distributed_table.tenant_id AS cte2_id FROM recursive_dml_queries.second_distributed_table WHERE (second_distributed_table.dept OPERATOR(pg_catalog.>=) 2)) UPDATE recursive_dml_queries.distributed_table SET dept = 10 RETURNING tenant_id, dept, info
 DEBUG:  common table expressions are not supported in distributed modifications
 DEBUG:  Plan 20 query after replacing subqueries and CTEs: UPDATE recursive_dml_queries.distributed_table SET dept = 5 FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept, intermediate_result.info FROM read_intermediate_result('20_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer, info jsonb)) cte_1 WHERE (distributed_table.tenant_id OPERATOR(pg_catalog.<) cte_1.tenant_id)
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE distributed_table;
+VACUUM ANALYZE second_distributed_table;
 WITH cte_1 AS (
     WITH cte_2 AS (
         SELECT tenant_id as cte2_id 

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1562,6 +1562,8 @@ SELECT create_distributed_table('partitioning_hash_join_test', 'id');
  
 (1 row)
 
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE partitioning_hash_join_test;
 -- see the query plan without partition-wise join
 EXPLAIN
 SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id, subid);

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -1542,6 +1542,9 @@ SELECT create_distributed_table('partitioning_hash_join_test', 'id');
 ERROR:  relation "partitioning_hash_join_test" does not exist
 LINE 1: SELECT create_distributed_table('partitioning_hash_join_test...
                                         ^
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE partitioning_hash_join_test;
+ERROR:  relation "partitioning_hash_join_test" does not exist
 -- see the query plan without partition-wise join
 EXPLAIN
 SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id, subid);

--- a/src/test/regress/expected/multi_partitioning_1.out
+++ b/src/test/regress/expected/multi_partitioning_1.out
@@ -1420,6 +1420,9 @@ SELECT create_distributed_table('partitioning_hash_join_test', 'id');
 ERROR:  relation "partitioning_hash_join_test" does not exist
 LINE 1: SELECT create_distributed_table('partitioning_hash_join_test...
                                         ^
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE partitioning_hash_join_test;
+ERROR:  relation "partitioning_hash_join_test" does not exist
 -- see the query plan without partition-wise join
 EXPLAIN
 SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id, subid);

--- a/src/test/regress/sql/dml_recursive.sql
+++ b/src/test/regress/sql/dml_recursive.sql
@@ -217,6 +217,10 @@ INSERT INTO
 	second_distributed_table (tenant_id, dept) 
 VALUES ('3', (SELECT 3));
 
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE distributed_table;
+VACUUM ANALYZE second_distributed_table;
+
 -- DML with an unreferenced SELECT CTE
 WITH cte_1 AS (
     WITH cte_2 AS (
@@ -233,6 +237,10 @@ UPDATE distributed_table
 SET dept = 5
 FROM cte_1
 WHERE distributed_table.tenant_id < cte_1.tenant_id;
+
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE distributed_table;
+VACUUM ANALYZE second_distributed_table;
 
 WITH cte_1 AS (
     WITH cte_2 AS (

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -994,6 +994,9 @@ CREATE TABLE partitioning_hash_join_test_2 PARTITION OF partitioning_hash_join_t
 
 SELECT create_distributed_table('partitioning_hash_join_test', 'id');
 
+-- ensure that EXPLAIN outputs are consistent
+VACUUM ANALYZE partitioning_hash_join_test;
+
 -- see the query plan without partition-wise join
 EXPLAIN
 SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id, subid);


### PR DESCRIPTION
In the scope of #2387.

In general, I thought adding `VACUUM ANALYZE ` should fix non-consistent `EXPLAIN` outputs. 

However, I realized that we've a random failure which is executed just after `VACUUM ANALYZE` as this [one](https://github.com/citusdata/citus/blob/master/src/test/regress/expected/multi_view.out#L797-L823). 

So, we should probably find a better solution.

I think there is no harm merging this in since it decreases the frequency of these issues.