### PR TITLE
Address constraint naming issue

### DIFF
--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -424,6 +424,11 @@ ALTER TABLE products ADD CHECK(product_no <> 0);
 ERROR:  cannot create constraint without a name on a distributed table
 ALTER TABLE products ADD EXCLUDE USING btree (product_no with =);
 ERROR:  cannot create constraint without a name on a distributed table
+-- ... with names, we can add/drop the constraints just fine
+ALTER TABLE products ADD CONSTRAINT nonzero_product_no CHECK(product_no <> 0);
+ALTER TABLE products ADD CONSTRAINT uniq_product_no EXCLUDE USING btree (product_no with =);
+ALTER TABLE products DROP CONSTRAINT nonzero_product_no;
+ALTER TABLE products DROP CONSTRAINT uniq_product_no;
 DROP TABLE products;
 -- Tests with transactions 
 CREATE TABLE products (

--- a/src/test/regress/expected/multi_create_table_constraints.out
+++ b/src/test/regress/expected/multi_create_table_constraints.out
@@ -350,6 +350,20 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.check_ex
 (2 rows)
 
 \c - - - :master_port
+-- Index-based constraints are created with shard-extended names, but others
+-- (e.g. expression-based table CHECK constraints) do _not_ have shardids in
+-- their object names, _at least originally as designed_. At some point, we
+-- mistakenly started extending _all_ constraint names, but _only_ for ALTER
+-- TABLE ... ADD CONSTRAINT commands (yes, even non-index constraints). So now
+-- the _same_ constraint definition could result in a non-extended name if made
+-- using CREATE TABLE and another name if made using AT ... ADD CONSTRAINT. So
+-- DROP CONSTRAINT started erroring because _it_ was also changed to always do
+-- shard-id extension. We've fixed that by looking for the non-extended name
+-- first and using it for DROP or VALIDATE commands that could be targeting it.
+-- As for the actual test: drop a constraint created by CREATE TABLE ... CHECK,
+-- which per the above description would have been created with a non-extended
+-- object name, but previously would have failed DROP as DROP does extension.
+ALTER TABLE check_example DROP CONSTRAINT check_example_other_col_check;
 -- drop unnecessary tables
 DROP TABLE pk_on_non_part_col, uq_on_non_part_col CASCADE;
 DROP TABLE pk_on_part_col, uq_part_col, uq_two_columns CASCADE;

--- a/src/test/regress/sql/multi_alter_table_add_constraints.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints.sql
@@ -367,6 +367,13 @@ ALTER TABLE products ADD PRIMARY KEY(product_no);
 ALTER TABLE products ADD CHECK(product_no <> 0);
 ALTER TABLE products ADD EXCLUDE USING btree (product_no with =);
 
+-- ... with names, we can add/drop the constraints just fine
+ALTER TABLE products ADD CONSTRAINT nonzero_product_no CHECK(product_no <> 0);
+ALTER TABLE products ADD CONSTRAINT uniq_product_no EXCLUDE USING btree (product_no with =);
+
+ALTER TABLE products DROP CONSTRAINT nonzero_product_no;
+ALTER TABLE products DROP CONSTRAINT uniq_product_no;
+
 DROP TABLE products;
 
 


### PR DESCRIPTION
DESCRIPTION: Make DROP/VALIDATE CONSTRAINT tolerant of ambiguous shard extension

I'll update this task tomorrow morning with more explanation. The comment in my SQL test file should give some basis for a review. @pykello, I've assigned to you. This change addresses the bug in a backportable way, but I think we should probably do something to clean up the ambiguous shard-extension issue (which silently changed at some point in the recent past).

I've got a bunch of GitHub windows open with various commits pointing to where this stuff was introduced; I've got to assume this was done unknowingly since it's quite undesirable.

Fixes #2484

# Tasks

  - [x] Write failing repro test
  - [x] Determine how implicitly-named `CHECK` constraints are deparsed
  - [x] Determine how `ALTER TABLE ... DROP CONSTRAINT ...` statements are deparsed
  - [x] Change `ALTER TABLE` deparse to be more tolerant of missing `shardid`
  - [x] Investigate similar occurrences of this problem
  - [x] Consider additional changes or creating additional issues
