### PR TITLE
Propagate metadata for master_update_node

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -250,6 +250,35 @@ GetNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port, co
 
 
 /*
+ * StartWorkerListConnections starts connections to the given worker list and
+ * returns them as a MultiConnection list.
+ */
+List *
+StartWorkerListConnections(List *workerNodeList, uint32 flags, const char *user,
+						   const char *database)
+{
+	List *connectionList = NIL;
+	ListCell *workerNodeCell = NULL;
+
+	foreach(workerNodeCell, workerNodeList)
+	{
+		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
+		char *nodeName = workerNode->workerName;
+		int nodePort = workerNode->workerPort;
+		MultiConnection *connection = NULL;
+		int connectionFlags = 0;
+
+		connection = StartNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
+													 user, database);
+
+		connectionList = lappend(connectionList, connection);
+	}
+
+	return connectionList;
+}
+
+
+/*
  * StartNodeUserDatabaseConnection() initiates a connection to a remote node.
  *
  * If user or database are NULL, the current session's defaults are used. The

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -443,9 +443,9 @@ ExecuteOptionalRemoteCommand(MultiConnection *connection, const char *command,
 
 	/*
 	 * store result if result has been set, when the user is not interested in the result
-	 * a NULL pointer could be passed and the result will be cleared
+	 * a NULL pointer could be passed and the result will be cleared.
 	 */
-	if (result)
+	if (result != NULL)
 	{
 		*result = localResult;
 	}
@@ -454,6 +454,7 @@ ExecuteOptionalRemoteCommand(MultiConnection *connection, const char *command,
 		PQclear(localResult);
 		ForgetResults(connection);
 	}
+
 	return RESPONSE_OKAY;
 }
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -31,6 +31,7 @@
 #include "distributed/master_metadata_utility.h"
 #include "distributed/master_protocol.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/metadata_sync.h"
 #include "distributed/multi_explain.h"
 #include "distributed/multi_join_order.h"
 #include "distributed/multi_logical_optimizer.h"
@@ -603,6 +604,30 @@ RegisterCitusConfigVariables(void)
 		60000, -1, 7 * 24 * 3600 * 1000,
 		PGC_SIGHUP,
 		GUC_UNIT_MS,
+		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"citus.metadata_sync_interval",
+		gettext_noop("Sets the time to wait between metadata syncs."),
+		gettext_noop("metadata sync needs to run every so often "
+					 "to synchronize metadata to metadata nodes "
+					 "that are out of sync."),
+		&MetadataSyncInterval,
+		60000, 1, 7 * 24 * 3600 * 1000,
+		PGC_SIGHUP,
+		GUC_UNIT_MS | GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"citus.metadata_sync_retry_interval",
+		gettext_noop("Sets the interval to retry failed metadata syncs."),
+		gettext_noop("metadata sync needs to run every so often "
+					 "to synchronize metadata to metadata nodes "
+					 "that are out of sync."),
+		&MetadataSyncRetryInterval,
+		5000, 1, 7 * 24 * 3600 * 1000,
+		PGC_SIGHUP,
+		GUC_UNIT_MS | GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(

--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -143,4 +143,8 @@ REVOKE ALL ON FUNCTION master_add_inactive_node(text,int,int,noderole,name) FROM
 REVOKE ALL ON FUNCTION master_add_node(text,int,int,noderole,name) FROM PUBLIC;
 REVOKE ALL ON FUNCTION master_add_secondary_node(text,int,text,int,name) FROM PUBLIC;
 
+ALTER TABLE pg_dist_node ADD COLUMN metadatasynced BOOLEAN DEFAULT FALSE;
+COMMENT ON COLUMN pg_dist_node.metadatasynced IS
+    'indicates whether the node has the most recent metadata';
+
 RESET search_path;

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -359,8 +359,8 @@ StartRemoteTransactionAbort(MultiConnection *connection)
 	 * [PREPARED]. If we've previously sent a PREPARE TRANSACTION, we always
 	 * want to wait for that result, as that shouldn't take long and will
 	 * reserve resources.  But if there's another query running, we don't want
-	 * to wait, because a longrunning statement may be running, force it to be
-	 * killed in that case.
+	 * to wait, because a long running statement may be running, so force it to
+	 * be killed in that case.
 	 */
 	if (transaction->transactionState == REMOTE_TRANS_PREPARING ||
 		transaction->transactionState == REMOTE_TRANS_PREPARED)
@@ -619,7 +619,7 @@ RemoteTransactionsBeginIfNecessary(List *connectionList)
 
 		/*
 		 * If a transaction already is in progress (including having failed),
-		 * don't start it again.  Thats quite normal if a piece of code allows
+		 * don't start it again. That's quite normal if a piece of code allows
 		 * cached connections.
 		 */
 		if (transaction->transactionState != REMOTE_TRANS_INVALID)
@@ -708,7 +708,7 @@ HandleRemoteTransactionResultError(MultiConnection *connection, PGresult *result
  * If the connection is marked as critical, and allowErrorPromotion is true,
  * this routine will ERROR out. The allowErrorPromotion case is primarily
  * required for the transaction management code itself. Usually it is helpful
- * to fail as soon as possible.  If !allowErrorPromotion transaction commit
+ * to fail as soon as possible. If !allowErrorPromotion transaction commit
  * will instead issue an error before committing on any node.
  */
 void

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -581,7 +581,10 @@ LookupNodeByNodeId(uint32 nodeId)
 		WorkerNode *workerNode = WorkerNodeArray[workerNodeIndex];
 		if (workerNode->nodeId == nodeId)
 		{
-			return workerNode;
+			WorkerNode *workerNodeCopy = palloc0(sizeof(WorkerNode));
+			memcpy(workerNodeCopy, workerNode, sizeof(WorkerNode));
+
+			return workerNodeCopy;
 		}
 	}
 
@@ -2858,6 +2861,7 @@ InitializeWorkerNodeCache(void)
 		workerNode->nodeId = currentNode->nodeId;
 		strlcpy(workerNode->workerRack, currentNode->workerRack, WORKER_LENGTH);
 		workerNode->hasMetadata = currentNode->hasMetadata;
+		workerNode->metadataSynced = currentNode->metadataSynced;
 		workerNode->isActive = currentNode->isActive;
 		workerNode->nodeRole = currentNode->nodeRole;
 		strlcpy(workerNode->nodeCluster, currentNode->nodeCluster, NAMEDATALEN);

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -177,8 +177,8 @@ ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort)
 			char *tableOwner = TableOwner(shardInterval->relationId);
 			List *commandList = CopyShardForeignConstraintCommandList(shardInterval);
 
