### PR TITLE
Improve failure handling on unified executor

### DIFF
--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -862,6 +862,42 @@ ConnectionAccessedDifferentPlacement(MultiConnection *connection,
 
 
 /*
+ * ConnectionModifiedPlacement returns true if any DML or DDL is executed over
+ * the connection on any placement/table.
+ */
+bool
+ConnectionModifiedPlacement(MultiConnection *connection)
+{
+	dlist_iter placementIter;
+
+	if (connection->remoteTransaction.transactionState == REMOTE_TRANS_INVALID)
+	{
+		/*
+		 * When StartPlacementListConnection() is called, we set the
+		 * hadDDL/hadDML even before the actual command is sent to
+		 * remote nodes. And, if this function is called at that
+		 * point, we should not assume that the connection has already
+		 * done any modifications.
+		 */
+		return false;
+	}
+
+	dlist_foreach(placementIter, &connection->referencedPlacements)
+	{
+		ConnectionReference *connectionReference =
+			dlist_container(ConnectionReference, connectionNode, placementIter.cur);
+
+		if (connectionReference->hadDDL || connectionReference->hadDML)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
  * ConnectionUsedForAnyPlacements returns true if the connection
  * has not been associated with any placement.
  */

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -822,7 +822,8 @@ TaskListRequires2PC(List *taskList)
 	}
 
 	multipleTasks = list_length(taskList) > 1;
-	if (multipleTasks && MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC)
+	if (!ReadOnlyTask(task->taskType) &&
+		multipleTasks && MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC)
 	{
 		return true;
 	}
@@ -834,6 +835,27 @@ TaskListRequires2PC(List *taskList)
 		{
 			return true;
 		}
+	}
+
+	return false;
+}
+
+
+/*
+ * ReadOnlyTask returns true if the input task does a read-only operation
+ * on the database.
+ */
+bool
+ReadOnlyTask(TaskType taskType)
+{
+	if (taskType == ROUTER_TASK || taskType == SQL_TASK)
+	{
+		/*
+		 * TODO: We currently do not execute modifying CTEs via ROUTER_TASK/SQL_TASK.
+		 * When we implement it, we should either not use the mentioned task types for
+		 * modifying CTEs detect them here.
+		 */
+		return true;
 	}
 
 	return false;

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -111,6 +111,8 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 
 		HandleRemoteTransactionConnectionError(connection, raiseErrors);
 	}
