### PR TITLE
    Force one connection per placement (or co-located placements) when requested

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -761,6 +761,17 @@ FinishConnectionListEstablishment(List *multiConnectionList)
 					uint32 eventMask = MultiConnectionStateEventMask(connectionState);
 					ModifyWaitEvent(waitEventSet, event->pos, eventMask, NULL);
 				}
+
+				/*
+				 * The state has changed to connected, update the connection's
+				 * state as well.
+				 */
+				if (connectionState->phase == MULTI_CONNECTION_PHASE_CONNECTED)
+				{
+					MultiConnection *connection = connectionState->connection;
+
+					connection->connectionState = MULTI_CONNECTION_CONNECTED;
+				}
 			}
 		}
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -604,6 +604,21 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.force_max_query_parallelization",
+		gettext_noop("Open as many connections as possible to maximize query "
+					 "parallelization"),
+		gettext_noop("When enabled, Citus will force the executor to use "
+					 "as many connections as possible while executing a "
+					 "parallel distributed query. If not enabled, the executor"
+					 "might choose to use less connections to optimize overall "
+					 "query execution throughput. Internally, setting this true "
+					 "will end up with using one connection per task."),
+		&ForceMaxQueryParallelization,
+		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
 		"citus.enable_deadlock_prevention",

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -32,6 +32,7 @@ extern int MultiShardConnectionType;
 
 
 extern bool WritableStandbyCoordinator;
+extern bool ForceMaxQueryParallelization;
 
 
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);

--- a/src/test/regress/expected/multi_real_time_transaction.out
+++ b/src/test/regress/expected/multi_real_time_transaction.out
@@ -1,4 +1,7 @@
 SET citus.next_shard_id TO 1610000;
+-- enforce 1 connection per placement since
+-- the tests are prepared for that
+SET citus.force_max_query_parallelization TO ON;
 CREATE SCHEMA multi_real_time_transaction;
 SET search_path = 'multi_real_time_transaction';
 SET citus.shard_replication_factor to 1;
@@ -368,9 +371,11 @@ SELECT pg_reload_conf();
 BEGIN;
 SET citus.select_opens_transaction_block TO off;
 -- This query would self-deadlock if it ran in a distributed transaction
-SELECT id, pg_advisory_lock(15) FROM test_table ORDER BY id;
- id | pg_advisory_lock 
-----+------------------
+-- we use a different advisory lock because previous tests
+-- still holds the advisory locks since the sessions are still active
+SELECT id, pg_advisory_xact_lock(16) FROM test_table ORDER BY id;
+ id | pg_advisory_xact_lock 
+----+-----------------------
   1 | 
   2 | 
   3 | 

--- a/src/test/regress/expected/multi_transaction_recovery.out
+++ b/src/test/regress/expected/multi_transaction_recovery.out
@@ -1,5 +1,8 @@
 -- Tests for prepared transaction recovery
 SET citus.next_shard_id TO 1220000;
+-- enforce 1 connection per placement since
+-- the tests are prepared for that
+SET citus.force_max_query_parallelization TO ON;
 -- Disable auto-recovery for the initial tests
 ALTER SYSTEM SET citus.recover_2pc_interval TO -1;
 SELECT pg_reload_conf();
@@ -27,6 +30,7 @@ BEGIN;
 CREATE TABLE should_be_sorted_into_middle (value int);
 PREPARE TRANSACTION 'citus_0_should_be_sorted_into_middle';
 \c - - - :master_port
+SET citus.force_max_query_parallelization TO ON;
 -- Add "fake" pg_dist_transaction records and run recovery
 INSERT INTO pg_dist_transaction VALUES (1, 'citus_0_should_commit');
 INSERT INTO pg_dist_transaction VALUES (1, 'citus_0_should_be_forgotten');
@@ -57,6 +61,7 @@ SELECT count(*) FROM pg_tables WHERE tablename = 'should_commit';
 (1 row)
 
 \c - - - :master_port
+SET citus.force_max_query_parallelization TO ON;
 SET citus.shard_replication_factor TO 2;
 SET citus.shard_count TO 2;
 SET citus.multi_shard_commit_protocol TO '2pc';

--- a/src/test/regress/expected/sequential_modifications.out
+++ b/src/test/regress/expected/sequential_modifications.out
@@ -4,6 +4,10 @@
 -- Note: this test should not be executed in parallel with
 -- other tests since we're relying on disabling 2PC recovery 
 --
+-- We're also setting force_max_query_parallelization throughout
+-- the tests because the test file has the assumption that
+-- each placement is accessed with a seperate connection
+SET citus.force_max_query_parallelization TO on;
 CREATE SCHEMA test_seq_ddl;
 SET search_path TO 'test_seq_ddl';
 SET citus.next_shard_id TO 16000;

--- a/src/test/regress/expected/with_dml.out
+++ b/src/test/regress/expected/with_dml.out
@@ -106,6 +106,10 @@ DEBUG:  Plan 16 query after replacing subqueries and CTEs: SELECT tenant_id FROM
 -- not a very meaningful query
 -- but has two modifying CTEs along with another
 -- modify statement
