### PR TITLE
Add support for column aliases on join clauses

### DIFF
--- a/src/backend/distributed/utils/ruleutils_10.c
+++ b/src/backend/distributed/utils/ruleutils_10.c
@@ -7134,6 +7134,12 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 			/* Else print column aliases as needed */
 			get_column_alias_list(colinfo, context);
 		}
+		/* check if column's are given aliases in distributed tables */
+		else if (colinfo->parentUsing != NIL)
+		{
+			Assert(colinfo->printaliases);
+			get_column_alias_list(colinfo, context);
+		}
 
 		/* Tablesample clause must go after any alias */
 		if ((rteKind == CITUS_RTE_RELATION || rteKind == CITUS_RTE_SHARD) &&

--- a/src/backend/distributed/utils/ruleutils_11.c
+++ b/src/backend/distributed/utils/ruleutils_11.c
@@ -7151,6 +7151,12 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 			/* Else print column aliases as needed */
 			get_column_alias_list(colinfo, context);
 		}
+		/* check if column's are given aliases in distributed tables */
+		else if (colinfo->parentUsing != NIL)
+		{
+			Assert(colinfo->printaliases);
+			get_column_alias_list(colinfo, context);
+		}
 
 		/* Tablesample clause must go after any alias */
 		if ((rteKind == CITUS_RTE_RELATION || rteKind == CITUS_RTE_SHARD) &&

--- a/src/test/regress/expected/multi_subquery_complex_queries.out
+++ b/src/test/regress/expected/multi_subquery_complex_queries.out
@@ -2690,3 +2690,62 @@ ORDER BY 1;
        5 |                       
 (4 rows)
 
+-- queries where column aliases are used
+-- the query is not very complex. join is given an alias with aliases
+-- for each output column
+SELECT k1 
+FROM (
+	SELECT k1, random()
+	FROM (users_table JOIN events_table USING (user_id)) k (k1, k2, k3)) l
+ORDER BY k1
+LIMIT 5;
+ k1 
+----
+  1
+  1
+  1
+  1
+  1
+(5 rows)
+
+SELECT DISTINCT k1 
+FROM (
+	SELECT k1, random()
+	FROM (users_table JOIN events_table USING (user_id)) k (k1, k2, k3)) l
+ORDER BY k1
+LIMIT 5;
+ k1 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
+SELECT x1, x3, value_2
+FROM (users_table u FULL JOIN events_table e ON (u.user_id = e.user_id)) k(x1, x2, x3, x4, x5)
+ORDER BY 1, 2, 3
+LIMIT 5;
+ x1 | x3 | value_2 
+----+----+---------
+  1 |  1 |       1
+  1 |  1 |       1
+  1 |  1 |       1
+  1 |  1 |       2
+  1 |  1 |       2
+(5 rows)
+
+SELECT x1, x3, value_2
+FROM (users_table u FULL JOIN events_table e USING (user_id)) k(x1, x2, x3, x4, x5)
+ORDER BY 1, 2, 3
+LIMIT 5;
+ x1 | x3 | value_2 
+----+----+---------
+  1 |  1 |       1
+  1 |  1 |       1
+  1 |  1 |       1
+  1 |  1 |       2
+  1 |  1 |       2
+(5 rows)
+

--- a/src/test/regress/sql/multi_subquery_complex_queries.sql
+++ b/src/test/regress/sql/multi_subquery_complex_queries.sql
@@ -2400,3 +2400,31 @@ FROM
   USING (user_id)
 GROUP BY a.user_id
 ORDER BY 1;
+
+-- queries where column aliases are used
+-- the query is not very complex. join is given an alias with aliases
+-- for each output column
+SELECT k1 
+FROM (
+	SELECT k1, random()
+	FROM (users_table JOIN events_table USING (user_id)) k (k1, k2, k3)) l
+ORDER BY k1
+LIMIT 5;
+
+SELECT DISTINCT k1 
+FROM (
+	SELECT k1, random()
+	FROM (users_table JOIN events_table USING (user_id)) k (k1, k2, k3)) l
+ORDER BY k1
+LIMIT 5;
+
+SELECT x1, x3, value_2
+FROM (users_table u FULL JOIN events_table e ON (u.user_id = e.user_id)) k(x1, x2, x3, x4, x5)
+ORDER BY 1, 2, 3
+LIMIT 5;
+
+SELECT x1, x3, value_2
+FROM (users_table u FULL JOIN events_table e USING (user_id)) k(x1, x2, x3, x4, x5)
+ORDER BY 1, 2, 3
+LIMIT 5;
+


### PR DESCRIPTION
DESCRIPTION: Add support for column aliases on join clauses

We can now support queries like below where join is given an alias with column names are renamed

```sql
SELECT * FROM (
    SELECT k1, random() FROM (users_table JOIN events_table USING (user_id)) k (k1, k2, k3)) l;
```

Fixes #2012 
