### PR TITLE
Add a column to pg_dist_node to enable metadata-only workers

### DIFF
--- a/citus.control
+++ b/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '8.0-12'
+default_version = '8.0-13'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -17,7 +17,7 @@ EXTVERSIONS = 5.0 5.0-1 5.0-2  \
 	7.3-1 7.3-2 7.3-3 \
 	7.4-1 7.4-2 7.4-3 \
 	7.5-1 7.5-2 7.5-3 7.5-4 7.5-5 7.5-6 7.5-7 \
-	8.0-1 8.0-2 8.0-3 8.0-4 8.0-5 8.0-6 8.0-7 8.0-8 8.0-9 8.0-10 8.0-11 8.0-12
+	8.0-1 8.0-2 8.0-3 8.0-4 8.0-5 8.0-6 8.0-7 8.0-8 8.0-9 8.0-10 8.0-11 8.0-12 8.0-13
 
 # All citus--*.sql files in the source directory
 DATA = $(patsubst $(citus_abs_srcdir)/%.sql,%.sql,$(wildcard $(citus_abs_srcdir)/$(EXTENSION)--*--*.sql))
@@ -238,6 +238,8 @@ $(EXTENSION)--8.0-10.sql: $(EXTENSION)--8.0-9.sql $(EXTENSION)--8.0-9--8.0-10.sq
 $(EXTENSION)--8.0-11.sql: $(EXTENSION)--8.0-10.sql $(EXTENSION)--8.0-10--8.0-11.sql
 	cat $^ > $@
 $(EXTENSION)--8.0-12.sql: $(EXTENSION)--8.0-11.sql $(EXTENSION)--8.0-11--8.0-12.sql
+	cat $^ > $@
+$(EXTENSION)--8.0-13.sql: $(EXTENSION)--8.0-12.sql $(EXTENSION)--8.0-12--8.0-13.sql
 	cat $^ > $@
 
 NO_PGXS = 1

--- a/src/backend/distributed/citus--8.0-12--8.0-13.sql
+++ b/src/backend/distributed/citus--8.0-12--8.0-13.sql
@@ -1,0 +1,100 @@
+SET search_path = 'pg_catalog';
+
+ALTER TABLE pg_dist_node ADD COLUMN isdatanode bool NOT NULL DEFAULT true;
+
+DROP FUNCTION master_add_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                groupid integer default 0,
+                                noderole noderole default 'primary',
+                                nodecluster name default 'default',
+                                OUT nodeid integer,
+                                OUT groupid integer,
+                                OUT nodename text,
+                                OUT nodeport integer,
+                                OUT noderack text,
+                                OUT hasmetadata boolean,
+                                OUT isactive bool,
+                                OUT noderole noderole,
+                                OUT nodecluster name,
+                                OUT isdatanode bool)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer,
+                                    groupid integer, noderole noderole, nodecluster name)
+  IS 'add node to the cluster';
+
+DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         groupid integer default 0,
+                                         noderole noderole default 'primary',
+                                         nodecluster name default 'default',
+                                         OUT nodeid integer,
+                                         OUT groupid integer,
+                                         OUT nodename text,
+                                         OUT nodeport integer,
+                                         OUT noderack text,
+                                         OUT hasmetadata boolean,
+                                         OUT isactive bool,
+                                         OUT noderole noderole,
+                                         OUT nodecluster name,
+                                         OUT isdatanode bool)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text,nodeport integer,
+                                             groupid integer, noderole noderole,
+                                             nodecluster name)
+  IS 'prepare node by adding it to pg_dist_node';
+
+DROP FUNCTION master_activate_node(text, integer);
+CREATE FUNCTION master_activate_node(nodename text,
+                                     nodeport integer,
+                                     OUT nodeid integer,
+                                     OUT groupid integer,
+                                     OUT nodename text,
+                                     OUT nodeport integer,
+                                     OUT noderack text,
+                                     OUT hasmetadata boolean,
+                                     OUT isactive bool,
+                                     OUT noderole noderole,
+                                     OUT nodecluster name,
+                                     OUT isdatanode bool)
+    RETURNS record
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME',$$master_activate_node$$;
+COMMENT ON FUNCTION master_activate_node(nodename text, nodeport integer)
+    IS 'activate a node which is in the cluster';
+
+DROP FUNCTION master_add_secondary_node(text, int, text, int, name);
+CREATE FUNCTION master_add_secondary_node(nodename text,
+                                          nodeport integer,
+                                          primaryname text,
+                                          primaryport integer,
+                                          nodecluster name default 'default',
+                                          OUT nodeid integer,
+                                          OUT groupid integer,
+                                          OUT nodename text,
+                                          OUT nodeport integer,
+                                          OUT noderack text,
+                                          OUT hasmetadata boolean,
+                                          OUT isactive bool,
+                                          OUT noderole noderole,
+                                          OUT nodecluster name,
+                                          OUT isdatanode bool)
+  RETURNS record
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_add_secondary_node$$;
+COMMENT ON FUNCTION master_add_secondary_node(nodename text, nodeport integer,
+                                              primaryname text, primaryport integer,
+                                              nodecluster name)
+  IS 'add a secondary node to the cluster';
+
+REVOKE ALL ON FUNCTION master_activate_node(text,int) FROM PUBLIC;
+REVOKE ALL ON FUNCTION master_add_inactive_node(text,int,int,noderole,name) FROM PUBLIC;
+REVOKE ALL ON FUNCTION master_add_node(text,int,int,noderole,name) FROM PUBLIC;
+REVOKE ALL ON FUNCTION master_add_secondary_node(text,int,text,int,name) FROM PUBLIC;
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '8.0-12'
+default_version = '8.0-13'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -276,7 +276,7 @@ create_reference_table(PG_FUNCTION_ARGS)
 	 */
 	EnsureRelationKindSupported(relationId);
 
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActivePrimaryDataNodeList();
 	workerCount = list_length(workerNodeList);
 
 	/* if there are no workers, error out */