+-- We need to force 1 connection per placement
+-- otherwise the coordinator insert select fails
+-- since COPY cannot be executed
+SET citus.force_max_query_parallelization TO on;
 WITH copy_to_other_table AS (
     INSERT INTO distributed_table 
         SELECT *
@@ -136,6 +140,7 @@ DEBUG:  generating subplan 20_1 for CTE copy_to_other_table: INSERT INTO with_dm
 DEBUG:  generating subplan 20_2 for CTE main_table_deleted: DELETE FROM with_dml.distributed_table WHERE ((dept OPERATOR(pg_catalog.<) 10) AND (NOT (EXISTS (SELECT 1 FROM with_dml.second_distributed_table WHERE ((second_distributed_table.dept OPERATOR(pg_catalog.=) 1) AND (second_distributed_table.tenant_id OPERATOR(pg_catalog.=) distributed_table.tenant_id)))))) RETURNING tenant_id, dept
 DEBUG:  generating subplan 20_3 for subquery SELECT main_table_deleted.tenant_id, main_table_deleted.dept FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept FROM read_intermediate_result('20_2'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer)) main_table_deleted EXCEPT SELECT copy_to_other_table.tenant_id, copy_to_other_table.dept FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept FROM read_intermediate_result('20_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer)) copy_to_other_table
 DEBUG:  Plan 20 query after replacing subqueries and CTEs: SELECT tenant_id, dept FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept FROM read_intermediate_result('20_3'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer)) citus_insert_select_subquery
+SET citus.force_max_query_parallelization TO off;
 -- CTE inside the UPDATE statement
 UPDATE 
 	second_distributed_table 

--- a/src/test/regress/sql/multi_real_time_transaction.sql
+++ b/src/test/regress/sql/multi_real_time_transaction.sql
@@ -1,5 +1,9 @@
 SET citus.next_shard_id TO 1610000;
 
+-- enforce 1 connection per placement since
+-- the tests are prepared for that
+SET citus.force_max_query_parallelization TO ON;
+
 CREATE SCHEMA multi_real_time_transaction;
 SET search_path = 'multi_real_time_transaction';
 SET citus.shard_replication_factor to 1;
@@ -220,6 +224,7 @@ SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
 SELECT id, pg_advisory_lock(15) FROM test_table ORDER BY 1 DESC;
 ROLLBACK;
 
+
 SET client_min_messages TO DEFAULT;
 alter system set deadlock_timeout TO DEFAULT;
 SELECT pg_reload_conf();
@@ -227,7 +232,9 @@ SELECT pg_reload_conf();
 BEGIN;
 SET citus.select_opens_transaction_block TO off;
 -- This query would self-deadlock if it ran in a distributed transaction
-SELECT id, pg_advisory_lock(15) FROM test_table ORDER BY id;
+-- we use a different advisory lock because previous tests
+-- still holds the advisory locks since the sessions are still active
+SELECT id, pg_advisory_xact_lock(16) FROM test_table ORDER BY id;
 END;
 
 DROP SCHEMA multi_real_time_transaction CASCADE;

--- a/src/test/regress/sql/sequential_modifications.sql
+++ b/src/test/regress/sql/sequential_modifications.sql
@@ -4,6 +4,12 @@
 -- Note: this test should not be executed in parallel with
 -- other tests since we're relying on disabling 2PC recovery 
 --
+-- We're also setting force_max_query_parallelization throughout
+-- the tests because the test file has the assumption that
+-- each placement is accessed with a seperate connection
+SET citus.force_max_query_parallelization TO on;
+
+
 CREATE SCHEMA test_seq_ddl;
 SET search_path TO 'test_seq_ddl';
 SET citus.next_shard_id TO 16000;

--- a/src/test/regress/sql/with_dml.sql
+++ b/src/test/regress/sql/with_dml.sql
@@ -82,6 +82,11 @@ INSERT INTO distributed_table
 -- not a very meaningful query
 -- but has two modifying CTEs along with another
 -- modify statement
+
+-- We need to force 1 connection per placement
+-- otherwise the coordinator insert select fails
+-- since COPY cannot be executed
+SET citus.force_max_query_parallelization TO on;
 WITH copy_to_other_table AS (
     INSERT INTO distributed_table 
         SELECT *
@@ -105,6 +110,8 @@ INSERT INTO second_distributed_table
         EXCEPT 
         SELECT *
             FROM copy_to_other_table;
+
+SET citus.force_max_query_parallelization TO off;
 
 -- CTE inside the UPDATE statement
 UPDATE 


### PR DESCRIPTION
This PR is against unified executor branch. This needs some more work, (a) add more tests that'd be fixed by this (b) when all the regression tests are executed with this flag `+push(@pgOptions, '-c', "citus.force_max_query_parallelization=on");`, one test crashes -- which might be directly related to this or maybe amplified by this (`multi_modifying_xacts.sql`)

    
    The existing executors (real-time and router) always open 1 connection per
    placement when parallel execution is requested.
    
    That might be useful under certain circumstances:
    
    (a) User wants to utilize as much as CPUs on the workers per
    distributed query
    (b) User has a transaction block which involves COPY command
    
    Also, lots of regression tests rely on this execution semantics.
    So, we'd enable few of the tests with this change as well.