### PR TITLE
Add executor locks to unified executor

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -100,8 +100,6 @@ static List * BuildPlacementAccessList(int32 groupId, List *relationShardList,
 static List * GetModifyConnections(Task *task, bool markCritical);
 static int64 ExecuteModifyTasks(List *taskList, bool expectResults,
 								ParamListInfo paramListInfo, CitusScanState *scanState);
-static void AcquireExecutorShardLock(Task *task, CmdType commandType);
-static void AcquireExecutorMultiShardLocks(List *taskList);
 static bool RequiresConsistentSnapshot(Task *task);
 static void RouterMultiModifyExecScan(CustomScanState *node);
 static void RouterSequentialModifyExecScan(CustomScanState *node);
@@ -154,7 +152,7 @@ AcquireMetadataLocks(List *taskList)
  * to communicate that the application is only generating commutative
  * UPDATE/DELETE/UPSERT commands and exclusive locks are unnecessary.
  */
-static void
+void
 AcquireExecutorShardLock(Task *task, CmdType commandType)
 {
 	LOCKMODE lockMode = NoLock;
@@ -346,7 +344,7 @@ AcquireExecutorShardLock(Task *task, CmdType commandType)
  * RowExclusiveLock, which is normally obtained by single-shard, commutative
  * writes.
  */
-static void
+void
 AcquireExecutorMultiShardLocks(List *taskList)
 {
 	ListCell *taskCell = NULL;

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -50,6 +50,8 @@ extern int64 ExecuteModifyTasksSequentiallyWithoutResults(List *taskList,
 														  CmdType operation);
 
 /* helper functions */
+extern void AcquireExecutorShardLock(Task *task, CmdType commandType);
+extern void AcquireExecutorMultiShardLocks(List *taskList);
 extern ShardPlacementAccess * CreatePlacementAccess(ShardPlacement *placement,
 													ShardPlacementAccessType accessType);
 extern bool TaskListRequires2PC(List *taskList);

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -7,20 +7,11 @@ create_distributed_table
 step s1-begin: 
     BEGIN;
 
-    -- we don't want to see any entries related to 2PC recovery
-    SET citus.max_cached_conns_per_worker TO 0;
-
 step s2-begin: 
 	BEGIN;
-        
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s3-begin: 
 	BEGIN;
-
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s1-alter-table: 
     ALTER TABLE test_table ADD COLUMN x INT;
@@ -41,7 +32,7 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
     ALTER TABLE test_table ADD COLUMN x INT;
 coordinator_host57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s3-view-worker: 
-	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' and query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
@@ -57,8 +48,6 @@ SELECT worker_apply_shard_ddl_command (105939, 'public', '
 SELECT worker_apply_shard_ddl_command (105938, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -76,20 +65,11 @@ create_distributed_table
 step s1-begin: 
     BEGIN;
 
-    -- we don't want to see any entries related to 2PC recovery
-    SET citus.max_cached_conns_per_worker TO 0;
-
 step s2-begin: 
 	BEGIN;
-        
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s3-begin: 
 	BEGIN;
-
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s1-insert: 
  	INSERT INTO test_table VALUES (100, 100);
@@ -110,12 +90,10 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
  	INSERT INTO test_table VALUES (100, 100);
 coordinator_host57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s3-view-worker: 
-	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' and query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
 INSERT INTO public.test_table_105944 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
@@ -134,20 +112,11 @@ create_distributed_table
 step s1-begin: 
     BEGIN;
 
-    -- we don't want to see any entries related to 2PC recovery
-    SET citus.max_cached_conns_per_worker TO 0;
-
 step s2-begin: 
 	BEGIN;
-        
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s3-begin: 
 	BEGIN;
-
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s1-select: 
    SELECT count(*) FROM test_table;
@@ -171,16 +140,12 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
    SELECT count(*) FROM test_table;
 coordinator_host57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s3-view-worker: 
-	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' and query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105949 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105948 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105947 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105946 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_105949 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_105948 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -198,20 +163,11 @@ create_distributed_table
 step s1-begin: 
     BEGIN;
 
-    -- we don't want to see any entries related to 2PC recovery
-    SET citus.max_cached_conns_per_worker TO 0;
-
 step s2-begin: 
 	BEGIN;
-        
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s3-begin: 
 	BEGIN;
-
-        -- we don't want to see any entries related to 2PC recovery
-        SET citus.max_cached_conns_per_worker TO 0;
 
 step s1-select-router: 
    SELECT count(*) FROM test_table WHERE column1 = 55;
@@ -235,13 +191,11 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
    SELECT count(*) FROM test_table WHERE column1 = 55;
 coordinator_host57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s3-view-worker: 
-	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' and query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
-SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM public.test_table_105951 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_105951 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -77,18 +77,18 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,299)        
+(0,168)        
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
-											  get_current_transaction_id();
+											  get_all_active_transactions();
 											') 
 		WHERE nodeport = 57637;
 ;
 
 nodename       nodeport       success        result         
 
-localhost      57637          t              (0,0)          
+localhost      57637          t              (0,168)        
 step s1-commit: 
     COMMIT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-302            301            f              
+171            170            f              
 transactionnumberwaitingtransactionnumbers
 
-301                           
-302            301            
+170                           
+171            170            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-306            305            f              
-307            305            f              
-307            306            t              
+175            174            f              
+176            174            f              
+176            175            t              
 transactionnumberwaitingtransactionnumbers
 
-305                           
-306            305            
-307            305,306        
+174                           
+175            174            
+176            174,175        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_insert_select_conflict.out
+++ b/src/test/regress/expected/isolation_insert_select_conflict.out
@@ -24,10 +24,10 @@ step s1-insert-into-select-conflict-update:
 col_1          col_2          
 
 1              1              
-5              5              
+2              2              
 3              3              
 4              4              
-2              2              
+5              5              
 step s2-begin: 
 	BEGIN;
 
@@ -121,10 +121,10 @@ step s2-insert-into-select-conflict-update: <... completed>
 col_1          col_2          
 
 1              1              
-5              5              
+2              2              
 3              3              
 4              4              
-2              2              
+5              5              
 step s2-commit: 
 	COMMIT;
 
@@ -153,10 +153,10 @@ step s1-insert-into-select-conflict-update:
 col_1          col_2          
 
 1              1              
-5              5              
+2              2              
 3              3              
 4              4              
-2              2              
+5              5              
 step s2-begin: 
 	BEGIN;
 
@@ -180,10 +180,10 @@ step s2-insert-into-select-conflict-update: <... completed>
 col_1          col_2          
 
 1              1              
-5              5              
+2              2              
 3              3              
 4              4              
-2              2              
+5              5              
 step s2-commit: 
 	COMMIT;
 
@@ -212,10 +212,10 @@ step s1-insert-into-select-conflict-update:
 col_1          col_2          
 
 1              1              
-5              5              
+2              2              
 3              3              
 4              4              
-2              2              
+5              5              
 step s2-begin: 
 	BEGIN;
 
@@ -264,10 +264,10 @@ step s1-insert-into-select-conflict-update-replication-factor-2:
 col_1          col_2          col_3          
 
 1              1                             
-5              5                             
+2              2                             
 3              3                             
 4              4                             
-2              2                             
+5              5                             
 step s2-begin-replication-factor-2: 
 	SET citus.shard_replication_factor to 2;
 	BEGIN;
@@ -292,10 +292,10 @@ step s2-insert-into-select-conflict-update-replication-factor-2: <... completed>
 col_1          col_2          col_3          
 
 1              1                             
-5              5                             
+2              2                             
 3              3                             
 4              4                             
-2              2                             
+5              5                             
 step s2-commit: 
 	COMMIT;
 

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1479,21 +1479,13 @@ WHERE
     pid = pg_backend_pid()
 ORDER BY
     1, 2, 3;
-      logicalrelid       | locktype |           mode           
--------------------------+----------+--------------------------
- partitioning_locks      | advisory | ShareUpdateExclusiveLock
- partitioning_locks      | advisory | ShareUpdateExclusiveLock
- partitioning_locks      | advisory | ShareUpdateExclusiveLock
- partitioning_locks      | advisory | ShareUpdateExclusiveLock
+      logicalrelid       | locktype |   mode           
+-------------------------+----------+-----------
  partitioning_locks_2009 | advisory | ShareLock
  partitioning_locks_2009 | advisory | ShareLock
  partitioning_locks_2009 | advisory | ShareLock
  partitioning_locks_2009 | advisory | ShareLock
- partitioning_locks_2009 | advisory | ShareUpdateExclusiveLock
- partitioning_locks_2009 | advisory | ShareUpdateExclusiveLock
- partitioning_locks_2009 | advisory | ShareUpdateExclusiveLock
- partitioning_locks_2009 | advisory | ShareUpdateExclusiveLock
-(12 rows)
+(4 rows)
 
 COMMIT;
 -- test shard resource locks with INSERT/SELECT

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -8,14 +8,15 @@ test: isolation_create_table_vs_add_remove_node
 # isolation_cluster_management such that tests
 # that come later can be parallelized
 test: isolation_cluster_management
+test: isolation_distributed_transaction_id
+test: isolation_dump_global_wait_edges
+test: isolation_dump_local_wait_edges
 test: isolation_dml_vs_repair isolation_copy_placement_vs_copy_placement
 
 test: isolation_concurrent_dml isolation_data_migration
 test: isolation_drop_shards isolation_copy_placement_vs_modification
 test: isolation_insert_vs_vacuum isolation_transaction_recovery
-test: isolation_distributed_transaction_id isolation_progress_monitoring
-test: isolation_dump_local_wait_edges
-test: isolation_dump_global_wait_edges
+test: isolation_progress_monitoring
 
 test: isolation_replace_wait_function
 test: isolation_distributed_deadlock_detection

--- a/src/test/regress/specs/isolation_distributed_transaction_id.spec
+++ b/src/test/regress/specs/isolation_distributed_transaction_id.spec
@@ -82,7 +82,7 @@ step "s2-get-first-worker-active-transactions"
 {
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 
-											  get_current_transaction_id();
+											  get_all_active_transactions();
 											') 
 		WHERE nodeport = 57637;
 ;


### PR DESCRIPTION
This change adds the executor locks to prevent concurrent non-commutative changes to replicas, and avoid deadlocks between multi-shard DML to the unified executor.