### PR TITLE
Make sure that the regression tests are resistant to execution order changes

### DIFF
--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -6,6 +6,9 @@ SET citus.next_placement_id TO 13300000;
 -- create co-located tables
 SET citus.shard_count = 4;
 SET citus.shard_replication_factor = 2;
+-- order of execution might change in parallel executions
+-- and the error details might contain the worker node
+-- so be less verbose with \set VERBOSITY TERSE when necessary
 CREATE TABLE raw_events_first (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint, UNIQUE(user_id, value_1));
 SELECT create_distributed_table('raw_events_first', 'user_id');
  create_distributed_table 
@@ -84,10 +87,10 @@ WHERE
 (6 rows)
 
 -- see that we get unique vialitons
+\set VERBOSITY TERSE
 INSERT INTO raw_events_second  SELECT * FROM raw_events_first;
 ERROR:  duplicate key value violates unique constraint "raw_events_second_user_id_value_1_key_13300004"
-DETAIL:  Key (user_id, value_1)=(1, 10) already exists.
-CONTEXT:  while executing command on localhost:57638
+\set VERBOSITY DEFAULT
 -- stable functions should be allowed
 INSERT INTO raw_events_second (user_id, time)
 SELECT
@@ -140,7 +143,6 @@ WHERE
   user_id = 0;
 WARNING:  function public.evaluate_on_master(integer) does not exist
 ERROR:  function public.evaluate_on_master(integer) does not exist
-\set VERBOSITY default
 -- add one more row
 INSERT INTO raw_events_first (user_id, time) VALUES
                          (7, now());
@@ -221,6 +223,7 @@ DEBUG:  Plan is router executable
 (1 row)
 
 -- hits two shards
+\set VERBOSITY TERSE
 INSERT INTO raw_events_second (user_id, value_1, value_3) 
 SELECT 
    user_id, value_1, value_3
@@ -235,8 +238,6 @@ DEBUG:  Skipping target shard interval 13300006 since SELECT query for it pruned
 DEBUG:  distributed statement: INSERT INTO public.raw_events_second_13300007 AS citus_table_alias (user_id, value_1, value_3) SELECT user_id, value_1, value_3 FROM public.raw_events_first_13300003 raw_events_first WHERE (((user_id OPERATOR(pg_catalog.=) 9) OR (user_id OPERATOR(pg_catalog.=) 16)) AND ((worker_hash(user_id) OPERATOR(pg_catalog.>=) 1073741824) AND (worker_hash(user_id) OPERATOR(pg_catalog.<=) 2147483647))) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "raw_events_second_user_id_value_1_key_13300007"
-DETAIL:  Key (user_id, value_1)=(9, 90) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- now do some aggregations
 INSERT INTO agg_events 
 SELECT
