### PR TITLE
Make sure to allocate connection keys/values in the connection context

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -280,9 +280,14 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	/* first step: copy global parameters to beginning of array */
 	for (paramIndex = 0; paramIndex < ConnParams.size; paramIndex++)
 	{
-		/* copy the keyword&value pointers to the new array */
-		connKeywords[paramIndex] = ConnParams.keywords[paramIndex];
-		connValues[paramIndex] = ConnParams.values[paramIndex];
+		/*
+		 * Copy the keyword&value strings to the new array since they might
+		 * be free()-d when settings are reloaded.
+		 */
+		connKeywords[paramIndex] =
+			MemoryContextStrdup(context, ConnParams.keywords[paramIndex]);
+		connValues[paramIndex] =
+			MemoryContextStrdup(context, ConnParams.values[paramIndex]);
 	}
 
 	/* second step: begin at end of global params and copy runtime ones */

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1224,6 +1224,9 @@ NodeConninfoGucAssignHook(const char *newval, void *extra)
 		AddConnParam(option->keyword, option->val);
 	}
 
+	/* notify that we've changed the parameters */
+	connectionParamHashValid = false;
+
 	PQconninfoFree(optionArray);
 }
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -3147,19 +3147,10 @@ CreateDistTableCache(void)
 void
 InvalidateMetadataSystemCache(void)
 {
-	ConnParamsHashEntry *entry = NULL;
-	HASH_SEQ_STATUS status;
-
-	hash_seq_init(&status, ConnParamsHash);
-
-	while ((entry = (ConnParamsHashEntry *) hash_seq_search(&status)) != NULL)
-	{
-		entry->isValid = false;
-	}
-
 	memset(&MetadataCache, 0, sizeof(MetadataCache));
 	workerNodeHashValid = false;
 	LocalGroupId = -1;
+	connectionParamHashValid = false;
 }
 
 

--- a/src/backend/distributed/worker/task_tracker.c
+++ b/src/backend/distributed/worker/task_tracker.c
@@ -861,15 +861,7 @@ ManageWorkerTasksHash(HTAB *WorkerTasksHash)
 
 	if (!WorkerTasksSharedState->conninfosValid)
 	{
-		ConnParamsHashEntry *entry = NULL;
-		HASH_SEQ_STATUS status;
-
-		hash_seq_init(&status, ConnParamsHash);
-
-		while ((entry = (ConnParamsHashEntry *) hash_seq_search(&status)) != NULL)
-		{
-			entry->isValid = false;
-		}
+		connectionParamHashValid = false;
 	}
 
 	/* schedule new tasks if we have any */

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -117,7 +117,6 @@ typedef struct ConnectionHashEntry
 typedef struct ConnParamsHashEntry
 {
 	ConnectionHashKey key;
-	bool isValid;
 	char **keywords;
 	char **values;
 } ConnParamsHashEntry;
@@ -132,6 +131,7 @@ extern char *NodeConninfo;
 /* the hash table */
 extern HTAB *ConnectionHash;
 extern HTAB *ConnParamsHash;
+extern bool connectionParamHashValid;
 
 /* context for all connection and transaction related memory */
 extern struct MemoryContextData *ConnectionContext;
@@ -142,6 +142,7 @@ extern void InitializeConnectionManagement(void);
 
 extern void InitConnParams(void);
 extern void ResetConnParams(void);
+extern void DeallocateConnectionParamHash(void);
 extern void AddConnParam(const char *keyword, const char *value);
 extern void GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 						  MemoryContext context);

--- a/src/test/regress/expected/multi_size_queries.out
+++ b/src/test/regress/expected/multi_size_queries.out
@@ -125,5 +125,46 @@ ALTER TABLE supplier ALTER COLUMN s_suppkey SET NOT NULL;
 select citus_table_size('supplier');
 ERROR:  citus size functions cannot be called in transaction blocks which contain multi-shard data modifications
 END;
+show citus.node_conninfo;
+ citus.node_conninfo 
+---------------------
+ sslmode=require
+(1 row)
+
+ALTER SYSTEM SET citus.node_conninfo = 'sslmode=require';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- make sure that any invalidation to the connection info
+-- wouldn't prevent future commands to fail
+SELECT citus_total_relation_size('customer_copy_hash');
+ citus_total_relation_size 
+---------------------------
+                   2646016
+(1 row)
+
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT citus_total_relation_size('customer_copy_hash');
+ citus_total_relation_size 
+---------------------------
+                   2646016
+(1 row)
+
+-- reset back to the original node_conninfo
+ALTER SYSTEM RESET citus.node_conninfo;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 DROP INDEX index_1;
 DROP INDEX index_2;

--- a/src/test/regress/sql/multi_size_queries.sql
+++ b/src/test/regress/sql/multi_size_queries.sql
@@ -65,5 +65,19 @@ ALTER TABLE supplier ALTER COLUMN s_suppkey SET NOT NULL;
 select citus_table_size('supplier');
 END;
 
+show citus.node_conninfo;
+ALTER SYSTEM SET citus.node_conninfo = 'sslmode=require';
+SELECT pg_reload_conf();
+
+-- make sure that any invalidation to the connection info
+-- wouldn't prevent future commands to fail
+SELECT citus_total_relation_size('customer_copy_hash');
+SELECT pg_reload_conf();
+SELECT citus_total_relation_size('customer_copy_hash');
+
+-- reset back to the original node_conninfo
+ALTER SYSTEM RESET citus.node_conninfo;
+SELECT pg_reload_conf();
+
 DROP INDEX index_1;
 DROP INDEX index_2;


### PR DESCRIPTION
DESCRIPTION: Fixes an invalidation bug  after setting citus.node_conninfo

Fixes #2607

This is required, otherwise we'd end-up in use-after-free bugs when
an invalidation comes in.

We already do the exact same things for runTime keywords, but not
connValues. And, this patch fixes it.
