### PR TITLE
Update failure test regression test outputs

### DIFF
--- a/src/test/regress/expected/failure_1pc_copy_append.out
+++ b/src/test/regress/expected/failure_1pc_copy_append.out
@@ -4,6 +4,8 @@ SELECT citus.mitmproxy('conn.allow()');
  
 (1 row)
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 1;
 SET citus.shard_count = 1;
 SET citus.shard_replication_factor = 2; -- one shard per worker
 SET citus.multi_shard_commit_protocol TO '1pc';
@@ -50,8 +52,8 @@ SELECT citus.dump_network_traffic();
  (0,worker,"[""RowDescription(fieldcount=2,fields=['F(name=min,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)', 'F(name=max,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)'])"", 'DataRow(columncount=2,columns=[""C(length=0,value=b\\'\\')"", ""C(length=1,value=b\\'0\\')""])', 'CommandComplete(command=SELECT 1)', 'ReadyForQuery(state=in_transaction_block)']")
  (0,coordinator,"['Query(query=COMMIT)']")
  (0,worker,"['CommandComplete(command=COMMIT)', 'ReadyForQuery(state=idle)']")
- (0,coordinator,"['Query(query=COPY (SELECT count(1) AS count FROM copy_test_100400 copy_test WHERE true) TO STDOUT)']")
- (0,worker,"[""CopyOutResponse(format=0,columncount=1,columns=['Anonymous(format=0)'])"", ""CopyData(data=b'4\\\\n')"", 'CopyDone()', 'CommandComplete(command=COPY 1)', 'ReadyForQuery(state=idle)']")
+ (0,coordinator,"['Query(query=SELECT count(1) AS count FROM copy_test_100400 copy_test WHERE true)']")
+ (0,worker,"[""RowDescription(fieldcount=1,fields=['F(name=count,tableoid=0,colattrnum=0,typoid=20,typlen=8,typmod=-1,format_code=0)'])"", 'DataRow(columncount=1,columns=[""C(length=0,value=b\\'\\')""])', 'CommandComplete(command=SELECT 1)', 'ReadyForQuery(state=idle)']")
 (20 rows)
 
 ---- all of the following tests test behavior with 2 shard placements ----
@@ -159,15 +161,24 @@ SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |     9060 |         101
 (2 rows)
 
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
 SELECT count(1) FROM copy_test;
-WARNING:  could not consume data from worker node
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
  count 
 -------
      4
 (1 row)
 
 ---- cancel the connection when we send the data ----
-SELECT citus.mitmproxy(format('conn.onCopyData().cancel(%s)', pg_backend_pid()));
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' ||  pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -225,9 +236,9 @@ SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p
  logicalrelid | shardid | shardstorage | shardminvalue | shardmaxvalue | shardid | shardstate | shardlength | nodename  | nodeport | placementid 
 --------------+---------+--------------+---------------+---------------+---------+------------+-------------+-----------+----------+-------------
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |     9060 |         101
- copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |     9060 |         112
+ copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |     9060 |         110
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |    57637 |         100
- copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |    57637 |         113
+ copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |    57637 |         111
 (4 rows)
 
 SELECT count(1) FROM copy_test;
@@ -258,8 +269,8 @@ SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p
 --------------+---------+--------------+---------------+---------------+---------+------------+-------------+-----------+----------+-------------
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |    57637 |         100
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |     9060 |         101
- copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |     9060 |         112
- copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |    57637 |         113
+ copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |     9060 |         110
+ copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |    57637 |         111
 (4 rows)
 
 SELECT count(1) FROM copy_test;
@@ -288,10 +299,10 @@ SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p
 --------------+---------+--------------+---------------+---------------+---------+------------+-------------+-----------+----------+-------------
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |    57637 |         100
  copy_test    |  100400 | t            | 0             | 3             |  100400 |          1 |        8192 | localhost |     9060 |         101
- copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |     9060 |         112
- copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |    57637 |         113
- copy_test    |  100409 | t            | 0             | 3             |  100409 |          3 |        8192 | localhost |     9060 |         116
- copy_test    |  100409 | t            | 0             | 3             |  100409 |          1 |        8192 | localhost |    57637 |         117
+ copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |     9060 |         110
+ copy_test    |  100407 | t            | 0             | 3             |  100407 |          1 |        8192 | localhost |    57637 |         111
+ copy_test    |  100409 | t            | 0             | 3             |  100409 |          3 |        8192 | localhost |     9060 |         114
+ copy_test    |  100409 | t            | 0             | 3             |  100409 |          1 |        8192 | localhost |    57637 |         115
 (6 rows)
 
 SELECT count(1) FROM copy_test;

--- a/src/test/regress/expected/failure_1pc_copy_hash.out
+++ b/src/test/regress/expected/failure_1pc_copy_hash.out
@@ -4,6 +4,8 @@ SELECT citus.mitmproxy('conn.allow()');
  
 (1 row)
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
 SET citus.shard_count = 1;
 SET citus.shard_replication_factor = 2; -- one shard per worker
 SET citus.multi_shard_commit_protocol TO '1pc';