@@ -286,7 +286,7 @@ create_reference_table(PG_FUNCTION_ARGS)
 
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 						errmsg("cannot create reference table \"%s\"", relationName),
-						errdetail("There are no active worker nodes.")));
+						errdetail("There are no active data nodes.")));
 	}
 
 	CreateDistributedTable(relationId, distributionColumn, DISTRIBUTE_BY_NONE,
@@ -825,7 +825,7 @@ EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 static void
 EnsureSchemaExistsOnAllNodes(Oid relationId)
 {
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = ActivePrimaryDataNodeList();
 	ListCell *workerNodeCell = NULL;
 	StringInfo applySchemaCreationDDL = makeStringInfo();
 

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -125,7 +125,7 @@ broadcast_intermediate_result(PG_FUNCTION_ARGS)
 	 */
 	BeginOrContinueCoordinatedTransaction();
 
-	nodeList = ActivePrimaryNodeList();
+	nodeList = ActivePrimaryDataNodeList();
 	estate = CreateExecutorState();
 	resultDest = (RemoteFileDestReceiver *) CreateRemoteFileDestReceiver(resultIdString,
 																		 estate, nodeList,

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -208,7 +208,7 @@ MultiTaskTrackerExecute(Job *job)
 	 * assigning and checking the status of tasks. The second (temporary) hash
 	 * helps us in fetching results data from worker nodes to the master node.
 	 */
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActivePrimaryDataNodeList();
 	taskTrackerCount = (uint32) list_length(workerNodeList);
 
 	/* connect as the current user for running queries */

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -166,7 +166,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	LockRelationOid(DistNodeRelationId(), RowShareLock);
 
 	/* load and sort the worker node list for deterministic placement */
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActivePrimaryDataNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* make sure we don't process cancel signals until all shards are created */
@@ -385,7 +385,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	}
 
 	/* load and sort the worker node list for deterministic placement */
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActivePrimaryDataNodeList();
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* get the next shard id */

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -151,7 +151,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 
 	/* if enough live groups, add an extra candidate node as backup */
 	{
-		uint32 primaryNodeCount = ActivePrimaryNodeCount();
+		uint32 primaryNodeCount = list_length(ActivePrimaryDataNodeList());
 
 		attemptableNodeCount = ShardReplicationFactor;
 		if (primaryNodeCount > ShardReplicationFactor)
@@ -171,7 +171,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 		}
 		else if (ShardPlacementPolicy == SHARD_PLACEMENT_ROUND_ROBIN)
 		{
-			List *workerNodeList = ActivePrimaryNodeList();
+			List *workerNodeList = ActivePrimaryDataNodeList();
 			candidateNode = WorkerGetRoundRobinCandidateNode(workerNodeList, shardId,
 															 candidateNodeIndex);
 		}

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -351,6 +351,37 @@ ActivePrimaryNodeList(void)
 
 
 /*
+ * ActivePrimaryDataNodeList returns a list of all active, primary worker nodes
+ * that can store data.
+ */
+List *
+ActivePrimaryDataNodeList(void)
+{
+	List *workerNodeList = NIL;
+	WorkerNode *workerNode = NULL;
+	HTAB *workerNodeHash = GetWorkerNodeHash();
+	HASH_SEQ_STATUS status;
+
+	EnsureModificationsCanRun();
+
+	hash_seq_init(&status, workerNodeHash);
+
+	while ((workerNode = hash_seq_search(&status)) != NULL)
+	{
+		if (workerNode->isActive && WorkerNodeIsPrimary(workerNode) &&
+			workerNode->isDataNode)
+		{
+			WorkerNode *workerNodeCopy = palloc0(sizeof(WorkerNode));
+			memcpy(workerNodeCopy, workerNode, sizeof(WorkerNode));
+			workerNodeList = lappend(workerNodeList, workerNodeCopy);
+		}
+	}
+
+	return workerNodeList;
+}
+
+
+/*
  * ActiveReadableNodeList returns a list of all nodes in workerNodeHash we can read from.
  */
 List *

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2739,6 +2739,7 @@ InitializeWorkerNodeCache(void)
 		workerNode->nodeId = currentNode->nodeId;
 		strlcpy(workerNode->workerRack, currentNode->workerRack, WORKER_LENGTH);
 		workerNode->hasMetadata = currentNode->hasMetadata;
+		workerNode->isDataNode = currentNode->isDataNode;
 		workerNode->isActive = currentNode->isActive;
 		workerNode->nodeRole = currentNode->nodeRole;
 		strlcpy(workerNode->nodeCluster, currentNode->nodeCluster, NAMEDATALEN);

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -132,7 +132,7 @@ ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort)
 	List *referenceShardIntervalList = NIL;
 	ListCell *referenceTableCell = NULL;
 	ListCell *referenceShardIntervalCell = NULL;
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = ActivePrimaryDataNodeList();
 	uint32 workerCount = 0;
 	Oid firstReferenceTableId = InvalidOid;
 	uint32 referenceTableColocationId = INVALID_COLOCATION_ID;
@@ -251,7 +251,7 @@ ReplicateShardToAllWorkers(ShardInterval *shardInterval)
 	/* prevent concurrent pg_dist_node changes */
 	LockRelationOid(DistNodeRelationId(), RowShareLock);
 
-	workerNodeList = ActivePrimaryNodeList();
+	workerNodeList = ActivePrimaryDataNodeList();
 
 	/*
 	 * We will iterate over all worker nodes and if healthy placement is not exist at
@@ -386,7 +386,7 @@ uint32
 CreateReferenceTableColocationId()
 {
 	uint32 colocationId = INVALID_COLOCATION_ID;
-	List *workerNodeList = ActivePrimaryNodeList();
+	List *workerNodeList = ActivePrimaryDataNodeList();
 	int shardCount = 1;
 	int replicationFactor = list_length(workerNodeList);
 	Oid distributionColumnType = InvalidOid;

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -20,7 +20,7 @@
  *  in particular their OUT parameters) must be changed whenever the definition of
  *  pg_dist_node changes.
  */
-#define Natts_pg_dist_node 9
+#define Natts_pg_dist_node 10
 #define Anum_pg_dist_node_nodeid 1
 #define Anum_pg_dist_node_groupid 2
 #define Anum_pg_dist_node_nodename 3
@@ -30,6 +30,7 @@
 #define Anum_pg_dist_node_isactive 7
 #define Anum_pg_dist_node_noderole 8
 #define Anum_pg_dist_node_nodecluster 9
+#define Anum_pg_dist_node_isdatanode 10
 
 #define GROUPID_SEQUENCE_NAME "pg_dist_groupid_seq"
 #define NODEID_SEQUENCE_NAME "pg_dist_node_nodeid_seq"

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -44,6 +44,7 @@ typedef struct WorkerNode
 	uint32 groupId;                     /* node's groupId; same for the nodes that are in the same group */
 	char workerRack[WORKER_LENGTH];     /* node's network location */
 	bool hasMetadata;                   /* node gets metadata changes */
+	bool isDataNode;                    /* node stors shards */
 	bool isActive;                      /* node's state */
 	Oid nodeRole;                       /* the node's role in its group */
 	char nodeCluster[NAMEDATALEN];      /* the cluster the node is a part of */
@@ -64,6 +65,7 @@ extern WorkerNode * WorkerGetRoundRobinCandidateNode(List *workerNodeList,
 extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern uint32 ActivePrimaryNodeCount(void);
 extern List * ActivePrimaryNodeList(void);
+extern List * ActivePrimaryDataNodeList(void);
 extern uint32 ActiveReadableNodeCount(void);
 extern List * ActiveReadableNodeList(void);
 extern WorkerNode * GetWorkerNodeByNodeId(int nodeId);

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -5,7 +5,7 @@ SET citus.next_shard_id TO 1220000;
 CREATE TABLE test_reference_table (y int primary key, name text);
 SELECT create_reference_table('test_reference_table');
 ERROR:  cannot create reference table "test_reference_table"
-DETAIL:  There are no active worker nodes.
+DETAIL:  There are no active data nodes.
 -- add the nodes to the cluster
 SELECT 1 FROM master_add_node('localhost', :worker_1_port);
  ?column? 
@@ -369,16 +369,16 @@ SELECT count(1) FROM pg_dist_node;
 SELECT
 	master_add_node('localhost', :worker_1_port),
 	master_add_node('localhost', :worker_2_port);
-                  master_add_node                   |                   master_add_node                   
-----------------------------------------------------+-----------------------------------------------------
- (11,9,localhost,57637,default,f,t,primary,default) | (12,10,localhost,57638,default,f,t,primary,default)
+                   master_add_node                    |                    master_add_node                    
+------------------------------------------------------+-------------------------------------------------------
+ (11,9,localhost,57637,default,f,t,primary,default,t) | (12,10,localhost,57638,default,f,t,primary,default,t)
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-     11 |       9 | localhost |    57637 | default  | f           | t        | primary  | default
-     12 |      10 | localhost |    57638 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | isdatanode 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------+------------
+     11 |       9 | localhost |    57637 | default  | f           | t        | primary  | default     | t
+     12 |      10 | localhost |    57638 | default  | f           | t        | primary  | default     | t
 (2 rows)
 
 -- check that mixed add/remove node commands work fine inside transaction
@@ -556,15 +556,15 @@ SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_g
 
 -- check that you can add a seconary to a non-default cluster, and activate it, and remove it
 SELECT master_add_inactive_node('localhost', 9999, groupid => :worker_2_group, nodecluster => 'olap', noderole => 'secondary');
-             master_add_inactive_node              
----------------------------------------------------
- (22,16,localhost,9999,default,f,f,secondary,olap)
+              master_add_inactive_node               
+-----------------------------------------------------
+ (22,16,localhost,9999,default,f,f,secondary,olap,t)
 (1 row)
 
 SELECT master_activate_node('localhost', 9999);
-               master_activate_node                
----------------------------------------------------
- (22,16,localhost,9999,default,f,t,secondary,olap)
+                master_activate_node                 
+-----------------------------------------------------
+ (22,16,localhost,9999,default,f,t,secondary,olap,t)
 (1 row)
 
 SELECT master_disable_node('localhost', 9999);
@@ -592,17 +592,17 @@ CONTEXT:  PL/pgSQL function citus.pg_dist_node_trigger_func() line 18 at RAISE
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole, nodecluster)
   VALUES ('localhost', 5000, 1000, 'primary', 'olap');
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
-DETAIL:  Failing row contains (19, 1000, localhost, 5000, default, f, t, primary, olap).
+DETAIL:  Failing row contains (19, 1000, localhost, 5000, default, f, t, primary, olap, t).
 UPDATE pg_dist_node SET nodecluster = 'olap'
   WHERE nodeport = :worker_1_port;
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
-DETAIL:  Failing row contains (16, 14, localhost, 57637, default, f, t, primary, olap).
+DETAIL:  Failing row contains (16, 14, localhost, 57637, default, f, t, primary, olap, t).
 -- check that you /can/ add a secondary node to a non-default cluster
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
 SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary', nodecluster=> 'olap');
-                  master_add_node                  
----------------------------------------------------
- (23,14,localhost,8888,default,f,t,secondary,olap)
+                   master_add_node                   
+-----------------------------------------------------
+ (23,14,localhost,8888,default,f,t,secondary,olap,t)
 (1 row)
 
 -- check that super-long cluster names are truncated
@@ -613,38 +613,38 @@ SELECT master_add_node('localhost', 8887, groupid => :worker_1_group, noderole =
 	'thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.'
 	'overflow'
 );
-                                               master_add_node                                                
---------------------------------------------------------------------------------------------------------------
- (24,14,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.)
+                                                master_add_node                                                 
+----------------------------------------------------------------------------------------------------------------
+ (24,14,localhost,8887,default,f,t,secondary,thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.,t)
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeport=8887;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           
---------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------
-     24 |      14 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           | isdatanode 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------+------------
+     24 |      14 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars. | t
 (1 row)
 
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
 -- them in any of the remaining tests
 -- master_add_secondary_node lets you skip looking up the groupid
 SELECT master_add_secondary_node('localhost', 9995, 'localhost', :worker_1_port);
-              master_add_secondary_node               
-------------------------------------------------------
- (25,14,localhost,9995,default,f,t,secondary,default)
+               master_add_secondary_node                
+--------------------------------------------------------
+ (25,14,localhost,9995,default,f,t,secondary,default,t)
 (1 row)
 
 SELECT master_add_secondary_node('localhost', 9994, primaryname => 'localhost', primaryport => :worker_2_port);
-              master_add_secondary_node               
-------------------------------------------------------
- (26,16,localhost,9994,default,f,t,secondary,default)
+               master_add_secondary_node                
+--------------------------------------------------------
+ (26,16,localhost,9994,default,f,t,secondary,default,t)
 (1 row)
 
 SELECT master_add_secondary_node('localhost', 9993, 'localhost', 2000);
 ERROR:  node at "localhost:2000" does not exist
 SELECT master_add_secondary_node('localhost', 9992, 'localhost', :worker_1_port, nodecluster => 'second-cluster');
-                  master_add_secondary_node                  
--------------------------------------------------------------
- (27,14,localhost,9992,default,f,t,secondary,second-cluster)
+                   master_add_secondary_node                   
+---------------------------------------------------------------
+ (27,14,localhost,9992,default,f,t,secondary,second-cluster,t)
 (1 row)
 
 SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset
@@ -661,10 +661,10 @@ SELECT master_update_node(:worker_1_node, 'somehost', 9000);
  
 (1 row)
 
-SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+----------+----------+----------+-------------+----------+----------+-------------
-     16 |      14 | somehost |     9000 | default  | f           | t        | primary  | default
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodeid = :worker_1_node;
+ nodename | nodeport 
+----------+----------
+ somehost |     9000
 (1 row)
 
 -- cleanup
@@ -674,9 +674,39 @@ SELECT master_update_node(:worker_1_node, 'localhost', :worker_1_port);
  
 (1 row)
 
-SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-     16 |      14 | localhost |    57637 | default  | f           | t        | primary  | default
+SELECT nodename, nodeport FROM pg_dist_node WHERE nodeid = :worker_1_node;
+ nodename  | nodeport 
+-----------+----------
+ localhost |    57637
 (1 row)
 
+-- setting isdatanode to false means that there should not be any shards on the node
+UPDATE pg_dist_node SET isdatanode = false WHERE nodeport = :worker_2_port;
+CREATE TABLE test_dist (x int, y int);
+CREATE TABLE test_ref (a int, b int);
+SELECT create_distributed_table('test_dist', 'x');
+ERROR:  replication_factor (2) exceeds number of worker nodes (1)
+HINT:  Add more worker nodes or try again with a lower replication factor.
+SELECT create_reference_table('test_ref');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT nodeport, count(*)
+FROM pg_dist_shard JOIN pg_dist_shard_placement USING (shardid)
+WHERE logicalrelid = 'test_dist'::regclass GROUP BY nodeport;
+ nodeport | count 
+----------+-------
+(0 rows)
+
+SELECT nodeport, count(*)
+FROM pg_dist_shard JOIN pg_dist_shard_placement USING (shardid)
+WHERE logicalrelid = 'test_ref'::regclass GROUP BY nodeport;
+ nodeport | count 
+----------+-------
+    57637 |     1
+(1 row)
+
+DROP TABLE test_dist, test_ref;
+UPDATE pg_dist_node SET isdatanode = true;

--- a/src/test/regress/expected/multi_metadata_attributes.out
+++ b/src/test/regress/expected/multi_metadata_attributes.out
@@ -9,7 +9,8 @@ ORDER BY attrelid, attname;
 --------------+-------------+---------------+---------------
  pg_dist_node | hasmetadata | t             | {f}
  pg_dist_node | isactive    | t             | {t}
+ pg_dist_node | isdatanode  | t             | {t}
  pg_dist_node | nodecluster | t             | {default}
  pg_dist_node | noderole    | t             | {primary}
-(4 rows)
+(5 rows)
 

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -180,10 +180,10 @@ SELECT count(*) FROM pg_dist_node WHERE hasmetadata=true;
 
 -- Ensure it works when run on a secondary node
 SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
-SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary');
-                  master_add_node                   
-----------------------------------------------------
- (4,1,localhost,8888,default,f,t,secondary,default)
+SELECT 1 FROM master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary');
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', 8888);
@@ -212,9 +212,9 @@ SELECT hasmetadata FROM pg_dist_node WHERE nodeport = 8888;
 
 -- Add a node to another cluster to make sure it's also synced
 SELECT master_add_secondary_node('localhost', 8889, 'localhost', :worker_1_port, nodecluster => 'second-cluster');
-                 master_add_secondary_node                 
------------------------------------------------------------
- (5,1,localhost,8889,default,f,t,secondary,second-cluster)
+                  master_add_secondary_node                  
+-------------------------------------------------------------
+ (5,1,localhost,8889,default,f,t,secondary,second-cluster,t)
 (1 row)
 
 -- Run start_metadata_sync_to_node and check that it marked hasmetadata for that worker
@@ -239,12 +239,12 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   
---------+---------+-----------+----------+----------+-------------+----------+-----------+----------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default
-      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default
-      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | isdatanode 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+----------------+------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        | t
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        | t
+      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        | t
+      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | t
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -378,12 +378,12 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   
---------+---------+-----------+----------+----------+-------------+----------+-----------+----------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default
-      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default
-      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | isdatanode 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+----------------+------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        | t
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        | t
+      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        | t
+      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | t
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -1171,10 +1171,10 @@ SELECT create_distributed_table('mx_table', 'a');
 (1 row)
 
 \c - postgres - :master_port
-SELECT master_add_node('localhost', :worker_2_port);
-                  master_add_node                  
----------------------------------------------------
- (6,4,localhost,57638,default,f,t,primary,default)
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
@@ -1389,11 +1389,11 @@ WHERE logicalrelid='mx_ref'::regclass;
 (1 row)
 
 \c - - - :master_port
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "mx_ref" to the node localhost:57638
-                  master_add_node                  
----------------------------------------------------
- (7,5,localhost,57638,default,f,t,primary,default)
+ ?column? 
+----------
+        1
 (1 row)
 
 SELECT shardid, nodename, nodeport 

--- a/src/test/regress/expected/multi_mx_create_table.out
+++ b/src/test/regress/expected/multi_mx_create_table.out
@@ -467,18 +467,18 @@ FROM pg_dist_partition NATURAL JOIN shard_counts
 ORDER BY colocationid, logicalrelid;
                       logicalrelid                      | colocationid | shard_count | partmethod | repmodel 
 --------------------------------------------------------+--------------+-------------+------------+----------
- citus_mx_test_schema_join_1.nation_hash                |            3 |           4 | h          | s
- citus_mx_test_schema_join_1.nation_hash_2              |            3 |           4 | h          | s
- citus_mx_test_schema_join_2.nation_hash                |            3 |           4 | h          | s
- citus_mx_test_schema.nation_hash_collation_search_path |            3 |           4 | h          | s
- citus_mx_test_schema.nation_hash_composite_types       |            3 |           4 | h          | s
- mx_ddl_table                                           |            3 |           4 | h          | s
- app_analytics_events_mx                                |            3 |           4 | h          | s
- company_employees_mx                                   |            3 |           4 | h          | s
- customer_mx                                            |            4 |           1 | n          | t
- nation_mx                                              |            4 |           1 | n          | t
- part_mx                                                |            4 |           1 | n          | t
- supplier_mx                                            |            4 |           1 | n          | t
+ citus_mx_test_schema_join_1.nation_hash                |            5 |           4 | h          | s
+ citus_mx_test_schema_join_1.nation_hash_2              |            5 |           4 | h          | s
+ citus_mx_test_schema_join_2.nation_hash                |            5 |           4 | h          | s
+ citus_mx_test_schema.nation_hash_collation_search_path |            5 |           4 | h          | s
+ citus_mx_test_schema.nation_hash_composite_types       |            5 |           4 | h          | s
+ mx_ddl_table                                           |            5 |           4 | h          | s
+ app_analytics_events_mx                                |            5 |           4 | h          | s
+ company_employees_mx                                   |            5 |           4 | h          | s
+ customer_mx                                            |            6 |           1 | n          | t
+ nation_mx                                              |            6 |           1 | n          | t
+ part_mx                                                |            6 |           1 | n          | t
+ supplier_mx                                            |            6 |           1 | n          | t
  nation_hash                                            |      1390000 |          16 | h          | s
  citus_mx_test_schema.nation_hash                       |      1390000 |          16 | h          | s
  lineitem_mx                                            |      1390001 |          16 | h          | s

--- a/src/test/regress/expected/multi_mx_hide_shard_names.out
+++ b/src/test/regress/expected/multi_mx_hide_shard_names.out
@@ -139,6 +139,7 @@ SELECT pg_table_is_visible('test_table_1130000'::regclass);
 SET search_path TO 'mx_hide_shard_names';
 SET citus.shard_count TO 4;
 SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 1131000;
 SET citus.replication_model TO 'streaming';
 -- not existing shard ids appended to the distributed table name
 CREATE TABLE test_table_102008(id int, time date);
@@ -156,12 +157,12 @@ SET search_path TO 'mx_hide_shard_names';
 -- name already exists :)
 CREATE TABLE test_table_2_1130000(id int, time date);
 SELECT * FROM citus_shards_on_worker ORDER BY 2;