-			SendCommandListToWorkerInSingleTransaction(nodeName, nodePort,
-													   tableOwner, commandList);
+			SendCommandListToWorkerInSingleTransaction(nodeName, nodePort, tableOwner,
+													   commandList);
 		}
 	}
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -182,6 +182,8 @@ extern MultiConnection * StartNodeConnection(uint32 flags, const char *hostname,
 extern MultiConnection * GetNodeUserDatabaseConnection(uint32 flags, const char *hostname,
 													   int32 port, const char *user, const
 													   char *database);
+extern List * StartWorkerListConnections(List *workerList, uint32 flags, const char *user,
+										 const char *database);
 extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 const char *hostname,
 														 int32 port,

--- a/src/include/distributed/maintenanced.h
+++ b/src/include/distributed/maintenanced.h
@@ -22,6 +22,7 @@
 extern double DistributedDeadlockDetectionTimeoutFactor;
 
 extern void StopMaintenanceDaemon(Oid databaseId);
+extern void TriggerMetadataSync(Oid databaseId);
 extern void InitializeMaintenanceDaemon(void);
 extern void InitializeMaintenanceDaemonBackend(void);
 

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -16,6 +16,9 @@
 #include "distributed/metadata_cache.h"
 #include "nodes/pg_list.h"
 
+/* config variables */
+extern int MetadataSyncInterval;
+extern int MetadataSyncRetryInterval;
 
 /* Functions declarations for metadata syncing */
 extern bool ClusterHasKnownMetadataWorkers(void);
@@ -37,7 +40,11 @@ extern char * CreateSchemaDDLCommand(Oid schemaId);
 extern char * PlacementUpsertCommand(uint64 shardId, uint64 placementId, int shardState,
 									 uint64 shardLength, int32 groupId);
 extern void CreateTableMetadataOnWorkers(Oid relationId);
-
+extern void MarkNodeMetadataSynced(char *nodeName, int32 nodePort, bool synced);
+extern bool SyncMetadataToNodes(void);
+extern bool SendOptionalCommandListToWorkerInTransaction(char *nodeName, int32 nodePort,
+														 char *nodeUser,
+														 List *commandList);
 
 #define DELETE_ALL_NODES "TRUNCATE pg_dist_node CASCADE"
 #define REMOVE_ALL_CLUSTERED_TABLES_COMMAND \
@@ -57,5 +64,6 @@ extern void CreateTableMetadataOnWorkers(Oid relationId);
 	"shardstate = EXCLUDED.shardstate, " \
 	"shardlength = EXCLUDED.shardlength, " \
 	"groupid = EXCLUDED.groupid"
+#define METADATA_SYNC_CHANNEL "metadata_sync"
 
 #endif /* METADATA_SYNC_H */

--- a/src/include/distributed/pg_dist_node.h
+++ b/src/include/distributed/pg_dist_node.h
@@ -20,7 +20,7 @@
  *  in particular their OUT parameters) must be changed whenever the definition of
  *  pg_dist_node changes.
  */
-#define Natts_pg_dist_node 9
+#define Natts_pg_dist_node 10
 #define Anum_pg_dist_node_nodeid 1
 #define Anum_pg_dist_node_groupid 2
 #define Anum_pg_dist_node_nodename 3
@@ -30,6 +30,7 @@
 #define Anum_pg_dist_node_isactive 7
 #define Anum_pg_dist_node_noderole 8
 #define Anum_pg_dist_node_nodecluster 9
+#define Anum_pg_dist_node_metadatasynced 10
 
 #define GROUPID_SEQUENCE_NAME "pg_dist_groupid_seq"
 #define NODEID_SEQUENCE_NAME "pg_dist_node_nodeid_seq"

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -47,6 +47,7 @@ typedef struct WorkerNode
 	bool isActive;                      /* node's state */
 	Oid nodeRole;                       /* the node's role in its group */
 	char nodeCluster[NAMEDATALEN];      /* the cluster the node is a part of */
+	bool metadataSynced;                /* node has the most recent metadata */
 } WorkerNode;
 
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-264            263            f              
+274            273            f              
 transactionnumberwaitingtransactionnumbers
 
-263                           
-264            263            
+273                           
+274            273            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-268            267            f              
-269            267            f              
-269            268            t              
+278            277            f              
+279            277            f              
+279            278            t              
 transactionnumberwaitingtransactionnumbers
 
-267                           
-268            267            
-269            267,268        
+277                           
+278            277            
+279            277,278        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-274            273            f              
+266            265            f              
 transactionnumberwaitingtransactionnumbers
 
-273                           
-274            273            
+265                           
+266            265            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-278            277            f              
-279            277            f              
-279            278            t              
+270            269            f              
+271            269            f              
+271            270            t              
 transactionnumberwaitingtransactionnumbers
 
-277                           
-278            277            
-279            277,278        
+269                           
+270            269            
+271            269,270        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges_0.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges_0.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-265            264            f              
+275            274            f              
 transactionnumberwaitingtransactionnumbers
 
-264                           
-265            264            
+274                           
+275            274            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-269            268            f              
-270            268            f              
-270            269            t              
+279            278            f              
+280            278            f              
+280            279            t              
 transactionnumberwaitingtransactionnumbers
 
-268                           
-269            268            
-270            268,269        
+278                           
+279            278            
+280            278,279        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges_0.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges_0.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-275            274            f              
+267            266            f              
 transactionnumberwaitingtransactionnumbers
 
-274                           
-275            274            
+266                           
+267            266            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-279            278            f              
-280            278            f              
-280            279            t              
+271            270            f              
+272            270            f              
+272            271            t              
 transactionnumberwaitingtransactionnumbers
 
