### PR TITLE
Failure/cancellation tests for mx metadata sync

### DIFF
--- a/src/test/regress/expected/failure_mx_metadata_sync.out
+++ b/src/test/regress/expected/failure_mx_metadata_sync.out
@@ -1,0 +1,170 @@
+--
+-- failure_mx_metadata_sync.sql
+--
+CREATE SCHEMA IF NOT EXISTS mx_metadata_sync;
+SET SEARCH_PATH = mx_metadata_sync;
+SET citus.shard_count TO 2;
+SET citus.next_shard_id TO 16000000;
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO 'streaming';
+SELECT pg_backend_pid() as pid \gset
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+CREATE TABLE t1 (id int PRIMARY KEY);
+SELECT create_distributed_table('t1', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO t1 SELECT x FROM generate_series(1,100) AS f(x);
+-- Initial metadata status
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_proxy_port;
+ hasmetadata 
+-------------
+ f
+(1 row)
+
+-- Failure to set groupid in the worker
+SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE pg_dist_local_group SET groupid").cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  canceling statement due to user request
+SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE pg_dist_local_group SET groupid").kill()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
+-- Failure to drop all tables in pg_dist_partition
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT worker_drop_distributed_table").cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  canceling statement due to user request
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT worker_drop_distributed_table").kill()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
+-- Failure to truncate pg_dist_node in the worker
+SELECT citus.mitmproxy('conn.onQuery(query="^TRUNCATE pg_dist_node CASCADE").cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  canceling statement due to user request
+SELECT citus.mitmproxy('conn.onQuery(query="^TRUNCATE pg_dist_node CASCADE").kill()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
+-- Failure to populate pg_dist_node in the worker
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT INTO pg_dist_node").cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  canceling statement due to user request
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT INTO pg_dist_node").kill()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
+-- Verify that coordinator knows worker does not have valid metadata
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_proxy_port;
+ hasmetadata 
+-------------
+ f
+(1 row)
+
+-- Verify we can sync metadata after unsuccessful attempts
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_proxy_port;
+ hasmetadata 
+-------------
+ t
+(1 row)
+
+-- Check failures on DDL command propagation
+CREATE TABLE t2 (id int PRIMARY KEY);
+SELECT citus.mitmproxy('conn.onParse(query="^INSERT INTO pg_dist_placement").kill()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT create_distributed_table('t2', 'id');
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
+SELECT citus.mitmproxy('conn.onParse(query="^INSERT INTO pg_dist_shard").cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT create_distributed_table('t2', 'id');
+ERROR:  canceling statement due to user request
+-- Verify that the table was not distributed
+SELECT count(*) > 0 AS is_table_distributed
+FROM pg_dist_partition
+WHERE logicalrelid='t2'::regclass;
+ is_table_distributed 
+----------------------
+ f
+(1 row)
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP SCHEMA mx_metadata_sync CASCADE;

--- a/src/test/regress/failure_schedule
+++ b/src/test/regress/failure_schedule
@@ -29,3 +29,4 @@ test: failure_insert_select_pushdown
 test: failure_single_mod
 test: failure_savepoints
 test: failure_multi_row_insert
+test: failure_mx_metadata_sync

--- a/src/test/regress/sql/failure_mx_metadata_sync.sql
+++ b/src/test/regress/sql/failure_mx_metadata_sync.sql
@@ -1,0 +1,69 @@
+--
+-- failure_mx_metadata_sync.sql
+--
+CREATE SCHEMA IF NOT EXISTS mx_metadata_sync;
+SET SEARCH_PATH = mx_metadata_sync;
+SET citus.shard_count TO 2;
+SET citus.next_shard_id TO 16000000;
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO 'streaming';
+
+SELECT pg_backend_pid() as pid \gset
+SELECT citus.mitmproxy('conn.allow()');
+
+CREATE TABLE t1 (id int PRIMARY KEY);
+SELECT create_distributed_table('t1', 'id');
+INSERT INTO t1 SELECT x FROM generate_series(1,100) AS f(x);
+
+-- Initial metadata status
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_proxy_port;
+
+-- Failure to set groupid in the worker
+SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE pg_dist_local_group SET groupid").cancel(' || :pid || ')');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE pg_dist_local_group SET groupid").kill()');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+
+-- Failure to drop all tables in pg_dist_partition
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT worker_drop_distributed_table").cancel(' || :pid || ')');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT worker_drop_distributed_table").kill()');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+
+-- Failure to truncate pg_dist_node in the worker
+SELECT citus.mitmproxy('conn.onQuery(query="^TRUNCATE pg_dist_node CASCADE").cancel(' || :pid || ')');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+SELECT citus.mitmproxy('conn.onQuery(query="^TRUNCATE pg_dist_node CASCADE").kill()');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+
+-- Failure to populate pg_dist_node in the worker
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT INTO pg_dist_node").cancel(' || :pid || ')');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT INTO pg_dist_node").kill()');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+
+-- Verify that coordinator knows worker does not have valid metadata
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_proxy_port;
+
+-- Verify we can sync metadata after unsuccessful attempts
+SELECT citus.mitmproxy('conn.allow()');
+SELECT start_metadata_sync_to_node('localhost', :worker_2_proxy_port);
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport=:worker_2_proxy_port;
+
+-- Check failures on DDL command propagation
+CREATE TABLE t2 (id int PRIMARY KEY);
+
+SELECT citus.mitmproxy('conn.onParse(query="^INSERT INTO pg_dist_placement").kill()');
+SELECT create_distributed_table('t2', 'id');
+
+SELECT citus.mitmproxy('conn.onParse(query="^INSERT INTO pg_dist_shard").cancel(' || :pid || ')');
+SELECT create_distributed_table('t2', 'id');
+
+-- Verify that the table was not distributed
+SELECT count(*) > 0 AS is_table_distributed
+FROM pg_dist_partition
+WHERE logicalrelid='t2'::regclass;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP SCHEMA mx_metadata_sync CASCADE;


### PR DESCRIPTION
DESCRIPTION: Add failure/cancellation tests for mx metadata sync
For remaining failure/cancellation tests, see https://github.com/citusdata/citus/issues/2262

This PR adds failure&cancellation tests during:
- initial `start_metadata_sync()` calls
- DDL queries that send metadata syncing messages to an MX node
- ~~`stop_metadata_sync()`~~ no network messages are exchanged during `stop_metadata_sync()` calls, so there is no possible way to test for failures. A former MX node is never aware that it is no longer receiving metadata.

This PR also extends our failure test capabilities by adding new network message type descriptions.
MX Metadata Syncing uses [Extended Query Protocol](https://www.postgresql.org/docs/11/protocol-message-types.html) between workers and this protocol introduces some network message types that our mitmproxy could not parse. For all possible message formats see [here](https://www.postgresql.org/docs/11/protocol-message-formats.html)

When a `start_metadata_sync` call is made these queries are sent to a worker in a single connection:
```sql
🚫BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(0, XX, '1999-12-31 16:00:00-08');)
✅UPDATE pg_dist_local_group SET groupid = 2
✅SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
✅TRUNCATE pg_dist_node CASCADE
✅INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 9060, 'default', TRUE, TRUE, 'primary'::noderole, 'default'))
🚫CREATE SCHEMA IF NOT EXISTS mx_metadata_sync AUTHORIZATION postgres
🚫CREATE TABLE mx_metadata_sync.t1 (id integer NOT NULL)
🚫ALTER TABLE mx_metadata_sync.t1 OWNER TO postgres
🚫ALTER TABLE mx_metadata_sync.t1 ADD CONSTRAINT t1_pkey PRIMARY KEY (id)
🚫ALTER TABLE mx_metadata_sync.t1 OWNER TO postgres
🚫INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey, colocationid, repmodel) VALUES ('mx_metadata_sync.t1'::regclass, 'h', column_name_to_column('mx_metadata_sync.t1','id'), 1, 's'))
🚫SELECT worker_create_truncate_trigger('mx_metadata_sync.t1'))
🚫INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (16000000, 1, 0, 2, 1),(16000001, 1, 0, 1, 2)
🚫INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_metadata_sync.t1'::regclass, 16000000, 't', '-2147483648', '-1'),('mx_metadata_sync.t1'::regclass, 16000001, 't', '0', '2147483647'))
🚫COMMIT
```