### PR TITLE
Fix: rename remote type on conflict

### DIFF
--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -1212,7 +1212,8 @@ GenerateBackupNameForTypeCollision(const ObjectAddress *address)
 
 	while (true)
 	{
-		int postfixLength = snprintf(postfix, NAMEDATALEN - 1, " (backup %d)", count);
+		int postfixLength = snprintf(postfix, NAMEDATALEN - 1, "(citus_backup_%d)",
+									 count);
 		int baseLength = strlen(baseName);
 		TypeName *newTypeName = NULL;
 		Oid typeOid = InvalidOid;
@@ -1225,7 +1226,7 @@ GenerateBackupNameForTypeCollision(const ObjectAddress *address)
 		strncpy(newName, baseName, baseLength);
 		strncpy(newName + baseLength, postfix, postfixLength);
 
-		rel->schemaname = newName;
+		rel->relname = newName;
 		newTypeName = makeTypeNameFromNameList(MakeNameListFromRangeVar(rel));
 
 		typeOid = LookupTypeNameOid(NULL, newTypeName, true);
@@ -1233,9 +1234,9 @@ GenerateBackupNameForTypeCollision(const ObjectAddress *address)
 		{
 			/*
 			 * Typename didn't exist yet.
-			 * Need to strdup the name as it was stack allocated during calculations.
+			 * Need to pstrdup the name as it was stack allocated during calculations.
 			 */
-			return strdup(newName);
+			return pstrdup(newName);
 		}
 
 		count++;
@@ -1243,6 +1244,11 @@ GenerateBackupNameForTypeCollision(const ObjectAddress *address)
 }
 
 
+/*
+ * CreateRenameTypeStmt creates a rename statement for a type based on its ObjectAddress.
+ * The rename statement will rename the existing object on its address to the value
+ * provided in newName.
+ */
 RenameStmt *
 CreateRenameTypeStmt(const ObjectAddress *address, char *newName)
 {

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -155,9 +155,9 @@ extern const ObjectAddress * RenameTypeAttributeStmtObjectAddress(RenameStmt *st
 																  bool missing_ok);
 extern const ObjectAddress * AlterTypeOwnerObjectAddress(AlterOwnerStmt *stmt,
 														 bool missing_ok);
-extern DropStmt * CreateDropStmtBasedOnCompositeTypeStmt(CompositeTypeStmt *stmt);
-extern DropStmt * CreateDropStmtBasedOnEnumStmt(CreateEnumStmt *stmt);
 extern List * CreateTypeDDLCommandsIdempotent(const ObjectAddress *typeAddress);
+extern char * GenerateBackupNameForTypeCollision(const ObjectAddress *address);
+extern RenameStmt * CreateRenameTypeStmt(const ObjectAddress *address, char *newName);
 
 /* vacuum.c - froward declarations */
 extern void ProcessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand);

--- a/src/test/regress/expected/distributed_types_conflict.out
+++ b/src/test/regress/expected/distributed_types_conflict.out
@@ -1,0 +1,43 @@
+SET citus.next_shard_id TO 20020000;
+CREATE SCHEMA type_conflict;
+SELECT run_command_on_workers($$CREATE SCHEMA type_conflict;$$);
+       run_command_on_workers        
+-------------------------------------
+ (localhost,57637,t,"CREATE SCHEMA")
+ (localhost,57638,t,"CREATE SCHEMA")
+(2 rows)
+
+-- create a type on a worker that should not cause data loss once overwritten with a type
+-- from the coordinator
+\c - - - :worker_1_port
+SET citus.enable_ddl_propagation TO off;
+SET search_path TO type_conflict;
+CREATE TYPE my_precious_type AS (secret text, should bool);
+CREATE TABLE local_table (a int, b my_precious_type);
+INSERT INTO local_table VALUES (42, ('always bring a towel', true)::my_precious_type);
+\c - - - :master_port
+SET search_path TO type_conflict;
+-- overwrite the type on the worker from the coordinator. The type should be over written
+-- but the data should not have been destroyed
+--CREATE TYPE my_precious_type AS (scatterd_secret text);
+-- verify the data is retained
+\c - - - :worker_1_port
+SET search_path TO type_conflict;
+\d+ local_table
+                                 Table "type_conflict.local_table"
+ Column |       Type       | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+------------------+-----------+----------+---------+----------+--------------+-------------
+ a      | integer          |           |          |         | plain    |              | 
+ b      | my_precious_type |           |          |         | extended |              | 
+
+SELECT * FROM local_table;
+ a  |             b              
+----+----------------------------
+ 42 | ("always bring a towel",t)
+(1 row)
+
+\c - - - :master_port
+SET search_path TO type_conflict;
+-- hide cascades
+SET client_min_messages TO error;
+DROP SCHEMA type_conflict CASCADE;

