### PR TITLE
Check for more in node metadata function tests.

### DIFF
--- a/src/test/regress/expected/isolation_add_node_vs_reference_table_operations.out
+++ b/src/test/regress/expected/isolation_add_node_vs_reference_table_operations.out
@@ -12,10 +12,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-copy-to-reference-table: 
 	COPY test_reference_table FROM PROGRAM 'echo 1 && echo 2 && echo 3 && echo 4 && echo 5';
  <waiting ...>
@@ -55,6 +60,7 @@ step s2-copy-to-reference-table:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -63,6 +69,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-content: 
 	SELECT
 		nodeport, success, result
@@ -92,10 +102,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-insert-to-reference-table: 
 	INSERT INTO test_reference_table VALUES (6);
  <waiting ...>
@@ -135,6 +150,7 @@ step s2-insert-to-reference-table:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -143,6 +159,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-content: 
 	SELECT
 		nodeport, success, result
@@ -172,10 +192,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-ddl-on-reference-table: 
 	CREATE INDEX reference_index ON test_reference_table(test_id);
  <waiting ...>
@@ -215,6 +240,7 @@ step s2-ddl-on-reference-table:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -223,6 +249,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-index-count: 
 	SELECT
 		nodeport, success, result
@@ -252,10 +282,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-reference-table-2: 
 	SELECT create_reference_table('test_reference_table_2');
  <waiting ...>
@@ -301,6 +336,7 @@ create_reference_table
                
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -309,6 +345,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-content-2: 
 	SELECT
 		nodeport, success, result
@@ -335,10 +375,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-copy-to-reference-table: 
 	COPY test_reference_table FROM PROGRAM 'echo 1 && echo 2 && echo 3 && echo 4 && echo 5';
  <waiting ...>
@@ -375,6 +420,7 @@ step s2-copy-to-reference-table:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -383,6 +429,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-content: 
 	SELECT
 		nodeport, success, result
@@ -409,10 +459,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-insert-to-reference-table: 
 	INSERT INTO test_reference_table VALUES (6);
  <waiting ...>
@@ -449,6 +504,7 @@ step s2-insert-to-reference-table:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -457,6 +513,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-content: 
 	SELECT
 		nodeport, success, result
@@ -483,10 +543,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-ddl-on-reference-table: 
 	CREATE INDEX reference_index ON test_reference_table(test_id);
  <waiting ...>
@@ -523,6 +588,7 @@ step s2-ddl-on-reference-table:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -531,6 +597,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-index-count: 
 	SELECT
 		nodeport, success, result
@@ -557,10 +627,15 @@ step s1-begin:
 
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-reference-table-2: 
 	SELECT create_reference_table('test_reference_table_2');
  <waiting ...>
@@ -603,6 +678,7 @@ create_reference_table
                
 step s1-add-second-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -611,6 +687,10 @@ step s1-add-second-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-print-content-2: 
 	SELECT
 		nodeport, success, result

--- a/src/test/regress/expected/isolation_cluster_management.out
+++ b/src/test/regress/expected/isolation_cluster_management.out
@@ -4,6 +4,7 @@ starting permutation: s1a
 step s1a: 
     SELECT 1 FROM master_add_node('localhost', 57637);
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
@@ -11,3 +12,7 @@ step s1a:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              

--- a/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
+++ b/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
@@ -1,11 +1,12 @@
 Parsed test spec with 4 sessions
 
 starting permutation: s1-print-distributed-objects s1-begin s1-add-worker s2-public-schema s2-create-table s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -23,6 +24,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -47,10 +52,15 @@ step s1-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-public-schema: 
     SET search_path TO public;
 
@@ -101,11 +111,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-begin s1-add-worker s2-public-schema s2-create-table s1-commit s2-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -123,6 +134,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -150,10 +165,15 @@ step s2-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-public-schema: 
     SET search_path TO public;
 
@@ -207,11 +227,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-begin s2-public-schema s2-create-table s1-add-worker s2-commit s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -229,6 +250,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -268,6 +293,7 @@ create_distributed_table
                
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -276,6 +302,10 @@ step s1-add-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s1-commit: 
     COMMIT;
 
@@ -313,11 +343,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s1-add-worker s2-create-schema s2-create-table s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -335,6 +366,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -359,10 +394,15 @@ step s1-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-schema: 
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
@@ -415,11 +455,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-begin s1-add-worker s2-create-schema s2-create-table s1-commit s2-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -437,6 +478,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -464,10 +509,15 @@ step s2-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-schema: 
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
@@ -523,11 +573,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-begin s2-create-schema s2-create-table s1-add-worker s2-commit s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -545,6 +596,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -585,6 +640,7 @@ create_distributed_table
                
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -593,6 +649,10 @@ step s1-add-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s1-commit: 
     COMMIT;
 
