### PR TITLE
Feature: optionally force master_update_node during failover

### DIFF
--- a/src/backend/distributed/citus--8.2-2--8.2-3.sql
+++ b/src/backend/distributed/citus--8.2-2--8.2-3.sql
@@ -20,4 +20,6 @@ COMMENT ON FUNCTION master_update_node(node_id int,
                                        force bool)
   IS 'change the location of a node';
 
+REVOKE ALL ON FUNCTION master_update_node(int,text,int,bool) FROM PUBLIC;
+
 RESET search_path;

--- a/src/backend/distributed/citus--8.2-2--8.2-3.sql
+++ b/src/backend/distributed/citus--8.2-2--8.2-3.sql
@@ -9,7 +9,8 @@ DROP FUNCTION master_update_node(node_id int,
 CREATE OR REPLACE FUNCTION master_update_node(node_id int,
                                               new_node_name text,
                                               new_node_port int,
-                                              force bool DEFAULT false)
+                                              force bool DEFAULT false,
+                                              lock_cooldown int DEFAULT 10000)
   RETURNS void
   LANGUAGE C STRICT
   AS 'MODULE_PATHNAME', $$master_update_node$$;
@@ -17,9 +18,10 @@ CREATE OR REPLACE FUNCTION master_update_node(node_id int,
 COMMENT ON FUNCTION master_update_node(node_id int,
                                        new_node_name text,
                                        new_node_port int,
-                                       force bool)
-  IS 'change the location of a node';
+                                       force bool,
+                                       lock_cooldown int)
+  IS 'change the location of a node. when force => true it will wait lock_cooldown ms before killing competing locks';
 
-REVOKE ALL ON FUNCTION master_update_node(int,text,int,bool) FROM PUBLIC;
+REVOKE ALL ON FUNCTION master_update_node(int,text,int,bool,int) FROM PUBLIC;
 
 RESET search_path;

--- a/src/backend/distributed/citus--8.2-2--8.2-3.sql
+++ b/src/backend/distributed/citus--8.2-2--8.2-3.sql
@@ -1,0 +1,23 @@
+/* citus--8.2-2--8.2-3 */
+
+SET search_path = 'pg_catalog';
+
+DROP FUNCTION master_update_node(node_id int,
+                                 new_node_name text,
+                                 new_node_port int);
+
+CREATE OR REPLACE FUNCTION master_update_node(node_id int,
+                                              new_node_name text,
+                                              new_node_port int,
+                                              force bool DEFAULT false)
+  RETURNS void
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_update_node$$;
+
+COMMENT ON FUNCTION master_update_node(node_id int,
+                                       new_node_name text,
+                                       new_node_port int,
+                                       force bool)
+  IS 'change the location of a node';
+
+RESET search_path;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '8.2-2'
+default_version = '8.2-3'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -29,6 +29,7 @@
 #include "utils/snapmgr.h"
 
 #include "distributed/citus_acquire_lock.h"
+#include "distributed/version_compat.h"
 
 /* forward declaration of background worker entrypoint */
 extern void LockAcquireHelperMain(Datum main_arg);
@@ -69,7 +70,9 @@ StartLockAcquireHelperBackgroundWorker(int backendToHelp)
 	snprintf(worker.bgw_name, BGW_MAXLEN,
 			 "Citus Lock Acquire Helper: %d/%u",
 			 backendToHelp, MyDatabaseId);
+#if PG_VERSION_NUM >= 110000
 	snprintf(worker.bgw_type, BGW_MAXLEN, "citus_lock_aqcuire");
