### PR TITLE
Update warnings in FinishRemoteTransactionCommit()

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -303,17 +303,8 @@ FinishRemoteTransactionCommit(MultiConnection *connection)
 
 		if (transaction->transactionState == REMOTE_TRANS_1PC_COMMITTING)
 		{
-			if (transaction->transactionCritical)
-			{
-				ereport(WARNING, (errmsg("failed to commit critical transaction "
-										 "on %s:%d, metadata is likely out of sync",
-										 connection->hostname, connection->port)));
-			}
-			else
-			{
-				ereport(WARNING, (errmsg("failed to commit transaction on %s:%d",
-										 connection->hostname, connection->port)));
-			}
+			ereport(WARNING, (errmsg("failed to commit transaction on %s:%d",
+									 connection->hostname, connection->port)));
 		}
 		else if (transaction->transactionState == REMOTE_TRANS_2PC_COMMITTING)
 		{

--- a/src/test/regress/expected/failure_1pc_copy_append.out
+++ b/src/test/regress/expected/failure_1pc_copy_append.out
@@ -286,7 +286,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
 COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' WITH CSV;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p

--- a/src/test/regress/expected/failure_1pc_copy_append_9.out
+++ b/src/test/regress/expected/failure_1pc_copy_append_9.out
@@ -289,7 +289,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
 COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' WITH CSV;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 SELECT * FROM pg_dist_shard s, pg_dist_shard_placement p

--- a/src/test/regress/expected/failure_1pc_copy_hash.out
+++ b/src/test/regress/expected/failure_1pc_copy_hash.out
@@ -126,7 +126,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT$").killall()');
 COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' WITH CSV;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 -- the shard is marked invalid
@@ -327,7 +327,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT$").killall()');
 COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' WITH CSV;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  could not commit transaction for shard 100400 on any active node
@@ -367,7 +367,7 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="COMMIT").killall()');
 COPY copy_test FROM PROGRAM 'echo 0, 0 && echo 1, 1 && echo 2, 4 && echo 3, 9' WITH CSV;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  could not commit transaction for shard 100400 on any active node

--- a/src/test/regress/expected/failure_ddl.out
+++ b/src/test/regress/expected/failure_ddl.out
@@ -220,12 +220,12 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="^COMMIT").kill()');
 ALTER TABLE test_table ADD COLUMN new_column INT;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  could not commit transaction for shard 100802 on any active node

--- a/src/test/regress/expected/failure_ddl_9.out
+++ b/src/test/regress/expected/failure_ddl_9.out
@@ -223,12 +223,12 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="^COMMIT").kill()');
 ALTER TABLE test_table ADD COLUMN new_column INT;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  could not commit transaction for shard 100802 on any active node

--- a/src/test/regress/expected/failure_multi_dml_9.out
+++ b/src/test/regress/expected/failure_multi_dml_9.out
@@ -393,7 +393,7 @@ UPDATE dml_test SET name = 'gamma' WHERE id = 3;
 COMMIT;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 --- should see all changes, but they only went to one placement (other is unhealthy)

--- a/src/test/regress/expected/failure_truncate.out
+++ b/src/test/regress/expected/failure_truncate.out
@@ -282,12 +282,12 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="^COMMIT").kill()');
 TRUNCATE test_table;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  could not commit transaction for shard 120002 on any active node

--- a/src/test/regress/expected/failure_truncate_9.out
+++ b/src/test/regress/expected/failure_truncate_9.out
@@ -285,12 +285,12 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="^COMMIT").kill()');
 TRUNCATE test_table;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 WARNING:  could not commit transaction for shard 120002 on any active node

--- a/src/test/regress/expected/failure_vacuum.out
+++ b/src/test/regress/expected/failure_vacuum.out
@@ -62,7 +62,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
 ANALYZE vacuum_test;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 -- ANALYZE transactions being critical is an open question, see #2430

--- a/src/test/regress/expected/failure_vacuum_0.out
+++ b/src/test/regress/expected/failure_vacuum_0.out
@@ -62,7 +62,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="^COMMIT").kill()');
 ANALYZE vacuum_test;
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
-WARNING:  failed to commit critical transaction on localhost:9060, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:9060
 WARNING:  connection not open
 CONTEXT:  while executing command on localhost:9060
 -- ANALYZE transactions being critical is an open question, see #2430

--- a/src/test/regress/expected/multi_modifying_xacts_9.out
+++ b/src/test/regress/expected/multi_modifying_xacts_9.out
@@ -377,9 +377,9 @@ DELETE FROM researchers WHERE lab_id = 6;
 \copy researchers FROM STDIN delimiter ','
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57638
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57637
 WARNING:  could not commit transaction for shard 1200001 on any active node
 ERROR:  could not commit transaction on any active node
 \unset VERBOSITY
@@ -620,7 +620,7 @@ INSERT INTO objects VALUES (2, 'BAD');
 INSERT INTO labs VALUES (9, 'Umbrella Corporation');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57638
 -- data should be persisted
 SELECT * FROM objects WHERE id = 2;
  id | name 
@@ -663,9 +663,9 @@ INSERT INTO labs VALUES (8, 'Aperture Science');
 INSERT INTO labs VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57637
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57638
 WARNING:  could not commit transaction for shard 1200002 on any active node
 WARNING:  could not commit transaction for shard 1200003 on any active node
 ERROR:  could not commit transaction on any active node
@@ -704,7 +704,7 @@ INSERT INTO labs VALUES (8, 'Aperture Science');
 INSERT INTO labs VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57637
 WARNING:  could not commit transaction for shard 1200002 on any active node
 \set VERBOSITY default
 -- data to objects should be persisted, but labs should not...

--- a/src/test/regress/expected/multi_mx_modifying_xacts.out
+++ b/src/test/regress/expected/multi_mx_modifying_xacts.out
@@ -337,7 +337,7 @@ INSERT INTO objects_mx VALUES (2, 'BAD');
 INSERT INTO labs_mx VALUES (9, 'Umbrella Corporation');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57637
 WARNING:  could not commit transaction for shard 1220103 on any active node
 WARNING:  could not commit transaction for shard 1220102 on any active node
 ERROR:  could not commit transaction on any active node
@@ -364,7 +364,7 @@ INSERT INTO labs_mx VALUES (8, 'Aperture Science');
 INSERT INTO labs_mx VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57637
 WARNING:  could not commit transaction for shard 1220103 on any active node
 WARNING:  could not commit transaction for shard 1220102 on any active node
 ERROR:  could not commit transaction on any active node
@@ -388,7 +388,7 @@ INSERT INTO labs_mx VALUES (8, 'Aperture Science');
 INSERT INTO labs_mx VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
-WARNING:  failed to commit critical transaction on localhost:57637, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57637
 WARNING:  could not commit transaction for shard 1220103 on any active node
 WARNING:  could not commit transaction for shard 1220102 on any active node
 ERROR:  could not commit transaction on any active node

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -668,7 +668,7 @@ COMMIT;
 WARNING:  duplicate key value violates unique constraint "ddl_commands_command_key"
 DETAIL:  Key (command)=(CREATE INDEX) already exists.
 CONTEXT:  while executing command on localhost:57638
-WARNING:  failed to commit critical transaction on localhost:57638, metadata is likely out of sync
+WARNING:  failed to commit transaction on localhost:57638
 -- The block should have committed with a warning
 SELECT indexname, tablename FROM pg_indexes WHERE tablename = 'single_shard_items' ORDER BY 1;
    indexname    |     tablename      


### PR DESCRIPTION
To fix inconsistent failure_ddl outputs