@@ -265,8 +266,6 @@ DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_t
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg, value_3_agg, value_4_agg) SELECT user_id, sum(value_1) AS sum, sum(value_3) AS sum, count(value_4) AS count FROM public.raw_events_first_13300003 raw_events_first WHERE ((worker_hash(user_id) OPERATOR(pg_catalog.>=) 1073741824) AND (worker_hash(user_id) OPERATOR(pg_catalog.<=) 2147483647)) GROUP BY value_2, user_id RETURNING citus_table_alias.user_id, citus_table_alias.value_1_agg, citus_table_alias.value_2_agg, citus_table_alias.value_3_agg, citus_table_alias.value_4_agg, citus_table_alias.agg_time
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "agg_events_user_id_value_1_agg_key_13300008"
-DETAIL:  Key (user_id, value_1_agg)=(1, 10) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- some subquery tests
 INSERT INTO agg_events 
             (value_1_agg, 
@@ -286,8 +285,6 @@ DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_t
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg) SELECT id, sum(value_1) AS sum FROM (SELECT raw_events_second.user_id AS id, raw_events_second.value_1 FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id OPERATOR(pg_catalog.=) raw_events_second.user_id)) foo WHERE ((worker_hash(id) OPERATOR(pg_catalog.>=) 1073741824) AND (worker_hash(id) OPERATOR(pg_catalog.<=) 2147483647)) GROUP BY id ORDER BY id
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "agg_events_user_id_value_1_agg_key_13300008"
-DETAIL:  Key (user_id, value_1_agg)=(1, 10) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- subquery one more level depth 
 INSERT INTO agg_events 
             (value_4_agg, 
@@ -310,8 +307,7 @@ DEBUG:  distributed statement: INSERT INTO public.agg_events_13300010 AS citus_t
 DEBUG:  distributed statement: INSERT INTO public.agg_events_13300011 AS citus_table_alias (user_id, value_1_agg, value_4_agg) SELECT id, v1, v4 FROM (SELECT sum(raw_events_second.value_4) AS v4, sum(raw_events_first.value_1) AS v1, raw_events_second.user_id AS id FROM public.raw_events_first_13300003 raw_events_first, public.raw_events_second_13300007 raw_events_second WHERE (raw_events_first.user_id OPERATOR(pg_catalog.=) raw_events_second.user_id) GROUP BY raw_events_second.user_id) foo WHERE ((worker_hash(id) OPERATOR(pg_catalog.>=) 1073741824) AND (worker_hash(id) OPERATOR(pg_catalog.<=) 2147483647)) ORDER BY id
 DEBUG:  Plan is router executable
 ERROR:  duplicate key value violates unique constraint "agg_events_user_id_value_1_agg_key_13300008"
-DETAIL:  Key (user_id, value_1_agg)=(1, 10) already exists.
-CONTEXT:  while executing command on localhost:57637
+\set VERBOSITY DEFAULT
 -- join between subqueries
 INSERT INTO agg_events
             (user_id)
@@ -1885,11 +1881,11 @@ FROM   (SELECT f1.key
                AS f2 
         WHERE  f1.key = f2.key 
         GROUP  BY 1) AS foo; 
-SELECT * FROM insert_select_varchar_test;
+SELECT * FROM insert_select_varchar_test ORDER BY 1 DESC, 2 DESC;
   key   | value 
 --------+-------
- test_2 |    30
  test_2 |   100
+ test_2 |    30
  test_1 |    10
 (3 rows)
 
@@ -2640,15 +2636,15 @@ FROM (
   FROM coerce_events
 ) AS ftop
 LIMIT 5;
-SELECT * FROM coerce_agg;
+SELECT * FROM coerce_agg ORDER BY 1 DESC, 2 DESC;
  user_id | value_1_agg 
 ---------+-------------
       10 | 10
-       1 | 1
-       1 | 1
       10 | 10
        2 | 2
        2 | 2
+       1 | 1
+       1 | 1
 (6 rows)
 
 TRUNCATE coerce_agg;
@@ -2662,7 +2658,7 @@ FROM (
 ) AS ftop
 LIMIT 5;
 ERROR:  value too long for type character(1)
-SELECT * FROM coerce_agg;
+SELECT * FROM coerce_agg ORDER BY 1 DESC, 2 DESC;
  user_id | value_1_agg 
 ---------+-------------
 (0 rows)
@@ -2690,11 +2686,11 @@ FROM (
   FROM coerce_events
 ) AS ftop
 LIMIT 5;
-SELECT * FROM coerce_agg;
+SELECT * FROM coerce_agg ORDER BY 1 DESC, 2 DESC;
  user_id | value_1_agg 
 ---------+-------------
-       1 | a    
        2 | b    
+       1 | a    
 (2 rows)
 
 TRUNCATE coerce_agg;
@@ -2704,6 +2700,7 @@ ALTER TABLE coerce_events ALTER COLUMN value_1 TYPE integer USING NULL;
 ALTER TABLE coerce_agg ALTER COLUMN value_1_agg TYPE integer USING NULL;
 ALTER TABLE coerce_agg ADD CONSTRAINT small_number CHECK (value_1_agg < 5);
 INSERT INTO coerce_events (user_id, value_1) VALUES (1, 1), (10, 10);
+\set VERBOSITY TERSE
 INSERT INTO coerce_agg(user_id, value_1_agg)
 SELECT *
 FROM (
@@ -2711,9 +2708,8 @@ FROM (
   FROM coerce_events
 ) AS ftop;
 ERROR:  new row for relation "coerce_agg_13300060" violates check constraint "small_number_13300060"
-DETAIL:  Failing row contains (10, 10).
-CONTEXT:  while executing command on localhost:57637
-SELECT * FROM coerce_agg;
+\set VERBOSITY DEFAULT
+SELECT * FROM coerce_agg ORDER BY 1 DESC, 2 DESC;
  user_id | value_1_agg 
 ---------+-------------
 (0 rows)
@@ -2731,11 +2727,11 @@ FROM (
   FROM coerce_events
 ) AS ftop
 LIMIT 5;
-SELECT * FROM coerce_agg;
+SELECT * FROM coerce_agg ORDER BY 1 DESC, 2 DESC;
  user_id | value_1_agg 
 ---------+-------------
-       1 | {1,1,1}
        2 | {2,2,2}
+       1 | {1,1,1}
 (2 rows)
 
 -- INSERT..SELECT + prepared statements + recursive planning

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1,6 +1,9 @@
 SET citus.shard_count TO 32;
 SET citus.next_shard_id TO 750000;
 SET citus.next_placement_id TO 750000;
+-- some failure messages that comes from the worker nodes
+-- might change due to parallel exectuions, so supress those
+-- using \set VERBOSITY terse
 -- ===================================================================
 -- test end-to-end modification functionality
 -- ===================================================================
@@ -154,25 +157,20 @@ SET client_min_messages TO ERROR;
 INSERT INTO limit_orders VALUES (NULL, 'T', 975234, DEFAULT);
 ERROR:  cannot perform an INSERT with NULL in the partition column
 -- INSERT violating column constraint
+\set VERBOSITY terse
 INSERT INTO limit_orders VALUES (18811, 'BUD', 14962, '2014-04-05 08:32:16', 'sell',
 								 -5.00);
 ERROR:  new row for relation "limit_orders_750000" violates check constraint "limit_orders_limit_price_check"
-DETAIL:  Failing row contains (18811, BUD, 14962, 2014-04-05 08:32:16, sell, -5.00).
-CONTEXT:  while executing command on localhost:57638
 -- INSERT violating primary key constraint
 INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58);
 ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
-DETAIL:  Key (id)=(32743) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- INSERT violating primary key constraint, with RETURNING specified.
 INSERT INTO limit_orders VALUES (32743, 'LUV', 5994, '2001-04-16 03:37:28', 'buy', 0.58) RETURNING *;
 ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
-DETAIL:  Key (id)=(32743) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- INSERT, with RETURNING specified, failing with a non-constraint error
 INSERT INTO limit_orders VALUES (34153, 'LEE', 5994, '2001-04-16 03:37:28', 'buy', 0.58) RETURNING id / 0;
 ERROR:  division by zero
-CONTEXT:  while executing command on localhost:57638
+\set VERBOSITY DEFAULT
 SET client_min_messages TO DEFAULT;
 -- commands with non-constant partition values are supported
 INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:45',
@@ -279,10 +277,11 @@ ERROR:  relation bidders is not distributed
 WITH new_orders AS (INSERT INTO limit_orders VALUES (411, 'FLO', 12, '2017-07-02 16:32:15', 'buy', 66))
 DELETE FROM limit_orders WHERE id < 0;
 -- we have to be careful that modifying CTEs are part of the transaction and can thus roll back
+\set VERBOSITY terse
 WITH new_orders AS (INSERT INTO limit_orders VALUES (412, 'FLO', 12, '2017-07-02 16:32:15', 'buy', 66))
 DELETE FROM limit_orders RETURNING id / 0;
 ERROR:  division by zero
-CONTEXT:  while executing command on localhost:57637
+\set VERBOSITY default
 SELECT * FROM limit_orders WHERE id = 412;
  id | symbol | bidder_id | placed_at | kind | limit_price 
 ----+--------+-----------+-----------+------+-------------
@@ -335,11 +334,10 @@ UPDATE limit_orders SET (kind, limit_price) = ('buy', 999) WHERE id = 246 RETURN
 (1 row)
 
 -- Test that on unique contraint violations, we fail fast
+\set VERBOSITY terse
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 INSERT INTO limit_orders VALUES (275, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 ERROR:  duplicate key value violates unique constraint "limit_orders_pkey_750001"
-DETAIL:  Key (id)=(275) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- Test that shards which miss a modification are marked unhealthy
 -- First: Connect to the second worker node
 \c - - - :worker_2_port
@@ -348,9 +346,9 @@ ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
 -- Third: Connect back to master node
 \c - - - :master_port
 -- Fourth: Perform an INSERT on the remaining node
+\set VERBOSITY terse
 INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 WARNING:  relation "public.limit_orders_750000" does not exist
-CONTEXT:  while executing command on localhost:57638
 -- Last: Verify the insert worked but the deleted placement is now unhealthy
 SELECT count(*) FROM limit_orders WHERE id = 276;
  count 
@@ -379,9 +377,10 @@ ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
 -- Third: Connect back to master node
 \c - - - :master_port
 -- Fourth: Perform an INSERT on the remaining node
+\set VERBOSITY terse
 INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
 ERROR:  relation "public.limit_orders_750000" does not exist
-CONTEXT:  while executing command on localhost:57637
+\set VERBOSITY DEFAULT
 -- Last: Verify worker is still healthy
 SELECT count(*)
 FROM   pg_dist_shard_placement AS sp,
@@ -479,10 +478,10 @@ SELECT array_of_values FROM limit_orders WHERE id = 246;
 -- STRICT functions work as expected
 CREATE FUNCTION temp_strict_func(integer,integer) RETURNS integer AS
 'SELECT COALESCE($1, 2) + COALESCE($1, 3);' LANGUAGE SQL STABLE STRICT;
+\set VERBOSITY terse
 UPDATE limit_orders SET bidder_id = temp_strict_func(1, null) WHERE id = 246;
 ERROR:  null value in column "bidder_id" violates not-null constraint
-DETAIL:  Failing row contains (246, GM, null, 2007-07-02 16:32:15, buy, 999, {1,2}).
-CONTEXT:  while executing command on localhost:57637
+\set VERBOSITY default
 SELECT array_of_values FROM limit_orders WHERE id = 246;
  array_of_values 
 -----------------

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -78,10 +78,10 @@ SELECT name FROM researchers WHERE lab_id = 1 AND id = 1;
 
 -- trigger a unique constraint violation
 BEGIN;
+\set VERBOSITY TERSE
 UPDATE researchers SET name = 'John Backus' WHERE id = 1 AND lab_id = 1;
 ERROR:  duplicate key value violates unique constraint "avoid_name_confusion_idx_1200000"
-DETAIL:  Key (lab_id, name)=(1, John Backus) already exists.
-CONTEXT:  while executing command on localhost:57637
+\set VERBOSITY DEFAULT
 ABORT;
 -- creating savepoints should work...
 BEGIN;

--- a/src/test/regress/expected/multi_name_lengths.out
+++ b/src/test/regress/expected/multi_name_lengths.out
@@ -81,14 +81,14 @@ ERROR:  cannot create constraint without a name on a distributed table
 ALTER TABLE name_lengths ADD CHECK (date_col_12345678901234567890123456789012345678901234567890 > '2014-01-01'::date);
 ERROR:  cannot create constraint without a name on a distributed table
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.name_lengths_225002'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.name_lengths_225002'::regclass ORDER BY 1 DESC, 2 DESC;
                             Column                            |       Type       | Modifiers 
 --------------------------------------------------------------+------------------+-----------
- col1                                                         | integer          | not null
- col2                                                         | integer          | not null
+ int_col_12345678901234567890123456789012345678901234567890   | integer          | default 1
  float_col_12345678901234567890123456789012345678901234567890 | double precision | 
  date_col_12345678901234567890123456789012345678901234567890  | date             | 
- int_col_12345678901234567890123456789012345678901234567890   | integer          | default 1
+ col2                                                         | integer          | not null
+ col1                                                         | integer          | not null
 (5 rows)
 
 \c - - - :master_port
@@ -101,7 +101,7 @@ ERROR:  cannot create constraint on "name_lengths"
 DETAIL:  Distributed relations cannot have UNIQUE, EXCLUDE, or PRIMARY KEY constraints that do not include the partition column (with an equality operator if EXCLUDE).
 ALTER TABLE name_lengths ADD CONSTRAINT nl_checky_12345678901234567890123456789012345678901234567890 CHECK (date_col_12345678901234567890123456789012345678901234567890 >= '2014-01-01'::date);
 \c - - - :worker_1_port
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_lengths_225002'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_lengths_225002'::regclass ORDER BY 1 DESC, 2 DESC;
                            Constraint                            |                                        Definition                                         
 -----------------------------------------------------------------+-------------------------------------------------------------------------------------------
  nl_checky_1234567890123456789012345678901234567_b16df46d_225002 | CHECK (date_col_12345678901234567890123456789012345678901234567890 >= '01-01-2014'::date)
@@ -109,16 +109,17 @@ SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_len
 
 \c - - - :master_port
 -- Placeholders for RENAME operations
+\set VERBOSITY TERSE
 ALTER TABLE name_lengths RENAME TO name_len_12345678901234567890123456789012345678901234567890;
 ERROR:  shard name name_len_12345678901234567890123456789012345678_fcd8ab6f_225002 exceeds 63 characters
-CONTEXT:  while executing command on localhost:57638
 ALTER TABLE name_lengths RENAME CONSTRAINT unique_12345678901234567890123456789012345678901234567890 TO unique2_12345678901234567890123456789012345678901234567890;
 ERROR:  renaming constraints belonging to distributed tables is currently unsupported
+\set VERBOSITY DEFAULT
 -- Verify that CREATE INDEX on already distributed table has proper shard names.
 CREATE INDEX tmp_idx_12345678901234567890123456789012345678901234567890 ON name_lengths(col2);
 \c - - - :worker_1_port
 SELECT "relname", "Column", "Type", "Definition" FROM index_attrs WHERE
-    relname LIKE 'tmp_idx_%';
+    relname LIKE 'tmp_idx_%' ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC;
                              relname                             | Column |  Type   | Definition 
 -----------------------------------------------------------------+--------+---------+------------
  tmp_idx_123456789012345678901234567890123456789_5e470afa_225003 | col2   | integer | col2
@@ -132,7 +133,7 @@ CREATE INDEX tmp_idx_12345678901234567890123456789012345678901234567890123456789
 NOTICE:  identifier "tmp_idx_123456789012345678901234567890123456789012345678901234567890" will be truncated to "tmp_idx_1234567890123456789012345678901234567890123456789012345"
 \c - - - :worker_1_port
 SELECT "relname", "Column", "Type", "Definition" FROM index_attrs WHERE
-    relname LIKE 'tmp_idx_%';
+    relname LIKE 'tmp_idx_%' ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC;
                              relname                             | Column |  Type   | Definition 
 -----------------------------------------------------------------+--------+---------+------------
  tmp_idx_123456789012345678901234567890123456789_5e470afa_225003 | col2   | integer | col2
@@ -171,7 +172,7 @@ CREATE TABLE sneaky_name_lengths (
  public | sneaky_name_lengths_int_col_1234567890123456789012345678901_key | index | postgres | sneaky_name_lengths
 (1 row)
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths'::regclass ORDER BY 1 DESC, 2 DESC;
                         Constraint                         |                                  Definition                                  
 -----------------------------------------------------------+------------------------------------------------------------------------------
  checky_12345678901234567890123456789012345678901234567890 | CHECK (int_col_123456789012345678901234567890123456789012345678901234 > 100)
@@ -197,7 +198,7 @@ SELECT master_create_worker_shards('sneaky_name_lengths', '2', '2');
  public | sneaky_name_lengths_int_col_1234567890123456789_6402d2cd_225006 | index | postgres | sneaky_name_lengths_225006
 (1 row)
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225006'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225006'::regclass ORDER BY 1 DESC, 2 DESC;
                         Constraint                         |                                  Definition                                  
 -----------------------------------------------------------+------------------------------------------------------------------------------
  checky_12345678901234567890123456789012345678901234567890 | CHECK (int_col_123456789012345678901234567890123456789012345678901234 > 100)

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -436,14 +436,14 @@ Partitions: partitioning_test_2009 FOR VALUES FROM ('01-01-2009') TO ('01-01-201
 INSERT INTO partitioning_test VALUES(21, '2014-02-02');
 INSERT INTO partitioning_test VALUES(22, '2015-04-02');
 -- see they are inserted into default partition
-SELECT * FROM partitioning_test WHERE id > 20;
+SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
  id |    time    
 ----+------------
  21 | 02-02-2014
  22 | 04-02-2015
 (2 rows)
 
-SELECT * FROM partitioning_test_default;
+SELECT * FROM partitioning_test_default ORDER BY 1, 2;
  id |    time    
 ----+------------
  21 | 02-02-2014
@@ -462,14 +462,14 @@ DELETE FROM partitioning_test_default WHERE time >= '2014-01-01' AND time < '201
 ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_default DEFAULT;
 END;
 -- see data is in the table, but some moved out from default partition
-SELECT * FROM partitioning_test WHERE id > 20;
+SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
  id |    time    
 ----+------------
  21 | 02-02-2014
  22 | 04-02-2015
 (2 rows)
 
-SELECT * FROM partitioning_test_default;
+SELECT * FROM partitioning_test_default ORDER BY 1, 2;
  id |    time    
 ----+------------
  22 | 04-02-2015

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -444,14 +444,14 @@ ERROR:  no partition of relation "partitioning_test_1660003" found for row
 DETAIL:  Partition key of the failing row contains ("time") = (2015-04-02).
 CONTEXT:  while executing command on localhost:57638
 -- see they are inserted into default partition
-SELECT * FROM partitioning_test WHERE id > 20;
+SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
  id | time 
 ----+------
 (0 rows)
 
-SELECT * FROM partitioning_test_default;
+SELECT * FROM partitioning_test_default ORDER BY 1, 2;
 ERROR:  relation "partitioning_test_default" does not exist
-LINE 1: SELECT * FROM partitioning_test_default;
+LINE 1: SELECT * FROM partitioning_test_default ORDER BY 1, 2;
                       ^
 -- create a new partition (will fail)
 CREATE TABLE partitioning_test_2014 PARTITION OF partitioning_test FOR VALUES FROM ('2014-01-01') TO ('2015-01-01');
@@ -470,14 +470,14 @@ LINE 1: ...ing_test ATTACH PARTITION partitioning_test_default DEFAULT;
                                                                ^
 END;
 -- see data is in the table, but some moved out from default partition
-SELECT * FROM partitioning_test WHERE id > 20;
+SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
  id | time 
 ----+------
 (0 rows)
 
-SELECT * FROM partitioning_test_default;
+SELECT * FROM partitioning_test_default ORDER BY 1, 2;
 ERROR:  relation "partitioning_test_default" does not exist
-LINE 1: SELECT * FROM partitioning_test_default;
+LINE 1: SELECT * FROM partitioning_test_default ORDER BY 1, 2;
                       ^
 -- test master_modify_multiple_shards
 -- master_modify_multiple_shards on partitioned table

--- a/src/test/regress/expected/multi_read_from_secondaries.out
+++ b/src/test/regress/expected/multi_read_from_secondaries.out
@@ -37,14 +37,14 @@ INSERT INTO dest_table (a, b) VALUES (1, 2);
 ERROR:  writing to worker nodes is not currently allowed
 DETAIL:  citus.use_secondary_nodes is set to 'always'
 -- router selects are allowed
-SELECT a FROM dest_table WHERE a = 1;
+SELECT a FROM dest_table WHERE a = 1 ORDER BY 1;
  a 
 ---
  1
 (1 row)
 
 -- real-time selects are also allowed
-SELECT a FROM dest_table;
+SELECT a FROM dest_table ORDER BY 1;
  a 
 ---
  1
@@ -66,10 +66,10 @@ FROM
 	     	source_table.a = dest_table.a AND 
 	     dest_table.b IN (1,2,3,4)
 	     ) SELECT * FROM cte ORDER BY 1 DESC LIMIT 5
-     ) as foo;
+     ) as foo ORDER BY 1;
 DEBUG:  generating subplan 4_1 for CTE cte: SELECT DISTINCT dest_table.a FROM public.dest_table, public.source_table WHERE ((source_table.a OPERATOR(pg_catalog.=) dest_table.a) AND (dest_table.b OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4])))
 DEBUG:  generating subplan 4_2 for subquery SELECT a FROM (SELECT intermediate_result.a FROM read_intermediate_result('4_1'::text, 'binary'::citus_copy_format) intermediate_result(a integer)) cte ORDER BY a DESC LIMIT 5
