### PR TITLE
Make sure that the regression tests are resistant to execution order changes

### DIFF
--- a/src/test/regress/expected/multi_mx_reference_table.out
+++ b/src/test/regress/expected/multi_mx_reference_table.out
@@ -764,7 +764,8 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test
 WHERE 
-	colocated_table_test.value_1 = reference_table_test.value_1;
+	colocated_table_test.value_1 = reference_table_test.value_1
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_1 
 ---------
@@ -777,7 +778,8 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test 
 WHERE 
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2 
 ---------
@@ -790,7 +792,8 @@ SELECT
 FROM 
 	colocated_table_test, reference_table_test
 WHERE 
-	reference_table_test.value_1 = colocated_table_test.value_1;
+	reference_table_test.value_1 = colocated_table_test.value_1
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2 
 ---------
@@ -803,7 +806,8 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ cartesian product "colocated_table_test_2" ]
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Cartesian products are currently unsupported
@@ -812,7 +816,8 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_1 = colocated_table_test_2.value_1 AND colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_1 = colocated_table_test_2.value_1 AND colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ local partition join "colocated_table_test_2" ]
  value_2 
 ---------
@@ -826,7 +831,8 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_2 = colocated_table_test_2.value_2 AND colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = colocated_table_test_2.value_2 AND colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ dual partition join "colocated_table_test_2" ]
  value_2 
 ---------
@@ -839,7 +845,8 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_1 = reference_table_test.value_1 AND colocated_table_test_2.value_1 = reference_table_test.value_1;
+	colocated_table_test.value_1 = reference_table_test.value_1 AND colocated_table_test_2.value_1 = reference_table_test.value_1
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ dual partition join "colocated_table_test_2" ]
  value_2 
 ---------

--- a/src/test/regress/expected/multi_mx_router_planner.out
+++ b/src/test/regress/expected/multi_mx_router_planner.out
@@ -844,24 +844,25 @@ HINT:  Set citus.enable_repartition_joins to on to enable repartitioning
 -- handled by real-time executor
 SELECT *
 	FROM articles_hash_mx
-	WHERE author_id >= 1 AND author_id <= 3;
+	WHERE author_id >= 1 AND author_id <= 3
+ORDER BY 1,2,3,4;
  id | author_id |    title     | word_count 
 ----+-----------+--------------+------------
   1 |         1 | arsenous     |       9572
+  2 |         2 | abducing     |      13642
   3 |         3 | asternal     |      10480
  11 |         1 | alamo        |       1347
+ 12 |         2 | archiblast   |      18185
  13 |         3 | aseyev       |       2255
  21 |         1 | arcading     |       5890
+ 22 |         2 | antipope     |       2728
  23 |         3 | abhorring    |       6799
  31 |         1 | athwartships |       7271
+ 32 |         2 | amazon       |      11342
  33 |         3 | autochrome   |       8180
  41 |         1 | aznavour     |      11814
- 43 |         3 | affixal      |      12723
-  2 |         2 | abducing     |      13642
- 12 |         2 | archiblast   |      18185
- 22 |         2 | antipope     |       2728
- 32 |         2 | amazon       |      11342
  42 |         2 | ausable      |      15885
+ 43 |         3 | affixal      |      12723
 (15 rows)
 
 SET citus.task_executor_type TO 'real-time';

--- a/src/test/regress/expected/multi_mx_schema_support.out
+++ b/src/test/regress/expected/multi_mx_schema_support.out
@@ -159,15 +159,15 @@ SELECT * FROM nation_hash  WHERE n_nationkey OPERATOR(===) 1;
            1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
 (1 row)
 
-SELECT * FROM citus_mx_test_schema.nation_hash_collation_search_path;
+SELECT * FROM citus_mx_test_schema.nation_hash_collation_search_path ORDER BY 1;
  n_nationkey |          n_name           | n_regionkey |                                                  n_comment                                                  
 -------------+---------------------------+-------------+-------------------------------------------------------------------------------------------------------------
-           1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
-           5 | ETHIOPIA                  |           0 | ven packages wake quickly. regu
            0 | ALGERIA                   |           0 | haggle. carefully final deposits detect slyly agai
+           1 | ARGENTINA                 |           1 | al foxes promise slyly according to the regular accounts. bold requests alon
+           2 | BRAZIL                    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
            3 | CANADA                    |           1 | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
            4 | EGYPT                     |           4 | y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
-           2 | BRAZIL                    |           1 | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special 
+           5 | ETHIOPIA                  |           0 | ven packages wake quickly. regu
 (6 rows)
 
 SELECT n_comment FROM citus_mx_test_schema.nation_hash_collation_search_path ORDER BY n_comment COLLATE citus_mx_test_schema.english;