-278                           
-279            278            
-280            278,279        
+270                           
+271            270            
+272            270,271        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_update_node.out
+++ b/src/test/regress/expected/isolation_update_node.out
@@ -22,13 +22,14 @@ step s2-update-node-2:
         (select nodeid from pg_dist_node where nodeport = 57638),
         'localhost',
         58638);
-
-?column?       
-
-1              
+ <waiting ...>
 step s1-commit: 
 	COMMIT;
 
+step s2-update-node-2: <... completed>
+?column?       
+
+1              
 step s1-show-nodes: 
     SELECT nodeid, nodename, nodeport, isactive
       FROM pg_dist_node
@@ -71,7 +72,9 @@ step s1-commit:
 	COMMIT;
 
 step s2-update-node-1: <... completed>
-error in steps s1-commit s2-update-node-1: ERROR:  tuple concurrently updated
+?column?       
+
+1              
 step s2-abort: 
 	ABORT;
 

--- a/src/test/regress/expected/isolation_update_node.out
+++ b/src/test/regress/expected/isolation_update_node.out
@@ -86,3 +86,47 @@ nodeid         nodename       nodeport       isactive
 24             localhost      58637          t              
 nodeid         nodename       nodeport       
 
+
+starting permutation: s1-begin s1-update-node-1 s2-start-metadata-sync-node-2 s1-commit s2-verify-metadata
+nodeid         nodename       nodeport       
+
+26             localhost      57637          
+27             localhost      57638          
+step s1-begin: 
+	BEGIN;
+
+step s1-update-node-1: 
+    SELECT 1 FROM master_update_node(
+        (select nodeid from pg_dist_node where nodeport = 57637),
+        'localhost',
+        58637);
+
+?column?       
+
+1              
+step s2-start-metadata-sync-node-2: 
+    SELECT start_metadata_sync_to_node('localhost', 57638);
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-start-metadata-sync-node-2: <... completed>
+start_metadata_sync_to_node
+
+               
+step s2-verify-metadata: 
+    SELECT nodeid, groupid, nodename, nodeport FROM pg_dist_node ORDER BY nodeid;
+    SELECT master_run_on_worker(
+        ARRAY['localhost'], ARRAY[57638],
+        ARRAY['SELECT jsonb_agg(ROW(nodeid, groupid, nodename, nodeport) ORDER BY nodeid) FROM  pg_dist_node'],
+        false);
+
+nodeid         groupid        nodename       nodeport       
+
+26             26             localhost      58637          
+27             27             localhost      57638          
+master_run_on_worker
+
+(localhost,57638,t,"[{""f1"": 26, ""f2"": 26, ""f3"": ""localhost"", ""f4"": 58637}, {""f1"": 27, ""f2"": 27, ""f3"": ""localhost"", ""f4"": 57638}]")
+nodeid         nodename       nodeport       
+

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -301,14 +301,19 @@ SELECT master_remove_node('localhost', 9990);
 
 -- clean-up
 DROP TABLE cluster_management_test;
--- check that adding/removing nodes are propagated to nodes with hasmetadata=true
+-- check that adding/removing nodes are propagated to nodes with metadata
 SELECT master_remove_node('localhost', :worker_2_port);
  master_remove_node 
 --------------------
  
 (1 row)
 
-UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
  ?column? 
 ----------
@@ -336,8 +341,13 @@ SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodep
 (0 rows)
 
 \c - - - :master_port
--- check that added nodes are not propagated to nodes with hasmetadata=false
-UPDATE pg_dist_node SET hasmetadata=false WHERE nodeport=:worker_1_port;
+-- check that added nodes are not propagated to nodes without metadata
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
  ?column? 
 ----------
@@ -376,10 +386,10 @@ SELECT
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-     11 |       9 | localhost |    57637 | default  | f           | t        | primary  | default
-     12 |      10 | localhost |    57638 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | metadatasynced 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------+----------------
+     11 |       9 | localhost |    57637 | default  | f           | t        | primary  | default     | f
+     12 |      10 | localhost |    57638 | default  | f           | t        | primary  | default     | f
 (2 rows)
 
 -- check that mixed add/remove node commands work fine inside transaction
@@ -408,7 +418,12 @@ SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodep
 ----------+----------
 (0 rows)
 
-UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
 BEGIN;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
  ?column? 
@@ -593,11 +608,11 @@ CONTEXT:  PL/pgSQL function citus_internal.pg_dist_node_trigger_func() line 18 a
 INSERT INTO pg_dist_node (nodename, nodeport, groupid, noderole, nodecluster)
   VALUES ('localhost', 5000, 1000, 'primary', 'olap');
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
-DETAIL:  Failing row contains (19, 1000, localhost, 5000, default, f, t, primary, olap).
+DETAIL:  Failing row contains (19, 1000, localhost, 5000, default, f, t, primary, olap, f).
 UPDATE pg_dist_node SET nodecluster = 'olap'
   WHERE nodeport = :worker_1_port;
 ERROR:  new row for relation "pg_dist_node" violates check constraint "primaries_are_only_allowed_in_the_default_cluster"
-DETAIL:  Failing row contains (16, 14, localhost, 57637, default, f, t, primary, olap).
+DETAIL:  Failing row contains (16, 14, localhost, 57637, default, f, t, primary, olap, f).
 -- check that you /can/ add a secondary node to a non-default cluster
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
 SELECT master_add_node('localhost', 8888, groupid => :worker_1_group, noderole => 'secondary', nodecluster=> 'olap');
