### PR TITLE
Update the regression test outputs in unified executor

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -19,3 +19,5 @@ s/\(id\)=\([0-9]+\)/(id)=(X)/g
 # shard table names for multi_subtransactions
 s/"t2_[0-9]+"/"t2_xxxxxxx"/g
 
+# normalize pkey constraints in multi_insert_select.sql
+s/"(raw_events_second_user_id_value_1_key_|agg_events_user_id_value_1_agg_key_)[0-9]+"/"\1xxxxxxx"/g

--- a/src/test/regress/bin/normalized_tests.lst
+++ b/src/test/regress/bin/normalized_tests.lst
@@ -3,4 +3,6 @@ multi_alter_table_add_constraints
 multi_alter_table_statements
 foreign_key_to_reference_table
 multi_subtransactions
+multi_modifying_xacts
+multi_insert_select
 

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -85,9 +85,7 @@ SELECT x, x2
 FROM interesting_squares JOIN (SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x text, x2 int)) squares ON (x = interested_in)
 WHERE user_id = 'jon'
 ORDER BY x;
-WARNING:  result "squares" does not exist
-WARNING:  result "squares" does not exist
-ERROR:  could not receive query results
+ERROR:  result "squares" does not exist
 \set VERBOSITY DEFAULT
 -- try to read the file as text, will fail because of binary encoding
 BEGIN;

--- a/src/test/regress/expected/multi_function_in_join.out
+++ b/src/test/regress/expected/multi_function_in_join.out
@@ -182,48 +182,36 @@ DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT table1.id, tab
 
 -- The following tests will fail as we do not support  all joins on
 -- all kinds of functions
+-- In other words, we cannot recursively plan the functions and hence 
+-- the query fails on the workers
 SET client_min_messages TO ERROR;
+\set VERBOSITY terse
 -- function joins in CTE results can create lateral joins that are not supported
-SELECT public.raise_failed_execution($cmd$
 WITH one_row AS (
     SELECT * FROM table1 WHERE id=52
     )
 SELECT table1.id, table1.data
 FROM one_row, table1, next_k_integers(one_row.id, 5) next_five_ids
 WHERE table1.id = next_five_ids;
-$cmd$);
-ERROR:  Task failed to execute
-CONTEXT:  PL/pgSQL function public.raise_failed_execution(text) line 6 at RAISE
+ERROR:  function functions_in_joins.next_k_integers(integer, integer) does not exist
 -- a user-defined immutable function
 CREATE OR REPLACE FUNCTION the_answer_to_life()
   RETURNS INTEGER IMMUTABLE AS 'SELECT 42' LANGUAGE SQL;
-SELECT public.raise_failed_execution($cmd$
-SELECT * FROM table1 JOIN the_answer_to_life() the_answer ON (id = the_answer)
-$cmd$);
-ERROR:  Task failed to execute
-CONTEXT:  PL/pgSQL function public.raise_failed_execution(text) line 6 at RAISE
+SELECT * FROM table1 JOIN the_answer_to_life() the_answer ON (id = the_answer);
+ERROR:  function functions_in_joins.the_answer_to_life() does not exist
+SELECT *
+FROM table1
+       JOIN next_k_integers(10,5) WITH ORDINALITY next_integers
+         ON (id = next_integers.result);
+ERROR:  function functions_in_joins.next_k_integers(integer, integer) does not exist
 -- WITH ORDINALITY clause
-SELECT public.raise_failed_execution($cmd$
 SELECT *
 FROM table1
        JOIN next_k_integers(10,5) WITH ORDINALITY next_integers
          ON (id = next_integers.result)
 ORDER BY id ASC;
-$cmd$);
-ERROR:  Task failed to execute
-CONTEXT:  PL/pgSQL function public.raise_failed_execution(text) line 6 at RAISE
+ERROR:  function functions_in_joins.next_k_integers(integer, integer) does not exist
 RESET client_min_messages;
 DROP SCHEMA functions_in_joins CASCADE;
 NOTICE:  drop cascades to 11 other objects
