### PR TITLE
Change the order of placement access added to the placement access list

### DIFF
--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1250,7 +1250,7 @@ GetModifyConnections(Task *task, bool markCritical)
 
 		/* create placement access for the placement that we're modifying */
 		placementModification = CreatePlacementAccess(taskPlacement, accessType);
-		placementAccessList = lappend(placementAccessList, placementModification);
+		placementAccessList = lcons(placementModification, placementAccessList);
 
 		/* get an appropriate connection for the DML statement */
 		multiConnection = GetPlacementListConnection(connectionFlags, placementAccessList,

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -538,7 +538,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	UPDATE referece_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute SELECT on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:5: Unrelated parallel DDL on distributed table followed by unrelated DDL on ref. table

--- a/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement_0.out
@@ -538,7 +538,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	UPDATE referece_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute SELECT on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference relation "referece_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:5: Unrelated parallel DDL on distributed table followed by unrelated DDL on ref. table


### PR DESCRIPTION
This is to make sure that the error messages related to foreign keys
to reference tables shows the exact placement access name instead of
SELECT.

This only changes the error message, doesn't have any other side effects.
The reason for the PR is to make sure that we give the same error messages
between the adaptive executor and the router executor.