### PR TITLE
Fix join alias resolution

### DIFF
--- a/src/backend/distributed/utils/ruleutils_10.c
+++ b/src/backend/distributed/utils/ruleutils_10.c
@@ -7246,8 +7246,16 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 		/* Yes, it's correct to put alias after the right paren ... */
 		if (j->alias != NULL)
 		{
+			/*
+			 * Note that it's correct to emit an alias clause if and only if
+			 * there was one originally.  Otherwise we'd be converting a named
+			 * join to unnamed or vice versa, which creates semantic
+			 * subtleties we don't want.  However, we might print a different
+			 * alias name than was there originally.
+			 */
 			appendStringInfo(buf, " %s",
-							 quote_identifier(j->alias->aliasname));
+							 quote_identifier(get_rtable_name(j->rtindex,
+															  context)));
 			get_column_alias_list(colinfo, context);
 		}
 	}

--- a/src/backend/distributed/utils/ruleutils_11.c
+++ b/src/backend/distributed/utils/ruleutils_11.c
@@ -7263,8 +7263,16 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 		/* Yes, it's correct to put alias after the right paren ... */
 		if (j->alias != NULL)
 		{
+			/*
+			 * Note that it's correct to emit an alias clause if and only if
+			 * there was one originally.  Otherwise we'd be converting a named
+			 * join to unnamed or vice versa, which creates semantic
+			 * subtleties we don't want.  However, we might print a different
+			 * alias name than was there originally.
+			 */
 			appendStringInfo(buf, " %s",
-							 quote_identifier(j->alias->aliasname));
+							 quote_identifier(get_rtable_name(j->rtindex,
+															  context)));
 			get_column_alias_list(colinfo, context);
 		}
 	}

--- a/src/test/regress/expected/multi_name_resolution.out
+++ b/src/test/regress/expected/multi_name_resolution.out
@@ -1,0 +1,41 @@
+--
+-- MULTI_NAME_RESOLUTION
+--
+-- There was a failure compiling queries with shadowed subquery aliases
+-- https://github.com/citusdata/citus/issues/2642
+CREATE SCHEMA multi_name_resolution;
+SET search_path TO multi_name_resolution;
+create table namenest1 (id integer primary key, user_id integer);
+create table namenest2 (id integer primary key, value_2 integer);
+select * from create_distributed_table('namenest1', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+select * from create_reference_table('namenest2');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+SELECT r
+FROM (
+	SELECT id_deep, random() as r -- prevent pulling up the subquery
+	FROM (
+		namenest1
+		JOIN namenest2 ON (namenest1.user_id = namenest2.value_2)
+	) AS join_alias(id_deep)
+) AS bar, (
+	namenest1
+	JOIN namenest2 ON (namenest1.user_id = namenest2.value_2)
+) AS join_alias(id_deep)
+WHERE bar.id_deep = join_alias.id_deep;
+ r 
+---
+(0 rows)
+
+DROP SCHEMA multi_name_resolution CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table namenest1
+drop cascades to table namenest2

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -21,6 +21,7 @@ test: multi_cluster_management
 test: multi_test_helpers
 test: multi_table_ddl
 test: multi_name_lengths
+test: multi_name_resolution
 test: multi_metadata_access
 test: multi_metadata_attributes
 

--- a/src/test/regress/sql/multi_name_resolution.sql
+++ b/src/test/regress/sql/multi_name_resolution.sql
@@ -1,0 +1,29 @@
+--
+-- MULTI_NAME_RESOLUTION
+--
+
+-- There was a failure compiling queries with shadowed subquery aliases
+-- https://github.com/citusdata/citus/issues/2642
+
+CREATE SCHEMA multi_name_resolution;
+SET search_path TO multi_name_resolution;
+
+create table namenest1 (id integer primary key, user_id integer);
+create table namenest2 (id integer primary key, value_2 integer);
+select * from create_distributed_table('namenest1', 'id');
+select * from create_reference_table('namenest2');
+
+SELECT r
+FROM (
+	SELECT id_deep, random() as r -- prevent pulling up the subquery
+	FROM (
+		namenest1
+		JOIN namenest2 ON (namenest1.user_id = namenest2.value_2)
+	) AS join_alias(id_deep)
+) AS bar, (
+	namenest1
+	JOIN namenest2 ON (namenest1.user_id = namenest2.value_2)
+) AS join_alias(id_deep)
+WHERE bar.id_deep = join_alias.id_deep;
+
+DROP SCHEMA multi_name_resolution CASCADE;


### PR DESCRIPTION
Fixes #2642

FROM (query) alias ignored renaming
In nested subqueries the select list would rename, while the join alias would not respect that

DESCRIPTION: fix error caused by joins with shadowed aliases
