### PR TITLE
Finish connection establishment in parallel for multiple connections

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -294,6 +294,11 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 		int64 rowCount = 0;
 		int64 colCount = 0;
 
+		if (PQstatus(connection->pgConn) != CONNECTION_OK)
+		{
+			continue;
+		}
+
 		result = GetRemoteCommandResult(connection, raiseInterrupts);
 		if (!IsResponseOK(result))
 		{

--- a/src/include/distributed/memutils.h
+++ b/src/include/distributed/memutils.h
@@ -1,0 +1,29 @@
+/*
+ * memutils.h
+ *   utility functions to help with postgres' memory management primitives
+ */
+
+#ifndef CITUS_MEMUTILS_H
+#define CITUS_MEMUTILS_H
+
+#include "utils/palloc.h"
+
+
+/*
+ * EnsureReleaseResource is an abstraction on MemoryContextRegisterResetCallback that
+ * allocates the space for the MemoryContextCallback and registers it to the current
+ * MemoryContext, ensuring the call of callback with arg as its argument during either the
+ * Reset of Delete of a MemoryContext.
+ */
+static inline void
+EnsureReleaseResource(MemoryContextCallbackFunction callback, void *arg)
+{
+	MemoryContextCallback *cb = MemoryContextAllocZero(CurrentMemoryContext,
+													   sizeof(MemoryContextCallback));
+	cb->func = callback;
+	cb->arg = arg;
+	MemoryContextRegisterResetCallback(CurrentMemoryContext, cb);
+}
+
+
+#endif /*CITUS_MEMUTILS_H */

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -88,6 +88,10 @@ check-failure: all
 	$(pg_regress_multi_check) --load-extension=citus --mitmproxy \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/failure_schedule $(EXTRA_TESTS)
 
+check-failure-base: all
+	$(pg_regress_multi_check) --load-extension=citus --mitmproxy \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/failure_base_schedule $(EXTRA_TESTS)
+
 clean distclean maintainer-clean:
 	rm -f $(output_files) $(input_files)
 	rm -rf tmp_check/

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -1,0 +1,129 @@
+--
+-- failure_connection_establishment.sql tests some behaviour of connection management when
+-- it fails to connect.
+--
+-- Failure cases covered:
+--  - timeout
+--
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+CREATE SCHEMA fail_connect;
+SET search_path TO 'fail_connect';
+SET citus.shard_count TO 4;
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1450000;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART 1450000;
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric
+);
+SELECT create_distributed_table('products', 'product_no');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- Can only add primary key constraint on distribution column (or group of columns
+-- including distribution column)
+-- Command below should error out since 'name' is not a distribution column
+ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(name);
+ERROR:  cannot create constraint on "products"
+DETAIL:  Distributed relations cannot have UNIQUE, EXCLUDE, or PRIMARY KEY constraints that do not include the partition column (with an equality operator if EXCLUDE).
+-- we will insert a connection delay here as this query was the cause for an investigation
+-- into connection establishment problems
+SET citus.node_connection_timeout TO 400;
+SELECT citus.mitmproxy('conn.delay(500)');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(product_no);
+WARNING:  could not establish connection after 400 ms
+ERROR:  connection error: localhost:9060
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+CREATE TABLE r1 (
+    id int PRIMARY KEY,
+    name text
+);
+INSERT INTO r1 (id, name) VALUES
+(1,'foo'),
+(2,'bar'),
+(3,'baz');
+SELECT create_reference_table('r1');
+NOTICE:  Copying data from local table...
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT citus.clear_network_traffic();
+ clear_network_traffic 
+-----------------------
+ 
+(1 row)
+
+SELECT citus.mitmproxy('conn.delay(500)');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+-- we cannot control which replica of the reference table will be queried and there is
+-- only one specific client we can control the connection for.
+-- by using round-robin task_assignment_policy we can force to hit both machines. We will
+-- use two output files to match both orders to verify there is 1 that times out and falls
+-- through to read from the other machine
+SET citus.task_assignment_policy TO 'round-robin';
+-- suppress the warning since we can't control which shard is chose first. Failure of this
+-- test would be if one of the queries does not return the result but an error.
+SET client_min_messages TO ERROR;
+SELECT name FROM r1 WHERE id = 2;
+ name 
+------
+ bar
+(1 row)
+
+SELECT name FROM r1 WHERE id = 2;
+ name 
+------
+ bar
+(1 row)
+
+-- verify a connection attempt was made to the intercepted node, this would have cause the
+-- connection to have been delayed and thus caused a timeout
+SELECT citus.dump_network_traffic();
+        dump_network_traffic         
+-------------------------------------
+ (0,coordinator,"[initial message]")
+(1 row)
+
+RESET client_min_messages;
+-- verify get_global_active_transactions works when a timeout happens on a connection
+SELECT get_global_active_transactions();
+WARNING:  could not establish connection after 400 ms
+WARNING:  connection error: localhost:9060
+ get_global_active_transactions 
+--------------------------------
+(0 rows)
+
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+DROP SCHEMA fail_connect CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table products
+drop cascades to table r1
+SET search_path TO default;

