### PR TITLE
Ensure that stack resizing logic works expected

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -52,6 +52,7 @@
 #include "distributed/worker_manager.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/worker_shard_visibility.h"
+#include "port/atomics.h"
 #include "postmaster/postmaster.h"
 #include "optimizer/planner.h"
 #include "optimizer/paths.h"
@@ -261,7 +262,24 @@ ResizeStackToMaximumDepth(void)
 	long max_stack_depth_bytes = max_stack_depth * 1024L;
 
 	stack_resizer = alloca(max_stack_depth_bytes);
+
+	/*
+	 * Different architectures might have different directions while
+	 * growing the stack. So, touch both ends.
+	 */
+	stack_resizer[0] = 0;
 	stack_resizer[max_stack_depth_bytes - 1] = 0;
+
+	/*
+	 * Passing the address to external function also prevents the function
+	 * from being optimized away, and the debug elog can also help with
+	 * diagnosis if needed.
+	 */
+	elog(DEBUG5, "entry stack is at %p, increased to %p, the top and bottom values of "
+				 "the stack is %d and %d", &stack_resizer[0],
+		 &stack_resizer[max_stack_depth_bytes - 1],
+		 stack_resizer[max_stack_depth_bytes - 1], stack_resizer[0]);
+
 #endif
 }
 


### PR DESCRIPTION
This commit has two goals:

(a) Ensure to access both edges of the allocated stack since it might depend on architecture
(b) Ensure that any compiler optimizations to prevent the function optimized away.

Stack size after the patch:
```
 sudo grep -A 1 stack /proc/2119/smaps
7ffe305a6000-7ffe307a9000 rw-p 00000000 00:00 0                          [stack]
Size:               2060 kB
```
Stack size before the patch:
```
 sudo grep -A 1 stack /proc/3610/smaps
7fff09957000-7fff09978000 rw-p 00000000 00:00 0                          [stack]
Size:                132 kB
```
DESCRIPTION: Fixes a bug that prevents stack size to be adjusted
