### PR TITLE
Add logic to propagate SET LOCAL at xact start

### DIFF
--- a/src/backend/distributed/commands/variableset.c
+++ b/src/backend/distributed/commands/variableset.c
@@ -1,0 +1,133 @@
+/*-------------------------------------------------------------------------
+ *
+ * variableset.c
+ *    Support for propagation of SET (commands to set variables)
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "c.h"
+
+#include "common/string.h"
+#include "distributed/commands.h"
+#include "distributed/commands/utility_hook.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_router_executor.h"
+#include "distributed/resource_lock.h"
+#include "distributed/transaction_management.h"
+#include "distributed/version_compat.h"
+#include "storage/lmgr.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "lib/ilist.h"
+#include "utils/varlena.h"
+#include "distributed/remote_commands.h"
+
+
+/*
+ * Checks whether a SET command modifies a variable which might violate assumptions
+ * made by Citus. Because we generally don't want a connection to be destroyed on error,
+ * and because we eagerly ensure the stack can be fully allocated (at backend startup),
+ * permitting changes to these two variables seems unwise. Also, ban propagating the
+ * SET command propagation setting (not for correctness, more to avoid confusion).
+ */
+bool
+SetCommandTargetIsValid(VariableSetStmt *setStmt)
+{
+	/* if this list grows considerably, switch to bsearch */
+	const char *blacklist[] = {
+		"citus.propagate_set_commands",
+		"client_encoding",
+		"exit_on_error",
+		"max_stack_depth"
+	};
+	Index idx = 0;
+
+	for (idx = 0; idx < lengthof(blacklist); idx++)
+	{
+		if (pg_strcasecmp(blacklist[idx], setStmt->name))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
+ * ProcessVariableSetStmt actually does the work of propagating a provided SET stmt
+ * to currently-participating worker nodes and adding the SET command test to a string
+ * keeping track of all propagated SET commands since (sub-)xact start.
+ */
+void
+ProcessVariableSetStmt(VariableSetStmt *setStmt, const char *setStmtString)
+{
+	dlist_iter iter;
+	const bool raiseInterrupts = true;
+	List *connectionList = NIL;
+
+	/* at present we only support SET LOCAL */
+	AssertArg(setStmt->is_local);
+
+	/* haven't seen any SET stmts so far in this (sub-)xact: initialize StringInfo */
+	if (activeSetStmts == NULL)
+	{
+		MemoryContext old_context = MemoryContextSwitchTo(CurTransactionContext);
+		activeSetStmts = makeStringInfo();
+		MemoryContextSwitchTo(old_context);
+	}
+
+	/* send text of SET stmt to participating nodes... */
+	dlist_foreach(iter, &InProgressTransactions)
+	{
+		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
+													  iter.cur);
+		RemoteTransaction *transaction = NULL;
+
+		transaction = &connection->remoteTransaction;
+		if (transaction->transactionFailed)
+		{
+			continue;
+		}
+
+		if (!SendRemoteCommand(connection, setStmtString))
+		{
+			const bool raiseErrors = true;
+			HandleRemoteTransactionConnectionError(connection, raiseErrors);
+		}
+
+		connectionList = lappend(connectionList, connection);
+	}
+
+	WaitForAllConnections(connectionList, raiseInterrupts);
+
+	/* ... and wait for the results */
+	dlist_foreach(iter, &InProgressTransactions)
+	{
+		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
+													  iter.cur);
+		RemoteTransaction *transaction = NULL;
+		const bool raiseErrors = true;
+
+		transaction = &connection->remoteTransaction;
+		if (transaction->transactionFailed)
+		{
+			continue;
+		}
+
+		ClearResults(connection, raiseErrors);
+	}
+
+	/* SET propagation successful: add to active SET stmt string */
+	appendStringInfoString(activeSetStmts, setStmtString);
+
+	/* ensure semicolon on end to allow appending future SET stmts */
+	if (!pg_str_endswith(setStmtString, ";"))
+	{
+		appendStringInfoChar(activeSetStmts, ';');
+	}
+}

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -29,15 +29,9 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_constraint.h"
-
-#if PG_VERSION_NUM < 110000
-
-/* pg_constraint_fn.h is gone in postgres 11,
- * get_relation_constraint_oid is merged into pg_constraint.h then
- */
+#if (PG_VERSION_NUM < 110000)
 #include "catalog/pg_constraint_fn.h"
 #endif
-
 #include "distributed/commands.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/relay_utility.h"

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -67,6 +67,7 @@ int FunctionCallLevel = 0;
 
 
 /* transaction management functions */
+static void BeginCoordinatedTransaction(void);
 static void CoordinatedTransactionCallback(XactEvent event, void *arg);
 static void CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId,
 											  SubTransactionId parentSubid, void *arg);
@@ -76,25 +77,6 @@ static void AdjustMaxPreparedTransactions(void);
 static void PushSubXact(SubTransactionId subId);
 static void PopSubXact(SubTransactionId subId);
 static void SwallowErrors(void (*func)());