+#endif
 
 	/* TODO verify we need both */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -227,8 +227,8 @@ LockAcquireHelperMain(Datum main_arg)
 
 	while (ShouldAcquireLock(100))
 	{
-		int i = 0;
-		int ret = 0;
+		int row = 0;
+		int spiStatus = 0;
 
 		elog(LOG, "canceling competing backends for backend %d", backendPid);
 
@@ -241,11 +241,11 @@ LockAcquireHelperMain(Datum main_arg)
 		PushActiveSnapshot(GetTransactionSnapshot());
 		pgstat_report_activity(STATE_RUNNING, sql.data);
 
-		ret = SPI_execute(sql.data, false, 0);
+		spiStatus = SPI_execute(sql.data, false, 0);
 
-		if (ret == SPI_OK_SELECT)
+		if (spiStatus == SPI_OK_SELECT)
 		{
-			for (i = 0; i < SPI_processed; i++)
+			for (row = 0; row < SPI_processed; row++)
 			{
 				/* TODO count the number of backends canceled and log about it */
 

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -146,6 +146,14 @@ lock_acquire_helper_sigterm(SIGNAL_ARGS)
 }
 
 
+/*
+ * ShouldAcquireLock tests if our backend should still proceed with acquiring the lock,
+ * and thus keep terminating conflicting backends. This function returns true until a
+ * SIGTERM, background worker termination signal, has been received.
+ *
+ * The function blocks for at most sleepms when called. During operation without being
+ * terminated this is the time between invocations to the backend termination logic.
+ */
 static bool
 ShouldAcquireLock(long sleepms)
 {

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -74,7 +74,6 @@ StartLockAcquireHelperBackgroundWorker(int backendToHelp)
 	snprintf(worker.bgw_type, BGW_MAXLEN, "citus_lock_aqcuire");
 #endif
 
-	/* TODO verify we need both */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
 	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
 	worker.bgw_restart_time = BGW_NEVER_RESTART;

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -1,0 +1,238 @@
+/*-------------------------------------------------------------------------
+ *
+ * acquire_lock.c
+ *	  A dynamic background worker that can help your backend to acquire its locks. This is
+ *	  an intrusive way of getting your way. The primary use of this will be to allow
+ *	  master_update_node to make progress during failure. When the system cannot possibly
+ *	  finish a transaction due to the host required to finish the transaction has failed
+ *	  it might be better to actively cancel the backend instead of waiting for it to fail.
+ *
+ * This file provides infrastructure for launching exactly one a background
+ * worker for every database in which citus is used.  That background worker
+ * can then perform work like deadlock detection, prepared transaction
+ * recovery, and cleanup.
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include "postgres.h"
+
+#include "access/xact.h"
+#include "executor/spi.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "utils/snapmgr.h"
+
+#include "distributed/citus_acquire_lock.h"
+
+/* forward declaration of background worker entrypoint */
+extern void LockAcquireHelperMain(Datum main_arg);
+
+/* forward declaration of helper functions */
+static void lock_acquire_helper_sigterm(SIGNAL_ARGS);
+static void EnsureStopLockAcquireHelper(void *arg);
+
+/* LockAcquireHelperArgs contains extra arguments to be used to start the worker */
+typedef struct LockAcquireHelperArgs
+{
+	Oid DatabaseId;
+} LockAcquireHelperArgs;
+
+static bool got_sigterm = false;
+
+
+/*
+ * StartLockAcquireHelperBackgroundWorker creates a background worker that will help the
+ * backend passed in as an argument to complete. The worker that is started will be
+ * terminated once the current memory context gets reset, to make sure it is cleaned up in
+ * all situations. It is however advised to call TerminateBackgroundWorker on the handle
+ * returned on the first possible moment the help is no longer required.
+ */
+BackgroundWorkerHandle *
+StartLockAcquireHelperBackgroundWorker(int backendToHelp)
+{
+	BackgroundWorkerHandle *handle = NULL;
+	LockAcquireHelperArgs args;
+	BackgroundWorker worker;
+	memset(&args, 0, sizeof(args));
+	memset(&worker, 0, sizeof(worker));
+
+	/* collect the extra arguments required for the background worker */
+	args.DatabaseId = MyDatabaseId;
+
+	/* construct the background worker and start it */
+	snprintf(worker.bgw_name, BGW_MAXLEN,
+			 "Citus Lock Acquire Helper: %d/%u",
+			 backendToHelp, MyDatabaseId);
+	snprintf(worker.bgw_type, BGW_MAXLEN, "citus_lock_aqcuire");
+
+	/* TODO verify we need both */
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+	worker.bgw_restart_time = BGW_NEVER_RESTART;
+
+	snprintf(worker.bgw_library_name, BGW_MAXLEN, "citus");
+	snprintf(worker.bgw_function_name, BGW_MAXLEN, "LockAcquireHelperMain");
+	worker.bgw_main_arg = Int32GetDatum(backendToHelp);
+	worker.bgw_notify_pid = 0;
+
+	/*
+	 * we check if args fits in bgw_extra to make sure it is safe to copy the data. Once
+	 * we exceed the size of data to copy this way we need to look into a different way of
+	 * passing the arguments to the worker.
+	 */
+	Assert(sizeof(worker.bgw_extra) >= sizeof(args));
+	memcpy(worker.bgw_extra, &args, sizeof(args));
+
+	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+	{
+		ereport(ERROR, (errmsg("could not start lock acquiring background worker to "
+							   "force the update"),
+						errhint("Increasing max_worker_processes might help.")));
+	}
+
+
+	MemoryContextCallback *cb = palloc0(sizeof(MemoryContextCallback));
+	cb->func = EnsureStopLockAcquireHelper;
+	cb->arg = handle;
+
+	MemoryContextRegisterResetCallback(CurrentMemoryContext, cb);
+
+	return handle;
+}
+
+
+/*
+ * EnsureStopLockAcquireHelper is designed to be called as a MemoryContextCallback. It
+ * takes a handle to the background worker and Terminates it. It is safe to be called on a
+ * handle that has already been terminated due to the guard around the generation number
+ * implemented in the handle by postgres.
+ */
+static void
+EnsureStopLockAcquireHelper(void *arg)
+{
+	BackgroundWorkerHandle *handle = (BackgroundWorkerHandle *) arg;
+	TerminateBackgroundWorker(handle);
+}
+
+
+/*
+ * Signal handler for SIGTERM
+ *		Set a flag to let the main loop to terminate, and set our latch to wake
+ *		it up.
+ */
+static void
+lock_acquire_helper_sigterm(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+
+	got_sigterm = true;
+	SetLatch(MyLatch);
+
+	errno = save_errno;
+}
+
+
+static bool
+ShouldAcquireLock(long sleepms)
+{
+	int rc;
+
+	rc = WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+				   sleepms * 1L, PG_WAIT_EXTENSION);
+	ResetLatch(MyLatch);
+
+	/* emergency bailout if postmaster has died */
+	if (rc & WL_POSTMASTER_DEATH)
+	{
+		proc_exit(1);
+	}
+
+	CHECK_FOR_INTERRUPTS();
+
+	return !got_sigterm;
+}
+
+
+/*
+ * LockAcquireHelperMain runs in a dynamic background worker to help master_update_node to
+ * acquire its locks.
+ */
+void
+LockAcquireHelperMain(Datum main_arg)
+{
+	int backendPid = DatumGetInt32(main_arg);
+	StringInfoData sql;
+	LockAcquireHelperArgs *args = (LockAcquireHelperArgs *) MyBgworkerEntry->bgw_extra;
+
+
+	pqsignal(SIGTERM, lock_acquire_helper_sigterm);
+
+	BackgroundWorkerUnblockSignals();
+
+	elog(LOG, "lock acquiring backend started for backend %d", backendPid);
+
+	/*
+	 * TODO add cooldown period before canceling backends
+	 */
+
+	/* connecting to the database */
+	BackgroundWorkerInitializeConnectionByOid(args->DatabaseId, InvalidOid, 0);
+
+	initStringInfo(&sql);
+	appendStringInfo(&sql,
+					 "SELECT pg_terminate_backend(conflicting.pid) FROM\n"
+					 "  pg_locks AS blocked,\n"
+					 "  pg_locks AS conflicting\n"
+					 "WHERE conflicting.database = blocked.database\n"
+					 "  AND conflicting.objid = blocked.objid\n"
+					 "  AND conflicting.granted = true\n"
+					 "  AND blocked.granted = false\n"
+					 "  AND blocked.pid = %d;",
+					 backendPid);
+
+	while (ShouldAcquireLock(100))
+	{
+		int ret;
+
+		elog(LOG, "canceling competing backends for backend %d", backendPid);
+
+		/*
+		 * Begin our transaction
+		 */
+		SetCurrentStatementStartTimestamp();
+		StartTransactionCommand();
+		SPI_connect();
+		PushActiveSnapshot(GetTransactionSnapshot());
+		pgstat_report_activity(STATE_RUNNING, sql.data);
+
+		ret = SPI_execute(sql.data, false, 0);
+
+		if (ret != SPI_OK_SELECT)
+		{
+			elog(FATAL, "cannot cancel competing backends for backend %d", backendPid);
+		}
+
+		/* TODO count the number of backends canceled and log about it */
+
+		/*
+		 * And finish our transaction.
+		 */
+		SPI_finish();
+		PopActiveSnapshot();
+		CommitTransactionCommand();
+		pgstat_report_stat(false);
+		pgstat_report_activity(STATE_IDLE, NULL);
+	}
+
+
+	elog(LOG, "lock acquiring backend finished for backend %d", backendPid);
+
+	/* safely got to the end, exit without problem */
+	proc_exit(0);
+}

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -186,16 +186,17 @@ LockAcquireHelperMain(Datum main_arg)
 	/* connecting to the database */
 	BackgroundWorkerInitializeConnectionByOid(args->DatabaseId, InvalidOid, 0);
 
+	/* TODO explain sql below */
 	initStringInfo(&sql);
 	appendStringInfo(&sql,
-					 "SELECT pg_terminate_backend(conflicting.pid) FROM\n"
-					 "  pg_locks AS blocked,\n"
-					 "  pg_locks AS conflicting\n"
-					 "WHERE conflicting.database = blocked.database\n"
-					 "  AND conflicting.objid = blocked.objid\n"
-					 "  AND conflicting.granted = true\n"
-					 "  AND blocked.granted = false\n"
-					 "  AND blocked.pid = %d;",
+					 "SELECT pg_terminate_backend(conflicting.pid)\n"
+					 "  FROM pg_locks AS blocked\n"
+					 "       JOIN pg_locks AS conflicting\n"
+					 "         ON (conflicting.database = blocked.database\n"
+					 "             AND conflicting.objid = blocked.objid)\n"
+					 " WHERE conflicting.granted = true\n"
+					 "   AND blocked.granted = false\n"
+					 "   AND blocked.pid = %d;",
 					 backendPid);
 
 	while (ShouldAcquireLock(100))

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -18,7 +18,10 @@
  */
 
 
+#include <unistd.h>
+
 #include "postgres.h"
+
 
 #include "access/xact.h"
 #include "executor/spi.h"
@@ -182,6 +185,7 @@ LockAcquireHelperMain(Datum main_arg)
 	/*
 	 * TODO add cooldown period before canceling backends
 	 */
+	sleep(1);
 
 	/* connecting to the database */
 	BackgroundWorkerInitializeConnectionByOid(args->DatabaseId, InvalidOid, 0);

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -159,6 +159,12 @@ ShouldAcquireLock(long sleepms)
 {
 	int rc;
 
+	/* early escape in case we already got the signal to stop acquiring the lock */
+	if (got_sigterm)
+	{
+		return false;
+	}
+
 	rc = WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
 				   sleepms * 1L, PG_WAIT_EXTENSION);
 	ResetLatch(MyLatch);

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -532,6 +532,12 @@ master_update_node(PG_FUNCTION_ARGS)
 	 * - This function blocks until all previous queries have finished. This
 	 *   means that long-running queries will prevent failover.
 	 *
+	 *   In case of node failure said long-running queries will fail in the end
+	 *   anyway as they will be unable to commit successfully on the failed
+	 *   machine. To cause quick failure of these queries use force => true
+	 *   during the invocation of master_update_node to terminate conflicting
+	 *   backends proactively.
+	 *
 	 * It might be worth blocking reads to a secondary for the same reasons,
 	 * though we currently only query secondaries on follower clusters
 	 * where these locks will have no effect.
@@ -545,7 +551,6 @@ master_update_node(PG_FUNCTION_ARGS)
 		if (force)
 		{
 			handle = StartLockAcquireHelperBackgroundWorker(MyProcPid, lock_cooldown);
-			ereport(NOTICE, (errmsg("force the update to the node")));
 		}
 
 		placementList = AllShardPlacementsOnNodeGroup(workerNode->groupId);

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -483,6 +483,7 @@ master_update_node(PG_FUNCTION_ARGS)
 	 * Defaults to false
 	 */
 	bool force = PG_GETARG_BOOL(3);
+	int32 lock_cooldown = PG_GETARG_INT32(4);
 
 	char *newNodeNameString = text_to_cstring(newNodeName);
 	WorkerNode *workerNode = NULL;
@@ -545,7 +546,7 @@ master_update_node(PG_FUNCTION_ARGS)
 		 */
 		if (force)
 		{
-			handle = StartLockAcquireHelperBackgroundWorker(MyProcPid);
+			handle = StartLockAcquireHelperBackgroundWorker(MyProcPid, lock_cooldown);
 			ereport(NOTICE, (errmsg("force the update to the node")));
 		}
 

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -8,8 +8,6 @@
 #include "miscadmin.h"
 #include "funcapi.h"
 
-#include <unistd.h>
-
 
 #include "access/genam.h"
 #include "access/heapam.h"

--- a/src/include/distributed/citus_acquire_lock.h
+++ b/src/include/distributed/citus_acquire_lock.h
@@ -3,7 +3,7 @@
  * citus_acquire_lock.h
  *	  Background worker to help with acquiering locks by canceling competing backends.
  *
- * Copyright (c) 2017, Citus Data, Inc.
+ * Copyright (c) 2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/citus_acquire_lock.h
+++ b/src/include/distributed/citus_acquire_lock.h
@@ -8,8 +8,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef CITUS_CITUS_ACQUIRE_LOCK_H
-#define CITUS_CITUS_ACQUIRE_LOCK_H
+#ifndef CITUS_ACQUIRE_LOCK_H
+#define CITUS_ACQUIRE_LOCK_H
 
 
 #include "postmaster/bgworker.h"
@@ -17,4 +17,4 @@
 BackgroundWorkerHandle * StartLockAcquireHelperBackgroundWorker(int backendToHelp,
 																int32 lock_cooldown);
 
-#endif /*CITUS_CITUS_ACQUIRE_LOCK_H */
+#endif /* CITUS_ACQUIRE_LOCK_H */

--- a/src/include/distributed/citus_acquire_lock.h
+++ b/src/include/distributed/citus_acquire_lock.h
@@ -11,8 +11,10 @@
 #ifndef CITUS_CITUS_ACQUIRE_LOCK_H
 #define CITUS_CITUS_ACQUIRE_LOCK_H
 
+
 #include "postmaster/bgworker.h"
 
-BackgroundWorkerHandle * StartLockAcquireHelperBackgroundWorker(int backendToHelp);
+BackgroundWorkerHandle * StartLockAcquireHelperBackgroundWorker(int backendToHelp,
+																int32 lock_cooldown);
 
 #endif /*CITUS_CITUS_ACQUIRE_LOCK_H */

--- a/src/include/distributed/citus_acquire_lock.h
+++ b/src/include/distributed/citus_acquire_lock.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * citus_acquire_lock.h
+ *	  Background worker to help with acquiering locks by canceling competing backends.
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CITUS_CITUS_ACQUIRE_LOCK_H
+#define CITUS_CITUS_ACQUIRE_LOCK_H
+
+#include "postmaster/bgworker.h"
+
+BackgroundWorkerHandle * StartLockAcquireHelperBackgroundWorker(int backendToHelp);
+
+#endif /*CITUS_CITUS_ACQUIRE_LOCK_H */

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -73,6 +73,10 @@ check-isolation: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/isolation_schedule $(EXTRA_TESTS)
 
+check-isolation-base: all tempinstall-main
+	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
+	-- $(MULTI_REGRESS_OPTS) $(EXTRA_TESTS)
+
 check-vanilla: all tempinstall-main
 	$(pg_regress_multi_check) --load-extension=citus --vanillatest
 

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -45,16 +45,16 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT worker_apply_shard_ddl_command (105941, 'public', '
+SELECT worker_apply_shard_ddl_command (105949, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (105940, 'public', '
+SELECT worker_apply_shard_ddl_command (105948, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (105939, 'public', '
+SELECT worker_apply_shard_ddl_command (105947, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (105938, 'public', '
+SELECT worker_apply_shard_ddl_command (105946, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
@@ -116,7 +116,7 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
 
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-INSERT INTO public.test_table_105944 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+INSERT INTO public.test_table_105952 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -177,10 +177,10 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
 
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105949 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105948 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105947 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_105946 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105957 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105956 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105955 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_105954 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -241,7 +241,7 @@ query          query_hostname query_hostport master_query_host_namemaster_query_
 
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 SELECT gid FROM pg_prepared_xacts WHERE gid LIKE 'citus\_0\_%'localhost      57637                         0              idle           Client         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM public.test_table_105951 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_105959 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_distributed_transaction_id.out
+++ b/src/test/regress/expected/isolation_distributed_transaction_id.out
@@ -77,7 +77,7 @@ step s1-get-current-transaction-id:
 
 row            
 
-(0,299)        
+(0,305)        
 step s2-get-first-worker-active-transactions: 
 		SELECT * FROM run_command_on_workers('SELECT row(initiator_node_identifier, transaction_number)
 												FROM	 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-302            301            f              
+308            307            f              
 transactionnumberwaitingtransactionnumbers
 
-301                           
-302            301            
+307                           
+308            307            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-306            305            f              
-307            305            f              
-307            306            t              
+312            311            f              
+313            311            f              
+313            312            t              
 transactionnumberwaitingtransactionnumbers
 
-305                           
-306            305            
-307            305,306        
+311                           
+312            311            
+313            311,312        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_master_update_node.out
+++ b/src/test/regress/expected/isolation_master_update_node.out
@@ -1,0 +1,57 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-insert s2-begin s2-update-node-1 s1-abort s2-abort
+create_distributed_table
+
+               
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
+step s2-begin: BEGIN;
+step s2-update-node-1: 
+    -- update a specific node by address
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10)
+      FROM pg_dist_node
+     WHERE nodename = 'localhost'
+       AND nodeport = 57637;
+ <waiting ...>
+step s1-abort: ABORT;
+step s2-update-node-1: <... completed>
+master_update_node
+
+               
+step s2-abort: ABORT;
+master_remove_node
+
+               
+               
+
+starting permutation: s1-begin s1-insert s2-begin s2-update-node-1-force s2-abort s1-abort
+create_distributed_table
+
+               
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
+step s2-begin: BEGIN;
+step s2-update-node-1-force: 
+    -- update a specific node by address (force)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true)
+      FROM pg_dist_node
+     WHERE nodename = 'localhost'
+       AND nodeport = 57637;
+ <waiting ...>
+step s2-update-node-1-force: <... completed>
+master_update_node
+
+               
+step s2-abort: ABORT;
+step s1-abort: ABORT;
+WARNING: this step had a leftover error message
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+master_remove_node
+
+               
+               

--- a/src/test/regress/expected/isolation_master_update_node.out
+++ b/src/test/regress/expected/isolation_master_update_node.out
@@ -34,7 +34,7 @@ step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
 step s2-begin: BEGIN;
 step s2-update-node-1-force: 
     -- update a specific node by address (force)
-    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 1000)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 100)
       FROM pg_dist_node
      WHERE nodename = 'localhost'
        AND nodeport = 57637;

--- a/src/test/regress/expected/isolation_master_update_node.out
+++ b/src/test/regress/expected/isolation_master_update_node.out
@@ -34,7 +34,7 @@ step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
 step s2-begin: BEGIN;
 step s2-update-node-1-force: 
     -- update a specific node by address (force)
-    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 1000)
       FROM pg_dist_node
      WHERE nodename = 'localhost'
        AND nodeport = 57637;

--- a/src/test/regress/expected/isolation_master_update_node_0.out
+++ b/src/test/regress/expected/isolation_master_update_node_0.out
@@ -1,0 +1,55 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-insert s2-begin s2-update-node-1 s1-abort s2-abort
+create_distributed_table
+
+               
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
+step s2-begin: BEGIN;
+step s2-update-node-1: 
+    -- update a specific node by address
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10)
+      FROM pg_dist_node
+     WHERE nodename = 'localhost'
+       AND nodeport = 57637;
+ <waiting ...>
+step s1-abort: ABORT;
+step s2-update-node-1: <... completed>
+master_update_node
+
+               
+step s2-abort: ABORT;
+master_remove_node
+
+               
+               
+
+starting permutation: s1-begin s1-insert s2-begin s2-update-node-1-force s2-abort s1-abort
+create_distributed_table
+
+               
+step s1-begin: BEGIN;
+step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
+step s2-begin: BEGIN;
+step s2-update-node-1-force: 
+    -- update a specific node by address (force)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true)
+      FROM pg_dist_node
+     WHERE nodename = 'localhost'
+       AND nodeport = 57637;
+ <waiting ...>
+step s2-update-node-1-force: <... completed>
+master_update_node
+
+               
+step s2-abort: ABORT;
+step s1-abort: ABORT;
+WARNING: this step had a leftover error message
+FATAL:  terminating connection due to administrator command
+SSL connection has been closed unexpectedly
+
+master_remove_node
+
+               
+               

--- a/src/test/regress/expected/isolation_master_update_node_0.out
+++ b/src/test/regress/expected/isolation_master_update_node_0.out
@@ -34,7 +34,7 @@ step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
 step s2-begin: BEGIN;
 step s2-update-node-1-force: 
     -- update a specific node by address (force)
-    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 1000)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 100)
       FROM pg_dist_node
      WHERE nodename = 'localhost'
        AND nodeport = 57637;

--- a/src/test/regress/expected/isolation_master_update_node_0.out
+++ b/src/test/regress/expected/isolation_master_update_node_0.out
@@ -34,7 +34,7 @@ step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
 step s2-begin: BEGIN;
 step s2-update-node-1-force: 
     -- update a specific node by address (force)
-    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 1000)
       FROM pg_dist_node
      WHERE nodename = 'localhost'
        AND nodeport = 57637;

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-finish:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102329"
+error in steps s1-finish s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102337"
 step s2-finish: 
   COMMIT;
 

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -147,7 +147,7 @@ GRANT EXECUTE ON FUNCTION master_add_node(text,int,int,noderole,name) TO node_me
 GRANT EXECUTE ON FUNCTION master_add_secondary_node(text,int,text,int,name) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_disable_node(text,int) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_remove_node(text,int) TO node_metadata_user;
-GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool) TO node_metadata_user;
+GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool,int) TO node_metadata_user;
 -- try to manipulate node metadata via non-super user
 SET ROLE non_super_user;
 SELECT 1 FROM master_initialize_node_metadata();

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -147,7 +147,7 @@ GRANT EXECUTE ON FUNCTION master_add_node(text,int,int,noderole,name) TO node_me
 GRANT EXECUTE ON FUNCTION master_add_secondary_node(text,int,text,int,name) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_disable_node(text,int) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_remove_node(text,int) TO node_metadata_user;
