### PR TITLE
Increase valgrind's max-stackframe

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -232,6 +232,7 @@ exec $valgrindPath \\
     --trace-children=yes --track-origins=yes --read-var-info=no \\
     --leak-check=no \\
     --error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END \\
+    --max-stackframe=16000000 \\
     --log-file=$valgrindLogFile \\
     $bindir/postgres.orig \\
     "\$@"


### PR DESCRIPTION
Valgrind uses `--max-stackframe` to check if an address is in current stack frame's bounds or not. The default is 2000000. We are doing a stack allocation of 2 * 1024 * 1024 at `ResizeStackToMaximumDepth()`, so writing and reading from it look like memory errors to valgrind. As suggested in `man valgrind`, we should increase `--max-stackframe` if our program has large stack-allocated arrays.

Fixes https://github.com/citusdata/citus/issues/2814