--- a/src/test/regress/expected/failure_cte_subquery.out
+++ b/src/test/regress/expected/failure_cte_subquery.out
@@ -83,10 +83,10 @@ FROM
      ORDER BY 1 DESC LIMIT 5
      ) as foo 
 	  WHERE foo.user_id = cte.user_id;
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-ERROR:  failed to execute task 1
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 	  
 -- kill at the third copy (pull)
 SELECT citus.mitmproxy('conn.onQuery(query="SELECT DISTINCT users_table.user").kill()');
@@ -118,9 +118,10 @@ FROM
      ORDER BY 1 DESC LIMIT 5
      ) as foo 
 	  WHERE foo.user_id = cte.user_id;
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-ERROR:  failed to execute task 1
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 -- cancel at the first copy (push)
 SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || :pid || ')');
  mitmproxy 
@@ -257,10 +258,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^DELETE FROM").kill()');
 
 WITH cte_delete as (DELETE FROM users_table WHERE user_name in ('A', 'D') RETURNING *)
 INSERT INTO users_table SELECT * FROM cte_delete;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify contents are the same
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
@@ -373,10 +374,10 @@ BEGIN;
 SET LOCAL citus.multi_shard_modify_mode = 'sequential';
 WITH cte_delete as (DELETE FROM users_table WHERE user_name in ('A', 'D') RETURNING *)
 INSERT INTO users_table SELECT * FROM cte_delete;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 END;
 RESET SEARCH_PATH;
 SELECT citus.mitmproxy('conn.allow()');

--- a/src/test/regress/expected/failure_ddl.out
+++ b/src/test/regress/expected/failure_ddl.out
@@ -5,6 +5,8 @@
 -- 
 CREATE SCHEMA ddl_failure;
 SET search_path TO 'ddl_failure';
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
 -- we don't want to see the prepared transaction numbers in the warnings
 SET client_min_messages TO ERROR;
 SELECT citus.mitmproxy('conn.allow()');
@@ -68,7 +70,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
   array_agg  
 -------------
@@ -98,10 +103,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").kil
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- show that we've never commited the changes
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
   array_agg  
@@ -377,7 +382,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 ALTER TABLE test_table DROP COLUMN new_column;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
        array_agg        
 ------------------------
@@ -407,10 +415,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").kil
 (1 row)
 
 ALTER TABLE test_table DROP COLUMN new_column;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
        array_agg        
 ------------------------
@@ -745,7 +753,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
   array_agg  
 -------------
@@ -775,10 +786,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").kil
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
   array_agg  
 -------------
@@ -1036,7 +1047,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT array_agg(name::text ORDER BY name::text) FROM public.table_attrs where relid = 'test_table'::regclass;
   array_agg  
 -------------
@@ -1066,10 +1080,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").kil
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- kill as soon as the coordinator after it sends worker_apply_shard_ddl_command 2nd time
 SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").after(2).kill()');
  mitmproxy 
@@ -1078,10 +1092,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").aft
 (1 row)
 
 ALTER TABLE test_table ADD COLUMN new_column INT;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- cancel as soon as the coordinator after it sends worker_apply_shard_ddl_command 2nd time
 SELECT citus.mitmproxy('conn.onQuery(query="worker_apply_shard_ddl_command").after(2).cancel(' ||  pg_backend_pid() || ')');
  mitmproxy 

--- a/src/test/regress/expected/failure_insert_select_pushdown.out
+++ b/src/test/regress/expected/failure_insert_select_pushdown.out
@@ -44,10 +44,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^INSERT INTO insert_select_pushdown"
 (1 row)
 
 INSERT INTO events_summary SELECT user_id, event_id, count(*) FROM events_table GROUP BY 1,2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 --verify nothing is modified
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
@@ -98,10 +98,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^INSERT INTO insert_select_pushdown"
 (1 row)
 
 INSERT INTO events_table SELECT * FROM events_table;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 --verify nothing is modified
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 

--- a/src/test/regress/expected/failure_insert_select_via_coordinator.out
+++ b/src/test/regress/expected/failure_insert_select_via_coordinator.out
@@ -53,10 +53,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
 (1 row)
 
 INSERT INTO events_summary SELECT event_id, event_type, count(*) FROM events_table GROUP BY 1,2;
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-ERROR:  failed to execute task 1
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
 -- kill data push
 SELECT citus.mitmproxy('conn.onQuery(query="^COPY coordinator_insert_select").kill()');
  mitmproxy 
@@ -109,10 +109,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
 (1 row)
 
 INSERT INTO events_reference SELECT event_type, count(*) FROM events_table GROUP BY 1;
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
-ERROR:  failed to execute task 1
+ERROR:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  while executing command on localhost:9060
 -- kill data push
 SELECT citus.mitmproxy('conn.onQuery(query="^COPY coordinator_insert_select").kill()');
  mitmproxy 

