### PR TITLE
Resolve parameters before using them

### DIFF
--- a/src/backend/distributed/executor/executor.c
+++ b/src/backend/distributed/executor/executor.c
@@ -1487,7 +1487,8 @@ StartPlacementExecutionOnSession(TaskPlacementExecution *placementExecution,
 		Oid *parameterTypes = NULL;
 		const char **parameterValues = NULL;
 
-		//paramListInfo = copyParamList(paramListInfo);
+		/* force evaluation of bound params */
+		paramListInfo = copyParamList(paramListInfo);
 
 		ExtractParametersFromParamListInfo(paramListInfo, &parameterTypes,
 										   &parameterValues);


### PR DESCRIPTION
The PR is against `unified_executor` branch.

For the details, see PostgreSQL's copyParamList().

This fixes several query failures, but not the failing tests yet. There are some minor unrelated failures on the same files, which will be handled separately.