### PR TITLE
Distribute CALL

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -1,7 +1,9 @@
 /*-------------------------------------------------------------------------
  *
  * call.c
- *    Commands for call remote stored procedures.
+ *    Commands for distributing CALL for distributed procedures.
+ *
+ *    Procedures can be distributed with create_distributed_function.
  *
  * Copyright (c) 2019, Citus Data, Inc.
  *
@@ -169,6 +171,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		TupleDesc tupleDesc = CallStmtResultDesc(callStmt);
 		TupleTableSlot *slot = MakeSingleTupleTableSlotCompat(tupleDesc,
 															  &TTSOpsMinimalTuple);
+		bool hasReturning = true;
 		Task *task = CitusMakeNode(Task);
 
 		task->jobId = INVALID_JOB_ID;
@@ -182,7 +185,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		task->taskPlacementList = placementList;
 
 		ExecuteTaskListExtended(ROW_MODIFY_NONE, list_make1(task),
-								tupleDesc, tupleStore, true,
+								tupleDesc, tupleStore, hasReturning,
 								MaxAdaptiveExecutorPoolSize);
 
 		while (tuplestore_gettupleslot(tupleStore, true, false, slot))

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -1,0 +1,181 @@
+/*-------------------------------------------------------------------------
+ *
+ * call.c
+ *    Commands for call remote stored procedures.
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#if PG_VERSION_NUM >= 110000
+
+#include "catalog/pg_proc.h"
+#include "commands/defrem.h"
+#include "distributed/colocation_utils.h"
+#include "distributed/commands.h"
+#include "distributed/connection_management.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_executor.h"
+#include "distributed/multi_physical_planner.h"
+#include "distributed/remote_commands.h"
+#include "distributed/shard_pruning.h"
+#include "distributed/version_compat.h"
+#include "distributed/worker_manager.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "miscadmin.h"
+#include "tcop/dest.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+
+static bool CallFuncExprRemotely(CallStmt *callStmt,
+								 DistObjectCacheEntry *procedure,
+								 FuncExpr *funcExpr, const char *queryString,
+								 DestReceiver *dest);
+
+/*
+ * CallDistributedProcedure calls a stored procedure on the worker if possible.
+ */
+bool
+CallDistributedProcedureRemotely(CallStmt *callStmt, const char *queryString,
+								 DestReceiver *dest)
+{
+	DistObjectCacheEntry *procedure = NULL;
+	FuncExpr *funcExpr = callStmt->funcexpr;
+	Oid functionId = funcExpr->funcid;
+
+	procedure = LookupDistObjectCacheEntry(ProcedureRelationId, functionId, 0);
+	if (procedure == NULL)
+	{
+		return false;
+	}
+
+	return CallFuncExprRemotely(callStmt, procedure, funcExpr, queryString, dest);
+}
+
+
+/*
+ * CallFuncExprRemotely calls a procedure of function on the worker if possible.
+ */
+static bool
+CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
+					 FuncExpr *funcExpr, const char *queryString, DestReceiver *dest)
+{
+	Oid colocatedRelationId = InvalidOid;
+	Const *partitionValue = NULL;
+	ShardInterval *shardInterval = NULL;
+	List *placementList = NIL;
+	ListCell *argCell = NULL;
+	WorkerNode *preferredWorkerNode = NULL;
+	DistTableCacheEntry *distTable = NULL;
+	ShardPlacement *placement = NULL;
+	WorkerNode *workerNode = NULL;
+
+	if (IsMultiStatementTransaction())
+	{
+		ereport(DEBUG2, (errmsg("cannot push down CALL in multi-statement transaction")));
+		return false;
+	}
+
+	colocatedRelationId = ColocatedTableId(procedure->colocationId);
+	if (colocatedRelationId == InvalidOid)
+	{
+		ereport(DEBUG2, (errmsg("stored procedure does not have co-located tables")));
+		return false;
+	}
+
+	if (procedure->distributionArgIndex < 0 ||
+		procedure->distributionArgIndex >= list_length(funcExpr->args))
+	{
+		ereport(DEBUG2, (errmsg("cannot push down invalid distribution_argument_index")));
+		return false;
+	}
+
+	foreach(argCell, funcExpr->args)
+	{
+		Node *argNode = (Node *) lfirst(argCell);
+		if (!IsA(argNode, Const))
+		{
+			ereport(DEBUG2, (errmsg("cannot push down non-constant argument value")));
+			return false;
+		}
+	}
+
+	partitionValue = (Const *) list_nth(funcExpr->args, procedure->distributionArgIndex);
+	distTable = DistributedTableCacheEntry(colocatedRelationId);
+	shardInterval = FindShardInterval(partitionValue->constvalue, distTable);
+
+	if (shardInterval == NULL)
+	{
+		ereport(DEBUG2, (errmsg("cannot push down call, failed to find shard interval")));
+		return false;
+	}
+
+	placementList = FinalizedShardPlacementList(shardInterval->shardId);
+	if (list_length(placementList) != 1)
+	{
+		/* punt on reference tables for now */
+		ereport(DEBUG2, (errmsg(
+							 "cannot push down CALL for reference tables or replicated distributed tables")));
+		return false;
+	}
+
+	placement = (ShardPlacement *) linitial(placementList);
+	workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
+
+	if (workerNode->hasMetadata)
+	{
+		/* we can execute this procedure on the worker! */
+		preferredWorkerNode = workerNode;
+	}
+
+	if (preferredWorkerNode == NULL)
+	{
+		ereport(DEBUG2, (errmsg("there is no worker node with metadata")));
+		return false;
+	}
+
+	{
+		Tuplestorestate *tupleStore = tuplestore_begin_heap(true, false, work_mem);
+		TupleDesc tupleDesc = CallStmtResultDesc(callStmt);
+		TupleTableSlot *slot = MakeSingleTupleTableSlotCompat(tupleDesc,
+															  &TTSOpsMinimalTuple);
+
+		Task *task = CitusMakeNode(Task);
+		task->jobId = INVALID_JOB_ID;
+		task->taskId = 0;
+		task->taskType = DDL_TASK;
+		task->queryString = pstrdup(queryString);
+		task->replicationModel = REPLICATION_MODEL_INVALID;
+		task->dependedTaskList = NIL;
+		task->anchorShardId = placement->shardId;
+		task->relationShardList = NIL;
+		task->taskPlacementList = placementList;
+
+		ExecuteTaskListExtended(ROW_MODIFY_COMMUTATIVE, list_make1(task),
+								tupleDesc, tupleStore, true,
+								MaxAdaptiveExecutorPoolSize);
+
+		while (tuplestore_gettupleslot(tupleStore, true, false, slot))
+		{
+			if (!dest->receiveSlot(slot, dest))
+			{
+				break;
+			}
+		}
+
+		/* Don't call tuplestore_end(tupleStore). It'll be freed soon enough in a top level CALL,
+		 * & dest->receiveSlot could conceivably rely on slots being long lived.
+		 */
+	}
+
+	return true;
+}
+
+
+#endif /* PG_VERSION_NUM >= 110000 */

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -81,27 +81,27 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 
 	if (IsMultiStatementTransaction())
 	{
-		ereport(DEBUG2, (errmsg("cannot push down CALL in multi-statement transaction")));
+		ereport(DEBUG1, (errmsg("cannot push down CALL in multi-statement transaction")));
 		return false;
 	}
 
 	colocatedRelationId = ColocatedTableId(procedure->colocationId);
 	if (colocatedRelationId == InvalidOid)
 	{
-		ereport(DEBUG2, (errmsg("stored procedure does not have co-located tables")));
+		ereport(DEBUG1, (errmsg("stored procedure does not have co-located tables")));
 		return false;
 	}
 
 	if (procedure->distributionArgIndex < 0 ||
 		procedure->distributionArgIndex >= list_length(funcExpr->args))
 	{
-		ereport(DEBUG2, (errmsg("cannot push down invalid distribution_argument_index")));
+		ereport(DEBUG1, (errmsg("cannot push down invalid distribution_argument_index")));
 		return false;
 	}
 
 	if (contain_volatile_functions((Node *) funcExpr->args))
 	{
-		ereport(DEBUG2, (errmsg("arguments in a distributed stored procedure must "
+		ereport(DEBUG1, (errmsg("arguments in a distributed stored procedure must "
 								"be constant expressions")));
 		return false;
 	}
@@ -119,7 +119,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 	partitionValue = (Const *) list_nth(funcExpr->args, procedure->distributionArgIndex);
 	if (!IsA(partitionValue, Const))
 	{
-		ereport(DEBUG2, (errmsg("distribution argument value must be a constant")));
+		ereport(DEBUG1, (errmsg("distribution argument value must be a constant")));
 		return false;
 	}
 
@@ -137,7 +137,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 	shardInterval = FindShardInterval(partitionValueDatum, distTable);
 	if (shardInterval == NULL)
 	{
-		ereport(DEBUG2, (errmsg("cannot push down call, failed to find shard interval")));
+		ereport(DEBUG1, (errmsg("cannot push down call, failed to find shard interval")));
 		return false;
 	}
 
@@ -154,9 +154,11 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 	workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
 	if (workerNode == NULL || !workerNode->hasMetadata || !workerNode->metadataSynced)
 	{
-		ereport(DEBUG2, (errmsg("there is no worker node with metadata")));
+		ereport(DEBUG1, (errmsg("there is no worker node with metadata")));
 		return false;
 	}
+
+	ereport(DEBUG1, (errmsg("pushing down the procedure")));
 
 	{
 		Tuplestorestate *tupleStore = tuplestore_begin_heap(true, false, work_mem);

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -219,7 +219,6 @@ static int64 RemoteCreateEmptyShard(char *relationName);
 static void MasterUpdateShardStatistics(uint64 shardId);
 static void RemoteUpdateShardStatistics(uint64 shardId);
 
-static void ConversionPathForTypes(Oid inputType, Oid destType, CopyCoercionData *result);
 static Oid TypeForColumnName(Oid relationId, TupleDesc tupleDescriptor, char *columnName);
 static Oid * TypeArrayFromTupleDescriptor(TupleDesc tupleDescriptor);
 static CopyCoercionData * ColumnCoercionPaths(TupleDesc destTupleDescriptor,
@@ -228,7 +227,6 @@ static CopyCoercionData * ColumnCoercionPaths(TupleDesc destTupleDescriptor,
 											  Oid *finalColumnTypeArray);
 static FmgrInfo * TypeOutputFunctions(uint32 columnCount, Oid *typeIdArray,
 									  bool binaryFormat);
-static Datum CoerceColumnValue(Datum inputValue, CopyCoercionData *coercionPath);
 static void CreateLocalTable(RangeVar *relation, char *nodeName, int32 nodePort);
 static List * CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist);
 static bool CopyStatementHasFormat(CopyStmt *copyStatement, char *formatName);
@@ -1384,7 +1382,7 @@ ReportCopyError(MultiConnection *connection, PGresult *result)
  * ConversionPathForTypes fills *result with all the data necessary for converting
  * Datums of type inputType to Datums of type destType.
  */
-static void
+void
 ConversionPathForTypes(Oid inputType, Oid destType, CopyCoercionData *result)
 {
 	Oid coercionFuncId = InvalidOid;
@@ -1743,7 +1741,7 @@ AppendCopyRowData(Datum *valueArray, bool *isNullArray, TupleDesc rowDescriptor,
  * CoerceColumnValue follows the instructions in *coercionPath and uses them to convert
  * inputValue into a Datum of the correct type.
  */
-static Datum
+Datum
 CoerceColumnValue(Datum inputValue, CopyCoercionData *coercionPath)
 {
 	switch (coercionPath->coercionType)

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -209,7 +209,7 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		 * the worker this can avoid making many network round trips.
 		 */
 		if (context == PROCESS_UTILITY_TOPLEVEL &&
-			CallDistributedProcedureRemotely(callStmt, queryString, dest))
+			CallDistributedProcedureRemotely(callStmt, dest))
 		{
 			return;
 		}

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -244,7 +244,7 @@ IsObjectDistributed(const ObjectAddress *address)
 	ScanKeyInit(&key[1], Anum_pg_dist_object_objid, BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(address->objectId));
 	ScanKeyInit(&key[2], Anum_pg_dist_object_objsubid, BTEqualStrategyNumber, F_INT4EQ,
-				ObjectIdGetDatum(address->objectSubId));
+				Int32GetDatum(address->objectSubId));
 	pgDistObjectScan = systable_beginscan(pgDistObjectRel, DistObjectPrimaryKeyIndexId(),
 										  true, NULL, 3, key);
 

--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -32,7 +32,7 @@ COMMENT ON FUNCTION pg_catalog.master_unmark_object_distributed(classid oid, obj
     IS 'remove an object address from citus.pg_dist_object once the object has been deleted';
 
 CREATE TABLE citus.pg_dist_object (
-	-- primary key
+	-- fields used for composite primary key
     classid oid NOT NULL,
     objid oid NOT NULL,
     objsubid integer NOT NULL,

--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -32,6 +32,7 @@ COMMENT ON FUNCTION pg_catalog.master_unmark_object_distributed(classid oid, obj
     IS 'remove an object address from citus.pg_dist_object once the object has been deleted';
 
 CREATE TABLE citus.pg_dist_object (
+	-- primary key
     classid oid NOT NULL,
     objid oid NOT NULL,
     objsubid integer NOT NULL,
@@ -48,6 +49,17 @@ CREATE TABLE citus.pg_dist_object (
 
     CONSTRAINT pg_dist_object_pkey PRIMARY KEY (classid, objid, objsubid)
 );
+
+CREATE FUNCTION master_dist_object_cache_invalidate()
+    RETURNS trigger
+    LANGUAGE C
+    AS 'MODULE_PATHNAME', $$master_dist_object_cache_invalidate$$;
+COMMENT ON FUNCTION master_dist_object_cache_invalidate()
+    IS 'register relcache invalidation for changed rows';
+CREATE TRIGGER dist_object_cache_invalidate
+    AFTER INSERT OR UPDATE OR DELETE
+    ON citus.pg_dist_object
+    FOR EACH ROW EXECUTE PROCEDURE master_dist_object_cache_invalidate();
 
 #include "udfs/create_distributed_function/9.0-1.sql"
 

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/9.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/9.0-1.sql
@@ -73,6 +73,7 @@ BEGIN
     FROM pg_catalog.pg_dist_partition p;
 
     -- restore pg_dist_object from the stable identifiers
+    -- DELETE/INSERT to avoid primary key violations
     WITH old_records AS (
         DELETE FROM
             citus.pg_dist_object

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
@@ -73,6 +73,7 @@ BEGIN
     FROM pg_catalog.pg_dist_partition p;
 
     -- restore pg_dist_object from the stable identifiers
+    -- DELETE/INSERT to avoid primary key violations
     WITH old_records AS (
         DELETE FROM
             citus.pg_dist_object

--- a/src/backend/distributed/utils/ruleutils_10.c
+++ b/src/backend/distributed/utils/ruleutils_10.c
@@ -452,6 +452,48 @@ pg_get_query_def(Query *query, StringInfo buffer)
 
 
 /*
+ * pg_get_rule_expr deparses an expression and returns the result as a string.
+ */
+char *
+pg_get_rule_expr(Node *expression)
+{
+	bool showImplicitCasts = true;
+	deparse_context context;
+	OverrideSearchPath *overridePath = NULL;
+	StringInfo buffer = makeStringInfo();
+
+	/*
+	 * Set search_path to NIL so that all objects outside of pg_catalog will be
+	 * schema-prefixed. pg_catalog will be added automatically when we call
+	 * PushOverrideSearchPath(), since we set addCatalog to true;
+	 */
+	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
+	overridePath->schemas = NIL;
+	overridePath->addCatalog = true;
+	PushOverrideSearchPath(overridePath);
+
+	context.buf = buffer;
+	context.namespaces = NIL;
+	context.windowClause = NIL;
+	context.windowTList = NIL;
+	context.varprefix = false;
+	context.prettyFlags = 0;
+	context.wrapColumn = WRAP_COLUMN_DEFAULT;
+	context.indentLevel = 0;
+	context.special_exprkind = EXPR_KIND_NONE;
+	context.distrelid = InvalidOid;
+	context.shardid = INVALID_SHARD_ID;
+
+	get_rule_expr(expression, &context, showImplicitCasts);
+
+	/* revert back to original search_path */
+	PopOverrideSearchPath();
+
+	return buffer->data;
+}
+
+
+/*
  * set_rtable_names: select RTE aliases to be used in printing a query
  *
  * We fill in dpns->rtable_names with a list of names that is one-for-one with

--- a/src/backend/distributed/utils/ruleutils_11.c
+++ b/src/backend/distributed/utils/ruleutils_11.c
@@ -452,6 +452,48 @@ pg_get_query_def(Query *query, StringInfo buffer)
 
 
 /*
+ * pg_get_rule_expr deparses an expression and returns the result as a string.
+ */
+char *
+pg_get_rule_expr(Node *expression)
+{
+	bool showImplicitCasts = true;
+	deparse_context context;
+	OverrideSearchPath *overridePath = NULL;
+	StringInfo buffer = makeStringInfo();
+
+	/*
+	 * Set search_path to NIL so that all objects outside of pg_catalog will be
+	 * schema-prefixed. pg_catalog will be added automatically when we call
+	 * PushOverrideSearchPath(), since we set addCatalog to true;
+	 */
+	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
+	overridePath->schemas = NIL;
+	overridePath->addCatalog = true;
+	PushOverrideSearchPath(overridePath);
+
+	context.buf = buffer;
+	context.namespaces = NIL;
+	context.windowClause = NIL;
+	context.windowTList = NIL;
+	context.varprefix = false;
+	context.prettyFlags = 0;
+	context.wrapColumn = WRAP_COLUMN_DEFAULT;
+	context.indentLevel = 0;
+	context.special_exprkind = EXPR_KIND_NONE;
+	context.distrelid = InvalidOid;
+	context.shardid = INVALID_SHARD_ID;
+
+	get_rule_expr(expression, &context, showImplicitCasts);
+
+	/* revert back to original search_path */
+	PopOverrideSearchPath();
+
+	return buffer->data;
+}
+
+
+/*
  * set_rtable_names: select RTE aliases to be used in printing a query
  *
  * We fill in dpns->rtable_names with a list of names that is one-for-one with

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -43,6 +43,7 @@ extern const char * RoleSpecString(RoleSpec *spec);
 
 /* Function declarations for version dependent PostgreSQL ruleutils functions */
 extern void pg_get_query_def(Query *query, StringInfo buffer);
+char * pg_get_rule_expr(Node *expression);
 extern void deparse_shard_query(Query *query, Oid distrelid, int64 shardid,
 								StringInfo buffer);
 extern char * generate_relation_name(Oid relid, List *namespaces);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -26,8 +26,7 @@ extern List * PlanClusterStmt(ClusterStmt *clusterStmt, const char *clusterComma
 #if PG_VERSION_NUM >= 110000
 
 /* call.c */
-extern bool CallDistributedProcedureRemotely(CallStmt *callStmt, const char *callCommand,
-											 DestReceiver *dest);
+extern bool CallDistributedProcedureRemotely(CallStmt *callStmt, DestReceiver *dest);
 #endif /* PG_VERSION_NUM >= 110000 */
 
 /* extension.c - forward declarations */

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -17,11 +17,18 @@
 
 #include "utils/rel.h"
 #include "nodes/parsenodes.h"
+#include "tcop/dest.h"
 
 
 /* cluster.c - forward declarations */
 extern List * PlanClusterStmt(ClusterStmt *clusterStmt, const char *clusterCommand);
 
+#if PG_VERSION_NUM >= 110000
+
+/* call.c */
+extern bool CallDistributedProcedureRemotely(CallStmt *callStmt, const char *callCommand,
+											 DestReceiver *dest);
+#endif /* PG_VERSION_NUM >= 110000 */
 
 /* extension.c - forward declarations */
 extern bool IsCitusExtensionStmt(Node *parsetree);

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -143,6 +143,8 @@ extern Node * ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag,
 							  const char *queryString);
 extern void CheckCopyPermissions(CopyStmt *copyStatement);
 extern bool IsCopyResultStmt(CopyStmt *copyStatement);
+extern void ConversionPathForTypes(Oid inputType, Oid destType, CopyCoercionData *result);
+extern Datum CoerceColumnValue(Datum inputValue, CopyCoercionData *coercionPath);
 
 
 #endif /* MULTI_COPY_H */

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -89,6 +89,24 @@ typedef struct
 	int *arrayOfPlacementArrayLengths;
 } DistTableCacheEntry;
 
+typedef struct DistObjectCacheEntryKey
+{
+	Oid classid;
+	Oid objid;
+	int32 objsubid;
+} DistObjectCacheEntryKey;
+
+typedef struct DistObjectCacheEntry
+{
+	/* lookup key - must be first. */
+	DistObjectCacheEntryKey key;
+
+	bool isValid;
+
+	int distributionArgIndex;
+	int colocationId;
+} DistObjectCacheEntry;
+
 
 extern bool IsDistributedTable(Oid relationId);
 extern List * DistributedTableList(void);
@@ -99,6 +117,10 @@ extern ShardPlacement * FindShardPlacementOnGroup(int32 groupId, uint64 shardId)
 extern GroupShardPlacement * LoadGroupShardPlacement(uint64 shardId, uint64 placementId);
 extern ShardPlacement * LoadShardPlacement(uint64 shardId, uint64 placementId);
 extern DistTableCacheEntry * DistributedTableCacheEntry(Oid distributedRelationId);
+extern DistObjectCacheEntry * DistributedObjectCacheEntry(Oid classid, Oid objid, int32
+														  objsubid);
+extern DistObjectCacheEntry * LookupDistObjectCacheEntry(Oid classid, Oid objid, int32
+														 objsubid);
 extern int32 GetLocalGroupId(void);
 extern List * DistTableOidList(void);
 extern Oid LookupShardRelation(int64 shardId, bool missing_ok);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -117,8 +117,6 @@ extern ShardPlacement * FindShardPlacementOnGroup(int32 groupId, uint64 shardId)
 extern GroupShardPlacement * LoadGroupShardPlacement(uint64 shardId, uint64 placementId);
 extern ShardPlacement * LoadShardPlacement(uint64 shardId, uint64 placementId);
 extern DistTableCacheEntry * DistributedTableCacheEntry(Oid distributedRelationId);
-extern DistObjectCacheEntry * DistributedObjectCacheEntry(Oid classid, Oid objid, int32
-														  objsubid);
 extern DistObjectCacheEntry * LookupDistObjectCacheEntry(Oid classid, Oid objid, int32
 														 objsubid);
 extern int32 GetLocalGroupId(void);

--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -18,14 +18,12 @@
 #define QUERY_SEND_FAILED 1
 #define RESPONSE_NOT_OKAY 2
 
-struct pg_result; /* target of the PGresult typedef */
-
 /* GUC, determining whether statements sent to remote nodes are logged */
 extern bool LogRemoteCommands;
 
 
 /* simple helpers */
-extern bool IsResponseOK(struct pg_result *result);
+extern bool IsResponseOK(PGresult *result);
 extern void ForgetResults(MultiConnection *connection);
 extern bool ClearResults(MultiConnection *connection, bool raiseErrors);
 extern bool ClearResultsDiscardWarnings(MultiConnection *connection, bool raiseErrors);
@@ -34,7 +32,7 @@ extern bool SqlStateMatchesCategory(char *sqlStateString, int category);
 
 /* report errors & warnings */
 extern void ReportConnectionError(MultiConnection *connection, int elevel);
-extern void ReportResultError(MultiConnection *connection, struct pg_result *result,
+extern void ReportResultError(MultiConnection *connection, PGresult *result,
 							  int elevel);
 extern char * pchomp(const char *in);
 extern void LogRemoteCommand(MultiConnection *connection, const char *command);
@@ -46,14 +44,14 @@ extern void ExecuteCriticalRemoteCommand(MultiConnection *connection,
 										 const char *command);
 extern int ExecuteOptionalRemoteCommand(MultiConnection *connection,
 										const char *command,
-										struct pg_result **result);
+										PGresult **result);
 extern int SendRemoteCommand(MultiConnection *connection, const char *command);
 extern int SendRemoteCommandParams(MultiConnection *connection, const char *command,
 								   int parameterCount, const Oid *parameterTypes,
 								   const char *const *parameterValues);
-extern List * ReadFirstColumnAsText(struct pg_result *queryResult);
-extern struct pg_result * GetRemoteCommandResult(MultiConnection *connection,
-												 bool raiseInterrupts);
+extern List * ReadFirstColumnAsText(PGresult *queryResult);
+extern PGresult * GetRemoteCommandResult(MultiConnection *connection,
+										 bool raiseInterrupts);
 extern bool PutRemoteCopyData(MultiConnection *connection, const char *buffer,
 							  int nbytes);
 extern bool PutRemoteCopyEnd(MultiConnection *connection, const char *errormsg);

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -255,7 +255,7 @@ END;$$;
 -- before distribution ...
 CALL multi_mx_call.mx_call_proc_tx(10);
 -- after distribution ...
-select create_distributed_function('mx_call_proc_tx(int)');
+select create_distributed_function('mx_call_proc_tx(int)', '$1', 'mx_call_dist_table_1');
 DEBUG:  switching to sequential query execution mode
 DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
  create_distributed_function 
@@ -263,7 +263,6 @@ DETAIL:  A distributed function is created. To make sure subsequent commands see
  
 (1 row)
 
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx', 'mx_call_dist_table_1'::regclass, 0);
 CALL multi_mx_call.mx_call_proc_tx(20);
 DEBUG:  pushing down the procedure
 ERROR:  relation "mx_call_dist_table_1" does not exist
@@ -287,7 +286,7 @@ BEGIN
     RAISE WARNING 'warning';
     RAISE EXCEPTION 'error';
 END;$$;
-select create_distributed_function('mx_call_proc_raise(int)');
+select create_distributed_function('mx_call_proc_raise(int)', '$1', 'mx_call_dist_table_1');
 DEBUG:  switching to sequential query execution mode
 DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
  create_distributed_function 
@@ -295,7 +294,6 @@ DETAIL:  A distributed function is created. To make sure subsequent commands see
  
 (1 row)
 
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_raise', 'mx_call_dist_table_1'::regclass, 0);
 call multi_mx_call.mx_call_proc_raise(2);
 DEBUG:  pushing down the procedure
 DEBUG:  warning
@@ -348,7 +346,7 @@ SET client_min_messages TO DEBUG1;
 --
 CREATE FUNCTION mx_call_add(int, int) RETURNS int
     AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE;
-SELECT create_distributed_function('mx_call_add(int,int)');
+SELECT create_distributed_function('mx_call_add(int,int)', '$1');
 DEBUG:  switching to sequential query execution mode
 DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
  create_distributed_function 

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -10,12 +10,36 @@ select create_distributed_table('mx_call_dist_table', 'id');
 (1 row)
 
 insert into mx_call_dist_table values (1),(2),(3),(4),(5);
+create type mx_call_enum as enum ('A', 'S', 'D', 'F');
 CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
 BEGIN
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
     y := y + (select sum(id) from mx_call_dist_table);
 END;
 $$;
+CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INOUT y mx_call_enum) LANGUAGE plpgsql AS $$
+BEGIN
+    y := x;
+    x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
+END;
+$$;
+CREATE FUNCTION mx_call_add(int, int) RETURNS int
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+call mx_call_proc(2, 0);
+ y  
+----
+ 18
+(1 row)
+
+call mx_call_proc_asdf('S', 'A');
+ x | y 
+---+---
+ F | S
+(1 row)
+
 select create_distributed_function('mx_call_proc(int,int)');
  create_distributed_function 
 -----------------------------
@@ -26,12 +50,122 @@ update citus.pg_dist_object
 set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
 from pg_proc, pg_dist_partition
 where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+select create_distributed_function('mx_call_proc_asdf(mx_call_enum,mx_call_enum)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc_asdf' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
 call mx_call_proc(2, 0);
  y  
 ----
  17
 (1 row)
 
+call mx_call_proc_asdf('S', 'A');
+ x | y 
+---+---
+ S | S
+(1 row)
+
+set client_min_messages to DEBUG2;
+begin;
+select sum(id) from mx_call_dist_table;
+DEBUG:  Router planner cannot handle multi-shard select queries
+ sum 
+-----
+  15
+(1 row)
+
+call mx_call_proc(2, 0);
+DEBUG:  cannot push down CALL in multi-statement transaction
+DEBUG:  Router planner cannot handle multi-shard select queries
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Router planner cannot handle multi-shard select queries
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  generating subplan 5_1 for subquery SELECT sum(id) AS sum FROM public.mx_call_dist_table
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Plan 5 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('5_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Creating router plan
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Plan is router executable
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+ y  
+----
+ 18
+(1 row)
+
+commit;
+update citus.pg_dist_object
+set distribution_argument_index = -1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, 0);
+DEBUG:  cannot push down invalid distribution_argument_index
+DEBUG:  Router planner cannot handle multi-shard select queries
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Router planner cannot handle multi-shard select queries
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  generating subplan 7_1 for subquery SELECT sum(id) AS sum FROM public.mx_call_dist_table
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Creating router plan
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Plan is router executable
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+ y  
+----
+ 18
+(1 row)
+
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, mx_call_add(3, 4));
+DEBUG:  cannot push down non-constant argument value
+DEBUG:  Router planner cannot handle multi-shard select queries
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Router planner cannot handle multi-shard select queries
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  generating subplan 9_1 for subquery SELECT sum(id) AS sum FROM public.mx_call_dist_table
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Plan 9 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('9_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Creating router plan
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  Plan is router executable
+CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
+PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+ y  
+----
+ 18
+(1 row)
+
+reset client_min_messages;
 DROP TABLE mx_call_dist_table;
 DROP PROCEDURE mx_call_proc;
 reset citus.shard_replication_factor;

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -390,14 +390,7 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  27
 (1 row)
 
---
--- clean-up
---
 reset client_min_messages;
-reset citus.shard_replication_factor;
-reset citus.replication_model;
-reset search_path;
 \set VERBOSITY terse
 drop schema multi_mx_call cascade;
 NOTICE:  drop cascades to 10 other objects
-\set VERBOSITY default

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -1,0 +1,38 @@
+-- Test passing off CALL to mx workers
+-- Create worker-local tables to test procedure calls were routed
+set citus.shard_replication_factor to 1;
+set citus.replication_model to 'streaming';
+CREATE TABLE mx_call_dist_table(id int);
+select create_distributed_table('mx_call_dist_table', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table values (1),(2),(3),(4),(5);
+CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
+BEGIN
+    y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
+    y := y + (select sum(id) from mx_call_dist_table);
+END;
+$$;
+select create_distributed_function('mx_call_proc(int,int)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, 0);
+ y  
+----
+ 17
+(1 row)
+
+DROP TABLE mx_call_dist_table;
+DROP PROCEDURE mx_call_proc;
+reset citus.shard_replication_factor;
+reset citus.replication_model;

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -1,172 +1,405 @@
 -- Test passing off CALL to mx workers
 -- Create worker-local tables to test procedure calls were routed
-set citus.shard_replication_factor to 1;
-set citus.replication_model to 'streaming';
-CREATE TABLE mx_call_dist_table(id int);
-select create_distributed_table('mx_call_dist_table', 'id');
+set citus.shard_replication_factor to 2;
+set citus.replication_model to 'statement';
+-- This table requires specific settings, create before getting into things
+create table mx_call_dist_table_replica(id int, val int);
+select create_distributed_table('mx_call_dist_table_replica', 'id');
  create_distributed_table 
 --------------------------
  
 (1 row)
 
-insert into mx_call_dist_table values (1),(2),(3),(4),(5);
-create type mx_call_enum as enum ('A', 'S', 'D', 'F');
-CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
+insert into mx_call_dist_table_replica values (9,1),(8,2),(7,3),(6,4),(5,5);
+set citus.shard_replication_factor to 1;
+set citus.replication_model to 'streaming';
+create schema multi_mx_call;
+set search_path to multi_mx_call, public;
+--
+-- Utility UDFs
+--
+-- 1. Marks the given procedure as colocated with the given table.
+-- 2. Marks the argument index with which we route the procedure.
+CREATE PROCEDURE colocate_proc_with_table(procname text, tablerelid regclass, argument_index int)
+LANGUAGE plpgsql AS $$
 BEGIN
+    update citus.pg_dist_object
+    set distribution_argument_index = argument_index, colocationid = pg_dist_partition.colocationid
+    from pg_proc, pg_dist_partition
+    where proname = procname and oid = objid and pg_dist_partition.logicalrelid = tablerelid;
+END;$$;
+--
+-- Create tables and procedures we want to use in tests
+--
+create table mx_call_dist_table_1(id int, val int);
+select create_distributed_table('mx_call_dist_table_1', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_1 values (3,1),(4,5),(9,2),(6,5),(3,5);
+create table mx_call_dist_table_2(id int, val int);
+select create_distributed_table('mx_call_dist_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_2 values (1,1),(1,2),(2,2),(3,3),(3,4);
+create table mx_call_dist_table_ref(id int, val int);
+select create_reference_table('mx_call_dist_table_ref');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_ref values (2,7),(1,8),(2,8),(1,8),(2,8);
+create type mx_call_enum as enum ('A', 'S', 'D', 'F');
+create table mx_call_dist_table_enum(id int, key mx_call_enum);
+select create_distributed_table('mx_call_dist_table_enum', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_enum values (1,'S'),(2,'A'),(3,'D'),(4,'F');
+CREATE PROCEDURE mx_call_proc(x int, INOUT y int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- groupid is 0 in coordinator and non-zero in workers, so by using it here
+    -- we make sure the procedure is being executed in the worker.
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
-    y := y + (select sum(id) from mx_call_dist_table);
-END;
-$$;
-CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INOUT y mx_call_enum) LANGUAGE plpgsql AS $$
+    -- we also make sure that we can run distributed queries in the procedures
+    -- that are routed to the workers.
+    y := y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id);
+END;$$;
+-- create another procedure which verifies:
+-- 1. we work fine with multiple return columns
+-- 2. we work fine in combination with custom types
+CREATE PROCEDURE mx_call_proc_custom_types(INOUT x mx_call_enum, INOUT y mx_call_enum)
+LANGUAGE plpgsql AS $$
 BEGIN
     y := x;
     x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
-END;
-$$;
-CREATE FUNCTION mx_call_add(int, int) RETURNS int
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
-    IMMUTABLE
-    RETURNS NULL ON NULL INPUT;
-call mx_call_proc(2, 0);
+END;$$;
+-- Test that undistributed procedures have no issue executing
+call multi_mx_call.mx_call_proc(2, 0);
  y  
 ----
- 18
+ 29
 (1 row)
 
-call mx_call_proc_asdf('S', 'A');
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
  x | y 
 ---+---
  F | S
 (1 row)
 
+-- Mark both procedures as distributed ...
 select create_distributed_function('mx_call_proc(int,int)');
  create_distributed_function 
 -----------------------------
  
 (1 row)
 
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-select create_distributed_function('mx_call_proc_asdf(mx_call_enum,mx_call_enum)');
+select create_distributed_function('mx_call_proc_custom_types(mx_call_enum,mx_call_enum)');
  create_distributed_function 
 -----------------------------
  
 (1 row)
 
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc_asdf' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, 0);
+-- We still don't route them to the workers, because they aren't
+-- colocated with any distributed tables.
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.mx_call_proc(2, 0);
+DEBUG:  stored procedure does not have co-located tables
+DEBUG:  generating subplan 8_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 8 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('8_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
- 17
+ 29
 (1 row)
 
-call mx_call_proc_asdf('S', 'A');
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+DEBUG:  stored procedure does not have co-located tables
+ x | y 
+---+---
+ F | S
+(1 row)
+
+-- Mark them as colocated with a table. Now we should route them to workers.
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
+call multi_mx_call.mx_call_proc(2, 0);
+DEBUG:  pushing down the procedure
+ y  
+----
+ 28
+(1 row)
+
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+DEBUG:  pushing down the procedure
  x | y 
 ---+---
  S | S
 (1 row)
 
-set client_min_messages to DEBUG2;
+-- We don't allow distributing calls inside transactions
 begin;
-select sum(id) from mx_call_dist_table;
-DEBUG:  Router planner cannot handle multi-shard select queries
- sum 
------
-  15
-(1 row)
-
-call mx_call_proc(2, 0);
+call multi_mx_call.mx_call_proc(2, 0);
 DEBUG:  cannot push down CALL in multi-statement transaction
-DEBUG:  Router planner cannot handle multi-shard select queries
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Router planner cannot handle multi-shard select queries
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  generating subplan 5_1 for subquery SELECT sum(id) AS sum FROM public.mx_call_dist_table
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Plan 5 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('5_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Creating router plan
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Plan is router executable
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  generating subplan 10_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
- 18
+ 29
 (1 row)
 
 commit;
-update citus.pg_dist_object
-set distribution_argument_index = -1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, 0);
+-- Drop the table colocated with mx_call_proc_custom_types. Now it shouldn't
+-- be routed to workers anymore.
+SET client_min_messages TO NOTICE;
+drop table mx_call_dist_table_enum;
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+DEBUG:  stored procedure does not have co-located tables
+ x | y 
+---+---
+ F | S
+(1 row)
+
+-- Make sure we do bounds checking on distributed argument index
+-- This also tests that we have cache invalidation for pg_dist_object updates
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
+call multi_mx_call.mx_call_proc(2, 0);
 DEBUG:  cannot push down invalid distribution_argument_index
-DEBUG:  Router planner cannot handle multi-shard select queries
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Router planner cannot handle multi-shard select queries
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  generating subplan 7_1 for subquery SELECT sum(id) AS sum FROM public.mx_call_dist_table
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Plan 7 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('7_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Creating router plan
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Plan is router executable
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+DEBUG:  generating subplan 12_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 12 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('12_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
- 18
+ 29
 (1 row)
 
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, mx_call_add(3, 4));
-DEBUG:  cannot push down non-constant argument value
-DEBUG:  Router planner cannot handle multi-shard select queries
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Router planner cannot handle multi-shard select queries
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  generating subplan 9_1 for subquery SELECT sum(id) AS sum FROM public.mx_call_dist_table
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Plan 9 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('9_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Creating router plan
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
-DEBUG:  Plan is router executable
-CONTEXT:  SQL statement "SELECT y + (select sum(id) from mx_call_dist_table)"
-PL/pgSQL function mx_call_proc(integer,integer) line 4 at assignment
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
+call multi_mx_call.mx_call_proc(2, 0);
+DEBUG:  cannot push down invalid distribution_argument_index
+DEBUG:  generating subplan 14_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('14_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
- 18
+ 29
 (1 row)
 
+-- We don't currently support colocating with reference tables
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
+call multi_mx_call.mx_call_proc(2, 0);
+DEBUG:  cannot push down CALL for reference tables
+DEBUG:  generating subplan 17_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 17 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('17_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+ y  
+----
+ 29
+(1 row)
+
+-- We don't currently support colocating with replicated tables
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
+call multi_mx_call.mx_call_proc(2, 0);
+DEBUG:  cannot push down CALL for replicated distributed tables
+DEBUG:  generating subplan 19_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+ y  
+----
+ 29
+(1 row)
+
+SET client_min_messages TO NOTICE;
+drop table mx_call_dist_table_replica;
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+-- Test that we handle transactional constructs correctly inside a procedure
+-- that is routed to the workers.
+CREATE PROCEDURE mx_call_proc_tx(x int) LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO mx_call_dist_table_1 VALUES (x, -1), (x+1, 4);
+    COMMIT;
+    UPDATE mx_call_dist_table_1 SET val = val+1 WHERE id >= x;
+    ROLLBACK;
+    -- Now do the final update!
+    UPDATE mx_call_dist_table_1 SET val = val-1 WHERE id >= x;
+END;$$;
+-- before distribution ...
+CALL multi_mx_call.mx_call_proc_tx(10);
+-- after distribution ...
+select create_distributed_function('mx_call_proc_tx(int)');
+DEBUG:  switching to sequential query execution mode
+DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx', 'mx_call_dist_table_1'::regclass, 0);
+CALL multi_mx_call.mx_call_proc_tx(20);
+DEBUG:  pushing down the procedure
+ERROR:  relation "mx_call_dist_table_1" does not exist
+CONTEXT:  while executing command on localhost:57637
+PL/pgSQL function multi_mx_call.mx_call_proc_tx(integer) line 3 at SQL statement
+SELECT id, val FROM mx_call_dist_table_1 ORDER BY id, val;
+ id | val 
+----+-----
+  3 |   1
+  3 |   5
+  4 |   5
+  6 |   5
+  9 |   2
+ 10 |  -2
+ 11 |   3
+(7 rows)
+
+-- Test that we properly propagate errors raised from procedures.
+CREATE PROCEDURE mx_call_proc_raise(x int) LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE WARNING 'warning';
+    RAISE EXCEPTION 'error';
+END;$$;
+select create_distributed_function('mx_call_proc_raise(int)');
+DEBUG:  switching to sequential query execution mode
+DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_raise', 'mx_call_dist_table_1'::regclass, 0);
+call multi_mx_call.mx_call_proc_raise(2);
+DEBUG:  pushing down the procedure
+DEBUG:  warning
+DETAIL:  WARNING from localhost:57638
+ERROR:  error
+CONTEXT:  while executing command on localhost:57638
+PL/pgSQL function multi_mx_call.mx_call_proc_raise(integer) line 4 at RAISE
+-- Test that we don't propagate to non-metadata worker nodes
+select stop_metadata_sync_to_node('localhost', :worker_1_port);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
+select stop_metadata_sync_to_node('localhost', :worker_2_port);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
+call multi_mx_call.mx_call_proc(2, 0);
+DEBUG:  there is no worker node with metadata
+DEBUG:  generating subplan 25_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+ y  
+----
+ 29
+(1 row)
+
+SET client_min_messages TO NOTICE;
+select start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+select start_metadata_sync_to_node('localhost', :worker_2_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+SET client_min_messages TO DEBUG1;
+--
+-- Test non-const parameter values
+--
+CREATE FUNCTION mx_call_add(int, int) RETURNS int
+    AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE;
+SELECT create_distributed_function('mx_call_add(int,int)');
+DEBUG:  switching to sequential query execution mode
+DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+-- non-const distribution parameters cannot be pushed down
+call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+DEBUG:  distribution argument value must be a constant
+DEBUG:  generating subplan 27_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 27 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('27_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+ y  
+----
+ 29
+(1 row)
+
+-- non-const parameter can be pushed down
+call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3, 4), 2);
+DEBUG:  pushing down the procedure
+ y  
+----
+ 33
+(1 row)
+
+-- volatile parameter cannot be pushed down
+call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+DEBUG:  arguments in a distributed stored procedure must be constant expressions
+DEBUG:  generating subplan 29_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  Plan 29 query after replacing subqueries and CTEs: SELECT (1 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('29_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+ y  
+----
+ 27
+(1 row)
+
+--
+-- clean-up
+--
 reset client_min_messages;
-DROP TABLE mx_call_dist_table;
-DROP PROCEDURE mx_call_proc;
 reset citus.shard_replication_factor;
 reset citus.replication_model;
+reset search_path;
+\set VERBOSITY terse
+drop schema multi_mx_call cascade;
+NOTICE:  drop cascades to 10 other objects
+\set VERBOSITY default

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -217,14 +217,10 @@ ERROR:  syntax error at or near "CALL"
 LINE 1: CALL multi_mx_call.mx_call_proc_tx(10);
         ^
 -- after distribution ...
-select create_distributed_function('mx_call_proc_tx(int)');
+select create_distributed_function('mx_call_proc_tx(int)', '$1', 'mx_call_dist_table_1');
 ERROR:  function "mx_call_proc_tx(int)" does not exist
-LINE 1: select create_distributed_function('mx_call_proc_tx(int)');
+LINE 1: select create_distributed_function('mx_call_proc_tx(int)', '...
                                            ^
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx', 'mx_call_dist_table_1'::regclass, 0);
-ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx...
-        ^
 CALL multi_mx_call.mx_call_proc_tx(20);
 ERROR:  syntax error at or near "CALL"
 LINE 1: CALL multi_mx_call.mx_call_proc_tx(20);
@@ -248,14 +244,10 @@ END;$$;
 ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: CREATE PROCEDURE mx_call_proc_raise(x int) LANGUAGE plpgsql ...
                ^
-select create_distributed_function('mx_call_proc_raise(int)');
+select create_distributed_function('mx_call_proc_raise(int)', '$1', 'mx_call_dist_table_1');
 ERROR:  function "mx_call_proc_raise(int)" does not exist
 LINE 1: select create_distributed_function('mx_call_proc_raise(int)'...
                                            ^
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_raise', 'mx_call_dist_table_1'::regclass, 0);
-ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc_ra...
-        ^
 call multi_mx_call.mx_call_proc_raise(2);
 ERROR:  syntax error at or near "call"
 LINE 1: call multi_mx_call.mx_call_proc_raise(2);
@@ -296,7 +288,7 @@ SET client_min_messages TO DEBUG1;
 --
 CREATE FUNCTION mx_call_add(int, int) RETURNS int
     AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE;
-SELECT create_distributed_function('mx_call_add(int,int)');
+SELECT create_distributed_function('mx_call_add(int,int)', '$1');
 DEBUG:  switching to sequential query execution mode
 DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
  create_distributed_function 

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -10,6 +10,7 @@ select create_distributed_table('mx_call_dist_table', 'id');
 (1 row)
 
 insert into mx_call_dist_table values (1),(2),(3),(4),(5);
+create type mx_call_enum as enum ('A', 'S', 'D', 'F');
 CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
 BEGIN
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
@@ -19,6 +20,28 @@ $$;
 ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE p...
                ^
+CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INOUT y mx_call_enum) LANGUAGE plpgsql AS $$
+BEGIN
+    y := x;
+    x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
+END;
+$$;
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INO...
+               ^
+CREATE FUNCTION mx_call_add(int, int) RETURNS int
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+call mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc(2, 0);
+        ^
+call mx_call_proc_asdf('S', 'A');
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc_asdf('S', 'A');
+        ^
 select create_distributed_function('mx_call_proc(int,int)');
 ERROR:  function "mx_call_proc(int,int)" does not exist
 LINE 1: select create_distributed_function('mx_call_proc(int,int)');
@@ -27,10 +50,53 @@ update citus.pg_dist_object
 set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
 from pg_proc, pg_dist_partition
 where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+select create_distributed_function('mx_call_proc_asdf(mx_call_enum,mx_call_enum)');
+ERROR:  function "mx_call_proc_asdf(mx_call_enum,mx_call_enum)" does not exist
+LINE 1: select create_distributed_function('mx_call_proc_asdf(mx_cal...
+                                           ^
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc_asdf' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
 call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
 LINE 1: call mx_call_proc(2, 0);
         ^
+call mx_call_proc_asdf('S', 'A');
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc_asdf('S', 'A');
+        ^
+set client_min_messages to DEBUG2;
+begin;
+select sum(id) from mx_call_dist_table;
+DEBUG:  Router planner cannot handle multi-shard select queries
+ sum 
+-----
+  15
+(1 row)
+
+call mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc(2, 0);
+        ^
+commit;
+update citus.pg_dist_object
+set distribution_argument_index = -1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc(2, 0);
+        ^
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, mx_call_add(3, 4));
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc(2, mx_call_add(3, 4));
+        ^
+reset client_min_messages;
 DROP TABLE mx_call_dist_table;
 DROP PROCEDURE mx_call_proc;
 ERROR:  syntax error at or near "PROCEDURE"

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -1,106 +1,332 @@
 -- Test passing off CALL to mx workers
 -- Create worker-local tables to test procedure calls were routed
-set citus.shard_replication_factor to 1;
-set citus.replication_model to 'streaming';
-CREATE TABLE mx_call_dist_table(id int);
-select create_distributed_table('mx_call_dist_table', 'id');
+set citus.shard_replication_factor to 2;
+set citus.replication_model to 'statement';
+-- This table requires specific settings, create before getting into things
+create table mx_call_dist_table_replica(id int, val int);
+select create_distributed_table('mx_call_dist_table_replica', 'id');
  create_distributed_table 
 --------------------------
  
 (1 row)
 
-insert into mx_call_dist_table values (1),(2),(3),(4),(5);
-create type mx_call_enum as enum ('A', 'S', 'D', 'F');
-CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
+insert into mx_call_dist_table_replica values (9,1),(8,2),(7,3),(6,4),(5,5);
+set citus.shard_replication_factor to 1;
+set citus.replication_model to 'streaming';
+create schema multi_mx_call;
+set search_path to multi_mx_call, public;
+--
+-- Utility UDFs
+--
+-- 1. Marks the given procedure as colocated with the given table.
+-- 2. Marks the argument index with which we route the procedure.
+CREATE PROCEDURE colocate_proc_with_table(procname text, tablerelid regclass, argument_index int)
+LANGUAGE plpgsql AS $$
 BEGIN
-    y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
-    y := y + (select sum(id) from mx_call_dist_table);
-END;
-$$;
+    update citus.pg_dist_object
+    set distribution_argument_index = argument_index, colocationid = pg_dist_partition.colocationid
+    from pg_proc, pg_dist_partition
+    where proname = procname and oid = objid and pg_dist_partition.logicalrelid = tablerelid;
+END;$$;
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE p...
+LINE 1: CREATE PROCEDURE colocate_proc_with_table(procname text, tab...
                ^
-CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INOUT y mx_call_enum) LANGUAGE plpgsql AS $$
+--
+-- Create tables and procedures we want to use in tests
+--
+create table mx_call_dist_table_1(id int, val int);
+select create_distributed_table('mx_call_dist_table_1', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_1 values (3,1),(4,5),(9,2),(6,5),(3,5);
+create table mx_call_dist_table_2(id int, val int);
+select create_distributed_table('mx_call_dist_table_2', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_2 values (1,1),(1,2),(2,2),(3,3),(3,4);
+create table mx_call_dist_table_ref(id int, val int);
+select create_reference_table('mx_call_dist_table_ref');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_ref values (2,7),(1,8),(2,8),(1,8),(2,8);
+create type mx_call_enum as enum ('A', 'S', 'D', 'F');
+create table mx_call_dist_table_enum(id int, key mx_call_enum);
+select create_distributed_table('mx_call_dist_table_enum', 'key');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table_enum values (1,'S'),(2,'A'),(3,'D'),(4,'F');
+CREATE PROCEDURE mx_call_proc(x int, INOUT y int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- groupid is 0 in coordinator and non-zero in workers, so by using it here
+    -- we make sure the procedure is being executed in the worker.
+    y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
+    -- we also make sure that we can run distributed queries in the procedures
+    -- that are routed to the workers.
+    y := y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id);
+END;$$;
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: CREATE PROCEDURE mx_call_proc(x int, INOUT y int)
+               ^
+-- create another procedure which verifies:
+-- 1. we work fine with multiple return columns
+-- 2. we work fine in combination with custom types
+CREATE PROCEDURE mx_call_proc_custom_types(INOUT x mx_call_enum, INOUT y mx_call_enum)
+LANGUAGE plpgsql AS $$
 BEGIN
     y := x;
     x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
-END;
-$$;
+END;$$;
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INO...
+LINE 1: CREATE PROCEDURE mx_call_proc_custom_types(INOUT x mx_call_e...
                ^
-CREATE FUNCTION mx_call_add(int, int) RETURNS int
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
-    IMMUTABLE
-    RETURNS NULL ON NULL INPUT;
-call mx_call_proc(2, 0);
+-- Test that undistributed procedures have no issue executing
+call multi_mx_call.mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc(2, 0);
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
         ^
-call mx_call_proc_asdf('S', 'A');
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc_asdf('S', 'A');
+LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
         ^
+-- Mark both procedures as distributed ...
 select create_distributed_function('mx_call_proc(int,int)');
 ERROR:  function "mx_call_proc(int,int)" does not exist
 LINE 1: select create_distributed_function('mx_call_proc(int,int)');
                                            ^
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-select create_distributed_function('mx_call_proc_asdf(mx_call_enum,mx_call_enum)');
-ERROR:  function "mx_call_proc_asdf(mx_call_enum,mx_call_enum)" does not exist
-LINE 1: select create_distributed_function('mx_call_proc_asdf(mx_cal...
+select create_distributed_function('mx_call_proc_custom_types(mx_call_enum,mx_call_enum)');
+ERROR:  function "mx_call_proc_custom_types(mx_call_enum,mx_call_enum)" does not exist
+LINE 1: select create_distributed_function('mx_call_proc_custom_type...
                                            ^
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc_asdf' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, 0);
+-- We still don't route them to the workers, because they aren't
+-- colocated with any distributed tables.
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc(2, 0);
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
         ^
-call mx_call_proc_asdf('S', 'A');
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc_asdf('S', 'A');
+LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
         ^
-set client_min_messages to DEBUG2;
+-- Mark them as colocated with a table. Now we should route them to workers.
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+        ^
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc_cu...
+        ^
+call multi_mx_call.mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+        ^
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+        ^
+-- We don't allow distributing calls inside transactions
 begin;
-select sum(id) from mx_call_dist_table;
-DEBUG:  Router planner cannot handle multi-shard select queries
- sum 
------
-  15
-(1 row)
-
-call mx_call_proc(2, 0);
+call multi_mx_call.mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc(2, 0);
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
         ^
 commit;
-update citus.pg_dist_object
-set distribution_argument_index = -1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, 0);
+-- Drop the table colocated with mx_call_proc_custom_types. Now it shouldn't
+-- be routed to workers anymore.
+SET client_min_messages TO NOTICE;
+drop table mx_call_dist_table_enum;
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc(2, 0);
+LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
         ^
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, mx_call_add(3, 4));
+-- Make sure we do bounds checking on distributed argument index
+-- This also tests that we have cache invalidation for pg_dist_object updates
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
 ERROR:  syntax error at or near "call"
-LINE 1: call mx_call_proc(2, mx_call_add(3, 4));
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
         ^
-reset client_min_messages;
-DROP TABLE mx_call_dist_table;
-DROP PROCEDURE mx_call_proc;
+call multi_mx_call.mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+        ^
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+        ^
+call multi_mx_call.mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+        ^
+-- We don't currently support colocating with reference tables
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+        ^
+call multi_mx_call.mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+        ^
+-- We don't currently support colocating with replicated tables
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+        ^
+call multi_mx_call.mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+        ^
+SET client_min_messages TO NOTICE;
+drop table mx_call_dist_table_replica;
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+        ^
+-- Test that we handle transactional constructs correctly inside a procedure
+-- that is routed to the workers.
+CREATE PROCEDURE mx_call_proc_tx(x int) LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO mx_call_dist_table_1 VALUES (x, -1), (x+1, 4);
+    COMMIT;
+    UPDATE mx_call_dist_table_1 SET val = val+1 WHERE id >= x;
+    ROLLBACK;
+    -- Now do the final update!
+    UPDATE mx_call_dist_table_1 SET val = val-1 WHERE id >= x;
+END;$$;
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: DROP PROCEDURE mx_call_proc;
-             ^
+LINE 1: CREATE PROCEDURE mx_call_proc_tx(x int) LANGUAGE plpgsql AS ...
+               ^
+-- before distribution ...
+CALL multi_mx_call.mx_call_proc_tx(10);
+ERROR:  syntax error at or near "CALL"
+LINE 1: CALL multi_mx_call.mx_call_proc_tx(10);
+        ^
+-- after distribution ...
+select create_distributed_function('mx_call_proc_tx(int)');
+ERROR:  function "mx_call_proc_tx(int)" does not exist
+LINE 1: select create_distributed_function('mx_call_proc_tx(int)');
+                                           ^
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx', 'mx_call_dist_table_1'::regclass, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx...
+        ^
+CALL multi_mx_call.mx_call_proc_tx(20);
+ERROR:  syntax error at or near "CALL"
+LINE 1: CALL multi_mx_call.mx_call_proc_tx(20);
+        ^
+SELECT id, val FROM mx_call_dist_table_1 ORDER BY id, val;
+ id | val 
+----+-----
+  3 |   1
+  3 |   5
+  4 |   5
+  6 |   5
+  9 |   2
+(5 rows)
+
+-- Test that we properly propagate errors raised from procedures.
+CREATE PROCEDURE mx_call_proc_raise(x int) LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE WARNING 'warning';
+    RAISE EXCEPTION 'error';
+END;$$;
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: CREATE PROCEDURE mx_call_proc_raise(x int) LANGUAGE plpgsql ...
+               ^
+select create_distributed_function('mx_call_proc_raise(int)');
+ERROR:  function "mx_call_proc_raise(int)" does not exist
+LINE 1: select create_distributed_function('mx_call_proc_raise(int)'...
+                                           ^
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_raise', 'mx_call_dist_table_1'::regclass, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc_ra...
+        ^
+call multi_mx_call.mx_call_proc_raise(2);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc_raise(2);
+        ^
+-- Test that we don't propagate to non-metadata worker nodes
+select stop_metadata_sync_to_node('localhost', :worker_1_port);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
+select stop_metadata_sync_to_node('localhost', :worker_2_port);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
+call multi_mx_call.mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+        ^
+SET client_min_messages TO NOTICE;
+select start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+select start_metadata_sync_to_node('localhost', :worker_2_port);
+ start_metadata_sync_to_node 
+-----------------------------
+ 
+(1 row)
+
+SET client_min_messages TO DEBUG1;
+--
+-- Test non-const parameter values
+--
+CREATE FUNCTION mx_call_add(int, int) RETURNS int
+    AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE;
+SELECT create_distributed_function('mx_call_add(int,int)');
+DEBUG:  switching to sequential query execution mode
+DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+-- non-const distribution parameters cannot be pushed down
+call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+        ^
+-- non-const parameter can be pushed down
+call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3, 4), 2);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3,...
+        ^
+-- volatile parameter cannot be pushed down
+call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+ERROR:  syntax error at or near "call"
+LINE 1: call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+        ^
+--
+-- clean-up
+--
+reset client_min_messages;
 reset citus.shard_replication_factor;
 reset citus.replication_model;
+reset search_path;
+\set VERBOSITY terse
+drop schema multi_mx_call cascade;
+NOTICE:  drop cascades to 5 other objects
+\set VERBOSITY default

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -311,14 +311,7 @@ call multi_mx_call.mx_call_proc(floor(random())::int, 2);
 ERROR:  syntax error at or near "call"
 LINE 1: call multi_mx_call.mx_call_proc(floor(random())::int, 2);
         ^
---
--- clean-up
---
 reset client_min_messages;
-reset citus.shard_replication_factor;
-reset citus.replication_model;
-reset search_path;
 \set VERBOSITY terse
 drop schema multi_mx_call cascade;
 NOTICE:  drop cascades to 5 other objects
-\set VERBOSITY default

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -1,0 +1,40 @@
+-- Test passing off CALL to mx workers
+-- Create worker-local tables to test procedure calls were routed
+set citus.shard_replication_factor to 1;
+set citus.replication_model to 'streaming';
+CREATE TABLE mx_call_dist_table(id int);
+select create_distributed_table('mx_call_dist_table', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+insert into mx_call_dist_table values (1),(2),(3),(4),(5);
+CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
+BEGIN
+    y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
+    y := y + (select sum(id) from mx_call_dist_table);
+END;
+$$;
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE p...
+               ^
+select create_distributed_function('mx_call_proc(int,int)');
+ERROR:  function "mx_call_proc(int,int)" does not exist
+LINE 1: select create_distributed_function('mx_call_proc(int,int)');
+                                           ^
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, 0);
+ERROR:  syntax error at or near "call"
+LINE 1: call mx_call_proc(2, 0);
+        ^
+DROP TABLE mx_call_dist_table;
+DROP PROCEDURE mx_call_proc;
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: DROP PROCEDURE mx_call_proc;
+             ^
+reset citus.shard_replication_factor;
+reset citus.replication_model;

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -32,6 +32,7 @@ test: recursive_dml_queries_mx multi_mx_truncate_from_worker
 test: multi_mx_repartition_udt_prepare mx_foreign_key_to_reference_table
 test: multi_mx_repartition_join_w1 multi_mx_repartition_join_w2 multi_mx_repartition_udt_w1 multi_mx_repartition_udt_w2
 test: multi_mx_metadata 
+test: multi_mx_call
 test: multi_mx_modifications local_shard_execution
 test: multi_mx_transaction_recovery
 test: multi_mx_modifying_xacts

--- a/src/test/regress/sql/multi_mx_call.sql
+++ b/src/test/regress/sql/multi_mx_call.sql
@@ -141,8 +141,7 @@ END;$$;
 -- before distribution ...
 CALL multi_mx_call.mx_call_proc_tx(10);
 -- after distribution ...
-select create_distributed_function('mx_call_proc_tx(int)');
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx', 'mx_call_dist_table_1'::regclass, 0);
+select create_distributed_function('mx_call_proc_tx(int)', '$1', 'mx_call_dist_table_1');
 CALL multi_mx_call.mx_call_proc_tx(20);
 SELECT id, val FROM mx_call_dist_table_1 ORDER BY id, val;
 
@@ -152,8 +151,7 @@ BEGIN
     RAISE WARNING 'warning';
     RAISE EXCEPTION 'error';
 END;$$;
-select create_distributed_function('mx_call_proc_raise(int)');
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_raise', 'mx_call_dist_table_1'::regclass, 0);
+select create_distributed_function('mx_call_proc_raise(int)', '$1', 'mx_call_dist_table_1');
 call multi_mx_call.mx_call_proc_raise(2);
 
 
@@ -171,7 +169,7 @@ SET client_min_messages TO DEBUG1;
 --
 CREATE FUNCTION mx_call_add(int, int) RETURNS int
     AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE;
-SELECT create_distributed_function('mx_call_add(int,int)');
+SELECT create_distributed_function('mx_call_add(int,int)', '$1');
 
 -- non-const distribution parameters cannot be pushed down
 call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));

--- a/src/test/regress/sql/multi_mx_call.sql
+++ b/src/test/regress/sql/multi_mx_call.sql
@@ -9,6 +9,8 @@ CREATE TABLE mx_call_dist_table(id int);
 select create_distributed_table('mx_call_dist_table', 'id');
 insert into mx_call_dist_table values (1),(2),(3),(4),(5);
 
+create type mx_call_enum as enum ('A', 'S', 'D', 'F');
+
 CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
 BEGIN
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
@@ -16,14 +18,56 @@ BEGIN
 END;
 $$;
 
+CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INOUT y mx_call_enum) LANGUAGE plpgsql AS $$
+BEGIN
+    y := x;
+    x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
+END;
+$$;
+
+CREATE FUNCTION mx_call_add(int, int) RETURNS int
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+
+call mx_call_proc(2, 0);
+call mx_call_proc_asdf('S', 'A');
+
 select create_distributed_function('mx_call_proc(int,int)');
 update citus.pg_dist_object
 set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
 from pg_proc, pg_dist_partition
 where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
 
-call mx_call_proc(2, 0);
+select create_distributed_function('mx_call_proc_asdf(mx_call_enum,mx_call_enum)');
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc_asdf' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
 
+call mx_call_proc(2, 0);
+call mx_call_proc_asdf('S', 'A');
+
+set client_min_messages to DEBUG2;
+begin;
+select sum(id) from mx_call_dist_table;
+call mx_call_proc(2, 0);
+commit;
+
+update citus.pg_dist_object
+set distribution_argument_index = -1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+call mx_call_proc(2, 0);
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+
+call mx_call_proc(2, mx_call_add(3, 4));
+
+reset client_min_messages;
 DROP TABLE mx_call_dist_table;
 DROP PROCEDURE mx_call_proc;
 reset citus.shard_replication_factor;

--- a/src/test/regress/sql/multi_mx_call.sql
+++ b/src/test/regress/sql/multi_mx_call.sql
@@ -2,73 +2,195 @@
 
 -- Create worker-local tables to test procedure calls were routed
 
+set citus.shard_replication_factor to 2;
+set citus.replication_model to 'statement';
+
+-- This table requires specific settings, create before getting into things
+create table mx_call_dist_table_replica(id int, val int);
+select create_distributed_table('mx_call_dist_table_replica', 'id');
+insert into mx_call_dist_table_replica values (9,1),(8,2),(7,3),(6,4),(5,5);
+
 set citus.shard_replication_factor to 1;
 set citus.replication_model to 'streaming';
 
-CREATE TABLE mx_call_dist_table(id int);
-select create_distributed_table('mx_call_dist_table', 'id');
-insert into mx_call_dist_table values (1),(2),(3),(4),(5);
+create schema multi_mx_call;
+set search_path to multi_mx_call, public;
+
+--
+-- Utility UDFs
+--
+
+-- 1. Marks the given procedure as colocated with the given table.
+-- 2. Marks the argument index with which we route the procedure.
+CREATE PROCEDURE colocate_proc_with_table(procname text, tablerelid regclass, argument_index int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    update citus.pg_dist_object
+    set distribution_argument_index = argument_index, colocationid = pg_dist_partition.colocationid
+    from pg_proc, pg_dist_partition
+    where proname = procname and oid = objid and pg_dist_partition.logicalrelid = tablerelid;
+END;$$;
+
+
+--
+-- Create tables and procedures we want to use in tests
+--
+create table mx_call_dist_table_1(id int, val int);
+select create_distributed_table('mx_call_dist_table_1', 'id');
+insert into mx_call_dist_table_1 values (3,1),(4,5),(9,2),(6,5),(3,5);
+
+create table mx_call_dist_table_2(id int, val int);
+select create_distributed_table('mx_call_dist_table_2', 'id');
+insert into mx_call_dist_table_2 values (1,1),(1,2),(2,2),(3,3),(3,4);
+
+create table mx_call_dist_table_ref(id int, val int);
+select create_reference_table('mx_call_dist_table_ref');
+insert into mx_call_dist_table_ref values (2,7),(1,8),(2,8),(1,8),(2,8);
 
 create type mx_call_enum as enum ('A', 'S', 'D', 'F');
+create table mx_call_dist_table_enum(id int, key mx_call_enum);
+select create_distributed_table('mx_call_dist_table_enum', 'key');
+insert into mx_call_dist_table_enum values (1,'S'),(2,'A'),(3,'D'),(4,'F');
 
-CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
+
+CREATE PROCEDURE mx_call_proc(x int, INOUT y int)
+LANGUAGE plpgsql AS $$
 BEGIN
+    -- groupid is 0 in coordinator and non-zero in workers, so by using it here
+    -- we make sure the procedure is being executed in the worker.
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
-    y := y + (select sum(id) from mx_call_dist_table);
-END;
-$$;
+    -- we also make sure that we can run distributed queries in the procedures
+    -- that are routed to the workers.
+    y := y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id);
+END;$$;
 
-CREATE PROCEDURE mx_call_proc_asdf(INOUT x mx_call_enum, INOUT y mx_call_enum) LANGUAGE plpgsql AS $$
+-- create another procedure which verifies:
+-- 1. we work fine with multiple return columns
+-- 2. we work fine in combination with custom types
+CREATE PROCEDURE mx_call_proc_custom_types(INOUT x mx_call_enum, INOUT y mx_call_enum)
+LANGUAGE plpgsql AS $$
 BEGIN
     y := x;
     x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
-END;
-$$;
+END;$$;
 
-CREATE FUNCTION mx_call_add(int, int) RETURNS int
-    AS 'select $1 + $2;'
-    LANGUAGE SQL
-    IMMUTABLE
-    RETURNS NULL ON NULL INPUT;
+-- Test that undistributed procedures have no issue executing
+call multi_mx_call.mx_call_proc(2, 0);
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 
-call mx_call_proc(2, 0);
-call mx_call_proc_asdf('S', 'A');
-
+-- Mark both procedures as distributed ...
 select create_distributed_function('mx_call_proc(int,int)');
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+select create_distributed_function('mx_call_proc_custom_types(mx_call_enum,mx_call_enum)');
 
-select create_distributed_function('mx_call_proc_asdf(mx_call_enum,mx_call_enum)');
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc_asdf' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+-- We still don't route them to the workers, because they aren't
+-- colocated with any distributed tables.
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.mx_call_proc(2, 0);
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 
-call mx_call_proc(2, 0);
-call mx_call_proc_asdf('S', 'A');
+-- Mark them as colocated with a table. Now we should route them to workers.
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
+call multi_mx_call.mx_call_proc(2, 0);
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 
-set client_min_messages to DEBUG2;
+-- We don't allow distributing calls inside transactions
 begin;
-select sum(id) from mx_call_dist_table;
-call mx_call_proc(2, 0);
+call multi_mx_call.mx_call_proc(2, 0);
 commit;
 
-update citus.pg_dist_object
-set distribution_argument_index = -1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
-call mx_call_proc(2, 0);
-update citus.pg_dist_object
-set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
-from pg_proc, pg_dist_partition
-where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+-- Drop the table colocated with mx_call_proc_custom_types. Now it shouldn't
+-- be routed to workers anymore.
+SET client_min_messages TO NOTICE;
+drop table mx_call_dist_table_enum;
+SET client_min_messages TO DEBUG1;
+call multi_mx_call.mx_call_proc_custom_types('S', 'A');
 
-call mx_call_proc(2, mx_call_add(3, 4));
+-- Make sure we do bounds checking on distributed argument index
+-- This also tests that we have cache invalidation for pg_dist_object updates
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
+call multi_mx_call.mx_call_proc(2, 0);
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
+call multi_mx_call.mx_call_proc(2, 0);
 
+-- We don't currently support colocating with reference tables
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
+call multi_mx_call.mx_call_proc(2, 0);
+
+-- We don't currently support colocating with replicated tables
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
+call multi_mx_call.mx_call_proc(2, 0);
+SET client_min_messages TO NOTICE;
+drop table mx_call_dist_table_replica;
+SET client_min_messages TO DEBUG1;
+
+call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+
+-- Test that we handle transactional constructs correctly inside a procedure
+-- that is routed to the workers.
+CREATE PROCEDURE mx_call_proc_tx(x int) LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO mx_call_dist_table_1 VALUES (x, -1), (x+1, 4);
+    COMMIT;
+    UPDATE mx_call_dist_table_1 SET val = val+1 WHERE id >= x;
+    ROLLBACK;
+    -- Now do the final update!
+    UPDATE mx_call_dist_table_1 SET val = val-1 WHERE id >= x;
+END;$$;
+
+-- before distribution ...
+CALL multi_mx_call.mx_call_proc_tx(10);
+-- after distribution ...
+select create_distributed_function('mx_call_proc_tx(int)');
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_tx', 'mx_call_dist_table_1'::regclass, 0);
+CALL multi_mx_call.mx_call_proc_tx(20);
+SELECT id, val FROM mx_call_dist_table_1 ORDER BY id, val;
+
+-- Test that we properly propagate errors raised from procedures.
+CREATE PROCEDURE mx_call_proc_raise(x int) LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE WARNING 'warning';
+    RAISE EXCEPTION 'error';
+END;$$;
+select create_distributed_function('mx_call_proc_raise(int)');
+call multi_mx_call.colocate_proc_with_table('mx_call_proc_raise', 'mx_call_dist_table_1'::regclass, 0);
+call multi_mx_call.mx_call_proc_raise(2);
+
+
+-- Test that we don't propagate to non-metadata worker nodes
+select stop_metadata_sync_to_node('localhost', :worker_1_port);
+select stop_metadata_sync_to_node('localhost', :worker_2_port);
+call multi_mx_call.mx_call_proc(2, 0);
+SET client_min_messages TO NOTICE;
+select start_metadata_sync_to_node('localhost', :worker_1_port);
+select start_metadata_sync_to_node('localhost', :worker_2_port);
+SET client_min_messages TO DEBUG1;
+
+--
+-- Test non-const parameter values
+--
+CREATE FUNCTION mx_call_add(int, int) RETURNS int
+    AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE;
+SELECT create_distributed_function('mx_call_add(int,int)');
+
+-- non-const distribution parameters cannot be pushed down
+call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+
+-- non-const parameter can be pushed down
+call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3, 4), 2);
+
+-- volatile parameter cannot be pushed down
+call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+
+--
+-- clean-up
+--
 reset client_min_messages;
-DROP TABLE mx_call_dist_table;
-DROP PROCEDURE mx_call_proc;
 reset citus.shard_replication_factor;
 reset citus.replication_model;
+reset search_path;
+
+\set VERBOSITY terse
+drop schema multi_mx_call cascade;
+\set VERBOSITY default
+

--- a/src/test/regress/sql/multi_mx_call.sql
+++ b/src/test/regress/sql/multi_mx_call.sql
@@ -180,15 +180,7 @@ call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3, 4), 2);
 -- volatile parameter cannot be pushed down
 call multi_mx_call.mx_call_proc(floor(random())::int, 2);
 
---
--- clean-up
---
 reset client_min_messages;
-reset citus.shard_replication_factor;
-reset citus.replication_model;
-reset search_path;
-
 \set VERBOSITY terse
 drop schema multi_mx_call cascade;
-\set VERBOSITY default
 

--- a/src/test/regress/sql/multi_mx_call.sql
+++ b/src/test/regress/sql/multi_mx_call.sql
@@ -1,0 +1,30 @@
+-- Test passing off CALL to mx workers
+
+-- Create worker-local tables to test procedure calls were routed
+
+set citus.shard_replication_factor to 1;
+set citus.replication_model to 'streaming';
+
+CREATE TABLE mx_call_dist_table(id int);
+select create_distributed_table('mx_call_dist_table', 'id');
+insert into mx_call_dist_table values (1),(2),(3),(4),(5);
+
+CREATE PROCEDURE mx_call_proc(x int, INOUT y int) LANGUAGE plpgsql AS $$
+BEGIN
+    y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
+    y := y + (select sum(id) from mx_call_dist_table);
+END;
+$$;
+
+select create_distributed_function('mx_call_proc(int,int)');
+update citus.pg_dist_object
+set distribution_argument_index = 1, colocationid = pg_dist_partition.colocationid
+from pg_proc, pg_dist_partition
+where proname = 'mx_call_proc' and oid = objid and pg_dist_partition.logicalrelid = 'mx_call_dist_table'::regclass;
+
+call mx_call_proc(2, 0);
+
+DROP TABLE mx_call_dist_table;
+DROP PROCEDURE mx_call_proc;
+reset citus.shard_replication_factor;
+reset citus.replication_model;


### PR DESCRIPTION
DESCRIPTION: implement infrastructure for routing `CALL` to MX workers

Mostly copied code from #2829 except it uses metadata_cache & pg_dist_object & etc

Closes #2945 
Closes #2946