-DETAIL:  drop cascades to table table1
-drop cascades to sequence numbers
-drop cascades to function add(integer,integer)
-drop cascades to function increment(integer)
-drop cascades to function next_k_integers(integer,integer)
-drop cascades to function get_set_of_records()
-drop cascades to function dup(integer)
-drop cascades to function the_minimum_id()
-drop cascades to type min_and_max
-drop cascades to function max_and_min()
-drop cascades to function the_answer_to_life()
 SET search_path TO DEFAULT;

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -143,7 +143,6 @@ FROM
   raw_events_first
 WHERE
   user_id = 0;
-WARNING:  function public.evaluate_on_master(integer) does not exist
 ERROR:  function public.evaluate_on_master(integer) does not exist
 -- add one more row
 INSERT INTO raw_events_first (user_id, time) VALUES
@@ -1714,14 +1713,13 @@ ALTER TABLE raw_events_second DROP COLUMN value_4;
 INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 100; 
 ROLLBACK;
 -- Altering a reference table and then performing an INSERT ... SELECT which
--- joins with the reference table is not allowed, since the INSERT ... SELECT
--- would read from the reference table over others connections than the ones
+-- joins with the reference table is allowed, since the INSERT ... SELECT
+-- would read from the reference table over the same connections with the ones
 -- that performed the parallel DDL.
 BEGIN;
 ALTER TABLE reference_table ADD COLUMN z int;
 INSERT INTO raw_events_first (user_id)
 SELECT user_id FROM raw_events_second JOIN reference_table USING (user_id);
-ERROR:  cannot establish a new connection for placement 13300025, since DDL has been executed on a connection that is in use
 ROLLBACK;
 -- the same test with sequential DDL should work fine
 BEGIN;

--- a/src/test/regress/expected/multi_query_directory_cleanup.out
+++ b/src/test/regress/expected/multi_query_directory_cleanup.out
@@ -215,55 +215,18 @@ FETCH 1 FROM c_19;
 (1 row)
 
 SELECT * FROM pg_ls_dir('base/pgsql_job_cache') f ORDER BY f;
-        f        
------------------
- master_job_0007
- master_job_0008
- master_job_0009
- master_job_0010
- master_job_0011
- master_job_0012
- master_job_0013
- master_job_0014
- master_job_0015
- master_job_0016
- master_job_0017
- master_job_0018
- master_job_0019
- master_job_0020
- master_job_0021
- master_job_0022
- master_job_0023
- master_job_0024
- master_job_0025
- master_job_0026
-(20 rows)
+ f 
+---
+(0 rows)
 
 -- close first, 17th (first after re-alloc) and last cursor.
 CLOSE c_00;
 CLOSE c_16;
 CLOSE c_19;
 SELECT * FROM pg_ls_dir('base/pgsql_job_cache') f ORDER BY f;
-        f        
------------------
- master_job_0008
- master_job_0009
- master_job_0010
- master_job_0011
- master_job_0012
- master_job_0013
- master_job_0014
- master_job_0015
- master_job_0016
- master_job_0017
- master_job_0018
- master_job_0019
- master_job_0020
- master_job_0021
- master_job_0022
- master_job_0024
- master_job_0025
-(17 rows)
+ f 
+---
+(0 rows)
 
 ROLLBACK;
 SELECT pg_ls_dir('base/pgsql_job_cache');

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -1907,13 +1907,8 @@ SELECT author_id FROM articles_append
 		author_id
 	LIMIT 1;
 DEBUG:  push down of limit count: 1
-WARNING:  relation "public.articles_append" does not exist
+ERROR:  relation "public.articles_append" does not exist
 CONTEXT:  while executing command on localhost:57638
-WARNING:  relation "public.articles_append" does not exist
-CONTEXT:  while executing command on localhost:57638
-WARNING:  relation "public.articles_append" does not exist
-CONTEXT:  while executing command on localhost:57638
-ERROR:  failed to execute task 1
 -- same query with where false but evaluation left to worker
 SELECT author_id FROM articles_append
 	WHERE 
