### PR TITLE
Search all outer node levels for lateral join params.

### DIFF
--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -32,6 +32,18 @@ typedef struct RelationRestrictionContext
 	List *relationRestrictionList;
 } RelationRestrictionContext;
 
+
+typedef struct RootPlanParams
+{
+	PlannerInfo *root;
+
+	/*
+	 * Copy of root->plan_params. root->plan_params is not preserved in
+	 * relation_restriction_equivalence, so we need to create a copy.
+	 */
+	List *plan_params;
+} RootPlanParams;
+
 typedef struct RelationRestriction
 {
 	Index index;
@@ -40,9 +52,10 @@ typedef struct RelationRestriction
 	RangeTblEntry *rte;
 	RelOptInfo *relOptInfo;
 	PlannerInfo *plannerInfo;
-	PlannerInfo *parentPlannerInfo;
-	List *parentPlannerParamList;
 	List *prunedShardIntervalList;
+
+	/* list of RootPlanParams for all outer nodes */
+	List *outerPlanParamsList;
 } RelationRestriction;
 
 typedef struct JoinRestrictionContext

--- a/src/test/regress/expected/multi_subquery_behavioral_analytics.out
+++ b/src/test/regress/expected/multi_subquery_behavioral_analytics.out
@@ -2249,6 +2249,37 @@ FROM
      6 |    
 (1 row)
 
+-- Test the case when a subquery has a lateral reference to two levels upper
+SELECT
+ b.user_id, b.value_2, b.cnt
+FROM (
+ SELECT
+   user_id,
+   value_2
+ FROM events_table
+ WHERE events_table.user_id BETWEEN 2 AND 5
+) a,
+LATERAL (
+ SELECT
+   user_id, value_2, count(*) as cnt
+ FROM (
+   SELECT
+     value_2, time, user_id
+   FROM events_table
+   WHERE user_id BETWEEN 2 AND 5
+     AND events_table.user_id = a.user_id
+     AND events_table.value_2 = a.value_2
+   ORDER BY time DESC
+ ) events
+ GROUP BY user_id, value_2
+) b
+ORDER BY user_id, value_2, cnt
+LIMIT 1;
+ user_id | value_2 | cnt 
+---------+---------+-----
+       2 |       0 |   1
+(1 row)
+
 DROP FUNCTION test_join_function_2(integer, integer);
 SELECT run_command_on_workers($f$
 

--- a/src/test/regress/expected/set_operations.out
+++ b/src/test/regress/expected/set_operations.out
@@ -671,12 +671,11 @@ SELECT * FROM test a WHERE x IN (SELECT x FROM test b UNION SELECT y FROM test c
 DEBUG:  generating subplan 144_1 for subquery SELECT x FROM recursive_union.test b
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
-DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  Plan 144 query after replacing subqueries and CTEs: SELECT x, y FROM recursive_union.test a WHERE (x OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.x FROM read_intermediate_result('144_1'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION SELECT c.y FROM recursive_union.test c WHERE (a.x OPERATOR(pg_catalog.=) c.x))) ORDER BY x, y
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
-DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
-ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+ERROR:  cannot push down this subquery
+DETAIL:  Complex subqueries and CTEs are not supported within a UNION
 -- force unions to be planned while subqueries are being planned
 SELECT * FROM ((SELECT * FROM test) UNION (SELECT * FROM test) ORDER BY 1,2 LIMIT 5) as foo ORDER BY 1 DESC LIMIT 3;
 DEBUG:  generating subplan 147_1 for subquery SELECT x, y FROM recursive_union.test

--- a/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
+++ b/src/test/regress/sql/multi_subquery_behavioral_analytics.sql
@@ -1839,6 +1839,33 @@ FROM
   ) AS temp;
 
 
+-- Test the case when a subquery has a lateral reference to two levels upper
+SELECT
+ b.user_id, b.value_2, b.cnt
+FROM (
+ SELECT
+   user_id,
+   value_2
+ FROM events_table
+ WHERE events_table.user_id BETWEEN 2 AND 5
+) a,
+LATERAL (
+ SELECT
+   user_id, value_2, count(*) as cnt
+ FROM (
+   SELECT
+     value_2, time, user_id
+   FROM events_table
+   WHERE user_id BETWEEN 2 AND 5
+     AND events_table.user_id = a.user_id
+     AND events_table.value_2 = a.value_2
+   ORDER BY time DESC
+ ) events
+ GROUP BY user_id, value_2
+) b
+ORDER BY user_id, value_2, cnt
+LIMIT 1;
+
 
 DROP FUNCTION test_join_function_2(integer, integer);
 


### PR DESCRIPTION
A planner node can have parameters that reference variables in outer level planner nodes. This can happen when doing a lateral join. Previously we only searched the parent node to resolve these parameters, but this parameters can be references to any of the outer levels. This patch fixes the code to search all of the outer levels.

DESCRIPTION: Search all outer node levels for lateral join params.

fixes #2641 