@@ -620,9 +635,9 @@ SELECT master_add_node('localhost', 8887, groupid => :worker_1_group, noderole =
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeport=8887;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           
---------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------
-     24 |      14 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars.
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |                           nodecluster                           | metadatasynced 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+-----------------------------------------------------------------+----------------
+     24 |      14 | localhost |     8887 | default  | f           | t        | secondary | thisisasixtyfourcharacterstringrepeatedfourtimestomake256chars. | f
 (1 row)
 
 -- don't remove the secondary and unavailable nodes, check that no commands are sent to
@@ -663,9 +678,9 @@ SELECT master_update_node(:worker_1_node, 'somehost', 9000);
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
- nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+----------+----------+----------+-------------+----------+----------+-------------
-     16 |      14 | somehost |     9000 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | metadatasynced 
+--------+---------+----------+----------+----------+-------------+----------+----------+-------------+----------------
+     16 |      14 | somehost |     9000 | default  | f           | t        | primary  | default     | f
 (1 row)
 
 -- cleanup
@@ -676,8 +691,8 @@ SELECT master_update_node(:worker_1_node, 'localhost', :worker_1_port);
 (1 row)
 
 SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-     16 |      14 | localhost |    57637 | default  | f           | t        | primary  | default
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | metadatasynced 
+--------+---------+-----------+----------+----------+-------------+----------+----------+-------------+----------------
+     16 |      14 | localhost |    57637 | default  | f           | t        | primary  | default     | f
 (1 row)
 

--- a/src/test/regress/expected/multi_metadata_attributes.out
+++ b/src/test/regress/expected/multi_metadata_attributes.out
@@ -5,11 +5,12 @@ SELECT attrelid::regclass, attname, atthasmissing, attmissingval
 FROM pg_attribute
 WHERE atthasmissing
 ORDER BY attrelid, attname;
-   attrelid   |   attname   | atthasmissing | attmissingval 
---------------+-------------+---------------+---------------
- pg_dist_node | hasmetadata | t             | {f}
- pg_dist_node | isactive    | t             | {t}
- pg_dist_node | nodecluster | t             | {default}
- pg_dist_node | noderole    | t             | {primary}
-(4 rows)
+   attrelid   |    attname     | atthasmissing | attmissingval 
+--------------+----------------+---------------+---------------
+ pg_dist_node | hasmetadata    | t             | {f}
+ pg_dist_node | isactive       | t             | {t}
+ pg_dist_node | metadatasynced | t             | {f}
+ pg_dist_node | nodecluster    | t             | {default}
+ pg_dist_node | noderole       | t             | {primary}
+(5 rows)
 

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -27,9 +27,9 @@ SELECT * FROM pg_dist_partition WHERE partmethod='h' AND repmodel='s';
 -- Show that, with no MX tables, metadata snapshot contains only the delete commands,
 -- pg_dist_node entries and reference tables
 SELECT unnest(master_metadata_snapshot()) order by 1;
-                                                                                                                                               unnest                                                                                                                                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+                                                                                                                                                              unnest                                                                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
 (3 rows)
@@ -60,7 +60,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  ALTER TABLE public.mx_test_table OWNER TO postgres
  ALTER TABLE public.mx_test_table OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey, colocationid, repmodel) VALUES ('public.mx_test_table'::regclass, 'h', column_name_to_column('public.mx_test_table','col_1'), 0, 's')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('public.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('public.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('public.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('public.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('public.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('public.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('public.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('public.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
@@ -81,7 +81,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  ALTER TABLE public.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON public.mx_test_table USING btree (col_2) TABLESPACE pg_default
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL)
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey, colocationid, repmodel) VALUES ('public.mx_test_table'::regclass, 'h', column_name_to_column('public.mx_test_table','col_1'), 0, 's')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('public.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('public.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('public.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('public.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('public.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('public.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('public.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('public.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
@@ -105,7 +105,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  ALTER TABLE mx_testing_schema.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey, colocationid, repmodel) VALUES ('mx_testing_schema.mx_test_table'::regclass, 'h', column_name_to_column('mx_testing_schema.mx_test_table','col_1'), 0, 's')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
@@ -133,7 +133,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  ALTER TABLE mx_testing_schema.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey, colocationid, repmodel) VALUES ('mx_testing_schema.mx_test_table'::regclass, 'h', column_name_to_column('mx_testing_schema.mx_test_table','col_1'), 0, 's')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
@@ -154,7 +154,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  ALTER TABLE mx_testing_schema.mx_test_table OWNER TO postgres
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2) TABLESPACE pg_default
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL)
- INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, TRUE, 'primary'::noderole, 'default')
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  INSERT INTO pg_dist_partition (logicalrelid, partmethod, partkey, colocationid, repmodel) VALUES ('mx_testing_schema.mx_test_table'::regclass, 'h', column_name_to_column('mx_testing_schema.mx_test_table','col_1'), 0, 's')
  INSERT INTO pg_dist_placement (shardid, shardstate, shardlength, groupid, placementid) VALUES (1310000, 1, 0, 1, 100000),(1310001, 1, 0, 2, 100001),(1310002, 1, 0, 1, 100002),(1310003, 1, 0, 2, 100003),(1310004, 1, 0, 1, 100004),(1310005, 1, 0, 2, 100005),(1310006, 1, 0, 1, 100006),(1310007, 1, 0, 2, 100007)
  INSERT INTO pg_dist_shard (logicalrelid, shardid, shardstorage, shardminvalue, shardmaxvalue) VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't', '-2147483648', '-1610612737'),('mx_testing_schema.mx_test_table'::regclass, 1310001, 't', '-1610612736', '-1073741825'),('mx_testing_schema.mx_test_table'::regclass, 1310002, 't', '-1073741824', '-536870913'),('mx_testing_schema.mx_test_table'::regclass, 1310003, 't', '-536870912', '-1'),('mx_testing_schema.mx_test_table'::regclass, 1310004, 't', '0', '536870911'),('mx_testing_schema.mx_test_table'::regclass, 1310005, 't', '536870912', '1073741823'),('mx_testing_schema.mx_test_table'::regclass, 1310006, 't', '1073741824', '1610612735'),('mx_testing_schema.mx_test_table'::regclass, 1310007, 't', '1610612736', '2147483647')
@@ -233,12 +233,12 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   
---------+---------+-----------+----------+----------+-------------+----------+-----------+----------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default
-      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default
-      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | metadatasynced 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+----------------+----------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        | f
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        | f
+      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        | f
+      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
@@ -372,12 +372,12 @@ SELECT * FROM pg_dist_local_group;
 (1 row)
 
 SELECT * FROM pg_dist_node ORDER BY nodeid;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   
