### PR TITLE
Make sure that TRUNCATE relies on unified executor

### DIFF
--- a/src/backend/distributed/master/master_truncate.c
+++ b/src/backend/distributed/master/master_truncate.c
@@ -77,14 +77,7 @@ citus_truncate_trigger(PG_FUNCTION_ARGS)
 	{
 		List *taskList = TruncateTaskList(relationId);
 
-		if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
-		{
-			ExecuteModifyTasksSequentiallyWithoutResults(taskList, CMD_UTILITY);
-		}
-		else
-		{
-			ExecuteModifyTasksWithoutResults(taskList);
-		}
+		ExecuteTaskList(CMD_UTILITY, taskList, DEFAULT_POOL_SIZE);
 	}
 
 	PG_RETURN_DATUM(PointerGetDatum(NULL));


### PR DESCRIPTION
With #2724, we've changed how `TRUNCATE` is implemented. This PR makes sure that `TRUNCATE` relies on unified executor on `unified_executor` branch.

You can also consider this as re-applying #2660 to unified executor on top of the #2724.