### PR TITLE
Create all distributed schemas as superuser on a separate connection

### DIFF
--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -75,6 +75,14 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	EnsureCoordinator();
 	CheckCitusVersion(ERROR);
 
+	/*
+	 * Ensure schema exists on each worker node. We can not run this function
+	 * transactionally, since we may create shards over separate sessions and
+	 * shard creation depends on the schema being present and visible from all
+	 * sessions.
+	 */
+	EnsureSchemaExistsOnAllNodes(distributedTableId);
+
 	CreateShardsWithRoundRobinPolicy(distributedTableId, shardCount, replicationFactor,
 									 useExclusiveConnections);
 

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -618,9 +618,7 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 	char tableType = 0;
 	char *tableSchemaDef = NULL;
 	char *tableColumnOptionsDef = NULL;
-	char *createSchemaCommand = NULL;
 	char *tableOwnerDef = NULL;
-	Oid schemaId = InvalidOid;
 
 	/*
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
@@ -644,14 +642,6 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 			tableDDLEventList = lappend(tableDDLEventList, extensionDef);
 		}
 		tableDDLEventList = lappend(tableDDLEventList, serverDef);
-	}
-
-	/* create schema if the table is not in the default namespace (public) */
-	schemaId = get_rel_namespace(relationId);
-	createSchemaCommand = CreateSchemaDDLCommand(schemaId);
-	if (createSchemaCommand != NULL)
-	{
-		tableDDLEventList = lappend(tableDDLEventList, createSchemaCommand);
 	}
 
 	/* fetch table schema and column option definitions */

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -233,6 +233,15 @@ RepairShardPlacement(int64 shardId, char *sourceNodeName, int32 sourceNodePort,
 
 	EnsureTableOwner(distributedTableId);
 
+	/*
+	 * Ensure schema exists on the target worker node. We can not run this
+	 * function transactionally, since we may create shards over separate
+	 * sessions and shard creation depends on the schema being present and
+	 * visible from all sessions.
+	 */
+	EnsureSchemaExistsOnNode(distributedTableId, targetNodeName,
+							 targetNodePort);
+
 	if (relationKind == RELKIND_FOREIGN_TABLE)
 	{
 		char *relationName = get_rel_name(distributedTableId);

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -99,6 +99,14 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	EnsureTablePermissions(relationId, ACL_INSERT);
 	CheckDistributedTable(relationId);
 
+	/*
+	 * Ensure schema exists on each worker node. We can not run this function
+	 * transactionally, since we may create shards over separate sessions and
+	 * shard creation depends on the schema being present and visible from all
+	 * sessions.
+	 */
+	EnsureSchemaExistsOnAllNodes(relationId);
+
 	/* don't allow the table to be dropped */
 	LockRelationOid(relationId, AccessShareLock);
 

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -296,6 +296,16 @@ ReplicateShardToNode(ShardInterval *shardInterval, char *nodeName, int nodePort)
 																 missingWorkerOk);
 	char *tableOwner = TableOwner(shardInterval->relationId);
 
+
+	/*
+	 * Ensure schema exists on the worker node. We can not run this
+	 * function transactionally, since we may create shards over separate
+	 * sessions and shard creation depends on the schema being present and
+	 * visible from all sessions.
+	 */
+	EnsureSchemaExistsOnNode(shardInterval->relationId, nodeName, nodePort);
+
+
 	/*
 	 * Although this function is used for reference tables and reference table shard
 	 * placements always have shardState = FILE_FINALIZED, in case of an upgrade of

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -151,6 +151,9 @@ extern void CreateDistributedTable(Oid relationId, Var *distributionColumn,
 								   char distributionMethod, char *colocateWithTableName,
 								   bool viaDeprecatedAPI);
 extern void CreateTruncateTrigger(Oid relationId);
+extern void EnsureSchemaExistsOnAllNodes(Oid relationId);
+extern void EnsureSchemaExistsOnNode(Oid relationId, char *nodeName,
+									 int32 nodePort);
 
 /* Remaining metadata utility functions  */
 extern char * TableOwner(Oid relationId);

--- a/src/test/regress/expected/failure_add_disable_node.out
+++ b/src/test/regress/expected/failure_add_disable_node.out
@@ -120,7 +120,6 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE SCHEMA").kill()');
 (1 row)
 
 SELECT master_activate_node('localhost', :worker_2_proxy_port);
-NOTICE:  Replicating reference table "user_table" to the node localhost:9060
 ERROR:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/regress/expected/failure_create_table.out
+++ b/src/test/regress/expected/failure_create_table.out
@@ -595,10 +595,10 @@ SELECT citus.mitmproxy('conn.kill()');
 (1 row)
 
 SELECT master_create_worker_shards('test_table_2', 4, 2);
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:9060
 ERROR:  connection error: localhost:9060
-DETAIL:  connection not open
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 SELECT count(*) FROM pg_dist_shard;
  count 
 -------

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -596,10 +596,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -613,14 +609,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -641,10 +629,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -658,14 +642,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -700,10 +676,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -717,14 +689,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -738,14 +702,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -768,10 +724,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -785,14 +737,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -820,10 +764,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -837,14 +777,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -867,14 +799,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -888,10 +812,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -918,14 +838,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -939,10 +851,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -1004,10 +912,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
 DEBUG:  switching to sequential query execution mode
 DETAIL:  Reference relation "test_table_1" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
 NOTICE:  Copying data from local table...
@@ -1048,10 +952,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
 NOTICE:  Copying data from local table...
 DEBUG:  Copied 101 rows
  create_reference_table 
@@ -1090,10 +990,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
 DEBUG:  switching to sequential query execution mode
 DETAIL:  Reference relation "test_table_1" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -1104,14 +1000,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -1149,10 +1037,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -1166,14 +1050,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  

--- a/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
@@ -596,10 +596,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -613,14 +609,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -641,10 +629,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -658,14 +642,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -700,10 +676,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -717,14 +689,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -738,14 +702,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -768,10 +724,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -785,14 +737,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -820,10 +764,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -837,14 +777,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -867,14 +799,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -888,10 +812,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -918,14 +838,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -939,10 +851,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -1004,10 +912,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
 DEBUG:  switching to sequential query execution mode
 DETAIL:  Reference relation "test_table_1" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
 NOTICE:  Copying data from local table...
@@ -1048,10 +952,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
 NOTICE:  Copying data from local table...
 DEBUG:  Copied 101 rows
  create_reference_table 
@@ -1090,10 +990,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
 DEBUG:  switching to sequential query execution mode
 DETAIL:  Reference relation "test_table_1" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -1104,14 +1000,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  
@@ -1149,10 +1037,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_reference_table 
 ------------------------
  
@@ -1166,14 +1050,6 @@ DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "test_fkey_to_ref_in_tx" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  create_distributed_table 
 --------------------------
  

--- a/src/test/regress/expected/multi_generate_ddl_commands.out
+++ b/src/test/regress/expected/multi_generate_ddl_commands.out
@@ -27,16 +27,6 @@ SELECT master_get_table_ddl_events('not_null_table');
  ALTER TABLE public.not_null_table OWNER TO postgres
 (2 rows)
 
--- ensure tables not in search path are schema-prefixed
-CREATE SCHEMA not_in_path CREATE TABLE simple_table (id bigint);
-SELECT master_get_table_ddl_events('not_in_path.simple_table');
-                  master_get_table_ddl_events                   
-----------------------------------------------------------------
- CREATE SCHEMA IF NOT EXISTS not_in_path AUTHORIZATION postgres
- CREATE TABLE not_in_path.simple_table (id bigint)
- ALTER TABLE not_in_path.simple_table OWNER TO postgres
-(3 rows)
-
 -- even more complex constraints should be preserved...
 CREATE TABLE column_constraint_table (
 	first_name text,

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -102,10 +102,8 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
- CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
- CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
  ALTER TABLE mx_testing_schema.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
@@ -115,7 +113,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(16 rows)
+(14 rows)
 
 -- Show that append distributed tables are not included in the metadata snapshot
 CREATE TABLE non_mx_test_table (col_1 int, col_2 text);
@@ -132,10 +130,8 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
- CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
- CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
  ALTER TABLE mx_testing_schema.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
@@ -145,7 +141,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(16 rows)
+(14 rows)
 
 -- Show that range distributed tables are not included in the metadata snapshot
 UPDATE pg_dist_partition SET partmethod='r' WHERE logicalrelid='non_mx_test_table'::regclass;
@@ -155,10 +151,8 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
- CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE')
  ALTER SEQUENCE mx_testing_schema.mx_test_table_col_3_seq OWNER TO postgres
- CREATE SCHEMA IF NOT EXISTS mx_testing_schema AUTHORIZATION postgres
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
  ALTER TABLE mx_testing_schema.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
@@ -168,7 +162,7 @@ SELECT unnest(master_metadata_snapshot());
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
-(16 rows)
+(14 rows)
 
 -- Test start_metadata_sync_to_node UDF
 -- Ensure that hasmetadata=false for all nodes

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -41,6 +41,9 @@ SET citus.enable_ddl_propagation TO off;
 CREATE USER full_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE USER usage_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 CREATE USER read_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
@@ -56,10 +59,14 @@ GRANT ALL ON TABLE test TO full_access;
 GRANT SELECT ON TABLE test TO read_access;
 CREATE SCHEMA full_access_user_schema;
 REVOKE ALL ON SCHEMA full_access_user_schema FROM PUBLIC;
-GRANT USAGE ON SCHEMA full_access_user_schema TO full_access;
+GRANT ALL ON SCHEMA full_access_user_schema TO full_access;
+GRANT USAGE ON SCHEMA full_access_user_schema TO usage_access;
 SET citus.enable_ddl_propagation TO DEFAULT;
 \c - - - :worker_1_port
 CREATE USER full_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE USER usage_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 CREATE USER read_access;
@@ -80,8 +87,13 @@ GRANT SELECT ON TABLE test_1420002 TO read_access;
 CREATE SCHEMA full_access_user_schema;
 REVOKE ALL ON SCHEMA full_access_user_schema FROM PUBLIC;
 GRANT USAGE ON SCHEMA full_access_user_schema TO full_access;
+GRANT ALL ON SCHEMA full_access_user_schema TO full_access;
+GRANT USAGE ON SCHEMA full_access_user_schema TO usage_access;
 \c - - - :worker_2_port
 CREATE USER full_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE USER usage_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 CREATE USER read_access;
@@ -102,6 +114,8 @@ GRANT SELECT ON TABLE test_1420003 TO read_access;
 CREATE SCHEMA full_access_user_schema;
 REVOKE ALL ON SCHEMA full_access_user_schema FROM PUBLIC;
 GRANT USAGE ON SCHEMA full_access_user_schema TO full_access;
+GRANT ALL ON SCHEMA full_access_user_schema TO full_access;
+GRANT USAGE ON SCHEMA full_access_user_schema TO usage_access;
 \c - - - :master_port
 -- create prepare tests
 PREPARE prepare_insert AS INSERT INTO test VALUES ($1);
@@ -363,7 +377,7 @@ $cmd$);
 -- its table distributed by the super user
 -- we want to make sure the schema and user are setup in such a way they can't create a
 -- table
-SET ROLE full_access;
+SET ROLE usage_access;
 CREATE TABLE full_access_user_schema.t1 (id int);
 ERROR:  permission denied for schema full_access_user_schema
 LINE 1: CREATE TABLE full_access_user_schema.t1 (id int);
@@ -371,9 +385,9 @@ LINE 1: CREATE TABLE full_access_user_schema.t1 (id int);
 RESET ROLE;
 -- now we create the table for the user
 CREATE TABLE full_access_user_schema.t1 (id int);
-ALTER TABLE full_access_user_schema.t1 OWNER TO full_access;
+ALTER TABLE full_access_user_schema.t1 OWNER TO usage_access;
 -- make sure we can insert data
-SET ROLE full_access;
+SET ROLE usage_access;
 INSERT INTO full_access_user_schema.t1 VALUES (1),(2),(3);
 -- creating the table should fail with a failure on the worker machine since the user is
 -- not allowed to create a table
@@ -397,14 +411,26 @@ SELECT result FROM run_command_on_workers($cmd$
     AND tablename LIKE 't1_%'
   LIMIT 1;
 $cmd$);
-   result    
--------------
- full_access
- full_access
+    result    
+--------------
+ usage_access
+ usage_access
 (2 rows)
 
+-- a user with all privileges on a schema should be able to distribute tables
+SET ROLE full_access;
+CREATE TABLE full_access_user_schema.t2(id int);
+SELECT create_distributed_table('full_access_user_schema.t2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+RESET ROLE;
 DROP SCHEMA full_access_user_schema CASCADE;
-NOTICE:  drop cascades to table full_access_user_schema.t1
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table full_access_user_schema.t1
+drop cascades to table full_access_user_schema.t2
 DROP TABLE
     my_table,
     my_table_with_data,

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -378,7 +378,7 @@ INSERT INTO full_access_user_schema.t1 VALUES (1),(2),(3);
 -- creating the table should fail with a failure on the worker machine since the user is
 -- not allowed to create a table
 SELECT create_distributed_table('full_access_user_schema.t1', 'id');
-ERROR:  permission denied for database regression
+ERROR:  permission denied for schema full_access_user_schema
 CONTEXT:  while executing command on localhost:57638
 RESET ROLE;
 -- now we distribute the table as super user

--- a/src/test/regress/expected/multi_multiuser_0.out
+++ b/src/test/regress/expected/multi_multiuser_0.out
@@ -41,6 +41,9 @@ SET citus.enable_ddl_propagation TO off;
 CREATE USER full_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE USER usage_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 CREATE USER read_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
@@ -56,10 +59,14 @@ GRANT ALL ON TABLE test TO full_access;
 GRANT SELECT ON TABLE test TO read_access;
 CREATE SCHEMA full_access_user_schema;
 REVOKE ALL ON SCHEMA full_access_user_schema FROM PUBLIC;
-GRANT USAGE ON SCHEMA full_access_user_schema TO full_access;
+GRANT ALL ON SCHEMA full_access_user_schema TO full_access;
+GRANT USAGE ON SCHEMA full_access_user_schema TO usage_access;
 SET citus.enable_ddl_propagation TO DEFAULT;
 \c - - - :worker_1_port
 CREATE USER full_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE USER usage_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 CREATE USER read_access;
@@ -80,8 +87,13 @@ GRANT SELECT ON TABLE test_1420002 TO read_access;
 CREATE SCHEMA full_access_user_schema;
 REVOKE ALL ON SCHEMA full_access_user_schema FROM PUBLIC;
 GRANT USAGE ON SCHEMA full_access_user_schema TO full_access;
+GRANT ALL ON SCHEMA full_access_user_schema TO full_access;
+GRANT USAGE ON SCHEMA full_access_user_schema TO usage_access;
 \c - - - :worker_2_port
 CREATE USER full_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE USER usage_access;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 CREATE USER read_access;
@@ -102,6 +114,8 @@ GRANT SELECT ON TABLE test_1420003 TO read_access;
 CREATE SCHEMA full_access_user_schema;
 REVOKE ALL ON SCHEMA full_access_user_schema FROM PUBLIC;
 GRANT USAGE ON SCHEMA full_access_user_schema TO full_access;
+GRANT ALL ON SCHEMA full_access_user_schema TO full_access;
+GRANT USAGE ON SCHEMA full_access_user_schema TO usage_access;
 \c - - - :master_port
 -- create prepare tests
 PREPARE prepare_insert AS INSERT INTO test VALUES ($1);
@@ -363,7 +377,7 @@ $cmd$);
 -- its table distributed by the super user
 -- we want to make sure the schema and user are setup in such a way they can't create a
 -- table
-SET ROLE full_access;
+SET ROLE usage_access;
 CREATE TABLE full_access_user_schema.t1 (id int);
 ERROR:  permission denied for schema full_access_user_schema
 LINE 1: CREATE TABLE full_access_user_schema.t1 (id int);
@@ -371,9 +385,9 @@ LINE 1: CREATE TABLE full_access_user_schema.t1 (id int);
 RESET ROLE;
 -- now we create the table for the user
 CREATE TABLE full_access_user_schema.t1 (id int);
-ALTER TABLE full_access_user_schema.t1 OWNER TO full_access;
+ALTER TABLE full_access_user_schema.t1 OWNER TO usage_access;
 -- make sure we can insert data
-SET ROLE full_access;
+SET ROLE usage_access;
 INSERT INTO full_access_user_schema.t1 VALUES (1),(2),(3);
 -- creating the table should fail with a failure on the worker machine since the user is
 -- not allowed to create a table
@@ -397,14 +411,26 @@ SELECT result FROM run_command_on_workers($cmd$
     AND tablename LIKE 't1_%'
   LIMIT 1;
 $cmd$);
-   result    
--------------
- full_access
- full_access
+    result    
+--------------
+ usage_access
+ usage_access
 (2 rows)
 
+-- a user with all privileges on a schema should be able to distribute tables
+SET ROLE full_access;
+CREATE TABLE full_access_user_schema.t2(id int);
+SELECT create_distributed_table('full_access_user_schema.t2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+RESET ROLE;
 DROP SCHEMA full_access_user_schema CASCADE;
-NOTICE:  drop cascades to table full_access_user_schema.t1
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table full_access_user_schema.t1
+drop cascades to table full_access_user_schema.t2
 DROP TABLE
     my_table,
     my_table_with_data,

--- a/src/test/regress/expected/multi_multiuser_0.out
+++ b/src/test/regress/expected/multi_multiuser_0.out
@@ -378,7 +378,7 @@ INSERT INTO full_access_user_schema.t1 VALUES (1),(2),(3);
 -- creating the table should fail with a failure on the worker machine since the user is
 -- not allowed to create a table
 SELECT create_distributed_table('full_access_user_schema.t1', 'id');
-ERROR:  permission denied for database regression
+ERROR:  permission denied for schema full_access_user_schema
 CONTEXT:  while executing command on localhost:57638
 RESET ROLE;
 -- now we distribute the table as super user

--- a/src/test/regress/expected/multi_partitioning_utils.out
+++ b/src/test/regress/expected/multi_partitioning_utils.out
@@ -220,9 +220,6 @@ SELECT generate_partition_information('partition_parent_schema.parent_table');
 
 -- we should be able to drop and re-create the partitioned table using the command that Citus generate
 SELECT drop_and_recreate_partitioned_table('partition_parent_schema.parent_table');
-NOTICE:  schema "partition_parent_schema" already exists, skipping
-CONTEXT:  SQL statement "CREATE SCHEMA IF NOT EXISTS partition_parent_schema AUTHORIZATION postgres"
-PL/pgSQL function drop_and_recreate_partitioned_table(regclass) line 15 at EXECUTE
  drop_and_recreate_partitioned_table 
 -------------------------------------
  

--- a/src/test/regress/expected/multi_partitioning_utils_0.out
+++ b/src/test/regress/expected/multi_partitioning_utils_0.out
@@ -219,9 +219,6 @@ SELECT generate_partition_information('partition_parent_schema.parent_table');
 
 -- we should be able to drop and re-create the partitioned table using the command that Citus generate
 SELECT drop_and_recreate_partitioned_table('partition_parent_schema.parent_table');
-NOTICE:  schema "partition_parent_schema" already exists, skipping
-CONTEXT:  SQL statement "CREATE SCHEMA IF NOT EXISTS partition_parent_schema AUTHORIZATION postgres"
-PL/pgSQL function drop_and_recreate_partitioned_table(regclass) line 15 at EXECUTE
  drop_and_recreate_partitioned_table 
 -------------------------------------
  

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1421,10 +1421,9 @@ DETAIL:  We currently don't support appending to shards in hash-partitioned or r
 SELECT master_get_table_ddl_events('reference_schema.reference_table_ddl');
                                                                            master_get_table_ddl_events                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- CREATE SCHEMA IF NOT EXISTS reference_schema AUTHORIZATION postgres
  CREATE TABLE reference_schema.reference_table_ddl (value_2 double precision DEFAULT 25.0, value_3 text NOT NULL, value_4 timestamp without time zone, value_5 double precision)
  ALTER TABLE reference_schema.reference_table_ddl OWNER TO postgres
-(3 rows)
+(2 rows)
 
 -- in reality, we wouldn't need to repair any reference table shard placements
 -- however, the test could be relevant for other purposes

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -245,6 +245,10 @@ DEBUG:  Plan is router executable
 
 CREATE TABLE company_employees (company_id int, employee_id int, manager_id int); 
 SELECT master_create_distributed_table('company_employees', 'company_id', 'hash');
+DEBUG:  schema "fast_path_router_select" already exists, skipping
+DETAIL:  NOTICE from localhost:57638
+DEBUG:  schema "fast_path_router_select" already exists, skipping
+DETAIL:  NOTICE from localhost:57637
  master_create_distributed_table 
 ---------------------------------
  
@@ -252,13 +256,9 @@ SELECT master_create_distributed_table('company_employees', 'company_id', 'hash'
 
 SELECT master_create_worker_shards('company_employees', 4, 1);
 DEBUG:  schema "fast_path_router_select" already exists, skipping
-DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "fast_path_router_select" already exists, skipping
 DETAIL:  NOTICE from localhost:57638
 DEBUG:  schema "fast_path_router_select" already exists, skipping
 DETAIL:  NOTICE from localhost:57637
-DEBUG:  schema "fast_path_router_select" already exists, skipping
-DETAIL:  NOTICE from localhost:57638
  master_create_worker_shards 
 -----------------------------
  

--- a/src/test/regress/sql/multi_generate_ddl_commands.sql
+++ b/src/test/regress/sql/multi_generate_ddl_commands.sql
@@ -22,11 +22,6 @@ CREATE TABLE not_null_table (
 
 SELECT master_get_table_ddl_events('not_null_table');
 
--- ensure tables not in search path are schema-prefixed
-CREATE SCHEMA not_in_path CREATE TABLE simple_table (id bigint);
-
-SELECT master_get_table_ddl_events('not_in_path.simple_table');
-
 -- even more complex constraints should be preserved...
 CREATE TABLE column_constraint_table (
 	first_name text,


### PR DESCRIPTION
DESCRIPTION: Create all distributed schemas as superuser on a separate connection

Citus can try to create schemas on workers in 5 different scenarios (see #1097 ). There are some cases where schema creation commands are executed multiple times (see #2283)

Before tackling the problems we have around distributing schemas, @marcocitus suggested that I simplify schema creation logic so that it will be easier understand how to move forward.

# My proposed solution:
- ~`start_metadata_sync_to_node` and streaming replication with metadata uses a single superuser connection that perform all the operations. I left them as it is~
- All ~other~ places of code that can create schemas are now removed and replaced with `EnsureSchemaExistsOnAllNodes()` calls that opens a superuser connection to the workers with a single `CREATE SCHEMA ..` query. Only after schema creation is successful, the operations move on.

# Notes:
- I studied all the UDF's and other queries that can potentially trigger schema creation in workers. Only if all the callers of a function needed schema creation, I moved the schema creation logic up to this function.

## Notes for reviewers
My work here is not yet complete. I will 
  - update my comments
  - check for stale comments
  - update PG10 test outputs
  - work on failure tests that are no longer valid as I changed the number of connections to workers, and this can potentially break our filters.

## Note to self
See if #2575 is still valid in this branch

# Current and old codepaths

`CreateSchemaDDLCommand(relationId)` is the function that creates `CREATE SCHEMA <schema> IF NOT EXISTS AUTHORIZATION <user>` queries. You can see all the codepaths that can send schema creation queries to the workers below.

## The current codepaths:
```
CreateSchemaDDLCommand(Oid) : char *
  EnsureSchemaExistsOnNode(?, char *, ?) : void
    EnsureSchemaExistsOnAllNodes(?) : void
      create_distributed_table(int) : ?
      create_reference_table(int) : ?
      master_create_distributed_table(int) : ?
      master_create_empty_shard(int) : ?
        CreateEmptyShard(char *) : ?
          MasterCreateEmptyShard(char *) : ?
            StartCopyToNewShard(ShardConnections *, ? *, ?) : ?
              CopyToNewShards(? *, char *, ?) : void
                CitusCopyFrom(? *, char *) : void
                  ProcessCopyStmt(? *, char *, const char *) : ? *
                    multi_ProcessUtility(? *, const char *, ?, ?, ? *, ? *, char *) : void
                      _PG_init() : void
                CopyFromWorkerNode(? *, char *) : void
                  CitusCopyFrom(? *, char *) : void
                    ProcessCopyStmt(? *, char *, const char *) : ? *
                      multi_ProcessUtility(? *, const char *, ?, ?, ? *, ? *, char *) : void
                        _PG_init() : void
      master_create_worker_shards(int) : ?
      MetadataCreateCommands() : List *
        master_metadata_snapshot(int) : ?
        start_metadata_sync_to_node(FunctionCallInfo) : Datum
    RepairShardPlacement(?, char *, ?, char *, ?) : void
      master_copy_shard_placement(int) : ?
    ReplicateShardToNode(ShardInterval *, char *, int) : void
      ReplicateAllReferenceTablesToNode(char *, int) : void
        ActivateNode(char *, int) : ?
          master_activate_node(int) : ?
          master_add_node(int) : ?
      ReplicateShardToAllWorkers(ShardInterval *) : void
        ReplicateSingleShardTableToAllWorkers(?) : void
          upgrade_to_reference_table(int) : ?
```

## The old codepaths
```
CreateSchemaDDLCommand(Oid) : char *
  EnsureSchemaExistsOnAllNodes(Oid) : void
    create_reference_table(FunctionCallInfo) : Datum
    CreateHashDistributedTableShards(Oid, Oid, _Bool) : void
      CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
        create_distributed_table(FunctionCallInfo) : Datum
        create_reference_table(FunctionCallInfo) : Datum
        CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
        master_create_distributed_table(FunctionCallInfo) : Datum
        ProcessAlterTableStmtAttachPartition(AlterTableStmt *) : void
          multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
            _PG_init() : void
        ProcessCreateTableStmtPartitionOf(CreateStmt *) : void
          multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
            _PG_init() : void
  GetTableCreationCommands(Oid, _Bool) : List *
    GetTableDDLEvents(Oid, _Bool) : List *
      CreateAppendDistributedShardPlacements(Oid, int64, List *, int) : void
        master_create_empty_shard(FunctionCallInfo) : Datum
          CreateEmptyShard(char *) : int64
            MasterCreateEmptyShard(char *) : int64
              StartCopyToNewShard(ShardConnections *, CopyStmt *, _Bool) : int64
                CopyToNewShards(CopyStmt *, char *, Oid) : void
                  CitusCopyFrom(CopyStmt *, char *) : void
                    ProcessCopyStmt(CopyStmt *, char *, const char *) : Node *
                      multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                        _PG_init() : void
                  CopyFromWorkerNode(CopyStmt *, char *) : void
                    CitusCopyFrom(CopyStmt *, char *) : void
                      ProcessCopyStmt(CopyStmt *, char *, const char *) : Node *
                        multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                          _PG_init() : void
      CreateShardsOnWorkers(Oid, List *, _Bool, _Bool) : void
        CreateColocatedShards(Oid, Oid, _Bool) : void
          CreateHashDistributedTableShards(Oid, Oid, _Bool) : void
            CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
              create_distributed_table(FunctionCallInfo) : Datum
              create_reference_table(FunctionCallInfo) : Datum
              CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
              master_create_distributed_table(FunctionCallInfo) : Datum
              ProcessAlterTableStmtAttachPartition(AlterTableStmt *) : void
                multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                  _PG_init() : void
              ProcessCreateTableStmtPartitionOf(CreateStmt *) : void
                multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                  _PG_init() : void
        CreateReferenceTableShard(Oid) : void
          CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
            create_distributed_table(FunctionCallInfo) : Datum
            create_reference_table(FunctionCallInfo) : Datum
            CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
            master_create_distributed_table(FunctionCallInfo) : Datum
            ProcessAlterTableStmtAttachPartition(AlterTableStmt *) : void
              multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                _PG_init() : void
            ProcessCreateTableStmtPartitionOf(CreateStmt *) : void
              multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                _PG_init() : void
        CreateShardsWithRoundRobinPolicy(Oid, int32, int32, _Bool) : void
          CreateHashDistributedTableShards(Oid, Oid, _Bool) : void
            CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
              create_distributed_table(FunctionCallInfo) : Datum
              create_reference_table(FunctionCallInfo) : Datum
              CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
              master_create_distributed_table(FunctionCallInfo) : Datum
              ProcessAlterTableStmtAttachPartition(AlterTableStmt *) : void
                multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                  _PG_init() : void
              ProcessCreateTableStmtPartitionOf(CreateStmt *) : void
                multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                  _PG_init() : void
          master_create_worker_shards(FunctionCallInfo) : Datum
      GetDistributedTableDDLEvents(Oid) : List *
        CreateTableMetadataOnWorkers(Oid) : void
          CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
            create_distributed_table(FunctionCallInfo) : Datum
            create_reference_table(FunctionCallInfo) : Datum
            CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
            master_create_distributed_table(FunctionCallInfo) : Datum
            ProcessAlterTableStmtAttachPartition(AlterTableStmt *) : void
              multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                _PG_init() : void
            ProcessCreateTableStmtPartitionOf(CreateStmt *) : void
              multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
                _PG_init() : void
          ReplicateSingleShardTableToAllWorkers(Oid) : void
            upgrade_to_reference_table(FunctionCallInfo) : Datum
      master_get_table_ddl_events(FunctionCallInfo) : Datum
      MetadataCreateCommands() : List *
        master_metadata_snapshot(FunctionCallInfo) : Datum
        start_metadata_sync_to_node(FunctionCallInfo) : Datum
    RecreateTableDDLCommandList(Oid) : List *
      CopyShardCommandList(ShardInterval *, char *, int32, _Bool) : List *
        CopyPartitionShardsCommandList(ShardInterval *, char *, int32) : List *
          RepairShardPlacement(int64, char *, int32, char *, int32) : void
            master_copy_shard_placement(FunctionCallInfo) : Datum
        RepairShardPlacement(int64, char *, int32, char *, int32) : void
          master_copy_shard_placement(FunctionCallInfo) : Datum
        ReplicateShardToNode(ShardInterval *, char *, int) : void
          ReplicateAllReferenceTablesToNode(char *, int) : void
            ActivateNode(char *, int) : Datum
              master_activate_node(FunctionCallInfo) : Datum
              master_add_node(FunctionCallInfo) : Datum
          ReplicateShardToAllWorkers(ShardInterval *) : void
            ReplicateSingleShardTableToAllWorkers(Oid) : void
              upgrade_to_reference_table(FunctionCallInfo) : Datum
  SequenceDDLCommandsForTable(Oid) : List *
    GetDistributedTableDDLEvents(Oid) : List *
      CreateTableMetadataOnWorkers(Oid) : void
        CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
          create_distributed_table(FunctionCallInfo) : Datum
          create_reference_table(FunctionCallInfo) : Datum
          CreateDistributedTable(Oid, Var *, char, char *, _Bool) : void
          master_create_distributed_table(FunctionCallInfo) : Datum
          ProcessAlterTableStmtAttachPartition(AlterTableStmt *) : void
            multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
              _PG_init() : void
          ProcessCreateTableStmtPartitionOf(CreateStmt *) : void
            multi_ProcessUtility(PlannedStmt *, const char *, ProcessUtilityContext, ParamListInfo, QueryEnvironment *, DestReceiver *, char *) : void
              _PG_init() : void
        ReplicateSingleShardTableToAllWorkers(Oid) : void
          upgrade_to_reference_table(FunctionCallInfo) : Datum
    MetadataCreateCommands() : List *
      master_metadata_snapshot(FunctionCallInfo) : Datum
      start_metadata_sync_to_node(FunctionCallInfo) : Datum
```