### PR TITLE
Fix memory leak on connection param invalidations

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -117,36 +117,6 @@ AddConnParam(const char *keyword, const char *value)
 
 
 /*
- * CopyConnectionParams copies input keywords/values into output keywords/values. All
- * memory allocations happen in the given context.
- */
-void
-CopyConnectionParams(MemoryContext context, char ***outputKeywords, char ***outputValues,
-					 char **inputKeywords, char **inputValues)
-{
-	int parameterIndex = 0;
-
-	char **connKeywords =
-		MemoryContextAllocZero(context, ConnParams.maxSize * sizeof(char *));
-	char **connValues =
-		MemoryContextAllocZero(context, ConnParams.maxSize * sizeof(char *));
-
-	while (inputKeywords[parameterIndex] != NULL)
-	{
-		connKeywords[parameterIndex] =
-			MemoryContextStrdup(context, inputKeywords[parameterIndex]);
-		connValues[parameterIndex] =
-			MemoryContextStrdup(context, inputValues[parameterIndex]);
-
-		++parameterIndex;
-	}
-
-	*outputKeywords = connKeywords;
-	*outputValues = connValues;
-}
-
-
-/*
  * DeallocateConnectionParamHash goes over the ConnParamsHash and deallocates
  * all parameters and values. Finally, all of the entries in the hash table is
  * deleted.

--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -280,9 +280,14 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	/* first step: copy global parameters to beginning of array */
 	for (paramIndex = 0; paramIndex < ConnParams.size; paramIndex++)
 	{
-		/* copy the keyword&value pointers to the new array */
-		connKeywords[paramIndex] = ConnParams.keywords[paramIndex];
-		connValues[paramIndex] = ConnParams.values[paramIndex];
+		/*
+		 * Copy the keyword&value strings to the new array since they might
+		 * be free()-d when settings are reloaded.
+		 */
+		connKeywords[paramIndex] =
+			MemoryContextStrdup(context, ConnParams.keywords[paramIndex]);
+		connValues[paramIndex] =
+			MemoryContextStrdup(context, ConnParams.values[paramIndex]);
 	}
 
 	/* second step: begin at end of global params and copy runtime ones */

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -702,6 +702,8 @@ StartConnectionEstablishment(ConnectionHashKey *key)
 	bool found = false;
 	MultiConnection *connection = NULL;
 	ConnParamsHashEntry *entry = NULL;
+	char **keywords = NULL;
+	char **values = NULL;
 
 	connection = MemoryContextAllocZero(ConnectionContext, sizeof(MultiConnection));
 	connection->internalConnectionContext =
@@ -723,9 +725,11 @@ StartConnectionEstablishment(ConnectionHashKey *key)
 	strlcpy(connection->database, key->database, NAMEDATALEN);
 	strlcpy(connection->user, key->user, NAMEDATALEN);
 
+	CopyConnectionParams(connection->internalConnectionContext, &keywords, &values,
+						 entry->keywords, entry->values);
 
-	connection->pgConn = PQconnectStartParams((const char **) entry->keywords,
-											  (const char **) entry->values,
+	connection->pgConn = PQconnectStartParams((const char **) keywords,
+											  (const char **) values,
 											  false);
 	connection->connectionStart = GetCurrentTimestamp();
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1206,6 +1206,9 @@ NodeConninfoGucAssignHook(const char *newval, void *extra)
 		AddConnParam(option->keyword, option->val);
 	}
 
+	/* notify that we've changed the parameters */
+	connectionParamHashValid = false;
+
 	PQconninfoFree(optionArray);
 }
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -3147,19 +3147,10 @@ CreateDistTableCache(void)
 void
 InvalidateMetadataSystemCache(void)
 {
-	ConnParamsHashEntry *entry = NULL;
-	HASH_SEQ_STATUS status;
-
-	hash_seq_init(&status, ConnParamsHash);
-
-	while ((entry = (ConnParamsHashEntry *) hash_seq_search(&status)) != NULL)
-	{
-		entry->isValid = false;
-	}
-
 	memset(&MetadataCache, 0, sizeof(MetadataCache));
 	workerNodeHashValid = false;
 	LocalGroupId = -1;
+	connectionParamHashValid = false;
 }
 
 

