### PR TITLE
Sort load_shard_placement_array by worker name/port

### DIFF
--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -109,7 +109,7 @@ ERROR:  could not find valid entry for shard 540005
 SELECT load_shard_placement_array(540001, false);
     load_shard_placement_array     
 -----------------------------------
- {localhost:57638,localhost:57637}
+ {localhost:57637,localhost:57638}
 (1 row)
 
 -- only one of which is finalized
@@ -123,7 +123,7 @@ SELECT load_shard_placement_array(540001, true);
 SELECT load_shard_placement_array(540001, false);
     load_shard_placement_array     
 -----------------------------------
- {localhost:57638,localhost:57637}
+ {localhost:57637,localhost:57638}
 (1 row)
 
 -- should see column id of 'name'


### PR DESCRIPTION
multi_distribution_metadata was failing randomly, e.g. in https://circleci.com/gh/citusdata/citus/24222.

Issue was that load_shard_placement_array() sorted placements by placement id, and different worker nodes took different placement ids from test to test.