### PR TITLE
Stabilize failure_truncate test output

### DIFF
--- a/src/test/regress/expected/failure_truncate.out
+++ b/src/test/regress/expected/failure_truncate.out
@@ -8,6 +8,8 @@ SET citus.next_shard_id TO 120000;
 SET client_min_messages TO ERROR;
 -- do not cache any connections
 SET citus.max_cached_conns_per_worker TO 0;
+-- use a predictable number of connections per task
+SET citus.force_max_query_parallelization TO on;
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy 
 -----------

--- a/src/test/regress/sql/failure_truncate.sql
+++ b/src/test/regress/sql/failure_truncate.sql
@@ -10,6 +10,9 @@ SET client_min_messages TO ERROR;
 -- do not cache any connections
 SET citus.max_cached_conns_per_worker TO 0;
 
+-- use a predictable number of connections per task
+SET citus.force_max_query_parallelization TO on;
+
 SELECT citus.mitmproxy('conn.allow()');
 
 -- we'll start with replication factor 1, 1PC and parallel mode


### PR DESCRIPTION
There is a `recover_prepared_transactions` in `failure_truncate` that is expected to return 4 because 4 connections were used, but sometimes it returns 3 because of the unified executor. Enable `citus.force_max_query_parallelization` to stabilize it.