### PR TITLE
Use gcc .d file support to recompile files when header files change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Global excludes across all subdirectories
+*.d
 *.o
 *.so
 *.so.[0-9]

--- a/Makefile.global.in
+++ b/Makefile.global.in
@@ -68,8 +68,8 @@ ifneq (@FLEX@,)
 endif
 
 # Add options passed to configure or computed therein, to CFLAGS/CPPFLAGS/...
-override CFLAGS += @CFLAGS@ @CITUS_CFLAGS@
-override CPPFLAGS := @CPPFLAGS@ @CITUS_CPPFLAGS@ -I '${citus_abs_top_srcdir}/src/include' -I'${citus_top_builddir}/src/include' $(CPPFLAGS)
+override CFLAGS += @CFLAGS@ $(DEPFLAGS) @CITUS_CFLAGS@
+override CPPFLAGS := @CPPFLAGS@ $(DEPFLAGS) @CITUS_CPPFLAGS@ -I '${citus_abs_top_srcdir}/src/include' -I'${citus_top_builddir}/src/include' $(CPPFLAGS)
 override LDFLAGS += @LDFLAGS@ @CITUS_LDFLAGS@
 
 # optional file with user defined, additional, rules

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -24,6 +24,12 @@ NO_PGXS = 1
 
 SHLIB_LINK = $(libpq)
 
+DEPFLAGS = -MMD -MP
+
+EXTRA_CLEAN = $(wildcard *.d */*.d)
+
+include $(wildcard *.d */*.d)
+
 include $(citus_top_builddir)/Makefile.global
 
 SHLIB_LINK += $(filter -lssl -lcrypto -lssleay32 -leay32, $(LIBS))


### PR DESCRIPTION
DESCRIPTION: Recompile .c files automatically when an included .h file changes

This uses the `-MMD` and `-MP` flags to create `.d` files when compiling a
`.c` file as well. These `.d` files are tiny makefiles that record all the
dependencies of the respective `.c` file. This way a `.c` file will be
recompiled whenever you change one of the `.h` files that it includes. So, the
main advantage of this is not having to run `make clean` whenever you change an
`.h` file .

These flags are supported both by GCC and Clang. I'm not sure if we support any
other compilers. If so, I'm not sure what the right way is to enable them
conditionally.