### PR TITLE
Sort output of INSERT ... SELECT ... RETURNING

### DIFF
--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -139,6 +139,11 @@ CoordinatorInsertSelectExecScan(CustomScanState *node)
 				ExecuteTaskListExtended(CMD_INSERT, prunedTaskList,
 										tupleDescriptor, scanState->tuplestorestate,
 									    hasReturning, DEFAULT_POOL_SIZE);
+
+				if (SortReturning && hasReturning)
+				{
+					SortTupleStore(scanState);
+				}
 			}
 		}
 		else

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -2217,10 +2217,10 @@ DEBUG:  Collecting INSERT ... SELECT results on coordinator
  user_id | time | value_1 | value_2 | value_3 | value_4 
 ---------+------+---------+---------+---------+---------
        1 |      |      11 |         |         |        
-       5 |      |      15 |         |         |        
+       2 |      |      12 |         |         |        
        3 |      |      13 |         |         |        
        4 |      |      14 |         |         |        
-       2 |      |      12 |         |         |        
+       5 |      |      15 |         |         |        
 (5 rows)
 
 RESET client_min_messages;


### PR DESCRIPTION
If we wanted to do this in `ExecuteTaskListExtended()` we had to pass even more arguments to it, so doing this in `insert_select_executor.c` for now.