---------+---------+-----------+----------+----------+-------------+----------+-----------+----------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default
-      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default
-      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster
+ nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | metadatasynced 
+--------+---------+-----------+----------+----------+-------------+----------+-----------+----------------+----------------
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        | t
+      2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        | f
+      4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        | f
+      5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;

--- a/src/test/regress/expected/multi_mx_master_update_node.out
+++ b/src/test/regress/expected/multi_mx_master_update_node.out
@@ -1,0 +1,373 @@
+-- Test creation of mx tables and metadata syncing
+SELECT nextval('pg_catalog.pg_dist_placement_placementid_seq') AS last_placement_id
+\gset
+SELECT nextval('pg_catalog.pg_dist_groupid_seq') AS last_group_id \gset
+SELECT nextval('pg_catalog.pg_dist_node_nodeid_seq') AS last_node_id \gset
+SELECT nextval('pg_catalog.pg_dist_colocationid_seq') AS last_colocation_id \gset
+SELECT nextval('pg_catalog.pg_dist_shardid_seq') AS last_shard_id \gset
+SET citus.replication_model TO streaming;
+SET citus.shard_count TO 8;
+SET citus.shard_replication_factor TO 1;
+-- set sync intervals to less than 15s so wait_until_metadata_sync never times out
+ALTER SYSTEM SET citus.metadata_sync_interval TO 3000;
+ALTER SYSTEM SET citus.metadata_sync_retry_interval TO 500;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+CREATE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'citus';
+-- Verifies pg_dist_node and pg_dist_palcement in the given worker matches the ones in coordinator
+CREATE FUNCTION verify_metadata(hostname TEXT, port INTEGER, master_port INTEGER DEFAULT 57636)
+    RETURNS BOOLEAN
+    LANGUAGE sql
+    AS $$
+WITH dist_node_summary AS (
+    SELECT 'SELECT jsonb_agg(ROW(nodeid, groupid, nodename, nodeport, isactive) ORDER BY nodeid) FROM  pg_dist_node' as query
+), dist_node_check AS (
+    SELECT count(distinct result) = 1 AS matches
+    FROM dist_node_summary CROSS JOIN LATERAL
+        master_run_on_worker(ARRAY[hostname, 'localhost'], ARRAY[port, master_port],
+                            ARRAY[dist_node_summary.query, dist_node_summary.query],
+                            false)
+), dist_placement_summary AS (
+    SELECT 'SELECT jsonb_agg(pg_dist_placement ORDER BY shardid) FROM pg_dist_placement)' AS query
+), dist_placement_check AS (
+    SELECT count(distinct result) = 1 AS matches
+    FROM dist_placement_summary CROSS JOIN LATERAL
+        master_run_on_worker(ARRAY[hostname, 'localhost'], ARRAY[port, master_port],
+                            ARRAY[dist_placement_summary.query, dist_placement_summary.query],
+                            false)
+)
+SELECT dist_node_check.matches AND dist_placement_check.matches
+FROM dist_node_check CROSS JOIN dist_placement_check
+$$;
+-- Simulates a readonly node by setting default_transaction_read_only. 
+CREATE FUNCTION mark_node_readonly(hostname TEXT, port INTEGER, isreadonly BOOLEAN)
+    RETURNS TEXT
+    LANGUAGE sql
+    AS $$
+    SELECT master_run_on_worker(ARRAY[hostname], ARRAY[port],
+           ARRAY['ALTER SYSTEM SET default_transaction_read_only TO ' || isreadonly::TEXT], false);
+    SELECT result FROM
+        master_run_on_worker(ARRAY[hostname], ARRAY[port],
+                             ARRAY['SELECT pg_reload_conf()'], false);
+$$;
+-- add a node to the cluster
+SELECT master_add_node('localhost', :worker_1_port) As nodeid_1 \gset
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    57637 | f           | f
+(1 row)
+
+-- create couple of tables
+CREATE TABLE ref_table(a int primary key);
+SELECT create_reference_table('ref_table');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+CREATE TABLE dist_table_1(a int primary key, b int references ref_table(a));
+SELECT create_distributed_table('dist_table_1', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- update the node
+SELECT 1 FROM master_update_node((SELECT nodeid FROM pg_dist_node),
+                                 'localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    57638 | f           | f
+(1 row)
+
+-- start syncing metadata to the node
+SELECT 1 FROM start_metadata_sync_to_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    57638 | t           | t
+(1 row)
+
+--------------------------------------------------------------------------
+-- Test that maintenance daemon syncs after master_update_node
+--------------------------------------------------------------------------
+-- Update the node again. We do this as epeatable read, so we just see the
+-- changes by master_update_node(). This is to avoid inconsistent results
+-- if the maintenance daemon does the metadata sync too fast.
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    57638 | t           | t
+(1 row)
+
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    57637 | t           | f
+(1 row)
+
+END;
+-- wait until maintenance daemon does the next metadata sync, and then
+-- check if metadata is synced again
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | t
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port);
+ verify_metadata 
+-----------------
+ t
+(1 row)
+
+-- Update the node to a non-existent node. This is to simulate updating to
+-- a unwriteable node.
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    57637 | t           | t
+(1 row)
+
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | nodename  | nodeport | hasmetadata | metadatasynced 
+--------+-----------+----------+-------------+----------------
+      2 | localhost |    12345 | t           | f
+(1 row)
+
+END;
+-- maintenace daemon metadata sync should fail, because node is still unwriteable.
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | f
+(1 row)
+
+-- update it back to :worker_1_port, now metadata should be synced
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | t
+(1 row)
+
+--------------------------------------------------------------------------
+-- Test updating a node when another node is in readonly-mode
+--------------------------------------------------------------------------
+SELECT FROM master_add_node('localhost', :worker_2_port) AS nodeid_2 \gset
+NOTICE:  Replicating reference table "ref_table" to the node localhost:57638
+SELECT 1 FROM start_metadata_sync_to_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+-- Create a table with shards on both nodes
+CREATE TABLE dist_table_2(a int);
+SELECT create_distributed_table('dist_table_2', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO dist_table_2 SELECT i FROM generate_series(1, 100) i;
+SELECT mark_node_readonly('localhost', :worker_2_port, TRUE);
+ mark_node_readonly 
+--------------------
+ t
+(1 row)
+
+-- Now updating the other node should try syncing to worker 2, but instead of
+-- failure, it should just warn and mark the readonly node as not synced.
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+WARNING:  cannot execute DELETE in a read-only transaction
+CONTEXT:  while executing command on localhost:57638
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | f
+      3 | t           | f
+(2 rows)
+
+-- worker_2 is out of sync, so further updates aren't sent to it and
+-- we shouldn't see the warnings.
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 23456);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | f
+      3 | t           | f
+(2 rows)
+
+-- Make the node writeable.
+SELECT mark_node_readonly('localhost', :worker_2_port, FALSE);
+ mark_node_readonly 
+--------------------
+ t
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+-- Mark the node readonly again, so the following master_update_node warns
+SELECT mark_node_readonly('localhost', :worker_2_port, TRUE);
+ mark_node_readonly 
+--------------------
+ t
+(1 row)
+
+-- Revert the nodeport of worker 1, metadata propagation to worker 2 should
+-- still fail, but after the failure, we should still be able to read from
+-- worker 2 in the same transaction!
+BEGIN;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+WARNING:  cannot execute DELETE in a read-only transaction
+CONTEXT:  while executing command on localhost:57638
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT count(*) FROM dist_table_2;
+ count 
+-------
+   100
+(1 row)
+
+END;
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+-- Make the node writeable.
+SELECT mark_node_readonly('localhost', :worker_2_port, FALSE);
+ mark_node_readonly 
+--------------------
+ t
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port),
+       verify_metadata('localhost', :worker_2_port);
+ verify_metadata | verify_metadata 
+-----------------+-----------------
+ t               | t
+(1 row)
+
+--------------------------------------------------------------------------
+-- Test that master_update_node rolls back properly
+--------------------------------------------------------------------------
+BEGIN;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+ ?column? 
+----------
+        1
+(1 row)
+
+ROLLBACK;
+SELECT verify_metadata('localhost', :worker_1_port),
+       verify_metadata('localhost', :worker_2_port);
+ verify_metadata | verify_metadata 
+-----------------+-----------------
+ t               | t
+(1 row)
+
+-- cleanup
+DROP TABLE dist_table_1, ref_table, dist_table_2;
+TRUNCATE pg_dist_colocation;
+SELECT count(*) FROM (SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node) t;
+ count 
+-------
+     2
+(1 row)
+
+ALTER SEQUENCE pg_catalog.pg_dist_groupid_seq RESTART :last_group_id;
+ALTER SEQUENCE pg_catalog.pg_dist_node_nodeid_seq RESTART :last_node_id;
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART :last_colocation_id;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART :last_placement_id;
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART :last_shard_id;
+RESET citus.shard_count;
+RESET citus.shard_replication_factor;
+RESET citus.replication_model;

