### PR TITLE
Attempt to improve slow start algorithm

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1764,10 +1764,10 @@ RunDistributedExecution(DistributedExecution *execution)
 	PG_END_TRY();
 }
 
+
 static void
 SpeedUpSlowStartIfNecessary(DistributedExecution *execution)
 {
-
 	/*
 	 * - No tasks has finished yet
 	 * - The slow start interval has not been already adjusted (or already disable by the user)
@@ -1777,22 +1777,22 @@ SpeedUpSlowStartIfNecessary(DistributedExecution *execution)
 	if (execution->unfinishedTaskCount == execution->totalTaskCount &&
 		execution->slowStartInterval > 0 &&
 		execution->executionStats->firstConnectionEstablishement > 0 &&
-		TimestampDifferenceExceeds(execution->executionStats->firstConnectionEstablishement,
-								  GetCurrentTimestamp(),
-								  ExecutorSlowStartInterval))
+		TimestampDifferenceExceeds(
+			execution->executionStats->firstConnectionEstablishement,
+			GetCurrentTimestamp(),
+			ExecutorSlowStartInterval))
+	{
+		ListCell *workerCell = NULL;
+
+		execution->slowStartInterval = 0;
+
+		foreach(workerCell, execution->workerList)
 		{
-			ListCell *workerCell = NULL;
+			WorkerPool *workerPool = lfirst(workerCell);
 
-			execution->slowStartInterval = 0;
-
-			foreach(workerCell, execution->workerList)
-			{
-				WorkerPool *workerPool = lfirst(workerCell);
-
-				workerPool->maxNewConnectionsPerCycle = UINT32_MAX;
-			}
+			workerPool->maxNewConnectionsPerCycle = UINT32_MAX;
 		}
-
+	}
 }
 
 
@@ -2102,7 +2102,7 @@ NextEventTimeout(DistributedExecution *execution)
 			long timeSinceLastConnectMs =
 				MillisecondsBetweenTimestamps(workerPool->lastConnectionOpenTime, now);
 			long timeUntilSlowStartInterval =
-					execution->slowStartInterval - timeSinceLastConnectMs;
+				execution->slowStartInterval - timeSinceLastConnectMs;
 
 			if (timeUntilSlowStartInterval < eventTimeout)
 			{
@@ -2180,7 +2180,8 @@ ConnectionStateMachine(WorkerSession *session)
 
 					if (executionStats->firstConnectionEstablishement == 0)
 					{
-						executionStats->firstConnectionEstablishement = GetCurrentTimestamp();
+						executionStats->firstConnectionEstablishement =
+							GetCurrentTimestamp();
 					}
 
 					break;
@@ -2221,7 +2222,8 @@ ConnectionStateMachine(WorkerSession *session)
 
 					if (executionStats->firstConnectionEstablishement == 0)
 					{
-						executionStats->firstConnectionEstablishement = GetCurrentTimestamp();
+						executionStats->firstConnectionEstablishement =
+							GetCurrentTimestamp();
 					}
 				}
 
@@ -2574,7 +2576,6 @@ TransactionStateMachine(WorkerSession *session)
 			}
 		}
 	}
-
 	/* iterate in case we can perform multiple transitions at once */
 	while (transaction->transactionState != currentState);
 }

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1635,9 +1635,11 @@ RunDistributedExecution(DistributedExecution *execution)
 			int eventCount = 0;
 			int eventIndex = 0;
 			ListCell *workerCell = NULL;
-			long timeout = NextEventTimeout(execution);
+			long timeout = 0;
 
 			SpeedUpSlowStartIfNecessary(execution);
+
+			timeout = NextEventTimeout(execution);
 
 			foreach(workerCell, execution->workerList)
 			{

--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -120,6 +120,8 @@ typedef enum
 typedef struct DistributedExecutionStats
 {
 	uint64 totalIntermediateResultSize;
+
+	TimestampTz firstConnectionEstablishement;
 } DistributedExecutionStats;
 
 


### PR DESCRIPTION
The idea is that if the task executions take long enough, we could speed up the slow start algorithm. The rationale is that we'll need all the connections anyway, so there is no need to wait while building up all the connections.


In practice, I really couldn't see any performance benefits. Irrespective of this change, setting  `citus.executor_slow_start_interval TO 0`  doesn't help much either. Not the when `citus.executor_slow_start_interval TO 0`, we're already by-passing the slow start algorithm at all.

Some tests results for the query `select count(*), pg_sleep(0.2) from users_table;` where we ensure that each task takes at least 200 msecs.

master + citus.executor_slow_start_interval TO 0;    `315ms`
master + citus.executor_slow_start_interval TO 10;    `322ms`
patch: `320ms`

I even tried with 128 shards, but still the improvements are in the noise level.

I'm guessing that postgres is somehow responding slower when Citus opens too many connection at the same time. 

So my conclusion is that this PR requires more investigation. @marcocitus and @pykello, given that we're short in-time for other tasks, I'm planning to leave this as a draft PR, and potentially come back in the next release. Any thoughts/preference?
