### PR TITLE
Make sure that the regression tests are resistant to execution order changes

### DIFF
--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -671,7 +671,7 @@ ALTER TABLE referencing_table DROP CONSTRAINT test_constraint;
 -- test MATCH SIMPLE
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH SIMPLE;
 INSERT INTO referencing_table VALUES(null, 2);
-SELECT * FROM referencing_table;
+SELECT * FROM referencing_table ORDER BY 1,2;
  id | ref_id 
 ----+--------
  10 |      1

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -1025,24 +1025,25 @@ SET citus.enable_repartition_joins TO OFF;
 -- handled by real-time executor
 SELECT *
 	FROM articles_hash
-	WHERE author_id >= 1 AND author_id <= 3;
+	WHERE author_id >= 1 AND author_id <= 3
+ORDER BY 1,2,3,4;
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
+  2 |         2 | abducing     |      13642
   3 |         3 | asternal     |      10480
  11 |         1 | alamo        |       1347
+ 12 |         2 | archiblast   |      18185
  13 |         3 | aseyev       |       2255
  21 |         1 | arcading     |       5890
+ 22 |         2 | antipope     |       2728
  23 |         3 | abhorring    |       6799
  31 |         1 | athwartships |       7271
+ 32 |         2 | amazon       |      11342
  33 |         3 | autochrome   |       8180
  41 |         1 | aznavour     |      11814
- 43 |         3 | affixal      |      12723
-  2 |         2 | abducing     |      13642
- 12 |         2 | archiblast   |      18185
- 22 |         2 | antipope     |       2728
- 32 |         2 | amazon       |      11342
  42 |         2 | ausable      |      15885
+ 43 |         3 | affixal      |      12723
 (15 rows)
 
 SET citus.task_executor_type TO 'real-time';

--- a/src/test/regress/sql/multi_foreign_key.sql
+++ b/src/test/regress/sql/multi_foreign_key.sql
@@ -392,7 +392,7 @@ ALTER TABLE referencing_table DROP CONSTRAINT test_constraint;
 -- test MATCH SIMPLE
 ALTER TABLE referencing_table ADD CONSTRAINT test_constraint FOREIGN KEY(ref_id, id) REFERENCES referenced_table(id, test_column) MATCH SIMPLE;
 INSERT INTO referencing_table VALUES(null, 2);
-SELECT * FROM referencing_table;
+SELECT * FROM referencing_table ORDER BY 1,2;
 DELETE FROM referencing_table WHERE ref_id = 2;
 ALTER TABLE referencing_table DROP CONSTRAINT test_constraint;
 

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -473,7 +473,8 @@ SET citus.enable_repartition_joins TO OFF;
 -- handled by real-time executor
 SELECT *
 	FROM articles_hash
-	WHERE author_id >= 1 AND author_id <= 3;
+	WHERE author_id >= 1 AND author_id <= 3
+ORDER BY 1,2,3,4;
 
 SET citus.task_executor_type TO 'real-time';
 


### PR DESCRIPTION
Same as #2657.

Since the changes are very trivial and only in the regression tests, I'll go ahead and merge once the tests pass.