### PR TITLE
Showcase worker node cache related memory issues (not intended to be merged)

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1444,6 +1444,9 @@ FindOrCreateWorkerPool(DistributedExecution *execution, WorkerNode *workerNode)
 	{
 		workerPool = lfirst(workerCell);
 
+		elog(WARNING, "name: %s, port: %u",
+			 workerPool->node->workerName, workerPool->node->workerPort);
+
 		if (WorkerNodeCompare(workerPool->node, workerNode, 0) == 0)
 		{
 			return workerPool;
@@ -1543,6 +1546,8 @@ static bool
 ShouldRunTasksSequentially(List *taskList)
 {
 	Task *initialTask = NULL;
+
+	return true;
 
 	if (list_length(taskList) < 2)
 	{

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -2768,6 +2768,8 @@ InitializeWorkerNodeCache(void)
 	int newWorkerNodeCount = 0;
 	WorkerNode **newWorkerNodeArray = NULL;
 	int workerNodeIndex = 0;
+	HASH_SEQ_STATUS status;
+	WorkerNode *node = NULL;
 
 	InitializeCaches();
 
@@ -2828,6 +2830,20 @@ InitializeWorkerNodeCache(void)
 
 		/* we do not need the currentNode anymore */
 		pfree(currentNode);
+	}
+
+	if (WorkerNodeHash != NULL)
+	{
+		hash_seq_init(&status, WorkerNodeHash);
+
+		node = (WorkerNode *) hash_seq_search(&status);
+		while (node != NULL)
+		{
+			node->workerPort = 0;
+			strcpy(node->workerName, "Invalidated");
+
+			node = (WorkerNode *) hash_seq_search(&status);
+		}
 	}
 
 	/* now, safe to destroy the old hash */


### PR DESCRIPTION
Setup:

```
create table t(a int, b int);
select create_distributed_table('t', 'a');
insert into t select i, i+1 from generate_series(1, 10000000) i;
```

Then, in window 1:

```
update t set b = 1;
```

In parallel, in window 2 run a command to modify set of worker nodes:

```
SELECT master_add_node('localhost', 5435);
```

In window 1, log will be something like:

```
2019-07-04 12:08:18.309 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:18.882 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:19.547 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:19.547 PDT [15340] WARNING:  name: localhost, port: 5434
2019-07-04 12:08:20.188 PDT [15340] WARNING:  name: Invalidated, port: 0
2019-07-04 12:08:20.188 PDT [15340] WARNING:  name: Invalidated, port: 0
2019-07-04 12:08:20.968 PDT [15340] WARNING:  name: Invalidated, port: 0
2019-07-04 12:08:20.968 PDT [15340] WARNING:  name: Invalidated, port: 0
2019-07-04 12:08:20.968 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:21.709 PDT [15340] WARNING:  name: , port: 0
2019-07-04 12:08:21.709 PDT [15340] WARNING:  name: �N(�%�2&�؞�, port: 0
2019-07-04 12:08:21.709 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:22.366 PDT [15340] WARNING:  name: , port: 0
2019-07-04 12:08:22.366 PDT [15340] WARNING:  name: �N(�%�2&�؞�, port: 0
2019-07-04 12:08:22.366 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:22.366 PDT [15340] WARNING:  name: localhost, port: 5434
2019-07-04 12:08:23.016 PDT [15340] WARNING:  name: , port: 0
2019-07-04 12:08:23.016 PDT [15340] WARNING:  name: �N(�%�2&�؞�, port: 0
2019-07-04 12:08:23.016 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:23.622 PDT [15340] WARNING:  name: , port: 0
2019-07-04 12:08:23.622 PDT [15340] WARNING:  name: �N(�%�2&�؞�, port: 0
2019-07-04 12:08:23.622 PDT [15340] WARNING:  name: localhost, port: 5433
2019-07-04 12:08:23.622 PDT [15340] WARNING:  name: localhost, port: 5434
2019-07-04 12:08:24.272 PDT [15340] WARNING:  name: , port: 0
2019-07-04 12:08:24.272 PDT [15340] WARNING:  name: �N(�%�2&�؞�, port: 0
2019-07-04 12:08:24.272 PDT [15340] WARNING:  name: localhost, port: 5433
```

Because cache was invalidated and the previous WorkerHash was freed and we are keeping items from that hash in worker pool of adaptive executor.

