### PR TITLE
Add ORDER BYs to multi_subquery and subqueries_deep tests

### DIFF
--- a/src/test/regress/expected/multi_subquery.out
+++ b/src/test/regress/expected/multi_subquery.out
@@ -134,7 +134,7 @@ FROM
 		FROM
 			lineitem_subquery
 		ORDER BY
-			l_quantity
+			l_orderkey, l_quantity
 		LIMIT 10
 		) lineitem_quantities
 	JOIN LATERAL
@@ -144,9 +144,9 @@ FROM
 			orders_subquery
 		WHERE
 			lineitem_quantities.l_orderkey = o_orderkey) orders_price ON true;
-           avg           
--------------------------
- 129027.1270000000000000
+          avg           
+------------------------
+ 17470.0940725222668915
 (1 row)
 
 -- Limit is only supported when subquery_pushdown is set
@@ -161,7 +161,7 @@ FROM
 		FROM
 			lineitem_subquery
 		ORDER BY
-			l_quantity
+			l_orderkey, l_quantity
 		LIMIT 10
 		) lineitem_quantities
 	JOIN LATERAL

--- a/src/test/regress/expected/subqueries_deep.out
+++ b/src/test/regress/expected/subqueries_deep.out
@@ -17,7 +17,7 @@ FROM
 									avg(event_type) as avg_val
 								FROM
 									(SELECT event_type, users_table.user_id FROM users_table, 
-															(SELECT user_id, event_type FROM events_table WHERE value_2 < 3 OFFSET 3) as foo
+															(SELECT user_id, event_type FROM events_table WHERE value_2 < 3 ORDER BY 1, 2 OFFSET 3) as foo
 															WHERE foo.user_id = users_table.user_id
 															) bar, users_table WHERE bar.user_id = users_table.user_id GROUP BY users_table.value_1
 							) as baz
@@ -25,7 +25,7 @@ FROM
 								    LIMIT 3
 	) as sub1
 	ORDER BY 1 DESC;
-DEBUG:  generating subplan 1_1 for subquery SELECT user_id, event_type FROM public.events_table WHERE (value_2 OPERATOR(pg_catalog.<) 3) OFFSET 3
+DEBUG:  generating subplan 1_1 for subquery SELECT user_id, event_type FROM public.events_table WHERE (value_2 OPERATOR(pg_catalog.<) 3) ORDER BY user_id, event_type OFFSET 3
 DEBUG:  generating subplan 1_2 for subquery SELECT avg(bar.event_type) AS avg_val FROM (SELECT foo.event_type, users_table_1.user_id FROM public.users_table users_table_1, (SELECT intermediate_result.user_id, intermediate_result.event_type FROM read_intermediate_result('1_1'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, event_type integer)) foo WHERE (foo.user_id OPERATOR(pg_catalog.=) users_table_1.user_id)) bar, public.users_table WHERE (bar.user_id OPERATOR(pg_catalog.=) users_table.user_id) GROUP BY users_table.value_1
 DEBUG:  push down of limit count: 3
 DEBUG:  generating subplan 1_3 for subquery SELECT users_table.user_id FROM public.users_table, (SELECT intermediate_result.avg_val FROM read_intermediate_result('1_2'::text, 'binary'::citus_copy_format) intermediate_result(avg_val numeric)) baz WHERE (baz.avg_val OPERATOR(pg_catalog.<) (users_table.user_id)::numeric) LIMIT 3

--- a/src/test/regress/sql/multi_subquery.sql
+++ b/src/test/regress/sql/multi_subquery.sql
@@ -100,7 +100,7 @@ FROM
 		FROM
 			lineitem_subquery
 		ORDER BY
-			l_quantity
+			l_orderkey, l_quantity
 		LIMIT 10
 		) lineitem_quantities
 	JOIN LATERAL
@@ -123,7 +123,7 @@ FROM
 		FROM
 			lineitem_subquery
 		ORDER BY
-			l_quantity
+			l_orderkey, l_quantity
 		LIMIT 10
 		) lineitem_quantities
 	JOIN LATERAL

--- a/src/test/regress/sql/subqueries_deep.sql
+++ b/src/test/regress/sql/subqueries_deep.sql
@@ -5,7 +5,6 @@ CREATE SCHEMA subquery_deep;
 SET search_path TO subquery_and_ctes, public;
 
 SET client_min_messages TO DEBUG1;
-
 -- subquery in FROM -> FROM -> FROM should be replaced due to OFFSET
 -- one level up subquery should be replaced due to GROUP BY on non partition key
 -- one level up subquery should be replaced due to LIMUT
@@ -19,7 +18,7 @@ FROM
 									avg(event_type) as avg_val
 								FROM
 									(SELECT event_type, users_table.user_id FROM users_table, 
-															(SELECT user_id, event_type FROM events_table WHERE value_2 < 3 OFFSET 3) as foo
+															(SELECT user_id, event_type FROM events_table WHERE value_2 < 3 ORDER BY 1, 2 OFFSET 3) as foo
 															WHERE foo.user_id = users_table.user_id
 															) bar, users_table WHERE bar.user_id = users_table.user_id GROUP BY users_table.value_1
 


### PR DESCRIPTION
Today's `ORDER BY` fixes. Same with #2657.