-       Schema        |           Name           | Type  |  Owner   
----------------------+--------------------------+-------+----------
- mx_hide_shard_names | test_table_102008_102012 | table | postgres
- mx_hide_shard_names | test_table_102008_102014 | table | postgres
- mx_hide_shard_names | test_table_1130000       | table | postgres
- mx_hide_shard_names | test_table_1130002       | table | postgres
+       Schema        |           Name            | Type  |  Owner   
+---------------------+---------------------------+-------+----------
+ mx_hide_shard_names | test_table_102008_1131000 | table | postgres
+ mx_hide_shard_names | test_table_102008_1131002 | table | postgres
+ mx_hide_shard_names | test_table_1130000        | table | postgres
+ mx_hide_shard_names | test_table_1130002        | table | postgres
 (4 rows)
 
 \d
@@ -179,6 +180,7 @@ CREATE SCHEMA mx_hide_shard_names_2;
 SET search_path TO 'mx_hide_shard_names_2';
 SET citus.shard_count TO 4;
 SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 1132000;
 SET citus.replication_model TO 'streaming';
 CREATE TABLE test_table(id int, time date);
 SELECT create_distributed_table('test_table', 'id');
@@ -191,12 +193,12 @@ CREATE INDEX test_index ON mx_hide_shard_names_2.test_table(id);
 \c - - - :worker_1_port
 SET search_path TO 'mx_hide_shard_names';
 SELECT * FROM citus_shards_on_worker ORDER BY 2;
