### PR TITLE
Implement direct COPY distributed_table TO STDOUT (better pg_dump)

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -80,6 +80,7 @@
 #include "distributed/worker_protocol.h"
 #include "executor/executor.h"
 #include "foreign/foreign.h"
+#include "libpq/libpq.h"
 #include "libpq/pqformat.h"
 #include "nodes/makefuncs.h"
 #include "tsearch/ts_locale.h"
@@ -102,7 +103,7 @@ static void CopyFromWorkerNode(CopyStmt *copyStatement, char *completionTag);
 static void CopyToExistingShards(CopyStmt *copyStatement, char *completionTag);
 static void CopyToNewShards(CopyStmt *copyStatement, char *completionTag, Oid relationId);
 static char MasterPartitionMethod(RangeVar *relation);
-static void RemoveMasterOptions(CopyStmt *copyStatement);
+static List * RemoveOptionFromList(List *optionList, char *optionName);
 static void OpenCopyConnections(CopyStmt *copyStatement,
 								ShardConnections *shardConnections, bool stopOnFailure,
 								bool useBinaryCopyFormat);
@@ -114,8 +115,7 @@ static void SendCopyBinaryHeaders(CopyOutState copyOutState, int64 shardId,
 								  List *connectionList);
 static void SendCopyBinaryFooters(CopyOutState copyOutState, int64 shardId,
 								  List *connectionList);
-static StringInfo ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId,
-										 bool useBinaryCopyFormat);
+static StringInfo ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId);
 static void SendCopyDataToAll(StringInfo dataBuffer, int64 shardId, List *connectionList);
 static void SendCopyDataToPlacement(StringInfo dataBuffer, int64 shardId,
 									MultiConnection *connection);
@@ -145,13 +145,19 @@ static bool CopyStatementHasFormat(CopyStmt *copyStatement, char *formatName);
 static bool IsCopyFromWorker(CopyStmt *copyStatement);
 static NodeAddress * MasterNodeAddress(CopyStmt *copyStatement);
 static void CitusCopyFrom(CopyStmt *copyStatement, char *completionTag);
+static void CitusCopyTo(CopyStmt *copyStatement, char *completionTag);
+static int64 ForwardCopyDataFromConnection(CopyOutState copyOutState,
+										   MultiConnection *connection);
 
 /* Private functions copied and adapted from copy.c in PostgreSQL */
+static void SendCopyBegin(CopyOutState cstate);
+static void SendCopyEnd(CopyOutState cstate);
 static void CopySendData(CopyOutState outputState, const void *databuf, int datasize);
 static void CopySendString(CopyOutState outputState, const char *str);
 static void CopySendChar(CopyOutState outputState, char c);
 static void CopySendInt32(CopyOutState outputState, int32 val);
 static void CopySendInt16(CopyOutState outputState, int16 val);
+static void CopySendEndOfRow(CopyOutState cstate);
 static void CopyAttributeOutText(CopyOutState outputState, char *string);
 static inline void CopyFlushOutput(CopyOutState outputState, char *start, char *pointer);
 
@@ -295,7 +301,8 @@ CopyFromWorkerNode(CopyStmt *copyStatement, char *completionTag)
 	 * Remove master node options from the copy statement because they are not
 	 * recognized by PostgreSQL machinery.
 	 */
-	RemoveMasterOptions(copyStatement);
+	copyStatement->options = RemoveOptionFromList(copyStatement->options, "master_host");
+	copyStatement->options = RemoveOptionFromList(copyStatement->options, "master_port");
 
 	CopyToNewShards(copyStatement, completionTag, relationId);
 
@@ -552,8 +559,17 @@ CopyToNewShards(CopyStmt *copyStatement, char *completionTag, Oid relationId)
 	 * From here on we use copyStatement as the template for the command
 	 * that we send to workers. This command does not have an attribute
 	 * list since NextCopyFrom will generate a value for all columns.
+	 * We also strip options.
 	 */
 	copyStatement->attlist = NIL;