@@ -1922,13 +1917,8 @@ SELECT author_id FROM articles_append
 		author_id
 	LIMIT 1;
 DEBUG:  push down of limit count: 1
-WARNING:  relation "public.articles_append" does not exist
+ERROR:  relation "public.articles_append" does not exist
 CONTEXT:  while executing command on localhost:57638
-WARNING:  relation "public.articles_append" does not exist
-CONTEXT:  while executing command on localhost:57638
-WARNING:  relation "public.articles_append" does not exist
-CONTEXT:  while executing command on localhost:57638
-ERROR:  failed to execute task 1
 -- same query on router planner with where false but evaluation left to worker
 SELECT author_id FROM articles_single_shard_hash
 	WHERE 
@@ -1938,9 +1928,8 @@ SELECT author_id FROM articles_single_shard_hash
 	LIMIT 1;
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
-WARNING:  relation "public.articles_single_shard_hash" does not exist
+ERROR:  relation "public.articles_single_shard_hash" does not exist
 CONTEXT:  while executing command on localhost:57637
-ERROR:  could not receive query results
 SELECT author_id FROM articles_hash
 	WHERE 
 		author_id = 1
@@ -1951,9 +1940,8 @@ SELECT author_id FROM articles_hash
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 DETAIL:  distribution column value: 1
-WARNING:  relation "public.articles_hash" does not exist
+ERROR:  relation "public.articles_hash" does not exist
 CONTEXT:  while executing command on localhost:57637
-ERROR:  could not receive query results
 -- create a dummy function to be used in filtering
 CREATE OR REPLACE FUNCTION someDummyFunction(regclass)
     RETURNS text AS
@@ -1989,9 +1977,8 @@ SELECT * FROM articles_hash
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 DETAIL:  distribution column value: 1
-WARNING:  relation "public.articles_hash" does not exist
+ERROR:  relation "public.articles_hash" does not exist
 CONTEXT:  while executing command on localhost:57637
-ERROR:  could not receive query results
 -- temporarily turn off debug messages before dropping the function
 SET client_min_messages TO 'NOTICE';
 DROP FUNCTION someDummyFunction(regclass);

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -1310,9 +1310,8 @@ DEBUG:  Distributed planning for a fast-path router query
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
 DETAIL:  distribution column value: 1
-WARNING:  relation "fast_path_router_select.articles_hash" does not exist
+ERROR:  relation "fast_path_router_select.articles_hash" does not exist
 CONTEXT:  while executing command on localhost:57637
-ERROR:  could not receive query results
 -- temporarily turn off debug messages before dropping the function
 SET client_min_messages TO 'NOTICE';
 DROP FUNCTION someDummyFunction(regclass);

--- a/src/test/regress/expected/subquery_and_cte.out
+++ b/src/test/regress/expected/subquery_and_cte.out
@@ -470,7 +470,7 @@ FOR i IN 1..3 LOOP
 			GROUP BY
 				user_id, cte.value_2);
 	EXCEPTION WHEN OTHERS THEN
-		IF SQLERRM LIKE 'failed to execute task%' THEN
+		IF SQLERRM LIKE 'more than one row returned by a subquery%%' THEN
 			errors_received := errors_received + 1;
 		END IF;
 	END;

--- a/src/test/regress/expected/with_transactions.out
+++ b/src/test/regress/expected/with_transactions.out
@@ -76,7 +76,7 @@ DEBUG:  generating subplan 9_2 for CTE ids_inserted: INSERT INTO with_transactio
 DEBUG:  Plan 9 query after replacing subqueries and CTEs: UPDATE with_transactions.raw_table SET created_at = 'Sat Feb 10 20:00:00 2001 PST'::timestamp with time zone WHERE ((tenant_id OPERATOR(pg_catalog.=) ANY (SELECT ids_inserted.tenant_id FROM (SELECT intermediate_result.tenant_id FROM read_intermediate_result('9_2'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id integer)) ids_inserted)) AND (tenant_id OPERATOR(pg_catalog.<) (SELECT distinct_count.count FROM (SELECT intermediate_result.count FROM read_intermediate_result('9_1'::text, 'binary'::citus_copy_format) intermediate_result(count bigint)) distinct_count)))
 	TRUNCATE second_raw_table;
 COMMIT;
