### PR TITLE
Refactor shard creation logic

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -364,6 +364,24 @@ LogRemoteCommand(MultiConnection *connection, const char *command)
 
 
 /*
+ * ExecuteCriticalRemoteCommandList calls ExecuteCriticalRemoteCommand for every
+ * command in the commandList.
+ */
+void
+ExecuteCriticalRemoteCommandList(MultiConnection *connection, List *commandList)
+{
+	ListCell *commandCell = NULL;
+
+	foreach(commandCell, commandList)
+	{
+		char *command = (char *) lfirst(commandCell);
+
+		ExecuteCriticalRemoteCommand(connection, command);
+	}
+}
+
+
+/*
  * ExecuteCriticalRemoteCommand executes a remote command that is critical
  * to the transaction. If the command fails then the transaction aborts.
  */

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -125,9 +125,9 @@ extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shard
 extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId,
 								  bool useExclusiveConnections);
 extern void CreateReferenceTableShard(Oid distributedTableId);
-extern void WorkerCreateShard(Oid relationId, int shardIndex, uint64 shardId,
-							  List *ddlCommandList, List *foreignConstraintCommandList,
-							  MultiConnection *connection);
+extern List * WorkerCreateShardCommandList(Oid relationId, int shardIndex, uint64 shardId,
+										   List *ddlCommandList,
+										   List *foreignConstraintCommandList);
 extern Oid ForeignConstraintGetReferencedTableId(char *queryString);
 extern void CheckHashPartitionedTable(Oid distributedTableId);
 extern void CheckTableSchemaNameForDrop(Oid relationId, char **schemaName,

--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -39,6 +39,8 @@ extern char * pchomp(const char *in);
 extern void LogRemoteCommand(MultiConnection *connection, const char *command);
 
 /* wrappers around libpq functions, with command logging support */
+extern void ExecuteCriticalRemoteCommandList(MultiConnection *connection,
+											 List *commandList);
 extern void ExecuteCriticalRemoteCommand(MultiConnection *connection,
 										 const char *command);
 extern int ExecuteOptionalRemoteCommand(MultiConnection *connection,


### PR DESCRIPTION
This is a preparation for the new executor, where creating shards
would go through the executor. So, explicitly generate the commands
for further processing.