-
-
-/*
- * BeginCoordinatedTransaction begins a coordinated transaction. No
- * pre-existing coordinated transaction may be in progress.
- */
-void
-BeginCoordinatedTransaction(void)
-{
-	if (CurrentCoordinatedTransactionState != COORD_TRANS_NONE &&
-		CurrentCoordinatedTransactionState != COORD_TRANS_IDLE)
-	{
-		ereport(ERROR, (errmsg("starting transaction in wrong state")));
-	}
-
-	CurrentCoordinatedTransactionState = COORD_TRANS_STARTED;
-
-	AssignDistributedTransactionId();
-}
 
 
 /*
@@ -153,6 +135,25 @@ InitializeTransactionManagement(void)
 												  8 * 1024,
 												  8 * 1024,
 												  8 * 1024);
+}
+
+
+/*
+ * BeginCoordinatedTransaction begins a coordinated transaction. No
+ * pre-existing coordinated transaction may be in progress./
+ */
+static void
+BeginCoordinatedTransaction(void)
+{
+	if (CurrentCoordinatedTransactionState != COORD_TRANS_NONE &&
+		CurrentCoordinatedTransactionState != COORD_TRANS_IDLE)
+	{
+		ereport(ERROR, (errmsg("starting transaction in wrong state")));
+	}
+
+	CurrentCoordinatedTransactionState = COORD_TRANS_STARTED;
+
+	AssignDistributedTransactionId();
 }
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -123,5 +123,7 @@ extern void ProcessTruncateStatement(TruncateStmt *truncateStatement);
 /* vacuum.c - froward declarations */
 extern void ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand);
 
+extern bool SetCommandTargetIsValid(VariableSetStmt *setStmt);
+extern void ProcessVariableSetStmt(VariableSetStmt *setStmt, const char *setCommand);
 
 #endif /*CITUS_COMMANDS_H */

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -16,8 +16,16 @@
 #include "utils/relcache.h"
 #include "tcop/utility.h"
 
+typedef enum
+{
+	PROPSETCMD_INVALID = -1,
+	PROPSETCMD_NONE, /* do not propagate SET commands */
+	PROPSETCMD_LOCAL, /* propagate SET LOCAL commands */
+	PROPSETCMD_SESSION, /* propagate SET commands, but not SET LOCAL ones */
+	PROPSETCMD_ALL /* propagate all SET commands */
+} PropSetCmdBehavior;
+extern PropSetCmdBehavior PropagateSetCommands;
 extern bool EnableDDLPropagation;
-
 
 /*
  * A DDLJob encapsulates the remote tasks and commands needed to process all or

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -10,6 +10,7 @@
 #define TRANSACTION_MANAGMENT_H
 
 #include "lib/ilist.h"
+#include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
 
 /* describes what kind of modifications have occurred in the current transaction */
@@ -53,6 +54,13 @@ typedef enum
 	COMMIT_PROTOCOL_2PC = 2
 } CommitProtocolType;
 
+/* Enumeration to keep track of context within nested sub-transactions */
+typedef struct SubXactContext
+{
+	SubTransactionId subId;
+	StringInfo setLocalCmds;
+} SubXactContext;
+
 /*
  * GUC that determines whether a SELECT in a transaction block should also run in
  * a transaction block on the worker.
@@ -85,6 +93,8 @@ extern int StoredProcedureLevel;
 /* number of nested function call levels we are currently in */
 extern int FunctionCallLevel;
 
+/* SET LOCAL statements active in the current (sub-)transaction. */
+extern StringInfo activeSetStmts;
 
 /*
  * Coordinated transaction management.
@@ -99,6 +109,7 @@ extern void InitializeTransactionManagement(void);
 
 /* other functions */
 extern List * ActiveSubXacts(void);
+extern List * ActiveSubXactContexts(void);
 
 
 #endif /*  TRANSACTION_MANAGMENT_H */

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -89,7 +89,6 @@ extern int FunctionCallLevel;
 /*
  * Coordinated transaction management.
  */
-extern void BeginCoordinatedTransaction(void);
 extern void BeginOrContinueCoordinatedTransaction(void);
 extern bool InCoordinatedTransaction(void);
 extern void CoordinatedTransactionUse2PC(void);

--- a/src/test/regress/expected/multi_real_time_transaction.out
+++ b/src/test/regress/expected/multi_real_time_transaction.out
@@ -341,6 +341,92 @@ BEGIN;
 SELECT id, pg_advisory_lock(15) FROM test_table;
 ERROR:  canceling the transaction since it was involved in a distributed deadlock
 ROLLBACK;