--- a/src/test/regress/expected/multi_mx_master_update_node.out
+++ b/src/test/regress/expected/multi_mx_master_update_node.out
@@ -233,11 +233,9 @@ SELECT mark_node_readonly('localhost', :worker_2_port, TRUE);
  t
 (1 row)
 
--- Now updating the other node should try syncing to worker 2, but instead of
--- failure, it should just warn and mark the readonly node as not synced.
+-- Now updating the other node will mark worker 2 as not synced.
+BEGIN;
 SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
-WARNING:  cannot execute DELETE in a read-only transaction
-CONTEXT:  while executing command on localhost:57638
  ?column? 
 ----------
         1
@@ -250,6 +248,7 @@ SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
       3 | t           | f
 (2 rows)
 
+COMMIT;
 -- worker_2 is out of sync, so further updates aren't sent to it and
 -- we shouldn't see the warnings.
 SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 23456);
@@ -285,13 +284,9 @@ SELECT mark_node_readonly('localhost', :worker_2_port, TRUE);
  t
 (1 row)
 
--- Revert the nodeport of worker 1, metadata propagation to worker 2 should
--- still fail, but after the failure, we should still be able to read from
--- worker 2 in the same transaction!
+-- Revert the nodeport of worker 1.
 BEGIN;
 SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
-WARNING:  cannot execute DELETE in a read-only transaction
-CONTEXT:  while executing command on localhost:57638
  ?column? 
 ----------
         1
@@ -347,6 +342,60 @@ SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
 (1 row)
 
 ROLLBACK;
+SELECT verify_metadata('localhost', :worker_1_port),
+       verify_metadata('localhost', :worker_2_port);
+ verify_metadata | verify_metadata 
+-----------------+-----------------
+ t               | t
+(1 row)
+
+--------------------------------------------------------------------------
+-- Test that master_update_node can appear in a prepared transaction.
+--------------------------------------------------------------------------
+BEGIN;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+ ?column? 
+----------
+        1
+(1 row)
+
+PREPARE TRANSACTION 'tx01';
+COMMIT PREPARED 'tx01';
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | f
+      3 | t           | t
+(2 rows)
+
+BEGIN;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+PREPARE TRANSACTION 'tx01';
+COMMIT PREPARED 'tx01';
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
+ nodeid | hasmetadata | metadatasynced 
+--------+-------------+----------------
+      2 | t           | t
+      3 | t           | t
+(2 rows)
+
 SELECT verify_metadata('localhost', :worker_1_port),
        verify_metadata('localhost', :worker_2_port);
  verify_metadata | verify_metadata 

--- a/src/test/regress/expected/multi_read_from_secondaries.out
+++ b/src/test/regress/expected/multi_read_from_secondaries.out
@@ -23,11 +23,11 @@ INSERT INTO dest_table (a, b) VALUES (1, 1);
 INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (10, 10);
 -- simluate actually having secondary nodes
