### PR TITLE
Don't execute ALTER TABLE constraint checks in coordinator.

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1198,7 +1198,7 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 			}
 		}
 	}
-	else if (alterTableType == AT_DetachPartition)
+	else if (alterTableType == AT_DetachPartition || alterTableType == AT_AttachPartition)
 	{
 		/* check if there are foreign constraints to reference tables */
 		if (HasForeignKeyToReferenceTable(relationId))

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1093,7 +1093,7 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
  * for two things for practial purpose for not doing the same checks
  * twice:
  *     (a) For any command, decide and return whether we should
- *         run the command in sequntial mode
+ *         run the command in sequential mode
  *     (b) For commands in a transaction block, set the transaction local
  *         multi-shard modify mode to sequential when necessary
  *
@@ -1185,17 +1185,6 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 			{
 				executeSequentially = true;
 			}
-
-			/*
-			 * Postgres performs additional selects when creating constraints
-			 * on partitioned tables. We need to set execution mode to
-			 * sequential for the select query so that ddl connections
-			 * we open does not fail due to previous select.
-			 */
-			if (executeSequentially && PartitionedTable(relationId))
-			{
-				SetLocalMultiShardModifyModeToSequential();
-			}
 		}
 	}
 	else if (alterTableType == AT_DetachPartition || alterTableType == AT_AttachPartition)
@@ -1204,7 +1193,6 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 		if (HasForeignKeyToReferenceTable(relationId))
 		{
 			executeSequentially = true;
-			SetLocalMultiShardModifyModeToSequential();
 		}
 	}
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -164,7 +164,9 @@ _PG_init(void)
 	 * (thus as the innermost/last running hook) to be able to do our
 	 * duties. For simplicity insist that all hooks are previously unused.
 	 */
