### PR TITLE
Set current snapshot in maintenance daemon.

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -375,6 +375,12 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 			InvalidateMetadataSystemCache();
 			StartTransactionCommand();
 
+			/*
+			 * Some functions in ruleutils.c, which we use to get the DDL for
+			 * metadata propagation, require an active snapshot.
+			 */
+			PushActiveSnapshot(GetTransactionSnapshot());
+
 			if (!LockCitusExtension())
 			{
 				ereport(DEBUG1, (errmsg("could not lock the citus extension, "
@@ -386,6 +392,7 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 				Async_Notify(METADATA_SYNC_CHANNEL, NULL);
 			}
 
+			PopActiveSnapshot();
 			CommitTransactionCommand();
 			ProcessCompletedNotifies();
 


### PR DESCRIPTION
`pg_get_constraintdef_command` requires a snapshot to be set.

Without this, `check-multi-mx` with `--enable-cassert` fails an assertion in `snapmgr.c`. I am still not sure why we need to do this, but this is how far I could get today.

Stack-trace for the crash is:

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f85d1ac0801 in __GI_abort () at abort.c:79
#2  0x000055a681e8b553 in ExceptionalCondition (
    conditionName=conditionName@entry=0x55a68208f540 "!(((&RegisteredSnapshots)->ph_root == ((void *)0)))", errorType=errorType@entry=0x55a681edc9bd "FailedAssertion", 
    fileName=fileName@entry=0x55a68208f2df "snapmgr.c", lineNumber=lineNumber@entry=327)
    at assert.c:54
#3  0x000055a681ecdc7b in GetTransactionSnapshot () at snapmgr.c:327
#4  0x000055a681e35a6b in pg_get_constraintdef_worker (constraintId=16767, 
    fullCommand=fullCommand@entry=true, prettyFlags=prettyFlags@entry=0, 
    missing_ok=missing_ok@entry=false) at ruleutils.c:1879
#5  0x000055a681e366ae in pg_get_constraintdef_command (constraintId=<optimized out>)
    at ruleutils.c:1864
#6  0x00007f85d0ba0ceb in GetTableIndexAndConstraintCommands (relationId=relationId@entry=16763)
    at master/master_node_protocol.c:740
#7  0x00007f85d0ba0e05 in GetTableDDLEvents (relationId=relationId@entry=16763, 
    includeSequenceDefaults=includeSequenceDefaults@entry=true)
    at master/master_node_protocol.c:566
#8  0x00007f85d0ba5f1c in MetadataCreateCommands () at metadata/metadata_sync.c:373
#9  0x00007f85d0ba60f0 in SyncMetadataSnapshotToNode (
    workerNode=workerNode@entry=0x55a68300e968, raiseOnError=raiseOnError@entry=false)
    at metadata/metadata_sync.c:240
#10 0x00007f85d0ba67b8 in SyncMetadataToNodes () at metadata/metadata_sync.c:1337
#11 0x00007f85d0bd4774 in CitusMaintenanceDaemonMain (main_arg=<optimized out>)
    at utils/maintenanced.c:386
#12 0x000055a681ce2094 in StartBackgroundWorker () at bgworker.c:834
#13 0x000055a681cee3f5 in do_start_bgworker (rw=0x55a682f401c0) at postmaster.c:5714
#14 maybe_start_bgworkers () at postmaster.c:5927
#15 0x000055a681ceedb8 in sigusr1_handler (postgres_signal_arg=<optimized out>)
    at postmaster.c:5088
#16 <signal handler called>
#17 0x00007f85d1b96ff7 in __GI___select (nfds=nfds@entry=6, 
    readfds=readfds@entry=0x7ffd6cc44e10, writefds=writefds@entry=0x0, 
    exceptfds=exceptfds@entry=0x0, timeout=timeout@entry=0x7ffd6cc44d70)
    at ../sysdeps/unix/sysv/linux/select.c:41
#18 0x000055a681a43167 in ServerLoop () at postmaster.c:1671
#19 0x000055a681cf0275 in PostmasterMain (argc=3, argv=0x55a682ecb7b0) at postmaster.c:1380
#20 0x000055a681a45565 in main (argc=3, argv=0x55a682ecb7b0) at main.c:228
```