-DEBUG:  Plan 4 query after replacing subqueries and CTEs: SELECT a FROM (SELECT intermediate_result.a FROM read_intermediate_result('4_2'::text, 'binary'::citus_copy_format) intermediate_result(a integer)) foo
+DEBUG:  Plan 4 query after replacing subqueries and CTEs: SELECT a FROM (SELECT intermediate_result.a FROM read_intermediate_result('4_2'::text, 'binary'::citus_copy_format) intermediate_result(a integer)) foo ORDER BY a
  a 
 ---
 (0 rows)

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -696,14 +696,15 @@ DEBUG:  Plan is router executable
 -- handled by real-time executor
 SELECT *
 	FROM articles_hash
-	WHERE author_id = 1 OR author_id = 18;
+	WHERE author_id = 1 OR author_id = 18
+ORDER BY 4 DESC, 3 DESC, 2 DESC, 1 DESC;
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
-  1 |         1 | arsenous     |       9572
- 11 |         1 | alamo        |       1347
- 21 |         1 | arcading     |       5890
- 31 |         1 | athwartships |       7271
  41 |         1 | aznavour     |      11814
+  1 |         1 | arsenous     |       9572
+ 31 |         1 | athwartships |       7271
+ 21 |         1 | arcading     |       5890
+ 11 |         1 | alamo        |       1347
 (5 rows)
 
 -- rename the output columns

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -406,17 +406,17 @@ SELECT master_modify_multiple_shards('UPDATE test_schema_support.nation_hash SET
 (1 row)
 
 --verify master_modify_multiple_shards
-SELECT * FROM test_schema_support.nation_hash;
+SELECT * FROM test_schema_support.nation_hash ORDER BY 1,2,3,4;
  n_nationkey |          n_name           | n_regionkey |                                                  n_comment                                                  
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
-           1 | ARGENTINA                 |           2 | al foxes promise slyly according to the regular accounts. bold requests alon
-           5 | ETHIOPIA                  |           1 | ven packages wake quickly. regu
-           7 | GERMANY                   |           4 | 
            0 | ALGERIA                   |           1 | haggle. carefully final deposits detect slyly agai
+           1 | ARGENTINA                 |           2 | al foxes promise slyly according to the regular accounts. bold requests alon
+           2 | BRAZIL                    |           2 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
            3 | CANADA                    |           2 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           5 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
+           5 | ETHIOPIA                  |           1 | ven packages wake quickly. regu
            6 | FRANCE                    |           4 | 
-           2 | BRAZIL                    |           2 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
+           7 | GERMANY                   |           4 | 
 (8 rows)
 
 --test with search_path is set
@@ -428,17 +428,17 @@ SELECT master_modify_multiple_shards('UPDATE nation_hash SET n_regionkey = n_reg
 (1 row)
 
 --verify master_modify_multiple_shards
-SELECT * FROM nation_hash;
+SELECT * FROM nation_hash ORDER BY 1,2,3,4;
  n_nationkey |          n_name           | n_regionkey |                                                  n_comment                                                  
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
-           1 | ARGENTINA                 |           3 | al foxes promise slyly according to the regular accounts. bold requests alon
-           5 | ETHIOPIA                  |           2 | ven packages wake quickly. regu
-           7 | GERMANY                   |           5 | 
            0 | ALGERIA                   |           2 | haggle. carefully final deposits detect slyly agai
+           1 | ARGENTINA                 |           3 | al foxes promise slyly according to the regular accounts. bold requests alon
+           2 | BRAZIL                    |           3 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
            3 | CANADA                    |           3 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           6 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
+           5 | ETHIOPIA                  |           2 | ven packages wake quickly. regu
            6 | FRANCE                    |           5 | 
-           2 | BRAZIL                    |           3 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
+           7 | GERMANY                   |           5 | 
 (8 rows)
 
 --test COLLATION with schema
@@ -471,15 +471,15 @@ SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 
 (1 row)
 
 \copy test_schema_support.nation_hash_collation FROM STDIN with delimiter '|';
-SELECT * FROM test_schema_support.nation_hash_collation;
+SELECT * FROM test_schema_support.nation_hash_collation ORDER BY 1,2,3,4;
  n_nationkey |          n_name           | n_regionkey |                                                  n_comment                                                  
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
-           1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
-           5 | ETHIOPIA                  |           0 | ven packages wake quickly. regu
            0 | ALGERIA                   |           0 | haggle. carefully final deposits detect slyly agai
+           1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
+           2 | BRAZIL                    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
            3 | CANADA                    |           1 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           4 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
-           2 | BRAZIL                    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
+           5 | ETHIOPIA                  |           0 | ven packages wake quickly. regu
 (6 rows)
 
 SELECT n_comment FROM test_schema_support.nation_hash_collation ORDER BY n_comment COLLATE test_schema_support.english;

--- a/src/test/regress/expected/multi_subquery_complex_queries.out
+++ b/src/test/regress/expected/multi_subquery_complex_queries.out
@@ -2086,7 +2086,7 @@ FROM
     value_3 DESC
    LIMIT 10) "some_users"
 ORDER BY
-  value_3 DESC 
+  value_3 DESC, user_id DESC 
 LIMIT 10;
  user_id | value_3 
 ---------+---------
@@ -2139,7 +2139,7 @@ FROM
       users.value_2 > 2
      LIMIT 1
     ) "some_users_data" ON TRUE