-	if (planner_hook != NULL || ProcessUtility_hook != NULL || ExecutorStart_hook != NULL)
+	if (planner_hook != NULL || ProcessUtility_hook != NULL || ExecutorStart_hook !=
+		NULL ||
+		ExecutorRun_hook != NULL)
 	{
 		ereport(ERROR, (errmsg("Citus has to be loaded first"),
 						errhint("Place citus at the beginning of "
@@ -209,6 +211,7 @@ _PG_init(void)
 	set_rel_pathlist_hook = multi_relation_restriction_hook;
 	set_join_pathlist_hook = multi_join_restriction_hook;
 	ExecutorStart_hook = CitusExecutorStart;
+	ExecutorRun_hook = CitusExecutorRun;
 
 	/* register hook for error messages */
 	emit_log_hook = multi_log_hook;

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -45,5 +45,6 @@ extern void CitusProcessUtility(Node *node, const char *queryString,
 extern void MarkInvalidateForeignKeyGraph(void);
 extern void InvalidateForeignKeyGraphForDDL(void);
 extern List * DDLTaskList(Oid relationId, const char *commandString);
+extern bool AlterTableInProgress(void);
 
 #endif /* MULTI_UTILITY_H */

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -32,6 +32,8 @@ extern bool WritableStandbyCoordinator;
 
 
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
+extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
+							 bool execute_once);
 extern TupleTableSlot * ReturnTupleFromTuplestore(CitusScanState *scanState);
 extern void LoadTuplesIntoTupleStore(CitusScanState *citusScanState, Job *workerJob);
 extern void ReadFileIntoTupleStore(char *fileName, char *copyFormat, TupleDesc

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -511,14 +511,14 @@ ERROR:  cannot execute DDL on reference relation "referece_table" because there 
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 5.4: Parallel UPDATE on distributed table follow by a related DDL on reference table
--- FIXME: Can we do better?
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE referece_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "referece_table"
 DEBUG:  building index "referece_table_pkey" on table "referece_table"
 DEBUG:  validating foreign key constraint "fkey"
-ERROR:  cannot perform DDL on placement 2380001, which has been read over multiple connections
+ERROR:  cannot execute DDL on reference relation "referece_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:1: Unrelated parallel DDL on distributed table followed by SELECT on ref. table
 BEGIN;

--- a/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
@@ -511,14 +511,14 @@ ERROR:  cannot execute DDL on reference relation "referece_table" because there 
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 5.4: Parallel UPDATE on distributed table follow by a related DDL on reference table
--- FIXME: Can we do better?
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE referece_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "referece_table"
 DEBUG:  building index "referece_table_pkey" on table "referece_table" serially
 DEBUG:  validating foreign key constraint "fkey"
-ERROR:  cannot perform DDL on placement 2380001, which has been read over multiple connections
+ERROR:  cannot execute DDL on reference relation "referece_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:1: Unrelated parallel DDL on distributed table followed by SELECT on ref. table
 BEGIN;

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1936,8 +1936,9 @@ INSERT INTO partitioning_test_2010 VALUES (1, '2010-02-01');
 -- This should fail because of foreign key constraint violation
 ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2010
       FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
-ERROR:  insert or update on table "partitioning_test_2010" violates foreign key constraint "partitioning_reference_fkey"
-DETAIL:  Key (id)=(1) is not present in table "reference_table".
+ERROR:  insert or update on table "partitioning_test_2010_1660191" violates foreign key constraint "partitioning_reference_fkey_1660179"
+DETAIL:  Key (id)=(1) is not present in table "reference_table_1660177".
+CONTEXT:  while executing command on localhost:57637
 -- Truncate, so attaching again won't fail
 TRUNCATE partitioning_test_2010;
 -- Attach a table which already has the same constraint

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1882,6 +1882,80 @@ ORDER BY
  "schema-test_2009" |     4
 (2 rows)
 
+-- test we don't deadlock when attaching and detaching partitions from partitioned
+-- tables with foreign keys
+CREATE TABLE reference_table(id int PRIMARY KEY);
+SELECT create_reference_table('reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+CREATE TABLE reference_table_2(id int PRIMARY KEY);
+SELECT create_reference_table('reference_table_2');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+CREATE TABLE partitioning_test_2008 PARTITION OF partitioning_test FOR VALUES FROM ('2008-01-01') TO ('2009-01-01');
+CREATE TABLE partitioning_test_2009 (LIKE partitioning_test);
+CREATE TABLE partitioning_test_2010 (LIKE partitioning_test);
+CREATE TABLE partitioning_test_2011 (LIKE partitioning_test);
+-- distributing partitioning_test will also distribute partitioning_test_2008
+SELECT create_distributed_table('partitioning_test', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('partitioning_test_2009', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('partitioning_test_2010', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('partitioning_test_2011', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE partitioning_test ADD CONSTRAINT partitioning_reference_fkey
+    FOREIGN KEY (id) REFERENCES reference_table(id) ON DELETE CASCADE;
+ALTER TABLE partitioning_test_2009 ADD CONSTRAINT partitioning_reference_fkey_2009
+    FOREIGN KEY (id) REFERENCES reference_table(id) ON DELETE CASCADE;
+INSERT INTO partitioning_test_2010 VALUES (1, '2010-02-01');
+-- This should fail because of foreign key constraint violation
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2010
+      FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+ERROR:  insert or update on table "partitioning_test_2010" violates foreign key constraint "partitioning_reference_fkey"
+DETAIL:  Key (id)=(1) is not present in table "reference_table".
+-- Truncate, so attaching again won't fail
+TRUNCATE partitioning_test_2010;
+-- Attach a table which already has the same constraint
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2009
+      FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+-- Attach a table which doesn't have the constraint
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2010
+      FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+-- Attach a table which has a different constraint
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2011
+      FOR VALUES FROM ('2011-01-01') TO ('2012-01-01');
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2008;
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2009;
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2010;
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2011;
+DROP TABLE partitioning_test, partitioning_test_2008, partitioning_test_2009,
+           partitioning_test_2010, partitioning_test_2011,
+           reference_table, reference_table_2;
 DROP SCHEMA partitioning_schema CASCADE;
 NOTICE:  drop cascades to table "schema-test"
 RESET SEARCH_PATH;

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -1806,6 +1806,82 @@ ORDER BY
  "schema-test_2009" |     4
 (2 rows)
 
+-- test we don't deadlock when attaching and detaching partitions from partitioned
+-- tables with foreign keys
+CREATE TABLE reference_table(id int PRIMARY KEY);
+SELECT create_reference_table('reference_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+CREATE TABLE reference_table_2(id int PRIMARY KEY);
+SELECT create_reference_table('reference_table_2');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+CREATE TABLE partitioning_test_2008 PARTITION OF partitioning_test FOR VALUES FROM ('2008-01-01') TO ('2009-01-01');
+CREATE TABLE partitioning_test_2009 (LIKE partitioning_test);
+CREATE TABLE partitioning_test_2010 (LIKE partitioning_test);
+CREATE TABLE partitioning_test_2011 (LIKE partitioning_test);
+-- distributing partitioning_test will also distribute partitioning_test_2008
+SELECT create_distributed_table('partitioning_test', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('partitioning_test_2009', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('partitioning_test_2010', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT create_distributed_table('partitioning_test_2011', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+ALTER TABLE partitioning_test ADD CONSTRAINT partitioning_reference_fkey
+    FOREIGN KEY (id) REFERENCES reference_table(id) ON DELETE CASCADE;
+ERROR:  foreign key constraints are not supported on partitioned tables
+LINE 1: ALTER TABLE partitioning_test ADD CONSTRAINT partitioning_re...
+                                          ^
+ALTER TABLE partitioning_test_2009 ADD CONSTRAINT partitioning_reference_fkey_2009
+    FOREIGN KEY (id) REFERENCES reference_table(id) ON DELETE CASCADE;
+INSERT INTO partitioning_test_2010 VALUES (1, '2010-02-01');
+-- This should fail because of foreign key constraint violation
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2010
+      FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+-- Truncate, so attaching again won't fail
+TRUNCATE partitioning_test_2010;
+-- Attach a table which already has the same constraint
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2009
+      FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+-- Attach a table which doesn't have the constraint
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2010
+      FOR VALUES FROM ('2010-01-01') TO ('2011-01-01');
+ERROR:  "partitioning_test_2010" is already a partition
+-- Attach a table which has a different constraint
+ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2011
+      FOR VALUES FROM ('2011-01-01') TO ('2012-01-01');
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2008;
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2009;
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2010;
+ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2011;
+DROP TABLE partitioning_test, partitioning_test_2008, partitioning_test_2009,
+           partitioning_test_2010, partitioning_test_2011,
+           reference_table, reference_table_2;
 DROP SCHEMA partitioning_schema CASCADE;
 NOTICE:  drop cascades to table "schema-test"
 RESET SEARCH_PATH;

--- a/src/test/regress/sql/foreign_key_restriction_enforcement.sql
+++ b/src/test/regress/sql/foreign_key_restriction_enforcement.sql
@@ -303,7 +303,6 @@ BEGIN;
 ROLLBACK;
 
 -- case 5.4: Parallel UPDATE on distributed table follow by a related DDL on reference table
--- FIXME: Can we do better?
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE referece_table ALTER COLUMN id SET DATA TYPE smallint;


### PR DESCRIPTION
These constraints will be validated in worker nodes, so no need to run them on coordinator.

Also fixes distributed deadlock for `ALTER TABLE ... ATTACH PARTITION`.

Fixes #2600

DESCRIPTION: Don't do redundant ALTER TABLE consistency checks at coordinator.
