### PR TITLE
CompareShardIntervals: if intervals are equal, compare id

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -8,8 +8,10 @@
 
 # In all tests, normalize worker ports, placement ids, and shard ids
 s/localhost:[0-9]+/localhost:xxxxx/g
+s/ port=[0-9]+ / port=xxxxx /g
 s/placement [0-9]+/placement xxxxx/g
 s/shard [0-9]+/shard xxxxx/g
+s/assigned task [0-9]+ to node/assigned task to node/
 
 # In foreign_key_to_reference_table, normalize shard table names, etc in
 # the generated plan


### PR DESCRIPTION
Works around sort being unstable

In pg10/pg11, returning 0 when both shards had null intervals caused `multi_prune_shard_list` to print equal shardids in descending order (whereas the test has them in ascending). Meanwhile in pg12 the currently broken null comparison was returning in descending order & with return 0 began returning in ascending order. All this to say that when you're using an unstable sort & you have an id, it's probably a good idea to fallback on the id when the comparison thinks the elements are equal

`multi_task_assignment_policy` was also impacted by this, so including normalization