-ORDER BY value_3 DESC
+ORDER BY value_3 DESC, user_id DESC
 LIMIT 10;
  user_id | value_3 
 ---------+---------
@@ -2646,7 +2646,7 @@ FROM
   ) AS b
   USING (user_id)
 GROUP BY user_id
-ORDER BY 1;
+ORDER BY 1, 2;
  user_id |      subquery_avg      
 ---------+------------------------
        1 |     2.3333333333333333
@@ -2681,7 +2681,7 @@ FROM
   ) AS b
   USING (user_id)
 GROUP BY a.user_id
-ORDER BY 1;
+ORDER BY 1, 2;
  user_id |      subquery_avg      
 ---------+------------------------
        1 |     2.3333333333333333

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -364,12 +364,12 @@ CREATE VIEW recent_users AS
 	SELECT user_id, max(time) as lastseen FROM users_table
 	GROUP BY user_id
 	HAVING max(time) > '2017-11-23 16:20:33.264457'::timestamp order by 2 DESC; 
-SELECT * FROM recent_users;
+SELECT * FROM recent_users ORDER BY 2 DESC, 1 DESC;
  user_id |            lastseen             
 ---------+---------------------------------
        1 | Thu Nov 23 17:30:34.635085 2017
-       5 | Thu Nov 23 16:48:32.08896 2017
        3 | Thu Nov 23 17:18:51.048758 2017
