### PR TITLE
enable_statistics_collection defaults to off (opt-in)

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1073,13 +1073,13 @@ RegisterCitusConfigVariables(void)
 					 "and operating system name. This configuration value controls "
 					 "whether these reports are sent."),
 		&EnableStatisticsCollection,
-#ifdef HAVE_LIBCURL
+#if defined(HAVE_LIBCURL) && defined(ENABLE_CITUS_STATISTICS_COLLECTION)
 		true,
 #else
 		false,
 #endif
 		PGC_SIGHUP,
-		GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL,
+		GUC_SUPERUSER_ONLY,
 		&StatisticsCollectionGucCheckHook,
 		NULL, NULL);
 


### PR DESCRIPTION
DESCRIPTION: citus.enable_statistics_collection defaults to off (opt-in)

Users can opt-in to statistics collection by setting `citus.enable_statistics_collection = on`. Package maintainers can choose to make it opt-out by using `-DENABLE_CITUS_STATISTICS_COLLECTION` during compilation.