### PR TITLE
Adaptive executor performance improvements

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -333,7 +333,6 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port, 
 	connection = StartConnectionEstablishment(&key);
 
 	dlist_push_tail(entry->connections, &connection->connectionNode);
-	entry->connectionCount++;
 
 	ResetShardPlacementAssociation(connection);
 
@@ -1065,8 +1064,6 @@ AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit)
 			cachedConnectionCount++;
 		}
 	}
-
-	entry->connectionCount = cachedConnectionCount;
 }
 
 
@@ -1171,30 +1168,4 @@ TrimLogLevel(const char *message)
 	} while (n < strlen(chompedMessage) && chompedMessage[n] == ' ');
 
 	return chompedMessage + n;
-}
-
-
-/*
- * NodeConnectionCount gets the number of connections to the given node
- * for the current username and database.
- */
-int
-NodeConnectionCount(char *hostname, int port)
-{
-	ConnectionHashKey key;
-	ConnectionHashEntry *entry = NULL;
-	bool found = false;
-
-	strlcpy(key.hostname, hostname, MAX_NODE_LENGTH);
-	key.port = port;
-	strlcpy(key.user, CurrentUserName(), NAMEDATALEN);
-	strlcpy(key.database, CurrentDatabaseName(), NAMEDATALEN);
-
-	entry = (ConnectionHashEntry *) hash_search(ConnectionHash, &key, HASH_FIND, &found);
-	if (!found)
-	{
-		return 0;
-	}
-
-	return entry->connectionCount;
 }

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1638,8 +1638,8 @@ RunDistributedExecution(DistributedExecution *execution)
 		/* additional 2 is for postmaster and latch */
 		int eventSetSize = list_length(execution->sessionList) + 2;
 
-		execution->waitEventSet = BuildWaitEventSet(execution->sessionList);
-		events = palloc0(eventSetSize * sizeof(WaitEvent));
+		/* always (re)build the wait event set the first time */
+		execution->connectionSetChanged = true;
 
 		while (execution->unfinishedTaskCount > 0 && !cancellationReceived)
 		{
@@ -1656,15 +1656,23 @@ RunDistributedExecution(DistributedExecution *execution)
 
 			if (execution->connectionSetChanged)
 			{
-				FreeWaitEventSet(execution->waitEventSet);
+				if (execution->waitEventSet != NULL)
+				{
+					FreeWaitEventSet(execution->waitEventSet);
+					execution->waitEventSet = NULL;
+				}
+
+				if (events != NULL)
+				{
+					/*
+					 * The execution might take a while, so explicitly free at this point
+					 * because we don't need anymore.
+					 */
+					pfree(events);
+					events = NULL;
+				}
 
 				execution->waitEventSet = BuildWaitEventSet(execution->sessionList);
-
-				/*
-				 * The execution might take a while, so explicitly free at this point
-				 * because we don't need anymore.
-				 */
-				pfree(events);
 
 				/* recalculate (and allocate) since the sessions have changed */
 				eventSetSize = list_length(execution->sessionList) + 2;
@@ -1731,8 +1739,16 @@ RunDistributedExecution(DistributedExecution *execution)
 			}
 		}
 
-		pfree(events);
-		FreeWaitEventSet(execution->waitEventSet);
+		if (events != NULL)
+		{
+			pfree(events);
+		}
+
+		if (execution->waitEventSet != NULL)
+		{
+			FreeWaitEventSet(execution->waitEventSet);
+			execution->waitEventSet = NULL;
+		}
 
 		CleanUpSessions(execution);
 	}
@@ -1744,7 +1760,11 @@ RunDistributedExecution(DistributedExecution *execution)
 		 */
 		UnclaimAllSessionConnections(execution->sessionList);
 
-		FreeWaitEventSet(execution->waitEventSet);
+		if (execution->waitEventSet != NULL)
+		{
+			FreeWaitEventSet(execution->waitEventSet);
+			execution->waitEventSet = NULL;
+		}
 
 		PG_RE_THROW();
 	}

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -389,6 +389,9 @@ typedef struct WorkerSession
 
 	/* index in the wait event set */
 	int waitEventSetIndex;
