### PR TITLE
get_catalog_object_by_oid requires an extra parameter in pg12

### DIFF
--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -94,7 +94,12 @@ ObjectExists(const ObjectAddress *address)
 		HeapTuple objtup;
 		Relation catalog = heap_open(address->classId, AccessShareLock);
 
+#if PG_VERSION_NUM >= 120000
+		objtup = get_catalog_object_by_oid(catalog, get_object_attnum_oid(
+											   address->classId), address->objectId);
+#else
 		objtup = get_catalog_object_by_oid(catalog, address->objectId);
+#endif
 		heap_close(catalog, AccessShareLock);
 		if (objtup != NULL)
 		{


### PR DESCRIPTION
While this fixes the compile error, pg12 still fails to create the schema in `multi_metadata_sync`