@@ -631,11 +691,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s2-create-schema s1-begin s2-begin s3-begin s1-add-worker s2-create-table s3-use-schema s3-create-table s1-commit s2-commit s3-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -653,6 +714,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -687,10 +752,15 @@ step s3-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-table: 
 	CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
@@ -758,11 +828,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s2-create-schema s1-begin s2-begin s3-begin s4-begin s1-add-worker s2-create-table s3-use-schema s3-create-table s4-use-schema s4-create-table s1-commit s2-commit s3-commit s4-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -780,6 +851,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -817,10 +892,15 @@ step s4-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-table: 
 	CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
@@ -904,11 +984,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-add-worker s2-create-schema s2-begin s3-begin s3-use-schema s2-create-table s3-create-table s2-commit s3-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -926,6 +1007,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -947,10 +1032,15 @@ master_remove_node
                
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-schema: 
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
@@ -1024,11 +1114,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-begin s4-begin s1-add-worker s2-create-schema s4-create-schema2 s2-create-table s4-create-table s1-commit s2-commit s4-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -1046,6 +1137,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -1076,10 +1171,15 @@ step s4-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-create-schema: 
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
@@ -1153,11 +1253,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s1-add-worker s2-public-schema s2-create-type s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -1175,6 +1276,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -1199,10 +1304,15 @@ step s1-begin:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s2-public-schema: 
     SET search_path TO public;
 
@@ -1248,11 +1358,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-public-schema s2-create-type s1-add-worker s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -1270,6 +1381,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -1300,10 +1415,15 @@ step s2-create-type:
 
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s1-commit: 
     COMMIT;
 
@@ -1342,11 +1462,12 @@ master_remove_node
                
 
 starting permutation: s1-print-distributed-objects s1-begin s2-begin s2-create-schema s2-create-type s2-create-table-with-type s1-add-worker s2-commit s1-commit s2-print-distributed-objects
-?column?       
+nodename       nodeport       isactive       
 
-1              
+localhost      57637          t              
 step s1-print-distributed-objects: 
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
@@ -1364,6 +1485,10 @@ step s1-print-distributed-objects:
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 pg_identify_object_as_address
 
 count          
@@ -1407,6 +1532,7 @@ create_distributed_table
                
 step s1-add-worker: 
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
  <waiting ...>
 step s2-commit: 
 	COMMIT;
@@ -1415,6 +1541,10 @@ step s1-add-worker: <... completed>
 ?column?       
 
 1              
+nodename       nodeport       isactive       
+
+localhost      57637          t              
+localhost      57638          t              
 step s1-commit: 
     COMMIT;
 

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -28,10 +28,11 @@ SELECT master_get_active_worker_nodes();
 (2 rows)
 
 -- try to add a node that is already in the cluster
-SELECT * FROM master_add_node('localhost', :worker_1_port);
- master_add_node 
------------------
-               1
+SELECT master_add_node('localhost', :worker_1_port) AS nodeid \gset
+SELECT nodeid, groupid FROM pg_dist_node WHERE nodeid = :nodeid;
+ nodeid | groupid 
+--------+---------
+      1 |       1
 (1 row)
 
 -- get the active nodes
@@ -78,10 +79,11 @@ SELECT master_get_active_worker_nodes();
 -- add some shard placements to the cluster
 SET citus.shard_count TO 16;
 SET citus.shard_replication_factor TO 1;
-SELECT * FROM master_activate_node('localhost', :worker_2_port);
- master_activate_node 
-----------------------
-                    3
+SELECT master_activate_node('localhost', :worker_2_port) AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
+ isactive 
+----------
+ t
 (1 row)
 
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
@@ -229,10 +231,11 @@ SELECT master_get_active_worker_nodes();
 (1 row)
 
 -- restore the node for next tests
-SELECT * FROM master_activate_node('localhost', :worker_2_port);
- master_activate_node 
-----------------------
-                    3
+SELECT master_activate_node('localhost', :worker_2_port) AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
+ isactive 
+----------
+ t
 (1 row)
 
 -- try to remove a node with active placements and see that node removal is failed

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -44,10 +44,11 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 SELECT master_add_node('localhost', :worker_2_port) AS worker_2_nodeid \gset
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeid=:worker_2_nodeid \gset
 -- add a secondary to check we don't attempt to replicate the table to it
-SELECT 1 FROM master_add_node('localhost', 9000, groupid=>:worker_2_group, noderole=>'secondary');
- ?column? 
+SELECT master_add_node('localhost', 9000, groupid=>:worker_2_group, noderole=>'secondary') AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
+ isactive 
 ----------
-        1
+ t
 (1 row)
 
 -- remove a node with reference table
@@ -59,10 +60,11 @@ SELECT create_reference_table('remove_node_reference_table');
 (1 row)
 
 -- make sure when we add a secondary we don't attempt to add placements to it