-       Schema        |           Name           | Type  |  Owner   
----------------------+--------------------------+-------+----------
- mx_hide_shard_names | test_table_102008_102012 | table | postgres
- mx_hide_shard_names | test_table_102008_102014 | table | postgres
- mx_hide_shard_names | test_table_1130000       | table | postgres
- mx_hide_shard_names | test_table_1130002       | table | postgres
+       Schema        |           Name            | Type  |  Owner   
+---------------------+---------------------------+-------+----------
+ mx_hide_shard_names | test_table_102008_1131000 | table | postgres
+ mx_hide_shard_names | test_table_102008_1131002 | table | postgres
+ mx_hide_shard_names | test_table_1130000        | table | postgres
+ mx_hide_shard_names | test_table_1130002        | table | postgres
 (4 rows)
 
 SELECT * FROM citus_shard_indexes_on_worker ORDER BY 2;
@@ -208,17 +210,17 @@ SELECT * FROM citus_shard_indexes_on_worker ORDER BY 2;
 
 SET search_path TO 'mx_hide_shard_names_2';
 SELECT * FROM citus_shards_on_worker ORDER BY 2;
-        Schema         |       Name        | Type  |  Owner   
------------------------+-------------------+-------+----------
- mx_hide_shard_names_2 | test_table_102016 | table | postgres
- mx_hide_shard_names_2 | test_table_102018 | table | postgres
+        Schema         |        Name        | Type  |  Owner   
+-----------------------+--------------------+-------+----------
+ mx_hide_shard_names_2 | test_table_1132000 | table | postgres
+ mx_hide_shard_names_2 | test_table_1132002 | table | postgres
 (2 rows)
 
 SELECT * FROM citus_shard_indexes_on_worker ORDER BY 2;
