### PR TITLE
Move an assert-only array-bound check to run-time.

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -100,7 +100,12 @@ ResetConnParams()
 void
 AddConnParam(const char *keyword, const char *value)
 {
-	Assert((ConnParams.size + 1) < ConnParams.maxSize);
+	if (ConnParams.size + 1 >= ConnParams.maxSize)
+	{
+		/* we expect developers to see that error messages */
+		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+						errmsg("ConnParams arrays bound check failed")));
+	}
 
 	ConnParams.keywords[ConnParams.size] = strdup(keyword);
 	ConnParams.values[ConnParams.size] = strdup(value);
@@ -263,7 +268,7 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	int paramIndex = 0;
 	int runtimeParamIndex = 0;
 
-	if (ConnParams.size + lengthof(runtimeKeywords) > ConnParams.maxSize)
+	if (ConnParams.size + lengthof(runtimeKeywords) >= ConnParams.maxSize)
 	{
 		/* unexpected, intended as developers rather than users */
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),


### PR DESCRIPTION
When the bound-check fails at run-time, better abort with an error message
rather than trying to user memory we did not allocate.

DESCRIPTION: Move an assert-only array-bound check to run-time.

The following regression doesn't seem related because it is not firing the new error condition and message. Are the tests unstable at this moment?

```diff
--- /Users/dim/dev/CitusData/citus/src/test/regress/expected/ssl_by_default.out	2018-12-20 10:10:43.000000000 +0100
+++ /Users/dim/dev/CitusData/citus/src/test/regress/results/ssl_by_default.out	2018-12-20 10:18:41.000000000 +0100
@@ -12,67 +12,67 @@
         substring(:'server_version', '\d+')::int >= 10 AS version_ten_or_above,
         :'ssl_ciphers' != 'none' AS hasssl
 )
 SELECT (
     true
     AND version_ten_or_above
     AND hasssl
 ) AS ssl_by_default_supported FROM features;
  ssl_by_default_supported 
 --------------------------
- t
+ f
 (1 row)
 
 SHOW ssl;
  ssl 
 -----
- on
+ off
 (1 row)
 
 SELECT run_command_on_workers($$
     SHOW ssl;
 $$);
  run_command_on_workers 
-------------------------
- (localhost,57637,t,on)
- (localhost,57638,t,on)
+-------------------------
+ (localhost,57637,t,off)
+ (localhost,57638,t,off)
 (2 rows)
 
 SHOW citus.node_conninfo;
  citus.node_conninfo 
 ---------------------
- sslmode=require
+ sslmode=prefer
 (1 row)
 
 SELECT run_command_on_workers($$
     SHOW citus.node_conninfo;
 $$);
        run_command_on_workers        
--------------------------------------
- (localhost,57637,t,sslmode=require)
- (localhost,57638,t,sslmode=require)
+------------------------------------
+ (localhost,57637,t,sslmode=prefer)
+ (localhost,57638,t,sslmode=prefer)
 (2 rows)
 
 SELECT run_command_on_workers($$
     SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid();
 $$);
  run_command_on_workers 
 ------------------------
- (localhost,57637,t,t)
- (localhost,57638,t,t)
+ (localhost,57637,t,f)
+ (localhost,57638,t,f)
 (2 rows)
 
 SHOW ssl_ciphers;
         ssl_ciphers         
-----------------------------
- TLSv1.2+HIGH:!aNULL:!eNULL
+-------------
+ none
 (1 row)
 
 SELECT run_command_on_workers($$
     SHOW ssl_ciphers;
 $$);
              run_command_on_workers             
-------------------------------------------------
- (localhost,57637,t,TLSv1.2+HIGH:!aNULL:!eNULL)
- (localhost,57638,t,TLSv1.2+HIGH:!aNULL:!eNULL)
+--------------------------
+ (localhost,57637,t,none)
+ (localhost,57638,t,none)
 (2 rows)
 

======================================================================

```