### PR TITLE
pg_dist_colocation: distributioncolumncollation

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -346,7 +346,8 @@ GetFunctionColocationId(Oid functionOid, char *colocateWithTableName,
 	{
 		/* check for default colocation group */
 		colocationId = ColocationId(ShardCount, ShardReplicationFactor,
-									distributionArgumentOid);
+									distributionArgumentOid, get_typcollation(
+										distributionArgumentOid));
 
 		if (colocationId == INVALID_COLOCATION_ID)
 		{

--- a/src/backend/distributed/master/master_split_shards.c
+++ b/src/backend/distributed/master/master_split_shards.c
@@ -81,8 +81,8 @@ worker_hash(PG_FUNCTION_ARGS)
 	fmgr_info_copy(hashFunction, &(typeEntry->hash_proc_finfo), CurrentMemoryContext);
 
 	/* calculate hash value */
-	Datum hashedValueDatum = FunctionCall1Coll(hashFunction, PG_GET_COLLATION(),
-											   valueDatum);
+	Datum hashedValueDatum =
+		FunctionCall1Coll(hashFunction, PG_GET_COLLATION(), valueDatum);
 
 	PG_RETURN_INT32(hashedValueDatum);
 }

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -276,7 +276,7 @@ PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 		InitFunctionCallInfoData(*(FunctionCallInfo) &
 								 context.compareIntervalFunctionCall,
 								 cacheEntry->shardIntervalCompareFunction,
-								 2, DEFAULT_COLLATION_OID, NULL, NULL);
+								 2, cacheEntry->partitionColumn->varcollid, NULL, NULL);
 	}
 	else
 	{
@@ -290,7 +290,7 @@ PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 		InitFunctionCallInfoData(*(FunctionCallInfo) &
 								 context.compareValueFunctionCall,
 								 cacheEntry->shardColumnCompareFunction,
-								 2, DEFAULT_COLLATION_OID, NULL, NULL);
+								 2, cacheEntry->partitionColumn->varcollid, NULL, NULL);
 	}
 	else
 	{
@@ -679,7 +679,7 @@ AddSAOPartitionKeyRestrictionToInstance(ClauseWalkerContext *context,
 			arrayEqualityOp->inputcollid = arrayOperatorExpression->inputcollid;
 			arrayEqualityOp->opresulttype = get_func_rettype(
 				arrayOperatorExpression->opfuncid);
-			arrayEqualityOp->opcollid = DEFAULT_COLLATION_OID;
+			arrayEqualityOp->opcollid = context->partitionColumn->varcollid;
 			arrayEqualityOp->location = -1;
 			arrayEqualityOp->args = list_make2(strippedLeftOpExpression, constElement);
 

--- a/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
+++ b/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
@@ -1,0 +1,11 @@
+ALTER TABLE pg_catalog.pg_dist_colocation ADD distributioncolumncollation oid;
+UPDATE pg_catalog.pg_dist_colocation dc SET distributioncolumncollation = t.typcollation
+	FROM pg_catalog.pg_type t WHERE t.oid = dc.distributioncolumntype;
+UPDATE pg_catalog.pg_dist_colocation dc SET distributioncolumncollation = 0 WHERE distributioncolumncollation IS NULL;
+ALTER TABLE pg_catalog.pg_dist_colocation ALTER COLUMN distributioncolumncollation SET NOT NULL;
+
+DROP INDEX pg_dist_colocation_configuration_index;
+-- distributioncolumntype should be listed first so that this index can be used for looking up reference tables' colocation id
+CREATE INDEX pg_dist_colocation_configuration_index
+ON pg_dist_colocation USING btree(distributioncolumntype, shardcount, replicationfactor, distributioncolumncollation);
+

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -167,15 +167,18 @@ MarkTablesColocated(Oid sourceRelationId, Oid targetRelationId)
 
 		Var *sourceDistributionColumn = DistPartitionKey(sourceRelationId);
 		Oid sourceDistributionColumnType = InvalidOid;
+		Oid sourceDistributionColumnCollation = InvalidOid;
 
 		/* reference tables has NULL distribution column */
 		if (sourceDistributionColumn != NULL)
 		{
 			sourceDistributionColumnType = sourceDistributionColumn->vartype;
+			sourceDistributionColumnCollation = sourceDistributionColumn->varcollid;
 		}
 
 		sourceColocationId = CreateColocationGroup(shardCount, shardReplicationFactor,
-												   sourceDistributionColumnType);
+												   sourceDistributionColumnType,
+												   sourceDistributionColumnCollation);
 		UpdateRelationColocationGroup(sourceRelationId, sourceColocationId);
 	}
 
