### PR TITLE
Task Tracker: fix error being copy pasted from above block

### DIFF
--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -447,7 +447,7 @@ MultiTaskTrackerExecute(Job *job)
 	}
 	else if (clusterFailed)
 	{
-		ereport(ERROR, (errmsg("failed to execute task %u", failedTaskId)));
+		ereport(ERROR, (errmsg("majority of nodes failed")));
 	}
 	else if (QueryCancelPending)
 	{


### PR DESCRIPTION
DESCRIPTION: Fix error message when cluster fails for task tracker