### PR TITLE
Add postgres upgrade job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 'citusdata/extbuilder:werror'
+      - image: 'citus/extbuilder:latest'
     steps:
       - checkout
       - run: 
@@ -204,9 +204,30 @@ jobs:
     steps:
       - attach_workspace: 
           at: .
-      - run:
+      - run: 
           name: 'Install and Test (check-failure)'
           command: 'install-and-test-ext check-failure'
+  test-10-11_check-pg-upgrade:
+    docker:
+      - image: 'citus/pgupgradetester:latest'
+    working_directory: /home/circleci/project     
+    steps:
+      - attach_workspace:
+          at: .
+      - run: 
+          name: 'Install and test postgres upgrade'
+          command: 'install-and-test-ext --target check-upgrade --old-pg-version 10 --new-pg-version 11'
+  test-11-12_check-pg-upgrade:
+    docker:
+      - image: 'citus/pgupgradetester:latest'
+    working_directory: /home/circleci/project     
+    steps:
+      - attach_workspace:
+          at: .
+      - run: 
+          name: 'Install and test postgres upgrade'
+          command: 'install-and-test-ext --target check-upgrade --old-pg-version 11 --new-pg-version 12'        
+
 workflows:
   version: 2
   build_and_test:
@@ -237,9 +258,14 @@ workflows:
       - test-11_check-failure:
           requires: [build]
 
-      - test-11_check-non-adaptive-multi:
+      - test-11_check-non-adaptive-multi: 
           requires: [build]
       - test-11_check-non-adaptive-failure:
           requires: [build]
       - test-11_check-non-adaptive-isolation:
           requires: [build]
+
+      - test-10-11_check-pg-upgrade: 
+          requires: [build]
+      - test-11-12_check-pg-upgrade: 
+          requires: [build]    


### PR DESCRIPTION
This PR adds postgres upgrade job. The upgrade job takes `--old-pg-version` and `--new-pg-version` parameters and it performs the upgrade test: https://github.com/citusdata/citus/blob/master/src/test/regress/Makefile#L144

You can see the image [here](https://github.com/citusdata/the-process/tree/upgradeTester/circleci/images/pgupgradetester)

Instead of putting the parameters to the [script file](https://github.com/citusdata/the-process/blob/upgradeTester/circleci/images/pgupgradetester/files/sbin/install-and-test-ext) that is run on docker I wanted to put them outside so that if we want to test different versions of postgres we dont need to:
- Change the parameters in the script
- Build the new image
- Push the new image

Currently we have postgres upgrade tests for:
- `pg10 -> pg11`
- `pg11 -> pg12`

For `build` job I am using my own image that has citus artifacts for postgres 12. I will push the same image to `citus` docker hub when the PR is approved(meaning other parts are agreed on.)

The upgrade job takes [39](https://circleci.com/gh/citusdata/citus/38512) seconds. 

Fixes #2974.