### PR TITLE
Make sure to clear `PGresult` in missing places

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -237,6 +237,7 @@ DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId, char *sizeQ
 	tableSizeString = tableSizeStringInfo->data;
 	tableSize = atol(tableSizeString);
 
+	PQclear(result);
 	ClearResults(connection, raiseErrors);
 
 	return tableSize;

--- a/src/backend/distributed/test/run_from_same_connection.c
+++ b/src/backend/distributed/test/run_from_same_connection.c
@@ -196,6 +196,7 @@ GetRemoteProcessId(MultiConnection *connection)
 	StringInfo queryStringInfo = makeStringInfo();
 	PGresult *result = NULL;
 	int64 rowCount = 0;
+	int64 resultValue = 0;
 
 	appendStringInfo(queryStringInfo, GET_PROCESS_ID);
 
@@ -208,7 +209,10 @@ GetRemoteProcessId(MultiConnection *connection)
 		PG_RETURN_VOID();
 	}
 
+	resultValue = ParseIntField(result, 0, 0);
+
+	PQclear(result);
 	ClearResults(connection, false);
 
-	return ParseIntField(result, 0, 0);
+	return resultValue;
 }

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -563,6 +563,7 @@ TableDDLCommandList(const char *nodeName, uint32 nodePort, const char *tableName
 	ExecuteOptionalRemoteCommand(connection, queryString->data, &result);
 	ddlCommandList = ReadFirstColumnAsText(result);
 
+	PQclear(result);
 	ForgetResults(connection);
 	CloseConnection(connection);
 


### PR DESCRIPTION
This leads to a memory leak otherwise.

DESCRIPTION: Fixes a bug that could lead to memory leak on `citus_relation_size`

To repro:
```SQL
SELECT citus_relation_size('table');
\watch 0.001
```

That seems like a minor issue, so I'm not tagging with backport.