### PR TITLE
Don't use flags that mac clang doesn't support as it does on other platforms

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -39,7 +39,7 @@ $(SQL_DEPDIR) $(SQL_BUILDDIR):
 	mkdir -p $(citus_abs_srcdir)/$@
 
 $(generated_sql_files): $(citus_abs_srcdir)/build/%: % $(SQL_DEPDIR) $(SQL_BUILDDIR)
-	cd $(citus_abs_srcdir) && cpp -undef -w -P -MMD -MP -MF $(SQL_DEPDIR)/$(*F).Po -MT $@ $< > $@
+	cd $(citus_abs_srcdir) && cpp -undef -w -P $< > $@
 
 SQL_Po_files := $(wildcard $(SQL_DEPDIR)/*.Po)
 ifneq (,$(SQL_Po_files))


### PR DESCRIPTION
The implication of this is we always need to `make clean` if we change any sql udf definition. We decided to merge this so that we could unblock mac users for now.