### PR TITLE
upgrade default ssl_ciphers to more restrictive on extension creation

### DIFF
--- a/src/test/regress/expected/ssl_by_default.out
+++ b/src/test/regress/expected/ssl_by_default.out
@@ -61,3 +61,18 @@ $$);
  (localhost,57638,t,t)
 (2 rows)
 
+SHOW ssl_ciphers;
+        ssl_ciphers         
+----------------------------
+ TLSv1.2+HIGH:!aNULL:!eNULL
+(1 row)
+
+SELECT run_command_on_workers($$
+    SHOW ssl_ciphers;
+$$);
+             run_command_on_workers             
+------------------------------------------------
+ (localhost,57637,t,TLSv1.2+HIGH:!aNULL:!eNULL)
+ (localhost,57638,t,TLSv1.2+HIGH:!aNULL:!eNULL)
+(2 rows)
+

--- a/src/test/regress/sql/ssl_by_default.sql
+++ b/src/test/regress/sql/ssl_by_default.sql
@@ -33,3 +33,8 @@ $$);
 SELECT run_command_on_workers($$
     SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid();
 $$);
+
+SHOW ssl_ciphers;
+SELECT run_command_on_workers($$
+    SHOW ssl_ciphers;
+$$);


### PR DESCRIPTION
Description: restrict SSL Ciphers to TLS1.2 and above

