### PR TITLE
Feature/drop function

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -26,21 +26,23 @@
 #include "access/xact.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_proc.h"
-#include "distributed/commands.h"
 #include "catalog/pg_type.h"
+#include "commands/extension.h"
 #include "distributed/colocation_utils.h"
-#include "distributed/master_protocol.h"
+#include "distributed/commands.h"
+#include "distributed/commands/utility_hook.h"
 #include "distributed/maintenanced.h"
-#include "distributed/metadata_sync.h"
+#include "distributed/master_protocol.h"
 #include "distributed/metadata/distobject.h"
 #include "distributed/metadata/pg_dist_object.h"
+#include "distributed/metadata_sync.h"
 #include "distributed/multi_executor.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/worker_transaction.h"
 #include "storage/lmgr.h"
 #include "utils/builtins.h"
-#include "utils/fmgrprotos.h"
 #include "utils/fmgroids.h"
+#include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
@@ -61,6 +63,7 @@ static void UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
 										   int *colocationId);
 static void EnsureSequentialModeForFunctionDDL(void);
 static void TriggerSyncMetadataToPrimaryNodes(void);
+static bool ShouldPropagateAlterFunction(const ObjectAddress *address);
 
 
 PG_FUNCTION_INFO_V1(create_distributed_function);
@@ -614,4 +617,38 @@ TriggerSyncMetadataToPrimaryNodes(void)
 	{
 		TriggerMetadataSync(MyDatabaseId);
 	}
+}
+
+
+/*
+ * ShouldPropagateAlterFunction returns, based on the address of a function, if alter
+ * statements targeting the function should be propagated.
+ */
+static bool
+ShouldPropagateAlterFunction(const ObjectAddress *address)
+{
+	if (creating_extension)
+	{
+		/*
+		 * extensions should be created separately on the workers, functions cascading
+		 * from an extension should therefor not be propagated.
+		 */
+		return false;
+	}
+
+	if (!EnableDependencyCreation)
+	{
+		/*
+		 * we are configured to disable object propagation, should not propagate anything
+		 */
+		return false;
+	}
+
+	if (!IsObjectDistributed(address))
+	{
+		/* do not propagate alter function for non-distributed functions */
+		return false;
+	}
+
+	return true;
 }

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -31,6 +31,7 @@
 #include "distributed/colocation_utils.h"
 #include "distributed/commands.h"
 #include "distributed/commands/utility_hook.h"
+#include "distributed/deparser.h"
 #include "distributed/maintenanced.h"
 #include "distributed/master_protocol.h"
 #include "distributed/metadata/distobject.h"
@@ -64,6 +65,7 @@ static void UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
 static void EnsureSequentialModeForFunctionDDL(void);
 static void TriggerSyncMetadataToPrimaryNodes(void);
 static bool ShouldPropagateAlterFunction(const ObjectAddress *address);
+static List * FunctionListToObjectAddresses(List *objectWithArgsList, bool missing_ok);
 
 
 PG_FUNCTION_INFO_V1(create_distributed_function);
@@ -651,4 +653,122 @@ ShouldPropagateAlterFunction(const ObjectAddress *address)
 	}
 
 	return true;
+}
+
+
+/*
+ * PlanDropFunctionStmt gets called during the planning phase of a DROP FUNCTION statement
+ * and returns a list of DDLJob's that will drop any distributed functions from the
+ * workers.
+ */
+List *
+PlanDropFunctionStmt(DropStmt *stmt, const char *queryString)
+{
+	List *oldObjectWithArgsList = stmt->objects;
+	List *distributedObjectWithArgsList = NIL;
+	List *distributedFunctionAddresses = NIL;
+	ListCell *addressCell = NULL;
+	const char *dropStmtSql = NULL;
+	List *commands = NULL;
+	List *objectAddresses = NIL;
+	ListCell *objectWithArgsListCell = NULL;
+
+	if (creating_extension)
+	{
+		/*
+		 * extensions should be created separately on the workers, types cascading from an
+		 * extension should therefor not be propagated here.
+		 */
+		return NIL;
+	}
+
+	if (!EnableDependencyCreation)
+	{
+		/*
+		 * we are configured to disable object propagation, should not propagate anything
+		 */
+		return NIL;
+	}
+
+
+	/*
+	 * Our statements need to be fully qualified so we can drop them from the right schema
+	 * on the workers
+	 */
+	QualifyTreeNode((Node *) stmt);
+
+	/*
+	 * map all functions to their object addresses and step through them in lock step to
+	 * create two lists with all distributed functions and their addresses.
+	 */
+	objectAddresses = FunctionListToObjectAddresses(oldObjectWithArgsList,
+													stmt->missing_ok);
+	forboth(objectWithArgsListCell, oldObjectWithArgsList, addressCell, objectAddresses)
+	{
+		ObjectAddress *address = (ObjectAddress *) lfirst(addressCell);
+		ObjectWithArgs *func = castNode(ObjectWithArgs, lfirst(objectWithArgsListCell));
+
+		if (!IsObjectDistributed(address))
+		{
+			continue;
+		}
+
+		/* collect information for all distributed functions */
+		distributedFunctionAddresses = lappend(distributedFunctionAddresses, address);
+		distributedObjectWithArgsList = lappend(distributedObjectWithArgsList, func);
+	}
+
+	if (list_length(distributedObjectWithArgsList) <= 0)
+	{
+		/* no distributed functions to drop */
+		return NIL;
+	}
+
+	/*
+	 * managing types can only be done on the coordinator if ddl propagation is on. when
+	 * it is off we will never get here. MX workers don't have a notion of distributed
+	 * types, so we block the call.
+	 */
+	EnsureCoordinator();
+
+	/* remove the entries for the distributed objects on dropping */
+	foreach(addressCell, distributedFunctionAddresses)
+	{
+		ObjectAddress *address = (ObjectAddress *) lfirst(addressCell);
+		UnmarkObjectDistributed(address);
+	}
+
+	stmt->objects = distributedObjectWithArgsList;
+	dropStmtSql = DeparseTreeNode((Node *) stmt);
+	stmt->objects = oldObjectWithArgsList;
+
+	/* to prevent recursion with mx we disable ddl propagation */
+	EnsureSequentialModeForFunctionDDL();
+
+	commands = list_make3(DISABLE_DDL_PROPAGATION,
+						  (void *) dropStmtSql,
+						  ENABLE_DDL_PROPAGATION);
+
+	return NodeDDLTaskList(ALL_WORKERS, commands);
+}
+
+
+static List *
+FunctionListToObjectAddresses(List *objectWithArgsList, bool missing_ok)
+{
+	List *result = NIL;
+	ListCell *objectWithArgsListCell = NULL;
+
+	foreach(objectWithArgsListCell, objectWithArgsList)
+	{
+		ObjectWithArgs *objectWithArgs = (ObjectWithArgs *) lfirst(
+			objectWithArgsListCell);
+		Oid funcOid = LookupFuncWithArgsCompat(OBJECT_FUNCTION, objectWithArgs,
+											   missing_ok);
+		ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+		ObjectAddressSet(*address, ProcedureRelationId, funcOid);
+		result = lappend(result, address);
+	}
+
+	return result;
 }

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -375,6 +375,11 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 					break;
 				}
 