+	copyStatement->options = NIL;
+
+	if (copyOutState->binary)
+	{
+		DefElem *binaryFormatOption = NULL;
+		binaryFormatOption = makeDefElem("format", (Node *) makeString("binary"), -1);
+		copyStatement->options = lappend(copyStatement->options, binaryFormatOption);
+	}
 
 	while (true)
 	{
@@ -757,31 +773,28 @@ MasterPartitionMethod(RangeVar *relation)
 
 
 /*
- * RemoveMasterOptions removes master node related copy options from the option
- * list of the copy statement.
+ * RemoveOptionFromList removes an option from a list of options in a
+ * COPY .. WITH (..) statement by name and returns the resulting list.
  */
-static void
-RemoveMasterOptions(CopyStmt *copyStatement)
+static List *
+RemoveOptionFromList(List *optionList, char *optionName)
 {
-	List *newOptionList = NIL;
 	ListCell *optionCell = NULL;
+	ListCell *previousCell = NULL;
 
-	/* walk over the list of all options */
-	foreach(optionCell, copyStatement->options)
+	foreach(optionCell, optionList)
 	{
 		DefElem *option = (DefElem *) lfirst(optionCell);
 
-		/* skip master related options */
-		if ((strncmp(option->defname, "master_host", NAMEDATALEN) == 0) ||
-			(strncmp(option->defname, "master_port", NAMEDATALEN) == 0))
+		if (strncmp(option->defname, optionName, NAMEDATALEN) == 0)
 		{
-			continue;
+			return list_delete_cell(optionList, optionCell, previousCell);
 		}
 
-		newOptionList = lappend(newOptionList, option);
+		previousCell = optionCell;
 	}
 
-	copyStatement->options = newOptionList;
+	return optionList;
 }
 
 
@@ -862,8 +875,7 @@ OpenCopyConnections(CopyStmt *copyStatement, ShardConnections *shardConnections,
 		ClaimConnectionExclusively(connection);
 		RemoteTransactionBeginIfNecessary(connection);
 
-		copyCommand = ConstructCopyStatement(copyStatement, shardConnections->shardId,
-											 useBinaryCopyFormat);
+		copyCommand = ConstructCopyStatement(copyStatement, shardConnections->shardId);
 
 		if (!SendRemoteCommand(connection, copyCommand->data))
 		{
@@ -1092,7 +1104,7 @@ SendCopyBinaryFooters(CopyOutState copyOutState, int64 shardId, List *connection
  * shard.
  */
 static StringInfo
-ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId, bool useBinaryCopyFormat)
+ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId)
 {
 	StringInfo command = makeStringInfo();
 
@@ -1115,35 +1127,76 @@ ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId, bool useBinaryCop
 
 		foreach(columnNameCell, copyStatement->attlist)
 		{
-			char *columnName = (char *) lfirst(columnNameCell);
+			char *columnName = strVal(lfirst(columnNameCell));
+			const char *quotedColumnName = quote_identifier(columnName);
 
 			if (!appendedFirstName)
 			{
-				appendStringInfo(command, "(%s", columnName);
+				appendStringInfo(command, "(%s", quotedColumnName);
 				appendedFirstName = true;
 			}
 			else
 			{
-				appendStringInfo(command, ", %s", columnName);
+				appendStringInfo(command, ", %s", quotedColumnName);
 			}
 		}
 
 		appendStringInfoString(command, ") ");
 	}
 
-	appendStringInfo(command, "FROM STDIN WITH ");
-
-	if (IsCopyResultStmt(copyStatement))
+	if (copyStatement->is_from)
 	{
-		appendStringInfoString(command, "(FORMAT RESULT)");
-	}
-	else if (useBinaryCopyFormat)
-	{
-		appendStringInfoString(command, "(FORMAT BINARY)");
+		appendStringInfo(command, "FROM STDIN");
 	}
 	else
 	{
-		appendStringInfoString(command, "(FORMAT TEXT)");
+		appendStringInfo(command, "TO STDOUT");
+	}
+
+	if (copyStatement->options != NIL)
+	{
+		ListCell *optionCell = NULL;
+
+		appendStringInfoString(command, " WITH (");
+
+		foreach(optionCell, copyStatement->options)
+		{
+			DefElem *defel = (DefElem *) lfirst(optionCell);
+
+			if (optionCell != list_head(copyStatement->options))
+			{
+				appendStringInfoString(command, ", ");
+			}
+
+			appendStringInfo(command, "%s", defel->defname);
+
+			if (defel->arg == NULL)
+			{
+				/* option without value */
+			}
+			else if (IsA(defel->arg, String))
+			{
+				char *value = defGetString(defel);
+
+				/* make sure strings are quoted (may contain reserved characters) */
+				appendStringInfo(command, " %s", quote_literal_cstr(value));
+			}
+			else if (IsA(defel->arg, List))
+			{
+				List *nameList = defGetStringList(defel);
+
+				appendStringInfo(command, " (%s)", NameListToQuotedString(nameList));
+			}
+			else
+			{
+				char *value = defGetString(defel);
+
+				/* numeric options or * should not have quotes */
+				appendStringInfo(command, " %s", value);
+			}
+		}
+
+		appendStringInfoString(command, ")");
 	}
 
 	return command;
@@ -1878,6 +1931,67 @@ RemoteUpdateShardStatistics(uint64 shardId)
 
 
 /* *INDENT-OFF* */
+
+
+/*
+ * Send copy start/stop messages for frontend copies.  These have changed
+ * in past protocol redesigns.
+ */
+static void
+SendCopyBegin(CopyOutState cstate)
+{
+	if (PG_PROTOCOL_MAJOR(FrontendProtocol) >= 3)
+	{
+		/* new way */
+		StringInfoData buf;
+		int			natts = list_length(cstate->attnumlist);
+		int16		format = (cstate->binary ? 1 : 0);
+		int			i;
+
+		pq_beginmessage(&buf, 'H');
+		pq_sendbyte(&buf, format);	/* overall format */
+		pq_sendint16(&buf, natts);
+		for (i = 0; i < natts; i++)
+			pq_sendint16(&buf, format); /* per-column formats */
+		pq_endmessage(&buf);
+		cstate->copy_dest = COPY_NEW_FE;
+	}
+	else
+	{
+		/* old way */
+		if (cstate->binary)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("COPY BINARY is not supported to stdout or from stdin")));
+		pq_putemptymessage('H');
+		/* grottiness needed for old COPY OUT protocol */
+		pq_startcopyout();
+		cstate->copy_dest = COPY_OLD_FE;
+	}
+}
+
+
+/* End a copy stream sent to the client */
+static void
+SendCopyEnd(CopyOutState cstate)
+{
+	if (cstate->copy_dest == COPY_NEW_FE)
+	{
+		/* Shouldn't have any unsent data */
+		Assert(cstate->fe_msgbuf->len == 0);
+		/* Send Copy Done message */
+		pq_putemptymessage('c');
+	}
+	else
+	{
+		CopySendData(cstate, "\\.", 2);
+		/* Need to flush out the trailer (this also appends a newline) */
+		CopySendEndOfRow(cstate);
+		pq_endcopyout(false);
+	}
+}
+
+
 /* Append data to the copy buffer in outputState */
 static void
 CopySendData(CopyOutState outputState, const void *databuf, int datasize)
