### PR TITLE
Relax reference table checks in subquery union pushdown

### DIFF
--- a/src/include/distributed/query_pushdown_planning.h
+++ b/src/include/distributed/query_pushdown_planning.h
@@ -36,9 +36,15 @@ extern DeferredErrorMessage * DeferErrorIfUnsupportedSubqueryPushdown(Query *
 																	  *
 																	  plannerRestrictionContext);
 extern DeferredErrorMessage * DeferErrorIfCannotPushdownSubquery(Query *subqueryTree,
+																 PlannerRestrictionContext
+																 *
+																 plannerRestrictionContext,
 																 bool
 																 outerMostQueryHasLimit);
-extern DeferredErrorMessage * DeferErrorIfUnsupportedUnionQuery(Query *queryTree);
+extern DeferredErrorMessage * DeferErrorIfUnsupportedUnionQuery(Query *queryTree,
+																PlannerRestrictionContext
+																*
+																plannerRestrictionContext);
 
 
 #endif /* QUERY_PUSHDOWN_PLANNING_H */

--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -305,6 +305,103 @@ DEBUG:  Plan is router executable
     14
 (1 row)
 
+-- can perform a union involving reference table if it is joined with
+-- a non-reference distributed table.
+SELECT user_id, item_id FROM
+	(SELECT user_id, item_id
+		FROM user_buy_test_table nonref
+			JOIN
+			users_ref_test_table ref
+			ON  nonref.item_id = ref.id
+		WHERE nonref.item_id != 3
+	UNION
+	(SELECT user_id, item_id FROM user_buy_test_table where item_id = 4)
+	) a
+ORDER BY 1, 2;
+ user_id | item_id 
+---------+---------
+       1 |       2
+       3 |       4
+       7 |       5
+(3 rows)
+
+-- union all is also supported if a reference table is joined
+-- with a non-reference distributed table
+SELECT user_id, item_id FROM
+	(SELECT user_id, item_id
+		FROM user_buy_test_table nonref
+			JOIN
+			users_ref_test_table ref
+			ON  nonref.item_id = ref.id
+		WHERE nonref.item_id != 3
+	UNION ALL
+	(SELECT user_id, item_id FROM user_buy_test_table where item_id = 4)
+	) a
+ORDER BY 1, 2;
+ user_id | item_id 
+---------+---------
+       1 |       2
+       3 |       4
+       3 |       4
+       7 |       5
+(4 rows)
+
+-- needs to pull data to coordinator when distribution key
+-- is not on the target list
+SELECT item_id FROM
+	(SELECT item_id
+		FROM user_buy_test_table nonref
+			JOIN
+			users_ref_test_table ref
+			ON  nonref.item_id = ref.id
+		WHERE nonref.item_id != 3
+	UNION ALL
+	(SELECT item_id FROM user_buy_test_table where item_id = 4)
+	) a
+ORDER BY 1;
+DEBUG:  generating subplan 39_1 for subquery SELECT nonref.item_id FROM (public.user_buy_test_table nonref JOIN public.users_ref_test_table ref ON ((nonref.item_id OPERATOR(pg_catalog.=) ref.id))) WHERE (nonref.item_id OPERATOR(pg_catalog.<>) 3)
+DEBUG:  generating subplan 39_2 for subquery SELECT item_id FROM public.user_buy_test_table WHERE (item_id OPERATOR(pg_catalog.=) 4)
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan 39_3 for subquery SELECT intermediate_result.item_id FROM read_intermediate_result('39_1'::text, 'binary'::citus_copy_format) intermediate_result(item_id integer) UNION ALL SELECT intermediate_result.item_id FROM read_intermediate_result('39_2'::text, 'binary'::citus_copy_format) intermediate_result(item_id integer)
+DEBUG:  Plan 39 query after replacing subqueries and CTEs: SELECT item_id FROM (SELECT intermediate_result.item_id FROM read_intermediate_result('39_3'::text, 'binary'::citus_copy_format) intermediate_result(item_id integer)) a ORDER BY item_id
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ item_id 
+---------
+       2
+       4
+       4
+       5
+(4 rows)
+
+-- needs to pull data to coordinator when subquery on a reference table
+-- is union'ed with a subquery on a distributed table. 
+SELECT user_id FROM
+	(SELECT id user_id
+		FROM users_ref_test_table ref
+		WHERE ref.id != 3
+	UNION
+	(SELECT user_id FROM user_buy_test_table where item_id = 4)
+	) a
+ORDER BY 1;
+DEBUG:  generating subplan 43_1 for subquery SELECT user_id FROM public.user_buy_test_table WHERE (item_id OPERATOR(pg_catalog.=) 4)
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan 43_2 for subquery SELECT ref.id AS user_id FROM public.users_ref_test_table ref WHERE (ref.id OPERATOR(pg_catalog.<>) 3) UNION SELECT intermediate_result.user_id FROM read_intermediate_result('43_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)
+DEBUG:  Plan 43 query after replacing subqueries and CTEs: SELECT user_id FROM (SELECT intermediate_result.user_id FROM read_intermediate_result('43_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)) a ORDER BY user_id
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ user_id 
+---------
+       1
+       2
+       3
+       4
+       5
+       6
+(6 rows)
+
 RESET client_min_messages;
 -- subquery without FROM can be the inner relationship in a join
 SELECT count(*) FROM
@@ -1179,8 +1276,8 @@ SELECT count(*) FROM
 (SELECT user_buy_test_table.user_id, random() FROM user_buy_test_table LEFT JOIN users_ref_test_table
   ON user_buy_test_table.user_id > users_ref_test_table.id) subquery_2
 WHERE subquery_1.user_id != subquery_2.user_id ;
-DEBUG:  generating subplan 79_1 for subquery SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.user_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))
-DEBUG:  Plan 79 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))) subquery_1, (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('79_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) subquery_2 WHERE (subquery_1.user_id OPERATOR(pg_catalog.<>) subquery_2.user_id)
+DEBUG:  generating subplan 83_1 for subquery SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.user_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))
+DEBUG:  Plan 83 query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT user_buy_test_table.user_id, random() AS random FROM (public.user_buy_test_table LEFT JOIN public.users_ref_test_table ON ((user_buy_test_table.item_id OPERATOR(pg_catalog.>) users_ref_test_table.id)))) subquery_1, (SELECT intermediate_result.user_id, intermediate_result.random FROM read_intermediate_result('83_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, random double precision)) subquery_2 WHERE (subquery_1.user_id OPERATOR(pg_catalog.<>) subquery_2.user_id)
  count 
 -------
     67
@@ -1225,8 +1322,8 @@ count(*) AS cnt, "generated_group_field"
   ORDER BY
     cnt DESC, generated_group_field ASC
   LIMIT 10;
-DEBUG:  generating subplan 81_1 for subquery SELECT user_id, value_2 AS generated_group_field FROM public.users_table users
-DEBUG:  Plan 81 query after replacing subqueries and CTEs: SELECT count(*) AS cnt, generated_group_field FROM (SELECT "eventQuery".user_id, random() AS random, "eventQuery".generated_group_field FROM (SELECT multi_group_wrapper_1."time", multi_group_wrapper_1.event_user_id, multi_group_wrapper_1.user_id, left_group_by_1.generated_group_field, random() AS random FROM ((SELECT temp_data_queries."time", temp_data_queries.event_user_id, user_filters_1.user_id FROM ((SELECT events."time", events.user_id AS event_user_id FROM public.events_table events WHERE (events.user_id OPERATOR(pg_catalog.>) 2)) temp_data_queries JOIN (SELECT users.user_id FROM public.users_reference_table users WHERE ((users.user_id OPERATOR(pg_catalog.>) 2) AND (users.value_2 OPERATOR(pg_catalog.=) 5))) user_filters_1 ON ((temp_data_queries.event_user_id OPERATOR(pg_catalog.<) user_filters_1.user_id)))) multi_group_wrapper_1 RIGHT JOIN (SELECT intermediate_result.user_id, intermediate_result.generated_group_field FROM read_intermediate_result('81_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, generated_group_field integer)) left_group_by_1 ON ((left_group_by_1.user_id OPERATOR(pg_catalog.>) multi_group_wrapper_1.event_user_id)))) "eventQuery") "pushedDownQuery" GROUP BY generated_group_field ORDER BY (count(*)) DESC, generated_group_field LIMIT 10
+DEBUG:  generating subplan 85_1 for subquery SELECT user_id, value_2 AS generated_group_field FROM public.users_table users
+DEBUG:  Plan 85 query after replacing subqueries and CTEs: SELECT count(*) AS cnt, generated_group_field FROM (SELECT "eventQuery".user_id, random() AS random, "eventQuery".generated_group_field FROM (SELECT multi_group_wrapper_1."time", multi_group_wrapper_1.event_user_id, multi_group_wrapper_1.user_id, left_group_by_1.generated_group_field, random() AS random FROM ((SELECT temp_data_queries."time", temp_data_queries.event_user_id, user_filters_1.user_id FROM ((SELECT events."time", events.user_id AS event_user_id FROM public.events_table events WHERE (events.user_id OPERATOR(pg_catalog.>) 2)) temp_data_queries JOIN (SELECT users.user_id FROM public.users_reference_table users WHERE ((users.user_id OPERATOR(pg_catalog.>) 2) AND (users.value_2 OPERATOR(pg_catalog.=) 5))) user_filters_1 ON ((temp_data_queries.event_user_id OPERATOR(pg_catalog.<) user_filters_1.user_id)))) multi_group_wrapper_1 RIGHT JOIN (SELECT intermediate_result.user_id, intermediate_result.generated_group_field FROM read_intermediate_result('85_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, generated_group_field integer)) left_group_by_1 ON ((left_group_by_1.user_id OPERATOR(pg_catalog.>) multi_group_wrapper_1.event_user_id)))) "eventQuery") "pushedDownQuery" GROUP BY generated_group_field ORDER BY (count(*)) DESC, generated_group_field LIMIT 10
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
 RESET client_min_messages;


### PR DESCRIPTION
DESCRIPTION: Relax subquery union pushdown restrictions for reference tables

Fixes #2518 