### PR TITLE
Prevent anchoring reference table shard ids when distributed tables are in join clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### citus v8.2.1 (April 03, 2019) ###
+
+* Fixes a bug that prevents stack size to be adjusted
+
+### citus v8.1.2 (April 03, 2019) ###
+
+* Don't do redundant ALTER TABLE consistency checks at coordinator
+
+* Fixes a bug that prevents stack size to be adjusted
+
+* Fix an issue with some DECLARE .. CURSOR WITH HOLD commands
+
 ### citus v8.2.0 (March 28, 2019) ###
 
 * Removes support and code for PostgreSQL 9.6

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -448,7 +448,7 @@ RemoteFileDestReceiverShutdown(DestReceiver *destReceiver)
 	}
 
 	/* close the COPY input */
-	EndRemoteCopy(0, connectionList, true);
+	EndRemoteCopy(0, connectionList);
 
 	if (resultDest->writeLocalFile)
 	{

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -2355,8 +2355,9 @@ AssignQueuedTasks(TaskTracker *taskTracker)
 
 		foreach(taskCell, tasksToAssignList)
 		{
-			taskState = (TrackerTaskState *) lfirst(taskCell);
 			BatchQueryStatus queryStatus = CLIENT_INVALID_BATCH_QUERY;
+
+			taskState = (TrackerTaskState *) lfirst(taskCell);
 
 			if (!batchSuccess)
 			{
@@ -2904,12 +2905,17 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 
 		foreach(activeTaskTrackerCell, activeTackTrackerList)
 		{
-			taskTracker = (TaskTracker *) lfirst(activeTaskTrackerCell);
-			int32 connectionId = taskTracker->connectionId;
-			const char *nodeName = taskTracker->workerName;
-			uint32 nodePort = taskTracker->workerPort;
+			int32 connectionId = 0;
+			char *nodeName = NULL;
+			uint32 nodePort = 0;
+			ResultStatus resultStatus = CLIENT_INVALID_RESULT_STATUS;
 
-			ResultStatus resultStatus = MultiClientResultStatus(connectionId);
+			taskTracker = (TaskTracker *) lfirst(activeTaskTrackerCell);
+			connectionId = taskTracker->connectionId;
+			nodeName = taskTracker->workerName;
+			nodePort = taskTracker->workerPort;
+
+			resultStatus = MultiClientResultStatus(connectionId);
 			if (resultStatus == CLIENT_RESULT_READY)
 			{
 				QueryStatus queryStatus = MultiClientQueryStatus(connectionId);

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -131,7 +131,7 @@ extern void AppendCopyRowData(Datum *valueArray, bool *isNullArray,
 							  CopyCoercionData *columnCoercionPaths);
 extern void AppendCopyBinaryHeaders(CopyOutState headerOutputState);
 extern void AppendCopyBinaryFooters(CopyOutState footerOutputState);
-extern void EndRemoteCopy(int64 shardId, List *connectionList, bool stopOnFailure);
+extern void EndRemoteCopy(int64 shardId, List *connectionList);
 extern Node * ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag,
 							  const char *queryString);
 extern void CheckCopyPermissions(CopyStmt *copyStatement);

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -184,7 +184,7 @@ RESET client_min_messages;
 -- which might change and we don't have any control over it.
 -- the important thing that we look for is that round-robin policy 
 -- should give the same output for executions in the same transaction 
--- and different output for executions that are not insdie the
+-- and different output for executions that are not inside the
 -- same transaction. To ensure that, we define a helper function
 BEGIN;
 SET LOCAL citus.explain_distributed_queries TO on;
@@ -201,12 +201,11 @@ SELECT count(DISTINCT value) FROM explain_outputs;
      1
 (1 row)
 
-DROP TABLE explain_outputs;
+TRUNCATE explain_outputs;
 COMMIT;
 -- now test round-robin policy outside
--- a transaction, we should see the assignements
+-- a transaction, we should see the assignments
 -- change on every execution
-CREATE TEMPORARY TABLE explain_outputs (value text);
 SET citus.task_assignment_policy TO 'round-robin';
 SET citus.explain_distributed_queries TO ON;
 INSERT INTO explain_outputs 
@@ -248,12 +247,11 @@ SELECT count(DISTINCT value) FROM explain_outputs;
      1
 (1 row)
 
-DROP TABLE explain_outputs;
+TRUNCATE explain_outputs;
 COMMIT;
 -- now test round-robin policy outside
--- a transaction, we should see the assignements
+-- a transaction, we should see the assignments
 -- change on every execution
-CREATE TEMPORARY TABLE explain_outputs (value text);
 SET citus.task_assignment_policy TO 'round-robin';
 SET citus.explain_distributed_queries TO ON;
 INSERT INTO explain_outputs 
@@ -268,6 +266,40 @@ SELECT count(DISTINCT value) FROM explain_outputs;
      2
 (1 row)
 
+TRUNCATE explain_outputs;
+-- test that the round robin policy detects the anchor shard correctly
+-- we should not pick a reference table shard as the anchor shard when joining with a distributed table
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE task_assignment_nonreplicated_hash (test_id  integer, ref_id integer);
+SELECT create_distributed_table('task_assignment_nonreplicated_hash', 'test_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- run the query two times to make sure that it hits the correct worker every time
+INSERT INTO explain_outputs
+SELECT parse_explain_output($cmd$
+EXPLAIN SELECT *
+FROM (SELECT * FROM task_assignment_nonreplicated_hash WHERE test_id = 3) AS dist
+       LEFT JOIN task_assignment_reference_table ref
+                 ON dist.ref_id = ref.test_id
+$cmd$, 'task_assignment_nonreplicated_hash');
+INSERT INTO explain_outputs
+SELECT parse_explain_output($cmd$
+EXPLAIN SELECT *
+FROM (SELECT * FROM task_assignment_nonreplicated_hash WHERE test_id = 3) AS dist
+       LEFT JOIN task_assignment_reference_table ref
+                 ON dist.ref_id = ref.test_id
+$cmd$, 'task_assignment_nonreplicated_hash');
+-- The count should be 1 since the shard exists in only one worker node
+SELECT count(DISTINCT value) FROM explain_outputs;
+ count 
+-------
+     1
+(1 row)
+
+TRUNCATE explain_outputs;
 RESET citus.task_assignment_policy;
 RESET client_min_messages;
 -- we should be able to use round-robin with router queries that 
@@ -292,4 +324,5 @@ WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
 (0 rows)
 
 ROLLBACK;
-DROP TABLE task_assignment_replicated_hash, task_assignment_reference_table;
+DROP TABLE task_assignment_replicated_hash, task_assignment_nonreplicated_hash,
+  task_assignment_reference_table, explain_outputs;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that selects wrong worker when using round-robin assignment

When using the round-robin task assignment policy, citus needs to find the worker that stores all the shards that are accessed in a query/subquery. 
- If the query accesses shards of reference tables only, it can be run on any workers that have the reference table.
- If there is a distributed table shard in the `FROM` clause, it is the deciding factor in which worker Citus should execute this query.

fixes #2680 