--- a/src/test/regress/expected/failure_multi_dml.out
+++ b/src/test/regress/expected/failure_multi_dml.out
@@ -33,10 +33,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^DELETE").kill()');
 
 BEGIN;
 DELETE FROM dml_test WHERE id = 1;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 DELETE FROM dml_test WHERE id = 2;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 INSERT INTO dml_test VALUES (5, 'Epsilon');
@@ -96,10 +96,10 @@ BEGIN;
 DELETE FROM dml_test WHERE id = 1;
 DELETE FROM dml_test WHERE id = 2;
 INSERT INTO dml_test VALUES (5, 'Epsilon');
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 UPDATE dml_test SET name = 'alpha' WHERE id = 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 UPDATE dml_test SET name = 'gamma' WHERE id = 3;
@@ -154,10 +154,10 @@ DELETE FROM dml_test WHERE id = 1;
 DELETE FROM dml_test WHERE id = 2;
 INSERT INTO dml_test VALUES (5, 'Epsilon');
 UPDATE dml_test SET name = 'alpha' WHERE id = 1;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 UPDATE dml_test SET name = 'gamma' WHERE id = 3;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
@@ -393,7 +393,7 @@ UPDATE dml_test SET name = 'gamma' WHERE id = 3;
 COMMIT;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit transaction on localhost:9060
+WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 --- should see all changes, but they only went to one placement (other is unhealthy)

--- a/src/test/regress/expected/failure_multi_shard_update_delete.out
+++ b/src/test/regress/expected/failure_multi_shard_update_delete.out
@@ -6,6 +6,8 @@ SET SEARCH_PATH = multi_shard;
 SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 201000;
 SET citus.shard_replication_factor TO 1;
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -61,10 +63,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="DELETE FROM").kill()');
 
 -- issue a multi shard delete
 DELETE FROM t2 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is deleted
 SELECT count(*) FROM t2;
  count 
@@ -80,10 +82,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="DELETE FROM multi_shard.t2_201005").
 (1 row)
 
 DELETE FROM t2 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is deleted
 SELECT count(*) FROM t2;
  count 
@@ -143,10 +145,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE").kill()');
 
 -- issue a multi shard update
 UPDATE t2 SET c = 4 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 2) AS b2, count(*) FILTER (WHERE c = 4) AS c4 FROM t2;
  b2 | c4 
@@ -162,10 +164,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="UPDATE multi_shard.t2_201005").kill(
 (1 row)
 
 UPDATE t2 SET c = 4 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 2) AS b2, count(*) FILTER (WHERE c = 4) AS c4 FROM t2;
  b2 | c4 
@@ -219,10 +221,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="DELETE FROM").kill()');
 
 -- issue a multi shard delete
 DELETE FROM t2 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is deleted
 SELECT count(*) FROM t2;
  count 
@@ -238,10 +240,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="DELETE FROM multi_shard.t2_201005").
 (1 row)
 
 DELETE FROM t2 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is deleted
 SELECT count(*) FROM t2;
  count 
@@ -301,10 +303,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE").kill()');
 
 -- issue a multi shard update
 UPDATE t2 SET c = 4 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 2) AS b2, count(*) FILTER (WHERE c = 4) AS c4 FROM t2;
  b2 | c4 
@@ -320,10 +322,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="UPDATE multi_shard.t2_201005").kill(
 (1 row)
 
 UPDATE t2 SET c = 4 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 2) AS b2, count(*) FILTER (WHERE c = 4) AS c4 FROM t2;
  b2 | c4 
@@ -394,10 +396,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="DELETE FROM").kill()');
 (1 row)
 
 DELETE FROM r1 WHERE a = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is deleted
 SELECT count(*) FILTER (WHERE b = 2) AS b2 FROM t2;
  b2 
@@ -412,10 +414,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="DELETE FROM").kill()');
 (1 row)
 
 DELETE FROM t2 WHERE b = 2;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is deleted
 SELECT count(*) FILTER (WHERE b = 2) AS b2 FROM t2;
  b2 