@@ -417,27 +420,31 @@ CompareShardPlacementsByNode(const void *leftElement, const void *rightElement)
 
 
 /*
- * ColocationId searches pg_dist_colocation for shard count, replication factor
- * and distribution column type. If a matching entry is found, it returns the
- * colocation id, otherwise it returns INVALID_COLOCATION_ID.
+ * ColocationId searches pg_dist_colocation for shard count, replication factor,
+ * distribution column type, and distribution column collation. If a matching entry
+ * is found, it returns the colocation id, otherwise returns INVALID_COLOCATION_ID.
  */
 uint32
-ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType)
+ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType, Oid
+			 distributionColumnCollation)
 {
 	uint32 colocationId = INVALID_COLOCATION_ID;
-	const int scanKeyCount = 3;
-	ScanKeyData scanKey[3];
+	const int scanKeyCount = 4;
+	ScanKeyData scanKey[4];
 	bool indexOK = true;
 
 	Relation pgDistColocation = heap_open(DistColocationRelationId(), AccessShareLock);
 
 	/* set scan arguments */
-	ScanKeyInit(&scanKey[0], Anum_pg_dist_colocation_shardcount,
-				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(shardCount));
-	ScanKeyInit(&scanKey[1], Anum_pg_dist_colocation_replicationfactor,
-				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(replicationFactor));
-	ScanKeyInit(&scanKey[2], Anum_pg_dist_colocation_distributioncolumntype,
+	ScanKeyInit(&scanKey[0], Anum_pg_dist_colocation_distributioncolumntype,
 				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(distributionColumnType));
+	ScanKeyInit(&scanKey[1], Anum_pg_dist_colocation_shardcount,
+				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(shardCount));
+	ScanKeyInit(&scanKey[2], Anum_pg_dist_colocation_replicationfactor,
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(replicationFactor));
+	ScanKeyInit(&scanKey[3], Anum_pg_dist_colocation_distributioncolumncollation,
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(
+					distributionColumnCollation));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistColocation,
 													DistColocationConfigurationIndexId(),
@@ -465,7 +472,8 @@ ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType)
  * colocation id.
  */
 uint32
-CreateColocationGroup(int shardCount, int replicationFactor, Oid distributionColumnType)
+CreateColocationGroup(int shardCount, int replicationFactor, Oid distributionColumnType,
+					  Oid distributionColumnCollation)
 {
 	uint32 colocationId = GetNextColocationId();
 	Datum values[Natts_pg_dist_colocation];
@@ -481,6 +489,8 @@ CreateColocationGroup(int shardCount, int replicationFactor, Oid distributionCol
 		UInt32GetDatum(replicationFactor);
 	values[Anum_pg_dist_colocation_distributioncolumntype - 1] =
 		ObjectIdGetDatum(distributionColumnType);
+	values[Anum_pg_dist_colocation_distributioncolumncollation - 1] =
+		ObjectIdGetDatum(distributionColumnCollation);
 
 	/* open colocation relation and insert the new tuple */
 	Relation pgDistColocation = heap_open(DistColocationRelationId(), RowExclusiveLock);
@@ -566,27 +576,23 @@ CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelationId)
 {
 	Oid sourceDistributionColumnType = InvalidOid;
 	Oid targetDistributionColumnType = InvalidOid;
+	Oid sourceDistributionColumnCollation = InvalidOid;
+	Oid targetDistributionColumnCollation = InvalidOid;
 
 	/* reference tables have NULL distribution column */
 	Var *sourceDistributionColumn = DistPartitionKey(sourceRelationId);
-	if (sourceDistributionColumn == NULL)
-	{
-		sourceDistributionColumnType = InvalidOid;
-	}
-	else
+	if (sourceDistributionColumn != NULL)
 	{
 		sourceDistributionColumnType = sourceDistributionColumn->vartype;
+		sourceDistributionColumnCollation = sourceDistributionColumn->varcollid;
 	}
 
 	/* reference tables have NULL distribution column */
 	Var *targetDistributionColumn = DistPartitionKey(targetRelationId);
-	if (targetDistributionColumn == NULL)
-	{
-		targetDistributionColumnType = InvalidOid;
-	}
-	else
+	if (targetDistributionColumn != NULL)
 	{
 		targetDistributionColumnType = targetDistributionColumn->vartype;
+		targetDistributionColumnCollation = targetDistributionColumn->varcollid;
 	}
 
 	if (sourceDistributionColumnType != targetDistributionColumnType)
@@ -597,6 +603,18 @@ CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelationId)
 		ereport(ERROR, (errmsg("cannot colocate tables %s and %s",
 							   sourceRelationName, targetRelationName),
 						errdetail("Distribution column types don't match for "
+								  "%s and %s.", sourceRelationName,
+								  targetRelationName)));
+	}
+
+	if (sourceDistributionColumnCollation != targetDistributionColumnCollation)
+	{
+		char *sourceRelationName = get_rel_name(sourceRelationId);
+		char *targetRelationName = get_rel_name(targetRelationId);
+
+		ereport(ERROR, (errmsg("cannot colocate tables %s and %s",
+							   sourceRelationName, targetRelationName),
+						errdetail("Distribution column collations don't match for "
 								  "%s and %s.", sourceRelationName,
 								  targetRelationName)));
 	}

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -375,6 +375,7 @@ CreateReferenceTableColocationId()
 {
 	int shardCount = 1;
 	Oid distributionColumnType = InvalidOid;
+	Oid distributionColumnCollation = InvalidOid;
 
 	/*
 	 * We don't maintain replication factor of reference tables anymore and
@@ -383,12 +384,15 @@ CreateReferenceTableColocationId()
 	int replicationFactor = -1;
 
 	/* check for existing colocations */
-	uint32 colocationId = ColocationId(shardCount, replicationFactor,
-									   distributionColumnType);
+	uint32 colocationId =
+		ColocationId(shardCount, replicationFactor, distributionColumnType,
+					 distributionColumnCollation);
+
 	if (colocationId == INVALID_COLOCATION_ID)
 	{
 		colocationId = CreateColocationGroup(shardCount, replicationFactor,
-											 distributionColumnType);
+											 distributionColumnType,
+											 distributionColumnCollation);
 	}
 
 	return colocationId;

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -52,6 +52,33 @@ LowestShardIntervalById(List *shardIntervalList)
 
 
 /*
+ * SortedShardIntervalArray sorts the input shardIntervalArray. Shard intervals with
+ * no min/max values are placed at the end of the array.
+ */
+ShardInterval **
+SortShardIntervalArray(ShardInterval **shardIntervalArray, int shardCount,
+					   Oid collation, FmgrInfo *shardIntervalSortCompareFunction)
+{
+	SortShardIntervalContext sortContext = {
+		.comparisonFunction = shardIntervalSortCompareFunction,
+		.collation = collation
+	};
+
+	/* short cut if there are no shard intervals in the array */
+	if (shardCount == 0)
+	{
+		return shardIntervalArray;
+	}
+
+	/* if a shard doesn't have min/max values, it's placed in the end of the array */
+	qsort_arg(shardIntervalArray, shardCount, sizeof(ShardInterval *),
+			  (qsort_arg_comparator) CompareShardIntervals, (void *) &sortContext);
+
+	return shardIntervalArray;
+}
+
+
+/*
  * CompareShardIntervals acts as a helper function to compare two shard intervals
  * by their minimum values, using the value's type comparison function.
  *
@@ -60,7 +87,7 @@ LowestShardIntervalById(List *shardIntervalList)
  */
 int
 CompareShardIntervals(const void *leftElement, const void *rightElement,
-					  FmgrInfo *typeCompareFunction)
+					  SortShardIntervalContext *sortContext)
 {
 	ShardInterval *leftShardInterval = *((ShardInterval **) leftElement);
 	ShardInterval *rightShardInterval = *((ShardInterval **) rightElement);
@@ -70,7 +97,7 @@ CompareShardIntervals(const void *leftElement, const void *rightElement,
 	bool rightHasNull = (!rightShardInterval->minValueExists ||
 						 !rightShardInterval->maxValueExists);
 
-	Assert(typeCompareFunction != NULL);
+	Assert(sortContext->comparisonFunction != NULL);
 
 	if (leftHasNull && rightHasNull)
 	{
@@ -89,7 +116,9 @@ CompareShardIntervals(const void *leftElement, const void *rightElement,
 		/* if both shard interval have min/max values, calculate comparison result */
 		Datum leftDatum = leftShardInterval->minValue;
 		Datum rightDatum = rightShardInterval->minValue;
-		Datum comparisonDatum = CompareCall2(typeCompareFunction, leftDatum, rightDatum);
+		Datum comparisonDatum = FunctionCall2Coll(sortContext->comparisonFunction,
+												  sortContext->collation, leftDatum,
+												  rightDatum);
 		comparisonResult = DatumGetInt32(comparisonDatum);
 	}
 
@@ -303,8 +332,10 @@ FindShardIntervalIndex(Datum searchedValue, DistTableCacheEntry *cacheEntry)
 		{
 			Assert(compareFunction != NULL);
 
+			Oid shardIntervalCollation = cacheEntry->partitionColumn->varcollid;
 			shardIndex = SearchCachedShardInterval(searchedValue, shardIntervalCache,
-												   shardCount, compareFunction);
+												   shardCount, shardIntervalCollation,
+												   compareFunction);
 
 			/* we should always return a valid shard index for hash partitioned tables */
 			if (shardIndex == INVALID_SHARD_INDEX)
@@ -345,8 +376,10 @@ FindShardIntervalIndex(Datum searchedValue, DistTableCacheEntry *cacheEntry)
 	{
 		Assert(compareFunction != NULL);
 
+		Oid shardIntervalCollation = cacheEntry->partitionColumn->varcollid;
 		shardIndex = SearchCachedShardInterval(searchedValue, shardIntervalCache,
-											   shardCount, compareFunction);
+											   shardCount, shardIntervalCollation,
+											   compareFunction);
 	}
 
 	return shardIndex;
@@ -370,7 +403,8 @@ FindShardIntervalIndex(Datum searchedValue, DistTableCacheEntry *cacheEntry)
  */
 int
 SearchCachedShardInterval(Datum partitionColumnValue, ShardInterval **shardIntervalCache,
-						  int shardCount, FmgrInfo *compareFunction)
+						  int shardCount, Oid shardIntervalCollation,
+						  FmgrInfo *compareFunction)
 {
 	int lowerBoundIndex = 0;
 	int upperBoundIndex = shardCount;
@@ -380,7 +414,7 @@ SearchCachedShardInterval(Datum partitionColumnValue, ShardInterval **shardInter
 		int middleIndex = (lowerBoundIndex + upperBoundIndex) / 2;
 
 		int minValueComparison = FunctionCall2Coll(compareFunction,
-												   DEFAULT_COLLATION_OID,
+												   shardIntervalCollation,
 												   partitionColumnValue,
 												   shardIntervalCache[middleIndex]->
 												   minValue);
@@ -392,7 +426,7 @@ SearchCachedShardInterval(Datum partitionColumnValue, ShardInterval **shardInter
 		}
 
 		int maxValueComparison = FunctionCall2Coll(compareFunction,
-												   DEFAULT_COLLATION_OID,
+												   shardIntervalCollation,
 												   partitionColumnValue,
 												   shardIntervalCache[middleIndex]->
 												   maxValue);

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -25,9 +25,11 @@ extern List * ColocatedTableList(Oid distributedTableId);
 extern List * ColocatedShardIntervalList(ShardInterval *shardInterval);
 extern Oid ColocatedTableId(Oid colocationId);
 extern uint64 ColocatedShardIdInRelation(Oid relationId, int shardIndex);
-uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType);
+uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType,
+					Oid distributionColumnCollation);
 extern uint32 CreateColocationGroup(int shardCount, int replicationFactor,
-									Oid distributionColumnType);
+									Oid distributionColumnType,
+									Oid distributionColumnCollation);
 extern uint32 GetNextColocationId(void);
 extern void CheckReplicationModel(Oid sourceRelationId, Oid targetRelationId);
 extern void CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelationId);