By default postgres allows TLS1 and TLS1.1 on most installations. This will recognise ssl_ciphers is set to the postgres default and upgrades it to `TLS1.2+HIGH:!eNULL:!aNULL`. [docs](https://www.openssl.org/docs/manmaster/man1/ciphers.html)

 - `TLS1.2+HIGH`: only allows ciphers that overlap between ciphers supported by TLS1.2 and HIGH
    "High" encryption cipher suites. This currently means those with key lengths larger than 128 bits, and some cipher suites with 128-bit keys.
- `!eNULL`: removes ciphers that offer no encryption
- `!aNULL`: removes ciphers that offer no authentication

Even though TLS1.2 is only the list of ciphers that are supported by TLS1.2, and therefore does not require TLS1.2, the resulting accepted connection configurations are only TLS 1.2 and above, for both openssl `1.0.x` and `1.1.x`.

# sslyze outputs

## openssl 1.0.2q:
```
$ sslyze --sslv2 --sslv3 --tlsv1 --tlsv1_1 --tlsv1_2 localhost:9700 --starttls=postgres --hide_rejected_ciphers



 AVAILABLE PLUGINS
 -----------------

  HeartbleedPlugin
  SessionResumptionPlugin
  HttpHeadersPlugin
  CertificateInfoPlugin
  RobotPlugin
  OpenSslCcsInjectionPlugin
  OpenSslCipherSuitesPlugin
  FallbackScsvPlugin
  CompressionPlugin
  SessionRenegotiationPlugin



 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   localhost:9700                      => 127.0.0.1




 SCAN RESULTS FOR LOCALHOST:9700 - 127.0.0.1
 -------------------------------------------

 * SSLV3 Cipher Suites:
      Server rejected all cipher suites.

 * TLSV1 Cipher Suites:
      Server rejected all cipher suites.

 * SSLV2 Cipher Suites:
      Server rejected all cipher suites.

 * TLSV1_2 Cipher Suites:
       Forward Secrecy                    OK - Supported
       RC4                                OK - Not Supported

     Preferred:
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             ECDH-256 bits  256 bits
     Accepted:
        TLS_DHE_RSA_WITH_AES_256_CBC_SHA256               DH-2048 bits   256 bits
        TLS_RSA_WITH_AES_256_CBC_SHA256                   -              256 bits
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384             ECDH-256 bits  256 bits
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             ECDH-256 bits  256 bits
        TLS_DHE_RSA_WITH_AES_256_GCM_SHA384               DH-2048 bits   256 bits
        TLS_RSA_WITH_AES_256_GCM_SHA384                   -              256 bits
        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             ECDH-256 bits  128 bits
        TLS_DHE_RSA_WITH_AES_128_CBC_SHA256               DH-2048 bits   128 bits
        TLS_RSA_WITH_AES_128_CBC_SHA256                   -              128 bits
        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256               DH-2048 bits   128 bits
        TLS_RSA_WITH_AES_128_GCM_SHA256                   -              128 bits
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256             ECDH-256 bits  128 bits

 * TLSV1_1 Cipher Suites:
      Server rejected all cipher suites.


 SCAN COMPLETED IN 0.49 S
 ------------------------
```

## openssl 1.1.1a
```
$ sslyze --sslv2 --sslv3 --tlsv1 --tlsv1_1 --tlsv1_2 localhost:9700 --starttls=postgres --hide_rejected_ciphers



 AVAILABLE PLUGINS
 -----------------

  FallbackScsvPlugin
  SessionRenegotiationPlugin
  OpenSslCipherSuitesPlugin
  SessionResumptionPlugin
  HttpHeadersPlugin
  HeartbleedPlugin
  CompressionPlugin
  CertificateInfoPlugin
  RobotPlugin
  OpenSslCcsInjectionPlugin



 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   localhost:9700                      => 127.0.0.1




 SCAN RESULTS FOR LOCALHOST:9700 - 127.0.0.1
 -------------------------------------------

 * TLSV1 Cipher Suites:
      Server rejected all cipher suites.

 * TLSV1_1 Cipher Suites:
      Server rejected all cipher suites.

 * SSLV2 Cipher Suites:
      Server rejected all cipher suites.

 * SSLV3 Cipher Suites:
      Server rejected all cipher suites.

 * TLSV1_2 Cipher Suites:
       Forward Secrecy                    OK - Supported
       RC4                                OK - Not Supported

     Preferred:
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             ECDH-256 bits  256 bits
     Accepted:
        TLS_DHE_RSA_WITH_AES_256_CBC_SHA256               DH-2048 bits   256 bits
        RSA_WITH_AES_256_CCM_8                            -              256 bits
        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256       -              256 bits
        TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256              -              256 bits
        TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256         -              256 bits
        RSA_WITH_AES_256_CCM                              -              256 bits
        TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256          -              256 bits
        ARIA256-GCM-SHA384                                -              256 bits
        TLS_RSA_WITH_AES_256_CBC_SHA256                   -              256 bits
        TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384        -              256 bits
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384             ECDH-256 bits  256 bits
        DHE_RSA_WITH_AES_256_CCM_8                        -              256 bits
        ECDHE-ARIA256-GCM-SHA384                          -              256 bits
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             ECDH-256 bits  256 bits
        TLS_DHE_RSA_WITH_AES_256_GCM_SHA384               DH-2048 bits   256 bits
        TLS_RSA_WITH_AES_256_GCM_SHA384                   -              256 bits
        TLS_DHE_RSA_WITH_AES_256_CCM                      -              256 bits
        DHE-RSA-ARIA256-GCM-SHA384                        -              256 bits
        TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256              -              128 bits
        RSA_WITH_AES_128_CCM_8                            -              128 bits
        RSA_WITH_AES_128_CCM                              -              128 bits
        DHE_RSA_WITH_AES_128_CCM                          -              128 bits
        TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256        -              128 bits
        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             ECDH-256 bits  128 bits
        ARIA128-GCM-SHA256                                -              128 bits
        DHE_RSA_WITH_AES_128_CCM_8                        -              128 bits
        TLS_DHE_RSA_WITH_AES_128_CBC_SHA256               DH-2048 bits   128 bits
        ECDHE-ARIA128-GCM-SHA256                          -              128 bits
        TLS_RSA_WITH_AES_128_CBC_SHA256                   -              128 bits
        TLS_RSA_WITH_AES_128_GCM_SHA256                   -              128 bits
        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256               DH-2048 bits   128 bits
        DHE-RSA-ARIA128-GCM-SHA256                        -              128 bits
        TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256          -              128 bits
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256             ECDH-256 bits  128 bits


 SCAN COMPLETED IN 0.40 S
 ------------------------
```