### PR TITLE
Improve closing connections that are not fully established in unified executor

### DIFF
--- a/src/backend/distributed/executor/executor.c
+++ b/src/backend/distributed/executor/executor.c
@@ -1256,6 +1256,17 @@ ConnectionStateMachine(WorkerSession *session)
 
 				/* remove the connection */
 				UnclaimConnection(connection);
+
+				/*
+				 * We forcefully close the underlying libpq connection because
+				 * we don't want any subsequent execution (either subPlan executions
+				 * or new command executions within a transaction block) use the
+				 * connection.
+				 *
+				 * However, we prefer to keep the MultiConnection around until
+				 * the end of FinishDistributedExecution() to simplify the code.
+				 * Thus, we prefer ShutdownConnection() over CloseConnection().
+				 */
 				ShutdownConnection(connection);
 
 				/* remove connection from wait event set */

--- a/src/backend/distributed/executor/executor.c
+++ b/src/backend/distributed/executor/executor.c
@@ -560,8 +560,13 @@ FinishDistributedExecution(DistributedExecution *execution)
 
 		UnclaimConnection(connection);
 
-		if (connection->connectionState == MULTI_CONNECTION_CONNECTING)
+		if (connection->connectionState == MULTI_CONNECTION_CONNECTING ||
+			connection->connectionState == MULTI_CONNECTION_FAILED)
 		{
+			/*
+			 * We want the MultiConnection go away and not used in
+			 * the subsequent executions.
+			 */
 			CloseConnection(connection);
 		}
 		else if (transactionState == REMOTE_TRANS_CLEARING_RESULTS)

--- a/src/backend/distributed/executor/executor.c
+++ b/src/backend/distributed/executor/executor.c
@@ -562,7 +562,7 @@ FinishDistributedExecution(DistributedExecution *execution)
 
 		if (connection->connectionState == MULTI_CONNECTION_CONNECTING)
 		{
-			ShutdownConnection(connection);
+			CloseConnection(connection);
 		}
 		else if (transactionState == REMOTE_TRANS_CLEARING_RESULTS)
 		{


### PR DESCRIPTION
This PR is against `unified_executor`.

It looks like we're calling wrong function to close the connections that have not been fully established. `ShutdownConnection ()` keeps the `MultiConnection` around with a closed connection, which ends up with `connection errors`, especially with recursively planned queries (or sometimes transaction blocks). The reason is that `ConnectionHash` would end-up with connections that are closed, and the next executions try to use those connections.

This doesn't implement what I had in mind where we'd have the options to forcefully close (like this) or wait until the connection is fully established. 

Without this fix, we see lots of intermittent/random connection errors, I'd propose to merge this and implement the actual solution later (and tick the item in #2665 later as well). 

(Note that we have one more use of `ShutdownConnection `, which looks fine given that we call it only when the transaction fails as we typically call `ShutdownConnection`)