@@ -1917,6 +2031,45 @@ CopySendInt16(CopyOutState outputState, int16 val)
 {
 	uint16 buf = htons((uint16) val);
 	CopySendData(outputState, &buf, sizeof(buf));
+}
+
+
+/* Send the row to the appropriate destination */
+static void
+CopySendEndOfRow(CopyOutState cstate)
+{
+	StringInfo	fe_msgbuf = cstate->fe_msgbuf;
+
+	switch (cstate->copy_dest)
+	{
+		case COPY_OLD_FE:
+			/* The FE/BE protocol uses \n as newline for all platforms */
+			if (!cstate->binary)
+				CopySendChar(cstate, '\n');
+
+			if (pq_putbytes(fe_msgbuf->data, fe_msgbuf->len))
+			{
+				/* no hope of recovering connection sync, so FATAL */
+				ereport(FATAL,
+						(errcode(ERRCODE_CONNECTION_FAILURE),
+						 errmsg("connection lost during COPY to stdout")));
+			}
+			break;
+		case COPY_NEW_FE:
+			/* The FE/BE protocol uses \n as newline for all platforms */
+			//if (!cstate->binary)
+			//	CopySendChar(cstate, '\n');
+
+			/* Dump the accumulated row as one CopyData message */
+			(void) pq_putmessage('d', fe_msgbuf->data, fe_msgbuf->len);
+			break;
+		case COPY_FILE:
+		case COPY_CALLBACK:
+			Assert(false);		/* Not yet supported. */
+			break;
+	}
+
+	resetStringInfo(fe_msgbuf);
 }
 
 
