### PR TITLE
Remove stopOnFailure flag from EndRemoteCopy()

### DIFF
--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -448,7 +448,7 @@ RemoteFileDestReceiverShutdown(DestReceiver *destReceiver)
 	}
 
 	/* close the COPY input */
-	EndRemoteCopy(0, connectionList, true);
+	EndRemoteCopy(0, connectionList);
 
 	if (resultDest->writeLocalFile)
 	{

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -131,7 +131,7 @@ extern void AppendCopyRowData(Datum *valueArray, bool *isNullArray,
 							  CopyCoercionData *columnCoercionPaths);
 extern void AppendCopyBinaryHeaders(CopyOutState headerOutputState);
 extern void AppendCopyBinaryFooters(CopyOutState footerOutputState);
-extern void EndRemoteCopy(int64 shardId, List *connectionList, bool stopOnFailure);
+extern void EndRemoteCopy(int64 shardId, List *connectionList);
 extern Node * ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag,
 							  const char *queryString);
 extern void CheckCopyPermissions(CopyStmt *copyStatement);


### PR DESCRIPTION
Because:
1. Its value is always `true`,
2. Our implementation for the `false` case was incorrect anyway. We always passed `raiseInterrupts = true` for the `GetRemoteCommandResult()` call in this function.
