### PR TITLE
Take partition locks correctly in unified executor

### DIFF
--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -296,6 +296,7 @@ CreateDistributedInsertSelectPlan(Query *originalQuery,
 	distributedPlan->masterQuery = NULL;
 	distributedPlan->routerExecutable = true;
 	distributedPlan->hasReturning = false;
+	distributedPlan->targetRelationId = targetRelationId;
 
 	if (list_length(originalQuery->returningList) > 0)
 	{

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -112,6 +112,7 @@ static DistributedPlan * CreateSingleTaskRouterPlan(Query *originalQuery,
 													Query *query,
 													PlannerRestrictionContext *
 													plannerRestrictionContext);
+static Oid ResultRelationOidForQuery(Query *query);
 static bool IsTidColumn(Node *node);
 static DeferredErrorMessage * MultiShardModifyQuerySupported(Query *originalQuery,
 															 PlannerRestrictionContext *
@@ -228,6 +229,7 @@ CreateModifyPlan(Query *originalQuery, Query *query,
 	distributedPlan->masterQuery = NULL;
 	distributedPlan->routerExecutable = true;
 	distributedPlan->hasReturning = false;
+	distributedPlan->targetRelationId = ResultRelationOidForQuery(query);
 
 	if (list_length(originalQuery->returningList) > 0)
 	{
@@ -502,6 +504,19 @@ ModifyQueryResultRelationId(Query *query)
 	Assert(OidIsValid(resultRte->relid));
 
 	return resultRte->relid;
+}
+
+
+/*
+ * ResultRelationOidForQuery returns the OID of the relation this is modified
+ * by a given query.
+ */
+static Oid
+ResultRelationOidForQuery(Query *query)
+{
+	RangeTblEntry *resultRTE = rt_fetch(query->resultRelation, query->rtable);
+
+	return resultRTE->relid;
 }
 
 

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -256,7 +256,7 @@ typedef struct DistributedPlan
 	/* target list of an INSERT ... SELECT via the coordinator */
 	List *insertTargetList;
 
-	/* target relation of an INSERT ... SELECT via the coordinator */
+	/* target relation of a modification */
 	Oid targetRelationId;
 
 	/*

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1422,12 +1422,10 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
  partitioning_locks      | relation | AccessExclusiveLock
  partitioning_locks      | relation | AccessShareLock
  partitioning_locks_2009 | relation | AccessExclusiveLock
- partitioning_locks_2009 | relation | AccessShareLock
  partitioning_locks_2009 | relation | ShareLock
  partitioning_locks_2010 | relation | AccessExclusiveLock
- partitioning_locks_2010 | relation | AccessShareLock
  partitioning_locks_2010 | relation | ShareLock
-(8 rows)
+(6 rows)
 
 COMMIT;
 -- test shard resource locks with multi-shard UPDATE


### PR DESCRIPTION
Take RowExclusiveLock for DML. We previously took AccessShareLock for TRUNCATE, but PostgreSQL does not do this, removed it from the test.