### PR TITLE
Fix multi_prune_shard_list

### DIFF
--- a/src/test/regress/expected/multi_null_minmax_value_pruning.out
+++ b/src/test/regress/expected/multi_null_minmax_value_pruning.out
@@ -3,7 +3,6 @@
 --
 -- This test checks that we can handle null min/max values in shard statistics
 -- and that we don't partition or join prune shards that have null values.
-SET citus.next_shard_id TO 760000;
 -- print major version number for version-specific tests
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int AS server_version;

--- a/src/test/regress/expected/multi_null_minmax_value_pruning_0.out
+++ b/src/test/regress/expected/multi_null_minmax_value_pruning_0.out
@@ -3,7 +3,6 @@
 --
 -- This test checks that we can handle null min/max values in shard statistics
 -- and that we don't partition or join prune shards that have null values.
-SET citus.next_shard_id TO 760000;
 -- print major version number for version-specific tests
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int AS server_version;

--- a/src/test/regress/expected/multi_prune_shard_list.out
+++ b/src/test/regress/expected/multi_prune_shard_list.out
@@ -1,3 +1,5 @@
+CREATE SCHEMA prune_shard_list;
+SET search_path TO prune_shard_list;
 SET citus.next_shard_id TO 800000;
 -- ===================================================================
 -- create test functions
@@ -95,37 +97,11 @@ SELECT print_sorted_shard_intervals('pruning');
 (1 row)
 
 -- update only min value for one shard
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103071;
+UPDATE pg_dist_shard set shardminvalue = NULL WHERE shardid = 800001;
 SELECT print_sorted_shard_intervals('pruning');
- print_sorted_shard_intervals  
--------------------------------
- {800000,800001,800002,800003}
-(1 row)
-
--- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103072;
-SELECT print_sorted_shard_intervals('pruning');
- print_sorted_shard_intervals  
--------------------------------
- {800000,800001,800002,800003}
-(1 row)
-
--- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103070;
-SELECT print_sorted_shard_intervals('pruning');
- print_sorted_shard_intervals  
--------------------------------
- {800000,800001,800002,800003}
-(1 row)
-
--- all shard placements are uninitialized
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103073;
-SELECT print_sorted_shard_intervals('pruning');
- print_sorted_shard_intervals  
--------------------------------
- {800000,800001,800002,800003}
-(1 row)
-
+ERROR:  hash partitioned table has uninitialized shards
+-- repair shard
+UPDATE pg_dist_shard set shardminvalue = -1073741824 WHERE shardid = 800001;
 -- create range distributed table observe shard pruning
 CREATE TABLE pruning_range ( species text, last_pruned date, plant_id integer );
 SELECT create_distributed_table('pruning_range', 'species', 'range');
@@ -160,10 +136,10 @@ SELECT master_create_empty_shard('pruning_range');
 (1 row)
 
 -- now the comparison is done via the partition column type, which is text
-UPDATE pg_dist_shard SET shardminvalue = 'a', shardmaxvalue = 'b' WHERE shardid = 103074;
-UPDATE pg_dist_shard SET shardminvalue = 'c', shardmaxvalue = 'd' WHERE shardid = 103075;
-UPDATE pg_dist_shard SET shardminvalue = 'e', shardmaxvalue = 'f' WHERE shardid = 103076;
-UPDATE pg_dist_shard SET shardminvalue = 'g', shardmaxvalue = 'h' WHERE shardid = 103077;
+UPDATE pg_dist_shard SET shardminvalue = 'a', shardmaxvalue = 'b' WHERE shardid = 800004;
+UPDATE pg_dist_shard SET shardminvalue = 'c', shardmaxvalue = 'd' WHERE shardid = 800005;
+UPDATE pg_dist_shard SET shardminvalue = 'e', shardmaxvalue = 'f' WHERE shardid = 800006;
+UPDATE pg_dist_shard SET shardminvalue = 'g', shardmaxvalue = 'h' WHERE shardid = 800007;
 -- print the ordering of shard intervals with range partitioning as well
 SELECT print_sorted_shard_intervals('pruning_range');
  print_sorted_shard_intervals  
@@ -172,31 +148,31 @@ SELECT print_sorted_shard_intervals('pruning_range');
 (1 row)
 
 -- update only min value for one shard
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103075;
+UPDATE pg_dist_shard set shardminvalue = NULL WHERE shardid = 800005;
 SELECT print_sorted_shard_intervals('pruning_range');
  print_sorted_shard_intervals  
 -------------------------------
- {800004,800005,800006,800007}
+ {800004,800006,800007,800005}
 (1 row)
 
 -- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103076;
+UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 800006;
 SELECT print_sorted_shard_intervals('pruning_range');
  print_sorted_shard_intervals  
 -------------------------------
- {800004,800005,800006,800007}
+ {800004,800007,800005,800006}
 (1 row)
 
 -- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103074;
+UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 800004;
 SELECT print_sorted_shard_intervals('pruning_range');
  print_sorted_shard_intervals  
 -------------------------------
- {800004,800005,800006,800007}
+ {800007,800004,800005,800006}
 (1 row)
 
 -- all shard placements are uninitialized
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103077;
+UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 800007;
 SELECT print_sorted_shard_intervals('pruning_range');
  print_sorted_shard_intervals  
 -------------------------------
