### PR TITLE
Prototype: Delegate procedure calls to worker nodes

### DIFF
--- a/src/backend/distributed/citus--8.3-1--8.3-2.sql
+++ b/src/backend/distributed/citus--8.3-1--8.3-2.sql
@@ -1,0 +1,52 @@
+/* citus--8.3-1--8.3-2 */
+
+CREATE SCHEMA citus_internal;
+
+/*
+ * We redundantly keep track of both OID and names in order to survive
+ * pg_upgrade, since function OIDs might change.
+ *
+ * TODO: handle function renames
+ */
+CREATE TABLE citus_internal.procedures (
+    procedure_id oid not null,
+    schema_name regnamespace not null,
+    procedure_name name not null,
+    distribution_arg_index int not null,
+    colocation_id int not null
+);
+
+-- create a primary key index with a known name
+CREATE UNIQUE INDEX procedures_procedure_id_idx ON citus_internal.procedures (procedure_id);
+ALTER TABLE citus_internal.procedures
+ADD CONSTRAINT procedures_pkey PRIMARY KEY USING INDEX procedures_procedure_id_idx;
+
+SELECT pg_catalog.pg_extension_config_dump('citus_internal.procedures', '');
+
+-- update OIDs after pg_upgrade (TODO: test)
+CREATE OR REPLACE FUNCTION citus_internal.procedure_insert_oid()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+BEGIN
+    SELECT oid INTO NEW.procedure_id
+    FROM pg_proc
+    WHERE proname = NEW.procedure_name
+    AND pronamespace = NEW.schema_name;
+    RETURN NEW;
+END;
+$function$;
+
+CREATE TRIGGER procedure_insert_oid
+BEFORE INSERT ON citus_internal.procedures
+FOR EACH ROW EXECUTE PROCEDURE citus_internal.procedure_insert_oid();
+
+CREATE FUNCTION pg_catalog.distribute_procedure(procedure_name regprocedure,
+                                                distribution_arg text DEFAULT NULL,
+                                                colocate_with text DEFAULT 'default')
+RETURNS bool
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$distribute_procedure$$;
+COMMENT ON FUNCTION pg_catalog.distribute_procedure(regprocedure, text, colocate_with text)
+IS 'replicate a procedure on all nodes';

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -1,0 +1,126 @@
+/*-------------------------------------------------------------------------
+ *
+ * call.c
+ *    Commands for call remote stored procedures.
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include "postgres.h"
+
+#include "distributed/colocation_utils.h"
+#include "distributed/commands.h"
+#include "distributed/connection_management.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/procedure_metadata.h"
+#include "distributed/remote_commands.h"
+#include "distributed/shard_pruning.h"
+#include "distributed/worker_manager.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "tcop/dest.h"
+
+
+static bool CallFuncExprRemotely(DistributedProcedureRecord *procedure,
+								 FuncExpr *funcExpr, const char *queryString,
+								 DestReceiver *dest);
+
+
+/*
+ * CallDistributedProcedure calls a stored procedure on the worker if possible.
+ */
+bool
+CallDistributedProcedureRemotely(CallStmt *callStmt, const char *queryString,
+								 DestReceiver *dest)
+{
+	DistributedProcedureRecord *procedure = NULL;
+	FuncExpr *funcExpr = callStmt->funcexpr;
+	Oid functionId = funcExpr->funcid;
+
+	procedure = LoadDistributedProcedureRecord(functionId);
+	if (procedure == NULL)
+	{
+		return false;
+	}
+
+	return CallFuncExprRemotely(procedure, funcExpr, queryString, dest);
+}
+
+
+/*
+ * CallFuncExprRemotely calls a procedure of function on the worker if possible.
+ */
+static bool
+CallFuncExprRemotely(DistributedProcedureRecord *procedure, FuncExpr *funcExpr,
+					 const char *queryString, DestReceiver *dest)
+{
+	Oid colocatedRelationId = InvalidOid;
+	Node *partitionValue = NULL;
+	List *shardList = NIL;
+	ShardInterval *shard = NULL;
+	List *placementList = NIL;
+	ListCell *placementCell = NULL;
+	WorkerNode *preferredWorkerNode = NULL;
+	int connectionFlags = 0;
+	MultiConnection *connection = NULL;
+
+	if (IsMultiStatementTransaction())
+	{
+		ereport(DEBUG2, (errmsg("cannot push down CALL in multi-statement transaction")));
+		return false;
+	}
+
+	colocatedRelationId = ColocatedTableId(procedure->colocationId);
+	if (colocatedRelationId == InvalidOid)
+	{
+		ereport(DEBUG2, (errmsg("stored procedure does not have co-located tables")));
+		return false;
+	}
+
+	partitionValue = list_nth(funcExpr->args, procedure->distributionArgumentIndex);
+
+	shardList = ShardsForPartitionColumnValue(colocatedRelationId, partitionValue);
+	if (list_length(shardList) != 1)
+	{
+		ereport(DEBUG2, (errmsg("cannot push down CALL when there are overlapping "
+								"shards")));
+		return false;
+	}
+
+	shard = (ShardInterval *) linitial(shardList);
+	placementList = FinalizedShardPlacementList(shard->shardId);
+	if (list_length(placementList) != 1)
+	{
+		/* punt on reference tables for now */
+		ereport(DEBUG2, (errmsg("cannot push down CALL without a distribution column")));
+		return false;
+	}
+
+	foreach(placementCell, placementList)
+	{
+		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);
+		WorkerNode *workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
+
+		if (workerNode->hasMetadata)
+		{
+			/* we can execute this procedure on the worker! */
+			preferredWorkerNode = workerNode;
+		}
+	}
+
+	if (preferredWorkerNode == NULL)
+	{
+		ereport(DEBUG2, (errmsg("there is no worker node with metadata")));
+		return false;
+	}
+
+	connection = GetNodeConnection(connectionFlags, preferredWorkerNode->workerName,
+								   preferredWorkerNode->workerPort);
+
+	ExecuteCriticalRemoteCommand(connection, queryString);
+
+	return true;
+}

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -149,6 +149,18 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 #if (PG_VERSION_NUM >= 110000)
 	if (IsA(parsetree, CallStmt))
 	{
+		CallStmt *callStmt = (CallStmt *) parsetree;
+
+		/*
+		 * If the procedure is distributed and we are using MX then we have the
+		 * possibility of calling it on the worker. If the data is located on
+		 * the worker this can avoid making many network round trips.
+		 */
+		if (CallDistributedProcedureRemotely(callStmt, queryString, dest))
+		{
+			return;
+		}
+
 		/*
 		 * Stored procedures are a bit strange in the sense that some statements
 		 * are not in a transaction block, but can be rolled back. We need to

--- a/src/backend/distributed/metadata/procedure_metadata.c
+++ b/src/backend/distributed/metadata/procedure_metadata.c
@@ -1,0 +1,412 @@
+/*
+ * procedure_metadata.c
+ *   Functions to load metadata on distributed stored procedures.
+ */
+#include "postgres.h"
+#include "miscadmin.h"
+#include "funcapi.h"
+
+
+#include "access/genam.h"
+#include "access/heapam.h"
+#include "access/htup.h"
+#include "access/htup_details.h"
+#include "access/skey.h"
+#include "access/tupmacs.h"
+#include "access/xact.h"
+#include "catalog/indexing.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
+#include "commands/sequence.h"
+#include "distributed/citus_procedures.h"
+#include "distributed/colocation_utils.h"
+#include "distributed/master_protocol.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_join_order.h"
+#include "distributed/procedure_metadata.h"
+#include "distributed/reference_table_utils.h"
+#include "distributed/worker_transaction.h"
+#include "storage/bufmgr.h"
+#include "storage/lmgr.h"
+#include "storage/lock.h"
+#include "storage/fd.h"
+#include "utils/builtins.h"
+#include "utils/catcache.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/rel.h"
+#include "utils/relcache.h"
+
+
+static const int DistributedProcedureCacheId = -102008;
+static CatCache *DistributedProcedureCache = NULL;
+static bool DistributedProcedureCacheInitialized = false;
+
+
+static int IndexOfArgumentName(HeapTuple procedureTuple, char *argumentName);
+static uint32 ColocationIdForFunction(Oid procedureId, Oid distributionArgumentType,
+									  char *colocateWithTableName);
+static void InsertDistributedProcedureRecord(DistributedProcedureRecord *record);
+static void CreateFunctionOnAllNodes(Oid procedureId);
+static Oid CitusInternalNamespaceId(void);
+static Oid CitusProceduresRelationId(void);
+static Oid CitusProceduresFunctionIdIndexId(void);
+
+
+PG_FUNCTION_INFO_V1(distribute_procedure);
+
+
+Datum
+distribute_procedure(PG_FUNCTION_ARGS)
+{
+	Oid procedureId = PG_GETARG_OID(0);
+	text *distributionColumnText = PG_GETARG_TEXT_P(1);
+	text *colocateWithTableNameText = PG_GETARG_TEXT_P(2);
+
+	int distributionArgIndex = -1;
+	Oid distributionArgType = InvalidOid;
+	char *colocateWithTableName = NULL;
+	HeapTuple procedureTuple = NULL;
+	Form_pg_proc procedureStruct;
+	int colocationId = INVALID_COLOCATION_ID;
+	DistributedProcedureRecord *procedureRecord = NULL;
+
+	CheckCitusVersion(ERROR);
+	EnsureCoordinator();
+
+	procedureTuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(procedureId));
+	if (!HeapTupleIsValid(procedureTuple))
+	{
+		elog(ERROR, "cache lookup failed for function %u", procedureId);
+	}
+
+	procedureStruct = (Form_pg_proc) GETSTRUCT(procedureTuple);
+
+	if (!PG_ARGISNULL(1))
+	{
+		char *distributionColumnName = text_to_cstring(distributionColumnText);
+		distributionArgIndex = IndexOfArgumentName(procedureTuple,
+												   distributionColumnName);
+		if (distributionArgIndex < 0)
+		{
+			ereport(ERROR, (errmsg("function does not have an argument named \"%s\"",
+								   distributionColumnName)));
+		}
+
+		distributionArgType = procedureStruct->proargtypes.values[distributionArgIndex];
+	}
+
+	colocateWithTableName = text_to_cstring(colocateWithTableNameText);
+
+	colocationId = ColocationIdForFunction(procedureId, distributionArgType,
+										   colocateWithTableName);
+
+	procedureRecord =
+		(DistributedProcedureRecord *) palloc0(sizeof(DistributedProcedureRecord));
+	procedureRecord->procedureId = procedureId;
+	procedureRecord->distributionArgumentIndex = distributionArgIndex;
+	procedureRecord->colocationId = colocationId;
+
+	InsertDistributedProcedureRecord(procedureRecord);
+	CreateFunctionOnAllNodes(procedureId);
+
+	ReleaseSysCache(procedureTuple);
+
+	PG_RETURN_BOOL(true);
+}
+
+
+/*
+ * IndexOfArgumentName finds the index of a function argument with the given
+ * name, or -1 if it cannot be found.
+ */
+static int
+IndexOfArgumentName(HeapTuple procedureTuple, char *argumentName)
+{
+	Datum proargnames = 0;
+	Datum proargmodes = 0;
+	int numberOfArguments = 0;
+	bool isNull = false;
+	char **argumentNames = NULL;
+	int argumentIndex = 0;
+
+	proargnames = SysCacheGetAttr(PROCNAMEARGSNSP, procedureTuple,
+								  Anum_pg_proc_proargnames, &isNull);
+	if (isNull)
+	{
+		return -1;
+	}
+
+	proargmodes = SysCacheGetAttr(PROCNAMEARGSNSP, procedureTuple,
+								  Anum_pg_proc_proargmodes, &isNull);
+
+	numberOfArguments = get_func_input_arg_names(proargnames, proargmodes,
+												 &argumentNames);
+	for (argumentIndex = 0; argumentIndex < numberOfArguments; argumentIndex++)
+	{
+		char *currentArgumentName = argumentNames[argumentIndex];
+
+		if (strncmp(currentArgumentName, argumentName, NAMEDATALEN) == 0)
+		{
+			return argumentIndex;
+		}
+	}
+
+	return -1;
+}
+
+
+/*
+ * ColocationIdForFunction
+ */
+static uint32
+ColocationIdForFunction(Oid procedureId, Oid distributionArgumentType,
+						char *colocateWithTableName)
+{
+	uint32 colocationId = INVALID_COLOCATION_ID;
+
+	/*
+	 * Get an exclusive lock on the colocation system catalog. Therefore, we
+	 * can be sure that there will no modifications on the colocation table
+	 * until this transaction is committed.
+	 */
+	Relation pgDistColocation = heap_open(DistColocationRelationId(), ExclusiveLock);
+
+	bool createdColocationGroup = false;
+
+	if (distributionArgumentType == InvalidOid)
+	{
+		return CreateReferenceTableColocationId();
+	}
+	if (pg_strncasecmp(colocateWithTableName, "default", NAMEDATALEN) == 0)
+	{
+		/* check for default colocation group */
+		colocationId = ColocationId(ShardCount, ShardReplicationFactor,
+									distributionArgumentType);
+
+		if (colocationId == INVALID_COLOCATION_ID)
+		{
+			colocationId = CreateColocationGroup(ShardCount, ShardReplicationFactor,
+												 distributionArgumentType);
+			createdColocationGroup = true;
+		}
+	}
+	else
+	{
+		text *colocateWithTableNameText = cstring_to_text(colocateWithTableName);
+		Oid sourceRelationId = ResolveRelationId(colocateWithTableNameText, false);
+		Var *sourceDistributionColumn = DistPartitionKey(sourceRelationId);
+
+		if (distributionArgumentType != sourceDistributionColumn->vartype)
+		{
+			char *functionName = get_func_name(procedureId);
+			char *relationName = get_rel_name(sourceRelationId);
+
+			ereport(ERROR, (errmsg("cannot colocate function %s with table %s",
+								   functionName, relationName),
+							errdetail("Distribution column types don't match for "
+									  "%s and %s.", functionName, relationName)));
+		}
+
+		colocationId = TableColocationId(sourceRelationId);
+	}
+
+	/*
+	 * If we created a new colocation group then we need to keep the lock to
+	 * prevent a concurrent create_distributed_table call from creating another
+	 * colocation group with the same parameters. If we're using an existing
+	 * colocation group then other transactions will use the same one.
+	 */
+	if (createdColocationGroup)
+	{
+		/* keep the exclusive lock */
+		heap_close(pgDistColocation, NoLock);
+	}
+	else
+	{
+		/* release the exclusive lock */
+		heap_close(pgDistColocation, ExclusiveLock);
+	}
+
+	return colocationId;
+}
+
+
+/*
+ * InsertDistributedProcedureRecord inserts a record into citus.procedures recording
+ * that the function should be distributed and
+ */
+static void
+InsertDistributedProcedureRecord(DistributedProcedureRecord *record)
+{
+	Relation citusProcedures = NULL;
+	TupleDesc tupleDescriptor = NULL;
+	HeapTuple procedureTuple = NULL;
+	Form_pg_proc procedureStruct;
+	HeapTuple distributedProcedureTuple = NULL;
+	Datum values[Natts_citus_procedures];
+	bool isNulls[Natts_citus_procedures];
+	Oid schemaId = InvalidOid;
+	Name procedureName = NULL;
+
+	procedureTuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(record->procedureId));
+	if (!HeapTupleIsValid(procedureTuple))
+	{
+		elog(ERROR, "cache lookup failed for function %u", record->procedureId);
+	}
+
+	procedureStruct = (Form_pg_proc) GETSTRUCT(procedureTuple);
+	schemaId = procedureStruct->pronamespace;
+	procedureName = &procedureStruct->proname;
+
+	/* form new shard tuple */
+	memset(values, 0, sizeof(values));
+	memset(isNulls, false, sizeof(isNulls));
+
+	values[Anum_citus_procedures_function_id - 1] = ObjectIdGetDatum(record->procedureId);
+	values[Anum_citus_procedures_schema_name - 1] = ObjectIdGetDatum(schemaId);
+	values[Anum_citus_procedures_procedure_name - 1] = NameGetDatum(procedureName);
+	values[Anum_citus_procedures_distribution_arg - 1] =
+		Int32GetDatum(record->distributionArgumentIndex);
+	values[Anum_citus_procedures_colocation_id - 1] = Int32GetDatum(record->colocationId);
+
+	citusProcedures = heap_open(CitusProceduresRelationId(), RowExclusiveLock);
+
+	tupleDescriptor = RelationGetDescr(citusProcedures);
+	distributedProcedureTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
+
+	CatalogTupleInsert(citusProcedures, distributedProcedureTuple);
+
+	CitusInvalidateRelcacheByRelid(CitusProceduresRelationId());
+
+	/* increment the counter so that next command can see the row */
+	CommandCounterIncrement();
+
+	/* close relation */
+	heap_close(citusProcedures, NoLock);
+
+	ReleaseSysCache(procedureTuple);
+}
+
+
+/*
+ * CreateFunctionOnAllNodes creates a given function on all nodes.
+ */
+static void
+CreateFunctionOnAllNodes(Oid procedureId)
+{
+	char *userName = NULL;
+	char *command = CreateFunctionCommand(procedureId);
+	int parameterCount = 0;
+
+	SendCommandToWorkersParams(WORKERS_WITH_METADATA, userName, command, parameterCount,
+							   NULL, NULL);
+}
+
+
+/*
+ * CreateFunctionCommand
+ */
+char *
+CreateFunctionCommand(Oid procedureId)
+{
+	Datum procedureIdDatum = ObjectIdGetDatum(procedureId);
+	Datum commandDatum = DirectFunctionCall1(pg_get_functiondef, procedureIdDatum);
+
+	return TextDatumGetCString(commandDatum);
+}
+
+
+/*
+ * CitusInternalNamespaceId returns the OID of the citus_internal namespace.
+ *
+ * TODO: caching
+ */
+static Oid
+CitusInternalNamespaceId(void)
+{
+	bool missingOK = false;
+
+	return get_namespace_oid("citus_internal", missingOK);
+}
+
+
+/*
+ * CitusProceduresRelationId returns the OID of citus.procedures.
+ *
+ * TODO: caching
+ */
+static Oid
+CitusProceduresRelationId(void)
+{
+	return get_relname_relid("procedures", CitusInternalNamespaceId());
+}
+
+
+/*
+ * CitusProceduresFunctionIdIndexId returns the OID of citus.procedures.
+ *
+ * TODO: caching
+ */
+static Oid
+CitusProceduresFunctionIdIndexId(void)
+{
+	return get_relname_relid("procedures_function_id_idx", CitusInternalNamespaceId());
+}
+
+
+/*
+ * LoadDistributedProcedureRecord loads a record from citus.procedures.
+ *
+ * TODO: caching
+ */
+DistributedProcedureRecord *
+LoadDistributedProcedureRecord(Oid procedureId)
+{
+	HeapTuple heapTuple = NULL;
+	DistributedProcedureRecord *record = NULL;
+
+	if (!DistributedProcedureCacheInitialized)
+	{
+		int keyColumnCount = 1;
+		int keyColumnArray[] = { Anum_citus_procedures_function_id, 0, 0, 0 };
+
+		DistributedProcedureCache = InitCatCache(DistributedProcedureCacheId,
+												 CitusProceduresRelationId(),
+												 CitusProceduresFunctionIdIndexId(),
+												 keyColumnCount,
+												 keyColumnArray,
+												 16);
+
+		/* load tuple descriptor */
+		InitCatCachePhase2(DistributedProcedureCache, false);
+												 
+		DistributedProcedureCacheInitialized = true;
+	}
+
+	heapTuple = SearchCatCache1(DistributedProcedureCache, ObjectIdGetDatum(procedureId));
+
+	if (HeapTupleIsValid(heapTuple))
+	{
+		Datum datumArray[Natts_citus_procedures];
+		bool isNullArray[Natts_citus_procedures];
+
+		heap_deform_tuple(heapTuple, DistributedProcedureCache->cc_tupdesc, datumArray,
+						  isNullArray);
+
+		record =
+			(DistributedProcedureRecord *) palloc0(sizeof(DistributedProcedureRecord));
+		record->procedureId =
+			DatumGetUInt32(datumArray[Anum_citus_procedures_function_id - 1]);
+		record->distributionArgumentIndex =
+			DatumGetUInt32(datumArray[Anum_citus_procedures_distribution_arg - 1]);
+		record->colocationId =
+			DatumGetInt32(datumArray[Anum_citus_procedures_colocation_id - 1]);
+
+		ReleaseCatCache(heapTuple);
+	}
+
+	return record;
+}

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -1550,3 +1550,24 @@ ExhaustivePruneOne(ShardInterval *curInterval,
 
 	return false;
 }
