### PR TITLE
Fix savepoints in unified executor.

### DIFF
--- a/src/backend/distributed/executor/executor.c
+++ b/src/backend/distributed/executor/executor.c
@@ -1799,6 +1799,12 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 		}
 		else if (resultStatus != PGRES_SINGLE_TUPLE)
 		{
+			/*
+			 * We can still recover from error using ROLLBACK TO SAVEPOINT,
+			 * unclaim all connections to allow that.
+			 */
+			FinishDistributedExecution(execution);
+
 			/* query failures are always hard errors */
 			ReportResultError(connection, result, ERROR);
 		}

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -1240,6 +1240,9 @@ FinishRemoteTransactionSavepointRollback(MultiConnection *connection, SubTransac
 
 	PQclear(result);
 	ForgetResults(connection);
+
+	/* reset transaction state so the executor can accept next commands in transaction */
+	transaction->transactionState = REMOTE_TRANS_STARTED;
 }
 
 

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -15,3 +15,7 @@ s/shard [0-9]+/shard xxxxx/g
 # the generated plan
 s/"(fkey_ref_|referenced_table_|referencing_table_)[0-9]+"/"\1xxxxxxx"/g
 s/\(id\)=\([0-9]+\)/(id)=(X)/g
+
+# shard table names for multi_subtransactions
+s/"t2_[0-9]+"/"t2_xxxxxxx"/g
+

--- a/src/test/regress/bin/normalized_tests.lst
+++ b/src/test/regress/bin/normalized_tests.lst
@@ -2,3 +2,5 @@
 multi_alter_table_add_constraints
 multi_alter_table_statements
 foreign_key_to_reference_table
+multi_subtransactions
+


### PR DESCRIPTION
It turns out that all we need to do is #2673 + reset state before throwing errors.