### PR TITLE
Fix wrong transaction recovery test output

### DIFF
--- a/src/test/regress/expected/multi_transaction_recovery.out
+++ b/src/test/regress/expected/multi_transaction_recovery.out
@@ -224,7 +224,10 @@ SELECT recover_prepared_transactions();
 (1 row)
 
 -- Create a single-replica table to enable 2PC in multi-statement transactions
+SET citus.shard_replication_factor TO 1;
 CREATE TABLE test_recovery_single (LIKE test_recovery);
+-- creating distributed table should write 2 transaction recovery records
+-- one connection/transaction per node
 SELECT create_distributed_table('test_recovery_single', 'x');
  create_distributed_table 
 --------------------------
@@ -232,6 +235,8 @@ SELECT create_distributed_table('test_recovery_single', 'x');
 (1 row)
 
 -- Multi-statement transactions should write 2 transaction recovery records
+-- since the transaction block expands the nodes that participate in the
+-- distributed transaction
 BEGIN;
 INSERT INTO test_recovery_single VALUES ('hello-0');
 INSERT INTO test_recovery_single VALUES ('hello-2');
@@ -239,7 +244,7 @@ COMMIT;
 SELECT count(*) FROM pg_dist_transaction;
  count 
 -------
-     2
+     4
 (1 row)
 
 -- Test whether auto-recovery runs

--- a/src/test/regress/sql/multi_transaction_recovery.sql
+++ b/src/test/regress/sql/multi_transaction_recovery.sql
@@ -110,10 +110,16 @@ SELECT count(*) FROM pg_dist_transaction;
 SELECT recover_prepared_transactions();
 
 -- Create a single-replica table to enable 2PC in multi-statement transactions
+SET citus.shard_replication_factor TO 1;
 CREATE TABLE test_recovery_single (LIKE test_recovery);
+
+-- creating distributed table should write 2 transaction recovery records
+-- one connection/transaction per node
 SELECT create_distributed_table('test_recovery_single', 'x');
 
 -- Multi-statement transactions should write 2 transaction recovery records
+-- since the transaction block expands the nodes that participate in the
+-- distributed transaction
 BEGIN;
 INSERT INTO test_recovery_single VALUES ('hello-0');
 INSERT INTO test_recovery_single VALUES ('hello-2');


### PR DESCRIPTION
If replication factor eqauls to 2 and there are two worker nodes,
even if two modifications hit different shards, Citus doesn't use
2PC. The reason is that it doesn't fit into the definition of
"expanding participating worker nodes".

Thus, we're simply fixing the test to fit in the comment
on top of it.

Came up during #2713 