+       5 | Thu Nov 23 16:48:32.08896 2017
 (3 rows)
 
 -- create a view for recent_events

--- a/src/test/regress/expected/multi_view_0.out
+++ b/src/test/regress/expected/multi_view_0.out
@@ -364,12 +364,12 @@ CREATE VIEW recent_users AS
 	SELECT user_id, max(time) as lastseen FROM users_table
 	GROUP BY user_id
 	HAVING max(time) > '2017-11-23 16:20:33.264457'::timestamp order by 2 DESC; 
-SELECT * FROM recent_users;
+SELECT * FROM recent_users ORDER BY 2 DESC, 1 DESC;
  user_id |            lastseen             
 ---------+---------------------------------
        1 | Thu Nov 23 17:30:34.635085 2017
-       5 | Thu Nov 23 16:48:32.08896 2017
        3 | Thu Nov 23 17:18:51.048758 2017
+       5 | Thu Nov 23 16:48:32.08896 2017
 (3 rows)
 
 -- create a view for recent_events

--- a/src/test/regress/input/multi_outer_join.source
+++ b/src/test/regress/input/multi_outer_join.source
@@ -334,7 +334,8 @@ SELECT
 	l_custkey, r_custkey
 FROM
 	multi_outer_join_left l1
-	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey);
+	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
+ORDER BY 1 DESC, 2 DESC;
 
 -- full outer join + anti (right) should work with 1-1 matched shards
 SELECT
@@ -343,7 +344,8 @@ FROM
 	multi_outer_join_left l1
 	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
 WHERE 
-	r_custkey is NULL;
+	r_custkey is NULL
+ORDER BY 1 DESC, 2 DESC;
 
 -- full outer join + anti (left) should work with 1-1 matched shards
 SELECT
@@ -352,7 +354,8 @@ FROM
 	multi_outer_join_left l1
 	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
 WHERE 
-	l_custkey is NULL;
+	l_custkey is NULL
+ORDER BY 1 DESC, 2 DESC;
 
 -- full outer join + anti (both) should work with 1-1 matched shards
 SELECT
@@ -361,14 +364,16 @@ FROM
 	multi_outer_join_left l1
 	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
 WHERE 
-	l_custkey is NULL or r_custkey is NULL;
+	l_custkey is NULL or r_custkey is NULL
+ORDER BY 1 DESC, 2 DESC;
 
 -- full outer join should error out for mismatched shards
 SELECT
 	l_custkey, t_custkey
 FROM
 	multi_outer_join_left l1
-	FULL JOIN multi_outer_join_third t1 ON (l1.l_custkey = t1.t_custkey);
+	FULL JOIN multi_outer_join_third t1 ON (l1.l_custkey = t1.t_custkey)
+ORDER BY 1 DESC, 2 DESC;
 
 -- inner join  + single shard left join should work
 SELECT
@@ -376,7 +381,8 @@ SELECT
 FROM
 	multi_outer_join_left l1
 	INNER JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
