### PR TITLE
Execute CREATE INDEX CONCURRENTLY in parallel

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -598,7 +598,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 
 		PG_TRY();
 		{
-			ExecuteModifyTasksSequentiallyWithoutResults(ddlJob->taskList, CMD_UTILITY);
+			ExecuteModifyTasksWithoutResults(ddlJob->taskList);
 
 			if (shouldSyncMetadata)
 			{

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1267,8 +1267,7 @@ ExecuteModifyTasksWithoutResults(List *taskList)
  * ExecuteModifyTasksSequentiallyWithoutResults basically calls ExecuteSingleModifyTask in
  * a loop in order to simulate sequential execution of a list of tasks. Useful
  * in cases where issuing commands in parallel before waiting for results could
- * result in deadlocks (such as CREATE INDEX CONCURRENTLY or foreign key creation to
- * reference tables).
+ * result in deadlocks (such as foreign key creation to reference tables).
  *
  * The function returns the affectedTupleCount if applicable. Otherwise, the function
  * returns 0.

--- a/src/test/regress/expected/failure_create_index_concurrently.out
+++ b/src/test/regress/expected/failure_create_index_concurrently.out
@@ -45,39 +45,6 @@ WHERE nodeport = :worker_2_proxy_port;
 
 DROP TABLE index_test;
 CREATE TABLE index_test(id int, value_1 int, value_2 int);
-SELECT create_distributed_table('index_test', 'id');
- create_distributed_table 
---------------------------
- 
-(1 row)
-
--- kill the connection at the second create command is issued
-SELECT citus.mitmproxy('conn.onQuery(query="CREATE").after(1).kill()');
- mitmproxy 
------------
- 
-(1 row)
-
-CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
-SELECT citus.mitmproxy('conn.allow()');
- mitmproxy 
------------
- 
-(1 row)
-
--- verify only one index is created
-SELECT * FROM run_command_on_workers($$SELECT count(*) FROM pg_indexes WHERE indexname LIKE 'idx_index_test%' $$)
-WHERE nodeport = :worker_2_proxy_port;
- nodename  | nodeport | success | result 
------------+----------+---------+--------
- localhost |     9060 | t       | 1
-(1 row)
-
-DROP TABLE index_test;
-CREATE TABLE index_test(id int, value_1 int, value_2 int);
 SELECT create_reference_table('index_test');
  create_reference_table 
 ------------------------

--- a/src/test/regress/sql/failure_create_index_concurrently.sql
+++ b/src/test/regress/sql/failure_create_index_concurrently.sql
@@ -28,23 +28,6 @@ DROP TABLE index_test;
 
 
 CREATE TABLE index_test(id int, value_1 int, value_2 int);
-SELECT create_distributed_table('index_test', 'id');
-
--- kill the connection at the second create command is issued
-SELECT citus.mitmproxy('conn.onQuery(query="CREATE").after(1).kill()');
-
-CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-
-SELECT citus.mitmproxy('conn.allow()');
-
--- verify only one index is created
-SELECT * FROM run_command_on_workers($$SELECT count(*) FROM pg_indexes WHERE indexname LIKE 'idx_index_test%' $$)
-WHERE nodeport = :worker_2_proxy_port;
-
-DROP TABLE index_test;
-
-
-CREATE TABLE index_test(id int, value_1 int, value_2 int);
 SELECT create_reference_table('index_test');
 
 -- kill the connection when create command is issued


### PR DESCRIPTION
DESCRIPTION: Execute CREATE INDEX CONCURRENTLY in parallel

As of https://github.com/postgres/postgres/commit/1dec82068b3b59b621e6b04040c150241f5060f3  the risk of deadlocks when running multiple CREATE INDEX CONCURRENTLY commands in parallel is gone. Switch to using parallel execution to improve performance.