### PR TITLE
Error out when a subquery has grouping set clause

### DIFF
--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -807,6 +807,14 @@ DeferErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLi
 		}
 	}
 
+	/* grouping sets are not allowed in subqueries*/
+	if (subqueryTree->groupingSets)
+	{
+		preconditionsSatisfied = false;
+		errorDetail = "could not run distributed query with GROUPING SETS, CUBE, "
+					  "or ROLLUP";
+	}
+
 	/*
 	 * We support window functions when the window function
 	 * is partitioned on distribution column.

--- a/src/test/regress/expected/subqueries_not_supported.out
+++ b/src/test/regress/expected/subqueries_not_supported.out
@@ -157,6 +157,17 @@ WHERE
 ;
 ERROR:  cannot push down this subquery
 DETAIL:  Having qual without group by on partition column is currently unsupported when a subquery references a column from another query
+-- We do not support GROUPING SETS in subqueries
+-- This also includes ROLLUP or CUBE clauses
+SELECT * FROM (SELECT user_id, value_1 FROM users_table GROUP BY GROUPING SETS ((user_id), (value_1))) s;
+ERROR:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
+HINT:  Consider using an equality filter on the distributed table's partition column.
+SELECT * FROM (SELECT user_id, value_1 FROM users_table GROUP BY ROLLUP (user_id, value_1)) s;
+ERROR:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
+HINT:  Consider using an equality filter on the distributed table's partition column.
+SELECT * FROM (SELECT user_id, value_1 FROM users_table GROUP BY CUBE (user_id, value_1)) s;
+ERROR:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
+HINT:  Consider using an equality filter on the distributed table's partition column.
 SET client_min_messages TO DEFAULT;
 DROP SCHEMA not_supported CASCADE;
 NOTICE:  drop cascades to table users_table_local

--- a/src/test/regress/sql/subqueries_not_supported.sql
+++ b/src/test/regress/sql/subqueries_not_supported.sql
@@ -149,6 +149,13 @@ WHERE
     )
 ;
 
+
+-- We do not support GROUPING SETS in subqueries
+-- This also includes ROLLUP or CUBE clauses
+SELECT * FROM (SELECT user_id, value_1 FROM users_table GROUP BY GROUPING SETS ((user_id), (value_1))) s;
+SELECT * FROM (SELECT user_id, value_1 FROM users_table GROUP BY ROLLUP (user_id, value_1)) s;
+SELECT * FROM (SELECT user_id, value_1 FROM users_table GROUP BY CUBE (user_id, value_1)) s;
+
 SET client_min_messages TO DEFAULT;
 
 DROP SCHEMA not_supported CASCADE;


### PR DESCRIPTION
Description: Do not allow GROUPING SET clauses in subqueries

We currently do not support GROUPING SETS (see #2219) but they can incorrectly pass through in subqueries.

Closes #2256 