### PR TITLE
Fix 2PC condition for DDL tasks

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -828,6 +828,15 @@ TaskListRequires2PC(List *taskList)
 		return true;
 	}
 
+	if (task->taskType == DDL_TASK)
+	{
+		if (MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC ||
+			task->replicationModel == REPLICATION_MODEL_2PC)
+		{
+			return true;
+		}
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
Fixes multi_alter_table_statements.

In the master branch, for DDL tasks `ExecuteModifyTasks()` is the function which decides if we should use 2PC for DDL tasks or not, which irrespective of length of taskLength, does the following check:

```
	if (MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC ||
		firstTask->replicationModel == REPLICATION_MODEL_2PC)
	{
		CoordinatedTransactionUse2PC();
	}
```

In unified executor we don't go that path, and we call `TaskListRequires2PC()` instead. I added the change to handle DDL tasks correctly.