--- a/src/include/distributed/pg_dist_colocation.h
+++ b/src/include/distributed/pg_dist_colocation.h
@@ -22,6 +22,7 @@ typedef struct FormData_pg_dist_colocation
 	uint32 shardcount;
 	uint32 replicationfactor;
 	Oid distributioncolumntype;
+	Oid distributioncolumncollation;
 } FormData_pg_dist_colocation;
 
 /* ----------------
@@ -35,11 +36,12 @@ typedef FormData_pg_dist_colocation *Form_pg_dist_colocation;
  *      compiler constants for pg_dist_colocation
  * ----------------
  */
-#define Natts_pg_dist_colocation 4
+#define Natts_pg_dist_colocation 5
 #define Anum_pg_dist_colocation_colocationid 1
 #define Anum_pg_dist_colocation_shardcount 2
 #define Anum_pg_dist_colocation_replicationfactor 3
 #define Anum_pg_dist_colocation_distributioncolumntype 4
+#define Anum_pg_dist_colocation_distributioncolumncollation 5
 
 #define COLOCATIONID_SEQUENCE_NAME "pg_dist_colocationid_seq"
 

--- a/src/include/distributed/shardinterval_utils.h
+++ b/src/include/distributed/shardinterval_utils.h
@@ -26,9 +26,21 @@ typedef struct ShardIntervalCompareFunctionCacheEntry
 	FmgrInfo *functionInfo;
 } ShardIntervalCompareFunctionCacheEntry;
 