--- a/src/test/regress/failure_base_schedule
+++ b/src/test/regress/failure_base_schedule
@@ -1,0 +1,6 @@
+# import this file (from psql you can use \i) to use mitmproxy manually
+test: failure_test_helpers
+
+# this should only be run by pg_regress_multi, you don't need it
+test: failure_setup
+test: multi_test_helpers

--- a/src/test/regress/failure_schedule
+++ b/src/test/regress/failure_schedule
@@ -30,3 +30,4 @@ test: failure_single_mod
 test: failure_savepoints
 test: failure_multi_row_insert
 test: failure_mx_metadata_sync
+test: failure_connection_establishment

--- a/src/test/regress/mitmscripts/fluent.py
+++ b/src/test/regress/mitmscripts/fluent.py
@@ -125,6 +125,10 @@ class ActionsMixin:
         self.next = CancelHandler(self.root, pid)
         return self.next
 
+    def delay(self, timeMs):
+        self.next = DelayHandler(self.root, timeMs)
+        return self.next
+
 class AcceptHandler(Handler):
     def __init__(self, root):
         super().__init__(root)
@@ -179,6 +183,15 @@ class CancelHandler(Handler):
         os.kill(self.pid, signal.SIGINT)
         # give the signal a chance to be received before we let the packet through
         time.sleep(0.1)
+        return 'done'
+
+class DelayHandler(Handler):
+    'Delay a packet by sleeping before deciding what to do'
+    def __init__(self, root, timeMs):
+        super().__init__(root)
+        self.timeMs = timeMs
+    def _handle(self, flow, message):
+        time.sleep(self.timeMs/1000.0)
         return 'done'
 
 class Contains(Handler, ActionsMixin, FilterableMixin):

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -1,0 +1,78 @@
+--
+-- failure_connection_establishment.sql tests some behaviour of connection management when
+-- it fails to connect.
+--
+-- Failure cases covered:
+--  - timeout
+--
+
+SELECT citus.mitmproxy('conn.allow()');
+
+CREATE SCHEMA fail_connect;
+SET search_path TO 'fail_connect';
+
+SET citus.shard_count TO 4;
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1450000;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART 1450000;
+
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric
+);
+SELECT create_distributed_table('products', 'product_no');
+
+-- Can only add primary key constraint on distribution column (or group of columns
+-- including distribution column)
+-- Command below should error out since 'name' is not a distribution column
+ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(name);
+
+
+-- we will insert a connection delay here as this query was the cause for an investigation
+-- into connection establishment problems
+SET citus.node_connection_timeout TO 400;
+SELECT citus.mitmproxy('conn.delay(500)');
+
+ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(product_no);
+
+SELECT citus.mitmproxy('conn.allow()');
+
+CREATE TABLE r1 (
+    id int PRIMARY KEY,
+    name text
+);
+INSERT INTO r1 (id, name) VALUES
+(1,'foo'),
+(2,'bar'),
+(3,'baz');
+
+SELECT create_reference_table('r1');
+
+SELECT citus.clear_network_traffic();
+SELECT citus.mitmproxy('conn.delay(500)');
+
+-- we cannot control which replica of the reference table will be queried and there is
+-- only one specific client we can control the connection for.
+-- by using round-robin task_assignment_policy we can force to hit both machines. We will
+-- use two output files to match both orders to verify there is 1 that times out and falls
+-- through to read from the other machine
+SET citus.task_assignment_policy TO 'round-robin';
+-- suppress the warning since we can't control which shard is chose first. Failure of this
+-- test would be if one of the queries does not return the result but an error.
+SET client_min_messages TO ERROR;
+SELECT name FROM r1 WHERE id = 2;
+SELECT name FROM r1 WHERE id = 2;
+
+-- verify a connection attempt was made to the intercepted node, this would have cause the
+-- connection to have been delayed and thus caused a timeout
+SELECT citus.dump_network_traffic();
+
+RESET client_min_messages;
+
+-- verify get_global_active_transactions works when a timeout happens on a connection
+SELECT get_global_active_transactions();
+
+
+SELECT citus.mitmproxy('conn.allow()');
+DROP SCHEMA fail_connect CASCADE;
+SET search_path TO default;


### PR DESCRIPTION
DESCRIPTION: Finish connection establishment in parallel for multiple connections

This change came out of #2556.

When running the test mentioned in the ticket in valgrind it tries to establish 64 connections over SSL. Due to old implementation of `FinishConnectionListEstablishment` the connections are effectively established in parallel. As SSL has more roundtrips and more compute per roundtrip compared to non-ssl it takes longer then ~60 seconds in valgrind which seem to be a magic time that sockets stay in `ESTAB` state on linux.

By processing the roundtrips in parallel connnection establishment should take less time, both in valgrind and in actual workloads.

Current state:
 - [x] regression tests pass
 - [x] failure tests pass
 - [x] running tests in valgrind pass*

Suspicion of short commings:
 - [x] timeouts on connection establishment seem to be handled in the single connection function and not here

* there is one (1) valgrind report on the use of uninitialized variable use in postgres, this has been observed before, but internal discussions died.