+				case OBJECT_FUNCTION:
+				{
+					ddlJobs = PlanDropFunctionStmt(dropStatement, queryString);
+				}
+
 				default:
 				{
 					/* unsupported type, skipping*/

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -44,6 +44,10 @@ extern bool TableReferencing(Oid relationId);
 extern bool ConstraintIsAForeignKey(char *constraintName, Oid relationId);
 
 
+/* function.c - forward devlarations */
+extern List * PlanDropFunctionStmt(DropStmt *stmt, const char *queryString);
+
+
 /* grant.c - forward declarations */
 extern List * PlanGrantStmt(GrantStmt *grantStmt);
 

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -41,6 +41,7 @@ CREATE FUNCTION add_mixed_param_names(integer, val1 integer) RETURNS integer
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
+RESET citus.enable_ddl_propagation;
 -- make sure that none of the active and primary nodes hasmetadata
 -- at the start of the test
 select bool_or(hasmetadata) from pg_dist_node WHERE isactive AND  noderole = 'primary';
@@ -104,6 +105,15 @@ SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY
 -----------+----------+---------+--------
  localhost |    57637 | t       | 5
  localhost |    57638 | t       | 5
+(2 rows)
+
+DROP FUNCTION add(int,int);
+-- call should fail as function should have been dropped
+SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
+ nodename  | nodeport | success |                                result                                
+-----------+----------+---------+----------------------------------------------------------------------
+ localhost |    57637 | f       | ERROR:  function function_tests.add(integer, integer) does not exist
+ localhost |    57638 | f       | ERROR:  function function_tests.add(integer, integer) does not exist
 (2 rows)
 
 -- postgres doesn't accept parameter names in the regprocedure input

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -54,6 +54,8 @@ WHERE pgd.refclassid = 'pg_extension'::regclass AND
 -- DROP EXTENSION pre-created by the regression suite
 DROP EXTENSION citus;
 \c
+-- these tests switch between citus versions and call ddl's that require pg_dist_object to be created
+SET citus.enable_object_propagation TO 'false';
 SET citus.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '7.0-1';
 ALTER EXTENSION citus UPDATE TO '7.0-2';

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -44,6 +44,8 @@ CREATE FUNCTION add_mixed_param_names(integer, val1 integer) RETURNS integer
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 
+RESET citus.enable_ddl_propagation;
+
 -- make sure that none of the active and primary nodes hasmetadata
 -- at the start of the test
 select bool_or(hasmetadata) from pg_dist_node WHERE isactive AND  noderole = 'primary';
@@ -66,6 +68,11 @@ SELECT * FROM run_command_on_workers('SELECT function_tests.dup(42);') ORDER BY 
 
 SELECT create_distributed_function('add(int,int)', '$1');
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
+
+DROP FUNCTION add(int,int);
+-- call should fail as function should have been dropped
+SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
+
 
 -- postgres doesn't accept parameter names in the regprocedure input
 SELECT create_distributed_function('add_with_param_names(val1 int, int)', 'val1');

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -53,6 +53,9 @@ WHERE pgd.refclassid = 'pg_extension'::regclass AND
 DROP EXTENSION citus;
 \c
 
+-- these tests switch between citus versions and call ddl's that require pg_dist_object to be created
+SET citus.enable_object_propagation TO 'false';
+
 SET citus.enable_version_checks TO 'false';
 
 CREATE EXTENSION citus VERSION '7.0-1';


### PR DESCRIPTION
DESCRIPTION: Add DROP FUNCTION propagation for distributed functions

includes #2986 

For functions that have been distributed and later dropped we want to send the drop commands to the workers to clean up the function. As one might drop multiple functions at once we filter the list to only contain distributed functions.


