### PR TITLE
Adjust intermediate result size limits to pass the regression tests

### DIFF
--- a/src/test/regress/expected/limit_intermediate_size.out
+++ b/src/test/regress/expected/limit_intermediate_size.out
@@ -1,5 +1,5 @@
 SET citus.enable_repartition_joins to ON;
-SET citus.max_intermediate_result_size TO 3;
+SET citus.max_intermediate_result_size TO 2;
 -- should fail because the copy size is ~4kB for each cte
 WITH cte AS 
 (
@@ -9,7 +9,7 @@ cte2 AS (
 	SELECT * FROM events_table
 ) 
 SELECT cte.user_id, cte.value_2 FROM cte,cte2 ORDER BY 1,2 LIMIT 10;
-ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 3 kB)
+ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 2 kB)
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 SET citus.max_intermediate_result_size TO 9;
@@ -39,42 +39,33 @@ ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size 
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 -- router queries should be able to get limitted too
-SET citus.max_intermediate_result_size TO 3;
+SET citus.max_intermediate_result_size TO 2;
 -- this should pass, since we fetch small portions in each subplan
 with cte as (select * from users_table where user_id=1),
 cte2 as (select * from users_table where user_id=2),
 cte3 as (select * from users_table where user_id=3),
 cte4 as (select * from users_table where user_id=4),
 cte5 as (select * from users_table where user_id=5)
-SELECT * FROM (
-(select * from cte)
+SELECT sum(c) FROM (
+(select count(*) as c from cte)
 UNION
-(select * from cte2)
+(select count(*) as c from cte2)
 UNION
-(select * from cte3)
+(select count(*) as c from cte3)
 UNION
-(select * from cte4)
+(select count(*) as c from cte4)
 UNION
-(select * from cte5)
-)a ORDER BY 1,2,3,4,5 LIMIT 10;
- user_id |              time               | value_1 | value_2 | value_3 | value_4 
----------+---------------------------------+---------+---------+---------+---------
-       1 | Wed Nov 22 22:51:43.132261 2017 |       4 |       0 |       3 |        
-       1 | Thu Nov 23 03:32:50.803031 2017 |       3 |       2 |       1 |        
-       1 | Thu Nov 23 09:26:42.145043 2017 |       1 |       3 |       3 |        
-       1 | Thu Nov 23 11:11:24.40789 2017  |       3 |       4 |       0 |        
-       1 | Thu Nov 23 11:44:57.515981 2017 |       4 |       3 |       4 |        
-       1 | Thu Nov 23 17:23:03.441394 2017 |       5 |       4 |       3 |        
-       1 | Thu Nov 23 17:30:34.635085 2017 |       3 |       4 |       4 |        
-       2 | Wed Nov 22 18:19:49.944985 2017 |       3 |       5 |       1 |        
-       2 | Thu Nov 23 00:19:14.138058 2017 |       3 |       4 |       0 |        
-       2 | Thu Nov 23 01:04:26.198826 2017 |       4 |       3 |       4 |        
-(10 rows)
+(select count(*) as c from cte5)
+) as foo;
+ sum 
+-----
+  91
+(1 row)
 
 -- if we fetch the same amount of data at once, it should fail
 WITH cte AS (SELECT * FROM users_table WHERE user_id IN (1,2,3,4,5))
 SELECT * FROM cte ORDER BY 1,2,3,4,5 LIMIT 10;
-ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 3 kB)
+ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 2 kB)
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 SET citus.max_intermediate_result_size TO 0;
@@ -131,6 +122,7 @@ ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size 
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 -- this will fail in real_time_executor
+SET citus.max_intermediate_result_size TO 2;
 WITH cte AS (
 	WITH cte2 AS (
 		SELECT * FROM users_table WHERE user_id IN (1, 2)
@@ -145,7 +137,7 @@ cte4 AS (
 )
 SELECT * FROM cte UNION ALL
 SELECT * FROM cte4 ORDER BY 1,2,3,4,5 LIMIT 5;
-ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 3 kB)
+ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 2 kB)
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 SET citus.max_intermediate_result_size TO 1;


### PR DESCRIPTION
This PR is against `unified_executor`.

The real-time executor uses COPY command to get the results
from the worker nodes. Unified executor avoids that which
results in less data transfer. Simply adjust the tests to lower
sizes.

