### PR TITLE
Refactor ExecuteModifyTasksSequentially.

### DIFF
--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -45,9 +45,13 @@ extern TupleTableSlot * RouterModifyExecScan(CustomScanState *node);
 extern void ExecuteMultipleTasks(CitusScanState *scanState, List *taskList,
 								 bool isModificationQuery, bool expectResults);
 
+int64 ExecuteModifyTasksSequentially(CitusScanState *scanState, List *taskList,
+									 CmdType operation, bool hasReturning);
 extern int64 ExecuteModifyTasksWithoutResults(List *taskList);
 extern int64 ExecuteModifyTasksSequentiallyWithoutResults(List *taskList,
 														  CmdType operation);
+extern ShardPlacementAccess * CreatePlacementAccess(ShardPlacement *placement,
+													ShardPlacementAccessType accessType);
 
 /* helper functions */
 extern bool TaskListRequires2PC(List *taskList);


### PR DESCRIPTION
1. Introduce `ExecuteModifyTasksSequentially`, for benefit of https://github.com/citusdata/citus/pull/2780
2. Make `RouterSequentialModifyExecScan` use `ExecuteModifyTasksSequentially`.
3. Make `CreatePlacementAccess` public, for benefit of #2780.