-	LEFT JOIN multi_outer_join_third_reference t1 ON (r1.r_custkey  = t1.t_custkey);
+	LEFT JOIN multi_outer_join_third_reference t1 ON (r1.r_custkey  = t1.t_custkey)
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
 
 -- inner (broadcast) join  + 2 shards left (local) join should work
 SELECT
@@ -384,7 +390,8 @@ SELECT
 FROM
 	multi_outer_join_left l1
 	INNER JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey)
-	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey);
+	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey)
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
 
 -- inner (local) join  + 2 shards left (dual partition) join
 SELECT
@@ -402,7 +409,9 @@ SELECT
 FROM
 	multi_outer_join_left l1
 	INNER JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey)
-	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey);
+	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey)
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
+
 
 -- inner (broadcast) join  + 2 shards left (local) + anti join should work
 SELECT
@@ -412,7 +421,8 @@ FROM
 	INNER JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey)
 	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey)
 WHERE
-	r_custkey is NULL;
+	r_custkey is NULL
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
 
 -- Test joinExpr aliases by performing an outer-join. 
 SELECT 
@@ -421,7 +431,8 @@ FROM
 	(multi_outer_join_right r1 
 	LEFT OUTER JOIN multi_outer_join_left l1 ON (l1.l_custkey = r1.r_custkey)) AS
     test(c_custkey, c_nationkey)
-    INNER JOIN multi_outer_join_third_reference t1 ON (test.c_custkey = t1.t_custkey);
+    INNER JOIN multi_outer_join_third_reference t1 ON (test.c_custkey = t1.t_custkey)
+ORDER BY 1 DESC;
 
 -- Outer joins with subqueries on distribution column
 SELECT
@@ -501,4 +512,5 @@ FROM
     left_values AS l
     LEFT JOIN right_values AS r ON l.val = r.val
 WHERE
-    r.val IS NULL;
+    r.val IS NULL
+ORDER BY 1 DESC, 2 DESC;

--- a/src/test/regress/output/multi_outer_join.source
+++ b/src/test/regress/output/multi_outer_join.source
@@ -488,29 +488,30 @@ SELECT
 	l_custkey, r_custkey
 FROM
 	multi_outer_join_left l1
-	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey);
+	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
+ORDER BY 1 DESC, 2 DESC;
  l_custkey | r_custkey 
 -----------+-----------
-        11 |        11
-        12 |        12
-        14 |        14
-        16 |        16
-        17 |        17
-        18 |        18
-        20 |        20
+           |        19
            |        15
            |        13
-           |        19
-        21 |        21
-        22 |        22
-        23 |          
-        24 |        24
-        25 |          
-        26 |        26
-        27 |        27
-        28 |        28
-        29 |          
         30 |        30
+        29 |          
+        28 |        28
+        27 |        27
+        26 |        26
+        25 |          
+        24 |        24
+        23 |          
+        22 |        22
+        21 |        21
+        20 |        20
+        18 |        18
+        17 |        17
+        16 |        16
+        14 |        14
+        12 |        12
+        11 |        11
 (20 rows)
 
 -- full outer join + anti (right) should work with 1-1 matched shards
@@ -520,12 +521,13 @@ FROM
 	multi_outer_join_left l1
 	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
 WHERE 
-	r_custkey is NULL;
+	r_custkey is NULL
+ORDER BY 1 DESC, 2 DESC;
  l_custkey | r_custkey 
 -----------+-----------
-        23 |          
-        25 |          
         29 |          
+        25 |          
+        23 |          
 (3 rows)
 
 -- full outer join + anti (left) should work with 1-1 matched shards
@@ -535,12 +537,13 @@ FROM
 	multi_outer_join_left l1
 	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
 WHERE 
-	l_custkey is NULL;
+	l_custkey is NULL
+ORDER BY 1 DESC, 2 DESC;
  l_custkey | r_custkey 
 -----------+-----------
+           |        19
            |        15
            |        13
-           |        19
 (3 rows)
 
 -- full outer join + anti (both) should work with 1-1 matched shards
@@ -550,15 +553,16 @@ FROM
 	multi_outer_join_left l1
 	FULL JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
 WHERE 
-	l_custkey is NULL or r_custkey is NULL;
+	l_custkey is NULL or r_custkey is NULL
+ORDER BY 1 DESC, 2 DESC;
  l_custkey | r_custkey 
 -----------+-----------
+           |        19
            |        15
            |        13
-           |        19
-        23 |          
-        25 |          
         29 |          
+        25 |          
+        23 |          
 (6 rows)
 
 -- full outer join should error out for mismatched shards
@@ -566,7 +570,8 @@ SELECT
 	l_custkey, t_custkey
 FROM
 	multi_outer_join_left l1
-	FULL JOIN multi_outer_join_third t1 ON (l1.l_custkey = t1.t_custkey);
+	FULL JOIN multi_outer_join_third t1 ON (l1.l_custkey = t1.t_custkey)
+ORDER BY 1 DESC, 2 DESC;
 ERROR:  shard counts of co-located tables do not match
 -- inner join  + single shard left join should work
 SELECT
@@ -574,23 +579,24 @@ SELECT
 FROM
 	multi_outer_join_left l1
 	INNER JOIN multi_outer_join_right r1 ON (l1.l_custkey = r1.r_custkey)
-	LEFT JOIN multi_outer_join_third_reference t1 ON (r1.r_custkey  = t1.t_custkey);
+	LEFT JOIN multi_outer_join_third_reference t1 ON (r1.r_custkey  = t1.t_custkey)
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
  l_custkey | r_custkey | t_custkey 
 -----------+-----------+-----------
-        11 |        11 |        11
-        12 |        12 |        12
-        14 |        14 |        14
-        16 |        16 |        16
-        17 |        17 |        17
-        18 |        18 |        18
-        20 |        20 |        20
-        21 |        21 |        21
-        22 |        22 |        22
-        24 |        24 |        24
-        26 |        26 |        26
-        27 |        27 |        27
-        28 |        28 |        28
         30 |        30 |        30
+        28 |        28 |        28
+        27 |        27 |        27
+        26 |        26 |        26
+        24 |        24 |        24
+        22 |        22 |        22
+        21 |        21 |        21
+        20 |        20 |        20
+        18 |        18 |        18
+        17 |        17 |        17
+        16 |        16 |        16
+        14 |        14 |        14
+        12 |        12 |        12
+        11 |        11 |        11
 (14 rows)
 
 -- inner (broadcast) join  + 2 shards left (local) join should work
@@ -599,26 +605,27 @@ SELECT
 FROM
 	multi_outer_join_left l1
 	INNER JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey)
-	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey);
+	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey)
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
  l_custkey | t_custkey | r_custkey 
 -----------+-----------+-----------