-SELECT 1 FROM master_add_node('localhost', 9001, groupid=>:worker_2_group, noderole=>'secondary');
- ?column? 
+SELECT master_add_node('localhost', 9001, groupid=>:worker_2_group, noderole=>'secondary') AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
+ isactive 
 ----------
-        1
+ t
 (1 row)
 
 SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;

--- a/src/test/regress/specs/isolation_add_node_vs_reference_table_operations.spec
+++ b/src/test/regress/specs/isolation_add_node_vs_reference_table_operations.spec
@@ -4,6 +4,7 @@ setup
 {	
 	SET citus.shard_replication_factor to 1;
 	SELECT 1 FROM master_add_node('localhost', 57637);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 	
 	CREATE TABLE test_reference_table (test_id integer);
 	CREATE TABLE test_reference_table_2 (test_id integer);
@@ -32,6 +33,7 @@ step "s1-begin"
 step "s1-add-second-worker"
 {
 	SELECT 1 FROM master_add_node('localhost', 57638);
+	SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 }
 
 step "s1-remove-second-worker"

--- a/src/test/regress/specs/isolation_cluster_management.spec
+++ b/src/test/regress/specs/isolation_cluster_management.spec
@@ -3,6 +3,7 @@ step "s1a"
 {
     SELECT 1 FROM master_add_node('localhost', 57637);
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 }
 
 permutation "s1a"

--- a/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
+++ b/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
@@ -4,6 +4,7 @@ setup
 {
     SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node;
 	SELECT 1 FROM master_add_node('localhost', 57637);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 }
 
 # ensure that both nodes exists for the remaining of the isolation tests
@@ -34,6 +35,7 @@ step "s1-begin"
 step "s1-add-worker"
 {
 	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 }
 
 step "s1-commit"
@@ -46,6 +48,7 @@ step "s1-commit"
 step "s1-print-distributed-objects"
 {
     SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT nodename, nodeport, isactive FROM pg_dist_node ORDER BY nodeid;
 
     -- print an overview of all distributed objects
     SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -15,7 +15,8 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT master_get_active_worker_nodes();
 
 -- try to add a node that is already in the cluster
-SELECT * FROM master_add_node('localhost', :worker_1_port);
+SELECT master_add_node('localhost', :worker_1_port) AS nodeid \gset
+SELECT nodeid, groupid FROM pg_dist_node WHERE nodeid = :nodeid;
 
 -- get the active nodes
 SELECT master_get_active_worker_nodes();
@@ -35,7 +36,8 @@ SELECT master_get_active_worker_nodes();
 SET citus.shard_count TO 16;
 SET citus.shard_replication_factor TO 1;
 
-SELECT * FROM master_activate_node('localhost', :worker_2_port);
+SELECT master_activate_node('localhost', :worker_2_port) AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
 SELECT create_distributed_table('cluster_management_test', 'col_1', 'hash');
 
@@ -95,7 +97,8 @@ ABORT;
 SELECT master_get_active_worker_nodes();
 
 -- restore the node for next tests
-SELECT * FROM master_activate_node('localhost', :worker_2_port);
+SELECT master_activate_node('localhost', :worker_2_port) AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
 
 -- try to remove a node with active placements and see that node removal is failed
 SELECT master_remove_node('localhost', :worker_2_port); 

--- a/src/test/regress/sql/multi_remove_node_reference_table.sql
+++ b/src/test/regress/sql/multi_remove_node_reference_table.sql
@@ -34,14 +34,16 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 SELECT master_add_node('localhost', :worker_2_port) AS worker_2_nodeid \gset
 SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeid=:worker_2_nodeid \gset
 -- add a secondary to check we don't attempt to replicate the table to it
-SELECT 1 FROM master_add_node('localhost', 9000, groupid=>:worker_2_group, noderole=>'secondary');
+SELECT master_add_node('localhost', 9000, groupid=>:worker_2_group, noderole=>'secondary') AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
 
 -- remove a node with reference table
 CREATE TABLE remove_node_reference_table(column1 int);
 SELECT create_reference_table('remove_node_reference_table');
 
 -- make sure when we add a secondary we don't attempt to add placements to it
-SELECT 1 FROM master_add_node('localhost', 9001, groupid=>:worker_2_group, noderole=>'secondary');
+SELECT master_add_node('localhost', 9001, groupid=>:worker_2_group, noderole=>'secondary') AS nodeid \gset
+SELECT isactive FROM pg_dist_node WHERE nodeid=:nodeid;
 SELECT count(*) FROM pg_dist_placement WHERE groupid = :worker_2_group;
 -- make sure when we disable a secondary we don't remove any placements
 SELECT master_disable_node('localhost', 9001);


### PR DESCRIPTION
https://github.com/citusdata/citus/pull/2963 reduced the information returned by `master_add_node`/`master_add_inactive_node`/`master_activate_node`, which caused tests using them to check for less information. This PR tries to check for the same information that we used to check for by querying `pg_dist_node`.