### PR TITLE
Deprecate master_modify_multiple_shards

### DIFF
--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -162,7 +162,7 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 							   "command"),
 						errdetail("Delete statements on hash-partitioned tables "
 								  "are not supported with master_apply_delete_command."),
-						errhint("Use master_modify_multiple_shards command instead.")));
+						errhint("Use the DELETE command instead.")));
 	}
 	else if (partitionMethod == DISTRIBUTE_BY_NONE)
 	{

--- a/src/test/regress/expected/isolation_append_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_append_copy_vs_all.out
@@ -299,23 +299,6 @@ count
 
 10             
 
-starting permutation: s1-initialize s1-begin s1-copy s2-master-modify-multiple-shards s1-commit s1-select-count
-create_distributed_table
-
-               
-step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
-step s1-begin: BEGIN;
-step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM append_copy;');
-master_modify_multiple_shards
-
-5              
-step s1-commit: COMMIT;
-step s1-select-count: SELECT COUNT(*) FROM append_copy;
-count          
-
-5              
-
 starting permutation: s1-initialize s1-begin s1-copy s2-master-apply-delete-command s1-commit s1-select-count
 create_distributed_table
 
@@ -637,23 +620,6 @@ step s1-select-count: SELECT COUNT(*) FROM append_copy;
 count          
 
 10             
-
-starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-copy s1-commit s1-select-count
-create_distributed_table
-
-               
-step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
-step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM append_copy;');
-master_modify_multiple_shards
-
-5              
-step s2-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s1-commit: COMMIT;
-step s1-select-count: SELECT COUNT(*) FROM append_copy;
-count          
-
-5              
 
 starting permutation: s1-initialize s1-begin s1-master-apply-delete-command s2-copy s1-commit s1-select-count
 create_distributed_table

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -36,16 +36,16 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT worker_apply_shard_ddl_command (105961, 'public', '
+SELECT worker_apply_shard_ddl_command (105941, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (105960, 'public', '
+SELECT worker_apply_shard_ddl_command (105940, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (105959, 'public', '
+SELECT worker_apply_shard_ddl_command (105939, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (105958, 'public', '
+SELECT worker_apply_shard_ddl_command (105938, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
@@ -98,7 +98,7 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
 
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-INSERT INTO public.test_table_105964 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+INSERT INTO public.test_table_105944 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -150,10 +150,10 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
 
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105969 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105968 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105967 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105966 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105949 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105948 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105947 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105946 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -205,7 +205,7 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
 
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM public.test_table_105971 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_105951 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 COMMIT         localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;

--- a/src/test/regress/expected/isolation_ddl_vs_all.out
+++ b/src/test/regress/expected/isolation_ddl_vs_all.out
@@ -310,12 +310,9 @@ step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id);
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM ddl_hash; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-5              
 step s2-commit: COMMIT;
 step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash%''');
 run_command_on_workers
@@ -384,12 +381,9 @@ step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM ddl_hash; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-5              
 step s2-commit: COMMIT;
 step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
 run_command_on_workers
@@ -458,12 +452,9 @@ step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM ddl_hash; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-5              
 step s2-commit: COMMIT;
 step s1-show-columns: SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1');
 run_command_on_workers
@@ -530,10 +521,7 @@ create_distributed_table
 step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM ddl_hash;
 step s2-ddl-create-index: CREATE INDEX ddl_hash_index ON ddl_hash(id); <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-create-index: <... completed>
@@ -600,10 +588,7 @@ create_distributed_table
                
 step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM ddl_hash;
 step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-create-index-concurrently: <... completed>
@@ -670,10 +655,7 @@ create_distributed_table
 step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM ddl_hash;
 step s2-ddl-add-column: ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-add-column: <... completed>
@@ -743,10 +725,7 @@ create_distributed_table
 step s1-initialize: COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM ddl_hash;
 step s2-ddl-rename-column: ALTER TABLE ddl_hash RENAME data TO new_column; <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-rename-column: <... completed>

--- a/src/test/regress/expected/isolation_delete_vs_all.out
+++ b/src/test/regress/expected/isolation_delete_vs_all.out
@@ -230,29 +230,6 @@ restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s2-begin s1-delete s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
-create_distributed_table
-
-               
-step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
-step s1-begin: BEGIN;
-step s2-begin: BEGIN;
-step s1-delete: DELETE FROM delete_hash WHERE id = 4;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM delete_hash;'); <waiting ...>
-step s1-commit: COMMIT;
-step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-4              
-step s2-commit: COMMIT;
-step s1-select-count: SELECT COUNT(*) FROM delete_hash;
-count          
-
-0              
-restore_isolation_tester_func
-
-               
-
 starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-delete s2-distribute-table s1-commit s2-commit s1-select-count
 create_distributed_table
 
@@ -462,29 +439,6 @@ step s1-select-count: SELECT COUNT(*) FROM delete_hash;
 count          
 
 4              
-restore_isolation_tester_func
-
-               
-
-starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-delete s1-commit s2-commit s1-select-count
-create_distributed_table
-
-               
-step s1-initialize: COPY delete_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
-step s1-begin: BEGIN;
-step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM delete_hash;');
-master_modify_multiple_shards
-
-5              
-step s2-delete: DELETE FROM delete_hash WHERE id = 4; <waiting ...>
-step s1-commit: COMMIT;
-step s2-delete: <... completed>
-step s2-commit: COMMIT;
-step s1-select-count: SELECT COUNT(*) FROM delete_hash;
-count          
-
-0              
 restore_isolation_tester_func
 
                

--- a/src/test/regress/expected/isolation_drop_vs_all.out
+++ b/src/test/regress/expected/isolation_drop_vs_all.out
@@ -182,24 +182,6 @@ restore_isolation_tester_func
 
                
 
-starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-master-modify-multiple-shards s1-commit s2-commit s1-select-count
-create_distributed_table
-
-               
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
-step s1-begin: BEGIN;
-step s2-begin: BEGIN;
-step s1-drop: DROP TABLE drop_hash;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DROP FROM drop_hash;');
-ERROR:  syntax error at or near "FROM"
-step s1-commit: COMMIT;
-step s2-commit: COMMIT;
-step s1-select-count: SELECT COUNT(*) FROM drop_hash;
-ERROR:  relation "drop_hash" does not exist
-restore_isolation_tester_func
-
-               
-
 starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-drop s2-distribute-table s1-commit s2-commit s1-select-count
 create_distributed_table
 
@@ -349,24 +331,6 @@ step s1-table-size: SELECT citus_total_relation_size('drop_hash');
 citus_total_relation_size
 
 57344          
-step s2-drop: DROP TABLE drop_hash;
-step s1-commit: COMMIT;
-step s2-commit: COMMIT;
-step s1-select-count: SELECT COUNT(*) FROM drop_hash;
-ERROR:  relation "drop_hash" does not exist
-restore_isolation_tester_func
-
-               
-
-starting permutation: s1-initialize s1-begin s2-begin s1-master-modify-multiple-shards s2-drop s1-commit s2-commit s1-select-count
-create_distributed_table
-
-               
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
-step s1-begin: BEGIN;
-step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DROP FROM drop_hash;');
-ERROR:  syntax error at or near "FROM"
 step s2-drop: DROP TABLE drop_hash;
 step s1-commit: COMMIT;
 step s2-commit: COMMIT;

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -306,10 +306,7 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM hash_copy;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
@@ -442,12 +439,9 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM hash_copy; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-10             
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count          
 
@@ -726,10 +720,7 @@ create_distributed_table
                
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM hash_copy;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM hash_copy;
 step s2-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;

--- a/src/test/regress/expected/isolation_insert_select_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_select_vs_all.out
@@ -288,10 +288,7 @@ step s1-initialize:
 
 step s1-begin: BEGIN;
 step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
-step s2-master-modify-multiple-shards-on-inserted: SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;');
-master_modify_multiple_shards
-
-10             
+step s2-master-modify-multiple-shards-on-inserted: DELETE FROM insert_of_insert_select_hash;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
 count          
@@ -607,10 +604,7 @@ step s1-initialize:
 
 step s1-begin: BEGIN;
 step s1-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;;
-step s2-master-modify-multiple-shards-on-selected: SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;');
-master_modify_multiple_shards
-
-10             
+step s2-master-modify-multiple-shards-on-selected: DELETE FROM select_of_insert_select_hash;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
 count          
@@ -903,10 +897,7 @@ step s1-initialize:
 	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a && echo 6, b && echo 7, c && echo 8, d && echo 9, e' WITH CSV;
 
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards-on-inserted: SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;');
-master_modify_multiple_shards
-
-10             
+step s1-master-modify-multiple-shards-on-inserted: DELETE FROM insert_of_insert_select_hash;
 step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;
@@ -1200,10 +1191,7 @@ step s1-initialize:
 	COPY select_of_insert_select_hash FROM PROGRAM 'echo 5, a && echo 6, b && echo 7, c && echo 8, d && echo 9, e' WITH CSV;
 
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards-on-selected: SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;');
-master_modify_multiple_shards
-
-10             
+step s1-master-modify-multiple-shards-on-selected: DELETE FROM select_of_insert_select_hash;
 step s2-insert-select: INSERT INTO insert_of_insert_select_hash SELECT * FROM select_of_insert_select_hash ORDER BY 1, 2 LIMIT 5;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_of_insert_select_hash;

--- a/src/test/regress/expected/isolation_insert_vs_all.out
+++ b/src/test/regress/expected/isolation_insert_vs_all.out
@@ -272,10 +272,7 @@ create_distributed_table
 step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert: INSERT INTO insert_hash VALUES(7, 'k');
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM insert_hash;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
@@ -498,10 +495,7 @@ create_distributed_table
                
 step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM insert_hash;
 step s2-insert: INSERT INTO insert_hash VALUES(7, 'k');
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
@@ -745,10 +739,7 @@ create_distributed_table
 step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM insert_hash;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;
 count          
@@ -971,10 +962,7 @@ create_distributed_table
                
 step s1-initialize: COPY insert_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM insert_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM insert_hash;
 step s2-insert-multi-row: INSERT INTO insert_hash VALUES(7, 'k'), (8, 'l'), (9, 'm');
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM insert_hash;

--- a/src/test/regress/expected/isolation_partitioned_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_partitioned_copy_vs_all.out
@@ -245,10 +245,7 @@ create_distributed_table
 step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM partitioned_copy;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
 count          
@@ -525,10 +522,7 @@ create_distributed_table
                
 step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM partitioned_copy;
 step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;

--- a/src/test/regress/expected/isolation_partitioned_copy_vs_all_0.out
+++ b/src/test/regress/expected/isolation_partitioned_copy_vs_all_0.out
@@ -245,10 +245,7 @@ create_distributed_table
 step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM partitioned_copy;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;
 count          
@@ -525,10 +522,7 @@ create_distributed_table
                
 step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM partitioned_copy;
 step s2-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM partitioned_copy;

--- a/src/test/regress/expected/isolation_range_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_range_copy_vs_all.out
@@ -306,10 +306,7 @@ create_distributed_table
 step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM range_copy;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM range_copy;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM range_copy;
 count          
@@ -644,10 +641,7 @@ create_distributed_table
                
 step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM range_copy;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM range_copy;
 step s2-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM range_copy;

--- a/src/test/regress/expected/isolation_reference_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_reference_copy_vs_all.out
@@ -309,12 +309,9 @@ create_reference_table
 step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5  && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM reference_copy;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM reference_copy; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-10             
 step s1-select-count: SELECT COUNT(*) FROM reference_copy;
 count          
 
@@ -616,10 +613,7 @@ create_reference_table
                
 step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM reference_copy;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM reference_copy;
 step s2-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV; <waiting ...>
 step s1-commit: COMMIT;
 step s2-copy: <... completed>

--- a/src/test/regress/expected/isolation_select_vs_all.out
+++ b/src/test/regress/expected/isolation_select_vs_all.out
@@ -516,10 +516,7 @@ step s1-router-select: SELECT * FROM select_append WHERE id = 1;
 id             data           int_data       
 
 1               b             1              
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM select_append;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
@@ -819,10 +816,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM select_append;
 step s2-router-select: SELECT * FROM select_append WHERE id = 1;
 id             data           int_data       
 
@@ -1211,10 +1205,7 @@ id             data           int_data
 2               c             2              
 3               d             3              
 4               e             4              
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM select_append;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
@@ -1522,10 +1513,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM select_append;
 step s2-real-time-select: SELECT * FROM select_append ORDER BY 1, 2;
 id             data           int_data       
 
@@ -1928,10 +1916,7 @@ id             data           int_data       id             data           int_d
 2               c             2              2               c             2              
 3               d             3              3               d             3              
 4               e             4              4               e             4              
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
-master_modify_multiple_shards
-
-5              
+step s2-master-modify-multiple-shards: DELETE FROM select_append;
 step s1-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 count          
@@ -2278,10 +2263,7 @@ create_distributed_table
                
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM select_append;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM select_append;
 step s2-task-tracker-select: 
 	SET citus.task_executor_type TO "task-tracker";
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;

--- a/src/test/regress/expected/isolation_truncate_vs_all.out
+++ b/src/test/regress/expected/isolation_truncate_vs_all.out
@@ -239,12 +239,9 @@ step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a && echo 1, b &&
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-truncate: TRUNCATE truncate_append;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM truncate_append;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM truncate_append; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-0              
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM truncate_append;
 count          
@@ -519,10 +516,7 @@ create_distributed_table
 step s1-initialize: COPY truncate_append FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM truncate_append;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM truncate_append;
 step s2-truncate: TRUNCATE truncate_append; <waiting ...>
 step s1-commit: COMMIT;
 step s2-truncate: <... completed>

--- a/src/test/regress/expected/isolation_update_vs_all.out
+++ b/src/test/regress/expected/isolation_update_vs_all.out
@@ -258,12 +258,9 @@ step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a && echo 1, b && ech
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-update: UPDATE update_hash SET data = 'l' WHERE id = 4;
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM update_hash; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-5              
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM update_hash;
 count          
@@ -514,10 +511,7 @@ create_distributed_table
 step s1-initialize: COPY update_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM update_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM update_hash;
 step s2-update: UPDATE update_hash SET data = 'l' WHERE id = 4; <waiting ...>
 step s1-commit: COMMIT;
 step s2-update: <... completed>

--- a/src/test/regress/expected/isolation_upsert_vs_all.out
+++ b/src/test/regress/expected/isolation_upsert_vs_all.out
@@ -278,12 +278,9 @@ step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a && echo 1, b && ech
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k';
-step s2-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;'); <waiting ...>
+step s2-master-modify-multiple-shards: DELETE FROM upsert_hash; <waiting ...>
 step s1-commit: COMMIT;
 step s2-master-modify-multiple-shards: <... completed>
-master_modify_multiple_shards
-
-5              
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM upsert_hash;
 count          
@@ -554,10 +551,7 @@ create_distributed_table
 step s1-initialize: COPY upsert_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
-step s1-master-modify-multiple-shards: SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;');
-master_modify_multiple_shards
-
-5              
+step s1-master-modify-multiple-shards: DELETE FROM upsert_hash;
 step s2-upsert: INSERT INTO upsert_hash VALUES(4, 'k') ON CONFLICT(id) DO UPDATE SET data = 'k'; <waiting ...>
 step s1-commit: COMMIT;
 step s2-upsert: <... completed>

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -194,12 +194,7 @@ SELECT * FROM referenced_table;
 -- multi shard cascading delete
 INSERT INTO referenced_table VALUES(2, 2);
 INSERT INTO referencing_table VALUES(2, 2);
-SELECT master_modify_multiple_shards('DELETE FROM referenced_table');
- master_modify_multiple_shards 
--------------------------------
-                             1
-(1 row)
-
+DELETE FROM referenced_table;
 SELECT * FROM referencing_table;
  id | ref_id 
 ----+--------
@@ -210,12 +205,7 @@ INSERT INTO referenced_table VALUES(3, 3);
 INSERT INTO referencing_table VALUES(3, 3);
 BEGIN;
 ALTER TABLE referencing_table ADD COLUMN x int DEFAULT 0;
-SELECT master_modify_multiple_shards('DELETE FROM referenced_table');
- master_modify_multiple_shards 
--------------------------------
-                             1
-(1 row)
-
+DELETE FROM referenced_table;
 COMMIT;
 DROP TABLE referencing_table;
 DROP TABLE referenced_table;

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1088,14 +1088,6 @@ UPDATE reference_summary_table SET average_value = average_query.average FROM (
 	) average_query
 WHERE id = 1;
 ERROR:  cannot perform select on a distributed table and modify a reference table
--- test master_modify_multiple_shards() with subqueries and expect to fail
-SELECT master_modify_multiple_shards('
-	UPDATE summary_table SET average_value = average_query.average FROM (
-		SELECT avg(value) AS average FROM raw_table WHERE id = 1
-		) average_query
-	WHERE id = 1');
-ERROR:  cannot run multi shard modify query with master_modify_multiple_shards when the query involves subquery or join
-DETAIL:  Execute the query without using master_modify_multiple_shards()
 -- test connection API via using COPY
 -- COPY on SELECT part
 BEGIN;

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -457,12 +457,7 @@ ROLLBACK;
 -- multi-shard operations can co-exist with DDL in a transactional way
 BEGIN;
 ALTER TABLE labs ADD COLUMN motto text;
-SELECT master_modify_multiple_shards('DELETE FROM labs');
- master_modify_multiple_shards 
--------------------------------
-                             8
-(1 row)
-
+DELETE FROM labs;
 ALTER TABLE labs ADD COLUMN score float;
 ROLLBACK;
 -- should have rolled everything back
@@ -1540,12 +1535,7 @@ ERROR:  cannot perform query with placements that were modified over multiple co
 END;
 -- make sure we can see cascading deletes
 BEGIN;
-SELECT master_modify_multiple_shards('DELETE FROM users');
- master_modify_multiple_shards 
--------------------------------
-                             2
-(1 row)
-
+DELETE FROM users;
 SELECT user_id FROM items JOIN itemgroups ON (item_group = gid) WHERE user_id = 1;
  user_id 
 ---------

--- a/src/test/regress/expected/multi_mx_ddl.out
+++ b/src/test/regress/expected/multi_mx_ddl.out
@@ -19,12 +19,7 @@ CREATE INDEX CONCURRENTLY ddl_test_concurrent_index ON mx_ddl_table(value);
 ALTER TABLE mx_ddl_table ADD COLUMN version INTEGER;
 -- SET DEFAULT
 ALTER TABLE mx_ddl_table ALTER COLUMN version SET DEFAULT 1; 
-SELECT master_modify_multiple_shards('UPDATE mx_ddl_table SET version=0.1 WHERE version IS NULL');
- master_modify_multiple_shards 
--------------------------------
-                             8
-(1 row)
-
+UPDATE mx_ddl_table SET version=0.1 WHERE version IS NULL;
 -- SET NOT NULL
 ALTER TABLE mx_ddl_table ALTER COLUMN version SET NOT NULL;
 -- See that the changes are applied on coordinator, worker tables and shards

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -475,14 +475,8 @@ SELECT * FROM partitioning_test_default ORDER BY 1, 2;
  22 | 04-02-2015
 (1 row)
 
--- test master_modify_multiple_shards
--- master_modify_multiple_shards on partitioned table
-SELECT master_modify_multiple_shards('UPDATE partitioning_test SET time = time + INTERVAL ''1 day''');
- master_modify_multiple_shards 
--------------------------------
-                            26
-(1 row)
-
+-- multi-shard UPDATE on partitioned table
+UPDATE partitioning_test SET time = time + INTERVAL '1 day';
 -- see rows are UPDATED
 SELECT * FROM partitioning_test ORDER BY 1;
  id |    time    
@@ -515,13 +509,8 @@ SELECT * FROM partitioning_test ORDER BY 1;
  22 | 04-03-2015
 (26 rows)
 
--- master_modify_multiple_shards on partition directly
-SELECT master_modify_multiple_shards('UPDATE partitioning_test_2009 SET time = time + INTERVAL ''1 day''');
- master_modify_multiple_shards 
--------------------------------
-                             6
-(1 row)
-
+-- multi-shard UPDATE on partition directly
+UPDATE partitioning_test_2009 SET time = time + INTERVAL '1 day';
 -- see rows are UPDATED
 SELECT * FROM partitioning_test_2009 ORDER BY 1;
  id |    time    
@@ -534,8 +523,8 @@ SELECT * FROM partitioning_test_2009 ORDER BY 1;
  19 | 02-04-2009
 (6 rows)
 
--- test master_modify_multiple_shards which fails in workers (updated value is outside of partition bounds)
-SELECT master_modify_multiple_shards('UPDATE partitioning_test_2009 SET time = time + INTERVAL ''6 month''');
+-- test multi-shard UPDATE which fails in workers (updated value is outside of partition bounds)
+UPDATE partitioning_test_2009 SET time = time + INTERVAL '6 month';
 ERROR:  new row for relation "partitioning_test_2009_1660005" violates partition constraint
 DETAIL:  Failing row contains (3, 2010-03-11).
 CONTEXT:  while executing command on localhost:57638
@@ -1396,22 +1385,19 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
 (5 rows)
 
 COMMIT;
--- test locks on master_modify_multiple_shards
+-- test locks on multi-shard UPDATE
 BEGIN;
-SELECT master_modify_multiple_shards('UPDATE partitioning_locks SET time = ''2009-03-01''');
- master_modify_multiple_shards 
--------------------------------
-                             0
-(1 row)
-
+UPDATE partitioning_locks SET time = '2009-03-01';
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;
         relation         | locktype |       mode       
 -------------------------+----------+------------------
  partitioning_locks      | relation | AccessShareLock
  partitioning_locks      | relation | RowExclusiveLock
+ partitioning_locks_2009 | relation | AccessShareLock
  partitioning_locks_2009 | relation | RowExclusiveLock
+ partitioning_locks_2010 | relation | AccessShareLock
  partitioning_locks_2010 | relation | RowExclusiveLock
-(4 rows)
+(6 rows)
 
 COMMIT;
 -- test locks on DDL
@@ -1444,14 +1430,9 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
 (8 rows)
 
 COMMIT;
--- test shard resource locks with master_modify_multiple_shards
+-- test shard resource locks with multi-shard UPDATE
 BEGIN;
-SELECT master_modify_multiple_shards('UPDATE partitioning_locks_2009 SET time = ''2009-03-01''');
- master_modify_multiple_shards 
--------------------------------
-                             0
-(1 row)
-
+UPDATE partitioning_locks_2009 SET time = '2009-03-01';
 -- see the locks on parent table
 SELECT
     logicalrelid,

--- a/src/test/regress/expected/multi_partitioning_0.out
+++ b/src/test/regress/expected/multi_partitioning_0.out
@@ -479,14 +479,8 @@ SELECT * FROM partitioning_test_default ORDER BY 1, 2;
 ERROR:  relation "partitioning_test_default" does not exist
 LINE 1: SELECT * FROM partitioning_test_default ORDER BY 1, 2;
                       ^
--- test master_modify_multiple_shards
--- master_modify_multiple_shards on partitioned table
-SELECT master_modify_multiple_shards('UPDATE partitioning_test SET time = time + INTERVAL ''1 day''');
- master_modify_multiple_shards 
--------------------------------
-                            24
-(1 row)
-
+-- multi-shard UPDATE on partitioned table
+UPDATE partitioning_test SET time = time + INTERVAL '1 day';
 -- see rows are UPDATED
 SELECT * FROM partitioning_test ORDER BY 1;
  id |    time    
@@ -517,13 +511,8 @@ SELECT * FROM partitioning_test ORDER BY 1;
  20 | 02-03-2010
 (24 rows)
 
--- master_modify_multiple_shards on partition directly
-SELECT master_modify_multiple_shards('UPDATE partitioning_test_2009 SET time = time + INTERVAL ''1 day''');
- master_modify_multiple_shards 
--------------------------------
-                             6
-(1 row)
-
+-- multi-shard UPDATE on partition directly
+UPDATE partitioning_test_2009 SET time = time + INTERVAL '1 day';
 -- see rows are UPDATED
 SELECT * FROM partitioning_test_2009 ORDER BY 1;
  id |    time    
@@ -536,8 +525,8 @@ SELECT * FROM partitioning_test_2009 ORDER BY 1;
  19 | 02-04-2009
 (6 rows)
 
--- test master_modify_multiple_shards which fails in workers (updated value is outside of partition bounds)
-SELECT master_modify_multiple_shards('UPDATE partitioning_test_2009 SET time = time + INTERVAL ''6 month''');
+-- test multi-shard UPDATE which fails in workers (updated value is outside of partition bounds)
+UPDATE partitioning_test_2009 SET time = time + INTERVAL '6 month';
 ERROR:  new row for relation "partitioning_test_2009_1660005" violates partition constraint
 DETAIL:  Failing row contains (3, 2010-03-11).
 CONTEXT:  while executing command on localhost:57638
@@ -1368,22 +1357,19 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
 (5 rows)
 
 COMMIT;
--- test locks on master_modify_multiple_shards
+-- test locks on multi-shard UPDATE
 BEGIN;
-SELECT master_modify_multiple_shards('UPDATE partitioning_locks SET time = ''2009-03-01''');
- master_modify_multiple_shards 
--------------------------------
-                             0
-(1 row)
-
+UPDATE partitioning_locks SET time = '2009-03-01';
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;
         relation         | locktype |       mode       
 -------------------------+----------+------------------
  partitioning_locks      | relation | AccessShareLock
  partitioning_locks      | relation | RowExclusiveLock
+ partitioning_locks_2009 | relation | AccessShareLock
  partitioning_locks_2009 | relation | RowExclusiveLock
+ partitioning_locks_2010 | relation | AccessShareLock
  partitioning_locks_2010 | relation | RowExclusiveLock
-(4 rows)
+(6 rows)
 
 COMMIT;
 -- test locks on DDL
@@ -1416,14 +1402,9 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
 (8 rows)
 
 COMMIT;
--- test shard resource locks with master_modify_multiple_shards
+-- test shard resource locks with multi-shard UPDATE
 BEGIN;
-SELECT master_modify_multiple_shards('UPDATE partitioning_locks_2009 SET time = ''2009-03-01''');
- master_modify_multiple_shards 
--------------------------------
-                             0
-(1 row)
-
+UPDATE partitioning_locks_2009 SET time = '2009-03-01';
 -- see the locks on parent table
 SELECT
     logicalrelid,

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -440,12 +440,7 @@ SELECT * FROM prepare_table ORDER BY key, value;
   18 |   180
 (36 rows)
 
-SELECT master_modify_multiple_shards('DELETE FROM prepare_table WHERE value >= 70');
- master_modify_multiple_shards 
--------------------------------
-                            12
-(1 row)
-
+DELETE FROM prepare_table WHERE value >= 70;
 -- check router executor select
 PREPARE prepared_router_partition_column_select(int) AS
 	SELECT

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1398,21 +1398,6 @@ DETAIL:  Delete statements on reference tables are not supported.
 SELECT master_create_empty_shard('reference_schema.reference_table_ddl');
 ERROR:  relation "reference_schema.reference_table_ddl" is a reference table
 DETAIL:  We currently don't support creating shards on reference tables
--- master_modify_multiple_shards works, but, does it make sense to use at all?
-INSERT INTO reference_schema.reference_table_ddl (value_2, value_3) VALUES (7, 'aa');
-SELECT master_modify_multiple_shards('DELETE FROM reference_schema.reference_table_ddl WHERE value_2 = 7');
- master_modify_multiple_shards 
--------------------------------
-                             1
-(1 row)
-
-INSERT INTO reference_schema.reference_table_ddl (value_2, value_3) VALUES (7, 'bb');
-SELECT master_modify_multiple_shards('DELETE FROM reference_schema.reference_table_ddl');
- master_modify_multiple_shards 
--------------------------------
-                             1
-(1 row)
-
 -- get/update the statistics
 SELECT part_storage_type, part_key, part_replica_count, part_max_size,
            part_placement_policy
@@ -1426,7 +1411,7 @@ SELECT shardid AS a_shard_id  FROM pg_dist_shard WHERE logicalrelid = 'reference
 SELECT master_update_shard_statistics(:a_shard_id);
  master_update_shard_statistics 
 --------------------------------
-                          16384
+                           8192
 (1 row)
 
 CREATE TABLE append_reference_tmp_table (id INT);
@@ -1607,16 +1592,6 @@ SELECT * FROM reference_table_test;
       10 |       2 | 2       | Fri Dec 02 00:00:00 2016
 (1 row)
 
--- DML+master_modify_multiple_shards is allowed
-BEGIN;
-INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
-SELECT master_modify_multiple_shards('DELETE FROM colocated_table_test');
- master_modify_multiple_shards 
--------------------------------
-                             9
-(1 row)
-
-ROLLBACK;
 -- DDL+DML is allowed
 BEGIN;
 ALTER TABLE reference_table_test ADD COLUMN value_dummy INT;

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -397,15 +397,10 @@ SELECT * FROM nation_hash  WHERE n_nationkey OPERATOR(===) 1;
            1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
 (1 row)
 
--- test with master_modify_multiple_shards
+-- test with multi-shard DML
 SET search_path TO public;
-SELECT master_modify_multiple_shards('UPDATE test_schema_support.nation_hash SET n_regionkey = n_regionkey + 1');
- master_modify_multiple_shards 
--------------------------------
-                             8
-(1 row)
-
---verify master_modify_multiple_shards
+UPDATE test_schema_support.nation_hash SET n_regionkey = n_regionkey + 1;
+--verify modification
 SELECT * FROM test_schema_support.nation_hash ORDER BY 1,2,3,4;
  n_nationkey |          n_name           | n_regionkey |                                                  n_comment                                                  
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
@@ -421,13 +416,8 @@ SELECT * FROM test_schema_support.nation_hash ORDER BY 1,2,3,4;
 
 --test with search_path is set
 SET search_path TO test_schema_support;
-SELECT master_modify_multiple_shards('UPDATE nation_hash SET n_regionkey = n_regionkey + 1');
- master_modify_multiple_shards 
--------------------------------
-                             8
-(1 row)
-
---verify master_modify_multiple_shards
+UPDATE nation_hash SET n_regionkey = n_regionkey + 1;
+--verify modification
 SELECT * FROM nation_hash ORDER BY 1,2,3,4;
  n_nationkey |          n_name           | n_regionkey |                                                  n_comment                                                  
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/multi_shard_modify.out
+++ b/src/test/regress/expected/multi_shard_modify.out
@@ -18,15 +18,19 @@ COPY multi_shard_modify_test (t_key, t_name, t_value) FROM STDIN WITH (FORMAT 'c
 -- Verify that master_modify_multiple_shards can be rolled back
 BEGIN;
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key > 10 AND t_key <= 13');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             3
+                             0
 (1 row)
 
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = 202');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 ROLLBACK;
@@ -36,33 +40,38 @@ SELECT count(*) FROM multi_shard_modify_test;
     27
 (1 row)
 
--- Check that master_modify_multiple_shards cannot be called with non-distributed tables
-CREATE TEMPORARY TABLE temporary_nondistributed_table (col_1 integer,col_2 text);
-INSERT INTO temporary_nondistributed_table VALUES (37, 'eren'), (31, 'onder');
-SELECT master_modify_multiple_shards('DELETE FROM temporary_nondistributed_table WHERE col_1 = 37');
-ERROR:  relation "temporary_nondistributed_table" is not a distributed table
 -- commands with volatile functions in their quals
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = (random() * 1000)');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
 ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_value = (random() * 1000)');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
 ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
 -- commands with immutable functions in their quals
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = abs(-3)');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 -- DELETE with expression in WHERE clause
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = (3*18-40)');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 -- commands with a USING a non distributed table error out
 CREATE TABLE temp_nations(name text, key integer);
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test USING temp_nations WHERE multi_shard_modify_test.t_value = temp_nations.key AND temp_nations.name = ''foobar'' ');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
 ERROR:  relation temp_nations is not distributed
 -- commands with a USING clause are unsupported
 SELECT create_distributed_table('temp_nations', 'name', 'hash');
@@ -72,14 +81,23 @@ SELECT create_distributed_table('temp_nations', 'name', 'hash');
 (1 row)
 
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test USING temp_nations WHERE multi_shard_modify_test.t_value = temp_nations.key AND temp_nations.name = ''foobar'' ');
-ERROR:  cannot run multi shard modify query with master_modify_multiple_shards when the query involves subquery or join
-DETAIL:  Execute the query without using master_modify_multiple_shards()
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 -- commands with a RETURNING clause are unsupported
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = 3 RETURNING *');
-ERROR:  master_modify_multiple_shards() does not support RETURNING
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+ master_modify_multiple_shards 
+-------------------------------
+                             0
+(1 row)
+
 -- commands containing a CTE are unsupported
 SELECT master_modify_multiple_shards('WITH deleted_stuff AS (INSERT INTO multi_shard_modify_test DEFAULT VALUES RETURNING *) DELETE FROM multi_shard_modify_test');
-ERROR:  common table expressions are not supported in distributed modifications
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+ERROR:  cannot perform an INSERT without a partition column value
 -- Check that we can successfully delete from multiple shards with 1PC
 SET citus.multi_shard_commit_protocol TO '1pc';
 SELECT count(*) FROM multi_shard_modify_test;
@@ -89,9 +107,11 @@ SELECT count(*) FROM multi_shard_modify_test;
 (1 row)
 
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key > 200');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             2
+                             0
 (1 row)
 
 SELECT count(*) FROM multi_shard_modify_test;
@@ -103,9 +123,11 @@ SELECT count(*) FROM multi_shard_modify_test;
 -- Check that we can successfully delete from multiple shards with 2PC
 SET citus.multi_shard_commit_protocol TO '2pc';
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key > 100');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             2
+                             0
 (1 row)
 
 SELECT count(*) FROM multi_shard_modify_test;
@@ -117,24 +139,34 @@ SELECT count(*) FROM multi_shard_modify_test;
 -- Check that shard pruning works
 SET client_min_messages TO DEBUG2;
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = 15');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 15
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 SET client_min_messages TO NOTICE;
 -- Check that master_modify_multiple_shards works without partition keys
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_name LIKE ''barce%'' ');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 -- Simple, Single Shard Update
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''warsaw'' WHERE t_key=17');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 SELECT t_name FROM multi_shard_modify_test WHERE t_key=17;
@@ -145,9 +177,11 @@ SELECT t_name FROM multi_shard_modify_test WHERE t_key=17;
 
 -- Simple, Multi Shard Update
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''???'' WHERE t_key>30 AND t_key<35');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             4
+                             0
 (1 row)
 
 SELECT t_name FROM multi_shard_modify_test WHERE t_key>30 AND t_key<35;
@@ -161,9 +195,11 @@ SELECT t_name FROM multi_shard_modify_test WHERE t_key>30 AND t_key<35;
 
 -- expression UPDATE
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value=8*37 WHERE t_key>30 AND t_key<35');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             4
+                             0
 (1 row)
 
 SELECT t_value FROM multi_shard_modify_test WHERE t_key>30 AND t_key<35;
@@ -177,9 +213,11 @@ SELECT t_value FROM multi_shard_modify_test WHERE t_key>30 AND t_key<35;
 
 -- multi-column UPDATE
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''somename'', t_value=333 WHERE t_key>30 AND t_key<35');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             4
+                             0
 (1 row)
 
 SELECT t_name, t_value FROM multi_shard_modify_test WHERE t_key>30 AND t_key<35;
@@ -193,9 +231,11 @@ SELECT t_name, t_value FROM multi_shard_modify_test WHERE t_key>30 AND t_key<35;
 
 -- commands with no constraints on the partition key are supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''nice city'' WHERE t_value < 0');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             2
+                             0
 (1 row)
 
 SELECT t_name FROM multi_shard_modify_test WHERE t_value < 0;
@@ -207,22 +247,39 @@ SELECT t_name FROM multi_shard_modify_test WHERE t_value < 0;
 
 -- attempting to change the partition key is unsupported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_key=3000 WHERE t_key < 10 ');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
 ERROR:  modifying the partition value of rows is not allowed
--- UPDATEs with a FROM clause are unsupported
+-- UPDATEs with a FROM clause are supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name = ''FAIL'' FROM temp_nations WHERE multi_shard_modify_test.t_key = 3 AND multi_shard_modify_test.t_value = temp_nations.key AND temp_nations.name = ''dummy'' ');
-ERROR:  cannot run multi shard modify query with master_modify_multiple_shards when the query involves subquery or join
-DETAIL:  Execute the query without using master_modify_multiple_shards()
--- commands with a RETURNING clause are unsupported
-SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''FAIL'' WHERE t_key=4 RETURNING *');
-ERROR:  master_modify_multiple_shards() does not support RETURNING
--- commands containing a CTE are unsupported
-SELECT master_modify_multiple_shards('WITH t AS (INSERT INTO multi_shard_modify_test DEFAULT VALUES RETURNING *) UPDATE multi_shard_modify_test SET t_name = ''FAIL'' ');
-ERROR:  common table expressions are not supported in distributed modifications
--- updates referencing just a var are supported
-SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value=t_key WHERE t_key = 10');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
+(1 row)
+
+-- commands with a RETURNING clause are unsupported
+SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name=''FAIL'' WHERE t_key=4 RETURNING *');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+ master_modify_multiple_shards 
+-------------------------------
+                             0
+(1 row)
+
+-- commands containing a CTE are unsupported
+SELECT master_modify_multiple_shards('WITH t AS (INSERT INTO multi_shard_modify_test DEFAULT VALUES RETURNING *) UPDATE multi_shard_modify_test SET t_name = ''FAIL'' ');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+ERROR:  cannot perform an INSERT without a partition column value
+-- updates referencing just a var are supported
+SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value=t_key WHERE t_key = 10');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
+ master_modify_multiple_shards 
+-------------------------------
+                             0
 (1 row)
 
 SELECT t_value FROM multi_shard_modify_test WHERE t_key=10;
@@ -233,9 +290,11 @@ SELECT t_value FROM multi_shard_modify_test WHERE t_key=10;
 
 -- updates referencing a column are supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value = t_value + 37 WHERE t_key = 10');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 SELECT t_value FROM multi_shard_modify_test WHERE t_key=10;
@@ -247,16 +306,20 @@ SELECT t_value FROM multi_shard_modify_test WHERE t_key=10;
 CREATE FUNCTION temp_stable_func() RETURNS integer AS 'SELECT 10;' LANGUAGE SQL STABLE;
 -- updates referencing non-IMMUTABLE functions are unsupported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name = ''FAIL!'' WHERE t_key = temp_stable_func()');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 -- updates referencing IMMUTABLE functions in SET section are supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value = abs(-78) WHERE t_key = 10');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 SELECT t_value FROM multi_shard_modify_test WHERE t_key=10;
@@ -267,19 +330,25 @@ SELECT t_value FROM multi_shard_modify_test WHERE t_key=10;
 
 -- updates referencing STABLE functions in SET section are supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value = temp_stable_func() * 2 WHERE t_key = 10');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 -- updates referencing VOLATILE functions in SET section are not supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_value = random() WHERE t_key = 10');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
 ERROR:  functions used in UPDATE queries on distributed tables must not be VOLATILE
 -- commands with stable functions in their quals are allowed
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = temp_stable_func()');
+WARNING:  master_modify_multiple_shards is deprecated and will be removed in a future release.
+HINT:  Run the command directly
  master_modify_multiple_shards 
 -------------------------------
-                             1
+                             0
 (1 row)
 
 SET citus.next_shard_id TO 102046;

--- a/src/test/regress/expected/multi_transaction_recovery.out
+++ b/src/test/regress/expected/multi_transaction_recovery.out
@@ -132,45 +132,6 @@ SELECT count(*) FROM pg_dist_transaction;
      0
 (1 row)
 
--- Committed master_modify_multiple_shards should write 4 transaction recovery records
-BEGIN;
-SELECT master_modify_multiple_shards($$UPDATE test_recovery SET y = 'world'$$); 
- master_modify_multiple_shards 
--------------------------------
-                             1
-(1 row)
-
-ROLLBACK;
-SELECT count(*) FROM pg_dist_transaction;
- count 
--------
-     0
-(1 row)
-
-SELECT master_modify_multiple_shards($$UPDATE test_recovery SET y = 'world'$$);
- master_modify_multiple_shards 
--------------------------------
-                             1
-(1 row)
-
-SELECT count(*) FROM pg_dist_transaction;
- count 
--------
-     4
-(1 row)
-
-SELECT recover_prepared_transactions();
- recover_prepared_transactions 
--------------------------------
-                             0
-(1 row)
-
-SELECT count(*) FROM pg_dist_transaction;
- count 
--------
-     0
-(1 row)
-
 -- Aborted INSERT..SELECT should not write transaction recovery records
 BEGIN;
 INSERT INTO test_recovery SELECT x, 'earth' FROM test_recovery;

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -139,31 +139,6 @@ SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.mx_tabl
 (3 rows)
 
 \d mx_test_index
--- master_modify_multiple_shards
-SELECT master_modify_multiple_shards('UPDATE mx_table SET col_2=''none''');
-ERROR:  operation is not allowed on this node
-HINT:  Connect to the coordinator and run it again.
-SELECT count(*) FROM mx_table WHERE col_2='none';
- count 
--------
-     0
-(1 row)
-
-SELECT count(*) FROM mx_table WHERE col_2!='none';
- count 
--------
-     5
-(1 row)
-
-SELECT master_modify_multiple_shards('DELETE FROM mx_table');
-ERROR:  operation is not allowed on this node
-HINT:  Connect to the coordinator and run it again.
-SELECT count(*) FROM mx_table;
- count 
--------
-     5
-(1 row)
-
 -- master_drop_all_shards
 SELECT master_drop_all_shards('mx_table'::regclass, 'public', 'mx_table');
 ERROR:  operation is not allowed on this node

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -71,12 +71,12 @@ EXECUTE sharded_query;
 SELECT master_apply_delete_command('DELETE FROM sharded_table WHERE id > 0');
 ERROR:  cannot delete from hash distributed table with this command
 DETAIL:  Delete statements on hash-partitioned tables are not supported with master_apply_delete_command.
-HINT:  Use master_modify_multiple_shards command instead.
+HINT:  Use the DELETE command instead.
 -- drop all shards
 SELECT master_apply_delete_command('DELETE FROM sharded_table');
 ERROR:  cannot delete from hash distributed table with this command
 DETAIL:  Delete statements on hash-partitioned tables are not supported with master_apply_delete_command.
-HINT:  Use master_modify_multiple_shards command instead.
+HINT:  Use the DELETE command instead.
 -- lock shard metadata: take some share locks and exclusive locks
 BEGIN;
 SELECT lock_shard_metadata(5, ARRAY[999001, 999002, 999002]);

--- a/src/test/regress/expected/multi_utilities_0.out
+++ b/src/test/regress/expected/multi_utilities_0.out
@@ -71,12 +71,12 @@ EXECUTE sharded_query;
 SELECT master_apply_delete_command('DELETE FROM sharded_table WHERE id > 0');
 ERROR:  cannot delete from hash distributed table with this command
 DETAIL:  Delete statements on hash-partitioned tables are not supported with master_apply_delete_command.
-HINT:  Use master_modify_multiple_shards command instead.
+HINT:  Use the DELETE command instead.
 -- drop all shards
 SELECT master_apply_delete_command('DELETE FROM sharded_table');
 ERROR:  cannot delete from hash distributed table with this command
 DETAIL:  Delete statements on hash-partitioned tables are not supported with master_apply_delete_command.
-HINT:  Use master_modify_multiple_shards command instead.
+HINT:  Use the DELETE command instead.
 -- lock shard metadata: take some share locks and exclusive locks
 BEGIN;
 SELECT lock_shard_metadata(5, ARRAY[999001, 999002, 999002]);

--- a/src/test/regress/expected/sequential_modifications.out
+++ b/src/test/regress/expected/sequential_modifications.out
@@ -381,12 +381,7 @@ SELECT recover_prepared_transactions();
                              0
 (1 row)
 
-SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test');
- master_modify_multiple_shards 
--------------------------------
-                             0
-(1 row)
-
+DELETE FROM multi_shard_modify_test;
 SELECT distributed_2PCs_are_equal_to_placement_count();
  distributed_2pcs_are_equal_to_placement_count 
 -----------------------------------------------
@@ -401,12 +396,7 @@ SELECT recover_prepared_transactions();
                              0
 (1 row)
 
-SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test');
- master_modify_multiple_shards 
--------------------------------
-                             0
-(1 row)
-
+DELETE FROM multi_shard_modify_test;
 SELECT distributed_2PCs_are_equal_to_worker_count();
  distributed_2pcs_are_equal_to_worker_count 
 --------------------------------------------
@@ -509,12 +499,7 @@ BEGIN;
 (1 row)
 
     INSERT INTO test_seq_multi_shard_update VALUES (0, 0), (1, 0), (2, 0), (3, 0), (4, 0);
-    SELECT master_modify_multiple_shards('DELETE FROM test_seq_multi_shard_update WHERE b < 2');
- master_modify_multiple_shards 
--------------------------------
-                             5
-(1 row)
-
+    DELETE FROM test_seq_multi_shard_update WHERE b < 2;
 COMMIT;
 SELECT distributed_2PCs_are_equal_to_worker_count();
  distributed_2pcs_are_equal_to_worker_count 

--- a/src/test/regress/input/multi_outer_join_reference.source
+++ b/src/test/regress/input/multi_outer_join_reference.source
@@ -177,10 +177,7 @@ UPDATE pg_dist_shard SET shardminvalue = '-2147483648' WHERE shardid = 1260006;
 UPDATE pg_dist_shard SET shardmaxvalue = '-1073741825' WHERE shardid = 1260006;
 
 -- empty tables
-SELECT master_modify_multiple_shards('DELETE FROM multi_outer_join_left_hash');
-SELECT master_modify_multiple_shards('DELETE FROM multi_outer_join_right_hash');
-
-DELETE FROM multi_outer_join_right_reference;
+TRUNCATE multi_outer_join_left_hash, multi_outer_join_right_hash, multi_outer_join_right_reference;
 
 -- reload shards with 1-1 matching
 \copy multi_outer_join_left_hash FROM '@abs_srcdir@/data/customer-1-15.data' with delimiter '|'

--- a/src/test/regress/output/multi_outer_join_reference.source
+++ b/src/test/regress/output/multi_outer_join_reference.source
@@ -228,19 +228,7 @@ ERROR:  hash partitioned table has overlapping shards
 UPDATE pg_dist_shard SET shardminvalue = '-2147483648' WHERE shardid = 1260006;
 UPDATE pg_dist_shard SET shardmaxvalue = '-1073741825' WHERE shardid = 1260006;
 -- empty tables
-SELECT master_modify_multiple_shards('DELETE FROM multi_outer_join_left_hash');
- master_modify_multiple_shards 
--------------------------------
-                            20
-(1 row)
-
-SELECT master_modify_multiple_shards('DELETE FROM multi_outer_join_right_hash');
- master_modify_multiple_shards 
--------------------------------
-                            45
-(1 row)
-
-DELETE FROM multi_outer_join_right_reference;
+TRUNCATE multi_outer_join_left_hash, multi_outer_join_right_hash, multi_outer_join_right_reference;
 -- reload shards with 1-1 matching
 \copy multi_outer_join_left_hash FROM '@abs_srcdir@/data/customer-1-15.data' with delimiter '|'
 \copy multi_outer_join_left_hash FROM '@abs_srcdir@/data/customer-21-30.data' with delimiter '|'

--- a/src/test/regress/specs/isolation_append_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_append_copy_vs_all.spec
@@ -42,7 +42,6 @@ step "s1-ddl-drop-column" { ALTER TABLE append_copy DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE append_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE append_copy ADD CONSTRAINT append_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('append_copy'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM append_copy;'); }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM append_copy WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('append_copy'::regclass, 'public', 'append_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE append_copy(id integer, data text, int_data int); }
@@ -76,7 +75,6 @@ step "s2-ddl-add-column" { ALTER TABLE append_copy ADD new_column int DEFAULT 0;
 step "s2-ddl-drop-column" { ALTER TABLE append_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE append_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('append_copy'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM append_copy;'); }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM append_copy WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('append_copy'::regclass, 'public', 'append_copy'); }
 step "s2-distribute-table" { SELECT create_distributed_table('append_copy', 'id', 'append'); }
@@ -101,7 +99,6 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-table-size" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-apply-delete-command" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-master-drop-all-shards" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-copy" "s2-distribute-table" "s1-commit" "s1-select-count"
@@ -122,7 +119,6 @@ permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-copy" "s1-commit"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-copy" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-apply-delete-command" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-master-drop-all-shards" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_ddl_vs_all.spec
+++ b/src/test/regress/specs/isolation_ddl_vs_all.spec
@@ -31,7 +31,7 @@ step "s1-ddl-add-column" { ALTER TABLE ddl_hash ADD new_column_1 int DEFAULT 0; 
 step "s1-ddl-drop-column" { ALTER TABLE ddl_hash DROP new_column_2; }
 step "s1-ddl-rename-column" { ALTER TABLE ddl_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('ddl_hash'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM ddl_hash; }
 step "s1-drop" { DROP TABLE ddl_hash; }
 step "s1-create-non-distributed-table" { CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('ddl_hash', 'id'); }
@@ -50,7 +50,7 @@ step "s2-ddl-add-column" { ALTER TABLE ddl_hash ADD new_column_2 int DEFAULT 0; 
 step "s2-ddl-drop-column" { ALTER TABLE ddl_hash DROP new_column_1; }
 step "s2-ddl-rename-column" { ALTER TABLE ddl_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('ddl_hash'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM ddl_hash;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM ddl_hash; }
 step "s2-create-non-distributed-table" { CREATE TABLE ddl_hash(id integer, data text); COPY ddl_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s2-distribute-table" { SELECT create_distributed_table('ddl_hash', 'id'); }
 step "s2-select" { SELECT * FROM ddl_hash ORDER BY 1, 2; }

--- a/src/test/regress/specs/isolation_delete_vs_all.spec
+++ b/src/test/regress/specs/isolation_delete_vs_all.spec
@@ -34,7 +34,6 @@ step "s1-ddl-add-column" { ALTER TABLE delete_hash ADD new_column int DEFAULT 0;
 step "s1-ddl-drop-column" { ALTER TABLE delete_hash DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE delete_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('delete_hash'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM delete_hash;'); }
 step "s1-create-non-distributed-table" { CREATE TABLE delete_hash(id integer, data text); COPY delete_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('delete_hash', 'id'); }
 step "s1-select-count" { SELECT COUNT(*) FROM delete_hash; }
@@ -55,7 +54,6 @@ step "s2-ddl-add-column" { ALTER TABLE delete_hash ADD new_column int DEFAULT 0;
 step "s2-ddl-drop-column" { ALTER TABLE delete_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE delete_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('delete_hash'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM delete_hash;'); }
 step "s2-create-non-distributed-table" { CREATE TABLE delete_hash(id integer, data text); COPY delete_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s2-distribute-table" { SELECT create_distributed_table('delete_hash', 'id'); }
 step "s2-select" { SELECT * FROM delete_hash ORDER BY 1, 2; }
@@ -74,7 +72,6 @@ permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-add-column
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-delete" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
 
 # permutations - DELETE second
@@ -86,5 +83,4 @@ permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-delete
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-delete" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-delete" "s1-commit" "s2-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_drop_vs_all.spec
+++ b/src/test/regress/specs/isolation_drop_vs_all.spec
@@ -32,7 +32,6 @@ step "s1-ddl-add-column" { ALTER TABLE drop_hash ADD new_column int DEFAULT 0; }
 step "s1-ddl-drop-column" { ALTER TABLE drop_hash DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE drop_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('drop_hash'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DROP FROM drop_hash;'); }
 step "s1-create-non-distributed-table" { CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('drop_hash', 'id'); }
 step "s1-select-count" { SELECT COUNT(*) FROM drop_hash; }
@@ -51,7 +50,6 @@ step "s2-ddl-add-column" { ALTER TABLE drop_hash ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE drop_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE drop_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('drop_hash'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DROP FROM drop_hash;'); }
 step "s2-create-non-distributed-table" { CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s2-distribute-table" { SELECT create_distributed_table('drop_hash', 'id'); }
 step "s2-select" { SELECT * FROM drop_hash ORDER BY 1, 2; }
@@ -68,7 +66,6 @@ permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-add-column" 
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-drop-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-ddl-rename-column" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-table-size" "s1-commit" "s2-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-master-modify-multiple-shards" "s1-commit" "s2-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-drop" "s2-distribute-table" "s1-commit" "s2-commit" "s1-select-count"
 
 # permutations - DROP second
@@ -78,5 +75,4 @@ permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-add-column" "s2-drop" 
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s2-begin" "s1-ddl-drop-column" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-ddl-rename-column" "s2-drop" "s1-commit" "s2-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s2-begin" "s1-distribute-table" "s2-drop" "s1-commit" "s2-commit" "s1-select-count"

--- a/src/test/regress/specs/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_hash_copy_vs_all.spec
@@ -42,7 +42,7 @@ step "s1-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE hash_copy ADD CONSTRAINT hash_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('hash_copy'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM hash_copy; }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE hash_copy(id integer, data text, int_data int); COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('hash_copy', 'id'); }
@@ -82,7 +82,7 @@ step "s2-ddl-add-column" { ALTER TABLE hash_copy ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('hash_copy'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM hash_copy;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM hash_copy; }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('hash_copy'::regclass, 'public', 'hash_copy'); }
 step "s2-distribute-table" { SELECT create_distributed_table('hash_copy', 'id'); }
 

--- a/src/test/regress/specs/isolation_insert_select_vs_all.spec
+++ b/src/test/regress/specs/isolation_insert_select_vs_all.spec
@@ -40,7 +40,7 @@ step "s1-ddl-add-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash 
 step "s1-ddl-drop-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash DROP new_column; }
 step "s1-ddl-rename-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash RENAME data TO new_column; }
 step "s1-table-size-on-inserted" { SELECT citus_total_relation_size('insert_of_insert_select_hash'); }
-step "s1-master-modify-multiple-shards-on-inserted" { SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;'); }
+step "s1-master-modify-multiple-shards-on-inserted" { DELETE FROM insert_of_insert_select_hash; }
 step "s1-master-drop-all-shards-on-inserted" { SELECT master_drop_all_shards('insert_of_insert_select_hash'::regclass, 'public', 'insert_of_insert_select_hash'); }
 step "s1-create-non-distributed-table-on-inserted" { CREATE TABLE insert_of_insert_select_hash(id integer, data text); }
 step "s1-distribute-table-on-inserted" { SELECT create_distributed_table('insert_of_insert_select_hash', 'id'); }
@@ -56,7 +56,7 @@ step "s1-ddl-add-column-on-selected" { ALTER TABLE select_of_insert_select_hash 
 step "s1-ddl-drop-column-on-selected" { ALTER TABLE select_of_insert_select_hash DROP new_column; }
 step "s1-ddl-rename-column-on-selected" { ALTER TABLE select_of_insert_select_hash RENAME data TO new_column; }
 step "s1-table-size-on-selected" { SELECT citus_total_relation_size('select_of_insert_select_hash'); }
-step "s1-master-modify-multiple-shards-on-selected" { SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;'); }
+step "s1-master-modify-multiple-shards-on-selected" { DELETE FROM select_of_insert_select_hash; }
 step "s1-master-drop-all-shards-on-selected" { SELECT master_drop_all_shards('select_of_insert_select_hash'::regclass, 'public', 'select_of_insert_select_hash'); }
 step "s1-create-non-distributed-table-on-selected" { CREATE TABLE select_of_insert_select_hash(id integer, data text); }
 step "s1-distribute-table-on-selected" { SELECT create_distributed_table('select_of_insert_select_hash', 'id'); }
@@ -79,7 +79,7 @@ step "s2-ddl-add-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash 
 step "s2-ddl-drop-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash DROP new_column; }
 step "s2-ddl-rename-column-on-inserted" { ALTER TABLE insert_of_insert_select_hash RENAME data TO new_column; }
 step "s2-table-size-on-inserted" { SELECT citus_total_relation_size('insert_of_insert_select_hash'); }
-step "s2-master-modify-multiple-shards-on-inserted" { SELECT master_modify_multiple_shards('DELETE FROM insert_of_insert_select_hash;'); }
+step "s2-master-modify-multiple-shards-on-inserted" { DELETE FROM insert_of_insert_select_hash; }
 step "s2-master-drop-all-shards-on-inserted" { SELECT master_drop_all_shards('insert_of_insert_select_hash'::regclass, 'public', 'insert_of_insert_select_hash'); }
 step "s2-create-non-distributed-table-on-inserted" { CREATE TABLE insert_of_insert_select_hash(id integer, data text); }
 step "s2-distribute-table-on-inserted" { SELECT create_distributed_table('insert_of_insert_select_hash', 'id'); }
@@ -94,7 +94,7 @@ step "s2-ddl-add-column-on-selected" { ALTER TABLE select_of_insert_select_hash 
 step "s2-ddl-drop-column-on-selected" { ALTER TABLE select_of_insert_select_hash DROP new_column; }
 step "s2-ddl-rename-column-on-selected" { ALTER TABLE select_of_insert_select_hash RENAME data TO new_column; }
 step "s2-table-size-on-selected" { SELECT citus_total_relation_size('select_of_insert_select_hash'); }
-step "s2-master-modify-multiple-shards-on-selected" { SELECT master_modify_multiple_shards('DELETE FROM select_of_insert_select_hash;'); }
+step "s2-master-modify-multiple-shards-on-selected" { DELETE FROM select_of_insert_select_hash; }
 step "s2-master-drop-all-shards-on-selected" { SELECT master_drop_all_shards('select_of_insert_select_hash'::regclass, 'public', 'select_of_insert_select_hash'); }
 step "s2-create-non-distributed-table-on-selected" { CREATE TABLE select_of_insert_select_hash(id integer, data text); }
 step "s2-distribute-table-on-selected" { SELECT create_distributed_table('select_of_insert_select_hash', 'id'); }

--- a/src/test/regress/specs/isolation_insert_vs_all.spec
+++ b/src/test/regress/specs/isolation_insert_vs_all.spec
@@ -33,7 +33,7 @@ step "s1-ddl-add-column" { ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
 step "s1-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('insert_hash'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM insert_hash; }
 step "s1-create-non-distributed-table" { CREATE TABLE insert_hash(id integer, data text); COPY insert_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
 step "s1-select-count" { SELECT COUNT(*) FROM insert_hash; }
@@ -57,7 +57,7 @@ step "s2-ddl-add-column" { ALTER TABLE insert_hash ADD new_column int DEFAULT 0;
 step "s2-ddl-drop-column" { ALTER TABLE insert_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE insert_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('insert_hash'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM insert_hash;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM insert_hash; }
 step "s2-distribute-table" { SELECT create_distributed_table('insert_hash', 'id'); }
 
 # permutations - INSERT vs INSERT

--- a/src/test/regress/specs/isolation_partitioned_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_partitioned_copy_vs_all.spec
@@ -45,7 +45,7 @@ step "s1-ddl-drop-column" { ALTER TABLE partitioned_copy DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE partitioned_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE partitioned_copy ADD CONSTRAINT partitioned_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('partitioned_copy'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM partitioned_copy; }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('partitioned_copy'::regclass, 'public', 'partitioned_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE partitioned_copy(id integer, data text, int_data int); COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('partitioned_copy', 'id'); }
@@ -78,7 +78,7 @@ step "s2-ddl-add-column" { ALTER TABLE partitioned_copy ADD new_column int DEFAU
 step "s2-ddl-drop-column" { ALTER TABLE partitioned_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE partitioned_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('partitioned_copy'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM partitioned_copy;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM partitioned_copy; }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('partitioned_copy'::regclass, 'public', 'partitioned_copy'); }
 step "s2-distribute-table" { SELECT create_distributed_table('partitioned_copy', 'id'); }
 

--- a/src/test/regress/specs/isolation_range_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_range_copy_vs_all.spec
@@ -42,7 +42,7 @@ step "s1-ddl-drop-column" { ALTER TABLE range_copy DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE range_copy ADD CONSTRAINT range_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('range_copy'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM range_copy; }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE range_copy(id integer, data text, int_data int); }
@@ -77,7 +77,7 @@ step "s2-ddl-add-column" { ALTER TABLE range_copy ADD new_column int DEFAULT 0; 
 step "s2-ddl-drop-column" { ALTER TABLE range_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE range_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('range_copy'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM range_copy;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM range_copy; }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM range_copy WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('range_copy'::regclass, 'public', 'range_copy'); }
 step "s2-distribute-table" { SELECT create_distributed_table('range_copy', 'id', 'range'); }

--- a/src/test/regress/specs/isolation_reference_copy_vs_all.spec
+++ b/src/test/regress/specs/isolation_reference_copy_vs_all.spec
@@ -42,7 +42,7 @@ step "s1-ddl-drop-column" { ALTER TABLE reference_copy DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE reference_copy RENAME data TO new_column; }
 step "s1-ddl-unique-constraint" { ALTER TABLE reference_copy ADD CONSTRAINT reference_copy_unique UNIQUE(id); }
 step "s1-table-size" { SELECT citus_total_relation_size('reference_copy'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM reference_copy;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM reference_copy; }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM reference_copy WHERE id <= 4;'); }
 step "s1-create-non-distributed-table" { CREATE TABLE reference_copy(id integer, data text, int_data int); COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV; }
 step "s1-distribute-table" { SELECT create_reference_table('reference_copy'); }
@@ -75,7 +75,7 @@ step "s2-ddl-add-column" { ALTER TABLE reference_copy ADD new_column int DEFAULT
 step "s2-ddl-drop-column" { ALTER TABLE reference_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE reference_copy RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('reference_copy'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM reference_copy;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM reference_copy; }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM reference_copy WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('reference_copy'::regclass, 'public', 'reference_copy'); }
 step "s2-create-non-distributed-table" { CREATE TABLE reference_copy(id integer, data text, int_data int); COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV; }

--- a/src/test/regress/specs/isolation_select_vs_all.spec
+++ b/src/test/regress/specs/isolation_select_vs_all.spec
@@ -39,7 +39,7 @@ step "s1-ddl-add-column" { ALTER TABLE select_append ADD new_column int DEFAULT 
 step "s1-ddl-drop-column" { ALTER TABLE select_append DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('select_append'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM select_append; }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
 step "s1-create-non-distributed-table" { CREATE TABLE select_append(id integer, data text, int_data int); }
@@ -71,7 +71,7 @@ step "s2-ddl-add-column" { ALTER TABLE select_append ADD new_column int DEFAULT 
 step "s2-ddl-drop-column" { ALTER TABLE select_append DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE select_append RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('select_append'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM select_append;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM select_append; }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM select_append WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('select_append'::regclass, 'public', 'append_copy'); }
 step "s2-distribute-table" { SELECT create_distributed_table('select_append', 'id', 'append'); }

--- a/src/test/regress/specs/isolation_truncate_vs_all.spec
+++ b/src/test/regress/specs/isolation_truncate_vs_all.spec
@@ -33,7 +33,7 @@ step "s1-ddl-add-column" { ALTER TABLE truncate_append ADD new_column int DEFAUL
 step "s1-ddl-drop-column" { ALTER TABLE truncate_append DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE truncate_append RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('truncate_append'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM truncate_append;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM truncate_append; }
 step "s1-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM truncate_append WHERE id <= 4;'); }
 step "s1-master-drop-all-shards" { SELECT master_drop_all_shards('truncate_append'::regclass, 'public', 'truncate_append'); }
 step "s1-create-non-distributed-table" { CREATE TABLE truncate_append(id integer, data text); }
@@ -55,7 +55,7 @@ step "s2-ddl-add-column" { ALTER TABLE truncate_append ADD new_column int DEFAUL
 step "s2-ddl-drop-column" { ALTER TABLE truncate_append DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE truncate_append RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('truncate_append'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM truncate_append;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM truncate_append; }
 step "s2-master-apply-delete-command" { SELECT master_apply_delete_command('DELETE FROM truncate_append WHERE id <= 4;'); }
 step "s2-master-drop-all-shards" { SELECT master_drop_all_shards('truncate_append'::regclass, 'public', 'truncate_append'); }
 step "s2-create-non-distributed-table" { CREATE TABLE truncate_append(id integer, data text); }

--- a/src/test/regress/specs/isolation_update_vs_all.spec
+++ b/src/test/regress/specs/isolation_update_vs_all.spec
@@ -35,7 +35,7 @@ step "s1-ddl-add-column" { ALTER TABLE update_hash ADD new_column int DEFAULT 0;
 step "s1-ddl-drop-column" { ALTER TABLE update_hash DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE update_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('update_hash'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM update_hash; }
 step "s1-create-non-distributed-table" { CREATE TABLE update_hash(id integer, data text); COPY update_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV; }
 step "s1-distribute-table" { SELECT create_distributed_table('update_hash', 'id'); }
 step "s1-select-count" { SELECT COUNT(*) FROM update_hash; }
@@ -57,7 +57,7 @@ step "s2-ddl-add-column" { ALTER TABLE update_hash ADD new_column int DEFAULT 0;
 step "s2-ddl-drop-column" { ALTER TABLE update_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE update_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('update_hash'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM update_hash;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM update_hash; }
 step "s2-distribute-table" { SELECT create_distributed_table('update_hash', 'id'); }
 step "s2-commit" { COMMIT; }
 

--- a/src/test/regress/specs/isolation_upsert_vs_all.spec
+++ b/src/test/regress/specs/isolation_upsert_vs_all.spec
@@ -36,7 +36,7 @@ step "s1-ddl-add-column" { ALTER TABLE upsert_hash ADD new_column int DEFAULT 0;
 step "s1-ddl-drop-column" { ALTER TABLE upsert_hash DROP new_column; }
 step "s1-ddl-rename-column" { ALTER TABLE upsert_hash RENAME data TO new_column; }
 step "s1-table-size" { SELECT citus_total_relation_size('upsert_hash'); }
-step "s1-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;'); }
+step "s1-master-modify-multiple-shards" { DELETE FROM upsert_hash; }
 step "s1-create-non-distributed-table" { CREATE TABLE upsert_hash(id integer PRIMARY KEY, data text); }
 step "s1-distribute-table" { SELECT create_distributed_table('upsert_hash', 'id'); }
 step "s1-select-count" { SELECT COUNT(*) FROM upsert_hash; }
@@ -59,7 +59,7 @@ step "s2-ddl-add-column" { ALTER TABLE upsert_hash ADD new_column int DEFAULT 0;
 step "s2-ddl-drop-column" { ALTER TABLE upsert_hash DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE upsert_hash RENAME data TO new_column; }
 step "s2-table-size" { SELECT citus_total_relation_size('upsert_hash'); }
-step "s2-master-modify-multiple-shards" { SELECT master_modify_multiple_shards('DELETE FROM upsert_hash;'); }
+step "s2-master-modify-multiple-shards" { DELETE FROM upsert_hash; }
 step "s2-distribute-table" { SELECT create_distributed_table('upsert_hash', 'id'); }
 step "s2-commit" { COMMIT; }
 

--- a/src/test/regress/sql/multi_foreign_key.sql
+++ b/src/test/regress/sql/multi_foreign_key.sql
@@ -135,7 +135,7 @@ SELECT * FROM referenced_table;
 -- multi shard cascading delete
 INSERT INTO referenced_table VALUES(2, 2);
 INSERT INTO referencing_table VALUES(2, 2);
-SELECT master_modify_multiple_shards('DELETE FROM referenced_table');
+DELETE FROM referenced_table;
 SELECT * FROM referencing_table;
 
 -- multi shard cascading delete with alter table
@@ -143,7 +143,7 @@ INSERT INTO referenced_table VALUES(3, 3);
 INSERT INTO referencing_table VALUES(3, 3);
 BEGIN;
 ALTER TABLE referencing_table ADD COLUMN x int DEFAULT 0;
-SELECT master_modify_multiple_shards('DELETE FROM referenced_table');
+DELETE FROM referenced_table;
 COMMIT;
 
 DROP TABLE referencing_table;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -701,13 +701,6 @@ UPDATE reference_summary_table SET average_value = average_query.average FROM (
 	) average_query
 WHERE id = 1;
 
--- test master_modify_multiple_shards() with subqueries and expect to fail
-SELECT master_modify_multiple_shards('
-	UPDATE summary_table SET average_value = average_query.average FROM (
-		SELECT avg(value) AS average FROM raw_table WHERE id = 1
-		) average_query
-	WHERE id = 1');
-
 -- test connection API via using COPY
 
 -- COPY on SELECT part

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -358,7 +358,7 @@ ROLLBACK;
 -- multi-shard operations can co-exist with DDL in a transactional way
 BEGIN;
 ALTER TABLE labs ADD COLUMN motto text;
-SELECT master_modify_multiple_shards('DELETE FROM labs');
+DELETE FROM labs;
 ALTER TABLE labs ADD COLUMN score float;
 ROLLBACK;
 
@@ -1136,7 +1136,7 @@ END;
 
 -- make sure we can see cascading deletes
 BEGIN;
-SELECT master_modify_multiple_shards('DELETE FROM users');
+DELETE FROM users;
 SELECT user_id FROM items JOIN itemgroups ON (item_group = gid) WHERE user_id = 1;
 SELECT user_id FROM items JOIN itemgroups ON (item_group = gid) WHERE user_id = 6;
 END;

--- a/src/test/regress/sql/multi_mx_ddl.sql
+++ b/src/test/regress/sql/multi_mx_ddl.sql
@@ -13,7 +13,7 @@ ALTER TABLE mx_ddl_table ADD COLUMN version INTEGER;
 -- SET DEFAULT
 ALTER TABLE mx_ddl_table ALTER COLUMN version SET DEFAULT 1; 
 
-SELECT master_modify_multiple_shards('UPDATE mx_ddl_table SET version=0.1 WHERE version IS NULL');
+UPDATE mx_ddl_table SET version=0.1 WHERE version IS NULL;
 
 -- SET NOT NULL
 ALTER TABLE mx_ddl_table ALTER COLUMN version SET NOT NULL;

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -308,21 +308,20 @@ END;
 SELECT * FROM partitioning_test WHERE id > 20 ORDER BY 1, 2;
 SELECT * FROM partitioning_test_default ORDER BY 1, 2;
 
--- test master_modify_multiple_shards
--- master_modify_multiple_shards on partitioned table
-SELECT master_modify_multiple_shards('UPDATE partitioning_test SET time = time + INTERVAL ''1 day''');
+-- multi-shard UPDATE on partitioned table
+UPDATE partitioning_test SET time = time + INTERVAL '1 day';
 
 -- see rows are UPDATED
 SELECT * FROM partitioning_test ORDER BY 1;
 
--- master_modify_multiple_shards on partition directly
-SELECT master_modify_multiple_shards('UPDATE partitioning_test_2009 SET time = time + INTERVAL ''1 day''');
+-- multi-shard UPDATE on partition directly
+UPDATE partitioning_test_2009 SET time = time + INTERVAL '1 day';
 
 -- see rows are UPDATED
 SELECT * FROM partitioning_test_2009 ORDER BY 1;
 
--- test master_modify_multiple_shards which fails in workers (updated value is outside of partition bounds)
-SELECT master_modify_multiple_shards('UPDATE partitioning_test_2009 SET time = time + INTERVAL ''6 month''');
+-- test multi-shard UPDATE which fails in workers (updated value is outside of partition bounds)
+UPDATE partitioning_test_2009 SET time = time + INTERVAL '6 month';
 
 --
 -- DDL in distributed partitioned tables
@@ -907,9 +906,9 @@ INSERT INTO partitioning_locks SELECT * FROM partitioning_locks_for_select LIMIT
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;
 COMMIT;
 
--- test locks on master_modify_multiple_shards
+-- test locks on multi-shard UPDATE
 BEGIN;
-SELECT master_modify_multiple_shards('UPDATE partitioning_locks SET time = ''2009-03-01''');
+UPDATE partitioning_locks SET time = '2009-03-01';
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;
 COMMIT;
 
@@ -925,9 +924,9 @@ TRUNCATE partitioning_locks;
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;
 COMMIT;
 
--- test shard resource locks with master_modify_multiple_shards
+-- test shard resource locks with multi-shard UPDATE
 BEGIN;
-SELECT master_modify_multiple_shards('UPDATE partitioning_locks_2009 SET time = ''2009-03-01''');
+UPDATE partitioning_locks_2009 SET time = '2009-03-01';
 
 -- see the locks on parent table
 SELECT

--- a/src/test/regress/sql/multi_prepare_sql.sql
+++ b/src/test/regress/sql/multi_prepare_sql.sql
@@ -278,7 +278,7 @@ EXECUTE prepared_non_partition_parameter_insert(60);
 -- check inserted values
 SELECT * FROM prepare_table ORDER BY key, value;
 
-SELECT master_modify_multiple_shards('DELETE FROM prepare_table WHERE value >= 70');
+DELETE FROM prepare_table WHERE value >= 70;
 
 -- check router executor select
 PREPARE prepared_router_partition_column_select(int) AS

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -889,12 +889,6 @@ SELECT master_apply_delete_command('DELETE FROM reference_schema.reference_table
 -- cannot add shards
 SELECT master_create_empty_shard('reference_schema.reference_table_ddl');
 
--- master_modify_multiple_shards works, but, does it make sense to use at all?
-INSERT INTO reference_schema.reference_table_ddl (value_2, value_3) VALUES (7, 'aa');
-SELECT master_modify_multiple_shards('DELETE FROM reference_schema.reference_table_ddl WHERE value_2 = 7');
-INSERT INTO reference_schema.reference_table_ddl (value_2, value_3) VALUES (7, 'bb');
-SELECT master_modify_multiple_shards('DELETE FROM reference_schema.reference_table_ddl');
-
 -- get/update the statistics
 SELECT part_storage_type, part_key, part_replica_count, part_max_size,
            part_placement_policy
@@ -999,12 +993,6 @@ BEGIN;
 UPDATE reference_table_test SET value_1 = 10 WHERE value_1 = 2;
 COMMIT;
 SELECT * FROM reference_table_test;
-
--- DML+master_modify_multiple_shards is allowed
-BEGIN;
-INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
-SELECT master_modify_multiple_shards('DELETE FROM colocated_table_test');
-ROLLBACK;
 
 -- DDL+DML is allowed
 BEGIN;

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -302,18 +302,18 @@ SET search_path TO test_schema_support;
 SELECT * FROM nation_hash  WHERE n_nationkey OPERATOR(===) 1;
 
 
--- test with master_modify_multiple_shards
+-- test with multi-shard DML
 SET search_path TO public;
-SELECT master_modify_multiple_shards('UPDATE test_schema_support.nation_hash SET n_regionkey = n_regionkey + 1');
+UPDATE test_schema_support.nation_hash SET n_regionkey = n_regionkey + 1;
 
---verify master_modify_multiple_shards
+--verify modification
 SELECT * FROM test_schema_support.nation_hash ORDER BY 1,2,3,4;
 
 --test with search_path is set
 SET search_path TO test_schema_support;
-SELECT master_modify_multiple_shards('UPDATE nation_hash SET n_regionkey = n_regionkey + 1');
+UPDATE nation_hash SET n_regionkey = n_regionkey + 1;
 
---verify master_modify_multiple_shards
+--verify modification
 SELECT * FROM nation_hash ORDER BY 1,2,3,4;
 
 

--- a/src/test/regress/sql/multi_shard_modify.sql
+++ b/src/test/regress/sql/multi_shard_modify.sql
@@ -53,11 +53,6 @@ ROLLBACK;
 
 SELECT count(*) FROM multi_shard_modify_test;
 
--- Check that master_modify_multiple_shards cannot be called with non-distributed tables
-CREATE TEMPORARY TABLE temporary_nondistributed_table (col_1 integer,col_2 text);
-INSERT INTO temporary_nondistributed_table VALUES (37, 'eren'), (31, 'onder');
-SELECT master_modify_multiple_shards('DELETE FROM temporary_nondistributed_table WHERE col_1 = 37');
-
 -- commands with volatile functions in their quals
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_key = (random() * 1000)');
 SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test WHERE t_value = (random() * 1000)');
@@ -125,7 +120,7 @@ SELECT t_name FROM multi_shard_modify_test WHERE t_value < 0;
 -- attempting to change the partition key is unsupported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_key=3000 WHERE t_key < 10 ');
 
--- UPDATEs with a FROM clause are unsupported
+-- UPDATEs with a FROM clause are supported
 SELECT master_modify_multiple_shards('UPDATE multi_shard_modify_test SET t_name = ''FAIL'' FROM temp_nations WHERE multi_shard_modify_test.t_key = 3 AND multi_shard_modify_test.t_value = temp_nations.key AND temp_nations.name = ''dummy'' ');
 
 -- commands with a RETURNING clause are unsupported

--- a/src/test/regress/sql/multi_transaction_recovery.sql
+++ b/src/test/regress/sql/multi_transaction_recovery.sql
@@ -70,18 +70,6 @@ SELECT count(*) FROM pg_dist_transaction;
 SELECT recover_prepared_transactions();
 SELECT count(*) FROM pg_dist_transaction;
 
--- Committed master_modify_multiple_shards should write 4 transaction recovery records
-BEGIN;
-SELECT master_modify_multiple_shards($$UPDATE test_recovery SET y = 'world'$$); 
-ROLLBACK;
-SELECT count(*) FROM pg_dist_transaction;
-
-SELECT master_modify_multiple_shards($$UPDATE test_recovery SET y = 'world'$$);
-
-SELECT count(*) FROM pg_dist_transaction;
-SELECT recover_prepared_transactions();
-SELECT count(*) FROM pg_dist_transaction;
-
 -- Aborted INSERT..SELECT should not write transaction recovery records
 BEGIN;
 INSERT INTO test_recovery SELECT x, 'earth' FROM test_recovery;

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -92,13 +92,6 @@ ALTER TABLE mx_table_2 ADD CONSTRAINT mx_fk_constraint FOREIGN KEY(col_1) REFERE
 SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.mx_table'::regclass;
 \d mx_test_index
 
--- master_modify_multiple_shards
-SELECT master_modify_multiple_shards('UPDATE mx_table SET col_2=''none''');
-SELECT count(*) FROM mx_table WHERE col_2='none';
-SELECT count(*) FROM mx_table WHERE col_2!='none';
-SELECT master_modify_multiple_shards('DELETE FROM mx_table');
-SELECT count(*) FROM mx_table;
-
 -- master_drop_all_shards
 SELECT master_drop_all_shards('mx_table'::regclass, 'public', 'mx_table');
 SELECT count(*) FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid='mx_table'::regclass;

--- a/src/test/regress/sql/sequential_modifications.sql
+++ b/src/test/regress/sql/sequential_modifications.sql
@@ -207,13 +207,13 @@ SELECT create_distributed_table('multi_shard_modify_test', 't_key');
 -- with parallel modification mode, we should see #shards records
 SET citus.multi_shard_modify_mode TO 'parallel';
 SELECT recover_prepared_transactions();
-SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test');
+DELETE FROM multi_shard_modify_test;
 SELECT distributed_2PCs_are_equal_to_placement_count();
 
 -- with sequential modification mode, we should see #primary worker records
 SET citus.multi_shard_modify_mode TO 'sequential';
 SELECT recover_prepared_transactions();
-SELECT master_modify_multiple_shards('DELETE FROM multi_shard_modify_test');
+DELETE FROM multi_shard_modify_test;
 SELECT distributed_2PCs_are_equal_to_worker_count();
 
 -- one more realistic test with sequential inserts and truncate in the same tx
@@ -267,7 +267,7 @@ BEGIN;
     SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
     SELECT create_distributed_table('test_seq_multi_shard_update', 'a');
     INSERT INTO test_seq_multi_shard_update VALUES (0, 0), (1, 0), (2, 0), (3, 0), (4, 0);
-    SELECT master_modify_multiple_shards('DELETE FROM test_seq_multi_shard_update WHERE b < 2');
+    DELETE FROM test_seq_multi_shard_update WHERE b < 2;
 COMMIT;
 SELECT distributed_2PCs_are_equal_to_worker_count();
 DROP TABLE test_seq_multi_shard_update;


### PR DESCRIPTION
DESCRIPTION: Deprecate master_modify_multiple_shards

`master_modify_multiple_shards` is starting to incur maintainenance costs that we'd rather not pay as we have full support for multi-shard DML and the function should no longer be used.

This PR replaces the internals of `master_modify_multiple_shards` by a call to `ExecuteQueryStringIntoDestReceiver`, which means the query now goes through the regular planner and executor and we no longer need to consider locking and such. As a side-effect, `master_modify_multiple_shards` no longer returns the number of affected rows, which did not seem worth investing in.

It also throws a deprecation warning whenever it is called and it is replaced or removed it in all regression tests except `multi_master_modify` just to verify it is still backwards compatible (apart from the output).