+
+	transaction->beginSent = true;
 }
 
 

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -53,6 +53,7 @@ extern int64 ExecuteModifyTasksSequentiallyWithoutResults(List *taskList,
 extern ShardPlacementAccess * CreatePlacementAccess(ShardPlacement *placement,
 													ShardPlacementAccessType accessType);
 extern bool TaskListRequires2PC(List *taskList);
+extern bool ReadOnlyTask(TaskType taskType);
 extern List * BuildPlacementSelectList(int32 groupId, List *relationShardList);
 extern List * BuildPlacementDDLList(int32 groupId, List *relationShardList);
 extern void ExtractParametersFromParamListInfo(ParamListInfo paramListInfo,

--- a/src/include/distributed/placement_connection.h
+++ b/src/include/distributed/placement_connection.h
@@ -69,6 +69,7 @@ extern void ResetShardPlacementAssociation(struct MultiConnection *connection);
 
 extern void InitPlacementConnectionManagement(void);
 
+extern bool ConnectionModifiedPlacement(MultiConnection *connection);
 extern bool ConnectionUsedForAnyPlacements(MultiConnection *connection);
 
 #endif /* PLACEMENT_CONNECTION_H */

--- a/src/include/distributed/remote_transaction.h
+++ b/src/include/distributed/remote_transaction.h
@@ -83,6 +83,9 @@ typedef struct RemoteTransaction
 
 	/* 2PC transaction name currently associated with connection */
 	char preparedName[NAMEDATALEN];
+
+	/* set when BEGIN is sent over the connection */
+	bool beginSent;
 } RemoteTransaction;
 
 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -346,27 +346,32 @@ ALTER TABLE limit_orders_750000 RENAME TO renamed_orders;
 -- Third: Connect back to master node
 \c - - - :master_port
 -- Fourth: Perform an INSERT on the remaining node
+-- the whole transaction should fail
 \set VERBOSITY terse
 INSERT INTO limit_orders VALUES (276, 'ADR', 140, '2007-07-02 16:32:15', 'sell', 43.67);
-WARNING:  relation "public.limit_orders_750000" does not exist
--- Last: Verify the insert worked but the deleted placement is now unhealthy
+ERROR:  relation "public.limit_orders_750000" does not exist
+-- set the shard name back
+\c - - - :worker_2_port
+-- Second: Move aside limit_orders shard on the second worker node
+ALTER TABLE renamed_orders RENAME TO limit_orders_750000;
+-- Connect back to master node
+\c - - - :master_port
+-- Verify the insert failed and both placements are healthy
 SELECT count(*) FROM limit_orders WHERE id = 276;
  count 
 -------
-     1
+     0
 (1 row)
 
 SELECT count(*)
 FROM   pg_dist_shard_placement AS sp,
 	   pg_dist_shard           AS s
 WHERE  sp.shardid = s.shardid
-AND    sp.nodename = 'localhost'
-AND    sp.nodeport = :worker_2_port
 AND    sp.shardstate = 3
 AND    s.logicalrelid = 'limit_orders'::regclass;
  count 
 -------
-     1
+     0
 (1 row)
 
 -- Test that if all shards miss a modification, no state change occurs

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -381,9 +381,9 @@ DELETE FROM researchers WHERE lab_id = 6;
 \copy researchers FROM STDIN delimiter ','
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
-WARNING:  illegal value
 WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  illegal value
+WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
 WARNING:  could not commit transaction for shard 1200001 on any active node
 ERROR:  could not commit transaction on any active node
 \unset VERBOSITY
@@ -424,7 +424,7 @@ BEGIN;
 \copy labs from stdin delimiter ','
 ALTER TABLE labs ADD COLUMN motto text;
 ABORT;
--- cannot perform parallel DDL once a connection is used for multiple shards
+-- can perform parallel DDL even a connection is used for multiple shards
 BEGIN;
 SELECT lab_id FROM researchers WHERE lab_id = 1 AND id = 0;
  lab_id 
@@ -437,7 +437,6 @@ SELECT lab_id FROM researchers WHERE lab_id = 2 AND id = 0;
 (0 rows)
 
 ALTER TABLE researchers ADD COLUMN motto text;
-ERROR:  cannot perform a parallel DDL command because multiple placements have been accessed over the same connection
 ROLLBACK;
 -- can perform sequential DDL once a connection is used for multiple shards
 BEGIN;
@@ -527,27 +526,25 @@ DEFERRABLE INITIALLY IMMEDIATE
 FOR EACH ROW EXECUTE PROCEDURE reject_bad();
 \c - - - :master_port
 -- test partial failure; worker_1 succeeds, 2 fails
+-- in this case, we expect the transaction to abort
 \set VERBOSITY terse
 BEGIN;
 INSERT INTO objects VALUES (1, 'apple');
 INSERT INTO objects VALUES (2, 'BAD');
-WARNING:  illegal value
-INSERT INTO labs VALUES (7, 'E Corp');
+ERROR:  illegal value
 COMMIT;
--- data should be persisted
+-- so the data should noy be persisted
 SELECT * FROM objects WHERE id = 2;
  id | name 
 ----+------
-  2 | BAD
-(1 row)
+(0 rows)
 
 SELECT * FROM labs WHERE id = 7;
- id |  name  
-----+--------
-  7 | E Corp
-(1 row)
+ id | name 
+----+------
+(0 rows)
 
--- but one placement should be bad
+-- and none of placements should be inactive
 SELECT count(*)
 FROM   pg_dist_shard_placement AS sp,
 	   pg_dist_shard           AS s
@@ -558,16 +555,12 @@ AND    sp.shardstate = 3
 AND    s.logicalrelid = 'objects'::regclass;
  count 
 -------
-     1
+     0
 (1 row)
 
 DELETE FROM objects;
--- mark shards as healthy again; delete all data
-UPDATE pg_dist_shard_placement AS sp SET shardstate = 1
-FROM   pg_dist_shard AS s
-WHERE  sp.shardid = s.shardid
-AND    s.logicalrelid = 'objects'::regclass;
--- what if there are errors on different shards at different times?
+-- there cannot be errors on different shards at different times
+-- because the first failure will fail the whole transaction
 \c - - - :worker_1_port
 CREATE FUNCTION reject_bad() RETURNS trigger AS $rb$
     BEGIN
@@ -586,10 +579,11 @@ FOR EACH ROW EXECUTE PROCEDURE reject_bad();
 BEGIN;
 INSERT INTO objects VALUES (1, 'apple');
 INSERT INTO objects VALUES (2, 'BAD');
-WARNING:  illegal value
-INSERT INTO labs VALUES (8, 'Aperture Science');
-INSERT INTO labs VALUES (9, 'BAD');
 ERROR:  illegal value
+INSERT INTO labs VALUES (8, 'Aperture Science');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+INSERT INTO labs VALUES (2, 'BAD');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
 -- data should NOT be persisted
 SELECT * FROM objects WHERE id = 1;
@@ -630,18 +624,12 @@ INSERT INTO objects VALUES (2, 'BAD');
 INSERT INTO labs VALUES (9, 'Umbrella Corporation');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57638
+WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
 -- data should be persisted
 SELECT * FROM objects WHERE id = 2;
  id | name 
 ----+------
   2 | BAD
-(1 row)
-
-SELECT * FROM labs WHERE id = 7;
- id |  name  
-----+--------
-  7 | E Corp
 (1 row)
 
 -- but one placement should be bad
@@ -679,9 +667,9 @@ INSERT INTO labs VALUES (8, 'Aperture Science');
 INSERT INTO labs VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57637
+WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57638
+WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
 WARNING:  could not commit transaction for shard 1200002 on any active node
 WARNING:  could not commit transaction for shard 1200003 on any active node
 ERROR:  could not commit transaction on any active node
@@ -720,7 +708,7 @@ INSERT INTO labs VALUES (8, 'Aperture Science');
 INSERT INTO labs VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57637
+WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
 WARNING:  could not commit transaction for shard 1200002 on any active node
 \set VERBOSITY default
 -- data to objects should be persisted, but labs should not...
@@ -1324,8 +1312,7 @@ ALTER USER test_user RENAME TO test_user_new;
 \c - test_user - :master_port
 -- fails on all shard placements
 INSERT INTO numbers_hash_failure_test VALUES (2,2);
-WARNING:  connection error: localhost:57638
-ERROR:  could not modify any active placements
+ERROR:  connection error: localhost:57638
 -- connect back to the master with the proper user to continue the tests 
 \c - :default_user - :master_port
 SET citus.next_shard_id TO 1200020;
@@ -1438,7 +1425,7 @@ INSERT INTO users VALUES (3, 'burak');
 \COPY items FROM STDIN WITH CSV
 ERROR:  cannot establish a new connection for placement 1200042, since DML has been executed on a connection that is in use
 END;
--- cannot perform parallel DDL after a co-located table has been read over 1 connection
+-- perform parallel DDL after a co-located table has been read over 1 connection
 BEGIN;
 SELECT id FROM users WHERE id = 1;
  id 
@@ -1453,8 +1440,7 @@ SELECT id FROM users WHERE id = 6;
 (1 row)
 
 ALTER TABLE items ADD COLUMN last_update timestamptz;
-ERROR:  cannot perform a parallel DDL command because multiple placements have been accessed over the same connection
-END;
+ROLLBACK;
 -- can perform sequential DDL after a co-located table has been read over 1 connection
 BEGIN;
 SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
@@ -1472,7 +1458,7 @@ SELECT id FROM users WHERE id = 6;
 
 ALTER TABLE items ADD COLUMN last_update timestamptz;
 ROLLBACK;
--- but the other way around is fine
+-- and the other way around is also fine
 BEGIN;
 ALTER TABLE items ADD COLUMN last_update timestamptz;
 SELECT id FROM users JOIN items ON (id = user_id) WHERE id = 1;
@@ -1502,7 +1488,9 @@ SELECT user_id FROM items JOIN itemgroups ON (item_group = gid) WHERE user_id = 
 ---------
 (0 rows)
 
--- perform a DDL command on the reference table
+-- perform a DDL command on the reference table errors
+-- because the current implementation of COPY always opens one connection
+-- per placement SELECTs have to use those connections for correctness  
 ALTER TABLE itemgroups ADD COLUMN last_update timestamptz;
 ERROR:  cannot perform DDL on placement 1200036, which has been read over multiple connections
 END;

--- a/src/test/regress/expected/multi_mx_modifying_xacts.out
+++ b/src/test/regress/expected/multi_mx_modifying_xacts.out
@@ -337,7 +337,7 @@ INSERT INTO objects_mx VALUES (2, 'BAD');
 INSERT INTO labs_mx VALUES (9, 'Umbrella Corporation');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57637
+WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
 WARNING:  could not commit transaction for shard 1220103 on any active node
 WARNING:  could not commit transaction for shard 1220102 on any active node
 ERROR:  could not commit transaction on any active node
@@ -364,7 +364,7 @@ INSERT INTO labs_mx VALUES (8, 'Aperture Science');
 INSERT INTO labs_mx VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57637
+WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
 WARNING:  could not commit transaction for shard 1220103 on any active node
 WARNING:  could not commit transaction for shard 1220102 on any active node
 ERROR:  could not commit transaction on any active node
@@ -388,7 +388,7 @@ INSERT INTO labs_mx VALUES (8, 'Aperture Science');
 INSERT INTO labs_mx VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit transaction on localhost:57637
+WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
 WARNING:  could not commit transaction for shard 1220103 on any active node
 WARNING:  could not commit transaction for shard 1220102 on any active node
 ERROR:  could not commit transaction on any active node

--- a/src/test/regress/expected/multi_transaction_recovery.out
+++ b/src/test/regress/expected/multi_transaction_recovery.out
@@ -213,6 +213,87 @@ SELECT count(*) FROM pg_dist_transaction;
      4
 (1 row)
 
+SELECT recover_prepared_transactions();
+ recover_prepared_transactions 
+-------------------------------
+                             0
+(1 row)
+
+-- the same test with citus.force_max_query_parallelization=off
+-- should be fine as well
+SET citus.force_max_query_parallelization TO OFF;
+BEGIN;
+INSERT INTO test_recovery_single VALUES ('hello-0');
+INSERT INTO test_recovery_single VALUES ('hello-2');
+COMMIT;
+SELECT count(*) FROM pg_dist_transaction;
+ count 
+-------
+     2
+(1 row)
+
+SELECT recover_prepared_transactions();
+ recover_prepared_transactions 
+-------------------------------
+                             0
+(1 row)
+
+-- slightly more complicated test with citus.force_max_query_parallelization=off
+-- should be fine as well
+SET citus.force_max_query_parallelization TO OFF;
+BEGIN;
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-0';
+ count 
+-------
+     2
+(1 row)
+
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-2';
+ count 
+-------
+     2
+(1 row)
+
+INSERT INTO test_recovery_single VALUES ('hello-0');
+INSERT INTO test_recovery_single VALUES ('hello-2');
+COMMIT;
+SELECT count(*) FROM pg_dist_transaction;
+ count 
+-------
+     2
+(1 row)
+
+SELECT recover_prepared_transactions();
+ recover_prepared_transactions 
+-------------------------------
+                             0
+(1 row)
+
+-- the same test as the above with citus.force_max_query_parallelization=on
+-- should be fine as well
+SET citus.force_max_query_parallelization TO ON;
+BEGIN;
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-0';
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-2';
+ count 
+-------
+     3
+(1 row)
+
+INSERT INTO test_recovery_single VALUES ('hello-0');
+INSERT INTO test_recovery_single VALUES ('hello-2');
+COMMIT;
+SELECT count(*) FROM pg_dist_transaction;
+ count 
+-------
+     2
+(1 row)
+
 -- Test whether auto-recovery runs
 ALTER SYSTEM SET citus.recover_2pc_interval TO 10;
 SELECT pg_reload_conf();

--- a/src/test/regress/sql/multi_transaction_recovery.sql
+++ b/src/test/regress/sql/multi_transaction_recovery.sql
@@ -120,6 +120,45 @@ INSERT INTO test_recovery_single VALUES ('hello-2');
 COMMIT;
 SELECT count(*) FROM pg_dist_transaction;
 
+SELECT recover_prepared_transactions();
+
+-- the same test with citus.force_max_query_parallelization=off
+-- should be fine as well
+SET citus.force_max_query_parallelization TO OFF;
+BEGIN;
+INSERT INTO test_recovery_single VALUES ('hello-0');
+INSERT INTO test_recovery_single VALUES ('hello-2');
+COMMIT;
+SELECT count(*) FROM pg_dist_transaction;
+
+SELECT recover_prepared_transactions();
+
+-- slightly more complicated test with citus.force_max_query_parallelization=off
+-- should be fine as well
+SET citus.force_max_query_parallelization TO OFF;
+BEGIN;
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-0';
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-2';
+INSERT INTO test_recovery_single VALUES ('hello-0');
+INSERT INTO test_recovery_single VALUES ('hello-2');
+COMMIT;
+SELECT count(*) FROM pg_dist_transaction;
+
+
+SELECT recover_prepared_transactions();
+
+-- the same test as the above with citus.force_max_query_parallelization=on
+-- should be fine as well
+SET citus.force_max_query_parallelization TO ON;
+BEGIN;
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-0';
+SELECT count(*) FROM test_recovery_single WHERE x = 'hello-2';
+INSERT INTO test_recovery_single VALUES ('hello-0');
+INSERT INTO test_recovery_single VALUES ('hello-2');
+COMMIT;
+SELECT count(*) FROM pg_dist_transaction;
+
+
 -- Test whether auto-recovery runs
 ALTER SYSTEM SET citus.recover_2pc_interval TO 10;
 SELECT pg_reload_conf();


### PR DESCRIPTION
This is a draft PR against unified_executor, I wanted to share my proposal here. @marcocitus and @pykello please let me know what you think about it. I want to add/adjust lots of tests, but before going after that I wanted to hear your thoughts in the mean time.

With this PR, we're defining the failure behavior of the new executor for DML and DDLs.

|  Failure Case										| Reference Table  | Distributed Table with replication == 1 | Distributed Table with replication > 1 | Applies for|
| ------------------------------------------- 		| ------------- | ------------- |------------- | ------ |
| Failure during connection establishment    		| Distributed query fails  | Distributed query fails  | Mark the placements what are assigned to the session (e.g., the session) with state INVALID**   | DML/DDL*|
| Failure during shard query execution one of the replicas  | Distributed query fails  | Distributed query fails  | Distributed query fails   |  DML/DDL/SELECT|
| Failure on a worker session where at least one successful shard query execution happened | Distributed query fails | Distributed query fails| Distributed query fails|DML/DDL/SELECT|

\*  `SELECT`s retry on a second placement
** We could even improve this to make it only happen on worker pools. But, here we prefer simplicity since replication > 1 is not very common use-case anymore. 

*** I also considered VACUUM/VACUUM ANALYZE as DDL in the above table since it was the case in the existing executors. 

The above table differs from the existing executors. The main difference is that the new executor throws an error on any failures during query execution. For example, if a long running SELECT fails, the new executor throws an error whereas the real-time executor tries the next replica and successfully finishes the query. Another difference is that, the new executor throws an error if a DML/DDL query in one of the shard replicas fails whereas the router executor marks the placement as INVALID. 


In summary, the new executor marks placements INACTIVE only when connection establishment for DML/DDL fails on a replicated distributed table (e.g., replication factor > 1). The design decision for this is two folded (a) It is very unlikely that a query fails on one of the placements of the same shard during the query execution (b) This implementation is a lot simpler





