### PR TITLE
Use `conn.killall()` instead of `conn.kill()` in the failure tests

### DIFF
--- a/src/test/regress/expected/failure_copy_on_hash.out
+++ b/src/test/regress/expected/failure_copy_on_hash.out
@@ -28,7 +28,7 @@ CREATE VIEW unhealthy_shard_count AS
 	ON pdsp.shardid=pds.shardid 
 	WHERE logicalrelid='copy_distributed_table.test_table'::regclass AND shardstate != 1;
 -- Just kill the connection after sending the first query to the worker.
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  
@@ -268,7 +268,7 @@ SELECT create_distributed_table('test_table_2','id');
  
 (1 row)
 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  

--- a/src/test/regress/expected/failure_copy_to_reference.out
+++ b/src/test/regress/expected/failure_copy_to_reference.out
@@ -28,7 +28,7 @@ CREATE VIEW unhealthy_shard_count AS
   WHERE logicalrelid='copy_reference_failure.test_table'::regclass AND shardstate != 1;
 -- in the first test, kill just in the first 
 -- response we get from the worker
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  

--- a/src/test/regress/expected/failure_create_distributed_table_non_empty.out
+++ b/src/test/regress/expected/failure_create_distributed_table_non_empty.out
@@ -15,7 +15,7 @@ SET citus.shard_count to 4;
 CREATE TABLE test_table(id int, value_1 int);
 INSERT INTO test_table VALUES (1,1),(2,2),(3,3),(4,4);
 -- in the first test, kill the first connection we sent from the coordinator
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  
@@ -570,7 +570,7 @@ DROP TABLE test_table;
 CREATE TABLE test_table(id int, value_1 int);
 INSERT INTO test_table VALUES (1,1),(2,2),(3,3),(4,4);
 SET citus.multi_shard_commit_protocol TO '1pc';
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  

--- a/src/test/regress/expected/failure_create_table.out
+++ b/src/test/regress/expected/failure_create_table.out
@@ -13,7 +13,7 @@ SET citus.shard_replication_factor TO 1;
 SET citus.shard_count to 4;
 CREATE TABLE test_table(id int, value_1 int);
 -- Kill connection before sending query to the worker 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  
@@ -335,7 +335,7 @@ SELECT run_command_on_workers($$SELECT count(*) FROM information_schema.tables W
 DROP TABLE temp_table;
 -- Test inside transaction
 -- Kill connection before sending query to the worker 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  
@@ -442,7 +442,7 @@ CREATE TABLE test_table(id int, value_1 int);
 -- Test inside transaction and with 1PC
 SET citus.multi_shard_commit_protocol TO "1pc";
 -- Kill connection before sending query to the worker with 1pc.
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  
@@ -588,7 +588,7 @@ SELECT master_create_distributed_table('test_table_2', 'id', 'hash');
 (1 row)
 
 -- Kill connection before sending query to the worker 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
  mitmproxy 
 -----------
  

--- a/src/test/regress/sql/failure_copy_on_hash.sql
+++ b/src/test/regress/sql/failure_copy_on_hash.sql
@@ -24,7 +24,7 @@ CREATE VIEW unhealthy_shard_count AS
 	WHERE logicalrelid='copy_distributed_table.test_table'::regclass AND shardstate != 1;
 
 -- Just kill the connection after sending the first query to the worker.
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 \COPY test_table FROM stdin delimiter ',';
 1,2
 3,4
@@ -138,7 +138,7 @@ SET citus.shard_replication_factor TO 2;
 CREATE TABLE test_table_2(id int, value_1 int);
 SELECT create_distributed_table('test_table_2','id');
 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 
 \COPY test_table_2 FROM stdin delimiter ',';
 1,2

--- a/src/test/regress/sql/failure_copy_to_reference.sql
+++ b/src/test/regress/sql/failure_copy_to_reference.sql
@@ -23,7 +23,7 @@ CREATE VIEW unhealthy_shard_count AS
 
 -- in the first test, kill just in the first 
 -- response we get from the worker
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 \copy test_table FROM STDIN DELIMITER ','
 1,2
 2,3

--- a/src/test/regress/sql/failure_create_distributed_table_non_empty.sql
+++ b/src/test/regress/sql/failure_create_distributed_table_non_empty.sql
@@ -14,7 +14,7 @@ CREATE TABLE test_table(id int, value_1 int);
 INSERT INTO test_table VALUES (1,1),(2,2),(3,3),(4,4);
 
 -- in the first test, kill the first connection we sent from the coordinator
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 SELECT create_distributed_table('test_table', 'id');
 SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;
 
@@ -198,7 +198,7 @@ CREATE TABLE test_table(id int, value_1 int);
 INSERT INTO test_table VALUES (1,1),(2,2),(3,3),(4,4);
 SET citus.multi_shard_commit_protocol TO '1pc';
 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 SELECT create_distributed_table('test_table', 'id');
 SELECT citus.mitmproxy('conn.allow()');
 SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;

--- a/src/test/regress/sql/failure_create_table.sql
+++ b/src/test/regress/sql/failure_create_table.sql
@@ -12,7 +12,7 @@ SET citus.shard_count to 4;
 CREATE TABLE test_table(id int, value_1 int);
 
 -- Kill connection before sending query to the worker 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 SELECT create_distributed_table('test_table','id');
 
 SELECT citus.mitmproxy('conn.allow()');
@@ -108,7 +108,7 @@ DROP TABLE temp_table;
 
 -- Test inside transaction
 -- Kill connection before sending query to the worker 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 
 BEGIN;
 SELECT create_distributed_table('test_table','id');
@@ -149,7 +149,7 @@ CREATE TABLE test_table(id int, value_1 int);
 SET citus.multi_shard_commit_protocol TO "1pc";
 
 -- Kill connection before sending query to the worker with 1pc.
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 
 BEGIN;
 SELECT create_distributed_table('test_table','id');
@@ -202,7 +202,7 @@ CREATE TABLE test_table_2(id int, value_1 int);
 SELECT master_create_distributed_table('test_table_2', 'id', 'hash');
 
 -- Kill connection before sending query to the worker 
-SELECT citus.mitmproxy('conn.kill()');
+SELECT citus.mitmproxy('conn.killall()');
 SELECT master_create_worker_shards('test_table_2', 4, 2);
 
 SELECT count(*) FROM pg_dist_shard;


### PR DESCRIPTION
Mostly opened to trigger travis failure tests, yet.

There seems to be an issue with `flow.kill`, which is fixed in never versions of mitmproxy but not the one that we use. Here is the link to that [issue](https://github.com/mitmproxy/mitmproxy/issues/2724).

I realized Citus regression tests randomly fails on right after `conn.kill()`, and trying to understand whether the change in this PR helps us.