@@ -2089,7 +2242,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 
 	Relation distributedRelation = NULL;
 	List *columnNameList = copyDest->columnNameList;
-	List *quotedColumnNameList = NIL;
+	List *attributeList = NIL;
 
 	ListCell *columnNameCell = NULL;
 
@@ -2190,13 +2343,13 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 			TypeOutputFunctions(columnCount, finalTypeArray, copyOutState->binary);
 	}
 
-	/* ensure the column names are properly quoted in the COPY statement */
+	/* wrap the column names as Values */
 	foreach(columnNameCell, columnNameList)
 	{
 		char *columnName = (char *) lfirst(columnNameCell);
-		char *quotedColumnName = (char *) quote_identifier(columnName);
+		Value *columnNameValue = makeString(columnName);
 
-		quotedColumnNameList = lappend(quotedColumnNameList, quotedColumnName);
+		attributeList = lappend(attributeList, columnNameValue);
 	}
 
 	if (partitionMethod != DISTRIBUTE_BY_NONE &&
@@ -2223,10 +2376,18 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	{
 		copyStatement->relation = makeRangeVar(schemaName, relationName, -1);
 		copyStatement->options = NIL;
+
+		if (copyOutState->binary)
+		{
+			DefElem *binaryFormatOption = NULL;
+
+			binaryFormatOption = makeDefElem("format", (Node *) makeString("binary"), -1);
+			copyStatement->options = lappend(copyStatement->options, binaryFormatOption);
+		}
 	}
 
 	copyStatement->query = NULL;
-	copyStatement->attlist = quotedColumnNameList;
+	copyStatement->attlist = attributeList;
 	copyStatement->is_from = true;
 	copyStatement->is_program = false;
 	copyStatement->filename = NULL;
@@ -2569,12 +2730,22 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 				CitusCopyFrom(copyStatement, completionTag);
 				return NULL;
 			}
