### PR TITLE
Ensure that master_modify_multiple_shards() returns the affectedTupleCount

### DIFF
--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -190,7 +190,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	taskList =
 		ModifyMultipleShardsTaskList(modifyQuery, prunedShardIntervalList, taskType);
 
-	ExecuteTaskList(operation, taskList);
+	affectedTupleCount = ExecuteTaskList(operation, taskList);
 
 	PG_RETURN_INT32(affectedTupleCount);
 }

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -34,7 +34,7 @@ extern bool WritableStandbyCoordinator;
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 							 bool execute_once);
-extern void ExecuteTaskList(CmdType operation, List *taskList);
+extern uint64 ExecuteTaskList(CmdType operation, List *taskList);
 extern TupleTableSlot * CitusExecScan(CustomScanState *node);
 extern TupleTableSlot * ReturnTupleFromTuplestore(CitusScanState *scanState);
 extern void LoadTuplesIntoTupleStore(CitusScanState *citusScanState, Job *workerJob);


### PR DESCRIPTION
The PR is against `unified_executor` branch. Our goal is to make sure that we fix issues on the branch one by one.

This change fixes 4 tests directly, so we have 33-35 left 😄 

```
multi_shard_modify
multi_schema_support
multi_outer_join_reference
multi_prepare_sql
```

I didn't like accessing `session->currentTask->shardCommandExecution`, but the other way around is passing `gotResults ` flag as well, which is not nice as well. So, I'm open for suggestion if you have any.