-        11 |        11 |        11
-        12 |        12 |        12
-        14 |        14 |        14
-        16 |        16 |        16
-        17 |        17 |        17
-        18 |        18 |        18
-        20 |        20 |        20
-        21 |        21 |        21
-        22 |        22 |        22
-        23 |        23 |          
-        24 |        24 |        24
-        25 |        25 |          
-        26 |        26 |        26
-        27 |        27 |        27
-        28 |        28 |        28
-        29 |        29 |          
         30 |        30 |        30
+        29 |        29 |          
+        28 |        28 |        28
+        27 |        27 |        27
+        26 |        26 |        26
+        25 |        25 |          
+        24 |        24 |        24
+        23 |        23 |          
+        22 |        22 |        22
+        21 |        21 |        21
+        20 |        20 |        20
+        18 |        18 |        18
+        17 |        17 |        17
+        16 |        16 |        16
+        14 |        14 |        14
+        12 |        12 |        12
+        11 |        11 |        11
 (17 rows)
 
 -- inner (local) join  + 2 shards left (dual partition) join
@@ -657,26 +664,27 @@ SELECT
 FROM
 	multi_outer_join_left l1
 	INNER JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey)
-	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey);
+	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey)
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
  l_custkey | t_custkey | r_custkey 
 -----------+-----------+-----------
-        11 |        11 |        11
-        12 |        12 |        12
-        14 |        14 |        14
-        16 |        16 |        16
-        17 |        17 |        17
-        18 |        18 |        18
-        20 |        20 |        20
-        21 |        21 |        21
-        22 |        22 |        22
-        23 |        23 |          
-        24 |        24 |        24
-        25 |        25 |          
-        26 |        26 |        26
-        27 |        27 |        27
-        28 |        28 |        28
-        29 |        29 |          
         30 |        30 |        30
+        29 |        29 |          
+        28 |        28 |        28
+        27 |        27 |        27
+        26 |        26 |        26
+        25 |        25 |          
+        24 |        24 |        24
+        23 |        23 |          
+        22 |        22 |        22
+        21 |        21 |        21
+        20 |        20 |        20
+        18 |        18 |        18
+        17 |        17 |        17
+        16 |        16 |        16
+        14 |        14 |        14
+        12 |        12 |        12
+        11 |        11 |        11
 (17 rows)
 
 -- inner (broadcast) join  + 2 shards left (local) + anti join should work
@@ -687,12 +695,13 @@ FROM
 	INNER JOIN multi_outer_join_third_reference t1 ON (l1.l_custkey = t1.t_custkey)
 	LEFT JOIN multi_outer_join_right r1 ON (l1.l_custkey  = r1.r_custkey)
 WHERE
-	r_custkey is NULL;
+	r_custkey is NULL
+ORDER BY 1 DESC, 2 DESC, 3 DESC;
  l_custkey | t_custkey | r_custkey 
 -----------+-----------+-----------
-        23 |        23 |          
-        25 |        25 |          
         29 |        29 |          
+        25 |        25 |          
+        23 |        23 |          
 (3 rows)
 
 -- Test joinExpr aliases by performing an outer-join. 
@@ -702,26 +711,27 @@ FROM
 	(multi_outer_join_right r1 
 	LEFT OUTER JOIN multi_outer_join_left l1 ON (l1.l_custkey = r1.r_custkey)) AS
     test(c_custkey, c_nationkey)
-    INNER JOIN multi_outer_join_third_reference t1 ON (test.c_custkey = t1.t_custkey);
+    INNER JOIN multi_outer_join_third_reference t1 ON (test.c_custkey = t1.t_custkey)
+ORDER BY 1 DESC;
  t_custkey 
 -----------
-        11
-        12
-        13
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        24
-        26
-        27
-        28
         30
+        28
+        27
+        26
+        24
+        22
+        21
+        20
+        19
+        18
+        17
+        16
+        15
+        14
+        13
+        12
+        11
 (17 rows)
 
 -- Outer joins with subqueries on distribution column
@@ -816,10 +826,11 @@ FROM
     left_values AS l
     LEFT JOIN right_values AS r ON l.val = r.val
 WHERE
-    r.val IS NULL;
+    r.val IS NULL
+ORDER BY 1 DESC, 2 DESC;
  val | val 
 -----+-----
-   1 |    
    5 |    
+   1 |    
 (2 rows)
 

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -58,7 +58,9 @@ SELECT name FROM researchers WHERE lab_id = 1 AND id = 1;
 
 -- trigger a unique constraint violation
 BEGIN;
+\set VERBOSITY TERSE
 UPDATE researchers SET name = 'John Backus' WHERE id = 1 AND lab_id = 1;
+\set VERBOSITY DEFAULT
 ABORT;
 
 -- creating savepoints should work...