+
+
+/*
+ * ShardsForPartitionColumnValue gets the shards for a single partition column value.
+ */
+List *
+ShardsForPartitionColumnValue(Oid relationId, Node *partitionColumnValue)
+{
+	Const *partitionValueConst = (Const *) strip_implicit_coercions(partitionColumnValue);
+	Index tableId = 1;
+	Var *partitionColumn = PartitionColumn(relationId, tableId);
+	OpExpr *equalityExpr = MakeOpExpression(partitionColumn, BTEqualStrategyNumber);
+	Const *rightConst = (Const *) get_rightop((Expr *) equalityExpr);
+	List *restrictClauseList = NIL;
+
+	memcpy(rightConst, partitionValueConst, sizeof(Const));
+
+	restrictClauseList = list_make1(equalityExpr);
+
+	return PruneShards(relationId, tableId, restrictClauseList, NULL);
+}

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -89,7 +89,9 @@ SendCommandToFirstWorker(char *command)
 void
 SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command)
 {
-	SendCommandToWorkersParams(targetWorkerSet, command, 0, NULL, NULL);
+	char *userName = CitusExtensionOwnerName();
+
+	SendCommandToWorkersParams(targetWorkerSet, userName, command, 0, NULL, NULL);
 }
 
 
@@ -154,7 +156,7 @@ SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
  * respectively.
  */
 void
-SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
+SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *userName, char *command,
 						   int parameterCount, const Oid *parameterTypes,
 						   const char *const *parameterValues)
 {
@@ -162,7 +164,6 @@ SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
 	ListCell *connectionCell = NULL;
 	List *workerNodeList = ActivePrimaryNodeList();
 	ListCell *workerNodeCell = NULL;
-	char *nodeUser = CitusExtensionOwnerName();
 
 	BeginOrContinueCoordinatedTransaction();
 	CoordinatedTransactionUse2PC();
@@ -189,7 +190,7 @@ SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
 		}
 
 		connection = StartNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
-													 nodeUser, NULL);
+													 userName, NULL);
 
 		MarkRemoteTransactionCritical(connection);
 

--- a/src/include/distributed/citus_procedures.h
+++ b/src/include/distributed/citus_procedures.h
@@ -1,0 +1,13 @@
+/*
+ * citus_procedures.h
+ */
+#ifndef CITUS_PROCEDURES_H
+#define CITUS_PROCEDURES_H
+
+#define Natts_citus_procedures 5
+#define Anum_citus_procedures_function_id 1
+#define Anum_citus_procedures_schema_name 2
+#define Anum_citus_procedures_procedure_name 3
+#define Anum_citus_procedures_distribution_arg 4
+#define Anum_citus_procedures_colocation_id 5
+#endif /* CITUS_PROCEDURES_H */

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -126,4 +126,9 @@ extern void ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand)
 extern bool ShouldPropagateSetCommand(VariableSetStmt *setStmt);
 extern void ProcessVariableSetStmt(VariableSetStmt *setStmt, const char *setCommand);
 
