### PR TITLE
Ignore test_times.log

### DIFF
--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -10,5 +10,8 @@
 /regression.diffs
 /regression.out
 
+# Regression test timing
+/test_times.log
+
 # Failure test side effets
 /proxy.output


### PR DESCRIPTION
Running tests locally generates `test_times.log` which shouldn't be committed, but is easy to miss when there are a lot of changes.
