### PR TITLE
create_distributed_table: include COLLATE on columns

### DIFF
--- a/src/backend/distributed/utils/citus_ruleutils.c
+++ b/src/backend/distributed/utils/citus_ruleutils.c
@@ -8,7 +8,6 @@
  */
 
 #include "postgres.h"
-#include "c.h"
 #include "miscadmin.h"
 
 #include <stddef.h>
@@ -28,6 +27,7 @@
 #include "catalog/pg_attribute.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_class.h"
+#include "catalog/pg_collation.h"
 #include "catalog/pg_extension.h"
 #include "catalog/pg_foreign_data_wrapper.h"
 #include "catalog/pg_index.h"
@@ -379,6 +379,13 @@ pg_get_tableschemadef_string(Oid tableRelationId, bool includeSequenceDefaults)
 			if (attributeForm->attnotnull)
 			{
 				appendStringInfoString(&buffer, " NOT NULL");
+			}
+
+			if (attributeForm->attcollation != InvalidOid &&
+				attributeForm->attcollation != DEFAULT_COLLATION_OID)
+			{
+				appendStringInfo(&buffer, " COLLATE %s", generate_collation_name(
+									 attributeForm->attcollation));
 			}
 		}
 	}

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -448,6 +448,13 @@ CREATE TABLE test_schema_support.nation_hash_collation(
     n_regionkey integer not null,
     n_comment varchar(152)
 );
+SELECT master_get_table_ddl_events('test_schema_support.nation_hash_collation') ORDER BY 1;
+                                                                                               master_get_table_ddl_events                                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ ALTER TABLE test_schema_support.nation_hash_collation OWNER TO postgres
+ CREATE TABLE test_schema_support.nation_hash_collation (n_nationkey integer NOT NULL, n_name character(25) NOT NULL COLLATE test_schema_support.english, n_regionkey integer NOT NULL, n_comment character varying(152))
+(2 rows)
+
 SELECT master_create_distributed_table('test_schema_support.nation_hash_collation', 'n_nationkey', 'hash');
  master_create_distributed_table 
 ---------------------------------

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -338,6 +338,7 @@ CREATE TABLE test_schema_support.nation_hash_collation(
     n_regionkey integer not null,
     n_comment varchar(152)
 );
+SELECT master_get_table_ddl_events('test_schema_support.nation_hash_collation') ORDER BY 1;
 SELECT master_create_distributed_table('test_schema_support.nation_hash_collation', 'n_nationkey', 'hash');
 SELECT master_create_worker_shards('test_schema_support.nation_hash_collation', 4, 2);
 


### PR DESCRIPTION
DESCRIPTION: Propagate column collation in create_distributed_table

Fixes issue noticed in #2907 
