### PR TITLE
Update control file

### DIFF
--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '8.2-4'
+default_version = '8.4-1'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog


### PR DESCRIPTION
When crerating the `8.3.0` packages in #2836 , I introduced a dummy sql migration file but I forgot to update `default_version` in `citus.control`