### PR TITLE
Avoid multiple pg_dist_colocation records being created for reference tables

### DIFF
--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -145,8 +145,8 @@ extern void DeletePartitionRow(Oid distributedRelationId);
 extern void DeleteShardRow(uint64 shardId);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern void DeleteShardPlacementRow(uint64 placementId);
-extern void UpdateColocationGroupReplicationFactor(uint32 colocationId,
-												   int replicationFactor);
+extern void UpdateColocationGroupReplicationFactorForReferenceTables(int
+																	 replicationFactor);
 extern void CreateDistributedTable(Oid relationId, Var *distributionColumn,
 								   char distributionMethod, char *colocateWithTableName,
 								   bool viaDeprecatedAPI);

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -1251,6 +1251,14 @@ SELECT create_reference_table('mx_ref');
  
 (1 row)
 
+-- make sure that adding/removing nodes doesn't cause
+-- multiple colocation entries for reference tables
+SELECT count(*) FROM pg_dist_colocation WHERE distributioncolumntype = 0;
+ count 
+-------
+     1
+(1 row)
+
 \dt mx_ref
          List of relations
  Schema |  Name  | Type  |  Owner   

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -141,7 +141,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
      
@@ -196,7 +196,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 \c - - - :worker_1_port
@@ -277,7 +277,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
      
@@ -335,7 +335,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 \c - - - :worker_1_port
@@ -385,7 +385,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
      
@@ -442,7 +442,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
      
@@ -500,7 +500,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 \c - - - :worker_1_port
@@ -558,7 +558,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 --verify the data is inserted
@@ -629,7 +629,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 \c - - - :worker_1_port
@@ -686,7 +686,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
      
@@ -753,7 +753,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 BEGIN;
@@ -840,7 +840,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table_schema.table1'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370004 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
      
@@ -897,7 +897,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table_schema.table1'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370004 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 \c - - - :worker_1_port
@@ -959,7 +959,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370004 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 \c - - - :worker_1_port
@@ -1016,7 +1016,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370004 |          1 |                 2 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 \c - - - :worker_1_port

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -117,7 +117,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370000 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -147,7 +147,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370000 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 -- test add same node twice
@@ -171,7 +171,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370000 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -200,7 +200,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370000 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_valid;
@@ -237,7 +237,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370001 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 BEGIN;
@@ -268,7 +268,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370001 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_rollback;
@@ -299,7 +299,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370001 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 BEGIN;
@@ -331,7 +331,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370001 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_commit;
@@ -381,7 +381,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370002 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 SELECT
@@ -393,7 +393,7 @@ WHERE
 ORDER BY logicalrelid;
               logicalrelid               | partmethod | colocationid | repmodel 
 -----------------------------------------+------------+--------------+----------
- replicate_reference_table_reference_one | n          |      1370002 | t
+ replicate_reference_table_reference_one | n          |        10004 | t
  replicate_reference_table_hash          | h          |      1360004 | c
 (2 rows)
 
@@ -443,7 +443,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370002 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -456,9 +456,9 @@ ORDER BY
 	logicalrelid;
               logicalrelid               | partmethod | colocationid | repmodel 
 -----------------------------------------+------------+--------------+----------
- replicate_reference_table_reference_one | n          |      1370002 | t
- replicate_reference_table_hash          | n          |      1370002 | t
- replicate_reference_table_reference_two | n          |      1370002 | t
+ replicate_reference_table_reference_one | n          |        10004 | t
+ replicate_reference_table_hash          | n          |        10004 | t
+ replicate_reference_table_reference_two | n          |        10004 | t
 (3 rows)
 
 DROP TABLE replicate_reference_table_reference_one;
@@ -542,7 +542,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_drop'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370003 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 BEGIN;
@@ -605,7 +605,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370004 |          1 |                 1 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -635,7 +635,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-      1370004 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_schema.table1;

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -180,7 +180,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_append'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT
@@ -202,7 +202,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -293,7 +293,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_one_worker'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT
@@ -315,7 +315,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -409,7 +409,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT
@@ -431,7 +431,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -523,7 +523,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_both_healthy'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT
@@ -545,7 +545,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -752,7 +752,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT
@@ -774,7 +774,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -1001,7 +1001,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_mx'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT
@@ -1023,7 +1023,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10005 |          1 |                 2 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 SELECT
@@ -1051,7 +1051,7 @@ WHERE
     logicalrelid = 'upgrade_reference_table_mx'::regclass;
  partmethod | partkeyisnull | colocationid | repmodel 
 ------------+---------------+--------------+----------
- n          | t             |        10005 | t
+ n          | t             |        10004 | t
 (1 row)
 
 SELECT

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -569,6 +569,11 @@ DROP USER mx_user;
 \c - - - :master_port
 CREATE TABLE mx_ref (col_1 int, col_2 text);
 SELECT create_reference_table('mx_ref');
+
+-- make sure that adding/removing nodes doesn't cause
+-- multiple colocation entries for reference tables
+SELECT count(*) FROM pg_dist_colocation WHERE distributioncolumntype = 0;
+
 \dt mx_ref
 
 \c - - - :worker_1_port


### PR DESCRIPTION
DESCRIPTION: Prevent pg_dist_colocation from having multiple records for reference tables

master_deactivate_node is updated to decrement the replication factor
Otherwise deactivation could have create_reference_table produce a second record

UpdateColocationGroupReplicationFactor is renamed UpdateColocationGroupReplicationFactorForReferenceTables
& the implementation looks up the record based on distributioncolumntype == InvalidOid, rather than by id
Otherwise the record's replication factor fails to be maintained when there are no reference tables

One downside to this change is that there's no index for looking up by distributiontype. `pg_dist_colocation_configuration_index` could serve that purpose if the order of columns was revised

Fixes #2873