+
+	/* events reported by the latest call to WaitEventSetWait */
+	int latestUnconsumedWaitEvents;
 } WorkerSession;
 
 
@@ -1722,6 +1725,7 @@ RunDistributedExecution(DistributedExecution *execution)
 				}
 
 				session = (WorkerSession *) event->user_data;
+				session->latestUnconsumedWaitEvents = event->events;
 
 				ConnectionStateMachine(session);
 			}
@@ -2573,11 +2577,13 @@ CheckConnectionReady(WorkerSession *session)
 		waitFlags = waitFlags | WL_SOCKET_WRITEABLE;
 	}
 
-	/* if reading fails, there's not much we can do */
-	if (PQconsumeInput(connection->pgConn) == 0)
+	if ((session->latestUnconsumedWaitEvents & WL_SOCKET_READABLE) != 0)
 	{
-		connection->connectionState = MULTI_CONNECTION_LOST;
-		return false;
+		if (PQconsumeInput(connection->pgConn) == 0)
+		{
+			connection->connectionState = MULTI_CONNECTION_LOST;
+			return false;
+		}
 	}
 
 	if (!PQisBusy(connection->pgConn))
@@ -2586,6 +2592,9 @@ CheckConnectionReady(WorkerSession *session)
 	}
 
 	UpdateConnectionWaitFlags(session, waitFlags);
+
+	/* don't consume input redundantly if we cycle back into CheckConnectionReady */
+	session->latestUnconsumedWaitEvents = 0;
 
 	return connectionReady;
 }

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1472,8 +1472,7 @@ FindOrCreateWorkerPool(DistributedExecution *execution, WorkerNode *workerNode)
 	workerPool->distributedExecution = execution;
 
 	/* "open" connections aggressively when there are cached connections */
-	nodeConnectionCount = NodeConnectionCount(workerNode->workerName,
-											  workerNode->workerPort);
+	nodeConnectionCount = MaxCachedConnectionsPerWorker;
 	workerPool->maxNewConnectionsPerCycle = Max(1, nodeConnectionCount);
 
 	dlist_init(&workerPool->pendingTaskQueue);

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1127,8 +1127,8 @@ CleanUpSessions(DistributedExecution *execution)
 
 		MultiConnection *connection = session->connection;
 
-		elog(DEBUG4, "Total number of commands sent over the session %ld: %ld",
-			 session->sessionId, session->commandsSent);
+		ereport(DEBUG4, (errmsg("Total number of commands sent over the session %ld: %ld",
+								session->sessionId, session->commandsSent)));
 
 		UnclaimConnection(connection);
 
@@ -1176,8 +1176,8 @@ CleanUpSessions(DistributedExecution *execution)
 				 * the connection and everything is cleared up. Otherwise, we'd have been
 				 * on MULTI_CONNECTION_FAILED state.
 				 */
-				elog(WARNING, "unexpected transaction state at the end of execution: %d",
-					 transactionState);
+				ereport(WARNING, (errmsg("unexpected transaction state at the end of "
+										 "execution: %d", transactionState)));
 			}
 
 			/* get ready for the next executions if we need use the same connection */
@@ -1185,8 +1185,8 @@ CleanUpSessions(DistributedExecution *execution)
 		}
 		else
 		{
-			elog(WARNING, "unexpected connection state at the end of execution: %d",
-				 connection->connectionState);
+			ereport(WARNING, (errmsg("unexpected connection state at the end of "
+									 "execution: %d", connection->connectionState)));
 		}
 	}
 }
@@ -1308,8 +1308,9 @@ AssignTasksToConnections(DistributedExecution *execution)
 				WorkerSession *session =
 					FindOrCreateWorkerSession(workerPool, connection);
 