--- a/src/test/regress/sql/multi_name_lengths.sql
+++ b/src/test/regress/sql/multi_name_lengths.sql
@@ -53,7 +53,7 @@ ALTER TABLE name_lengths ADD EXCLUDE (int_col_1234567890123456789012345678901234
 ALTER TABLE name_lengths ADD CHECK (date_col_12345678901234567890123456789012345678901234567890 > '2014-01-01'::date);
 
 \c - - - :worker_1_port
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.name_lengths_225002'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.name_lengths_225002'::regclass ORDER BY 1 DESC, 2 DESC;
 \c - - - :master_port
 
 -- Placeholders for unsupported add constraints with EXPLICIT names that are too long
@@ -62,12 +62,15 @@ ALTER TABLE name_lengths ADD CONSTRAINT nl_exclude_12345678901234567890123456789
 ALTER TABLE name_lengths ADD CONSTRAINT nl_checky_12345678901234567890123456789012345678901234567890 CHECK (date_col_12345678901234567890123456789012345678901234567890 >= '2014-01-01'::date);
 
 \c - - - :worker_1_port
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_lengths_225002'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.name_lengths_225002'::regclass ORDER BY 1 DESC, 2 DESC;
 \c - - - :master_port
 
 -- Placeholders for RENAME operations
+\set VERBOSITY TERSE
 ALTER TABLE name_lengths RENAME TO name_len_12345678901234567890123456789012345678901234567890;
 ALTER TABLE name_lengths RENAME CONSTRAINT unique_12345678901234567890123456789012345678901234567890 TO unique2_12345678901234567890123456789012345678901234567890;
+
+\set VERBOSITY DEFAULT
 
 -- Verify that CREATE INDEX on already distributed table has proper shard names.
 
@@ -75,7 +78,7 @@ CREATE INDEX tmp_idx_12345678901234567890123456789012345678901234567890 ON name_
 
 \c - - - :worker_1_port
 SELECT "relname", "Column", "Type", "Definition" FROM index_attrs WHERE
-    relname LIKE 'tmp_idx_%';
+    relname LIKE 'tmp_idx_%' ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC;
 \c - - - :master_port
 
 -- Verify that a new index name > 63 characters is auto-truncated
@@ -84,7 +87,7 @@ CREATE INDEX tmp_idx_12345678901234567890123456789012345678901234567890123456789
 
 \c - - - :worker_1_port
 SELECT "relname", "Column", "Type", "Definition" FROM index_attrs WHERE
-    relname LIKE 'tmp_idx_%';
+    relname LIKE 'tmp_idx_%' ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC;
 \c - - - :master_port
 
 SET citus.shard_count TO 2;
@@ -108,14 +111,14 @@ CREATE TABLE sneaky_name_lengths (
         );
 
 \di public.sneaky_name_lengths*
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths'::regclass ORDER BY 1 DESC, 2 DESC;
 
 SELECT master_create_distributed_table('sneaky_name_lengths', 'int_col_123456789012345678901234567890123456789012345678901234', 'hash');
 SELECT master_create_worker_shards('sneaky_name_lengths', '2', '2');
 
 \c - - - :worker_1_port
 \di public.sneaky*225006
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225006'::regclass;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225006'::regclass ORDER BY 1 DESC, 2 DESC;
 \c - - - :master_port
 
 SET citus.shard_count TO 2;

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -290,8 +290,8 @@ INSERT INTO partitioning_test VALUES(21, '2014-02-02');
 INSERT INTO partitioning_test VALUES(22, '2015-04-02');
 
 -- see they are inserted into default partition
-SELECT * FROM partitioning_test WHERE id > 20;
-SELECT * FROM partitioning_test_default;
+SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
+SELECT * FROM partitioning_test_default ORDER BY 1, 2;
 
 -- create a new partition (will fail)
 CREATE TABLE partitioning_test_2014 PARTITION OF partitioning_test FOR VALUES FROM ('2014-01-01') TO ('2015-01-01');
@@ -305,8 +305,8 @@ ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_default DEFAULT
 END;
 
 -- see data is in the table, but some moved out from default partition
-SELECT * FROM partitioning_test WHERE id > 20;
-SELECT * FROM partitioning_test_default;
+SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
+SELECT * FROM partitioning_test_default ORDER BY 1, 2;
 
 -- test master_modify_multiple_shards
 -- master_modify_multiple_shards on partitioned table

--- a/src/test/regress/sql/multi_read_from_secondaries.sql
+++ b/src/test/regress/sql/multi_read_from_secondaries.sql
@@ -28,10 +28,10 @@ UPDATE pg_dist_node SET noderole = 'secondary';
 INSERT INTO dest_table (a, b) VALUES (1, 2);
 
 -- router selects are allowed
-SELECT a FROM dest_table WHERE a = 1;
+SELECT a FROM dest_table WHERE a = 1 ORDER BY 1;
 
 -- real-time selects are also allowed
-SELECT a FROM dest_table;
+SELECT a FROM dest_table ORDER BY 1;
 
 -- subqueries are also allowed
 SET client_min_messages TO DEBUG1;
@@ -48,7 +48,7 @@ FROM
 	     	source_table.a = dest_table.a AND 
 	     dest_table.b IN (1,2,3,4)
 	     ) SELECT * FROM cte ORDER BY 1 DESC LIMIT 5
-     ) as foo;
+     ) as foo ORDER BY 1;
 SET client_min_messages TO DEFAULT;
 
 -- insert into is definitely not allowed

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -330,7 +330,8 @@ SELECT *
 -- handled by real-time executor
 SELECT *
 	FROM articles_hash
-	WHERE author_id = 1 OR author_id = 18;
+	WHERE author_id = 1 OR author_id = 18
+ORDER BY 4 DESC, 3 DESC, 2 DESC, 1 DESC;
 
 -- rename the output columns
 SELECT id as article_id, word_count * id as random_value

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -307,14 +307,14 @@ SET search_path TO public;
 SELECT master_modify_multiple_shards('UPDATE test_schema_support.nation_hash SET n_regionkey = n_regionkey + 1');
 
 --verify master_modify_multiple_shards
-SELECT * FROM test_schema_support.nation_hash;
+SELECT * FROM test_schema_support.nation_hash ORDER BY 1,2,3,4;
 
 --test with search_path is set
 SET search_path TO test_schema_support;
 SELECT master_modify_multiple_shards('UPDATE nation_hash SET n_regionkey = n_regionkey + 1');
 
 --verify master_modify_multiple_shards
-SELECT * FROM nation_hash;
+SELECT * FROM nation_hash ORDER BY 1,2,3,4;
 
 
 --test COLLATION with schema
@@ -350,7 +350,7 @@ SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 
 5|ETHIOPIA|0|ven packages wake quickly. regu
 \.
 
-SELECT * FROM test_schema_support.nation_hash_collation;
+SELECT * FROM test_schema_support.nation_hash_collation ORDER BY 1,2,3,4;
 SELECT n_comment FROM test_schema_support.nation_hash_collation ORDER BY n_comment COLLATE test_schema_support.english;
 
 --test with search_path is set

--- a/src/test/regress/sql/multi_subquery_complex_queries.sql
+++ b/src/test/regress/sql/multi_subquery_complex_queries.sql
@@ -1890,7 +1890,7 @@ FROM
     value_3 DESC
    LIMIT 10) "some_users"
 ORDER BY
-  value_3 DESC 
+  value_3 DESC, user_id DESC 
 LIMIT 10;
 
 -- longer nested lateral join wth top level join
@@ -1931,7 +1931,7 @@ FROM
       users.value_2 > 2
      LIMIT 1
     ) "some_users_data" ON TRUE
-ORDER BY value_3 DESC
+ORDER BY value_3 DESC, user_id DESC
 LIMIT 10;
 
 SET citus.subquery_pushdown to OFF;
@@ -2371,7 +2371,7 @@ FROM
   ) AS b
   USING (user_id)
 GROUP BY user_id
-ORDER BY 1;
+ORDER BY 1, 2;
 
 -- see the comment for the above query
 SELECT a.user_id, avg(b.value_2) as subquery_avg
@@ -2399,7 +2399,7 @@ FROM
   ) AS b
   USING (user_id)
 GROUP BY a.user_id
-ORDER BY 1;
+ORDER BY 1, 2;
 
 -- queries where column aliases are used
 -- the query is not very complex. join is given an alias with aliases

--- a/src/test/regress/sql/multi_view.sql
+++ b/src/test/regress/sql/multi_view.sql
@@ -182,7 +182,7 @@ CREATE VIEW recent_users AS
 	SELECT user_id, max(time) as lastseen FROM users_table
 	GROUP BY user_id
 	HAVING max(time) > '2017-11-23 16:20:33.264457'::timestamp order by 2 DESC; 
-SELECT * FROM recent_users;
+SELECT * FROM recent_users ORDER BY 2 DESC, 1 DESC;
 
 -- create a view for recent_events
 CREATE VIEW recent_events AS


### PR DESCRIPTION
Mostly a preparation for #2435 where execution order on the shards might change. So, add missing `ORDER BY`s and be less verbose if the worker node host/port is printed in the error messages, especially when replication factor > 1.

There might be some missing ones, which I'll keep opening PRs as I find more.