### PR TITLE
Force max parallelization to create shards if asked to use exclusive connections

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -3394,3 +3394,17 @@ BuildWaitEventSet(List *sessionList)
 
 	return waitEventSet;
 }
+
+
+/*
+ * SetLocalForceMaxQueryParallelization simply a C interface for
+ * setting the following:
+ *      SET LOCAL citus.multi_shard_modify_mode TO on;
+ */
+void
+SetLocalForceMaxQueryParallelization(void)
+{
+	set_config_option("citus.force_max_query_parallelization", "on",
+					  (superuser() ? PGC_SUSET : PGC_USERSET), PGC_S_SESSION,
+					  GUC_ACTION_LOCAL, true, 0, false);
+}

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -59,6 +59,7 @@ extern void ExecuteQueryIntoDestReceiver(Query *query, ParamListInfo params,
 extern void ExecutePlanIntoDestReceiver(PlannedStmt *queryPlan, ParamListInfo params,
 										DestReceiver *dest);
 extern void SetLocalMultiShardModifyModeToSequential(void);
+extern void SetLocalForceMaxQueryParallelization(void);
 extern void SortTupleStore(CitusScanState *scanState);
 
 


### PR DESCRIPTION
We are doing so to make creating distributed tables fast when they contain local data or inside a transaction block.