### PR TITLE
Adjust the default max pool size

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -497,7 +497,7 @@ typedef struct TaskPlacementExecution
 
 /* GUC, determining whether Citus opens 1 connection per task */
 bool ForceMaxQueryParallelization = false;
-int MaxAdaptiveExecutorPoolSize = 4;
+int MaxAdaptiveExecutorPoolSize = 16;
 
 /* GUC, number of ms to wait between opening connections to the same worker */
 int ExecutorSlowStartInterval = 10;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -758,10 +758,16 @@ RegisterCitusConfigVariables(void)
 
 	DefineCustomIntVariable(
 		"citus.max_adaptive_executor_pool_size",
-		gettext_noop("Sets the maximum number of connections used per distributed query "
-					 "for each worker node. This is only effective when "
-					 "citus.task_executor_type is set to adaptive."),
-		gettext_noop("See src/backend/executor/adaptive_executor.c for the details"),
+		gettext_noop("Sets the maximum number of connections per worker node used by "
+					 "the adaptive executor to execute a multi-shard command"),
+		gettext_noop("The adaptive executor may open multiple connections per worker "
+					 "node when running multi-shard commands to parallelize the command "
+					 "across multiple cores on the worker. This setting specifies the "
+					 "maximum number of connections it will open. The number of "
+					 "connections is also bounded by the number of shards on the node. "
+					 "This setting can be used to reduce the memory usage of a query "
+					 "and allow a higher degree of concurrency when concurrent "
+					 "multi-shard queries open too many connections to a worker."),
 		&MaxAdaptiveExecutorPoolSize,
 		16, 1, INT_MAX,
 		PGC_USERSET,

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -759,11 +759,11 @@ RegisterCitusConfigVariables(void)
 	DefineCustomIntVariable(
 		"citus.max_adaptive_executor_pool_size",
 		gettext_noop("Sets the maximum number of connections used per distributed query "
-					 "for each worker node. If set to zero, adaptive executor is "
-					 "disabled"),
-		gettext_noop("See src/backend/executor/README for the details"),
+					 "for each worker node. This is only effective when "
+					 "citus.task_executor_type is set to adaptive."),
+		gettext_noop("See src/backend/executor/adaptive_executor.c for the details"),
 		&MaxAdaptiveExecutorPoolSize,
-		4, 1, INT_MAX,
+		16, 1, INT_MAX,
 		PGC_USERSET,
 		0,
 		NULL, NULL, NULL);


### PR DESCRIPTION
With default shard count = 32, this makes sense. And, we implicitly considered this as the default while discussing internally.

On the other hand, we could even set to a higher value. Anyway, I think it is a decent value to set for now.