### PR TITLE
Raise an error when REINDEX TABLE or INDEX is invoked on a distributed relation

### DIFF
--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -169,6 +169,69 @@ PlanIndexStmt(IndexStmt *createIndexStatement, const char *createIndexCommand)
 
 
 /*
+ * ErrorIfReindexOnDistributedTable determines whether a given REINDEX
+ * involves a distributed table, & raises an error if so.
+ */
+void
+ErrorIfReindexOnDistributedTable(ReindexStmt *ReindexStatement)
+{
+	Relation relation = NULL;
+	Oid relationId = InvalidOid;
+	bool isDistributedRelation = false;
+	LOCKMODE lockmode = AccessShareLock;
+
+	/*
+	 * We first check whether a distributed relation is affected. For that, we need to
+	 * open the relation.
+	 */
+	if (ReindexStatement->relation == NULL)
+	{
+		/* ignore REINDEX SCHEMA, REINDEX SYSTEM, and REINDEX DATABASE */
+		return;
+	}
+
+	Assert(ReindexStatement->relkind == REINDEX_OBJECT_INDEX ||
+		   ReindexStatement->relkind == REINDEX_OBJECT_TABLE);
+
+	/*
+	 * XXX: Consider using RangeVarGetRelidExtended with a permission
+	 * checking callback. Right now we'll acquire the lock before having
+	 * checked permissions.
+	 */
+	if (ReindexStatement->kind == REINDEX_OBJECT_INDEX)
+	{
+		Oid indOid = RangeVarGetRelid(ReindexStatement->relation,
+									  NoLock, false);
+		relation = index_open(indOid, lockmode);
+		relationId = IndexGetRelation(indOid, false);
+	}
+	else
+	{
+		relation = heap_openrv(ReindexStatement->relation, lockmode);
+		relationId = RelationGetRelid(relation);
+	}
+
+	isDistributedRelation = IsDistributedTable(relationId);
+
+	if (ReindexStatement->kind == REINDEX_OBJECT_INDEX)
+	{
+		index_close(relation, NoLock);
+	}
+	else
+	{
+		heap_close(relation, NoLock);
+	}
+
+	if (isDistributedRelation)
+	{
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg(
+							"REINDEX is not implemented for distributed relations")));
+	}
+}
+
+
+/*
  * PlanDropIndexStmt determines whether a given DROP INDEX statement involves
  * a distributed table. If so (and if the statement does not use unsupported
  * options), it modifies the input statement to ensure proper execution against

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -279,6 +279,11 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 			ddlJobs = PlanIndexStmt((IndexStmt *) parsetree, queryString);
 		}
 
+		if (IsA(parsetree, ReindexStmt))
+		{
+			ErrorIfReindexOnDistributedTable((ReindexStmt *) parsetree);
+		}
+
 		if (IsA(parsetree, DropStmt))
 		{
 			DropStmt *dropStatement = (DropStmt *) parsetree;

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -52,6 +52,7 @@ extern List * PlanGrantStmt(GrantStmt *grantStmt);
 extern bool IsIndexRenameStmt(RenameStmt *renameStmt);
 extern List * PlanIndexStmt(IndexStmt *createIndexStatement,
 							const char *createIndexCommand);
+extern void ErrorIfReindexOnDistributedTable(ReindexStmt *ReindexStatement);
 extern List * PlanDropIndexStmt(DropStmt *dropIndexStatement,
 								const char *dropIndexCommand);
 extern void PostProcessIndexStmt(IndexStmt *indexStmt);

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -205,6 +205,20 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 (16 rows)
 
 --
+-- REINDEX
+--
+SET citus.log_remote_commands to on;
+SET client_min_messages = LOG;
+REINDEX INDEX lineitem_orderkey_index;
+ERROR:  REINDEX is not implemented for distributed relations
+REINDEX TABLE lineitem;
+ERROR:  REINDEX is not implemented for distributed relations
+REINDEX SCHEMA public;
+REINDEX DATABASE regression;
+REINDEX SYSTEM regression;
+SET citus.log_remote_commands to off;
+RESET client_min_messages;
+--
 -- DROP INDEX
 --
 -- Verify that we can't drop multiple indexes in a single command

--- a/src/test/regress/expected/multi_index_statements_0.out
+++ b/src/test/regress/expected/multi_index_statements_0.out
@@ -206,6 +206,20 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
 (15 rows)
 
 --
+-- REINDEX
+--
+SET citus.log_remote_commands to on;
+SET client_min_messages = LOG;
+REINDEX INDEX lineitem_orderkey_index;
+ERROR:  REINDEX is not implemented for distributed relations
+REINDEX TABLE lineitem;
+ERROR:  REINDEX is not implemented for distributed relations
+REINDEX SCHEMA public;
+REINDEX DATABASE regression;
+REINDEX SYSTEM regression;
+SET citus.log_remote_commands to off;
+RESET client_min_messages;
+--
 -- DROP INDEX
 --
 -- Verify that we can't drop multiple indexes in a single command

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -114,6 +114,20 @@ CREATE INDEX ON lineitem (l_orderkey);
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
 
 --
+-- REINDEX
+--
+
+SET citus.log_remote_commands to on;
+SET client_min_messages = LOG;
+REINDEX INDEX lineitem_orderkey_index;
+REINDEX TABLE lineitem;
+REINDEX SCHEMA public;
+REINDEX DATABASE regression;
+REINDEX SYSTEM regression;
+SET citus.log_remote_commands to off;
+RESET client_min_messages;
+
+--
 -- DROP INDEX
 --
 


### PR DESCRIPTION
DESCRIPTION: Raise an error when reindexing a distributed table or an index of a distributed table

Propagation is implemented by #2899, but this is more straight forward to fit into the next release
