### PR TITLE
 Add columns to pg_dist_object for distributed functions

### DIFF
--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -38,6 +38,11 @@ CREATE TABLE citus.pg_dist_object (
     object_names text[] DEFAULT NULL,
     object_args text[] DEFAULT NULL,
 
+    -- fields that are only valid for distributed
+    -- functions/procedures
+    distribution_argument_index int,
+    colocationid int,
+
     CONSTRAINT pg_dist_object_pkey PRIMARY KEY (classid, objid, objsubid)
 );
 

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/9.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/9.0-1.sql
@@ -79,13 +79,17 @@ BEGIN
         RETURNING
             type,
             object_names,
-            object_args
+            object_args,
+            distribution_argument_index,
+            colocationid
     )
-    INSERT INTO citus.pg_dist_object (classid, objid, objsubid)
+    INSERT INTO citus.pg_dist_object (classid, objid, objsubid, distribution_argument_index, colocationid)
     SELECT
         address.classid,
         address.objid,
-        address.objsubid
+        address.objsubid,
+        naming.distribution_argument_index,
+        naming.colocationid
     FROM
         old_records naming,
         pg_get_object_address(naming.type, naming.object_names, naming.object_args) address;

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
@@ -79,13 +79,17 @@ BEGIN
         RETURNING
             type,
             object_names,
-            object_args
+            object_args,
+            distribution_argument_index,
+            colocationid
     )
-    INSERT INTO citus.pg_dist_object (classid, objid, objsubid)
+    INSERT INTO citus.pg_dist_object (classid, objid, objsubid, distribution_argument_index, colocationid)
     SELECT
         address.classid,
         address.objid,
-        address.objsubid
+        address.objsubid,
+        naming.distribution_argument_index,
+        naming.colocationid
     FROM
         old_records naming,
         pg_get_object_address(naming.type, naming.object_names, naming.object_args) address;

--- a/src/include/distributed/metadata/pg_dist_object.h
+++ b/src/include/distributed/metadata/pg_dist_object.h
@@ -28,6 +28,9 @@ typedef struct FormData_pg_dist_object
 	Oid objid;        /* object id of the distributed object */
 	int32 objsubid;   /* object sub id of the distributed object, eg. attnum */
 
+	uint32 distribution_argument_index; /* only valid for distributed functions/procedures */
+	uint32 colocationid;            /* only valid for distributed functions/procedures */
+
 #ifdef CATALOG_VARLEN           /* variable-length fields start here */
 	text type;
 	text[] object_names;

--- a/src/include/distributed/pg_dist_object.h
+++ b/src/include/distributed/pg_dist_object.h
@@ -1,0 +1,29 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_dist_object.h
+ *	  definition of the relation that holds the object information on the
+ *	  cluster (pg_dist_object).
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PG_DIST_OBJECT_H
+#define PG_DIST_OBJECT_H
+
+/* ----------------
+ *      compiler constants for pg_dist_object
+ * ----------------
+ */
+#define Natts_pg_dist_object 8
+#define Anum_pg_dist_object_classid 1
+#define Anum_pg_dist_object_objid 2
+#define Anum_pg_dist_object_objsubid 3
+#define Anum_pg_dist_object_type 4
+#define Anum_pg_dist_object_object_names 5
+#define Anum_pg_dist_object_object_args 6
+#define Anum_pg_dist_object_distribution_arg_index 7
+#define Anum_pg_dist_object_colocation_id 8
+
+#endif /* PG_DIST_OBJECT_H */


### PR DESCRIPTION
Both my work and #2965 relies on the changes here. So, let's merge this to master and do not block/rely on each other.

@serprex This change is already based on #2965, so can you please review this? 

Note: The internal data structures always rely on the index (even if we might consider using parameter name), because that's cheaper to keep and process.