### PR TITLE
Fix distributed deadlock in TRUNATE

### DIFF
--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -34,6 +34,7 @@
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
 #include "storage/lock.h"
+#include "storage/lmgr.h"
 #include "utils/builtins.h"
 #include "utils/elog.h"
 #include "utils/errcodes.h"
@@ -230,6 +231,9 @@ RepairShardPlacement(int64 shardId, char *sourceNodeName, int32 sourceNodePort,
 	List *foreignConstraintCommandList = NIL;
 	List *placementList = NIL;
 	ShardPlacement *placement = NULL;
+
+	/* prevent table from being dropped */
+	LockRelationOid(distributedTableId, AccessShareLock);
 
 	EnsureTableOwner(distributedTableId);
 

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -24,6 +24,7 @@
 #include "distributed/shardinterval_utils.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
+#include "pgstat.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
@@ -32,6 +33,7 @@
 
 
 static char * PartitionBound(Oid partitionId);
+static Relation try_relation_open_nolock(Oid relationId);
 
 
 /*
@@ -69,7 +71,7 @@ PartitionedTable(Oid relationId)
 bool
 PartitionedTableNoLock(Oid relationId)
 {
-	Relation rel = try_relation_open(relationId, NoLock);
+	Relation rel = try_relation_open_nolock(relationId);
 	bool partitionedTable = false;
 
 	/* don't error out for tables that are dropped */
@@ -122,7 +124,7 @@ PartitionTable(Oid relationId)
 bool
 PartitionTableNoLock(Oid relationId)
 {
-	Relation rel = try_relation_open(relationId, NoLock);
+	Relation rel = try_relation_open_nolock(relationId);
 	bool partitionTable = false;
 
 	/* don't error out for tables that are dropped */
@@ -137,6 +139,39 @@ PartitionTableNoLock(Oid relationId)
 	heap_close(rel, NoLock);
 
 	return partitionTable;
+}
+
+
+/*
+ * try_relation_open_nolock opens a relation with given relationId without
+ * acquiring locks. PostgreSQL's try_relation_open() asserts that caller
+ * has already acquired a lock on the relation, which we don't always do.
+ *
+ * ATTENTION:
+ *   1. Sync this with try_relation_open(). It hasn't changed for 10 to 12
+ *      releases though.
+ *   2. We should remove this after we fix the locking/distributed deadlock
+ *      issues with MX Truncate. See https://github.com/citusdata/citus/pull/2894
+ *      for more discussion.
+ */
+static Relation
+try_relation_open_nolock(Oid relationId)
+{
+	Relation relation = NULL;
+	if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(relationId)))
+	{
+		return NULL;
+	}
+
+	relation = RelationIdGetRelation(relationId);
+	if (!RelationIsValid(relation))
+	{
+		return NULL;
+	}
+
+	pgstat_initstats(relation);
+
+	return relation;
 }
 
 


### PR DESCRIPTION
This is to fix two issues at the same time:
1. Not to get distributed deadlock for concurrent TRUNCATE from MX nodes
2. Not hit `Assert(CheckRelationLockedByMe(...))` in postgres 12.

Getting any locks in `ProcessTruncateStatement()` (even if we release it right after acquisition)
causes distributed deadlock when doing `TRUNCATE` from MX workers. To reproduce the
deadlock before this commit:

1. Create a MX distributed table `test`.
2. `echo "TRUNCATE test;" > f.sql`
3. Run:

```
pgbench -f f.sql -p 5433 -P 1 -c4 -j4 -T 25 postgres &
pgbench -f f.sql -p 5434 -P 1 -c4 -j4 -T 25 postgres &
pgbench -f f.sql -p 5435 -P 1 -c4 -j4 -T 25 postgres &
```

You will notice that some transactions are cancelled because of distributed deadlock.

