### PR TITLE
Add feature flag to turn off create type propagation

### DIFF
--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -81,6 +81,9 @@
 #define CREATE_OR_REPLACE_COMMAND "SELECT worker_create_or_replace_object(%s);"
 
 
+/* guc to turn of the automatic type distribution */
+bool EnableCreateTypePropagation = true;
+
 /* forward declaration for helper functions*/
 static List * FilterNameListForDistributedTypes(List *objects, bool missing_ok);
 static List * TypeNameListToObjectAddresses(List *objects);
@@ -1392,6 +1395,14 @@ EnsureSequentialModeForTypeDDL(void)
 static bool
 ShouldPropagateTypeCreate()
 {
+	if (!EnableCreateTypePropagation)
+	{
+		/*
+		 * Administrator has turned of type creation propagation
+		 */
+		return false;
+	}
+
 	if (creating_extension)
 	{
 		/*

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -693,6 +693,16 @@ RegisterCitusConfigVariables(void)
 		0,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.enable_create_type_propagation",
+		gettext_noop("Enables propagating of CREATE TYPE statements to workers"),
+		NULL,
+		&EnableCreateTypePropagation,
+		true,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	DefineCustomEnumVariable(
 		"citus.propagate_set_commands",
 		gettext_noop("Sets which SET commands are propagated to workers."),

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -28,6 +28,7 @@ typedef enum
 } PropSetCmdBehavior;
 extern PropSetCmdBehavior PropagateSetCommands;
 extern bool EnableDDLPropagation;
+extern bool EnableCreateTypePropagation;
 
 /*
  * A DDLJob encapsulates the remote tasks and commands needed to process all or

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -310,6 +310,46 @@ ALTER TYPE type_tests2.distributed_enum_type SET SCHEMA type_tests;
 ALTER TYPE distributed_enum_type ADD VALUE 'b' BEFORE 'c';
 ALTER TYPE distributed_enum_type ADD VALUE 'd' AFTER 'c';
 ALTER TYPE distributed_enum_type RENAME VALUE 'd' TO 'something-with-quotes''andstuff';
+-- make sure types are not distributed by default when feature flag is turned off
+SET citus.enable_create_type_propagation TO off;
+CREATE TYPE feature_flag_composite_type AS (a int, b int);
+CREATE TYPE feature_flag_enum_type AS ENUM ('a', 'b');
+-- verify types do not exist on workers
+SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');
+ count 
+-------
+     2
+(1 row)
+
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- verify they are still distributed when required
+CREATE TABLE feature_flag_table (a int PRIMARY KEY, b feature_flag_composite_type, c feature_flag_enum_type);
+SELECT create_distributed_table('feature_flag_table','a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');
+ count 
+-------
+     2
+(1 row)
+
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,2)
+ (localhost,57638,t,2)
+(2 rows)
+
+RESET citus.enable_create_type_propagation;
 -- clear objects
 SET client_min_messages TO fatal; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;

--- a/src/test/regress/expected/distributed_types_0.out
+++ b/src/test/regress/expected/distributed_types_0.out
@@ -310,6 +310,46 @@ ALTER TYPE type_tests2.distributed_enum_type SET SCHEMA type_tests;
 ALTER TYPE distributed_enum_type ADD VALUE 'b' BEFORE 'c';
 ALTER TYPE distributed_enum_type ADD VALUE 'd' AFTER 'c';
 ALTER TYPE distributed_enum_type RENAME VALUE 'd' TO 'something-with-quotes''andstuff';
+-- make sure types are not distributed by default when feature flag is turned off
+SET citus.enable_create_type_propagation TO off;
+CREATE TYPE feature_flag_composite_type AS (a int, b int);
+CREATE TYPE feature_flag_enum_type AS ENUM ('a', 'b');
+-- verify types do not exist on workers
+SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');
+ count 
+-------
+     2
+(1 row)
+
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- verify they are still distributed when required
+CREATE TABLE feature_flag_table (a int PRIMARY KEY, b feature_flag_composite_type, c feature_flag_enum_type);
+SELECT create_distributed_table('feature_flag_table','a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');
+ count 
+-------
+     2
+(1 row)
+
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('feature_flag_composite_type', 'feature_flag_enum_type');$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,2)
+ (localhost,57638,t,2)
+(2 rows)
+
+RESET citus.enable_create_type_propagation;
 -- clear objects
 SET client_min_messages TO fatal; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;


### PR DESCRIPTION
DESCRIPTION: Add feature flag to turn off create type propagation

Solves #2954 

When `citus.enable_create_type_propagation` is set to `false` citus will not propagate `CREATE TYPE` statements to the workers. Types are still distributed when tables that depend on these types are distributed.