--- a/src/test/regress/expected/distributed_types_conflict.out
+++ b/src/test/regress/expected/distributed_types_conflict.out
@@ -23,12 +23,21 @@ CREATE TYPE my_precious_type AS (scatterd_secret text);
 -- verify the data is retained
 \c - - - :worker_1_port
 SET search_path TO type_conflict;
-\d+ local_table
-                                          Table "type_conflict.local_table"
- Column |                Type                | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+------------------------------------+-----------+----------+---------+----------+--------------+-------------
- a      | integer                            |           |          |         | plain    |              | 
- b      | "my_precious_type(citus_backup_0)" |           |          |         | extended |              | 
+-- show fields for table
+  SELECT pg_class.relname,
+         attname,
+         atttype.typname
+    FROM pg_attribute
+    JOIN pg_class ON (attrelid = pg_class.oid)
+    JOIN pg_type AS atttype ON (atttypid = atttype.oid)
+   WHERE pg_class.relname = 'local_table'
+     AND attnum > 0
+ORDER BY attnum;
+   relname   | attname |             typname              
+-------------+---------+----------------------------------
+ local_table | a       | int4
+ local_table | b       | my_precious_type(citus_backup_0)
+(2 rows)
 
 SELECT * FROM local_table;
  a  |             b              
@@ -74,6 +83,25 @@ SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflict
 ---------------------------------
  t
 (1 row)
+
+-- verify they have been created with their names and attributes
+SELECT pg_type.typname,
+       string_agg(attname || ' ' || atttype.typname, ', ' ORDER BY attnum) AS fields
+FROM pg_attribute
+         JOIN pg_class ON (attrelid = pg_class.oid)
+         JOIN pg_type ON (pg_class.reltype = pg_type.oid)
+         JOIN pg_type AS atttype ON (atttypid = atttype.oid)
+WHERE pg_type.typname LIKE 'multi_conflicting_type%'
+GROUP BY pg_type.typname;
+                             typname                             |             fields             
+-----------------------------------------------------------------+--------------------------------
+ multi_conflicting_type                                          | a int4, b int4, c int4, d int4
+ multi_conflicting_type(citus_backup_0)                          | a int4, b int4
+ multi_conflicting_type(citus_backup_1)                          | a int4, b int4, c int4
+ multi_conflicting_type_with_a_really_long_name_(citus_backup_0) | a int4, b int4
+ multi_conflicting_type_with_a_really_long_name_(citus_backup_1) | a int4, b int4, c int4
+ multi_conflicting_type_with_a_really_long_name_that_truncates   | a int4, b int4, c int4, d int4
+(6 rows)
 
 -- hide cascades
 SET client_min_messages TO error;

