### PR TITLE
Fix: schema leak onto create index statement cache

### DIFF
--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1247,9 +1247,9 @@ SELECT ddl_in_plpgsql2();
 
 -- verify the index is created in the correct schema
 SELECT schemaname, indexrelname FROM pg_stat_all_indexes WHERE indexrelname = 'prepared_index';
- schemaname |  indexrelname  
-------------+----------------
- public     | prepared_index
+ schemaname  |  indexrelname  
+-------------+----------------
+ otherschema | prepared_index
 (1 row)
 
 RESET search_path;

--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1214,7 +1214,7 @@ SELECT ddl_in_plpgsql();
 
 -- test prepared ddl with multi search path to make sure the schema name doesn't leak on
 -- to the cached statement
-CREATE OR REPLACE FUNCTION ddl_in_plpgsql2()
+CREATE OR REPLACE FUNCTION ddl_in_plpgsql()
 RETURNS VOID  AS
 $BODY$
 BEGIN
@@ -1223,9 +1223,9 @@ END;
 $BODY$ LANGUAGE plpgsql;
 CREATE SCHEMA otherschema;
 SET search_path TO otherschema, public;
-SELECT ddl_in_plpgsql2();
- ddl_in_plpgsql2 
------------------
+SELECT ddl_in_plpgsql();
+ ddl_in_plpgsql 
+----------------
  
 (1 row)
 
@@ -1239,9 +1239,9 @@ SELECT create_distributed_table('prepare_ddl', 'x');
  
 (1 row)
 
-SELECT ddl_in_plpgsql2();
- ddl_in_plpgsql2 
------------------
+SELECT ddl_in_plpgsql();
+ ddl_in_plpgsql 
+----------------
  
 (1 row)
 
@@ -1252,6 +1252,9 @@ SELECT schemaname, indexrelname FROM pg_stat_all_indexes WHERE indexrelname = 'p
  otherschema | prepared_index
 (1 row)
 
+-- cleanup
+DROP TABLE prepare_ddl;
+DROP SCHEMA otherschema;
 RESET search_path;
 -- test prepared COPY
 CREATE OR REPLACE FUNCTION copy_in_plpgsql()

--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -1212,6 +1212,47 @@ SELECT ddl_in_plpgsql();
  
 (1 row)
 
+-- test prepared ddl with multi search path to make sure the schema name doesn't leak on
+-- to the cached statement
+CREATE OR REPLACE FUNCTION ddl_in_plpgsql2()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    CREATE INDEX prepared_index ON prepare_ddl(x);
+END;
+$BODY$ LANGUAGE plpgsql;
+CREATE SCHEMA otherschema;
+SET search_path TO otherschema, public;
+SELECT ddl_in_plpgsql2();
+ ddl_in_plpgsql2 
+-----------------
+ 
+(1 row)
+
+DROP INDEX prepared_index;
+-- this creates the same table it 'otherschema'. If there is a leak the index will not be
+-- created on this table, but instead on the table in the public schema
+CREATE TABLE prepare_ddl (x int, y int);
+SELECT create_distributed_table('prepare_ddl', 'x');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT ddl_in_plpgsql2();
+ ddl_in_plpgsql2 
+-----------------
+ 
+(1 row)
+
+-- verify the index is created in the correct schema
+SELECT schemaname, indexrelname FROM pg_stat_all_indexes WHERE indexrelname = 'prepared_index';
+ schemaname |  indexrelname  
+------------+----------------
+ public     | prepared_index
+(1 row)
+
+RESET search_path;
 -- test prepared COPY
 CREATE OR REPLACE FUNCTION copy_in_plpgsql()
 RETURNS VOID  AS

--- a/src/test/regress/sql/multi_prepare_plsql.sql
+++ b/src/test/regress/sql/multi_prepare_plsql.sql
@@ -557,7 +557,7 @@ SELECT ddl_in_plpgsql();
 
 -- test prepared ddl with multi search path to make sure the schema name doesn't leak on
 -- to the cached statement
-CREATE OR REPLACE FUNCTION ddl_in_plpgsql2()
+CREATE OR REPLACE FUNCTION ddl_in_plpgsql()
 RETURNS VOID  AS
 $BODY$
 BEGIN
@@ -568,7 +568,7 @@ $BODY$ LANGUAGE plpgsql;
 CREATE SCHEMA otherschema;
 SET search_path TO otherschema, public;
 
-SELECT ddl_in_plpgsql2();
+SELECT ddl_in_plpgsql();
 DROP INDEX prepared_index;
 
 -- this creates the same table it 'otherschema'. If there is a leak the index will not be
@@ -576,9 +576,13 @@ DROP INDEX prepared_index;
 CREATE TABLE prepare_ddl (x int, y int);
 SELECT create_distributed_table('prepare_ddl', 'x');
 
-SELECT ddl_in_plpgsql2();
+SELECT ddl_in_plpgsql();
 -- verify the index is created in the correct schema
 SELECT schemaname, indexrelname FROM pg_stat_all_indexes WHERE indexrelname = 'prepared_index';
+
+-- cleanup
+DROP TABLE prepare_ddl;
+DROP SCHEMA otherschema;
 
 RESET search_path;
 

--- a/src/test/regress/sql/multi_prepare_plsql.sql
+++ b/src/test/regress/sql/multi_prepare_plsql.sql
@@ -555,6 +555,33 @@ $BODY$ LANGUAGE plpgsql;
 SELECT ddl_in_plpgsql();
 SELECT ddl_in_plpgsql();
 
+-- test prepared ddl with multi search path to make sure the schema name doesn't leak on
+-- to the cached statement
+CREATE OR REPLACE FUNCTION ddl_in_plpgsql2()
+RETURNS VOID  AS
+$BODY$
+BEGIN
+    CREATE INDEX prepared_index ON prepare_ddl(x);
+END;
+$BODY$ LANGUAGE plpgsql;
+
+CREATE SCHEMA otherschema;
+SET search_path TO otherschema, public;
+
+SELECT ddl_in_plpgsql2();
+DROP INDEX prepared_index;
+
+-- this creates the same table it 'otherschema'. If there is a leak the index will not be
+-- created on this table, but instead on the table in the public schema
+CREATE TABLE prepare_ddl (x int, y int);
+SELECT create_distributed_table('prepare_ddl', 'x');
+
+SELECT ddl_in_plpgsql2();
+-- verify the index is created in the correct schema
+SELECT schemaname, indexrelname FROM pg_stat_all_indexes WHERE indexrelname = 'prepared_index';
+
+RESET search_path;
+
 -- test prepared COPY
 CREATE OR REPLACE FUNCTION copy_in_plpgsql()
 RETURNS VOID  AS


### PR DESCRIPTION
DESCRIPTION: Fix schema leak on CREATE INDEX statement

When a CREATE INDEX is cached between execution we might leak the schema name onto the cached statement of an earlier execution preventing the right index to be created.

Even though the cache is cleared when the search_path changes we can trigger this behaviour by having the schema already on the search path before a colliding table is created in a schema earlier on the `search_path`. When calling an unqualified create index via a function (used to trigger the caching behaviour) we see that the index is created on the wrong table after the schema leaked onto the statement.

By copying the complete `PlannedStmt` and `utilityStmt` during our planning phase for distributed ddls we make sure we are not leaking the schema name onto a cached data structure.

Caveat; COPY statements already have a lot of parsestree copying ongoing without directly putting it back on the `pstmt`. We should verify that copies modify the statement and potentially copy the complete `pstmt` there already.