-GRANT EXECUTE ON FUNCTION master_update_node(int,text,int) TO node_metadata_user;
+GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool) TO node_metadata_user;
 -- try to manipulate node metadata via non-super user
 SET ROLE non_super_user;
 SELECT 1 FROM master_initialize_node_metadata();

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -3,6 +3,7 @@ test: isolation_update_node
 test: isolation_update_node_lock_writes
 test: isolation_add_node_vs_reference_table_operations
 test: isolation_create_table_vs_add_remove_node
+test: isolation_master_update_node
 
 # tests that change node metadata should precede
 # isolation_cluster_management such that tests

--- a/src/test/regress/specs/isolation_citus_dist_activity.spec
+++ b/src/test/regress/specs/isolation_citus_dist_activity.spec
@@ -1,5 +1,11 @@
 setup
 {
+    -- would be great if we could SET citus.next_shard_id TO 107000;
+    -- unfortunately that will cause messages like
+    -- ERROR:  cached metadata for shard 107000 is inconsistent
+    -- to show up. This test is therefore subject to change due to
+    -- addition of tests or permutations prior to this test.
+
     SET citus.shard_replication_factor TO 1;
     SET citus.shard_count TO 4;
     -- we don't want to see any entries related to 2PC recovery

--- a/src/test/regress/specs/isolation_master_update_node.spec
+++ b/src/test/regress/specs/isolation_master_update_node.spec
@@ -1,0 +1,43 @@
+setup
+{
+    SELECT 1 FROM master_add_node('localhost', 57637);
+    SELECT 1 FROM master_add_node('localhost', 57638);
+
+    CREATE TABLE t1(a int);
+    SELECT create_distributed_table('t1','a');
+}
+
+teardown
+{
+    DROP TABLE t1;
+
+    -- remove the nodes again
+    SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node;
+}
+
+session "s1"
+step "s1-begin" { BEGIN; }
+step "s1-insert" { INSERT INTO t1 SELECT generate_series(1, 100); }
+step "s1-verify-terminated" { -- verify the connection has been terminated }
+step "s1-abort" { ABORT; }
+
+session "s2"
+step "s2-begin" { BEGIN; }
+step "s2-update-node-1" {
+    -- update a specific node by address
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10)
+      FROM pg_dist_node
+     WHERE nodename = 'localhost'
+       AND nodeport = 57637;
+}
+step "s2-update-node-1-force" {
+    -- update a specific node by address (force)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true)
+      FROM pg_dist_node
+     WHERE nodename = 'localhost'
+       AND nodeport = 57637;
+}
+step "s2-abort" { ABORT; }
+
+permutation "s1-begin" "s1-insert" "s2-begin" "s2-update-node-1" "s1-abort" "s2-abort"
+permutation "s1-begin" "s1-insert" "s2-begin" "s2-update-node-1-force" "s2-abort" "s1-abort"