-				elog(DEBUG4, "Session %ld (%s:%d) has an assigned task",
-					 session->sessionId, connection->hostname, connection->port);
+				ereport(DEBUG4, (errmsg("Session %ld (%s:%d) has an assigned task",
+										session->sessionId, connection->hostname,
+										connection->port)));
 
 				placementExecution->assignedSession = session;
 
@@ -1442,7 +1443,8 @@ ExecutionOrderForTask(RowModifyLevel modLevel, Task *task)
 		case MERGE_FETCH_TASK:
 		default:
 		{
-			elog(ERROR, "unsupported task type %d in adaptive executor", task->taskType);
+			ereport(ERROR, (errmsg("unsupported task type %d in adaptive executor",
+								   task->taskType)));
 		}
 	}
 }
@@ -1879,8 +1881,8 @@ ManageWorkerPool(WorkerPool *workerPool)
 		return;
 	}
 
-	elog(DEBUG4, "opening %d new connections to %s:%d", newConnectionCount,
-		 workerPool->nodeName, workerPool->nodePort);
+	ereport(DEBUG4, (errmsg("opening %d new connections to %s:%d", newConnectionCount,
+							workerPool->nodeName, workerPool->nodePort)));
 
 	for (connectionIndex = 0; connectionIndex < newConnectionCount; connectionIndex++)
 	{
@@ -2143,8 +2145,10 @@ ConnectionStateMachine(WorkerSession *session)
 				ConnStatusType status = PQstatus(connection->pgConn);
 				if (status == CONNECTION_OK)
 				{
-					elog(DEBUG4, "established connection to %s:%d for session %ld",
-						 connection->hostname, connection->port, session->sessionId);
+					ereport(DEBUG4, (errmsg("established connection to %s:%d for "
+											"session %ld",
+											connection->hostname, connection->port,
+											session->sessionId)));
 
 					workerPool->activeConnectionCount++;
 					workerPool->idleConnectionCount++;
@@ -2176,8 +2180,10 @@ ConnectionStateMachine(WorkerSession *session)
 				}
 				else
 				{
-					elog(DEBUG4, "established connection to %s:%d for session %ld",
-						 connection->hostname, connection->port, session->sessionId);
+					ereport(DEBUG4, (errmsg("established connection to %s:%d for "
+											"session %ld",
+											connection->hostname, connection->port,
+											session->sessionId)));
 
 					workerPool->activeConnectionCount++;
 					workerPool->idleConnectionCount++;

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1810,7 +1810,10 @@ ManageWorkerPool(WorkerPool *workerPool)
 	}
 
 	/* we might fail the execution or warn the user about connection timeouts */
-	CheckConnectionTimeout(workerPool);
+	if (workerPool->checkForPoolTimeout)
+	{
+		CheckConnectionTimeout(workerPool);
+	}
 
 	if (failedConnectionCount >= 1)
 	{

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -128,7 +128,6 @@ typedef struct ConnectionHashEntry
 {
 	ConnectionHashKey key;
 	dlist_head *connections;
-	int connectionCount;
 } ConnectionHashEntry;
 
 /* hash entry for cached connection parameters */
@@ -191,7 +190,6 @@ extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 extern void CloseNodeConnectionsAfterTransaction(char *nodeName, int nodePort);
 extern void CloseConnection(MultiConnection *connection);
 extern void ShutdownConnection(MultiConnection *connection);
-extern int NodeConnectionCount(char *nodeName, int nodePort);
 
 /* dealing with a connection */
 extern void FinishConnectionListEstablishment(List *multiConnectionList);


### PR DESCRIPTION
- Avoid a call to FreeWaitEventSet by not creating an empty set
- Avoid calls to PQconsumeInput by checking the wait events
- Revert the change that removed use of `ModifyWaitEvent``
- Remove use of NodeConnectionCount (it's expensive)
- Remove calls to FindWorkerNode
- Skip timeout checks when checkForPoolTimeout is false
- Replace elog with errmsg