### PR TITLE
Fix a use after free in adaptive executor

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1171,16 +1171,15 @@ CleanUpSessions(DistributedExecution *execution)
 				elog(WARNING, "unexpected transaction state at the end of execution: %d",
 					 transactionState);
 			}
+
+			/* get ready for the next executions if we need use the same connection */
+			connection->waitFlags = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
 		}
 		else
 		{
 			elog(WARNING, "unexpected connection state at the end of execution: %d",
 				 connection->connectionState);
 		}
-
-		/* get ready for the next executions if we need use the same connection */
-		connection->waitFlags = WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
-		execution->waitFlagsChanged = true;
 	}
 }
 


### PR DESCRIPTION
`connection` is freed when it is failed in which case we shouldn't access it anymore. Also, we are done with the execution, so no need to set `waitFlagsChanged`.