### PR TITLE
Git ignore LLVM bitcode files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ win32ver.rc
 *.exe
 lib*dll.def
 lib*.pc
+*.bc
 
 # Local excludes in root directory
 /config.log


### PR DESCRIPTION
Compiling with `--with-llvm` results in lots of `*.bc` files which should be ignored when committing to repository.