@@ -494,10 +496,10 @@ UPDATE t3 SET c = q.c FROM (
 	SELECT b, max(c) as c FROM t2  GROUP BY b) q
 WHERE t3.b = q.b
 RETURNING *;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 --- verify nothing is updated
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
@@ -550,10 +552,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="UPDATE multi_shard.t3_201013").kill(
 (1 row)
 
 UPDATE t3 SET b = 2 WHERE b = 1;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FROM t3;
  b1 | b2 
@@ -585,10 +587,10 @@ SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FRO
 
 -- following will fail
 UPDATE t3 SET b = 2 WHERE b = 1;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 END;
 -- verify everything is rolled back
 SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FROM t2;
@@ -604,10 +606,10 @@ SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FRO
 (1 row)
 
 UPDATE t3 SET b = 1 WHERE b = 2 RETURNING *;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FROM t3;
  b1 | b2 
@@ -624,10 +626,10 @@ SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FRO
 (1 row)
 
 UPDATE t3 SET b = 2 WHERE b = 1;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- verify nothing is updated
 SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FROM t3;
  b1 | b2 
@@ -659,10 +661,10 @@ SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FRO
 
 -- following will fail
 UPDATE t3 SET b = 2 WHERE b = 1;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 END;
 -- verify everything is rolled back
 SELECT count(*) FILTER (WHERE b = 1) b1, count(*) FILTER (WHERE b = 2) AS b2 FROM t2;

--- a/src/test/regress/expected/failure_real_time_select.out
+++ b/src/test/regress/expected/failure_real_time_select.out
@@ -26,18 +26,20 @@ INSERT INTO test_table VALUES(1,1,1),(1,2,2),(2,1,1),(2,2,2),(3,1,1),(3,2,2);
 -- Kill when the first COPY command arrived, since we have a single placement 
 -- it is expected to error out.
 SET client_min_messages TO ERROR;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
  mitmproxy 
 -----------
  
 (1 row)
 
-SELECT public.raise_failed_execution('SELECT count(*) FROM test_table');
-ERROR:  Task failed to execute
-CONTEXT:  PL/pgSQL function public.raise_failed_execution(text) line 6 at RAISE
+SELECT count(*) FROM test_table;
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SET client_min_messages TO DEFAULT;
 -- Kill the connection with a CTE
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
  mitmproxy 
 -----------
  
@@ -47,29 +49,31 @@ WITH
 results AS (SELECT * FROM test_table)
 SELECT * FROM test_table, results
 WHERE test_table.id = results.id;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 -- Since the outer query uses the connection opened by the CTE,
 -- killing connection after first successful query should break.
 SET client_min_messages TO ERROR;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
  mitmproxy 
 -----------
  
 (1 row)
 
-SELECT public.raise_failed_execution('WITH
-			results AS (SELECT * FROM test_table)
-			SELECT * FROM test_table, results
-			WHERE test_table.id = results.id');
-ERROR:  Task failed to execute
-CONTEXT:  PL/pgSQL function public.raise_failed_execution(text) line 6 at RAISE
+WITH results AS (SELECT * FROM test_table)
+SELECT * FROM test_table, results
+WHERE test_table.id = results.id;
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SET client_min_messages TO DEFAULT;
 -- In parallel execution mode Citus opens separate connections for each shard
 -- so killing the connection after the first copy does not break it.
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SET citus.force_max_query_parallelization=ON;
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
  mitmproxy 
 -----------
  
@@ -81,8 +85,10 @@ SELECT count(*) FROM test_table;
      6
 (1 row)
 
+-- set back the force flag to original value
+SET citus.force_max_query_parallelization=OFF;
 -- Cancel a real-time executor query
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -91,7 +97,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid()
 SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 -- Cancel a query within the transaction
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -102,7 +108,7 @@ SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 COMMIT;
 -- Cancel a query within the transaction after a multi-shard update
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -125,11 +131,9 @@ results AS (SELECT * FROM test_table)
 SELECT * FROM test_table
 WHERE test_table.id > (SELECT id FROM results);
 ERROR:  canceling statement due to user request
--- Since Citus opens a new connection after a failure within the real time
--- execution and after(1).kill() kills connection after a successful execution
--- for each connection, following transaciton does not fail.
+-- Citus fails if the connection that is already used fails afterwards
 SET citus.multi_shard_modify_mode to sequential;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
  mitmproxy 
 -----------
  
@@ -137,15 +141,13 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
 
 BEGIN;
 SELECT count(*) FROM test_table;
-WARNING:  could not consume data from worker node
- count 
--------
-     6
-(1 row)
-
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 COMMIT;
 -- Cancel a real-time executor query - in sequential mode
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -154,7 +156,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid()
 SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 -- Cancel a query within the transaction - in sequential mode
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -165,7 +167,7 @@ SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 COMMIT;
 -- Cancel the query within a transaction after a single succesful run
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -180,6 +182,12 @@ COMMIT;
 DROP TABLE test_table;
 SET citus.multi_shard_modify_mode to default;
 -- Create table with shard placements on each node
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
 SET citus.shard_replication_factor to 2;
 CREATE TABLE test_table(id int, value_1 int, value_2 int);
 SELECT create_distributed_table('test_table','id');
@@ -190,17 +198,23 @@ SELECT create_distributed_table('test_table','id');
 
 -- Populate data to the table
 INSERT INTO test_table VALUES(1,1,1),(1,2,2),(2,1,1),(2,2,2),(3,1,1),(3,2,2);
--- Kill when the first COPY command arrived, since we have placements on each node
+-- Kill when the first SELECT command arrived, since we have placements on each node
 -- it shouldn't fail.
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
  mitmproxy 
 -----------
  
 (1 row)
 
 SELECT count(*) FROM test_table;
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
  count 
 -------
      6
@@ -208,7 +222,7 @@ WARNING:  could not consume data from worker node
 
 -- Kill within the transaction, since we have placements on each node
 -- it shouldn't fail.
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
  mitmproxy 
 -----------
  
@@ -216,8 +230,14 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
 
 BEGIN;
 SELECT count(*) FROM test_table;
-WARNING:  could not consume data from worker node
-WARNING:  could not consume data from worker node
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
  count 
 -------
      6
@@ -225,7 +245,7 @@ WARNING:  could not consume data from worker node
 
 COMMIT;
 -- Cancel a real-time executor query
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -234,7 +254,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid()
 SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 -- Cancel a query within the transaction
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -245,7 +265,7 @@ SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 COMMIT;
 -- Cancel a query within the transaction after a multi-shard update
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -257,7 +277,7 @@ SELECT count(*) FROM test_table;
 ERROR:  canceling statement due to user request
 COMMIT;
 -- Cancel a query with CTE
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
  mitmproxy 
 -----------
  
@@ -271,7 +291,7 @@ ERROR:  canceling statement due to user request
 -- Since we have the placement on each node, test with sequential mode
 -- should pass as well.
 SET citus.multi_shard_modify_mode to sequential;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
  mitmproxy 
 -----------
  
@@ -279,7 +299,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
 
 BEGIN;
 SELECT count(*) FROM test_table;
-WARNING:  could not consume data from worker node
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
  count 
 -------
      6

--- a/src/test/regress/expected/failure_ref_tables.out
+++ b/src/test/regress/expected/failure_ref_tables.out
@@ -33,10 +33,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").kill()');
 (1 row)
 
 INSERT INTO ref_table VALUES (5, 6);
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT COUNT(*) FROM ref_table WHERE key=5;
  count 
 -------
@@ -51,10 +51,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE").kill()');
 (1 row)
 
 UPDATE ref_table SET key=7 RETURNING value;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT COUNT(*) FROM ref_table WHERE key=7;
  count 
 -------
@@ -71,10 +71,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE").kill()');
 BEGIN;
 DELETE FROM ref_table WHERE key=5;
 UPDATE ref_table SET key=value;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 COMMIT;
 SELECT COUNT(*) FROM ref_table WHERE key=value;
  count 

--- a/src/test/regress/expected/failure_single_mod.out
+++ b/src/test/regress/expected/failure_single_mod.out
@@ -27,10 +27,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").kill()');
 (1 row)
 
 INSERT INTO mod_test VALUES (2, 6);
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT COUNT(*) FROM mod_test WHERE key=2;
  count 
 -------
@@ -63,10 +63,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^UPDATE").kill()');
 (1 row)
 
 UPDATE mod_test SET value='ok' WHERE key=2 RETURNING key;
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
  key 
 -----
    2
@@ -102,17 +102,11 @@ INSERT INTO mod_test VALUES (2, 6);
 INSERT INTO mod_test VALUES (2, 7);
 DELETE FROM mod_test WHERE key=2 AND value = '7';
 UPDATE mod_test SET value='ok' WHERE key=2;
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 COMMIT;
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
 SELECT COUNT(*) FROM mod_test WHERE key=2;
  count 
 -------

--- a/src/test/regress/expected/failure_single_select.out
+++ b/src/test/regress/expected/failure_single_select.out
@@ -28,20 +28,20 @@ SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
 (1 row)
 
 SELECT * FROM select_test WHERE key = 2;
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
  key |   value   
 -----+-----------
    2 | test data
 (1 row)
 
 SELECT * FROM select_test WHERE key = 2;
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
  key |   value   
 -----+-----------
    2 | test data
@@ -57,10 +57,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
 BEGIN;
 INSERT INTO select_test VALUES (2, 'more data');
 SELECT * FROM select_test WHERE key = 2;
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
  key |   value   
 -----+-----------
    2 | test data
@@ -69,6 +69,10 @@ CONTEXT:  while executing command on localhost:9060
 
 INSERT INTO select_test VALUES (2, 'even more data');
 SELECT * FROM select_test WHERE key = 2;
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
  key |     value      
 -----+----------------
    2 | test data
@@ -77,12 +81,6 @@ SELECT * FROM select_test WHERE key = 2;
 (3 rows)
 
 COMMIT;
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
 -- some clean up
 UPDATE pg_dist_shard_placement SET shardstate = 1
 WHERE shardid IN (
@@ -162,10 +160,10 @@ SELECT * FROM select_test WHERE key = 2;
 
 INSERT INTO select_test VALUES (2, 'even more data');
 SELECT * FROM select_test WHERE key = 2;
-WARNING:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
  key |     value      
 -----+----------------
    2 | more data
@@ -173,12 +171,6 @@ CONTEXT:  while executing command on localhost:9060
 (2 rows)
 
 COMMIT;
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(2).kill()');
  mitmproxy 
 -----------
@@ -223,11 +215,10 @@ SELECT * FROM select_test WHERE key = 1;
 (1 row)
 
 SELECT * FROM select_test WHERE key = 1;
-WARNING:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
-ERROR:  could not receive query results
 -- now the same test with query cancellation
 SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).cancel(' ||  pg_backend_pid() || ')');
  mitmproxy 

--- a/src/test/regress/expected/failure_truncate.out
+++ b/src/test/regress/expected/failure_truncate.out
@@ -6,6 +6,8 @@ SET search_path TO 'truncate_failure';
 SET citus.next_shard_id TO 120000;
 -- we don't want to see the prepared transaction numbers in the warnings
 SET client_min_messages TO ERROR;
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -98,7 +100,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 TRUNCATE test_table;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -152,10 +157,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="TRUNCATE TABLE truncate_failure.test
 (1 row)
 
 TRUNCATE test_table;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -426,10 +431,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^TRUNCATE TABLE").after(2).kill()');
 (1 row)
 
 TRUNCATE reference_table CASCADE;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -628,7 +633,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 TRUNCATE test_table;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -682,10 +690,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^TRUNCATE TABLE truncate_failure.tes
 (1 row)
 
 TRUNCATE test_table;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -1004,7 +1012,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL R
 (1 row)
 
 TRUNCATE test_table;
-ERROR:  failure on connection marked as essential: localhost:9060
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -1058,10 +1069,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="TRUNCATE TABLE truncate_failure.test
 (1 row)
 
 TRUNCATE test_table;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------

--- a/src/test/regress/expected/failure_vacuum.out
+++ b/src/test/regress/expected/failure_vacuum.out
@@ -35,10 +35,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^VACUUM").kill()');
 (1 row)
 
 VACUUM vacuum_test;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.onQuery(query="^ANALYZE").kill()');
  mitmproxy 
 -----------
@@ -46,10 +46,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^ANALYZE").kill()');
 (1 row)
 
 ANALYZE vacuum_test;
-ERROR:  server closed the connection unexpectedly
+WARNING:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
  mitmproxy 
 -----------
@@ -57,12 +57,15 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
 (1 row)
 
 ANALYZE vacuum_test;
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
 -- ANALYZE transactions being critical is an open question, see #2430
+-- show that we marked as INVALID on COMMIT FAILURE
+SELECT shardid, shardstate FROM pg_dist_shard_placement where shardstate != 1 AND 
+shardid in ( SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'vacuum_test'::regclass);
+ shardid | shardstate 
+---------+------------
+  102097 |          3
+(1 row)
+
 UPDATE pg_dist_shard_placement SET shardstate = 1
 WHERE shardid IN (
   SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'vacuum_test'::regclass
@@ -112,10 +115,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^VACUUM.*other").kill()');
 (1 row)
 
 VACUUM vacuum_test, other_vacuum_test;
-ERROR:  server closed the connection unexpectedly
+ERROR:  connection error: localhost:9060
+DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  while executing command on localhost:9060
 SELECT citus.mitmproxy('conn.onQuery(query="^VACUUM.*other").cancel(' ||  pg_backend_pid() || ')');
  mitmproxy 
 -----------

--- a/src/test/regress/expected/multi_query_directory_cleanup_0.out
+++ b/src/test/regress/expected/multi_query_directory_cleanup_0.out
@@ -1,0 +1,273 @@
+--
+-- MULTI_QUERY_DIRECTORY_CLEANUP
+--
+-- We execute sub-queries on worker nodes, and copy query results to a directory
+-- on the master node for final processing. When the query completes or fails,
+-- the resource owner should automatically clean up these intermediate query
+-- result files.
+SET citus.next_shard_id TO 810000;
+SET citus.enable_unique_job_ids TO off;
+BEGIN;
+-- pg_ls_dir() displays jobids. We explicitly set the jobId sequence
+-- here so that the regression output becomes independent of the
+-- number of jobs executed prior to running this test.
+SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT pg_ls_dir('base/pgsql_job_cache');
+ pg_ls_dir 
+-----------
+(0 rows)
+
+COMMIT;
+SELECT pg_ls_dir('base/pgsql_job_cache');
+ pg_ls_dir 
+-----------
+(0 rows)
+
+BEGIN;
+SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT pg_ls_dir('base/pgsql_job_cache');
+ pg_ls_dir 
+-----------
+(0 rows)
+
+ROLLBACK;
+SELECT pg_ls_dir('base/pgsql_job_cache');
+ pg_ls_dir 
+-----------
+(0 rows)
+
+-- Test that multiple job directories are all cleaned up correctly,
+-- both individually (by closing a cursor) and in bulk when ending a
+-- transaction.
+BEGIN;
+DECLARE c_00 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_00;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_01 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_01;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_02 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_02;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_03 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_03;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_04 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_04;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_05 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_05;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_06 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_06;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_07 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_07;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_08 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_08;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_09 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_09;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_10 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_10;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_11 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_11;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_12 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_12;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_13 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_13;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_14 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_14;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_15 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_15;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_16 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_16;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_17 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_17;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_18 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_18;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+DECLARE c_19 CURSOR FOR SELECT sum(l_extendedprice * l_discount) as revenue FROM lineitem;
+FETCH 1 FROM c_19;
+    revenue    
+---------------
+ 22770844.7654
+(1 row)
+
+SELECT * FROM pg_ls_dir('base/pgsql_job_cache') f ORDER BY f;
+        f        
+-----------------
+ master_job_0007
+ master_job_0008
+ master_job_0009
+ master_job_0010
+ master_job_0011
+ master_job_0012
+ master_job_0013
+ master_job_0014
+ master_job_0015
+ master_job_0016
+ master_job_0017
+ master_job_0018
+ master_job_0019
+ master_job_0020
+ master_job_0021
+ master_job_0022
+ master_job_0023
+ master_job_0024
+ master_job_0025
+ master_job_0026
+(20 rows)
+
+-- close first, 17th (first after re-alloc) and last cursor.
+CLOSE c_00;
+CLOSE c_16;
+CLOSE c_19;
+SELECT * FROM pg_ls_dir('base/pgsql_job_cache') f ORDER BY f;
+        f        
+-----------------
+ master_job_0008
+ master_job_0009
+ master_job_0010
+ master_job_0011
+ master_job_0012
+ master_job_0013
+ master_job_0014
+ master_job_0015
+ master_job_0016
+ master_job_0017
+ master_job_0018
+ master_job_0019
+ master_job_0020
+ master_job_0021
+ master_job_0022
+ master_job_0024
+ master_job_0025
+(17 rows)
+
+ROLLBACK;
+SELECT pg_ls_dir('base/pgsql_job_cache');
+ pg_ls_dir 
+-----------
+(0 rows)
+

--- a/src/test/regress/failure_schedule
+++ b/src/test/regress/failure_schedule
@@ -4,7 +4,6 @@ test: failure_test_helpers
 # this should only be run by pg_regress_multi, you don't need it
 test: failure_setup
 test: multi_test_helpers
-
 test: failure_ddl
 test: failure_truncate
 test: failure_create_index_concurrently

--- a/src/test/regress/sql/failure_1pc_copy_append.sql
+++ b/src/test/regress/sql/failure_1pc_copy_append.sql
@@ -1,5 +1,8 @@
 SELECT citus.mitmproxy('conn.allow()');
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 1;
+
 SET citus.shard_count = 1;
 SET citus.shard_replication_factor = 2; -- one shard per worker
 SET citus.multi_shard_commit_protocol TO '1pc';
@@ -49,10 +52,12 @@ COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' W
 SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p
   WHERE (s.shardid = p.shardid) AND s.logicalrelid = 'copy_test'::regclass
   ORDER BY placementid;
+
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
 SELECT count(1) FROM copy_test;
 
 ---- cancel the connection when we send the data ----
-SELECT citus.mitmproxy(format('conn.onCopyData().cancel(%s)', pg_backend_pid()));
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' ||  pg_backend_pid() || ')');
 COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' WITH CSV;
 SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p
   WHERE (s.shardid = p.shardid) AND s.logicalrelid = 'copy_test'::regclass

--- a/src/test/regress/sql/failure_1pc_copy_hash.sql
+++ b/src/test/regress/sql/failure_1pc_copy_hash.sql
@@ -1,5 +1,8 @@
 SELECT citus.mitmproxy('conn.allow()');
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
+
 SET citus.shard_count = 1;
 SET citus.shard_replication_factor = 2; -- one shard per worker
 SET citus.multi_shard_commit_protocol TO '1pc';

--- a/src/test/regress/sql/failure_ddl.sql
+++ b/src/test/regress/sql/failure_ddl.sql
@@ -9,6 +9,9 @@ CREATE SCHEMA ddl_failure;
 
 SET search_path TO 'ddl_failure';
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
+
 -- we don't want to see the prepared transaction numbers in the warnings
 SET client_min_messages TO ERROR;
 

--- a/src/test/regress/sql/failure_multi_shard_update_delete.sql
+++ b/src/test/regress/sql/failure_multi_shard_update_delete.sql
@@ -8,6 +8,9 @@ SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 201000;
 SET citus.shard_replication_factor TO 1;
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
+
 SELECT citus.mitmproxy('conn.allow()');
 
 CREATE TABLE t1(a int PRIMARY KEY, b int, c int);

--- a/src/test/regress/sql/failure_real_time_select.sql
+++ b/src/test/regress/sql/failure_real_time_select.sql
@@ -20,12 +20,12 @@ INSERT INTO test_table VALUES(1,1,1),(1,2,2),(2,1,1),(2,2,2),(3,1,1),(3,2,2);
 -- Kill when the first COPY command arrived, since we have a single placement 
 -- it is expected to error out.
 SET client_min_messages TO ERROR;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
-SELECT public.raise_failed_execution('SELECT count(*) FROM test_table');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
+SELECT count(*) FROM test_table;
 SET client_min_messages TO DEFAULT;
 
 -- Kill the connection with a CTE
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
 WITH
 results AS (SELECT * FROM test_table)
 SELECT * FROM test_table, results
@@ -34,30 +34,33 @@ WHERE test_table.id = results.id;
 -- Since the outer query uses the connection opened by the CTE,
 -- killing connection after first successful query should break.
 SET client_min_messages TO ERROR;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
-SELECT public.raise_failed_execution('WITH
-			results AS (SELECT * FROM test_table)
-			SELECT * FROM test_table, results
-			WHERE test_table.id = results.id');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
+WITH results AS (SELECT * FROM test_table)
+SELECT * FROM test_table, results
+WHERE test_table.id = results.id;
 SET client_min_messages TO DEFAULT;
 
 -- In parallel execution mode Citus opens separate connections for each shard
 -- so killing the connection after the first copy does not break it.
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SET citus.force_max_query_parallelization=ON;
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
 SELECT count(*) FROM test_table;
 
+-- set back the force flag to original value
+SET citus.force_max_query_parallelization=OFF;
+
 -- Cancel a real-time executor query
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 SELECT count(*) FROM test_table;
 
 -- Cancel a query within the transaction
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;
 
 -- Cancel a query within the transaction after a multi-shard update
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 BEGIN;
 UPDATE test_table SET value_1 = value_1 + 1;
 SELECT count(*) FROM test_table;
@@ -70,27 +73,25 @@ results AS (SELECT * FROM test_table)
 SELECT * FROM test_table
 WHERE test_table.id > (SELECT id FROM results);
 
--- Since Citus opens a new connection after a failure within the real time
--- execution and after(1).kill() kills connection after a successful execution
--- for each connection, following transaciton does not fail.
+-- Citus fails if the connection that is already used fails afterwards
 SET citus.multi_shard_modify_mode to sequential;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;
 
 -- Cancel a real-time executor query - in sequential mode
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 SELECT count(*) FROM test_table;
 
 -- Cancel a query within the transaction - in sequential mode
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;
 
 -- Cancel the query within a transaction after a single succesful run
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).cancel(' || pg_backend_pid() || ')');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;
@@ -101,6 +102,7 @@ DROP TABLE test_table;
 SET citus.multi_shard_modify_mode to default;
 
 -- Create table with shard placements on each node
+SELECT citus.mitmproxy('conn.allow()');
 SET citus.shard_replication_factor to 2;
 CREATE TABLE test_table(id int, value_1 int, value_2 int);
 SELECT create_distributed_table('test_table','id');
@@ -108,37 +110,37 @@ SELECT create_distributed_table('test_table','id');
 -- Populate data to the table
 INSERT INTO test_table VALUES(1,1,1),(1,2,2),(2,1,1),(2,2,2),(3,1,1),(3,2,2);
 
--- Kill when the first COPY command arrived, since we have placements on each node
+-- Kill when the first SELECT command arrived, since we have placements on each node
 -- it shouldn't fail.
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
 SELECT count(*) FROM test_table;
 
 -- Kill within the transaction, since we have placements on each node
 -- it shouldn't fail.
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").kill()');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;
 
 -- Cancel a real-time executor query
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 SELECT count(*) FROM test_table;
 
 -- Cancel a query within the transaction
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;
 
 -- Cancel a query within the transaction after a multi-shard update
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 BEGIN;
 UPDATE test_table SET value_1 = value_1 + 1;
 SELECT count(*) FROM test_table;
 COMMIT;
 
 -- Cancel a query with CTE
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").cancel(' || pg_backend_pid() || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").cancel(' || pg_backend_pid() || ')');
 WITH
 results AS (SELECT * FROM test_table)
 SELECT * FROM test_table
@@ -147,7 +149,7 @@ WHERE test_table.id > (SELECT id FROM results);
 -- Since we have the placement on each node, test with sequential mode
 -- should pass as well.
 SET citus.multi_shard_modify_mode to sequential;
-SELECT citus.mitmproxy('conn.onQuery(query="^COPY").after(1).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(1).kill()');
 BEGIN;
 SELECT count(*) FROM test_table;
 COMMIT;

--- a/src/test/regress/sql/failure_truncate.sql
+++ b/src/test/regress/sql/failure_truncate.sql
@@ -7,6 +7,9 @@ SET citus.next_shard_id TO 120000;
 -- we don't want to see the prepared transaction numbers in the warnings
 SET client_min_messages TO ERROR;
 
+-- do not cache any connections
+SET citus.max_cached_conns_per_worker TO 0;
+
 SELECT citus.mitmproxy('conn.allow()');
 
 -- we'll start with replication factor 1, 1PC and parallel mode

--- a/src/test/regress/sql/failure_vacuum.sql
+++ b/src/test/regress/sql/failure_vacuum.sql
@@ -23,6 +23,10 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
 ANALYZE vacuum_test;
 
 -- ANALYZE transactions being critical is an open question, see #2430
+-- show that we marked as INVALID on COMMIT FAILURE
+SELECT shardid, shardstate FROM pg_dist_shard_placement where shardstate != 1 AND 
+shardid in ( SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'vacuum_test'::regclass);
+
 UPDATE pg_dist_shard_placement SET shardstate = 1
 WHERE shardid IN (
   SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'vacuum_test'::regclass


### PR DESCRIPTION
We've changed the failure behaviour a bit, and also the error messages
that show up to the user. This PR covers majority of the updates.

4 failure tests are failing:
- `failure_savepoints` crashing, @pykello will look into that.
- `multi_row_insert` will just work on top of #2735 
- `failure_vacuum` is failing, I need to discuss the failure behaviour for `VACUUM` with @pykello and @marcocitus 
- `failure_connection_establishment` is failing because we used to have `could not establish connection after XXX msecs` error. Should we have that on the unified executor as well?


Anyway, this is ready for a quick review, we can handle the above one-by-one separately.