-        Schema         |       Name        | Type  |  Owner   |       Table       
------------------------+-------------------+-------+----------+-------------------
- mx_hide_shard_names_2 | test_index_102016 | index | postgres | test_table_102016
- mx_hide_shard_names_2 | test_index_102018 | index | postgres | test_table_102018
+        Schema         |        Name        | Type  |  Owner   |       Table        
+-----------------------+--------------------+-------+----------+--------------------
+ mx_hide_shard_names_2 | test_index_1132000 | index | postgres | test_table_1132000
+ mx_hide_shard_names_2 | test_index_1132002 | index | postgres | test_table_1132002
 (2 rows)
 
 SET search_path TO 'mx_hide_shard_names_2, mx_hide_shard_names';
@@ -239,6 +241,7 @@ SET citus.shard_replication_factor TO 1;
 SET citus.replication_model TO 'streaming';
 CREATE SCHEMA mx_hide_shard_names_3;
 SET search_path TO 'mx_hide_shard_names_3';
+SET citus.next_shard_id TO 1133000;
 -- Verify that a table name > 56 characters handled properly.
 CREATE TABLE too_long_12345678901234567890123456789012345678901234567890 (
         col1 integer not null,
@@ -254,8 +257,8 @@ SET search_path TO 'mx_hide_shard_names_3';
 SELECT * FROM citus_shards_on_worker ORDER BY 2;
         Schema         |                              Name                               | Type  |  Owner   
 -----------------------+-----------------------------------------------------------------+-------+----------
- mx_hide_shard_names_3 | too_long_12345678901234567890123456789012345678_e0119164_102020 | table | postgres
- mx_hide_shard_names_3 | too_long_12345678901234567890123456789012345678_e0119164_102022 | table | postgres
+ mx_hide_shard_names_3 | too_long_1234567890123456789012345678901234567_e0119164_1133000 | table | postgres
+ mx_hide_shard_names_3 | too_long_1234567890123456789012345678901234567_e0119164_1133002 | table | postgres
 (2 rows)
 
 \d
@@ -272,6 +275,7 @@ SET citus.shard_replication_factor TO 1;
 SET citus.replication_model TO 'streaming';
 CREATE SCHEMA "CiTuS.TeeN";
 SET search_path TO "CiTuS.TeeN";
+SET citus.next_shard_id TO 1134000;
 CREATE TABLE "TeeNTabLE.1!?!"(id int, "TeNANt_Id" int);
 CREATE INDEX "MyTenantIndex" ON  "CiTuS.TeeN"."TeeNTabLE.1!?!"("TeNANt_Id");
 -- create distributed table with weird names
@@ -284,17 +288,17 @@ SELECT create_distributed_table('"CiTuS.TeeN"."TeeNTabLE.1!?!"', 'TeNANt_Id');
 \c - - - :worker_1_port
 SET search_path TO "CiTuS.TeeN";
 SELECT * FROM citus_shards_on_worker ORDER BY 2;
-   Schema   |         Name          | Type  |  Owner   
-------------+-----------------------+-------+----------
- CiTuS.TeeN | TeeNTabLE.1!?!_102024 | table | postgres
- CiTuS.TeeN | TeeNTabLE.1!?!_102026 | table | postgres
+   Schema   |          Name          | Type  |  Owner   
+------------+------------------------+-------+----------
+ CiTuS.TeeN | TeeNTabLE.1!?!_1134000 | table | postgres
+ CiTuS.TeeN | TeeNTabLE.1!?!_1134002 | table | postgres
 (2 rows)
 
 SELECT * FROM citus_shard_indexes_on_worker ORDER BY 2;
-   Schema   |         Name         | Type  |  Owner   |         Table         
-------------+----------------------+-------+----------+-----------------------
- CiTuS.TeeN | MyTenantIndex_102024 | index | postgres | TeeNTabLE.1!?!_102024
- CiTuS.TeeN | MyTenantIndex_102026 | index | postgres | TeeNTabLE.1!?!_102026
+   Schema   |         Name          | Type  |  Owner   |         Table          
+------------+-----------------------+-------+----------+------------------------
+ CiTuS.TeeN | MyTenantIndex_1134000 | index | postgres | TeeNTabLE.1!?!_1134000
+ CiTuS.TeeN | MyTenantIndex_1134002 | index | postgres | TeeNTabLE.1!?!_1134002
 (2 rows)
 
 \d

--- a/src/test/regress/expected/multi_read_from_secondaries.out
+++ b/src/test/regress/expected/multi_read_from_secondaries.out
@@ -23,13 +23,6 @@ INSERT INTO dest_table (a, b) VALUES (1, 1);
 INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (10, 10);
 -- simluate actually having secondary nodes
-SELECT * FROM pg_dist_node;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-      1 |       1 | localhost |    57637 | default  | f           | t        | primary  | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default
-(2 rows)
-
 UPDATE pg_dist_node SET noderole = 'secondary';
 \c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"
 -- inserts are disallowed

--- a/src/test/regress/expected/multi_transactional_drop_shards.out
+++ b/src/test/regress/expected/multi_transactional_drop_shards.out
@@ -654,11 +654,11 @@ ORDER BY
 
 \c - - - :master_port
 -- try using the coordinator as a worker and then dropping the table
-SELECT master_add_node('localhost', :master_port);
+SELECT 1 FROM master_add_node('localhost', :master_port);
 NOTICE:  Replicating reference table "transactional_drop_reference" to the node localhost:57636
-                        master_add_node                        
----------------------------------------------------------------
- (1380010,1380008,localhost,57636,default,f,t,primary,default)
+ ?column? 
+----------
+        1
 (1 row)
 
 CREATE TABLE citus_local (id serial, k int);

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -69,7 +69,7 @@ SELECT count(*) FROM pg_dist_node WHERE hasmetadata=true;
 
 -- Ensure it works when run on a secondary node
 SELECT groupid AS worker_1_group FROM pg_dist_node WHERE nodeport = :worker_1_port \gset
-SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary');
+SELECT 1 FROM master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary');
 SELECT start_metadata_sync_to_node('localhost', 8888);
 SELECT hasmetadata FROM pg_dist_node WHERE nodeport = 8888;
 SELECT stop_metadata_sync_to_node('localhost', 8888);
@@ -520,7 +520,7 @@ SET citus.replication_model TO 'streaming';
 SELECT create_distributed_table('mx_table', 'a');
 
 \c - postgres - :master_port
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 
 \c - mx_user - :worker_1_port
@@ -634,7 +634,7 @@ FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement
 WHERE logicalrelid='mx_ref'::regclass;
 
 \c - - - :master_port
-SELECT master_add_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 SELECT shardid, nodename, nodeport 
 FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement

--- a/src/test/regress/sql/multi_mx_hide_shard_names.sql
+++ b/src/test/regress/sql/multi_mx_hide_shard_names.sql
@@ -83,6 +83,7 @@ SELECT pg_table_is_visible('test_table_1130000'::regclass);
 SET search_path TO 'mx_hide_shard_names';
 SET citus.shard_count TO 4;
 SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 1131000;
 
 SET citus.replication_model TO 'streaming';
 
@@ -109,6 +110,7 @@ CREATE SCHEMA mx_hide_shard_names_2;
 SET search_path TO 'mx_hide_shard_names_2';
 SET citus.shard_count TO 4;
 SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 1132000;
 
 SET citus.replication_model TO 'streaming';
 CREATE TABLE test_table(id int, time date);
@@ -136,6 +138,7 @@ SET citus.replication_model TO 'streaming';
 
 CREATE SCHEMA mx_hide_shard_names_3;
 SET search_path TO 'mx_hide_shard_names_3';
+SET citus.next_shard_id TO 1133000;
 
 -- Verify that a table name > 56 characters handled properly.
 CREATE TABLE too_long_12345678901234567890123456789012345678901234567890 (
@@ -160,6 +163,7 @@ SET citus.replication_model TO 'streaming';
 
 CREATE SCHEMA "CiTuS.TeeN";
 SET search_path TO "CiTuS.TeeN";
+SET citus.next_shard_id TO 1134000;
 
 CREATE TABLE "TeeNTabLE.1!?!"(id int, "TeNANt_Id" int);
 

--- a/src/test/regress/sql/multi_read_from_secondaries.sql
+++ b/src/test/regress/sql/multi_read_from_secondaries.sql
@@ -19,7 +19,6 @@ INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (10, 10);
 
 -- simluate actually having secondary nodes
-SELECT * FROM pg_dist_node;
 UPDATE pg_dist_node SET noderole = 'secondary';
 
 \c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"

--- a/src/test/regress/sql/multi_transactional_drop_shards.sql
+++ b/src/test/regress/sql/multi_transactional_drop_shards.sql
@@ -364,7 +364,7 @@ ORDER BY
 \c - - - :master_port
 
 -- try using the coordinator as a worker and then dropping the table
-SELECT master_add_node('localhost', :master_port);
+SELECT 1 FROM master_add_node('localhost', :master_port);
 CREATE TABLE citus_local (id serial, k int);
 SELECT create_distributed_table('citus_local', 'id');
 INSERT INTO citus_local (k) VALUES (2);


### PR DESCRIPTION
DESCRIPTION: Add a column to pg_dist_node to enable metadata-only workers

This PR adds an `isdatanode` column to `pg_dist_node`, which allows you to specify whether a node should have shards created on it (default is `true`). This opens the door for having metadata-only/query nodes.

I did not add a more official API for it yet. I imagine it would be something like `add_query_node`. We can use this to gain some experience with it and figure out naming before adding more official support.

(probably not an 8.1 item)