--- a/src/test/regress/expected/distributed_types_conflict.out
+++ b/src/test/regress/expected/distributed_types_conflict.out
@@ -19,16 +19,16 @@ INSERT INTO local_table VALUES (42, ('always bring a towel', true)::my_precious_
 SET search_path TO type_conflict;
 -- overwrite the type on the worker from the coordinator. The type should be over written
 -- but the data should not have been destroyed
---CREATE TYPE my_precious_type AS (scatterd_secret text);
+CREATE TYPE my_precious_type AS (scatterd_secret text);
 -- verify the data is retained
 \c - - - :worker_1_port
 SET search_path TO type_conflict;
 \d+ local_table
-                                 Table "type_conflict.local_table"
- Column |       Type       | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+------------------+-----------+----------+---------+----------+--------------+-------------
- a      | integer          |           |          |         | plain    |              | 
- b      | my_precious_type |           |          |         | extended |              | 
+                                        Table "type_conflict.local_table"
+ Column |             Type              | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-------------------------------+-----------+----------+---------+----------+--------------+-------------
+ a      | integer                       |           |          |         | plain    |              | 
+ b      | "my_precious_type (backup 0)" |           |          |         | extended |              | 
 
 SELECT * FROM local_table;
  a  |             b              

--- a/src/test/regress/expected/distributed_types_conflict.out
+++ b/src/test/regress/expected/distributed_types_conflict.out
@@ -24,11 +24,11 @@ CREATE TYPE my_precious_type AS (scatterd_secret text);
 \c - - - :worker_1_port
 SET search_path TO type_conflict;
 \d+ local_table
-                                        Table "type_conflict.local_table"
- Column |             Type              | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-------------------------------+-----------+----------+---------+----------+--------------+-------------
- a      | integer                       |           |          |         | plain    |              | 
- b      | "my_precious_type (backup 0)" |           |          |         | extended |              | 
+                                          Table "type_conflict.local_table"
+ Column |                Type                | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ a      | integer                            |           |          |         | plain    |              | 
+ b      | "my_precious_type(citus_backup_0)" |           |          |         | extended |              | 
 
 SELECT * FROM local_table;
  a  |             b              
@@ -38,6 +38,43 @@ SELECT * FROM local_table;
 
 \c - - - :master_port
 SET search_path TO type_conflict;
+-- make sure worker_create_or_replace correctly generates new names while types are existing
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type AS (a int, b int);');
+ worker_create_or_replace_object 
+---------------------------------
+ t
+(1 row)
+
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type AS (a int, b int, c int);');
+ worker_create_or_replace_object 
+---------------------------------
+ t
+(1 row)
+
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type AS (a int, b int, c int, d int);');
+ worker_create_or_replace_object 
+---------------------------------
+ t
+(1 row)
+
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type_with_a_really_long_name_that_truncates AS (a int, b int);');
+ worker_create_or_replace_object 
+---------------------------------
+ t
+(1 row)
+
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type_with_a_really_long_name_that_truncates AS (a int, b int, c int);');
+ worker_create_or_replace_object 
+---------------------------------
+ t
+(1 row)
+
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type_with_a_really_long_name_that_truncates AS (a int, b int, c int, d int);');
+ worker_create_or_replace_object 
+---------------------------------
+ t
+(1 row)
+
 -- hide cascades
 SET client_min_messages TO error;
 DROP SCHEMA type_conflict CASCADE;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -280,5 +280,5 @@ test: ssl_by_default
 # ---------
 # object distribution tests
 # ---------
-test: distributed_types
+test: distributed_types distributed_types_conflict
 test: distributed_functions

--- a/src/test/regress/sql/distributed_types_conflict.sql
+++ b/src/test/regress/sql/distributed_types_conflict.sql
@@ -27,6 +27,15 @@ SELECT * FROM local_table;
 \c - - - :master_port
 SET search_path TO type_conflict;
 
+-- make sure worker_create_or_replace correctly generates new names while types are existing
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type AS (a int, b int);');
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type AS (a int, b int, c int);');
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type AS (a int, b int, c int, d int);');
+
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type_with_a_really_long_name_that_truncates AS (a int, b int);');
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type_with_a_really_long_name_that_truncates AS (a int, b int, c int);');
+SELECT worker_create_or_replace_object('CREATE TYPE type_conflict.multi_conflicting_type_with_a_really_long_name_that_truncates AS (a int, b int, c int, d int);');
+
 -- hide cascades
 SET client_min_messages TO error;
 DROP SCHEMA type_conflict CASCADE;

--- a/src/test/regress/sql/distributed_types_conflict.sql
+++ b/src/test/regress/sql/distributed_types_conflict.sql
@@ -16,7 +16,7 @@ SET search_path TO type_conflict;
 
 -- overwrite the type on the worker from the coordinator. The type should be over written
 -- but the data should not have been destroyed
---CREATE TYPE my_precious_type AS (scatterd_secret text);
+CREATE TYPE my_precious_type AS (scatterd_secret text);
 
 -- verify the data is retained
 \c - - - :worker_1_port

--- a/src/test/regress/sql/distributed_types_conflict.sql
+++ b/src/test/regress/sql/distributed_types_conflict.sql
@@ -1,0 +1,32 @@
+SET citus.next_shard_id TO 20020000;
+
+CREATE SCHEMA type_conflict;
+SELECT run_command_on_workers($$CREATE SCHEMA type_conflict;$$);
+
+-- create a type on a worker that should not cause data loss once overwritten with a type
+-- from the coordinator
+\c - - - :worker_1_port
+SET citus.enable_ddl_propagation TO off;
+SET search_path TO type_conflict;
+CREATE TYPE my_precious_type AS (secret text, should bool);
+CREATE TABLE local_table (a int, b my_precious_type);
+INSERT INTO local_table VALUES (42, ('always bring a towel', true)::my_precious_type);
+\c - - - :master_port
+SET search_path TO type_conflict;
+
+-- overwrite the type on the worker from the coordinator. The type should be over written
+-- but the data should not have been destroyed
+--CREATE TYPE my_precious_type AS (scatterd_secret text);
+
+-- verify the data is retained
+\c - - - :worker_1_port
+SET search_path TO type_conflict;
+\d+ local_table
+SELECT * FROM local_table;
+
+\c - - - :master_port
+SET search_path TO type_conflict;
+
+-- hide cascades
+SET client_min_messages TO error;
+DROP SCHEMA type_conflict CASCADE;


### PR DESCRIPTION
DESCRIPTION: Rename remote types during type propagation

Solves #2953 

To prevent data to be destructed when a remote type differs from the type on the coordinator during type propagation we wanted to rename the type instead of `DROP CASCADE`.

This patch removes the `DROP` logic and adds the creation of a rename statement to a free name.