### PR TITLE
Ensure that unified executor doesn't ignore sequential execution of DDLJob's

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -535,6 +535,7 @@ static void
 ExecuteDistributedDDLJob(DDLJob *ddlJob)
 {
 	bool shouldSyncMetadata = ShouldSyncTableMetadata(ddlJob->targetRelationId);
+	int targetPoolSize = ddlJob->executeSequentially ? 1 : DEFAULT_POOL_SIZE;
 
 	EnsureCoordinator();
 	EnsurePartitionTableNotReplicated(ddlJob->targetRelationId);
@@ -559,7 +560,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 			SendCommandToWorkers(WORKERS_WITH_METADATA, (char *) ddlJob->commandString);
 		}
 
-		ExecuteTaskList(CMD_UTILITY, ddlJob->taskList);
+		ExecuteTaskList(CMD_UTILITY, ddlJob->taskList, targetPoolSize);
 	}
 	else
 	{
@@ -570,7 +571,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 
 		PG_TRY();
 		{
-			ExecuteTaskList(CMD_UTILITY, ddlJob->taskList);
+			ExecuteTaskList(CMD_UTILITY, ddlJob->taskList, targetPoolSize);
 
 			if (shouldSyncMetadata)
 			{

--- a/src/backend/distributed/commands/vacuum.c
+++ b/src/backend/distributed/commands/vacuum.c
@@ -74,6 +74,7 @@ ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand)
 		{
 			List *vacuumColumnList = NIL;
 			List *taskList = NIL;
+			int targetPoolSize = DEFAULT_POOL_SIZE;
 
 			/*
 			 * VACUUM commands cannot run inside a transaction block, so we use
@@ -92,7 +93,7 @@ ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand)
 			vacuumColumnList = VacuumColumnList(vacuumStmt, relationIndex);
 			taskList = VacuumTaskList(relationId, vacuumStmt->options, vacuumColumnList);
 
-			ExecuteTaskList(CMD_UTILITY, taskList);
+			ExecuteTaskList(CMD_UTILITY, taskList, targetPoolSize);
 
 			executedVacuumCount++;
 		}

--- a/src/backend/distributed/executor/executor.c
+++ b/src/backend/distributed/executor/executor.c
@@ -335,7 +335,7 @@ CitusExecScan(CustomScanState *node)
 		EState *executorState = scanState->customScanState.ss.ps.state;
 		bool randomAccess = true;
 		bool interTransactions = false;
-		int targetPoolSize = 4;
+		int targetPoolSize = DEFAULT_POOL_SIZE;
 
 		/* we are taking locks on partitions of partitioned tables */
 		LockPartitionsInRelationList(distributedPlan->relationIdList, AccessShareLock);
@@ -381,10 +381,9 @@ CitusExecScan(CustomScanState *node)
 
 
 uint64
-ExecuteTaskList(CmdType operation, List *taskList)
+ExecuteTaskList(CmdType operation, List *taskList, int targetPoolSize)
 {
 	DistributedPlan *distributedPlan = NULL;
-	int targetPoolSize = 4;
 	DistributedExecution *execution = NULL;
 
 	distributedPlan = CitusMakeNode(DistributedPlan);

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -93,6 +93,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	TaskType taskType = TASK_TYPE_INVALID_FIRST;
 	bool truncateOperation = false;
 	RawStmt *rawStmt = (RawStmt *) ParseTreeRawStmt(queryString);
+	int targetPoolSize = DEFAULT_POOL_SIZE;
 	queryTreeNode = rawStmt->stmt;
 
 	CheckCitusVersion(ERROR);
@@ -190,7 +191,7 @@ master_modify_multiple_shards(PG_FUNCTION_ARGS)
 	taskList =
 		ModifyMultipleShardsTaskList(modifyQuery, prunedShardIntervalList, taskType);
 
-	affectedTupleCount = ExecuteTaskList(operation, taskList);
+	affectedTupleCount = ExecuteTaskList(operation, taskList, targetPoolSize);
 
 	PG_RETURN_INT32(affectedTupleCount);
 }

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -18,6 +18,9 @@
 #include "distributed/multi_physical_planner.h"
 #include "distributed/multi_server_executor.h"
 
+/* we'll make this configurable, just a temporary global variable */
+#define DEFAULT_POOL_SIZE 4
+
 
 /* managed via guc.c */
 typedef enum
@@ -34,7 +37,7 @@ extern bool WritableStandbyCoordinator;
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 							 bool execute_once);
-extern uint64 ExecuteTaskList(CmdType operation, List *taskList);
+extern uint64 ExecuteTaskList(CmdType operation, List *taskList, int targetPoolSize);
 extern TupleTableSlot * CitusExecScan(CustomScanState *node);
 extern TupleTableSlot * ReturnTupleFromTuplestore(CitusScanState *scanState);
 extern void LoadTuplesIntoTupleStore(CitusScanState *citusScanState, Job *workerJob);


### PR DESCRIPTION
Certain DDL commands, mainly creating foreign keys to reference tables,
should be executed sequentially. Otherwise, we'd end up with a self
distributed deadlock.

To overcome this situation, we set a flag `DDLJob->executeSequentially`
and execute it sequentially. Note that we have to do this because
the command might not be called within a transaction block, and
we cannot call `SetLocalMultiShardModifyModeToSequential()`.

This fixes at least two test: `multi_insert_select_on_conflit.sql` and
`multi_foreign_key.sql`

Also, I wouldn't mind scattering local `targetPoolSize` variables within
the code. The reason is that we'll soon have a GUC (or a global
variable based on a GUC) that'd set the pool size. In that case, we'd
simply replace `targetPoolSize` with the global variables.
