### PR TITLE
Address unsafe coercion removal in pruning logic

### DIFF
--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -534,8 +534,7 @@ PrunableExpressionsWalker(Node *node, ClauseWalkerContext *context)
 
 		if (!prune->addedToPruningInstances)
 		{
-			context->pruningInstances = lappend(context->pruningInstances,
-												prune);
+			context->pruningInstances = lappend(context->pruningInstances, prune);
 			prune->addedToPruningInstances = true;
 		}
 
@@ -565,8 +564,8 @@ PrunableExpressionsWalker(Node *node, ClauseWalkerContext *context)
 			 * Found a restriction on the partition column itself. Update the
 			 * current constraint with the new information.
 			 */
-			AddPartitionKeyRestrictionToInstance(context,
-												 opClause, varClause, constantClause);
+			AddPartitionKeyRestrictionToInstance(context, opClause, varClause,
+												 constantClause);
 		}
 		else if (constantClause && varClause &&
 				 varClause->varattno == RESERVED_HASHED_COLUMN_ID)
@@ -597,8 +596,7 @@ PrunableExpressionsWalker(Node *node, ClauseWalkerContext *context)
 		 */
 		if (!prune->addedToPruningInstances)
 		{
-			context->pruningInstances = lappend(context->pruningInstances,
-												prune);
+			context->pruningInstances = lappend(context->pruningInstances, prune);
 			prune->addedToPruningInstances = true;
 		}
 
