### PR TITLE
Prototype: Execute query locally if shards are local

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -345,6 +345,7 @@ CitusCopyFrom(CopyStmt *copyStatement, char *completionTag)
 	}
 
 	XactModificationLevel = XACT_MODIFICATION_DATA;
+	LocalTaskExecutionLevel = LOCAL_EXECUTION_DISALLOWED;
 }
 
 

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -452,6 +452,7 @@ ExecutePlanIntoDestReceiver(PlannedStmt *queryPlan, ParamListInfo params,
 	Portal portal = NULL;
 	int eflags = 0;
 	long count = FETCH_ALL;
+	char *completionTag = NULL;
 
 	/* create a new portal for executing the query */
 	portal = CreateNewPortal();
@@ -467,7 +468,7 @@ ExecutePlanIntoDestReceiver(PlannedStmt *queryPlan, ParamListInfo params,
 					  NULL);
 
 	PortalStart(portal, params, eflags, GetActiveSnapshot());
-	PortalRun(portal, count, false, true, dest, dest, NULL);
+	PortalRun(portal, count, false, true, dest, dest, completionTag);
 	PortalDrop(portal, false);
 }
 

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -212,7 +212,7 @@ UpdateRelationToShardNames(Node *node, List *relationShardList)
 
 	newRte = (RangeTblEntry *) node;
 
-	if (newRte->rtekind != RTE_RELATION)
+	if (GetRangeTblKind(newRte) != CITUS_RTE_RELATION)
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -12,6 +12,7 @@
 #include <float.h>
 #include <limits.h>
 
+#include "catalog/namespace.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_type.h"
 #include "distributed/citus_nodefuncs.h"
@@ -81,9 +82,7 @@ static void AdjustReadIntermediateResultCost(RangeTblEntry *rangeTableEntry,
 											 RelOptInfo *relOptInfo);
 static List * OuterPlanParamsList(PlannerInfo *root);
 static List * CopyPlanParamList(List *originalPlanParamList);
-static PlannerRestrictionContext * CreateAndPushPlannerRestrictionContext(void);
 static PlannerRestrictionContext * CurrentPlannerRestrictionContext(void);
-static void PopPlannerRestrictionContext(void);
 static void ResetPlannerRestrictionContext(
 	PlannerRestrictionContext *plannerRestrictionContext);
 static bool HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams);
@@ -1524,7 +1523,7 @@ CopyPlanParamList(List *originalPlanParamList)
  * plannerRestrictionContextList. Finally, the planner restriction context is
  * inserted to the beginning of the plannerRestrictionContextList and it is returned.
  */
