### PR TITLE
Stop using master_modify_multiple_shards in TRUNCATE

### DIFF
--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -1111,6 +1111,16 @@ SELECT create_distributed_table('"CiTUS.TEEN2"."CAPITAL_TABLE"', 'i');
  
 (1 row)
 
+-- truncate tables with weird names
+INSERT INTO "CiTuS.TeeN"."TeeNTabLE.1!?!" VALUES(1, 1);
+INSERT INTO "CiTUS.TEEN2"."CAPITAL_TABLE" VALUES(0, 1);
+TRUNCATE "CiTuS.TeeN"."TeeNTabLE.1!?!", "CiTUS.TEEN2"."CAPITAL_TABLE";
+SELECT count(*) FROM "CiTUS.TEEN2"."CAPITAL_TABLE";
+ count 
+-------
+     0
+(1 row)
+
 -- insert into table with weird names
 INSERT INTO "CiTuS.TeeN"."TeeNTabLE.1!?!" VALUES(1, 1),(1, 0),(0, 1),(2, 3),(3, 2),(4, 4);
 INSERT INTO "CiTUS.TEEN2"."CAPITAL_TABLE" VALUES(0, 1),(1, 0),(2, 1),(4, 3),(3, 2),(4, 4);

--- a/src/test/regress/expected/multi_truncate.out
+++ b/src/test/regress/expected/multi_truncate.out
@@ -2,6 +2,8 @@
 -- MULTI_TRUNCATE
 --
 SET citus.next_shard_id TO 1210000;
+CREATE SCHEMA multi_truncate;
+SET search_path TO multi_truncate;
 --
 -- truncate for append distribution
 -- expect all shards to be dropped
@@ -362,4 +364,5 @@ SELECT * FROM test_local_truncate;
  1 | 2
 (1 row)
 
-DROP TABLE test_local_truncate;
+DROP SCHEMA multi_truncate CASCADE;
+NOTICE:  drop cascades to table test_local_truncate

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -798,6 +798,12 @@ CREATE TABLE "CiTUS.TEEN2"."CAPITAL_TABLE"(i int, j int);
 SELECT create_distributed_table('"CiTuS.TeeN"."TeeNTabLE.1!?!"', 'TeNANt_Id');
 SELECT create_distributed_table('"CiTUS.TEEN2"."CAPITAL_TABLE"', 'i');
 
+-- truncate tables with weird names
+INSERT INTO "CiTuS.TeeN"."TeeNTabLE.1!?!" VALUES(1, 1);
+INSERT INTO "CiTUS.TEEN2"."CAPITAL_TABLE" VALUES(0, 1);
+TRUNCATE "CiTuS.TeeN"."TeeNTabLE.1!?!", "CiTUS.TEEN2"."CAPITAL_TABLE";
+SELECT count(*) FROM "CiTUS.TEEN2"."CAPITAL_TABLE";
+
 -- insert into table with weird names
 INSERT INTO "CiTuS.TeeN"."TeeNTabLE.1!?!" VALUES(1, 1),(1, 0),(0, 1),(2, 3),(3, 2),(4, 4);
 INSERT INTO "CiTUS.TEEN2"."CAPITAL_TABLE" VALUES(0, 1),(1, 0),(2, 1),(4, 3),(3, 2),(4, 4);

--- a/src/test/regress/sql/multi_truncate.sql
+++ b/src/test/regress/sql/multi_truncate.sql
@@ -4,6 +4,8 @@
 
 
 SET citus.next_shard_id TO 1210000;
+CREATE SCHEMA multi_truncate;
+SET search_path TO multi_truncate;
 
 --
 -- truncate for append distribution
@@ -220,4 +222,4 @@ DELETE FROM pg_dist_partition WHERE logicalrelid = 'test_local_truncate'::regcla
 -- Ensure local data is not truncated
 SELECT * FROM test_local_truncate;
 
-DROP TABLE test_local_truncate;
+DROP SCHEMA multi_truncate CASCADE;


### PR DESCRIPTION
We currently rely on `master_modify_multiple_shards` in truncate, but I plan to deprecate and remove that function. This PR changes the truncate implementation to construct a task list and execute it directly. I considered calling `ExecuteDistributedDDLJob`, but we do not want the truncate to propagate to workers with metadata in MX.

We should clean up truncate further and handle it fully in the utility hook, since the current trigger-based implementation complicates upgrades and causes issues like #2630 .