### PR TITLE
Propagate REINDEX TABLE & REINDEX INDEX

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -386,7 +386,7 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 
 		if (IsA(parsetree, ReindexStmt))
 		{
-			ErrorIfReindexOnDistributedTable((ReindexStmt *) parsetree);
+			ddlJobs = PlanReindexStmt((ReindexStmt *) parsetree, queryString);
 		}
 
 		if (IsA(parsetree, DropStmt))

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -406,15 +406,6 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 
 				AppendShardIdToName(objectName, shardId);
 			}
-			else if (objectType == REINDEX_OBJECT_DATABASE)
-			{
-				ereport(ERROR, (errmsg("cannot extend name for multi-relation reindex")));
-			}
-			else
-			{
-				ereport(ERROR, (errmsg("invalid object type in reindex statement"),
-								errdetail("Object type: %u", (uint32) objectType)));
-			}
 
 			break;
 		}

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -35,6 +35,8 @@ extern void EnsureRelationKindSupported(Oid relationId);
 extern char * pg_get_tablecolumnoptionsdef_string(Oid tableRelationId);
 extern void deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid,
 										  int64 shardid, StringInfo buffer);
+extern void deparse_shard_reindex_statement(ReindexStmt *origStmt, Oid distrelid,
+											int64 shardid, StringInfo buffer);
 extern char * pg_get_indexclusterdef_string(Oid indexRelationId);
 extern List * pg_get_table_grants(Oid relationId);
 extern bool contain_nextval_expression_walker(Node *node, void *context);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -58,7 +58,8 @@ extern List * PlanGrantStmt(GrantStmt *grantStmt);
 extern bool IsIndexRenameStmt(RenameStmt *renameStmt);
 extern List * PlanIndexStmt(IndexStmt *createIndexStatement,
 							const char *createIndexCommand);
-extern void ErrorIfReindexOnDistributedTable(ReindexStmt *ReindexStatement);
+extern List * PlanReindexStmt(ReindexStmt *ReindexStatement,
+							  const char *ReindexCommand);
 extern List * PlanDropIndexStmt(DropStmt *dropIndexStatement,
 								const char *dropIndexCommand);
 extern void PostProcessIndexStmt(IndexStmt *indexStmt);

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -207,17 +207,11 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 --
 -- REINDEX
 --
-SET citus.log_remote_commands to on;
-SET client_min_messages = LOG;
 REINDEX INDEX lineitem_orderkey_index;
-ERROR:  REINDEX is not implemented for distributed relations
 REINDEX TABLE lineitem;
-ERROR:  REINDEX is not implemented for distributed relations
 REINDEX SCHEMA public;
 REINDEX DATABASE regression;
 REINDEX SYSTEM regression;
-SET citus.log_remote_commands to off;
-RESET client_min_messages;
 --
 -- DROP INDEX
 --

--- a/src/test/regress/expected/multi_index_statements_0.out
+++ b/src/test/regress/expected/multi_index_statements_0.out
@@ -208,17 +208,11 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 --
 -- REINDEX
 --
-SET citus.log_remote_commands to on;
-SET client_min_messages = LOG;
 REINDEX INDEX lineitem_orderkey_index;
-ERROR:  REINDEX is not implemented for distributed relations
 REINDEX TABLE lineitem;
-ERROR:  REINDEX is not implemented for distributed relations
 REINDEX SCHEMA public;
 REINDEX DATABASE regression;
 REINDEX SYSTEM regression;
-SET citus.log_remote_commands to off;
-RESET client_min_messages;
 --
 -- DROP INDEX
 --

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -117,15 +117,11 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 -- REINDEX
 --
 
-SET citus.log_remote_commands to on;
-SET client_min_messages = LOG;
 REINDEX INDEX lineitem_orderkey_index;
 REINDEX TABLE lineitem;
 REINDEX SCHEMA public;
 REINDEX DATABASE regression;
 REINDEX SYSTEM regression;
-SET citus.log_remote_commands to off;
-RESET client_min_messages;
 
 --
 -- DROP INDEX


### PR DESCRIPTION
DESCRIPTION: Propagate reindex on tables & index

I wrote this because @onderkalaci wanted `REINDEX CONCURRENTLY` to error out, & then I found that the reindex logic I assumed existed wasn't there, so I wrote what I assumed

This doesn't include logic to handle changes in pg12

Not sure what desirable behavior is for reindex schema/database/system, whether that should go on to include worker nodes

Since this is a bit late in the release cycle, I'll be creating a `reindex-error` branch (#2900) which eschews doing the right thing in favor of raising an error, which doesn't require thinking about locking scenarios