--- a/src/test/regress/expected/multi_subquery_complex_reference_clause.out
+++ b/src/test/regress/expected/multi_subquery_complex_reference_clause.out
@@ -576,12 +576,13 @@ SELECT * FROM
               users_table as "users"
             WHERE
               user_id > 2 and value_2 = 1) as foo_in ON (event_val_2 = user_id)) as foo LEFT JOIN
-           (SELECT user_id as user_user_id FROM users_table) as fooo ON (user_id = user_user_id)) as bar;
+           (SELECT user_id as user_user_id FROM users_table) as fooo ON (user_id = user_user_id)) as bar
+ORDER BY 1;
  user_id 
 ---------
-       5
        3
        4
+       5
 (3 rows)
 
 -- the same query but this time reference table is in the outer part of the query

--- a/src/test/regress/sql/multi_mx_reference_table.sql
+++ b/src/test/regress/sql/multi_mx_reference_table.sql
@@ -476,35 +476,41 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test
 WHERE 
-	colocated_table_test.value_1 = reference_table_test.value_1;
+	colocated_table_test.value_1 = reference_table_test.value_1
+ORDER BY 1;
 
 SELECT 
 	colocated_table_test.value_2
 FROM 
 	reference_table_test, colocated_table_test 
 WHERE 
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 
 SELECT 
 	colocated_table_test.value_2
 FROM 
 	colocated_table_test, reference_table_test
 WHERE 
-	reference_table_test.value_1 = colocated_table_test.value_1;
+	reference_table_test.value_1 = colocated_table_test.value_1
+ORDER BY 1;
+
 
 SELECT 
 	colocated_table_test.value_2 
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 
 SELECT 
 	colocated_table_test.value_2 
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_1 = colocated_table_test_2.value_1 AND colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_1 = colocated_table_test_2.value_1 AND colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 
 SET citus.task_executor_type to "task-tracker";
 SELECT 
@@ -512,14 +518,16 @@ SELECT
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_2 = colocated_table_test_2.value_2 AND colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = colocated_table_test_2.value_2 AND colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 
 SELECT 
 	reference_table_test.value_2 
 FROM 
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE 
-	colocated_table_test.value_1 = reference_table_test.value_1 AND colocated_table_test_2.value_1 = reference_table_test.value_1;
+	colocated_table_test.value_1 = reference_table_test.value_1 AND colocated_table_test_2.value_1 = reference_table_test.value_1
+ORDER BY 1;
 
 
 SET client_min_messages TO NOTICE;

--- a/src/test/regress/sql/multi_mx_router_planner.sql
+++ b/src/test/regress/sql/multi_mx_router_planner.sql
@@ -379,7 +379,8 @@ SELECT *
 -- handled by real-time executor
 SELECT *
 	FROM articles_hash_mx
-	WHERE author_id >= 1 AND author_id <= 3;
+	WHERE author_id >= 1 AND author_id <= 3
+ORDER BY 1,2,3,4;
 
 SET citus.task_executor_type TO 'real-time';
 

--- a/src/test/regress/sql/multi_mx_schema_support.sql
+++ b/src/test/regress/sql/multi_mx_schema_support.sql
@@ -86,7 +86,7 @@ SET search_path TO citus_mx_test_schema;
 SELECT * FROM nation_hash  WHERE n_nationkey OPERATOR(===) 1;
 
 
-SELECT * FROM citus_mx_test_schema.nation_hash_collation_search_path;
+SELECT * FROM citus_mx_test_schema.nation_hash_collation_search_path ORDER BY 1;
 SELECT n_comment FROM citus_mx_test_schema.nation_hash_collation_search_path ORDER BY n_comment COLLATE citus_mx_test_schema.english;
 
 SET search_path  TO citus_mx_test_schema;

--- a/src/test/regress/sql/multi_subquery_complex_reference_clause.sql
+++ b/src/test/regress/sql/multi_subquery_complex_reference_clause.sql
@@ -354,7 +354,8 @@ SELECT * FROM
               users_table as "users"
             WHERE
               user_id > 2 and value_2 = 1) as foo_in ON (event_val_2 = user_id)) as foo LEFT JOIN
-           (SELECT user_id as user_user_id FROM users_table) as fooo ON (user_id = user_user_id)) as bar;
+           (SELECT user_id as user_user_id FROM users_table) as fooo ON (user_id = user_user_id)) as bar
+ORDER BY 1;
 
 -- the same query but this time reference table is in the outer part of the query
 SELECT * FROM


### PR DESCRIPTION
Same as #2657 but mostly for `check-multi-mx` tests.

Since the changes are very trivial and only in the regression tests, I'll go ahead and merge once the tests pass. Otherwise, maintaining these branches becomes a burden.

@pykello Feel free to go over the PR and revert it if you see anything unusual/wrong etc.