--- a/src/test/regress/specs/isolation_master_update_node.spec
+++ b/src/test/regress/specs/isolation_master_update_node.spec
@@ -32,7 +32,7 @@ step "s2-update-node-1" {
 }
 step "s2-update-node-1-force" {
     -- update a specific node by address (force)
-    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 1000)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 100)
       FROM pg_dist_node
      WHERE nodename = 'localhost'
        AND nodeport = 57637;

--- a/src/test/regress/specs/isolation_master_update_node.spec
+++ b/src/test/regress/specs/isolation_master_update_node.spec
@@ -32,7 +32,7 @@ step "s2-update-node-1" {
 }
 step "s2-update-node-1-force" {
     -- update a specific node by address (force)
-    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true)
+    SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 1000)
       FROM pg_dist_node
      WHERE nodename = 'localhost'
        AND nodeport = 57637;

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -65,7 +65,7 @@ GRANT EXECUTE ON FUNCTION master_add_node(text,int,int,noderole,name) TO node_me
 GRANT EXECUTE ON FUNCTION master_add_secondary_node(text,int,text,int,name) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_disable_node(text,int) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_remove_node(text,int) TO node_metadata_user;
-GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool) TO node_metadata_user;
+GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool,int) TO node_metadata_user;
 
 -- try to manipulate node metadata via non-super user
 SET ROLE non_super_user;

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -65,7 +65,7 @@ GRANT EXECUTE ON FUNCTION master_add_node(text,int,int,noderole,name) TO node_me
 GRANT EXECUTE ON FUNCTION master_add_secondary_node(text,int,text,int,name) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_disable_node(text,int) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_remove_node(text,int) TO node_metadata_user;
