### PR TITLE
Simplify round robin logic on router queries

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -174,7 +174,6 @@ static bool HasMergeTaskDependencies(List *sqlTaskList);
 static List * GreedyAssignTaskList(List *taskList);
 static Task * GreedyAssignTask(WorkerNode *workerNode, List *taskList,
 							   List *activeShardPlacementLists);
-static List * RoundRobinReorder(Task *task, List *placementList);
 static List * ReorderAndAssignTaskList(List *taskList,
 									   List * (*reorderFunction)(Task *, List *));
 static int CompareTasksByShardId(const void *leftElement, const void *rightElement);
@@ -5088,7 +5087,7 @@ RoundRobinAssignTaskList(List *taskList)
  * Citus generates since the distributed transactionId is generated during the execution
  * where as task-assignment happens duing the planning.
  */
-static List *
+List *
 RoundRobinReorder(Task *task, List *placementList)
 {
 	TransactionId transactionId = GetMyProcLocalTransactionId();

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -351,7 +351,6 @@ extern List * TaskListDifference(const List *list1, const List *list2);
 extern List * AssignAnchorShardTaskList(List *taskList);
 extern List * FirstReplicaAssignTaskList(List *taskList);
 extern List * RoundRobinAssignTaskList(List *taskList);
-extern List * RoundRobinPerTransactionAssignTaskList(List *taskList);
 extern int CompareTasksByTaskId(const void *leftElement, const void *rightElement);
 
 /* function declaration for creating Task */

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -351,6 +351,7 @@ extern List * TaskListDifference(const List *list1, const List *list2);
 extern List * AssignAnchorShardTaskList(List *taskList);
 extern List * FirstReplicaAssignTaskList(List *taskList);
 extern List * RoundRobinAssignTaskList(List *taskList);
+extern List * RoundRobinReorder(Task *task, List *placementList);
 extern int CompareTasksByTaskId(const void *leftElement, const void *rightElement);
 
 /* function declaration for creating Task */

--- a/src/test/regress/expected/multi_task_assignment_policy.out
+++ b/src/test/regress/expected/multi_task_assignment_policy.out
@@ -19,17 +19,16 @@ DECLARE
        shardOfTheTask text;
 begin
   for r in execute qry loop
-       IF r LIKE '%port%' THEN
-       portOfTheTask = substring(r, '([0-9]{1,10})');
+    IF r LIKE '%port%' THEN
+      portOfTheTask = substring(r, '([0-9]{1,10})');
     END IF;
 
     IF r LIKE '%' || table_name || '%' THEN
-       shardOfTheTask = substring(r, '([0-9]{1,10})');
-       return QUERY SELECT  shardOfTheTask || '@' || portOfTheTask ;
+      shardOfTheTask = substring(r, '([0-9]{5,10})');
     END IF;
 
   end loop;
-  return;
+  return QUERY SELECT shardOfTheTask || '@' || portOfTheTask;
 end; $$ language plpgsql;
 SET citus.explain_distributed_queries TO off;
 -- Check that our policies for assigning tasks to worker nodes run as expected.
@@ -300,11 +299,8 @@ SELECT count(DISTINCT value) FROM explain_outputs;
 (1 row)
 
 TRUNCATE explain_outputs;
-RESET citus.task_assignment_policy;
-RESET client_min_messages;
--- we should be able to use round-robin with router queries that 
+-- We should be able to use round-robin with router queries that
 -- only contains intermediate results
-BEGIN;
 CREATE TABLE task_assignment_test_table_2 (test_id integer);
 SELECT create_distributed_table('task_assignment_test_table_2', 'test_id');
  create_distributed_table 
@@ -312,17 +308,26 @@ SELECT create_distributed_table('task_assignment_test_table_2', 'test_id');
  
 (1 row)
 
-WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
- test_id 
----------
-(0 rows)
+SET citus.task_assignment_policy TO 'round-robin';
+-- Run the query two times to make sure that it hits two different workers
+-- on consecutive runs
+INSERT INTO explain_outputs
+SELECT parse_explain_output($cmd$
+EXPLAIN WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1
+$cmd$, 'task_assignment_test_table_2');
+INSERT INTO explain_outputs
+SELECT parse_explain_output($cmd$
+EXPLAIN WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1
+$cmd$, 'task_assignment_test_table_2');
+-- The count should be 2 since the intermediate results are processed on
+-- different workers
+SELECT count(DISTINCT value) FROM explain_outputs;
+ count 
+-------
+     2
+(1 row)
 
-SET LOCAL citus.task_assignment_policy TO 'round-robin';
-WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
- test_id 
----------
-(0 rows)
-
-ROLLBACK;
+RESET citus.task_assignment_policy;
+RESET client_min_messages;
 DROP TABLE task_assignment_replicated_hash, task_assignment_nonreplicated_hash,
-  task_assignment_reference_table, explain_outputs;
+  task_assignment_reference_table, task_assignment_test_table_2, explain_outputs;

--- a/src/test/regress/sql/multi_task_assignment_policy.sql
+++ b/src/test/regress/sql/multi_task_assignment_policy.sql
@@ -18,17 +18,16 @@ DECLARE
        shardOfTheTask text;
 begin
   for r in execute qry loop
-       IF r LIKE '%port%' THEN
-       portOfTheTask = substring(r, '([0-9]{1,10})');
+    IF r LIKE '%port%' THEN
+      portOfTheTask = substring(r, '([0-9]{1,10})');
     END IF;
 
     IF r LIKE '%' || table_name || '%' THEN
-       shardOfTheTask = substring(r, '([0-9]{1,10})');
-       return QUERY SELECT  shardOfTheTask || '@' || portOfTheTask ;
+      shardOfTheTask = substring(r, '([0-9]{5,10})');
     END IF;
 
   end loop;
-  return;
+  return QUERY SELECT shardOfTheTask || '@' || portOfTheTask;
 end; $$ language plpgsql;
 
 
@@ -236,19 +235,31 @@ $cmd$, 'task_assignment_nonreplicated_hash');
 SELECT count(DISTINCT value) FROM explain_outputs;
 TRUNCATE explain_outputs;
 
