### PR TITLE
Feature disable object propagation

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -25,6 +25,7 @@
 
 static List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
 
+bool EnableDependencyCreation = true;
 
 /*
  * EnsureDependenciesExists finds all the dependencies that we support and makes sure

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -61,7 +61,6 @@ static void ApplyAddToDependencyList(void *context, Form_pg_depend pg_depend);
 static List * ExpandCitusSupportedTypes(void *context, const ObjectAddress *target);
 
 /* forward declaration of support functions to decide what to follow */
-static bool SupportedDependencyByCitus(const ObjectAddress *address);
 static bool IsObjectAddressOwnedByExtension(const ObjectAddress *target);
 
 
@@ -303,7 +302,7 @@ IsObjectAddressCollected(const ObjectAddress *findAddress,
  * SupportedDependencyByCitus returns whether citus has support to distribute the object
  * addressed.
  */
-static bool
+bool
 SupportedDependencyByCitus(const ObjectAddress *address)
 {
 	if (!EnableDependencyCreation)

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -694,6 +694,17 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.enable_object_propagation",
+		gettext_noop("Enables propagating object creation for more complex objects, "
+					 "schema's will always be created"),
+		NULL,
+		&EnableDependencyCreation,
+		true,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.enable_create_type_propagation",
 		gettext_noop("Enables propagating of CREATE TYPE statements to workers"),
 		NULL,

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -28,6 +28,7 @@ typedef enum
 } PropSetCmdBehavior;
 extern PropSetCmdBehavior PropagateSetCommands;
 extern bool EnableDDLPropagation;
+extern bool EnableDependencyCreation;
 extern bool EnableCreateTypePropagation;
 
 /*

--- a/src/include/distributed/metadata/dependency.h
+++ b/src/include/distributed/metadata/dependency.h
@@ -19,5 +19,6 @@
 
 extern List * GetDependenciesForObject(const ObjectAddress *target);
 extern List * OrderObjectAddressListInDependencyOrder(List *objectAddressList);
+extern bool SupportedDependencyByCitus(const ObjectAddress *address);
 
 #endif /* CITUS_DEPENDENCY_H */

--- a/src/test/regress/expected/disable_object_propagation.out
+++ b/src/test/regress/expected/disable_object_propagation.out
@@ -19,14 +19,17 @@ CREATE TYPE tt1 AS (a int , b int);
 CREATE TABLE t2 (a int PRIMARY KEY, b tt1);
 SELECT create_distributed_table('t2', 'a');
 ERROR:  type "disabled_object_propagation.tt1" does not exist
-CONTEXT:  while executing command on localhost:57638
-SELECT run_command_on_workers($$
+CONTEXT:  while executing command on localhost:57637
+SELECT 1 FROM run_command_on_workers($$
+    BEGIN;
+    SET LOCAL citus.enable_ddl_propagation TO off;
     CREATE TYPE disabled_object_propagation.tt1 AS (a int , b int);
+    COMMIT;
 $$);
-      run_command_on_workers       
------------------------------------
- (localhost,57637,t,"CREATE TYPE")
- (localhost,57638,t,"CREATE TYPE")
+ ?column? 
+----------
+        1
+        1
 (2 rows)
 
 SELECT create_distributed_table('t2', 'a');
@@ -40,14 +43,17 @@ CREATE TYPE tt2 AS ENUM ('a', 'b');
 CREATE TABLE t3 (a int PRIMARY KEY, b tt2);
 SELECT create_distributed_table('t3', 'a');
 ERROR:  type "disabled_object_propagation.tt2" does not exist
-CONTEXT:  while executing command on localhost:57638
-SELECT run_command_on_workers($$
+CONTEXT:  while executing command on localhost:57637
+SELECT 1 FROM  run_command_on_workers($$
+    BEGIN;
+    SET LOCAL citus.enable_ddl_propagation TO off;
     CREATE TYPE disabled_object_propagation.tt2 AS ENUM ('a', 'b');
+    COMMIT;
 $$);
-      run_command_on_workers       
------------------------------------
- (localhost,57637,t,"CREATE TYPE")
- (localhost,57638,t,"CREATE TYPE")
+ ?column? 
+----------
+        1
+        1
 (2 rows)
 
 SELECT create_distributed_table('t3', 'a');

--- a/src/test/regress/expected/disable_object_propagation.out
+++ b/src/test/regress/expected/disable_object_propagation.out
@@ -19,7 +19,7 @@ CREATE TYPE tt1 AS (a int , b int);
 CREATE TABLE t2 (a int PRIMARY KEY, b tt1);
 SELECT create_distributed_table('t2', 'a');
 ERROR:  type "disabled_object_propagation.tt1" does not exist
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 SELECT run_command_on_workers($$
     CREATE TYPE disabled_object_propagation.tt1 AS (a int , b int);
 $$);
@@ -40,7 +40,7 @@ CREATE TYPE tt2 AS ENUM ('a', 'b');
 CREATE TABLE t3 (a int PRIMARY KEY, b tt2);
 SELECT create_distributed_table('t3', 'a');
 ERROR:  type "disabled_object_propagation.tt2" does not exist
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 SELECT run_command_on_workers($$
     CREATE TYPE disabled_object_propagation.tt2 AS ENUM ('a', 'b');
 $$);
@@ -82,6 +82,7 @@ ALTER TYPE tt3 OWNER TO typeowner_for_disabled_object_propagation_guc;
 ALTER TYPE tt3 RENAME ATTRIBUTE c TO d;
 ALTER TYPE tt3 RENAME TO tt4;
 ALTER TYPE tt4 SET SCHEMA disabled_object_propagation2;
+DROP TYPE disabled_object_propagation2.tt4;
 -- verify no changes have been made to the type on the remote servers. tt3 is used as a name since the rename should not have been propagated
 SELECT run_command_on_workers($$
 SELECT row(nspname, typname, usename)

--- a/src/test/regress/expected/disable_object_propagation.out
+++ b/src/test/regress/expected/disable_object_propagation.out
@@ -1,0 +1,119 @@
+SET citus.next_shard_id TO 20030000;
+SET citus.enable_object_propagation TO false; -- all tests here verify old behaviour without distributing types,functions,etc automatically
+CREATE USER typeowner_for_disabled_object_propagation_guc;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+CREATE SCHEMA disabled_object_propagation;
+CREATE SCHEMA disabled_object_propagation2;
+SET search_path TO disabled_object_propagation;
+-- verify the table gets created, which requires schema distribution to still work
+CREATE TABLE t1 (a int PRIMARY KEY , b int);
+SELECT create_distributed_table('t1','a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- verify types are not created, preventing distributed tables to be created unless created manually on the workers
+CREATE TYPE tt1 AS (a int , b int);
+CREATE TABLE t2 (a int PRIMARY KEY, b tt1);
+SELECT create_distributed_table('t2', 'a');
+ERROR:  type "disabled_object_propagation.tt1" does not exist
+CONTEXT:  while executing command on localhost:57637
+SELECT run_command_on_workers($$
+    CREATE TYPE disabled_object_propagation.tt1 AS (a int , b int);
+$$);
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE TYPE")
+ (localhost,57638,t,"CREATE TYPE")
+(2 rows)
+
+SELECT create_distributed_table('t2', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- verify enum types are not created, preventing distributed tables to be created unless created manually on the workers
+CREATE TYPE tt2 AS ENUM ('a', 'b');
+CREATE TABLE t3 (a int PRIMARY KEY, b tt2);
+SELECT create_distributed_table('t3', 'a');
+ERROR:  type "disabled_object_propagation.tt2" does not exist
+CONTEXT:  while executing command on localhost:57637
+SELECT run_command_on_workers($$
+    CREATE TYPE disabled_object_propagation.tt2 AS ENUM ('a', 'b');
+$$);
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE TYPE")
+ (localhost,57638,t,"CREATE TYPE")
+(2 rows)
+
+SELECT create_distributed_table('t3', 'a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- verify ALTER TYPE statements are not propagated for types, even though they are marked distributed
+BEGIN;
+-- object propagation is turned off after xact finished, type is already marked distributed by then
+SET LOCAL citus.enable_object_propagation TO on;
+CREATE TYPE tt3 AS (a int, b int);
+CREATE TABLE t4 (a int PRIMARY KEY, b tt3);
+SELECT create_distributed_table('t4','a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+DROP TABLE t4; -- as long as the table is using the type some operations are hard to force
+COMMIT;
+-- verify the type is distributed
+SELECT count(*) FROM citus.pg_dist_object WHERE objid = 'disabled_object_propagation.tt3'::regtype::oid;
+ count 
+-------
+     1
+(1 row)
+
+ALTER TYPE tt3 ADD ATTRIBUTE c int, DROP ATTRIBUTE b, ALTER ATTRIBUTE a SET DATA TYPE text COLLATE "en_US";
+ALTER TYPE tt3 OWNER TO typeowner_for_disabled_object_propagation_guc;
+ALTER TYPE tt3 RENAME ATTRIBUTE c TO d;
+ALTER TYPE tt3 RENAME TO tt4;
+ALTER TYPE tt4 SET SCHEMA disabled_object_propagation2;
+-- verify no changes have been made to the type on the remote servers. tt3 is used as a name since the rename should not have been propagated
+SELECT run_command_on_workers($$
+SELECT row(nspname, typname, usename)
+  FROM pg_type
+  JOIN pg_user ON (typowner = usesysid)
+  JOIN pg_namespace ON (pg_namespace.oid = typnamespace)
+ WHERE typname = 'tt3';
+$$);
+                      run_command_on_workers                      
+------------------------------------------------------------------
+ (localhost,57637,t,"(disabled_object_propagation,tt3,postgres)")
+ (localhost,57638,t,"(disabled_object_propagation,tt3,postgres)")
+(2 rows)
+
+SELECT run_command_on_workers($$
+  SELECT row(pg_type.typname, string_agg(attname || ' ' || atttype.typname, ', ' ORDER BY attnum))
+    FROM pg_attribute
+    JOIN pg_class ON (attrelid = pg_class.oid)
+    JOIN pg_type ON (pg_class.reltype = pg_type.oid)
+    JOIN pg_type AS atttype ON (atttypid = atttype.oid)
+   WHERE pg_type.typname = 'tt3'
+GROUP BY pg_type.typname;
+$$);
+             run_command_on_workers             
+------------------------------------------------
+ (localhost,57637,t,"(tt3,""a int4, b int4"")")
+ (localhost,57638,t,"(tt3,""a int4, b int4"")")
+(2 rows)
+
+-- suppress any warnings during cleanup
+SET client_min_messages TO fatal;
+RESET citus.enable_object_propagation;
+DROP SCHEMA disabled_object_propagation CASCADE;
+DROP SCHEMA disabled_object_propagation2 CASCADE;
+DROP USER typeowner_for_disabled_object_propagation_guc;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -280,5 +280,5 @@ test: ssl_by_default
 # ---------
 # object distribution tests
 # ---------
-test: distributed_types distributed_types_conflict
+test: distributed_types distributed_types_conflict disable_object_propagation
 test: distributed_functions

--- a/src/test/regress/sql/disable_object_propagation.sql
+++ b/src/test/regress/sql/disable_object_propagation.sql
@@ -1,0 +1,75 @@
+SET citus.next_shard_id TO 20030000;
+SET citus.enable_object_propagation TO false; -- all tests here verify old behaviour without distributing types,functions,etc automatically
+
+CREATE USER typeowner_for_disabled_object_propagation_guc;
+CREATE SCHEMA disabled_object_propagation;
+CREATE SCHEMA disabled_object_propagation2;
+SET search_path TO disabled_object_propagation;
+
+-- verify the table gets created, which requires schema distribution to still work
+CREATE TABLE t1 (a int PRIMARY KEY , b int);
+SELECT create_distributed_table('t1','a');
+
+-- verify types are not created, preventing distributed tables to be created unless created manually on the workers
+CREATE TYPE tt1 AS (a int , b int);
+CREATE TABLE t2 (a int PRIMARY KEY, b tt1);
+SELECT create_distributed_table('t2', 'a');
+SELECT run_command_on_workers($$
+    CREATE TYPE disabled_object_propagation.tt1 AS (a int , b int);
+$$);
+SELECT create_distributed_table('t2', 'a');
+
+-- verify enum types are not created, preventing distributed tables to be created unless created manually on the workers
+CREATE TYPE tt2 AS ENUM ('a', 'b');
+CREATE TABLE t3 (a int PRIMARY KEY, b tt2);
+SELECT create_distributed_table('t3', 'a');
+SELECT run_command_on_workers($$
+    CREATE TYPE disabled_object_propagation.tt2 AS ENUM ('a', 'b');
+$$);
+SELECT create_distributed_table('t3', 'a');
+
+-- verify ALTER TYPE statements are not propagated for types, even though they are marked distributed
+BEGIN;
+-- object propagation is turned off after xact finished, type is already marked distributed by then
+SET LOCAL citus.enable_object_propagation TO on;
+CREATE TYPE tt3 AS (a int, b int);
+CREATE TABLE t4 (a int PRIMARY KEY, b tt3);
+SELECT create_distributed_table('t4','a');
+DROP TABLE t4; -- as long as the table is using the type some operations are hard to force
+COMMIT;
+
+-- verify the type is distributed
+SELECT count(*) FROM citus.pg_dist_object WHERE objid = 'disabled_object_propagation.tt3'::regtype::oid;
+
+ALTER TYPE tt3 ADD ATTRIBUTE c int, DROP ATTRIBUTE b, ALTER ATTRIBUTE a SET DATA TYPE text COLLATE "en_US";
+ALTER TYPE tt3 OWNER TO typeowner_for_disabled_object_propagation_guc;
+ALTER TYPE tt3 RENAME ATTRIBUTE c TO d;
+ALTER TYPE tt3 RENAME TO tt4;
+ALTER TYPE tt4 SET SCHEMA disabled_object_propagation2;
+
+-- verify no changes have been made to the type on the remote servers. tt3 is used as a name since the rename should not have been propagated
+SELECT run_command_on_workers($$
+SELECT row(nspname, typname, usename)
+  FROM pg_type
+  JOIN pg_user ON (typowner = usesysid)
+  JOIN pg_namespace ON (pg_namespace.oid = typnamespace)
+ WHERE typname = 'tt3';
+$$);
+
+SELECT run_command_on_workers($$
+  SELECT row(pg_type.typname, string_agg(attname || ' ' || atttype.typname, ', ' ORDER BY attnum))
+    FROM pg_attribute
+    JOIN pg_class ON (attrelid = pg_class.oid)
+    JOIN pg_type ON (pg_class.reltype = pg_type.oid)
+    JOIN pg_type AS atttype ON (atttypid = atttype.oid)
+   WHERE pg_type.typname = 'tt3'
+GROUP BY pg_type.typname;
+$$);
+
+-- suppress any warnings during cleanup
+SET client_min_messages TO fatal;
+RESET citus.enable_object_propagation;
+DROP SCHEMA disabled_object_propagation CASCADE;
+DROP SCHEMA disabled_object_propagation2 CASCADE;
+DROP USER typeowner_for_disabled_object_propagation_guc;
+

--- a/src/test/regress/sql/disable_object_propagation.sql
+++ b/src/test/regress/sql/disable_object_propagation.sql
@@ -46,6 +46,7 @@ ALTER TYPE tt3 OWNER TO typeowner_for_disabled_object_propagation_guc;
 ALTER TYPE tt3 RENAME ATTRIBUTE c TO d;
 ALTER TYPE tt3 RENAME TO tt4;
 ALTER TYPE tt4 SET SCHEMA disabled_object_propagation2;
+DROP TYPE disabled_object_propagation2.tt4;
 
 -- verify no changes have been made to the type on the remote servers. tt3 is used as a name since the rename should not have been propagated
 SELECT run_command_on_workers($$

--- a/src/test/regress/sql/disable_object_propagation.sql
+++ b/src/test/regress/sql/disable_object_propagation.sql
@@ -14,8 +14,11 @@ SELECT create_distributed_table('t1','a');
 CREATE TYPE tt1 AS (a int , b int);
 CREATE TABLE t2 (a int PRIMARY KEY, b tt1);
 SELECT create_distributed_table('t2', 'a');
-SELECT run_command_on_workers($$
+SELECT 1 FROM run_command_on_workers($$
+    BEGIN;
+    SET LOCAL citus.enable_ddl_propagation TO off;
     CREATE TYPE disabled_object_propagation.tt1 AS (a int , b int);
+    COMMIT;
 $$);
 SELECT create_distributed_table('t2', 'a');
 
@@ -23,8 +26,11 @@ SELECT create_distributed_table('t2', 'a');
 CREATE TYPE tt2 AS ENUM ('a', 'b');
 CREATE TABLE t3 (a int PRIMARY KEY, b tt2);
 SELECT create_distributed_table('t3', 'a');
-SELECT run_command_on_workers($$
+SELECT 1 FROM  run_command_on_workers($$
+    BEGIN;
+    SET LOCAL citus.enable_ddl_propagation TO off;
     CREATE TYPE disabled_object_propagation.tt2 AS ENUM ('a', 'b');
+    COMMIT;
 $$);
 SELECT create_distributed_table('t3', 'a');
 


### PR DESCRIPTION
DESCRIPTION: Provide a GUC to turn of the new dependency propagation functionality

Expansion on #2954 

In the case the dependency propagation functionality introduced in 9.0 causes issues to a cluster of a user they can turn it off almost completely. The only dependency that will still be propagated and kept track of is the schema to emulate the old behaviour.

GUC to change is `citus.enable_object_propagation`. When set to `false` the functionality will be mostly turned off. Be aware that objects marked as distributed in `pg_dist_object` will still be kept in the catalog as a distributed object. Alter statements to these objects will not be propagated to workers and may cause desynchronisation.