-GRANT EXECUTE ON FUNCTION master_update_node(int,text,int) TO node_metadata_user;
+GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool) TO node_metadata_user;
 
 -- try to manipulate node metadata via non-super user
 SET ROLE non_super_user;


### PR DESCRIPTION
DESCRIPTION: Feature: optionally force master_update_node during failover

When `master_update_node` is called to update a node's location it waits for appropriate locks to become available. This is useful during normal operation as new operations will be blocked till after the metadata update while running operations have time to finish.

When `master_update_node` is called after a node failure it is less useful to wait for running operations to finish as they can't. The lock being held indicates an operation that once attempted to commit will fail as the machine already failed. Now the downside is the failover is postponed till the termination point of the operation. This has been observed by users to take a significant amount of time causing the rest of the system to be observed unavailable.

With this patch it is possible in such situations to invoke `master_update_node` with 2 optional arguments:
 - `force` (bool defaults to `false`): When called with true the update of the metadata will be forced to proceed by terminating conflicting backends. A cancel is not enough as the backend might be in idle time (eg. an interactive session, or going back and forth between an appliaction), therefore a more intrusive solution of termination is used here.
 - `lock_cooldown` (int defaults to `10000`): This is the time in milliseconds before conflicting backends are terminated. This is to allow the backends to finish cleanly before terminating them. This allows the user to set an upperbound to the expected time to complete the metadata update, eg. performing the failover.

The functionality is implemented by spawning a background worker that has the task of helping a certain backend in acquiring its locks. The backend is either terminated on successful execution of the metadata update, or once the memory context of the expression gets reset, eg. on a cancel of the statement.