--- a/src/backend/distributed/worker/task_tracker.c
+++ b/src/backend/distributed/worker/task_tracker.c
@@ -861,15 +861,7 @@ ManageWorkerTasksHash(HTAB *WorkerTasksHash)
 
 	if (!WorkerTasksSharedState->conninfosValid)
 	{
-		ConnParamsHashEntry *entry = NULL;
-		HASH_SEQ_STATUS status;
-
-		hash_seq_init(&status, ConnParamsHash);
-
-		while ((entry = (ConnParamsHashEntry *) hash_seq_search(&status)) != NULL)
-		{
-			entry->isValid = false;
-		}
+		connectionParamHashValid = false;
 	}
 
 	/* schedule new tasks if we have any */

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -145,6 +145,10 @@ extern void InitializeConnectionManagement(void);
 
 extern void InitConnParams(void);
 extern void ResetConnParams(void);
+extern void CopyConnectionParams(MemoryContext context, char ***outputKeywords,
+								 char ***outputValues, char **inputKeywords,
+								 char **inputValues);
+extern void DeallocateConnectionParamHash(void);
 extern void AddConnParam(const char *keyword, const char *value);
 extern void GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 						  MemoryContext context);

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -85,6 +85,9 @@ typedef struct MultiConnection
 
 	/* number of bytes sent to PQputCopyData() since last flush */
 	uint64 copyBytesWrittenSinceLastFlush;
+
+	/* connection parameters are stored here */
+	MemoryContext internalConnectionContext;
 } MultiConnection;
 
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -85,9 +85,6 @@ typedef struct MultiConnection
 
 	/* number of bytes sent to PQputCopyData() since last flush */
 	uint64 copyBytesWrittenSinceLastFlush;
-
-	/* connection parameters are stored here */
-	MemoryContext internalConnectionContext;
 } MultiConnection;
 
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -120,7 +120,6 @@ typedef struct ConnectionHashEntry
 typedef struct ConnParamsHashEntry
 {
 	ConnectionHashKey key;
-	bool isValid;
 	char **keywords;
 	char **values;
 } ConnParamsHashEntry;
@@ -135,6 +134,7 @@ extern char *NodeConninfo;
 /* the hash table */
 extern HTAB *ConnectionHash;
 extern HTAB *ConnParamsHash;
+extern bool connectionParamHashValid;
 
 /* context for all connection and transaction related memory */
 extern struct MemoryContextData *ConnectionContext;

--- a/src/test/regress/expected/multi_size_queries.out
+++ b/src/test/regress/expected/multi_size_queries.out
@@ -125,5 +125,46 @@ ALTER TABLE supplier ALTER COLUMN s_suppkey SET NOT NULL;
 select citus_table_size('supplier');
 ERROR:  citus size functions cannot be called in transaction blocks which contain multi-shard data modifications
 END;
+show citus.node_conninfo;
+ citus.node_conninfo 
+---------------------
+ sslmode=require
+(1 row)
+
+ALTER SYSTEM SET citus.node_conninfo = 'sslmode=require';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- make sure that any invalidation to the connection info
+-- wouldn't prevent future commands to fail
+SELECT citus_total_relation_size('customer_copy_hash');
+ citus_total_relation_size 
+---------------------------
+                   2646016
+(1 row)
+
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT citus_total_relation_size('customer_copy_hash');
+ citus_total_relation_size 
+---------------------------
+                   2646016
+(1 row)
+
+-- reset back to the original node_conninfo
+ALTER SYSTEM RESET citus.node_conninfo;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 DROP INDEX index_1;
 DROP INDEX index_2;

--- a/src/test/regress/sql/multi_size_queries.sql
+++ b/src/test/regress/sql/multi_size_queries.sql
@@ -65,5 +65,19 @@ ALTER TABLE supplier ALTER COLUMN s_suppkey SET NOT NULL;
 select citus_table_size('supplier');
 END;
 
+show citus.node_conninfo;
+ALTER SYSTEM SET citus.node_conninfo = 'sslmode=require';
+SELECT pg_reload_conf();
+
+-- make sure that any invalidation to the connection info
+-- wouldn't prevent future commands to fail
+SELECT citus_total_relation_size('customer_copy_hash');
+SELECT pg_reload_conf();
+SELECT citus_total_relation_size('customer_copy_hash');
+
+-- reset back to the original node_conninfo
+ALTER SYSTEM RESET citus.node_conninfo;
+SELECT pg_reload_conf();
+
 DROP INDEX index_1;
 DROP INDEX index_2;


### PR DESCRIPTION
Change memory allocations for to prevent memory leaks discussed [here](https://github.com/citusdata/citus/pull/2611#discussion_r259832277).

There are 4 commits which are small enough to follow. 

I'm not very happy with this PR since now we're allocating up to 1KB per connection and also adding few CPU cycles that happens every time a new connection is established. 

@jasonmp85 and @marcocitus, do you have any alternatives in mind? I'll do some benchmarks to see the overhead the PR adds.


(We also need to add one more commit to enterprise to change the invalidation auth info and pool info )