-SELECT * FROM pg_dist_node;
- nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster 
---------+---------+-----------+----------+----------+-------------+----------+----------+-------------
-      1 |       1 | localhost |    57637 | default  | f           | t        | primary  | default
-      2 |       2 | localhost |    57638 | default  | f           | t        | primary  | default
+SELECT nodeid, groupid, nodename, nodeport, noderack, isactive, noderole, nodecluster FROM pg_dist_node;
+ nodeid | groupid | nodename  | nodeport | noderack | isactive | noderole | nodecluster 
+--------+---------+-----------+----------+----------+----------+----------+-------------
+      1 |       1 | localhost |    57637 | default  | t        | primary  | default
+      2 |       2 | localhost |    57638 | default  | t        | primary  | default
 (2 rows)
 
 UPDATE pg_dist_node SET noderole = 'secondary';

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -14,6 +14,7 @@
 # Tests around schema changes, these are run first, so there's no preexisting objects.
 # ---
 test: multi_extension
+test: multi_mx_master_update_node
 test: multi_cluster_management
 test: multi_test_helpers
 

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -134,9 +134,9 @@ SELECT master_remove_node('localhost', 9990);
 -- clean-up
 DROP TABLE cluster_management_test;
 
--- check that adding/removing nodes are propagated to nodes with hasmetadata=true
+-- check that adding/removing nodes are propagated to nodes with metadata
 SELECT master_remove_node('localhost', :worker_2_port);
-UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 \c - - - :worker_1_port
 SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
@@ -146,8 +146,8 @@ SELECT master_remove_node('localhost', :worker_2_port);
 SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
 \c - - - :master_port
 
--- check that added nodes are not propagated to nodes with hasmetadata=false
-UPDATE pg_dist_node SET hasmetadata=false WHERE nodeport=:worker_1_port;
+-- check that added nodes are not propagated to nodes without metadata
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 \c - - - :worker_1_port
 SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
@@ -174,7 +174,7 @@ COMMIT;
 
 SELECT nodename, nodeport FROM pg_dist_node WHERE nodename='localhost' AND nodeport=:worker_2_port;
 
-UPDATE pg_dist_node SET hasmetadata=true WHERE nodeport=:worker_1_port;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 BEGIN;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT master_remove_node('localhost', :worker_2_port);

--- a/src/test/regress/sql/multi_mx_master_update_node.sql
+++ b/src/test/regress/sql/multi_mx_master_update_node.sql
@@ -1,0 +1,191 @@
+-- Test creation of mx tables and metadata syncing
+
+SELECT nextval('pg_catalog.pg_dist_placement_placementid_seq') AS last_placement_id
+\gset
+SELECT nextval('pg_catalog.pg_dist_groupid_seq') AS last_group_id \gset
+SELECT nextval('pg_catalog.pg_dist_node_nodeid_seq') AS last_node_id \gset
+SELECT nextval('pg_catalog.pg_dist_colocationid_seq') AS last_colocation_id \gset
+SELECT nextval('pg_catalog.pg_dist_shardid_seq') AS last_shard_id \gset
+
+
+SET citus.replication_model TO streaming;
+SET citus.shard_count TO 8;
+SET citus.shard_replication_factor TO 1;
+
+-- set sync intervals to less than 15s so wait_until_metadata_sync never times out
+ALTER SYSTEM SET citus.metadata_sync_interval TO 3000;
+ALTER SYSTEM SET citus.metadata_sync_retry_interval TO 500;
+SELECT pg_reload_conf();
+
+CREATE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'citus';
+
+-- Verifies pg_dist_node and pg_dist_palcement in the given worker matches the ones in coordinator
+CREATE FUNCTION verify_metadata(hostname TEXT, port INTEGER, master_port INTEGER DEFAULT 57636)
+    RETURNS BOOLEAN
+    LANGUAGE sql
+    AS $$
+WITH dist_node_summary AS (
+    SELECT 'SELECT jsonb_agg(ROW(nodeid, groupid, nodename, nodeport, isactive) ORDER BY nodeid) FROM  pg_dist_node' as query
+), dist_node_check AS (
+    SELECT count(distinct result) = 1 AS matches
+    FROM dist_node_summary CROSS JOIN LATERAL
+        master_run_on_worker(ARRAY[hostname, 'localhost'], ARRAY[port, master_port],
+                            ARRAY[dist_node_summary.query, dist_node_summary.query],
+                            false)
+), dist_placement_summary AS (
+    SELECT 'SELECT jsonb_agg(pg_dist_placement ORDER BY shardid) FROM pg_dist_placement)' AS query
+), dist_placement_check AS (
+    SELECT count(distinct result) = 1 AS matches
+    FROM dist_placement_summary CROSS JOIN LATERAL
+        master_run_on_worker(ARRAY[hostname, 'localhost'], ARRAY[port, master_port],
+                            ARRAY[dist_placement_summary.query, dist_placement_summary.query],
+                            false)
+)
+SELECT dist_node_check.matches AND dist_placement_check.matches
+FROM dist_node_check CROSS JOIN dist_placement_check
+$$;
+
+-- Simulates a readonly node by setting default_transaction_read_only. 
+CREATE FUNCTION mark_node_readonly(hostname TEXT, port INTEGER, isreadonly BOOLEAN)
+    RETURNS TEXT
+    LANGUAGE sql
+    AS $$
+    SELECT master_run_on_worker(ARRAY[hostname], ARRAY[port],
+           ARRAY['ALTER SYSTEM SET default_transaction_read_only TO ' || isreadonly::TEXT], false);
+    SELECT result FROM
+        master_run_on_worker(ARRAY[hostname], ARRAY[port],
+                             ARRAY['SELECT pg_reload_conf()'], false);
+$$;
+
+-- add a node to the cluster
+SELECT master_add_node('localhost', :worker_1_port) As nodeid_1 \gset
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+
+-- create couple of tables
+CREATE TABLE ref_table(a int primary key);
+SELECT create_reference_table('ref_table');
+
+CREATE TABLE dist_table_1(a int primary key, b int references ref_table(a));
+SELECT create_distributed_table('dist_table_1', 'a');
+
+-- update the node
+SELECT 1 FROM master_update_node((SELECT nodeid FROM pg_dist_node),
+                                 'localhost', :worker_2_port);
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+
+-- start syncing metadata to the node
+SELECT 1 FROM start_metadata_sync_to_node('localhost', :worker_2_port);
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+
+--------------------------------------------------------------------------
+-- Test that maintenance daemon syncs after master_update_node
+--------------------------------------------------------------------------
+
+-- Update the node again. We do this as epeatable read, so we just see the
+-- changes by master_update_node(). This is to avoid inconsistent results
+-- if the maintenance daemon does the metadata sync too fast.
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+END;
+
+-- wait until maintenance daemon does the next metadata sync, and then
+-- check if metadata is synced again
+SELECT wait_until_metadata_sync();
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
+
+SELECT verify_metadata('localhost', :worker_1_port);
+
+-- Update the node to a non-existent node. This is to simulate updating to
+-- a unwriteable node.
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+SELECT nodeid, nodename, nodeport, hasmetadata, metadatasynced FROM pg_dist_node;
+END;
+
+-- maintenace daemon metadata sync should fail, because node is still unwriteable.
+SELECT wait_until_metadata_sync();
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
+
+-- update it back to :worker_1_port, now metadata should be synced
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+SELECT wait_until_metadata_sync();
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
+
+--------------------------------------------------------------------------
+-- Test updating a node when another node is in readonly-mode
+--------------------------------------------------------------------------
+
+SELECT FROM master_add_node('localhost', :worker_2_port) AS nodeid_2 \gset
+SELECT 1 FROM start_metadata_sync_to_node('localhost', :worker_2_port);
+
+-- Create a table with shards on both nodes
+CREATE TABLE dist_table_2(a int);
+SELECT create_distributed_table('dist_table_2', 'a');
+INSERT INTO dist_table_2 SELECT i FROM generate_series(1, 100) i;
+
+SELECT mark_node_readonly('localhost', :worker_2_port, TRUE);
+
+-- Now updating the other node should try syncing to worker 2, but instead of
+-- failure, it should just warn and mark the readonly node as not synced.
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
+
+-- worker_2 is out of sync, so further updates aren't sent to it and
+-- we shouldn't see the warnings.
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 23456);
+SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node ORDER BY nodeid;
+
+-- Make the node writeable.
+SELECT mark_node_readonly('localhost', :worker_2_port, FALSE);
+SELECT wait_until_metadata_sync();
+
+-- Mark the node readonly again, so the following master_update_node warns
+SELECT mark_node_readonly('localhost', :worker_2_port, TRUE);
+
+-- Revert the nodeport of worker 1, metadata propagation to worker 2 should
+-- still fail, but after the failure, we should still be able to read from
+-- worker 2 in the same transaction!
+BEGIN;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+SELECT count(*) FROM dist_table_2;
+END;
+
+SELECT wait_until_metadata_sync();
+
+-- Make the node writeable.
+SELECT mark_node_readonly('localhost', :worker_2_port, FALSE);
+SELECT wait_until_metadata_sync();
+
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+SELECT verify_metadata('localhost', :worker_1_port),
+       verify_metadata('localhost', :worker_2_port);
+
+--------------------------------------------------------------------------
+-- Test that master_update_node rolls back properly
+--------------------------------------------------------------------------
+BEGIN;
+SELECT 1 FROM master_update_node(:nodeid_1, 'localhost', 12345);
+ROLLBACK;
+
+SELECT verify_metadata('localhost', :worker_1_port),
+       verify_metadata('localhost', :worker_2_port);
+
+-- cleanup
+DROP TABLE dist_table_1, ref_table, dist_table_2;
+TRUNCATE pg_dist_colocation;
+SELECT count(*) FROM (SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node) t;
+ALTER SEQUENCE pg_catalog.pg_dist_groupid_seq RESTART :last_group_id;
+ALTER SEQUENCE pg_catalog.pg_dist_node_nodeid_seq RESTART :last_node_id;
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART :last_colocation_id;
+ALTER SEQUENCE pg_catalog.pg_dist_placement_placementid_seq RESTART :last_placement_id;
+ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART :last_shard_id;
+
+RESET citus.shard_count;
+RESET citus.shard_replication_factor;
+RESET citus.replication_model;

