### PR TITLE
Don't schedule tasks on inactive nodes.

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -5271,7 +5271,7 @@ ActivePlacementList(List *placementList)
 
 		/* check if the worker node for this shard placement is active */
 		workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
-		if (workerNode != NULL)
+		if (workerNode != NULL && workerNode->isActive)
 		{
 			activePlacementList = lappend(activePlacementList, placement);
 		}

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -5213,6 +5213,12 @@ ActiveShardPlacementLists(List *taskList)
 
 		/* filter out shard placements that reside in inactive nodes */
 		List *activeShardPlacementList = ActivePlacementList(shardPlacementList);
+		if (activeShardPlacementList == NIL)
+		{
+			ereport(ERROR,
+					(errmsg("no active placements were found for shard " UINT64_FORMAT,
+							anchorShardId)));
+		}
 
 		/* sort shard placements by their creation time */
 		activeShardPlacementList = SortList(activeShardPlacementList,


### PR DESCRIPTION
Before this patch,

```sql
postgres=# create table t(a int);
CREATE TABLE
postgres=# set citus.shard_replication_factor to 2;
SET
postgres=# select create_distributed_table('t', 'a');
 create_distributed_table
--------------------------

(1 row)
postgres=# select master_disable_node('localhost', 5434);
NOTICE:  Node localhost:5434 has active shard placements. Some queries may fail after this operation. Use SELECT master_activate_node('localhost', 5434) to activate this node back.

(Exit psql and start it again)

postgres=# explain select count(*) from t;
ERROR:  failed to assign 16 task(s) to worker nodes
```

DESCRIPTION: Don't schedule tasks on inactive nodes.