### PR TITLE
Unified executor honors citus.node_connection_timeout

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -67,7 +67,6 @@ typedef struct MultiConnectionPollState
 static bool MultiConnectionStatePoll(MultiConnectionPollState *connectionState);
 static WaitEventSet * WaitEventSetFromMultiConnectionStates(List *connections,
 															int *waitCount);
-static long DeadlineTimestampTzToTimeout(TimestampTz deadline);
 static void CloseNotReadyMultiConnectionStates(List *connectionStates);
 static uint32 MultiConnectionStateEventMask(MultiConnectionPollState *connectionState);
 
@@ -803,7 +802,7 @@ FinishConnectionListEstablishment(List *multiConnectionList)
  * before the deadline provided as an argument will be reached. The outcome can be used to
  * pass to the Wait of an EventSet to make sure it returns after the timeout has passed.
  */
-static long
+long
 DeadlineTimestampTzToTimeout(TimestampTz deadline)
 {
 	long secs = 0;

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -197,6 +197,7 @@ extern void FinishConnectionListEstablishment(List *multiConnectionList);
 extern void FinishConnectionEstablishment(MultiConnection *connection);
 extern void ClaimConnectionExclusively(MultiConnection *connection);
 extern void UnclaimConnection(MultiConnection *connection);
+extern long DeadlineTimestampTzToTimeout(TimestampTz deadline);
 
 /* dealing with notice handler */
 extern void SetCitusNoticeProcessor(MultiConnection *connection);

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -44,8 +44,7 @@ SELECT citus.mitmproxy('conn.delay(500)');
 (1 row)
 
 ALTER TABLE products ADD CONSTRAINT p_key PRIMARY KEY(product_no);
-WARNING:  could not establish connection after 400 ms
-ERROR:  connection error: localhost:9060
+ERROR:  could not establish any connections to the node localhost:9060 after 400 ms
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------
@@ -81,13 +80,13 @@ SELECT citus.mitmproxy('conn.delay(500)');
 
 -- we cannot control which replica of the reference table will be queried and there is
 -- only one specific client we can control the connection for.
--- by using round-robin task_assignment_policy we can force to hit both machines. We will
--- use two output files to match both orders to verify there is 1 that times out and falls
--- through to read from the other machine
+-- by using round-robin task_assignment_policy we can force to hit both machines. 
+-- and in the end, dumping the network traffic shows that the connection establishment
+-- is initiated to the node behind the proxy
+SET client_min_messages TO ERROR;
 SET citus.task_assignment_policy TO 'round-robin';
 -- suppress the warning since we can't control which shard is chose first. Failure of this
 -- test would be if one of the queries does not return the result but an error.
-SET client_min_messages TO ERROR;
 SELECT name FROM r1 WHERE id = 2;
  name 
 ------
@@ -108,6 +107,119 @@ SELECT citus.dump_network_traffic();
  (0,coordinator,"[initial message]")
 (1 row)
 
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+-- similar test with the above but this time on a 
+-- distributed table instead of a reference table
+-- and with citus.force_max_query_parallelization is set
+SET citus.force_max_query_parallelization TO ON;
+SELECT citus.mitmproxy('conn.delay(500)');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+-- suppress the warning since we can't control which shard is chose first. Failure of this
+-- test would be if one of the queries does not return the result but an error.
+SELECT count(*) FROM products;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM products;
+ count 
+-------
+     0
+(1 row)
+
+-- use OFFSET 1 to prevent printing the line where source 
+-- is the worker
+SELECT citus.dump_network_traffic() ORDER BY 1 OFFSET 1;
+        dump_network_traffic         
+-------------------------------------
+ (1,coordinator,"[initial message]")
+(1 row)
+
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE single_replicatated(key int);
+SELECT create_distributed_table('single_replicatated', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- this time the table is single replicated and we're still using the
+-- the max parallelization flag, so the query should fail
+SET citus.force_max_query_parallelization TO ON;
+SELECT citus.mitmproxy('conn.delay(500)');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+SELECT count(*) FROM single_replicatated;
+ERROR:  could not establish any connections to the node localhost:9060 after 400 ms
+SET citus.force_max_query_parallelization TO OFF;
+-- one similar test, but this time on modification queries
+-- to see that connection establishement failures could
+-- mark placement INVALID
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+BEGIN;
+SELECT 
+	count(*) as invalid_placement_count
+FROM 
+	pg_dist_shard_placement 
+WHERE 
+	shardstate = 3 AND 
+	shardid IN (SELECT shardid from pg_dist_shard where logicalrelid = 'products'::regclass);
+ invalid_placement_count 
+-------------------------
+                       0
+(1 row)
+
+SELECT citus.mitmproxy('conn.delay(500)');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+INSERT INTO products VALUES (100, '100', 100);
+COMMIT;
+SELECT 
+	count(*) as invalid_placement_count
+FROM 
+	pg_dist_shard_placement 
+WHERE 
+	shardstate = 3 AND 
+	shardid IN (SELECT shardid from pg_dist_shard where logicalrelid = 'products'::regclass);
+ invalid_placement_count 
+-------------------------
+                       1
+(1 row)
+
+-- show that INSERT went through
+SELECT count(*) FROM products WHERE product_no = 100;
+ count 
+-------
+     1
+(1 row)
+
 RESET client_min_messages;
 -- verify get_global_active_transactions works when a timeout happens on a connection
 SELECT get_global_active_transactions();
@@ -124,7 +236,8 @@ SELECT citus.mitmproxy('conn.allow()');
 (1 row)
 
 DROP SCHEMA fail_connect CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table products
 drop cascades to table r1
+drop cascades to table single_replicatated
 SET search_path TO default;

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -54,19 +54,75 @@ SELECT citus.mitmproxy('conn.delay(500)');
 
 -- we cannot control which replica of the reference table will be queried and there is
 -- only one specific client we can control the connection for.
--- by using round-robin task_assignment_policy we can force to hit both machines. We will
--- use two output files to match both orders to verify there is 1 that times out and falls
--- through to read from the other machine
+-- by using round-robin task_assignment_policy we can force to hit both machines. 
+-- and in the end, dumping the network traffic shows that the connection establishment
+-- is initiated to the node behind the proxy
+SET client_min_messages TO ERROR;
 SET citus.task_assignment_policy TO 'round-robin';
 -- suppress the warning since we can't control which shard is chose first. Failure of this
 -- test would be if one of the queries does not return the result but an error.
-SET client_min_messages TO ERROR;
 SELECT name FROM r1 WHERE id = 2;
 SELECT name FROM r1 WHERE id = 2;
 
 -- verify a connection attempt was made to the intercepted node, this would have cause the
 -- connection to have been delayed and thus caused a timeout
 SELECT citus.dump_network_traffic();
+
+SELECT citus.mitmproxy('conn.allow()');
+
+-- similar test with the above but this time on a 
+-- distributed table instead of a reference table
+-- and with citus.force_max_query_parallelization is set
+SET citus.force_max_query_parallelization TO ON;
+SELECT citus.mitmproxy('conn.delay(500)');
+-- suppress the warning since we can't control which shard is chose first. Failure of this
+-- test would be if one of the queries does not return the result but an error.
+SELECT count(*) FROM products;
+SELECT count(*) FROM products;
+
+-- use OFFSET 1 to prevent printing the line where source 
+-- is the worker
+SELECT citus.dump_network_traffic() ORDER BY 1 OFFSET 1;
+
+SELECT citus.mitmproxy('conn.allow()');
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE single_replicatated(key int);
+SELECT create_distributed_table('single_replicatated', 'key');
+
+-- this time the table is single replicated and we're still using the
+-- the max parallelization flag, so the query should fail
+SET citus.force_max_query_parallelization TO ON;
+SELECT citus.mitmproxy('conn.delay(500)');
+SELECT count(*) FROM single_replicatated;
+
+SET citus.force_max_query_parallelization TO OFF;
+
+-- one similar test, but this time on modification queries
+-- to see that connection establishement failures could
+-- mark placement INVALID
+SELECT citus.mitmproxy('conn.allow()');
+BEGIN;
+SELECT 
+	count(*) as invalid_placement_count
+FROM 
+	pg_dist_shard_placement 
+WHERE 
+	shardstate = 3 AND 
+	shardid IN (SELECT shardid from pg_dist_shard where logicalrelid = 'products'::regclass);
+SELECT citus.mitmproxy('conn.delay(500)');
+INSERT INTO products VALUES (100, '100', 100);
+COMMIT;
+SELECT 
+	count(*) as invalid_placement_count
+FROM 
+	pg_dist_shard_placement 
+WHERE 
+	shardstate = 3 AND 
+	shardid IN (SELECT shardid from pg_dist_shard where logicalrelid = 'products'::regclass);
+
+-- show that INSERT went through
+SELECT count(*) FROM products WHERE product_no = 100;
+
 
 RESET client_min_messages;
 


### PR DESCRIPTION
This PR is on top of multiple PRs #2713, #2738 and #2740, so might make sense to review those first. Due to some rebase issue, I had to include 2 commits, where the first commit is coming from #2740. So, if you want to review this PR, please only review the second one here.
   
```
With this commit, unified executor errors out if even
a single connection cannot be established within
`citus.node_connection_timeout.`
    
And, as a side effect this fixes failure_connection_establishment
test.
```