--- sequential insert followed by parallel update causes execution issues
+-- sequential insert followed by parallel update works just fine
 WITH ids_inserted AS
 (
   INSERT INTO raw_table VALUES (11, 1000, now()), (12, 1000, now()), (13, 1000, now()) RETURNING tenant_id 
@@ -85,18 +85,17 @@ UPDATE raw_table SET created_at = '2001-02-10 20:00:00' WHERE tenant_id IN (SELE
 DEBUG:  common table expressions are not supported in distributed modifications
 DEBUG:  generating subplan 12_1 for CTE ids_inserted: INSERT INTO with_transactions.raw_table (tenant_id, income, created_at) VALUES (11,1000,now()), (12,1000,now()), (13,1000,now()) RETURNING raw_table.tenant_id
 DEBUG:  Plan 12 query after replacing subqueries and CTEs: UPDATE with_transactions.raw_table SET created_at = 'Sat Feb 10 20:00:00 2001 PST'::timestamp with time zone WHERE (tenant_id OPERATOR(pg_catalog.=) ANY (SELECT ids_inserted.tenant_id FROM (SELECT intermediate_result.tenant_id FROM read_intermediate_result('12_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id integer)) ids_inserted))
-ERROR:  cannot establish a new connection for placement 800007, since DML has been executed on a connection that is in use
 -- make sure that everything committed
 SELECT count(*) FROM raw_table;
  count 
 -------
-   102
+   105
 (1 row)
 
 SELECT count(*) FROM raw_table WHERE created_at = '2001-02-10 20:00:00';
  count 
 -------
-     1
+     4
 (1 row)
 
 SELECT count(*) FROM second_raw_table;

--- a/src/test/regress/sql/multi_insert_select.sql
+++ b/src/test/regress/sql/multi_insert_select.sql
@@ -1368,8 +1368,8 @@ INSERT INTO raw_events_first SELECT * FROM raw_events_second WHERE user_id = 100
 ROLLBACK;
 
 -- Altering a reference table and then performing an INSERT ... SELECT which
--- joins with the reference table is not allowed, since the INSERT ... SELECT
--- would read from the reference table over others connections than the ones
+-- joins with the reference table is allowed, since the INSERT ... SELECT
+-- would read from the reference table over the same connections with the ones
 -- that performed the parallel DDL.
 BEGIN;
 ALTER TABLE reference_table ADD COLUMN z int;

--- a/src/test/regress/sql/subquery_and_cte.sql
+++ b/src/test/regress/sql/subquery_and_cte.sql
@@ -345,7 +345,7 @@ FOR i IN 1..3 LOOP
 			GROUP BY
 				user_id, cte.value_2);
 	EXCEPTION WHEN OTHERS THEN
-		IF SQLERRM LIKE 'failed to execute task%' THEN
+		IF SQLERRM LIKE 'more than one row returned by a subquery%%' THEN
 			errors_received := errors_received + 1;
 		END IF;
 	END;

--- a/src/test/regress/sql/with_transactions.sql
+++ b/src/test/regress/sql/with_transactions.sql
@@ -58,7 +58,7 @@ BEGIN;
 	TRUNCATE second_raw_table;
 COMMIT;
 
--- sequential insert followed by parallel update causes execution issues
+-- sequential insert followed by parallel update works just fine
 WITH ids_inserted AS
 (
   INSERT INTO raw_table VALUES (11, 1000, now()), (12, 1000, now()), (13, 1000, now()) RETURNING tenant_id 


### PR DESCRIPTION
This PR is on top of #2713 and fixes several minor regression tests. Each commit is self explanatory. But basically, we're either supporting a complicated transaction block or producing much better error messages.

After this one, we only have **3** remaining failing tests in check-multi and check-multi-mx. Those tests include the two known issues: (a) COPY cannot re-use connections yet (b) We're not properly acquiring the partitioning locks yet





