### PR TITLE
Update year as 2012-2019

### DIFF
--- a/configure
+++ b/configure
@@ -9,7 +9,7 @@
 # This configure script is free software; the Free Software Foundation
 # gives unlimited permission to copy, distribute and modify it.
 #
-# Copyright (c) 2012-2017, Citus Data, Inc.
+# Copyright (c) 2012-2019, Citus Data, Inc.
 ## -------------------- ##
 ## M4sh Initialization. ##
 ## -------------------- ##
@@ -1408,7 +1408,7 @@ Copyright (C) 2012 Free Software Foundation, Inc.
 This configure script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it.
 
-Copyright (c) 2012-2017, Citus Data, Inc.
+Copyright (c) 2012-2019, Citus Data, Inc.
 _ACEOF
   exit
 fi

--- a/configure.in
+++ b/configure.in
@@ -6,7 +6,7 @@
 # into the SCM.
 
 AC_INIT([Citus], [8.4devel])
-AC_COPYRIGHT([Copyright (c) 2012-2017, Citus Data, Inc.])
+AC_COPYRIGHT([Copyright (c) 2012-2019, Citus Data, Inc.])
 
 # we'll need sed and awk for some of the version commands
 AC_PROG_SED

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -3,7 +3,7 @@
  * create_distributed_relation.c
  *	  Routines relation to the creation of distributed relations.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/drop_distributed_table.c
+++ b/src/backend/distributed/commands/drop_distributed_table.c
@@ -3,7 +3,7 @@
  * drop_distributed_table.c
  *	  Routines related to dropping distributed relations from a trigger.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/transmit.c
+++ b/src/backend/distributed/commands/transmit.c
@@ -3,7 +3,7 @@
  * transmit.c
  *	  Routines for transmitting regular files between two nodes.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -21,7 +21,7 @@
  * ProcessUtility, which will plan the query via the distributed planner
  * hook.
  *
- * Copyright (c) 2012-2018, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -4,7 +4,7 @@
  *
  * Definitions of custom scan methods for all executor types.
  *
- * Copyright (c) 2012-2017, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"

--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -5,7 +5,7 @@
  * This file contains the libpq-specific parts of executing queries on remote
  * nodes.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -4,7 +4,7 @@
  *
  * Entrypoint into distributed query execution.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -8,7 +8,7 @@
  * the results that are fetched from a single worker is sent to the output console
  * directly. Lastly, router executor can only execute a single task.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  */
 
 #include "postgres.h" /* IWYU pragma: keep */

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -7,7 +7,7 @@
  * routines are implement backend-side logic; and they trigger executions
  * on the client-side via function hooks that they load.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/executor/query_stats.c
+++ b/src/backend/distributed/executor/query_stats.c
@@ -3,7 +3,7 @@
  * query_stats.c
  *    Statement-level statistics for distributed queries.
  *
- * Copyright (c) 2012-2018, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -9,7 +9,7 @@
  * one-phase or two-phase fashion, depending on the citus.multi_shard_commit_protocol
  * setting.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -4,7 +4,7 @@
  *	  Routines for requesting information from the master node for creating or
  *	  updating shards.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -4,7 +4,7 @@
  *	  Routines for reading worker nodes from membership file, and allocating
  *	  candidate nodes for shard placement.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -3,7 +3,7 @@
  * distributed_planner.c
  *	  General Citus planner code.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -3,7 +3,7 @@
  * multi_explain.c
  *	  Citus explain support.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -4,7 +4,7 @@
  *
  * Routines for constructing the join order list using a rule-based approach.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -4,7 +4,7 @@
  *	  Routines for optimizing logical plan trees based on multi-relational
  *	  algebra.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -5,7 +5,7 @@
  * Routines for constructing a logical plan tree from the given Query tree
  * structure. This new logical plan is based on multi-relational algebra rules.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/planner/multi_master_planner.c
+++ b/src/backend/distributed/planner/multi_master_planner.c
@@ -4,7 +4,7 @@
  *	  Routines for building create table and select into table statements on the
  *	  master node.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4,7 +4,7 @@
  *	  Routines for creating physical plans from given multi-relational algebra
  *	  trees.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -5,7 +5,7 @@
  * Routines for handling DDL statements that relate to relay files. These
  * routines extend relation, index and constraint names in utility commands.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -3,7 +3,7 @@
  * shared_library_init.c
  *	  Functionality related to the initialization of the Citus extension.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 1996-2014, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
