### PR TITLE
Update workerNodeList after sorting

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -263,7 +263,7 @@ MetadataCreateCommands(void)
 	bool includeSequenceDefaults = true;
 
 	/* make sure we have deterministic output for our tests */
-	SortList(workerNodeList, CompareWorkerNodes);
+	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	/* generate insert command for pg_dist_node table */
 	nodeListInsertCommand = NodeListInsertCommand(workerNodeList);


### PR DESCRIPTION
`SortList()` does not mutate the list given in the parameters, and the original list should be replaced with the sorted one here.

I checked all other usages of the said `SortList()`. 