@@ -740,8 +738,7 @@ AddPartitionKeyRestrictionToInstance(ClauseWalkerContext *context, OpExpr *opCla
 	/* at this point, we'd better be able to pass binary Datums to comparison functions */
 	Assert(IsBinaryCoercible(constantClause->consttype, partitionColumn->vartype));
 
-	btreeInterpretationList =
-		get_op_btree_interpretation(opClause->opno);
+	btreeInterpretationList = get_op_btree_interpretation(opClause->opno);
 	foreach(btreeInterpretationCell, btreeInterpretationList)
 	{
 		OpBtreeInterpretation *btreeInterpretation =
@@ -846,8 +843,7 @@ AddPartitionKeyRestrictionToInstance(ClauseWalkerContext *context, OpExpr *opCla
 
 	if (!matchedOp)
 	{
-		prune->otherRestrictions =
-			lappend(prune->otherRestrictions, opClause);
+		prune->otherRestrictions = lappend(prune->otherRestrictions, opClause);
 	}
 	else
 	{

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -806,6 +806,19 @@ AddPartitionKeyRestrictionToInstance(ClauseWalkerContext *context, OpExpr *opCla
 
 			case ROWCOMPARE_NE:
 			{
+				/*
+				 * This case should only arise when ALL list elements have this
+				 * "strategy" number set. Skipping to the end of the list might
+				 * protect us if that assumption is violated, and an Assert can
+				 * notify us if it ever is...
+				 */
+
+				/* should see this value immediately */
+				Assert(btreeInterpretationCell == btreeInterpretationList->head);
+
+				/* stop processing early, would only see unsupported nodes anyhow */
+				btreeInterpretationCell = btreeInterpretationList->tail;
+
 				/* TODO: could add support for this, if we feel like it */
 				matchedOp = false;
 				break;

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -63,6 +63,7 @@
 #include "nodes/nodeFuncs.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
+#include "parser/parse_coerce.h"
 #include "utils/arrayaccess.h"
 #include "utils/catcache.h"
 #include "utils/lsyscache.h"
@@ -715,12 +716,14 @@ AddNewConjuction(ClauseWalkerContext *context, OpExpr *op)
  */
 static void
 AddPartitionKeyRestrictionToInstance(ClauseWalkerContext *context, OpExpr *opClause,
-									 Var *varClause, Const *constantClause)
+									 Var *partitionColumn, Const *constantClause)
 {
 	PruningInstance *prune = context->currentPruningInstance;
 	List *btreeInterpretationList = NULL;
 	ListCell *btreeInterpretationCell = NULL;
 	bool matchedOp = false;
+
+	Assert(IsBinaryCoercible(constantClause->consttype, partitionColumn->vartype));
 
 	btreeInterpretationList =
 		get_op_btree_interpretation(opClause->opno);
@@ -837,6 +840,9 @@ AddHashRestrictionToInstance(ClauseWalkerContext *context, OpExpr *opClause,
 	PruningInstance *prune = context->currentPruningInstance;
 	List *btreeInterpretationList = NULL;
 	ListCell *btreeInterpretationCell = NULL;
+
+	/* be paranoid */
+	Assert(IsBinaryCoercible(constantClause->consttype, INT4OID));
 
 	btreeInterpretationList =
 		get_op_btree_interpretation(opClause->opno);

--- a/src/test/regress/expected/multi_prune_shard_list.out
+++ b/src/test/regress/expected/multi_prune_shard_list.out
@@ -203,3 +203,27 @@ SELECT print_sorted_shard_intervals('pruning_range');
  {800004,800005,800006,800007}
 (1 row)
 
+-- ===================================================================
+-- test pruning using values whose types are coerced
+-- ===================================================================
+CREATE TABLE coerce_hash (
+	id bigint NOT NULL,
+	value text NOT NULL
+);
+SELECT create_distributed_table('coerce_hash', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- PostgreSQL will cast id to numeric rather than 1.0 to bigint...
+-- We used to blindly pass the RHS' Datum to our comparison func.,
+-- resulting in inaccurate pruning. An Assert now verifies type-
+-- compatibility; the following would crash the server in an Assert-
+-- before the underlying issue was addressed. It looks like a boring
+-- test now, but if the old behavior is restored, it should crash again.
+SELECT * FROM coerce_hash WHERE id = 1.0::numeric;
+ id | value 
+----+-------
+(0 rows)
+

--- a/src/test/regress/expected/multi_prune_shard_list.out
+++ b/src/test/regress/expected/multi_prune_shard_list.out
@@ -216,14 +216,38 @@ SELECT create_distributed_table('coerce_hash', 'id');
  
 (1 row)
 
+INSERT INTO coerce_hash VALUES (1, 'test value');
+-- All three of the following should return the same results...
+-- SELECT with same type as partition column
+SELECT * FROM coerce_hash WHERE id = 1::bigint;
+ id |   value    
+----+------------
+  1 | test value
+(1 row)
+
+-- SELECT with similar type to partition column
+SELECT * FROM coerce_hash WHERE id = 1;
+ id |   value    
+----+------------
+  1 | test value
+(1 row)
+
+-- SELECT with numeric type (original impetus for this change)
 -- PostgreSQL will cast id to numeric rather than 1.0 to bigint...
 -- We used to blindly pass the RHS' Datum to our comparison func.,
 -- resulting in inaccurate pruning. An Assert now verifies type-
 -- compatibility; the following would crash the server in an Assert-
 -- before the underlying issue was addressed. It looks like a boring
 -- test now, but if the old behavior is restored, it should crash again.
+SELECT * FROM coerce_hash WHERE id = 1.0;
+ id |   value    
+----+------------
+  1 | test value
+(1 row)
+
 SELECT * FROM coerce_hash WHERE id = 1.0::numeric;
- id | value 
-----+-------
-(0 rows)
+ id |   value    
+----+------------
+  1 | test value
+(1 row)
 

--- a/src/test/regress/sql/multi_prune_shard_list.sql
+++ b/src/test/regress/sql/multi_prune_shard_list.sql
@@ -130,10 +130,24 @@ CREATE TABLE coerce_hash (
 );
 SELECT create_distributed_table('coerce_hash', 'id');
 
+INSERT INTO coerce_hash VALUES (1, 'test value');
+
+-- All three of the following should return the same results...
+
+-- SELECT with same type as partition column
+SELECT * FROM coerce_hash WHERE id = 1::bigint;
+
+-- SELECT with similar type to partition column
+SELECT * FROM coerce_hash WHERE id = 1;
+
+-- SELECT with numeric type (original impetus for this change)
+
 -- PostgreSQL will cast id to numeric rather than 1.0 to bigint...
 -- We used to blindly pass the RHS' Datum to our comparison func.,
 -- resulting in inaccurate pruning. An Assert now verifies type-
 -- compatibility; the following would crash the server in an Assert-
 -- before the underlying issue was addressed. It looks like a boring
 -- test now, but if the old behavior is restored, it should crash again.
+SELECT * FROM coerce_hash WHERE id = 1.0;
+
 SELECT * FROM coerce_hash WHERE id = 1.0::numeric;

--- a/src/test/regress/sql/multi_prune_shard_list.sql
+++ b/src/test/regress/sql/multi_prune_shard_list.sql
@@ -119,3 +119,21 @@ SELECT print_sorted_shard_intervals('pruning_range');
 -- all shard placements are uninitialized
 UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103077;
 SELECT print_sorted_shard_intervals('pruning_range');
+
+-- ===================================================================
+-- test pruning using values whose types are coerced
+-- ===================================================================
+
+CREATE TABLE coerce_hash (
+	id bigint NOT NULL,
+	value text NOT NULL
+);
+SELECT create_distributed_table('coerce_hash', 'id');
+
+-- PostgreSQL will cast id to numeric rather than 1.0 to bigint...
+-- We used to blindly pass the RHS' Datum to our comparison func.,
+-- resulting in inaccurate pruning. An Assert now verifies type-
+-- compatibility; the following would crash the server in an Assert-
+-- before the underlying issue was addressed. It looks like a boring
+-- test now, but if the old behavior is restored, it should crash again.
+SELECT * FROM coerce_hash WHERE id = 1.0::numeric;


### PR DESCRIPTION
The root cause of this bug is what I believe is an assumption that `strip_implicit_coercions` only removes e.g. `RelabelType` nodes and (mostly) returns a pointer to a binary-compatible type. This is _not_ true; _any_ implicit coercion will be stripped, even e.g. a `FuncExpr`.

The provided repro case had a query attempting to SELECT based on an equality constraint between an `integer` column and `numeric` constant. While one might assume PostgreSQL would cast the `numeric` to the type of the column, that's not what happens. It's _possible_ there is actually an equality operator that can directly compare the two types. If so, PostgreSQL would have used that. In this case, such an operator does not exist, so PostgreSQL looks for candidates that can compare a type both sides of the clause can be (losslessly) converted into. There _does not seem to be any preference for the `Var`'s type_.

So PostgreSQL decided `numeric_eq` was a good pick and wrapped the `integer` in a cast to `numeric`, rather than the other way around. We come in and strip all implicit coercions and then _pass the `Const`'s `Datum` directly to our pruning comparison function without checking types_, essentially handing a binary `numeric` to a function expecting `integer`.

I've addressed this by (a) adding some `Assert`s to ensure we're always calling these functions with types that are at least binary-coercible into the expected argument types, and (b) pruning logic will proactively coerce any restriction values into the partition column type before doing any function dispatches. I believe the issues is resolved.

DESCRIPTION: Fixes a bug related to pruning shards using a coerced value

Fixes #2605