- * Portions Copyright (c) 2012-2017, Citus Data, Inc.
+ * Portions Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/citus_nodefuncs.c
+++ b/src/backend/distributed/utils/citus_nodefuncs.c
@@ -3,7 +3,7 @@
  * citus_nodefuncs.c
  *	  Helper functions for dealing with nodes
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 1996-2014, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
- * Portions Copyright (c) 2012-2016, Citus Data, Inc.
+ * Portions Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * NOTES
  *	  This is a wrapper around postgres' nodeToString() that additionally

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 1996-2014, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
- * Portions Copyright (c) 2012-2015, Citus Data, Inc.
+ * Portions Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/citus_ruleutils.c
+++ b/src/backend/distributed/utils/citus_ruleutils.c
@@ -3,7 +3,7 @@
  * citus_ruleutils.c
  *	  Version independent ruleutils wrapper
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/utils/function_utils.c
+++ b/src/backend/distributed/utils/function_utils.c
@@ -3,7 +3,7 @@
  * function_utils.c
  *	  Utilities regarding calls to PG functions
  *
- * Copyright (c) 2012-2018, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -3,7 +3,7 @@
  * metadata_cache.c
  *	  Distributed table metadata cache
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/utils/multi_resowner.c
+++ b/src/backend/distributed/utils/multi_resowner.c
@@ -10,7 +10,7 @@
  * probably rather use a hash table using the pointer value of the resource
  * owner as key.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/utils/node_metadata.c
+++ b/src/backend/distributed/utils/node_metadata.c
@@ -2,7 +2,7 @@
  * node_metadata.c
  *	  Functions that operate on pg_dist_node
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  */
 #include "postgres.h"
 #include "miscadmin.h"

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -9,7 +9,7 @@
  * advisory locks, but luckily advisory locks only two values for 'field4' in
  * the locktag.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/backend/distributed/worker/task_tracker.c
+++ b/src/backend/distributed/worker/task_tracker.c
@@ -18,7 +18,7 @@
  * For details on how the task tracker manages resources during process start-up
  * and shutdown, please see the writeboard on our Basecamp project website.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -6,7 +6,7 @@
  * routines allow for the master node to assign tasks to the task tracker, check
  * these tasks' statuses, and remove these tasks when they are no longer needed.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -5,7 +5,7 @@
  * Routines for fetching remote resources from other nodes to this worker node,
  * and materializing these resources on this node if necessary.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/worker/worker_file_access_protocol.c
+++ b/src/backend/distributed/worker/worker_file_access_protocol.c
@@ -4,7 +4,7 @@
  *
  * Routines for accessing file related information on this worker node.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/worker/worker_merge_protocol.c
+++ b/src/backend/distributed/worker/worker_merge_protocol.c
@@ -6,7 +6,7 @@
  * files is one of the threee distributed execution primitives that we apply on
  * worker nodes.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -7,7 +7,7 @@
  * nodes; and when partitioning data, we follow Hadoop's naming conventions as
  * much as possible.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -4,7 +4,7 @@
  * Implements the functions for hiding shards on the Citus MX
  * worker (data) nodes.
  *
- * Copyright (c) 2012-2018, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  */
 
 #include "postgres.h"

--- a/src/backend/distributed/worker/worker_sql_task_protocol.c
+++ b/src/backend/distributed/worker/worker_sql_task_protocol.c
@@ -4,7 +4,7 @@
  *
  * Routines for executing SQL tasks during task-tracker execution.
  *
- * Copyright (c) 2012-2018, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/citus_clauses.h
+++ b/src/include/distributed/citus_clauses.h
@@ -3,7 +3,7 @@
  * citus_clauses.h
  *  Routines roughly equivalent to postgres' util/clauses.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/citus_custom_scan.h
+++ b/src/include/distributed/citus_custom_scan.h
@@ -3,7 +3,7 @@
  * citus_custom_scan.h
  *	  Export all custom scan and custom exec methods.
  *
- * Copyright (c) 2012-2017, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/citus_nodefuncs.h
+++ b/src/include/distributed/citus_nodefuncs.h
@@ -3,7 +3,7 @@
  * citus_nodefuncs.h
  *	  Node (de-)serialization support for Citus.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/citus_nodes.h
+++ b/src/include/distributed/citus_nodes.h
@@ -23,7 +23,7 @@
  *   * Use DEFINE_NODE_METHODS within the nodeMethods array (near the
  *     bottom of citus_nodefuncs.c) to register the node in PostgreSQL
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -4,7 +4,7 @@
  *	  Citus ruleutils wrapper functions and exported PostgreSQL ruleutils
  *	  functions.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -3,7 +3,7 @@
  * utility_hook.h
  *	  Citus utility hook and related functionality.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -3,7 +3,7 @@
  * distributed_planner.h
  *	  General Citus planner code.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/function_utils.h
+++ b/src/include/distributed/function_utils.h
@@ -3,7 +3,7 @@
  * function_utils.h
  *	  Utilities regarding calls to PG functions
  *
- * Copyright (c) 2012-2018, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -4,7 +4,7 @@
  *	  Header for shared declarations for access to master node data. These data
  *	  are used to create new shards or update existing ones.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -3,7 +3,7 @@
  * metadata_cache.h
  *	  Executor support for Citus.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/multi_client_executor.h