--- a/src/test/regress/sql/multi_read_from_secondaries.sql
+++ b/src/test/regress/sql/multi_read_from_secondaries.sql
@@ -19,7 +19,7 @@ INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (10, 10);
 
 -- simluate actually having secondary nodes
-SELECT * FROM pg_dist_node;
+SELECT nodeid, groupid, nodename, nodeport, noderack, isactive, noderole, nodecluster FROM pg_dist_node;
 UPDATE pg_dist_node SET noderole = 'secondary';
 
 \c "dbname=regression options='-c\ citus.use_secondary_nodes=always'"


### PR DESCRIPTION
DESCRIPTION: Make master_update_node MX compatible

Addresses https://github.com/citusdata/citus/issues/2915

Previously we were not propagating changes done by `master_update_node()` to other nodes, now we do. The common use-case for `master_update_node()` is by HA tools like pg_auto_failover. 

Ususaly the new node is in standby mode, so we cannot update the metadata in the new node. To address this, a new `pg_dist_node.metadatasynced` column is added which tracks if a metadata node's metadata tables are in sync with the coordinator node.

`master_update_node()` sets the `metadatasynced` of metadata nodes to false. Maintenance daemon checks for out-of-sync metadata nodes and tries syncing them. We don't want to wait too long after `master_update_node()` for the next sync, so `master_update_node()` calls `TriggerMetadataSync()` to trigger the maintenance daemon to do a sync asap.

It is possible that the HA tool calls multiple `master_update_node()`s around the same time, which means we have multiple stand-by nodes in the cluster, in which case maintenance daemon will eventually sync the metadata to all of the newly promoted nodes.

In the tests we needed a mean for waiting until next sync. To enable this, we use postgresqls' `LISTEN/NOTIFY` commands. The maintenance daemon does a `NOTIFY metadata_sync` after doing a metadata sync. `wait_until_metadata_sync()` does a `LISTEN metadata_sync()`, so it can get the notification.

The test files have couple of other interesting UDFs:
 - `verify_metadata(nodename, nodeport)` verifies that metadata tables in a worker have the same entries as the coordinator. Right now, it just compares the pg_dist_node and pg_dist_placement entries.
 - `mark_node_readonly` simulates a readonly node by setting `default_transaction_read_only` in that node.

Todo:
- [x] Test with pg_auto_failover
