### PR TITLE
Also check rewrittenQuery jointree for outer join

### DIFF
--- a/src/test/regress/expected/multi_subquery.out
+++ b/src/test/regress/expected/multi_subquery.out
@@ -462,6 +462,25 @@ SELECT DISTINCT ON (t1.user_id) t1.user_id, t2.value_1, t2.value_2, t2.value_3
  ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC 
  LIMIT 5;
 ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
+-- outer joins as subqueries should work
+-- https://github.com/citusdata/citus/issues/2739
+SELECT user_id, value_1, event_type
+FROM (
+	SELECT a.user_id, a.value_1, b.event_type
+	FROM users_table a
+	LEFT JOIN events_table b ON a.user_id = b.user_id
+) lo
+ORDER BY 1, 2, 3
+LIMIT 5;
+ user_id | value_1 | event_type 
+---------+---------+------------
+       1 |       1 |          0
+       1 |       1 |          0
+       1 |       1 |          1
+       1 |       1 |          1
+       1 |       1 |          2
+(5 rows)
+
 -- inner joins on reference tables with functions works
 SELECT DISTINCT ON (t1.user_id) t1.user_id, t2.value_1, t2.value_2, t2.value_3
 FROM events_table t1

--- a/src/test/regress/expected/non_colocated_subquery_joins.out
+++ b/src/test/regress/expected/non_colocated_subquery_joins.out
@@ -957,7 +957,7 @@ $$);
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
 DEBUG:  skipping recursive planning for the subquery since it contains references to outer queries
-ERROR:  cannot perform distributed planning on this query
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 -- similar to the above, make sure that we skip recursive plannig when
 -- the subquery contains only intermediate results
 SELECT *

--- a/src/test/regress/sql/multi_subquery.sql
+++ b/src/test/regress/sql/multi_subquery.sql
@@ -314,6 +314,17 @@ SELECT DISTINCT ON (t1.user_id) t1.user_id, t2.value_1, t2.value_2, t2.value_3
  ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC 
  LIMIT 5;
 
+-- outer joins as subqueries should work
+-- https://github.com/citusdata/citus/issues/2739
+SELECT user_id, value_1, event_type
+FROM (
+	SELECT a.user_id, a.value_1, b.event_type
+	FROM users_table a
+	LEFT JOIN events_table b ON a.user_id = b.user_id
+) lo
+ORDER BY 1, 2, 3
+LIMIT 5;
+
 -- inner joins on reference tables with functions works
 SELECT DISTINCT ON (t1.user_id) t1.user_id, t2.value_1, t2.value_2, t2.value_3
 FROM events_table t1


### PR DESCRIPTION
Fixes #2739 

DESCRIPTION: Fix a regression in outer joining subqueries introduced in 0.8.2

This is currently a straight forward fix based on the comment made by @onderkalaci. I will look to investigate further as to how this regression was introduced & whether there's a deeper issue here

Aside: to backport this to 8.2 do I make a pull request to release-8.2?