+++ b/src/include/distributed/multi_client_executor.h
@@ -4,7 +4,7 @@
  *	  Type and function pointer declarations for executing client-side (libpq)
  *	  logic.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -3,7 +3,7 @@
  * multi_executor.h
  *	  Executor support for Citus.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -3,7 +3,7 @@
  * multi_explain.h
  *	  Explain support for Citus.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/multi_join_order.h
+++ b/src/include/distributed/multi_join_order.h
@@ -5,7 +5,7 @@
  * Type and function declarations for determining a left-only join order for a
  * distributed query plan.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/multi_logical_optimizer.h
+++ b/src/include/distributed/multi_logical_optimizer.h
@@ -4,7 +4,7 @@
  *	  Type and function declarations for optimizing multi-relation based logical
  *	  plans.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -4,7 +4,7 @@
  *	  Type declarations for multi-relational algebra operators, and function
  *	  declarations for building logical plans over distributed relations.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/multi_master_planner.h
+++ b/src/include/distributed/multi_master_planner.h
@@ -4,7 +4,7 @@
  *	  Function declarations for building planned statements; these statements
  *	  are then executed on the master node.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -4,7 +4,7 @@
  *	  Type and function declarations used in creating the distributed execution
  *	  plan.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/multi_resowner.h
+++ b/src/include/distributed/multi_resowner.h
@@ -3,7 +3,7 @@
  * multi_resowner.h
  *	  Citus resource owner integration.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 #ifndef MULTI_RESOWNER_H

--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -4,7 +4,7 @@
  *	  Type and function declarations for executing remote jobs from a backend;
  *	  the ensemble of these jobs form the distributed execution plan.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -3,7 +3,7 @@
  * pg_dist_node.h
  *	  definition of the relation that holds the nodes on the cluster (pg_dist_node).
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/pg_dist_partition.h
+++ b/src/include/distributed/pg_dist_partition.h
@@ -7,7 +7,7 @@
  * partitioning for (smaller physical tables that we partition data to are
  * handled in another system catalog).
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/pg_dist_placement.h
+++ b/src/include/distributed/pg_dist_placement.h
@@ -9,7 +9,7 @@
  * the master reconciles these shard reports, and determines outdated, under-
  * and over-replicated shards.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/pg_dist_shard.h
+++ b/src/include/distributed/pg_dist_shard.h
@@ -8,7 +8,7 @@
  * concerning the creation, deletion, merging, and split of remote partitions
  * reference this table.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/relay_utility.h
+++ b/src/include/distributed/relay_utility.h
@@ -5,7 +5,7 @@
  * Header and type declarations that extend relation, index and constraint names
  * with the appropriate shard identifiers.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id:$
  *

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -3,7 +3,7 @@
  * resource_lock.h
  *	  Locking Infrastructure for Citus.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 

--- a/src/include/distributed/task_tracker.h
+++ b/src/include/distributed/task_tracker.h
@@ -5,7 +5,7 @@
  * Header and type declarations for coordinating execution of tasks and data
  * source transfers on worker nodes.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/task_tracker_protocol.h
+++ b/src/include/distributed/task_tracker_protocol.h
@@ -5,7 +5,7 @@
  * Header and type declarations for assigning tasks to and removing tasks from
  * the task tracker running on this node.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/transmit.h
+++ b/src/include/distributed/transmit.h
@@ -3,7 +3,7 @@
  * transmit.h
  *	  Shared declarations for transmitting files between remote nodes.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -4,7 +4,7 @@
  *	  Header and type declarations for managing worker nodes and for placing
  *	  shards on worker nodes in an intelligent manner.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -4,7 +4,7 @@
  *	  Header for shared declarations that are used for caching remote resources
  *	  on worker nodes, and also for applying distributed execution primitives.
  *
- * Copyright (c) 2012-2016, Citus Data, Inc.
+ * Copyright (c) 2012-2019, Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -3,7 +3,7 @@
 #
 # pg_regress_multi.pl - Test runner for Citus
 #
-# Portions Copyright (c) 2012-2016, Citus Data, Inc.
+# Portions Copyright (c) 2012-2019, Citus Data, Inc.
 # Portions Copyright (c) 1996-2015, PostgreSQL Global Development Group
 # Portions Copyright (c) 1994, Regents of the University of California
 #


### PR DESCRIPTION
This PR updates all outdated years as `2012-2019`.

The following command from the root is used for updating:
`grep -rli '2012-2015' * | xargs -i@ sed -i 's/2012-2015/2012-2019/g' @`
`grep -rli '2012-2016' * | xargs -i@ sed -i 's/2012-2016/2012-2019/g' @`
`grep -rli '2012-2017' * | xargs -i@ sed -i 's/2012-2017/2012-2019/g' @`
`grep -rli '2012-2018' * | xargs -i@ sed -i 's/2012-2018/2012-2019/g' @`