-RESET citus.task_assignment_policy;
-RESET client_min_messages;
-
--- we should be able to use round-robin with router queries that 
+-- We should be able to use round-robin with router queries that
 -- only contains intermediate results
-BEGIN;
 CREATE TABLE task_assignment_test_table_2 (test_id integer);
 SELECT create_distributed_table('task_assignment_test_table_2', 'test_id');
 
-WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
-SET LOCAL citus.task_assignment_policy TO 'round-robin';
-WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1;
-ROLLBACK;
+SET citus.task_assignment_policy TO 'round-robin';
+
+-- Run the query two times to make sure that it hits two different workers
+-- on consecutive runs
+INSERT INTO explain_outputs
+SELECT parse_explain_output($cmd$
+EXPLAIN WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1
+$cmd$, 'task_assignment_test_table_2');
+
+INSERT INTO explain_outputs
+SELECT parse_explain_output($cmd$
+EXPLAIN WITH q1 AS (SELECT * FROM task_assignment_test_table_2) SELECT * FROM q1
+$cmd$, 'task_assignment_test_table_2');
+
+-- The count should be 2 since the intermediate results are processed on
+-- different workers
+SELECT count(DISTINCT value) FROM explain_outputs;
+
+RESET citus.task_assignment_policy;
+RESET client_min_messages;
 
 DROP TABLE task_assignment_replicated_hash, task_assignment_nonreplicated_hash,
-  task_assignment_reference_table, explain_outputs;
+  task_assignment_reference_table, task_assignment_test_table_2, explain_outputs;


### PR DESCRIPTION
DESCRIPTION: Improves round robin logic on router queries

This PR includes 2 minor improvements to Router queries with Round-Robin policy.

- If a query is router executable, we create a Task list that contains a single task. Therefore there is no need to sort it.
- For creating a router plan, the list of active shard placements are already calculated, no need to repeat this logic in calls to `RoundRobinAssignTaskList()` in physical planner. Thus I replaced this function call with a simpler alternative

The changes here are advised by @marcocitus https://github.com/citusdata/citus/issues/2595#issuecomment-492248397. Closes #2595 