### PR TITLE
Remove CheckForUpdates

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -329,15 +329,6 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 				FlushDistTableCache();
 				WarnIfSyncDNS();
 				statsCollectionSuccess = CollectBasicUsageStatistics();
-				if (statsCollectionSuccess)
-				{
-					/*
-					 * Checking for updates only when collecting statistics succeeds,
-					 * so we don't log update messages twice when we retry statistics
-					 * collection in a minute.
-					 */
-					CheckForUpdates();
-				}
 			}
 
 			/*

--- a/src/include/distributed/statistics_collection.h
+++ b/src/include/distributed/statistics_collection.h
@@ -32,7 +32,6 @@ extern bool EnableStatisticsCollection;
 
 extern void WarnIfSyncDNS(void);
 extern bool CollectBasicUsageStatistics(void);
-extern void CheckForUpdates(void);
 
 #endif /* HAVE_LIBCURL */
 


### PR DESCRIPTION
https://reports.citusdata.com/v1/releases/latest
We haven't updated the version CheckForUpdates sees since 7.1.0

DESCRIPTION: Remove unused functionality to check for updates

This becomes even more fringe after making statisitics collection default off. We should either add a separate GUC for checking for updates & fix the check, or remove it. I've implemented removing it here

This also removes a chunk of code we had no tests for

Settles how to move forward with https://github.com/citusdata/citus_docs/pull/867 by removing talk of CheckForUpdates from docs