+/* commands.c */
+extern bool CallDistributedProcedureRemotely(CallStmt *callStmt, const char *callCommand,
+											 DestReceiver *dest);
+
+
 #endif /*CITUS_COMMANDS_H */

--- a/src/include/distributed/procedure_metadata.h
+++ b/src/include/distributed/procedure_metadata.h
@@ -1,0 +1,21 @@
+/*
+ * procedure_metadata.h
+ *   Types and functions to load metadata about distributed stored procedures.
+ */
+#ifndef PROCEDURE_METADATA_H
+#define PROCEDURE_METADATA_H
+
+
+typedef struct DistributedProcedureRecord
+{
+	Oid procedureId;
+	int distributionArgumentIndex;
+	int colocationId;
+} DistributedProcedureRecord;
+
+
+extern DistributedProcedureRecord * LoadDistributedProcedureRecord(Oid procedureId);
+extern char * CreateFunctionCommand(Oid procedureId);
+
+
+#endif /* PROCEDURE_METADATA_H */

--- a/src/include/distributed/shard_pruning.h
+++ b/src/include/distributed/shard_pruning.h
@@ -20,5 +20,6 @@
 extern List * PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 						  Const **partitionValueConst);
 extern bool ContainsFalseClause(List *whereClauseList);
+extern List * ShardsForPartitionColumnValue(Oid relationId, Node *partitionColumnValue);
 
 #endif /* SHARD_PRUNING_H_ */

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -34,8 +34,9 @@ extern void SendCommandToFirstWorker(char *command);
 extern void SendCommandToWorkers(TargetWorkerSet targetWorkerSet, char *command);
 extern void SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet,
 										 List *commandList);
