### PR TITLE
Decrease CPU overhead of some of the planner functions

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -1051,6 +1051,13 @@ RemoteFinalizedShardPlacementList(uint64 shardId)
 			shardPlacement->nodeName = nodeName;
 			shardPlacement->nodePort = nodePort;
 
+			/*
+			 * We cannot know the nodeId, but it is not necessary at this point either.
+			 * This is only used to to look up the connection for a group of co-located
+			 * placements, but append-distributed tables are never co-located.
+			 */
+			shardPlacement->nodeId = -1;
+
 			finalizedPlacementList = lappend(finalizedPlacementList, shardPlacement);
 		}
 	}

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -251,7 +251,7 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port, 
 	}
 	else
 	{
-		strlcpy(key.database, get_database_name(MyDatabaseId), NAMEDATALEN);
+		strlcpy(key.database, CurrentDatabaseName(), NAMEDATALEN);
 	}
 
 	if (CurrentCoordinatedTransactionState == COORD_TRANS_NONE)

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -133,8 +133,7 @@ static HTAB *ConnectionPlacementHash;
 typedef struct ColocatedPlacementsHashKey
 {
 	/* to identify host - database can't differ */
-	char nodeName[MAX_NODE_LENGTH];
-	uint32 nodePort;
+	int nodeId;
 
 	/* colocation group, or invalid */
 	uint32 colocationGroupId;
@@ -689,8 +688,7 @@ FindOrCreatePlacementEntry(ShardPlacement *placement)
 			ColocatedPlacementsHashKey key;
 			ColocatedPlacementsHashEntry *colocatedEntry = NULL;
 
-			strlcpy(key.nodeName, placement->nodeName, MAX_NODE_LENGTH);
-			key.nodePort = placement->nodePort;
+			key.nodeId = placement->nodeId;
 			key.colocationGroupId = placement->colocationGroupId;
 			key.representativeValue = placement->representativeValue;
 
@@ -1149,8 +1147,7 @@ ColocatedPlacementsHashHash(const void *key, Size keysize)
 	ColocatedPlacementsHashKey *entry = (ColocatedPlacementsHashKey *) key;
 	uint32 hash = 0;
 
-	hash = string_hash(entry->nodeName, NAMEDATALEN);
-	hash = hash_combine(hash, hash_uint32(entry->nodePort));
+	hash = hash_uint32(entry->nodeId);
 	hash = hash_combine(hash, hash_uint32(entry->colocationGroupId));
 	hash = hash_combine(hash, hash_uint32(entry->representativeValue));
 
@@ -1164,8 +1161,7 @@ ColocatedPlacementsHashCompare(const void *a, const void *b, Size keysize)
 	ColocatedPlacementsHashKey *ca = (ColocatedPlacementsHashKey *) a;
 	ColocatedPlacementsHashKey *cb = (ColocatedPlacementsHashKey *) b;
 
-	if (strncmp(ca->nodeName, cb->nodeName, MAX_NODE_LENGTH) != 0 ||
-		ca->nodePort != cb->nodePort ||
+	if (ca->nodeId != cb->nodeId ||
 		ca->colocationGroupId != cb->colocationGroupId ||
 		ca->representativeValue != cb->representativeValue)
 	{

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -871,7 +871,7 @@ TrackerConnectPoll(TaskTracker *taskTracker)
 		{
 			char *nodeName = taskTracker->workerName;
 			uint32 nodePort = taskTracker->workerPort;
-			char *nodeDatabase = get_database_name(MyDatabaseId);
+			char *nodeDatabase = CurrentDatabaseName();
 			char *nodeUser = taskTracker->userName;
 
 			int32 connectionId = MultiClientConnectStart(nodeName, nodePort,

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -507,7 +507,7 @@ ExplainTaskPlacement(ShardPlacement *taskPlacement, List *explainOutputList,
 	StringInfo nodeAddress = makeStringInfo();
 	char *nodeName = taskPlacement->nodeName;
 	uint32 nodePort = taskPlacement->nodePort;
-	char *nodeDatabase = get_database_name(MyDatabaseId);
+	char *nodeDatabase = CurrentDatabaseName();
 	ListCell *explainOutputCell = NULL;
 	int rowIndex = 0;
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2552,8 +2552,7 @@ CoPlacedShardIntervals(ShardInterval *firstInterval, ShardInterval *secondInterv
 		ShardPlacement *secondShardPlacement = (ShardPlacement *) lfirst(
 			secondShardPlacementCell);
 
-		if (strcmp(firstShardPlacement->nodeName, secondShardPlacement->nodeName) != 0 ||
-			firstShardPlacement->nodePort != secondShardPlacement->nodePort)
+		if (firstShardPlacement->nodeId != secondShardPlacement->nodeId)
 		{
 			return false;
 		}
@@ -5375,6 +5374,7 @@ AssignDualHashTaskList(List *taskList)
 			ShardPlacement *taskPlacement = CitusMakeNode(ShardPlacement);
 			taskPlacement->nodeName = pstrdup(workerNode->workerName);
 			taskPlacement->nodePort = workerNode->workerPort;
+			taskPlacement->nodeId = workerNode->nodeId;
 
 			taskPlacementList = lappend(taskPlacementList, taskPlacement);
 		}

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2027,6 +2027,7 @@ PlanRouterQuery(Query *originalQuery,
 				(ShardPlacement *) CitusMakeNode(ShardPlacement);
 			dummyPlacement->nodeName = workerNode->workerName;
 			dummyPlacement->nodePort = workerNode->workerPort;
+			dummyPlacement->nodeId = workerNode->nodeId;
 			dummyPlacement->groupId = workerNode->groupId;
 
 			workerList = lappend(workerList, dummyPlacement);

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1543,16 +1543,18 @@ CreateTask(TaskType taskType)
  * ExtractFirstDistributedTableId takes a given query, and finds the relationId
  * for the first distributed table in that query. If the function cannot find a
  * distributed table, it returns InvalidOid.
+ *
+ * We only use this function for modifications and fast path queries, which
+ * should have the first distributed table in the top-level rtable.
  */
 Oid
 ExtractFirstDistributedTableId(Query *query)
 {
-	List *rangeTableList = NIL;
+	List *rangeTableList = query->rtable;
 	ListCell *rangeTableCell = NULL;
 	Oid distributedTableId = InvalidOid;
 
-	/* extract range table entries */
-	ExtractRangeTableEntryWalker((Node *) query, &rangeTableList);
+	Assert(IsModifyCommand(query) || FastPathRouterQuery(query));
 
 	foreach(rangeTableCell, rangeTableList)
 	{

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1505,6 +1505,7 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 	pushedDownQuery->rtable = copyObject(queryTree->rtable);
 	pushedDownQuery->setOperations = copyObject(queryTree->setOperations);
 	pushedDownQuery->querySource = queryTree->querySource;
+	pushedDownQuery->hasSubLinks = queryTree->hasSubLinks;
 
 	subqueryNode = MultiSubqueryPushdownTable(pushedDownQuery);
 

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -200,6 +200,7 @@ CopyNodeShardPlacement(COPYFUNC_ARGS)
 	COPY_SCALAR_FIELD(groupId);
 	COPY_STRING_FIELD(nodeName);
 	COPY_SCALAR_FIELD(nodePort);
+	COPY_SCALAR_FIELD(nodeId);
 	COPY_SCALAR_FIELD(partitionMethod);
 	COPY_SCALAR_FIELD(colocationGroupId);
 	COPY_SCALAR_FIELD(representativeValue);

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -405,6 +405,7 @@ OutShardPlacement(OUTFUNC_ARGS)
 	WRITE_INT_FIELD(groupId);
 	WRITE_STRING_FIELD(nodeName);
 	WRITE_UINT_FIELD(nodePort);
+	WRITE_INT_FIELD(nodeId);
 	/* so we can deal with 0 */
 	WRITE_INT_FIELD(partitionMethod);
 	WRITE_UINT_FIELD(colocationGroupId);

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -315,6 +315,7 @@ ReadShardPlacement(READFUNC_ARGS)
 	READ_INT_FIELD(groupId);
 	READ_STRING_FIELD(nodeName);
 	READ_UINT_FIELD(nodePort);
+	READ_INT_FIELD(nodeId);
 	/* so we can deal with 0 */
 	READ_INT_FIELD(partitionMethod);
 	READ_UINT_FIELD(colocationGroupId);

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -420,25 +420,12 @@ CompareShardPlacementsByNode(const void *leftElement, const void *rightElement)
 	const ShardPlacement *leftPlacement = *((const ShardPlacement **) leftElement);
 	const ShardPlacement *rightPlacement = *((const ShardPlacement **) rightElement);
 
-	char *leftNodeName = leftPlacement->nodeName;
-	char *rightNodeName = rightPlacement->nodeName;
-
-	uint32 leftNodePort = leftPlacement->nodePort;
-	uint32 rightNodePort = rightPlacement->nodePort;
-
-	/* first compare node names */
-	int nodeNameCompare = strncmp(leftNodeName, rightNodeName, WORKER_LENGTH);
-	if (nodeNameCompare != 0)
-	{
-		return nodeNameCompare;
-	}
-
 	/* if node names are same, check node ports */
-	if (leftNodePort < rightNodePort)
+	if (leftPlacement->nodeId < rightPlacement->nodeId)
 	{
 		return -1;
 	}
-	else if (leftNodePort > rightNodePort)
+	else if (leftPlacement->nodeId > rightPlacement->nodeId)
 	{
 		return 1;
 	}

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -526,6 +526,7 @@ ResolveGroupShardPlacement(GroupShardPlacement *groupShardPlacement,
 
 	shardPlacement->nodeName = pstrdup(workerNode->workerName);
 	shardPlacement->nodePort = workerNode->workerPort;
+	shardPlacement->nodeId = workerNode->nodeId;
 
 	/* fill in remaining fields */
 	Assert(tableEntry->partitionMethod != 0);

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -368,7 +368,7 @@ CreateTask(uint64 jobId, uint32 taskId, char *taskCallString)
 {
 	WorkerTask *workerTask = NULL;
 	uint32 assignmentTime = 0;
-	char *databaseName = get_database_name(MyDatabaseId);
+	char *databaseName = CurrentDatabaseName();
 	char *userName = CurrentUserName();
 
 	/* increase task priority for cleanup tasks */

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -248,7 +248,7 @@ ReceiveRegularFile(const char *nodeName, uint32 nodePort, const char *nodeUser,
 	}
 
 	/* we use the same database name on the master and worker nodes */
-	nodeDatabase = get_database_name(MyDatabaseId);
+	nodeDatabase = CurrentDatabaseName();
 
 	/* connect to remote node */
 	connectionId = MultiClientConnect(nodeName, nodePort, nodeDatabase, nodeUser);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -83,6 +83,7 @@ typedef struct RelationRowLock
 
 extern PlannedStmt * distributed_planner(Query *parse, int cursorOptions,
 										 ParamListInfo boundParams);
+extern List * ExtractRangeTableEntryList(Query *query);
 extern bool NeedsDistributedPlanning(Query *query);
 extern struct DistributedPlan * GetDistributedPlan(CustomScan *node);
 extern void multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -99,6 +99,7 @@ typedef struct ShardPlacement
 	/* the rest of the fields aren't from pg_dist_placement */
 	char *nodeName;
 	uint32 nodePort;
+	int nodeId;
 	char partitionMethod;
 	uint32 colocationGroupId;
 	uint32 representativeValue;

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -167,4 +167,7 @@ extern Oid BinaryCopyFormatId(void);
 extern Oid CitusExtensionOwner(void);
 extern char * CitusExtensionOwnerName(void);
 extern char * CurrentUserName(void);
+extern char * CurrentDatabaseName(void);
+
+
 #endif /* METADATA_CACHE_H */


### PR DESCRIPTION
Heavily based on [faster_all_the_things](https://github.com/citusdata/citus/compare/faster_all_the_things) with minor changes and extra comments. The goal is to improve the performance for few planner utility functions. 

There are 5 commits each is isolated and should be easy to review.

Simple pgbench test output for select-only benchmarks:

master: tps = 40864.160762 (including connections establishing)
branch: tps = 41875.625976 (including connections establishing)

Difference:  ~%2.5