-static PlannerRestrictionContext *
+PlannerRestrictionContext *
 CreateAndPushPlannerRestrictionContext(void)
 {
 	PlannerRestrictionContext *plannerRestrictionContext =
@@ -1577,7 +1576,7 @@ CurrentPlannerRestrictionContext(void)
  * PopPlannerRestrictionContext removes the most recently added restriction contexts from
  * the planner restriction context list. The function assumes the list is not empty.
  */
-static void
+void
 PopPlannerRestrictionContext(void)
 {
 	plannerRestrictionContextList = list_delete_first(plannerRestrictionContextList);

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -453,6 +453,17 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.enable_local_execution",
+		gettext_noop("Enables queries on shards that are local to the current node "
+					 "to be planned and executed locally."),
+		NULL,
+		&EnableLocalExecution,
+		true,
+		PGC_USERSET,
+		0,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.override_table_visibility",
 		gettext_noop("Enables replacing occurencens of pg_catalog.pg_table_visible() "
 					 "with pg_catalog.citus_table_visible()"),

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -23,6 +23,7 @@
 #include "distributed/connection_management.h"
 #include "distributed/hash_helpers.h"
 #include "distributed/intermediate_results.h"
+#include "distributed/multi_executor.h"
 #include "distributed/multi_shard_transaction.h"
 #include "distributed/transaction_management.h"
 #include "distributed/placement_connection.h"
@@ -224,6 +225,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 
 			CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 			XactModificationLevel = XACT_MODIFICATION_NONE;
+			LocalTaskExecutionLevel = LOCAL_EXECUTION_ALLOWED;
 			dlist_init(&InProgressTransactions);
 			activeSetStmts = NULL;
 			CoordinatedTransactionUses2PC = false;
@@ -277,6 +279,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 
 			CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 			XactModificationLevel = XACT_MODIFICATION_NONE;
+			LocalTaskExecutionLevel = LOCAL_EXECUTION_ALLOWED;
 			dlist_init(&InProgressTransactions);
 			activeSetStmts = NULL;
 			CoordinatedTransactionUses2PC = false;

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -532,6 +532,7 @@ ResolveGroupShardPlacement(GroupShardPlacement *groupShardPlacement,
 	shardPlacement->nodeName = pstrdup(workerNode->workerName);
 	shardPlacement->nodePort = workerNode->workerPort;
 	shardPlacement->nodeId = workerNode->nodeId;
+	shardPlacement->groupId = groupId;
 
 	/* fill in remaining fields */
 	Assert(tableEntry->partitionMethod != 0);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -24,6 +24,8 @@
 
 #define CURSOR_OPT_FORCE_DISTRIBUTED 0x080000
 
+struct DistributedPlan;
+
 typedef struct RelationRestrictionContext
 {
 	bool hasDistributedRelation;
@@ -99,6 +101,9 @@ extern PlannedStmt * distributed_planner(Query *parse, int cursorOptions,
 extern List * ExtractRangeTableEntryList(Query *query);
 extern bool NeedsDistributedPlanning(Query *query);
 extern struct DistributedPlan * GetDistributedPlan(CustomScan *node);
+extern bool PlanCanBeExecutedLocally(struct DistributedPlan *distributedPlan);
+extern PlannedStmt * LocalShardPlannedStmt(struct DistributedPlan *distributedPlan,
+										   ParamListInfo boundParams);
 extern void multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 											Index index, RangeTblEntry *rte);
 extern void multi_join_restriction_hook(PlannerInfo *root,
@@ -116,5 +121,7 @@ extern bool IsMultiTaskPlan(struct DistributedPlan *distributedPlan);
 extern bool IsMultiShardModifyPlan(struct DistributedPlan *distributedPlan);
 extern RangeTblEntry * RemoteScanRangeTableEntry(List *columnNameList);
 extern int GetRTEIdentity(RangeTblEntry *rte);
+extern PlannerRestrictionContext * CreateAndPushPlannerRestrictionContext(void);
+extern void PopPlannerRestrictionContext(void);
 
 #endif /* DISTRIBUTED_PLANNER_H */

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -19,6 +19,14 @@
 #include "distributed/multi_server_executor.h"
 
 
+typedef enum LocalExecutionLevel
+{
+	LOCAL_EXECUTION_DISALLOWED,
+	LOCAL_EXECUTION_ALLOWED,
+	LOCAL_EXECUTION_REQUIRED,
+} LocalExecutionLevel;
+extern LocalExecutionLevel LocalTaskExecutionLevel;
+
 /* managed via guc.c */
 typedef enum
 {
@@ -28,6 +36,7 @@ typedef enum
 extern int MultiShardConnectionType;
 
 
+extern bool EnableLocalExecution;
 extern bool WritableStandbyCoordinator;
 extern bool ForceMaxQueryParallelization;
 extern int MaxAdaptiveExecutorPoolSize;


### PR DESCRIPTION
In #2829 we're delegating function calls to worker nodes, but we're still making connections to localhost. incurring the overhead of another backend and significantly lowering the achievable concurrency and throughput.

This PR plans and executes tasks that are local to the current node via the regular planner after rewriting the query tree to have shard names instead of table names (without re-parsing the query). This needs to happen after initial function evaluation (to do shard pruning) and locking. 

Currently the local tasks are executed prior to running `AdaptiveExecutor`. Strictly speaking they should be executed during `AdaptiveExecutor` to preserve execution order to avoid deadlock in multi-row inserts. On the other hand, we do not strictly enforce deadlock prevention in MX for multi-shard UPDATE/DELETE either and deadlocks in multi-row insert should be rare.

Pushing this branch mainly to do some benchmarks alongside #2829 and opening the PR for information sharing purposes.