-extern void SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *command,
-									   int parameterCount, const Oid *parameterTypes,
+extern void SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, char *userName,
+									   char *command, int parameterCount,
+									   const Oid *parameterTypes,
 									   const char *const *parameterValues);
 extern void SendCommandListToWorkerInSingleTransaction(char *nodeName, int32 nodePort,
 													   char *nodeUser, List *commandList);


### PR DESCRIPTION
Citus currently always executes stored procedures on the coordinator node, which results in high response times and low throughput since every command in the procedure involves one or more network round-trip between the coordinator and workers and incurs planning/execution overhead, even if all the commands go to the same worker node.

This PR implements a basic mechanism for defining distributed functions and procedures using `distribute_procedure`. The procedure is initally replicated to all nodes and has a distribution argument which is used for routing calls to worker nodes with metadata (à la MX). The worker node is chosen based on a the value in the "distribution argument" according to the distribution of a co-located distributed table.

The idea is that the stored procedure would have a tenant ID argument and the node executing the procedure is the one storing the data for that tenant, to avoid network round-trips. Because the worker node has the full metadata, it is still able to handle multi-shard queries within the procedure in case not all queries have distribution column filters or there are writes to a reference table. That way, we avoid having to do careful analysis of the function to ensure it only touches co-located shards.

I'm mainly pushing this branch to do some benchmarks and opening the PR for information sharing purposes.

Currently only CALL is delegated to the worker nodes, the function is not yet created on `master_activate_node`, there is no way to undistribute a function, and the metadata is not updated after changes to a function (e.g. DROP FUNCTION).

I'm also experimenting a bit with storing the metadata in an upgrade-safe manner, since the OIDs of the functions may not be preserved during pg_upgrade. The `proargtypes` still need to be added to uniquely identify the function and renames and schema changes need te be handled. We may want to consider a simpler solution (e.g. a pre-upgrade script). 