### PR TITLE
Fix comments for RemoteFileDestReceiverStartup and CitusCopyDestReceiverStartup

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2074,7 +2074,8 @@ CreateCitusCopyDestReceiver(Oid tableId, List *columnNameList, int partitionColu
 
 /*
  * CitusCopyDestReceiverStartup implements the rStartup interface of
- * CitusCopyDestReceiver. It opens the relation
+ * CitusCopyDestReceiver. It opens the relation, acquires necessary
+ * locks, and initializes the state required for doing the copy.
  */
 static void
 CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -215,7 +215,8 @@ CreateRemoteFileDestReceiver(char *resultId, EState *executorState,
 
 /*
  * RemoteFileDestReceiverStartup implements the rStartup interface of
- * RemoteFileDestReceiver. It opens the relation
+ * RemoteFileDestReceiver. It opens connections to the nodes in initialNodeList,
+ * and sends the COPY command on all connections.
  */
 static void
 RemoteFileDestReceiverStartup(DestReceiver *dest, int operation,


### PR DESCRIPTION
Noticed this while reading the code to understand how an INSERT INTO in a CTE expression works ...