### PR TITLE
Fix isolation_copy_placement_vs_modification in unified executor branch

### DIFF
--- a/src/test/regress/expected/isolation_copy_placement_vs_modification.out
+++ b/src/test/regress/expected/isolation_copy_placement_vs_modification.out
@@ -9,6 +9,7 @@ step s1-insert:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -62,6 +63,7 @@ step s1-insert:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -112,6 +114,7 @@ step s1-load-cache:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -162,6 +165,7 @@ step s1-load-cache:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -212,6 +216,7 @@ step s1-load-cache:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -262,6 +267,7 @@ step s1-insert:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -312,6 +318,7 @@ step s1-insert:
 
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -359,6 +366,7 @@ nodeport       success        result
 starting permutation: s1-begin s1-select s2-set-placement-inactive s2-begin s2-repair-placement s1-insert s2-commit s1-commit s2-print-content
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -406,6 +414,7 @@ nodeport       success        result
 starting permutation: s1-begin s1-select s2-set-placement-inactive s2-begin s2-repair-placement s1-copy s2-commit s1-commit s2-print-content
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;
@@ -453,6 +462,7 @@ nodeport       success        result
 starting permutation: s1-begin s1-select s2-set-placement-inactive s2-begin s2-repair-placement s1-ddl s2-commit s1-commit s2-print-index-count
 step s1-begin: 
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 
 step s1-select: 
 	SELECT count(*) FROM test_copy_placement_vs_modification WHERE x = 5;

--- a/src/test/regress/specs/isolation_copy_placement_vs_modification.spec
+++ b/src/test/regress/specs/isolation_copy_placement_vs_modification.spec
@@ -21,6 +21,7 @@ session "s1"
 step "s1-begin"
 {
     BEGIN;
+	SET LOCAL citus.select_opens_transaction_block TO off;
 }
 
 # since test_copy_placement_vs_modification has rep > 1 simple select query doesn't hit all placements


### PR DESCRIPTION
The unified executor properly opens transaction blocks on the worker when the first statement is a single shard SELECT, this caused the `isolation_copy_placement_vs_modification` test to hang indefinitely.