-			else if (!copyStatement->is_from)
+			else if (copyStatement->filename == NULL && !copyStatement->is_program &&
+					 !CopyStatementHasFormat(copyStatement, "binary"))
 			{
 				/*
-				 * The copy code only handles SELECTs in COPY ... TO on master tables,
-				 * as that can be done non-invasively. To handle COPY master_rel TO
-				 * the copy statement is replaced by a generated select statement.
+				 * COPY table TO STDOUT is handled by specialized logic to
+				 * avoid buffering the table on the coordinator. This enables
+				 * pg_dump of large tables.
+				 */
+				CitusCopyTo(copyStatement, completionTag);
+				return NULL;
+			}
+			else
+			{
+				/*
+				 * COPY table TO PROGRAM / file is handled by wrapping the table
+				 * in a SELECT * FROM table and going through the result COPY logic.
 				 */
 				ColumnRef *allColumns = makeNode(ColumnRef);
 				SelectStmt *selectStmt = makeNode(SelectStmt);
@@ -2649,6 +2820,153 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 
 
 	return (Node *) copyStatement;
+}
+
+
+/*
+ * CitusCopyTo runs a COPY .. TO STDOUT command on each shard to to a full
+ * table dump.
+ */
+static void
+CitusCopyTo(CopyStmt *copyStatement, char *completionTag)
+{
+	List *shardIntervalList = NIL;
+	ListCell *shardIntervalCell = NULL;
+	Relation distributedRelation = NULL;
+	TupleDesc tupleDescriptor = NULL;
+	Oid relationId = InvalidOid;
+	CopyOutState copyOutState = NULL;
+	int64 tuplesSent = 0;
+
+	distributedRelation = heap_openrv(copyStatement->relation, AccessShareLock);
+	relationId = RelationGetRelid(distributedRelation);
+	tupleDescriptor = RelationGetDescr(distributedRelation);
+
+	copyOutState = (CopyOutState) palloc0(sizeof(CopyOutStateData));
+	copyOutState->fe_msgbuf = makeStringInfo();
+	copyOutState->binary = false;
+	copyOutState->attnumlist = CopyGetAttnums(tupleDescriptor, distributedRelation,
+											  copyStatement->attlist);
+
+	SendCopyBegin(copyOutState);
+
+	shardIntervalList = LoadShardIntervalList(relationId);
+
+	foreach(shardIntervalCell, shardIntervalList)
+	{
+		ShardInterval *shardInterval = lfirst(shardIntervalCell);
+		List *shardPlacementList = FinalizedShardPlacementList(shardInterval->shardId);
+		ListCell *shardPlacementCell = NULL;
+		int placementIndex = 0;
+		StringInfo copyCommand = NULL;
+
+		copyCommand = ConstructCopyStatement(copyStatement, shardInterval->shardId);
+
+		foreach(shardPlacementCell, shardPlacementList)
+		{
+			ShardPlacement *shardPlacement = lfirst(shardPlacementCell);
+			MultiConnection *connection = NULL;
+			int connectionFlags = 0;
+			char *userName = NULL;
+			const bool raiseErrors = true;
+			PGresult *result = NULL;
+
+			connection = GetPlacementConnection(connectionFlags, shardPlacement,
+												userName);
+
+			if (placementIndex == list_length(shardPlacementList) - 1)
+			{
+				/* last chance for this shard */
+				MarkRemoteTransactionCritical(connection);
+			}
+
+			if (PQstatus(connection->pgConn) != CONNECTION_OK)
+			{
+				HandleRemoteTransactionConnectionError(connection, raiseErrors);
+				continue;
+			}
+
+			RemoteTransactionBeginIfNecessary(connection);
+
+			if (!SendRemoteCommand(connection, copyCommand->data))
+			{
+				HandleRemoteTransactionConnectionError(connection, raiseErrors);
+				continue;
+			}
+
+			result = GetRemoteCommandResult(connection, raiseErrors);
+			if (PQresultStatus(result) != PGRES_COPY_OUT)
+			{
+				ReportResultError(connection, result, ERROR);
+			}
+
+			PQclear(result);
+
+			tuplesSent += ForwardCopyDataFromConnection(copyOutState, connection);
+			break;
+		}
+
+		if (shardIntervalCell == list_head(shardIntervalList))
+		{
+			/* remove header after the first shard */
+			RemoveOptionFromList(copyStatement->options, "header");
+		}
+	}
+
+	SendCopyEnd(copyOutState);
+
+	heap_close(distributedRelation, AccessShareLock);
+
+	if (completionTag != NULL)
+	{
+		snprintf(completionTag, COMPLETION_TAG_BUFSIZE, "COPY " UINT64_FORMAT,
+				 tuplesSent);
+	}
+}
+
+
+/*
+ * ForwardCopyDataFromConnection forwards copy data received over the given connection
+ * to the client or file descriptor.
+ */
+static int64
+ForwardCopyDataFromConnection(CopyOutState copyOutState, MultiConnection *connection)
+{
+	int receiveLength = 0;
+	char *receiveBuffer = NULL;
+	const int useAsync = 0;
+	bool raiseErrors = true;
+	PGresult *result = NULL;
+	int64 tuplesSent = 0;
+
+	/* receive copy data message in a synchronous manner */
+	receiveLength = PQgetCopyData(connection->pgConn, &receiveBuffer, useAsync);
+	while (receiveLength > 0)
+	{
+		CopySendData(copyOutState, receiveBuffer, receiveLength);
+		CopySendEndOfRow(copyOutState);
+		tuplesSent++;
+
+		PQfreemem(receiveBuffer);
+
+		receiveLength = PQgetCopyData(connection->pgConn, &receiveBuffer, useAsync);
+	}
+
+	if (receiveLength != -1)
+	{
+		ReportConnectionError(connection, ERROR);
+	}
+
+	result = GetRemoteCommandResult(connection, raiseErrors);
+	if (!IsResponseOK(result))
+	{
+		ReportResultError(connection, result, ERROR);
+	}
+
+	PQclear(result);
+	ClearResults(connection, raiseErrors);
+
+	return tuplesSent;
 }
 
 

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -25,14 +25,28 @@
 
 
 /*
+ * CitusCopyDest indicates the source or destination of a COPY command.
+ */
+typedef enum CitusCopyDest
+{
+	COPY_FILE,                  /* to/from file (or a piped program) */
+	COPY_OLD_FE,                /* to/from frontend (2.0 protocol) */
+	COPY_NEW_FE,                /* to/from frontend (3.0 protocol) */
+	COPY_CALLBACK               /* to/from callback function */
+} CitusCopyDest;
+
+
+/*
  * A smaller version of copy.c's CopyStateData, trimmed to the elements
  * necessary to copy out results. While it'd be a bit nicer to share code,
  * it'd require changing core postgres code.
  */
 typedef struct CopyOutStateData
 {
+	CitusCopyDest copy_dest;    /* type of copy source/destination */
 	StringInfo fe_msgbuf;       /* used for all dests during COPY TO, only for
 	                             * dest == COPY_NEW_FE in COPY FROM */
+	List *attnumlist;           /* integer list of attnums to copy */
 	int file_encoding;          /* file or remote side's character encoding */
 	bool need_transcoding;              /* file encoding diff from server? */
 	bool binary;                /* binary format? */

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -9,6 +9,7 @@
 # Regression test output
 /regression.diffs
 /regression.out
+/test_times.log
 
 # Failure test side effets
 /proxy.output

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -948,8 +948,8 @@ COPY reference_table_test (value_2, value_3, value_4) FROM STDIN WITH CSV;
 COPY reference_table_test (value_3) FROM STDIN WITH CSV;
 COPY reference_table_test FROM STDIN WITH CSV;
 COPY reference_table_test TO STDOUT WITH CSV;
-1,1,1,Fri Jan 01 00:00:00 2016
-,2,2,Sat Jan 02 00:00:00 2016
+1,1,1,2016-01-01 00:00:00
+,2,2,2016-01-02 00:00:00
 ,,3,
 ,,,
 -- INSERT INTO SELECT among reference tables

--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -540,8 +540,6 @@ DETAIL:  distribution column value: 1
 
 -- copying from a single shard table does not require the master query
 COPY articles_single_shard TO stdout;
-DEBUG:  Creating router plan
-DEBUG:  Plan is router executable
 50	10	anjanette	19519
 -- error out for queries with aggregates
 SELECT avg(word_count)

--- a/src/test/regress/expected/multi_simple_queries_0.out
+++ b/src/test/regress/expected/multi_simple_queries_0.out
@@ -484,8 +484,6 @@ DETAIL:  distribution column value: 1
 
 -- copying from a single shard table does not require the master query
 COPY articles_single_shard TO stdout;
-DEBUG:  Creating router plan
-DEBUG:  Plan is router executable
 50	10	anjanette	19519
 -- error out for queries with aggregates
 SELECT avg(word_count)

--- a/src/test/regress/expected/pg_dump.out
+++ b/src/test/regress/expected/pg_dump.out
@@ -1,0 +1,120 @@
+CREATE TEMPORARY TABLE output (line text);
+CREATE SCHEMA dumper;
+SET search_path TO 'dumper';
+SET citus.next_shard_id TO 2900000;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE data (
+	key int,
+	value text
+);
+SELECT create_distributed_table('data', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+COPY data FROM STDIN WITH (format csv, delimiter '|', escape '\');
+-- duplicate the data using pg_dump
+\COPY output FROM PROGRAM 'pg_dump --quote-all-identifiers -h localhost -p 57636 -U postgres -d regression -t dumper.data --data-only | psql -tAX -h localhost -p 57636 -U postgres -d regression'
+-- data should now appear twice
+COPY data TO STDOUT;
+1	{this:is,json:1}
+1	{this:is,json:1}
+3	{{}:\t}
+4	{}
+3	{{}:\t}
+4	{}
+2	{$":9}
+2	{$":9}
+-- go crazy with names
+CREATE TABLE "weird.table" (
+	"key," int primary key,
+	"data.jsonb" jsonb,
+	"?empty(" text default ''
+);
+CREATE INDEX ON "weird.table" USING GIN ("data.jsonb" jsonb_path_ops);
+SELECT create_distributed_table('"weird.table"', 'key,');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+COPY "weird.table" ("key,", "data.jsonb") FROM STDIN WITH (format 'text');
+-- fast table dump with many options
+COPY dumper."weird.table" ("data.jsonb", "?empty(")TO STDOUT WITH (format csv, force_quote ("?empty("), null 'null', delimiter '?', quote '_', header 1);
+data.jsonb?_?empty(_
+{"weird": {"table": "{:"}}?__
+_{"?\"": []}_?__
+-- do a full pg_dump of the schema, use some weird quote/escape/delimiter characters to capture the full line
+\COPY output FROM PROGRAM 'pg_dump -f results/pg_dump.tmp -h localhost -p 57636 -U postgres -d regression -n dumper --quote-all-identifiers' WITH (format csv, delimiter '|', escape '^', quote '^')
+-- drop the schema
+DROP SCHEMA dumper CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table data
+drop cascades to table "weird.table"
+-- recreate the schema
+\COPY (SELECT line FROM output WHERE line IS NOT NULL) TO PROGRAM 'psql -tAX -h localhost -p 57636 -U postgres -d regression -f results/pg_dump.tmp' WITH (format csv, delimiter '|', escape '^', quote '^')
+SET
+SET
+SET
+SET
+SET
+
+SET
+SET
+SET
+CREATE SCHEMA
+ALTER SCHEMA
+SET
+SET
+CREATE TABLE
+ALTER TABLE
+CREATE TABLE
+ALTER TABLE
+COPY 8
+COPY 2
+ALTER TABLE
+CREATE INDEX
+-- redistribute the schema
+SELECT create_distributed_table('data', 'key');
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('"weird.table"', 'key,');
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- check the table contents
+COPY data (value) TO STDOUT WITH (format csv, force_quote *);
+"{this:is,json:1}"
+"{this:is,json:1}"
+"{{}:	}"
+"{}"
+"{{}:	}"
+"{}"
+"{$"":9}"
+"{$"":9}"
+COPY dumper."weird.table" ("data.jsonb", "?empty(") TO STDOUT WITH (format csv, force_quote ("?empty("), null 'null', header true);
+data.jsonb,?empty(
+"{""weird"": {""table"": ""{:""}}",""
+"{""?\"""": []}",""
+SELECT * FROM master_get_table_ddl_events('"weird.table"');
+                                                   master_get_table_ddl_events                                                   
+---------------------------------------------------------------------------------------------------------------------------------
+ CREATE SCHEMA IF NOT EXISTS dumper AUTHORIZATION postgres
+ CREATE TABLE dumper."weird.table" ("key," integer NOT NULL, "data.jsonb" jsonb, "?empty(" text DEFAULT ''::text)
+ ALTER TABLE dumper."weird.table" OWNER TO postgres
+ CREATE INDEX "weird.table_data.jsonb_idx" ON dumper."weird.table" USING gin ("data.jsonb" jsonb_path_ops) TABLESPACE pg_default
+ ALTER TABLE dumper."weird.table" ADD CONSTRAINT "weird.table_pkey" PRIMARY KEY ("key,")
+(5 rows)
+
+DROP SCHEMA dumper CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table data
+drop cascades to table "weird.table"

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -184,7 +184,7 @@ test: multi_transaction_recovery
 # multi_copy creates hash and range-partitioned tables and performs COPY
 # multi_router_planner creates hash partitioned tables.
 # ---------
-test: multi_copy fast_path_router_modify
+test: multi_copy fast_path_router_modify pg_dump
 test: multi_router_planner multi_router_planner_fast_path
 
 # ----------

--- a/src/test/regress/sql/pg_dump.sql
+++ b/src/test/regress/sql/pg_dump.sql
@@ -1,0 +1,64 @@
+CREATE TEMPORARY TABLE output (line text);
+
+CREATE SCHEMA dumper;
+SET search_path TO 'dumper';
+
+SET citus.next_shard_id TO 2900000;
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE data (
+	key int,
+	value text
+);
+SELECT create_distributed_table('data', 'key');
+
+COPY data FROM STDIN WITH (format csv, delimiter '|', escape '\');
+1|{"this":"is","json":1}
+2|{"$\"":9}
+3|{"{}":"	"}
+4|{}
+\.
+
+-- duplicate the data using pg_dump
+\COPY output FROM PROGRAM 'pg_dump --quote-all-identifiers -h localhost -p 57636 -U postgres -d regression -t dumper.data --data-only | psql -tAX -h localhost -p 57636 -U postgres -d regression'
+
+-- data should now appear twice
+COPY data TO STDOUT;
+
+-- go crazy with names
+CREATE TABLE "weird.table" (
+	"key," int primary key,
+	"data.jsonb" jsonb,
+	"?empty(" text default ''
+);
+CREATE INDEX ON "weird.table" USING GIN ("data.jsonb" jsonb_path_ops);
+SELECT create_distributed_table('"weird.table"', 'key,');
+
+COPY "weird.table" ("key,", "data.jsonb") FROM STDIN WITH (format 'text');
+1	{"weird":{"table":"{:"}}
+2	{"?\\\"":[]}
+\.
+
+-- fast table dump with many options
+COPY dumper."weird.table" ("data.jsonb", "?empty(")TO STDOUT WITH (format csv, force_quote ("?empty("), null 'null', delimiter '?', quote '_', header 1);
+
+-- do a full pg_dump of the schema, use some weird quote/escape/delimiter characters to capture the full line
+\COPY output FROM PROGRAM 'pg_dump -f results/pg_dump.tmp -h localhost -p 57636 -U postgres -d regression -n dumper --quote-all-identifiers' WITH (format csv, delimiter '|', escape '^', quote '^')
+
+-- drop the schema
+DROP SCHEMA dumper CASCADE;
+
+-- recreate the schema
+\COPY (SELECT line FROM output WHERE line IS NOT NULL) TO PROGRAM 'psql -tAX -h localhost -p 57636 -U postgres -d regression -f results/pg_dump.tmp' WITH (format csv, delimiter '|', escape '^', quote '^')
+
+-- redistribute the schema
+SELECT create_distributed_table('data', 'key');
+SELECT create_distributed_table('"weird.table"', 'key,');
+
+-- check the table contents
+COPY data (value) TO STDOUT WITH (format csv, force_quote *);
+COPY dumper."weird.table" ("data.jsonb", "?empty(") TO STDOUT WITH (format csv, force_quote ("?empty("), null 'null', header true);
+
+SELECT * FROM master_get_table_ddl_events('"weird.table"');
+
+DROP SCHEMA dumper CASCADE;


### PR DESCRIPTION
DESCRIPTION: Implement direct COPY distributed_table TO STDOUT (better pg_dump)

To dump all the data in a table, `pg_dump` issues `COPY table TO STDOUT` commands. Citus rewrites `COPY distributed_table TO STDOUT` to `COPY (SELECT * FROM distributed_table) TO STDOUT` and then executes it via the real-time executor. That means the contents of each shard are written to a file on the coordinator, then to a tuple store, and finally to the client. When there is a large distributed table, that will cause the coordinator to run out of disk space.

This PR fixes the problem by propagating the `COPY distributed_table TO STDOUT` command to each shard (sequentially) and forwarding the result byte-by-byte.

This can make pg_dump 5-10x faster in typical situations and has a much lower memory and CPU footprint. Most importantly, it does not use any disk space on the coordinator.

This approach does have some downsides:
- Snapshots are further apart
- Loss of (I/O) parallelism
- Binary COPY, and COPY .. TO file/program fall back to real-time executor because the added complexity did not seem worth it

The first item could be resolved by using repeatable read, but that will require some more time.

Fixes #2306 
