### PR TITLE
Warn we are not propagating GRANT/REVOKE to workers

### DIFF
--- a/src/backend/distributed/commands/grant.c
+++ b/src/backend/distributed/commands/grant.c
@@ -8,12 +8,67 @@
  *-------------------------------------------------------------------------
  */
 
+#include "postgres.h"
+
+#include "catalog/namespace.h"
 #include "distributed/commands.h"
+#include "distributed/metadata_cache.h"
 
 
 /* placeholder for PlanGrantStmt */
 List *
 PlanGrantStmt(GrantStmt *grantStmt)
 {
+	bool showPropagationWarning = false;
+
+
+	if (grantStmt->targtype == ACL_TARGET_ALL_IN_SCHEMA)
+	{
+		showPropagationWarning = true;
+	}
+	else if (grantStmt->targtype == ACL_TARGET_OBJECT)
+	{
+		switch (grantStmt->objtype)
+		{
+			case OBJECT_SCHEMA:
+			case OBJECT_DATABASE:
+			{
+				showPropagationWarning = true;
+				break;
+			}
+
+			case OBJECT_TABLE:
+			{
+				ListCell *rangeVarCell = NULL;
+
+				foreach(rangeVarCell, grantStmt->objects)
+				{
+					RangeVar *rangeVar = (RangeVar *) lfirst(rangeVarCell);
+
+					Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
+					if (OidIsValid(relationId) && IsDistributedTable(relationId))
+					{
+						showPropagationWarning = true;
+						break;
+					}
+				}
+
+				break;
+			}
+
+			/* no need to warn when object is sequence, domain, function, etc. */
+			default:
+			{
+				break;
+			}
+		}
+	}
+
+	if (showPropagationWarning)
+	{
+		const char *type = grantStmt->is_grant ? "GRANT" : "REVOKE";
+		ereport(WARNING, (errmsg("not propagating %s command to worker nodes", type)));
+	}
+
 	return NIL;
 }


### PR DESCRIPTION
Fixes #2637 

DESCRIPTION: Warn we are not propagating GRANT/REVOKE to workers in community edition.