### PR TITLE
Review some strcpy/memcpy/strprintf/sscanf usage in the code.

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -260,15 +260,37 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	/* auth keywords will begin after global and runtime ones are appended */
 	Index authParamsIdx = ConnParams.size + lengthof(runtimeKeywords);
 
+	int paramIndex = 0;
+	int runtimeParamIndex = 0;
+
+	if (ConnParams.size + lengthof(runtimeKeywords) > ConnParams.maxSize)
+	{
+		/* unexpected, intended as developers rather than users */
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("too many connParams entries")));
+	}
+
 	pg_ltoa(key->port, nodePortString); /* populate node port string with port */
 
 	/* first step: copy global parameters to beginning of array */
-	memcpy(connKeywords, ConnParams.keywords, ConnParams.size * sizeof(char *));
-	memcpy(connValues, ConnParams.values, ConnParams.size * sizeof(char *));
+	for (paramIndex = 0; paramIndex < ConnParams.size; paramIndex++)
+	{
+		/* copy the keyword&value pointers to the new array */
+		connKeywords[paramIndex] = ConnParams.keywords[paramIndex];
+		connValues[paramIndex] = ConnParams.values[paramIndex];
+	}
 
 	/* second step: begin at end of global params and copy runtime ones */
-	memcpy(&connKeywords[ConnParams.size], runtimeKeywords, sizeof(runtimeKeywords));
-	memcpy(&connValues[ConnParams.size], runtimeValues, sizeof(runtimeValues));
+	for (runtimeParamIndex = 0;
+		 runtimeParamIndex < lengthof(runtimeKeywords);
+		 runtimeParamIndex++)
+	{
+		/* copy the keyword&value pointers to the new array */
+		connKeywords[ConnParams.size + runtimeParamIndex] =
+			(char *) runtimeKeywords[runtimeParamIndex];
+		connValues[ConnParams.size + runtimeParamIndex] =
+			(char *) runtimeValues[runtimeParamIndex];
+	}
 
 	/* final step: add terminal NULL, required by libpq */
 	connKeywords[authParamsIdx] = connValues[authParamsIdx] = NULL;

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -689,7 +689,7 @@ FindOrCreatePlacementEntry(ShardPlacement *placement)
 			ColocatedPlacementsHashKey key;
 			ColocatedPlacementsHashEntry *colocatedEntry = NULL;
 
-			strcpy(key.nodeName, placement->nodeName);
+			strlcpy(key.nodeName, placement->nodeName, MAX_NODE_LENGTH);
 			key.nodePort = placement->nodePort;
 			key.colocationGroupId = placement->colocationGroupId;
 			key.representativeValue = placement->representativeValue;


### PR DESCRIPTION
In answer to a security audit, we double check buffer sizes and avoid known-dangerous operations such as sscanf.