### PR TITLE
Fix multi_extension in check-multi-vg

### DIFF
--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -406,7 +406,7 @@ $$;
 ERROR:  create distributed table failed
 CONTEXT:  PL/pgSQL function inline_code_block line 6 at RAISE
 \c regression
-\c - - - :worker_1_port
-DROP DATABASE another;
 \c - - - :master_port
+DROP DATABASE another;
+\c - - - :worker_1_port
 DROP DATABASE another;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -380,9 +380,9 @@ END;
 $$;
 
 \c regression
-\c - - - :worker_1_port
+\c - - - :master_port
 DROP DATABASE another;
 
-\c - - - :master_port
+\c - - - :worker_1_port
 DROP DATABASE another;
 


### PR DESCRIPTION
multi_extension was failing with:

```
 \c - - - :worker_1_port
 DROP DATABASE another;
+ERROR:  database "another" is being accessed by other users
+DETAIL:  There is 1 other session using the database.
 \c - - - :master_port
 DROP DATABASE another;
```

When I dumped `SELECT pg_dist_activity()` in the previous version of the test, it seems that there is an ongoing `SELECT * FROM dump_local_wait_edges()` sent by the coordinator to the worker which causes the error above.

Reversing the order to drop the database first from the coordinator then from the worker fixes the issue.
