### PR TITLE
Support foreign keys to reference tables in unified executor

### DIFF
--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -451,6 +451,9 @@ AssignPlacementListToConnection(List *placementAccessList, MultiConnection *conn
 		{
 			placementConnection->hadDML = true;
 		}
+
+		/* record the relation access mapping */
+		AssociatePlacementAccessWithRelation(placement, accessType);
 	}
 }
 

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -546,7 +546,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	UPDATE referece_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute SELECT on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:5: Unrelated parallel DDL on distributed table followed by unrelated DDL on ref. table

--- a/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
@@ -546,7 +546,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	UPDATE referece_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute SELECT on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:5: Unrelated parallel DDL on distributed table followed by unrelated DDL on ref. table


### PR DESCRIPTION
The idea for supporting foreign keys to reference tables is simple:
Keep track of the relation accesses within a transaction block.
* If a parallel access happens on a distributed table which
          has a foreign key to a reference table, one cannot modify
          the reference table in the same transaction. Otherwise,
          we're very likely to end-up with a self-distributed deadlock.
* If an access to a reference table happens, and then a parallel
          access to a distributed table (which has a fkey to the reference
          table) happens, we switch to sequential mode.
    
Unified executor misses the function calls that marks the relation
    accesses during the execution. Thus, simply add the necessary calls
    and let the logic kick in.

This PR includes a commit from #2688 so would be good if both
PRs are reviewed together.


The PR fixes several regression tests:`foreign_key_restriction_enforcement`, `relation_access_tracking`, `foreign_key_to_reference_table`, `validate_constraint` and `multi_reference_table`.  Well, few of the tests mentioned above still fails due to very minor test output differences, which will be fixed altogether later.