+/*
+ * SortShardIntervalContext is the context parameter in SortShardIntervalArray
+ */
+typedef struct SortShardIntervalContext
+{
+	FmgrInfo *comparisonFunction;
+	Oid collation;
+} SortShardIntervalContext;
+
+extern ShardInterval ** SortShardIntervalArray(ShardInterval **shardIntervalArray, int
+											   shardCount, Oid collation,
+											   FmgrInfo *shardIntervalSortCompareFunction);
 extern ShardInterval * LowestShardIntervalById(List *shardIntervalList);
 extern int CompareShardIntervals(const void *leftElement, const void *rightElement,
-								 FmgrInfo *typeCompareFunction);
+								 SortShardIntervalContext *sortContext);
 extern int CompareShardIntervalsById(const void *leftElement, const void *rightElement);
 extern int CompareShardPlacementsByShardId(const void *leftElement, const
 										   void *rightElement);
@@ -40,7 +52,8 @@ extern ShardInterval * FindShardInterval(Datum partitionColumnValue,
 extern int FindShardIntervalIndex(Datum searchedValue, DistTableCacheEntry *cacheEntry);
 extern int SearchCachedShardInterval(Datum partitionColumnValue,
 									 ShardInterval **shardIntervalCache,
-									 int shardCount, FmgrInfo *compareFunction);
+									 int shardCount, Oid shardIntervalCollation,
+									 FmgrInfo *compareFunction);
 extern bool SingleReplicatedTable(Oid relationId);
 
 

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -82,7 +82,6 @@ typedef struct HashPartitionContext
 	FmgrInfo *comparisonFunction;
 	ShardInterval **syntheticShardIntervalArray;
 	uint32 partitionCount;
