### PR TITLE
Queries with only intermediate results do not rely on task assignment policy

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1630,10 +1630,15 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 		 * Queries to reference tables, or distributed tables with multiple replica's have
 		 * their task placements reordered according to the configured
 		 * task_assignment_policy. This is only applicable to select queries as the modify
-		 * queries will be reordered to _always_ use the first-replica policy during
-		 * execution.
+		 * queries will _always_ be executed on all placements.
+		 *
+		 * We also ignore queries that are targeting only intermediate results (e.g., no
+		 * valid anchorShardId).
 		 */
-		ReorderTaskPlacementsByTaskAssignmentPolicy(job, TaskAssignmentPolicy);
+		if (shardId != INVALID_SHARD_ID)
+		{
+			ReorderTaskPlacementsByTaskAssignmentPolicy(job, TaskAssignmentPolicy);
+		}
 	}
 	else if (isMultiShardModifyQuery)
 	{

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -212,3 +212,25 @@ DEBUG:  Plan is router executable
 (2 rows)
 
 ROLLBACK;
+-- we should be able to use round-robin with router queries that 
+-- only contains intermediate results
+BEGIN;
+CREATE TABLE task_assignment_test_table_2 (test_id integer);
+SELECT create_distributed_table('task_assignment_test_table_2', 'test_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
+ test_id 
+---------
+(0 rows)
+
+SET LOCAL citus.task_assignment_policy TO 'round-robin';
+WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
+ test_id 
+---------
+(0 rows)
+
+ROLLBACK;

--- a/src/test/regress/sql/multi_task_assignment_policy.sql
+++ b/src/test/regress/sql/multi_task_assignment_policy.sql
@@ -119,3 +119,18 @@ EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
 EXPLAIN (COSTS FALSE) SELECT * FROM task_assignment_reference_table;
 
 ROLLBACK;
+
+
+
+-- we should be able to use round-robin with router queries that 
+-- only contains intermediate results
+BEGIN;
+CREATE TABLE task_assignment_test_table_2 (test_id integer);
+SELECT create_distributed_table('task_assignment_test_table_2', 'test_id');
+
+WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
+SET LOCAL citus.task_assignment_policy TO 'round-robin';
+WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
+ROLLBACK;
+
+


### PR DESCRIPTION
Fixes #2594 

Previously we allowed task assignment policy to have affect on router queries
with only intermediate results. However, that is erroneous since the code-path
that assigns placements relies on shardIds and placements, which doesn't exists
for intermediate results.

With this commit, we do not apply task assignment policies when a router query
hits only intermediate results.

DESCRIPTION: Queries with only intermediate results do not rely on task assignment policy