### PR TITLE
Fix: Remove early escape in walking pg_depend

### DIFF
--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -211,7 +211,7 @@ recurse_pg_depend(const ObjectAddress *target,
 		if (follow == NULL || !follow(context, pg_depend))
 		{
 			/* skip all pg_depend entries the user didn't want to follow */
-			return;
+			continue;
 		}
 
 		/*

--- a/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
+++ b/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
@@ -8,7 +8,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -58,7 +58,7 @@ create_distributed_table
                
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -86,7 +86,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -142,7 +142,7 @@ step s2-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -170,7 +170,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -226,7 +226,7 @@ step s1-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -254,7 +254,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -305,7 +305,7 @@ create_distributed_table
                
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -334,7 +334,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -391,7 +391,7 @@ step s2-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -420,7 +420,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -477,7 +477,7 @@ step s1-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -506,7 +506,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -582,7 +582,7 @@ step s3-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -611,7 +611,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -706,7 +706,7 @@ step s4-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -735,7 +735,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -804,7 +804,7 @@ step s3-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -833,7 +833,7 @@ step s1-print-distributed-objects:
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -910,7 +910,7 @@ step s4-commit:
 
 step s2-print-distributed-objects: 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';

--- a/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
+++ b/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
@@ -47,7 +47,7 @@ step "s1-print-distributed-objects"
     SELECT nodename, nodeport, isactive FROM master_add_node('localhost', 57638);
 
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
@@ -92,7 +92,7 @@ step "s2-commit"
 step "s2-print-distributed-objects"
 {
     -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object;
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
 
     -- print if the schema has been created
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';


### PR DESCRIPTION
DESCRIPTION: Fix bug in pg_depend_recurse introduced in #2882

This is a bug that got in when we inlined the body of a function into this loop. Earlier revisions had two loops, hence a function that would be reused.

With a return instead of a continue the list of dependencies being walked is dependent on the order in which we find them in pg_depend. This became apparent during pg12 compatibility. The order of entries in pg12 was luckily different causing a random test to fail due to this return.

By changing it to a continue we only skip the entries that we don’t want to follow instead of skipping all entries that happen to be found later.