+-- test propagation of SET LOCAL
+-- gonna need a non-superuser as we'll use RLS to test GUC propagation
+CREATE USER rls_user;
+GRANT ALL ON SCHEMA multi_real_time_transaction TO rls_user;
+GRANT ALL ON ALL TABLES IN SCHEMA multi_real_time_transaction TO rls_user;
+SELECT run_command_on_workers('CREATE USER rls_user');
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+SELECT run_command_on_workers('GRANT ALL ON SCHEMA multi_real_time_transaction TO rls_user');
+  run_command_on_workers   
+---------------------------
+ (localhost,57637,t,GRANT)
+ (localhost,57638,t,GRANT)
+(2 rows)
+
+SELECT run_command_on_workers('GRANT ALL ON ALL TABLES IN SCHEMA multi_real_time_transaction TO rls_user');
+  run_command_on_workers   
+---------------------------
+ (localhost,57637,t,GRANT)
+ (localhost,57638,t,GRANT)
+(2 rows)
+
+-- create trigger on one worker to reject access if GUC not
+\c - - - :worker_1_port
+SET search_path = 'multi_real_time_transaction';
+ALTER TABLE test_table_1610000 ENABLE ROW LEVEL SECURITY;
+CREATE POLICY hide_by_default ON test_table_1610000 TO PUBLIC
+    USING (COALESCE(current_setting('app.show_rows', TRUE)::bool, FALSE));
+\c - - - :master_port
+SET ROLE rls_user;
+SET search_path = 'multi_real_time_transaction';
+-- shouldn't see all rows because of RLS
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+BEGIN;
+-- without enabling SET LOCAL prop, still won't work
+SET LOCAL app.show_rows TO TRUE;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+SET LOCAL citus.propagate_set_commands TO 'local';
+-- now we should be good to go
+SET LOCAL app.show_rows TO TRUE;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+SAVEPOINT disable_rls;
+SET LOCAL app.show_rows TO FALSE;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+ROLLBACK TO SAVEPOINT disable_rls;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+SAVEPOINT disable_rls_for_real;
+SET LOCAL app.show_rows TO FALSE;
+RELEASE SAVEPOINT disable_rls_for_real;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+COMMIT;
+RESET ROLE;
 -- sequential real-time queries should be successfully executed
 -- since the queries are sent over the same connection
 BEGIN;

--- a/src/test/regress/expected/multi_real_time_transaction_0.out
+++ b/src/test/regress/expected/multi_real_time_transaction_0.out
@@ -349,6 +349,92 @@ BEGIN;
 SELECT id, pg_advisory_lock(15) FROM test_table;
 ERROR:  canceling the transaction since it was involved in a distributed deadlock
 ROLLBACK;
+-- test propagation of SET LOCAL
+-- gonna need a non-superuser as we'll use RLS to test GUC propagation
+CREATE USER rls_user;
+GRANT ALL ON SCHEMA multi_real_time_transaction TO rls_user;
+GRANT ALL ON ALL TABLES IN SCHEMA multi_real_time_transaction TO rls_user;
+SELECT run_command_on_workers('CREATE USER rls_user');
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+SELECT run_command_on_workers('GRANT ALL ON SCHEMA multi_real_time_transaction TO rls_user');
+  run_command_on_workers   
+---------------------------
+ (localhost,57637,t,GRANT)
+ (localhost,57638,t,GRANT)
+(2 rows)
+
+SELECT run_command_on_workers('GRANT ALL ON ALL TABLES IN SCHEMA multi_real_time_transaction TO rls_user');
+  run_command_on_workers   
+---------------------------
+ (localhost,57637,t,GRANT)
+ (localhost,57638,t,GRANT)
+(2 rows)
+
+-- create trigger on one worker to reject access if GUC not
+\c - - - :worker_1_port
+SET search_path = 'multi_real_time_transaction';
+ALTER TABLE test_table_1610000 ENABLE ROW LEVEL SECURITY;
+CREATE POLICY hide_by_default ON test_table_1610000 TO PUBLIC
+    USING (COALESCE(current_setting('app.show_rows', TRUE)::bool, FALSE));
+\c - - - :master_port
+SET ROLE rls_user;
+SET search_path = 'multi_real_time_transaction';
+-- shouldn't see all rows because of RLS
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+BEGIN;
+-- without enabling SET LOCAL prop, still won't work
+SET LOCAL app.show_rows TO TRUE;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+SET LOCAL citus.propagate_set_commands TO 'local';
+-- now we should be good to go
+SET LOCAL app.show_rows TO TRUE;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+SAVEPOINT disable_rls;
+SET LOCAL app.show_rows TO FALSE;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+ROLLBACK TO SAVEPOINT disable_rls;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     6
+(1 row)
+
+SAVEPOINT disable_rls_for_real;
+SET LOCAL app.show_rows TO FALSE;
+RELEASE SAVEPOINT disable_rls_for_real;
+SELECT COUNT(*) FROM test_table;
+ count 
+-------
+     4
+(1 row)
+
+COMMIT;
+RESET ROLE;
 -- sequential real-time queries should be successfully executed
 -- since the queries are sent over the same connection
 BEGIN;


### PR DESCRIPTION
Partially addresses #1327 (which discusses _all_ config, not just `SET LOCAL`)

DESCRIPTION: Add logic to propagate SET LOCAL at xact start

# Tasks
  - [x] Add failing SQL test
  - [x] Add GUC to whitelist propagated settings (for now); do not allow PostgreSQL ones (for now)
  - [x] During transactions, detect matching `SET LOCAL` commands and…
  - [x] Push down to any already-open remote transactions, and…
  - [x] Append to a list of needed local settings for any further remote transactions, and…
  - [x] During any subsequent remote transactions, add the `SET` commands after the initial `BEGIN` (but in the same network hop)
  - [x] Show test passes