-	Oid collation;
 	bool hasUniformHashDistribution;
 } HashPartitionContext;
 
@@ -137,7 +136,6 @@ extern StringInfo UserTaskFilename(StringInfo directoryName, uint32 taskId);
 extern List * ColumnDefinitionList(List *columnNameList, List *columnTypeList);
 extern CreateStmt * CreateStatement(RangeVar *relation, List *columnDefinitionList);
 extern CopyStmt * CopyStatement(RangeVar *relation, char *sourceFilename);
-extern Datum CompareCall2(FmgrInfo *funcInfo, Datum leftArgument, Datum rightArgument);
 
 /* Function declaration for parsing tree node */
 extern Node * ParseTreeNode(const char *ddlCommand);

--- a/src/test/regress/expected/distributed_collations.out
+++ b/src/test/regress/expected/distributed_collations.out
@@ -53,6 +53,34 @@ SELECT * FROM collation_tests.test_propagate WHERE t2 < 'b' COLLATE "C";
   2 | Voẞr | Vossr
 (1 row)
 
+-- Test range table with collated distribution column
+CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
+SELECT create_distributed_table('test_range', 'key', 'range');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT master_create_empty_shard('test_range') AS new_shard_id
+\gset
+UPDATE pg_dist_shard SET shardminvalue = 'a', shardmaxvalue = 'f'
+WHERE shardid = :new_shard_id;
+SELECT master_create_empty_shard('test_range') AS new_shard_id
+\gset
+UPDATE pg_dist_shard SET shardminvalue = 'G', shardmaxvalue = 'Z'
+WHERE shardid = :new_shard_id;
+-- without german_phonebook collation, this would fail
+INSERT INTO test_range VALUES (U&'\00E4sop', 1), (U&'Vo\1E9Er', 2);
+-- without german_phonebook collation, this would not be router executable
+SET client_min_messages TO debug;
+SELECT * FROM test_range WHERE key > 'Ab' AND key < U&'\00E4z';
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ key  | val 
+------+-----
+ äsop |   1
+(1 row)
+
 \c - - - :worker_1_port
 SELECT c.collname, nsp.nspname, a.rolname
 FROM pg_collation c

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -431,13 +431,13 @@ NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
 SELECT * FROM pg_dist_colocation 
     WHERE colocationid >= 1 AND colocationid < 1000 
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            3 |          4 |                 2 |                     23
-            4 |          2 |                 2 |                     23
-            5 |          2 |                 1 |                     23
-            6 |          2 |                 2 |                     25
-            7 |          8 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            3 |          4 |                 2 |                     23 |                           0
+            4 |          2 |                 2 |                     23 |                           0
+            5 |          2 |                 1 |                     23 |                           0
+            6 |          2 |                 2 |                     25 |                         100
+            7 |          8 |                 2 |                     23 |                           0
 (5 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
@@ -459,17 +459,17 @@ SELECT logicalrelid, colocationid FROM pg_dist_partition
 -- check effects of dropping tables
 DROP TABLE table1_groupA;
 SELECT * FROM pg_dist_colocation WHERE colocationid = 4;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            4 |          2 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            4 |          2 |                 2 |                     23 |                           0
 (1 row)
 
 -- dropping all tables in a colocation group also deletes the colocation group
 DROP TABLE table2_groupA;
 SELECT * FROM pg_dist_colocation WHERE colocationid = 4;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            4 |          2 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            4 |          2 |                 2 |                     23 |                           0
 (1 row)
 
 -- create dropped colocation group again
@@ -555,14 +555,14 @@ SELECT create_distributed_table('table1_group_default', 'id', colocate_with => '
 SELECT * FROM pg_dist_colocation
     WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            3 |          4 |                 2 |                     23
-            4 |          2 |                 2 |                     23
-            5 |          2 |                 1 |                     23
-            6 |          2 |                 2 |                     25
-            7 |          8 |                 2 |                     23
-           11 |          3 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            3 |          4 |                 2 |                     23 |                           0
+            4 |          2 |                 2 |                     23 |                           0
+            5 |          2 |                 1 |                     23 |                           0
+            6 |          2 |                 2 |                     25 |                         100
+            7 |          8 |                 2 |                     23 |                           0
+           11 |          3 |                 2 |                     23 |                           0
 (6 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
@@ -650,14 +650,14 @@ SELECT create_reference_table('table2_groupF');
 SELECT * FROM pg_dist_colocation
     WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            3 |          4 |                 2 |                     23
-            4 |          2 |                 2 |                     23
-            5 |          2 |                 1 |                     23
-            6 |          2 |                 2 |                     25
-            7 |          8 |                 2 |                     23
-           11 |          3 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            3 |          4 |                 2 |                     23 |                           0
+            4 |          2 |                 2 |                     23 |                           0
+            5 |          2 |                 1 |                     23 |                           0
+            6 |          2 |                 2 |                     25 |                         100
+            7 |          8 |                 2 |                     23 |                           0
+           11 |          3 |                 2 |                     23 |                           0
 (6 rows)
 
 -- cross check with internal colocation API
@@ -839,8 +839,8 @@ UPDATE pg_dist_partition SET colocationid = 0
 SELECT * FROM pg_dist_colocation
     WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
 (0 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
@@ -870,8 +870,8 @@ DETAIL:  Shard counts don't match for table1_groupb and table1_groupd.
 SELECT * FROM pg_dist_colocation
     WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
 (0 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
@@ -938,12 +938,12 @@ SELECT create_distributed_table('table2_group_none', 'id', colocate_with => 'NON
 SELECT * FROM pg_dist_colocation 
     WHERE colocationid >= 1 AND colocationid < 1000 
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            2 |          2 |                 1 |                     23
-            3 |          2 |                 2 |                     25
-            4 |          8 |                 2 |                     23
-            5 |          2 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            2 |          2 |                 1 |                     23 |                           0
+            3 |          2 |                 2 |                     25 |                         100
+            4 |          8 |                 2 |                     23 |                           0
+            5 |          2 |                 2 |                     23 |                           0
 (4 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition
@@ -982,11 +982,11 @@ SELECT mark_tables_colocated('table1_group_none', ARRAY['table2_group_none']);
 SELECT * FROM pg_dist_colocation
     WHERE colocationid >= 1 AND colocationid < 1000
     ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-            2 |          2 |                 1 |                     23
-            3 |          2 |                 2 |                     25
-            4 |          8 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+            2 |          2 |                 1 |                     23 |                           0
+            3 |          2 |                 2 |                     25 |                         100
+            4 |          8 |                 2 |                     23 |                           0
 (3 rows)
 
 SELECT logicalrelid, colocationid FROM pg_dist_partition

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -295,8 +295,8 @@ SELECT "Column", "Type", "Definition" FROM index_attrs WHERE
 
 -- Check that pg_dist_colocation is not synced
 SELECT * FROM pg_dist_colocation ORDER BY colocationid;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
 (0 rows)
 
 -- Make sure that truncate trigger has been set for the MX table on worker

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -140,9 +140,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -193,9 +193,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -273,9 +273,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -329,9 +329,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -378,9 +378,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -433,9 +433,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -489,9 +489,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -545,9 +545,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 --verify the data is inserted
@@ -614,9 +614,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -670,9 +670,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -735,9 +735,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 BEGIN;
@@ -767,8 +767,8 @@ WHERE
 (0 rows)
 
 SELECT * FROM pg_dist_colocation WHERE colocationid = 1380000;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
 (0 rows)
 
 -- re-add the node for next tests
@@ -822,9 +822,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table_schema.table1'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -878,9 +878,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table_schema.table1'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -938,9 +938,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port
@@ -993,9 +993,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 \c - - - :worker_1_port

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -116,9 +116,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -147,9 +147,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 -- test add same node twice
@@ -172,9 +172,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -202,9 +202,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 DROP TABLE replicate_reference_table_valid;
@@ -240,9 +240,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 BEGIN;
@@ -272,9 +272,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 DROP TABLE replicate_reference_table_rollback;
@@ -304,9 +304,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 BEGIN;
@@ -337,9 +337,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 DROP TABLE replicate_reference_table_commit;
@@ -387,9 +387,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT colocationid AS reference_table_colocationid FROM pg_dist_colocation WHERE distributioncolumntype = 0 \gset
@@ -448,9 +448,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT
@@ -545,9 +545,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_drop'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 BEGIN;
@@ -573,8 +573,8 @@ ORDER BY shardid, nodeport;
 (0 rows)
 
 SELECT * FROM pg_dist_colocation WHERE colocationid = 1370009;
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
 (0 rows)
 
 -- test adding a node while there is a reference table at another schema
@@ -610,9 +610,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -641,9 +641,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 DROP TABLE replicate_reference_table_schema.table1;

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -155,8 +155,8 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
 (0 rows)
 
 SELECT count(*) active_primaries FROM pg_dist_node WHERE isactive AND noderole='primary' \gset
@@ -209,9 +209,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT
@@ -267,9 +267,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360001 |          1 |                 1 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360001 |          1 |                 1 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -321,9 +321,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT
@@ -381,9 +381,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360002 |          1 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360002 |          1 |                 2 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -436,9 +436,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT
@@ -494,9 +494,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360003 |          1 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360003 |          1 |                 2 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -548,9 +548,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT
@@ -607,9 +607,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360004 |          1 |                 1 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -663,9 +663,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360004 |          1 |                 1 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -722,9 +722,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360004 |          1 |                 1 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -778,9 +778,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT
@@ -848,9 +848,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360005 |          1 |                 1 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360005 |          1 |                 1 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -899,9 +899,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360005 |          1 |                 1 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360005 |          1 |                 1 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -968,9 +968,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360006 |          1 |                 2 |                     23
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+      1360006 |          1 |                 2 |                     23 |                           0
 (1 row)
 
 SELECT
@@ -1023,9 +1023,9 @@ WHERE colocationid IN
     (SELECT colocationid
      FROM pg_dist_partition
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                -1 |                      0
+ colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation 
+--------------+------------+-------------------+------------------------+-----------------------------
+        10004 |          1 |                -1 |                      0 |                           0
 (1 row)
 
 SELECT

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -365,8 +365,40 @@ SELECT DISTINCT y FROM test;
  25
 (1 row)
 
+-- non deterministic collations
+CREATE COLLATION test_pg12.case_insensitive (
+	provider = icu,
+	locale = 'und-u-ks-level2',
+	deterministic = false
+);
+CREATE TABLE col_test (
+	id int,
+	val text collate case_insensitive
+);
+insert into col_test values
+	(1, 'asdF'), (2, 'vAlue'), (3, 'asDF');
+-- Hash distribution of non deterministic collations are unsupported
+select create_distributed_table('col_test', 'val');
+ERROR:  Hash distributed partition columns may not use a non deterministic collation
+select create_distributed_table('col_test', 'id');
+NOTICE:  Copying data from local table...
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into col_test values
+	(4, 'vALue'), (5, 'AsDf'), (6, 'value');
+select count(*)
+from col_test
+where val = 'asdf';
+ count 
+-------
+     3
+(1 row)
+
 \set VERBOSITY terse
 drop schema test_pg12 cascade;
-NOTICE:  drop cascades to 11 other objects
+NOTICE:  drop cascades to 13 other objects
 \set VERBOSITY default
 SET citus.shard_replication_factor to 2;

--- a/src/test/regress/sql/distributed_collations.sql
+++ b/src/test/regress/sql/distributed_collations.sql
@@ -35,6 +35,26 @@ SELECT create_distributed_table('test_propagate', 'id');
 SELECT * FROM collation_tests.test_propagate WHERE t2 < 'b';
 SELECT * FROM collation_tests.test_propagate WHERE t2 < 'b' COLLATE "C";
 
+-- Test range table with collated distribution column
+CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
+SELECT create_distributed_table('test_range', 'key', 'range');
+SELECT master_create_empty_shard('test_range') AS new_shard_id
+\gset
+UPDATE pg_dist_shard SET shardminvalue = 'a', shardmaxvalue = 'f'
+WHERE shardid = :new_shard_id;
+
+SELECT master_create_empty_shard('test_range') AS new_shard_id
+\gset
+UPDATE pg_dist_shard SET shardminvalue = 'G', shardmaxvalue = 'Z'
+WHERE shardid = :new_shard_id;
+
+-- without german_phonebook collation, this would fail
+INSERT INTO test_range VALUES (U&'\00E4sop', 1), (U&'Vo\1E9Er', 2);
+
+-- without german_phonebook collation, this would not be router executable
+SET client_min_messages TO debug;
+SELECT * FROM test_range WHERE key > 'Ab' AND key < U&'\00E4z';
+
 \c - - - :worker_1_port
 SELECT c.collname, nsp.nspname, a.rolname
 FROM pg_collation c


### PR DESCRIPTION
DESCRIPTION: Respect collations on distribution columns. Do not allow non-deterministic collations to be hash distributed

Initially started with wanting to test non deterministic collations, found out we don't properly support collations on partition columns at all. ICU's hashing changes with every version, so this rejects using non deterministic collations for hash distribution

Tried coming up with tests for https://github.com/citusdata/citus/commit/be3285828f17c8841d649361edc2aa3dd094f0cb

This causes tests to require compiling postgres with `--with-icu`

`CREATE COLLATION` is not currently being propagated. I'd like to wait for #2882 to properly implement that

Involved having tables with different collations on their distribution keys not be colocated