@@ -251,3 +227,15 @@ SELECT * FROM coerce_hash WHERE id = 1.0::numeric;
   1 | test value
 (1 row)
 
+SET search_path TO public;
+DROP SCHEMA prune_shard_list CASCADE;
+NOTICE:  drop cascades to 9 other objects
+DETAIL:  drop cascades to function prune_shard_list.prune_using_no_values(regclass)
+drop cascades to function prune_shard_list.prune_using_single_value(regclass,text)
+drop cascades to function prune_shard_list.prune_using_either_value(regclass,text,text)
+drop cascades to function prune_shard_list.prune_using_both_values(regclass,text,text)
+drop cascades to function prune_shard_list.debug_equality_expression(regclass)
+drop cascades to function prune_shard_list.print_sorted_shard_intervals(regclass)
+drop cascades to table prune_shard_list.pruning
+drop cascades to table prune_shard_list.pruning_range
+drop cascades to table prune_shard_list.coerce_hash

--- a/src/test/regress/sql/multi_null_minmax_value_pruning.sql
+++ b/src/test/regress/sql/multi_null_minmax_value_pruning.sql
@@ -6,8 +6,6 @@
 -- and that we don't partition or join prune shards that have null values.
 
 
-SET citus.next_shard_id TO 760000;
-
 -- print major version number for version-specific tests
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int AS server_version;

--- a/src/test/regress/sql/multi_prune_shard_list.sql
+++ b/src/test/regress/sql/multi_prune_shard_list.sql
@@ -1,3 +1,5 @@
+CREATE SCHEMA prune_shard_list;
+SET search_path TO prune_shard_list;
 
 SET citus.next_shard_id TO 800000;
 
@@ -70,20 +72,11 @@ SELECT debug_equality_expression('pruning');
 SELECT print_sorted_shard_intervals('pruning');
 
 -- update only min value for one shard
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103071;
+UPDATE pg_dist_shard set shardminvalue = NULL WHERE shardid = 800001;
 SELECT print_sorted_shard_intervals('pruning');
 
--- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103072;
-SELECT print_sorted_shard_intervals('pruning');
-
--- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103070;
-SELECT print_sorted_shard_intervals('pruning');
-
--- all shard placements are uninitialized
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103073;
-SELECT print_sorted_shard_intervals('pruning');
+-- repair shard
+UPDATE pg_dist_shard set shardminvalue = -1073741824 WHERE shardid = 800001;
 
 -- create range distributed table observe shard pruning
 CREATE TABLE pruning_range ( species text, last_pruned date, plant_id integer );
@@ -96,28 +89,28 @@ SELECT master_create_empty_shard('pruning_range');
 SELECT master_create_empty_shard('pruning_range');
 
 -- now the comparison is done via the partition column type, which is text
-UPDATE pg_dist_shard SET shardminvalue = 'a', shardmaxvalue = 'b' WHERE shardid = 103074;
-UPDATE pg_dist_shard SET shardminvalue = 'c', shardmaxvalue = 'd' WHERE shardid = 103075;
-UPDATE pg_dist_shard SET shardminvalue = 'e', shardmaxvalue = 'f' WHERE shardid = 103076;
-UPDATE pg_dist_shard SET shardminvalue = 'g', shardmaxvalue = 'h' WHERE shardid = 103077;
+UPDATE pg_dist_shard SET shardminvalue = 'a', shardmaxvalue = 'b' WHERE shardid = 800004;
+UPDATE pg_dist_shard SET shardminvalue = 'c', shardmaxvalue = 'd' WHERE shardid = 800005;
+UPDATE pg_dist_shard SET shardminvalue = 'e', shardmaxvalue = 'f' WHERE shardid = 800006;
+UPDATE pg_dist_shard SET shardminvalue = 'g', shardmaxvalue = 'h' WHERE shardid = 800007;
 
 -- print the ordering of shard intervals with range partitioning as well
 SELECT print_sorted_shard_intervals('pruning_range');
 
 -- update only min value for one shard
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103075;
+UPDATE pg_dist_shard set shardminvalue = NULL WHERE shardid = 800005;
 SELECT print_sorted_shard_intervals('pruning_range');
 
 -- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103076;
+UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 800006;
 SELECT print_sorted_shard_intervals('pruning_range');
 
 -- now lets have one more shard without min/max values
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103074;
+UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 800004;
 SELECT print_sorted_shard_intervals('pruning_range');
 
 -- all shard placements are uninitialized
-UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 103077;
+UPDATE pg_dist_shard set shardminvalue = NULL, shardmaxvalue = NULL WHERE shardid = 800007;
 SELECT print_sorted_shard_intervals('pruning_range');
 
 -- ===================================================================
@@ -151,3 +144,6 @@ SELECT * FROM coerce_hash WHERE id = 1;
 SELECT * FROM coerce_hash WHERE id = 1.0;
 
 SELECT * FROM coerce_hash WHERE id = 1.0::numeric;
+
+SET search_path TO public;
+DROP SCHEMA prune_shard_list CASCADE;


### PR DESCRIPTION
 & don't set next_shard_id unnecessarily in multi_null_minmax_value_pruning

Test wasn't properly updated in 5512bb359a1663f5f39526670cb7708bdc2bb20b