### PR TITLE
Ensure that citus_dist_activity test outputs do not change

### DIFF
--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -1,6 +1,6 @@
 Parsed test spec with 3 sessions
 
-starting permutation: s1-begin s2-begin s3-begin s1-alter-table s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-alter-table s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -16,6 +16,12 @@ step s3-begin:
 step s1-alter-table: 
     ALTER TABLE test_table ADD COLUMN x INT;
 
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	
@@ -54,7 +60,7 @@ step s3-rollback:
 	ROLLBACK;
 
 
-starting permutation: s1-begin s2-begin s3-begin s1-insert s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-insert s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -70,6 +76,12 @@ step s3-begin:
 step s1-insert: 
  	INSERT INTO test_table VALUES (100, 100);
 
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	
@@ -97,7 +109,7 @@ step s3-rollback:
 	ROLLBACK;
 
 
-starting permutation: s1-begin s2-begin s3-begin s1-select s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-select s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -116,6 +128,12 @@ step s1-select:
 count          
 
 0              
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	
@@ -146,7 +164,7 @@ step s3-rollback:
 	ROLLBACK;
 
 
-starting permutation: s1-begin s2-begin s3-begin s1-select-router s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-select-router s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -165,6 +183,12 @@ step s1-select-router:
 count          
 
 0              
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	

--- a/src/test/regress/expected/isolation_citus_dist_activity_0.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity_0.out
@@ -1,6 +1,6 @@
 Parsed test spec with 3 sessions
 
-starting permutation: s1-begin s2-begin s3-begin s1-alter-table s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-alter-table s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -16,6 +16,12 @@ step s3-begin:
 step s1-alter-table: 
     ALTER TABLE test_table ADD COLUMN x INT;
 
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	
@@ -54,7 +60,7 @@ step s3-rollback:
 	ROLLBACK;
 
 
-starting permutation: s1-begin s2-begin s3-begin s1-insert s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-insert s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -70,6 +76,12 @@ step s3-begin:
 step s1-insert: 
  	INSERT INTO test_table VALUES (100, 100);
 
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	
@@ -97,7 +109,7 @@ step s3-rollback:
 	ROLLBACK;
 
 
-starting permutation: s1-begin s2-begin s3-begin s1-select s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-select s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -116,6 +128,12 @@ step s1-select:
 count          
 
 0              
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	
@@ -146,7 +164,7 @@ step s3-rollback:
 	ROLLBACK;
 
 
-starting permutation: s1-begin s2-begin s3-begin s1-select-router s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
+starting permutation: s1-begin s2-begin s3-begin s1-select-router s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
 create_distributed_table
 
                
@@ -165,6 +183,12 @@ step s1-select-router:
 count          
 
 0              
+step s2-sleep: 
+	SELECT pg_sleep(0.2);
+
+pg_sleep       
+
+               
 step s2-view-dist: 
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
 	

--- a/src/test/regress/specs/isolation_citus_dist_activity.spec
+++ b/src/test/regress/specs/isolation_citus_dist_activity.spec
@@ -56,6 +56,11 @@ step "s2-rollback"
 	ROLLBACK;
 }
 
+step "s2-sleep"
+{
+	SELECT pg_sleep(0.2);
+}
+
 step "s2-view-dist"
 {
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity ORDER BY query DESC;
@@ -79,8 +84,9 @@ step "s3-view-worker"
 	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity ORDER BY query DESC;
 }
 
-
-permutation "s1-begin" "s2-begin" "s3-begin" "s1-alter-table" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
-permutation "s1-begin" "s2-begin" "s3-begin" "s1-insert" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
-permutation "s1-begin" "s2-begin" "s3-begin" "s1-select" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
-permutation "s1-begin" "s2-begin" "s3-begin" "s1-select-router" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
+# we prefer to sleep before "s2-view-dist" so that we can ensure
+# the "wait_event" in the output doesn't change randomly (e.g., NULL to CliendRead etc.)
+permutation "s1-begin" "s2-begin" "s3-begin" "s1-alter-table" "s2-sleep" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
+permutation "s1-begin" "s2-begin" "s3-begin" "s1-insert" "s2-sleep" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
+permutation "s1-begin" "s2-begin" "s3-begin" "s1-select" "s2-sleep" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"
+permutation "s1-begin" "s2-begin" "s3-begin" "s1-select-router" "s2-sleep" "s2-view-dist" "s3-view-worker" "s2-rollback" "s1-commit" "s3-rollback"


### PR DESCRIPTION
Since there is no lock ordering among the query that is executed
and the select from the view, we prefer to add a timeout before
printing the activity.
