### PR TITLE
Disable flappy test

### DIFF
--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -41,16 +41,16 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT worker_apply_shard_ddl_command (102217, 'public', '
+SELECT worker_apply_shard_ddl_command (1300004, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102216, 'public', '
+SELECT worker_apply_shard_ddl_command (1300003, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102215, 'public', '
+SELECT worker_apply_shard_ddl_command (1300002, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102214, 'public', '
+SELECT worker_apply_shard_ddl_command (1300001, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
@@ -104,7 +104,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-INSERT INTO public.test_table_102220 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+INSERT INTO public.test_table_1300008 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -159,10 +159,10 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT count(*) AS count FROM test_table_102225 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM test_table_102224 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM test_table_102223 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM test_table_102222 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_1300014 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_1300013 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_1300012 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_1300011 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -217,7 +217,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT count(*) AS count FROM public.test_table_102227 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_1300017 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -41,16 +41,16 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT worker_apply_shard_ddl_command (102197, 'public', '
+SELECT worker_apply_shard_ddl_command (102217, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102196, 'public', '
+SELECT worker_apply_shard_ddl_command (102216, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102195, 'public', '
+SELECT worker_apply_shard_ddl_command (102215, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102194, 'public', '
+SELECT worker_apply_shard_ddl_command (102214, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
@@ -104,7 +104,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-INSERT INTO public.test_table_102200 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+INSERT INTO public.test_table_102220 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -159,10 +159,10 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT count(*) AS count FROM test_table_102205 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM test_table_102204 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM test_table_102203 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT count(*) AS count FROM test_table_102202 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_102225 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_102224 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_102223 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM test_table_102222 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -217,7 +217,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT count(*) AS count FROM public.test_table_102207 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_102227 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_citus_dist_activity_9.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity_9.out
@@ -41,16 +41,16 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT worker_apply_shard_ddl_command (102217, 'public', '
+SELECT worker_apply_shard_ddl_command (1300004, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102216, 'public', '
+SELECT worker_apply_shard_ddl_command (1300003, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102215, 'public', '
+SELECT worker_apply_shard_ddl_command (1300002, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102214, 'public', '
+SELECT worker_apply_shard_ddl_command (1300001, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
@@ -104,7 +104,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-INSERT INTO public.test_table_102220 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+INSERT INTO public.test_table_1300008 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -159,10 +159,10 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-COPY (SELECT count(*) AS count FROM test_table_102225 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_102224 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_102223 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_102222 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_1300014 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_1300013 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_1300012 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_1300011 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -217,7 +217,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT count(*) AS count FROM public.test_table_102227 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_1300017 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_citus_dist_activity_9.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity_9.out
@@ -41,16 +41,16 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT worker_apply_shard_ddl_command (102197, 'public', '
+SELECT worker_apply_shard_ddl_command (102217, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102196, 'public', '
+SELECT worker_apply_shard_ddl_command (102216, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102195, 'public', '
+SELECT worker_apply_shard_ddl_command (102215, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-SELECT worker_apply_shard_ddl_command (102194, 'public', '
+SELECT worker_apply_shard_ddl_command (102214, 'public', '
     ALTER TABLE test_table ADD COLUMN x INT;
 ')localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
@@ -104,7 +104,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-INSERT INTO public.test_table_102200 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+INSERT INTO public.test_table_102220 (column1, column2) VALUES (100, 100)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -159,10 +159,10 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-COPY (SELECT count(*) AS count FROM test_table_102205 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_102204 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_102203 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
-COPY (SELECT count(*) AS count FROM test_table_102202 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_102225 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_102224 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_102223 test_table WHERE true) TO STDOUTlocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
+COPY (SELECT count(*) AS count FROM test_table_102222 test_table WHERE true) TO STDOUTlocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 
@@ -217,7 +217,7 @@ step s3-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname        
 
-SELECT count(*) AS count FROM public.test_table_102207 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
+SELECT count(*) AS count FROM public.test_table_102227 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)localhost      57638                         0              idle           Client         ClientRead     postgres       regression     
 step s2-rollback: 
 	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-269            268            f              
+282            281            f              
 transactionnumberwaitingtransactionnumbers
 
-268                           
-269            268            
+281                           
+282            281            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-273            272            f              
-274            272            f              
-274            273            t              
+286            285            f              
+287            285            f              
+287            286            t              
 transactionnumberwaitingtransactionnumbers
 
-272                           
-273            272            
-274            272,273        
+285                           
+286            285            
+287            285,286        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-282            281            f              
+276            275            f              
 transactionnumberwaitingtransactionnumbers
 
-281                           
-282            281            
+275                           
+276            275            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-286            285            f              
-287            285            f              
-287            286            t              
+280            279            f              
+281            279            f              
+281            280            t              
 transactionnumberwaitingtransactionnumbers
 
-285                           
-286            285            
-287            285,286        
+279                           
+280            279            
+281            279,280        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges_0.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges_0.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-270            269            f              
+283            282            f              
 transactionnumberwaitingtransactionnumbers
 
-269                           
-270            269            
+282                           
+283            282            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-274            273            f              
-275            273            f              
-275            274            t              
+287            286            f              
+288            286            f              
+288            287            t              
 transactionnumberwaitingtransactionnumbers
 
-273                           
-274            273            
-275            273,274        
+286                           
+287            286            
+288            286,287        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_dump_global_wait_edges_9.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges_9.out
@@ -29,11 +29,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-283            282            f              
+275            274            f              
 transactionnumberwaitingtransactionnumbers
 
-282                           
-283            282            
+274                           
+275            274            
 step s1-abort: 
     ABORT;
 
@@ -77,14 +77,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-287            286            f              
-288            286            f              
-288            287            t              
+279            278            f              
+280            278            f              
+280            279            t              
 transactionnumberwaitingtransactionnumbers
 
-286                           
-287            286            
-288            286,287        
+278                           
+279            278            
+280            278,279        
 step s1-abort: 
     ABORT;
 

--- a/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
+++ b/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
@@ -911,6 +911,174 @@ master_remove_node
                
                
 
+starting permutation: s1-print-distributed-objects s2-create-schema s1-begin s2-begin s3-begin s4-begin s1-add-worker s2-create-table s3-use-schema s3-create-table s4-use-schema s4-create-table s1-commit s2-commit s3-commit s4-commit s2-print-distributed-objects
+?column?       
+
+1              
+step s1-print-distributed-objects: 
+    SELECT 1 FROM master_add_node('localhost', 57638);
+
+    -- print an overview of all distributed objects
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
+
+    -- print if the schema has been created
+    SELECT count(*) FROM pg_namespace where nspname = 'myschema';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
+
+    -- print if the type has been created
+	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
+
+    -- print if the function has been created
+    SELECT count(*) FROM pg_proc WHERE proname='add';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='add';$$);
+
+    SELECT master_remove_node('localhost', 57638);
+
+?column?       
+
+1              
+pg_identify_object_as_address
+
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+master_remove_node
+
+               
+step s2-create-schema: 
+    CREATE SCHEMA myschema;
+    SET search_path TO myschema;
+
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s3-begin: 
+	BEGIN;
+
+step s4-begin: 
+	BEGIN;
+
+step s1-add-worker: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s2-create-table: 
+	CREATE TABLE t1 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+	SET citus.shard_replication_factor TO 1;
+	SELECT create_distributed_table('t1', 'a');
+ <waiting ...>
+step s3-use-schema: 
+    SET search_path TO myschema;
+
+step s3-create-table: 
+	CREATE TABLE t2 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+	SET citus.shard_replication_factor TO 1;
+	SELECT create_distributed_table('t2', 'a');
+ <waiting ...>
+step s4-use-schema: 
+    SET search_path TO myschema;
+
+step s4-create-table: 
+	CREATE TABLE t3 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+	SET citus.shard_replication_factor TO 1;
+	SELECT create_distributed_table('t3', 'a');
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-create-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: 
+	COMMIT;
+
+step s3-create-table: <... completed>
+create_distributed_table
+
+               
+step s4-create-table: <... completed>
+create_distributed_table
+
+               
+step s3-commit: 
+	COMMIT;
+
+step s4-commit: 
+	COMMIT;
+
+step s2-print-distributed-objects: 
+    -- print an overview of all distributed objects
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
+
+    -- print if the schema has been created
+    SELECT count(*) FROM pg_namespace where nspname = 'myschema';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
+
+    -- print if the type has been created
+	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
+
+    -- print if the function has been created
+    SELECT count(*) FROM pg_proc WHERE proname='add';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='add';$$);
+
+pg_identify_object_as_address
+
+(schema,{myschema},{})
+count          
+
+1              
+run_command_on_workers
+
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+master_remove_node
+
+               
+               
+
 starting permutation: s1-print-distributed-objects s1-add-worker s2-create-schema s2-begin s3-begin s3-use-schema s2-create-table s3-create-table s2-commit s3-commit s2-print-distributed-objects
 ?column?       
 
@@ -1027,6 +1195,157 @@ step s2-print-distributed-objects:
 pg_identify_object_as_address
 
 (schema,{myschema},{})
+count          
+
+1              
+run_command_on_workers
+
+(localhost,57637,t,1)
+(localhost,57638,t,1)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+master_remove_node
+
+               
+               
+
+starting permutation: s1-print-distributed-objects s1-begin s2-begin s4-begin s1-add-worker s2-create-schema s4-create-schema2 s2-create-table s4-create-table s1-commit s2-commit s4-commit s2-print-distributed-objects
+?column?       
+
+1              
+step s1-print-distributed-objects: 
+    SELECT 1 FROM master_add_node('localhost', 57638);
+
+    -- print an overview of all distributed objects
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
+
+    -- print if the schema has been created
+    SELECT count(*) FROM pg_namespace where nspname = 'myschema';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
+
+    -- print if the type has been created
+	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
+
+    -- print if the function has been created
+    SELECT count(*) FROM pg_proc WHERE proname='add';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='add';$$);
+
+    SELECT master_remove_node('localhost', 57638);
+
+?column?       
+
+1              
+pg_identify_object_as_address
+
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+count          
+
+0              
+run_command_on_workers
+
+(localhost,57637,t,0)
+(localhost,57638,t,0)
+master_remove_node
+
+               
+step s1-begin: 
+    BEGIN;
+
+step s2-begin: 
+	BEGIN;
+
+step s4-begin: 
+	BEGIN;
+
+step s1-add-worker: 
+	SELECT 1 FROM master_add_node('localhost', 57638);
+
+?column?       
+
+1              
+step s2-create-schema: 
+    CREATE SCHEMA myschema;
+    SET search_path TO myschema;
+
+step s4-create-schema2: 
+    CREATE SCHEMA myschema2;
+    SET search_path TO myschema2;
+
+step s2-create-table: 
+	CREATE TABLE t1 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+	SET citus.shard_replication_factor TO 1;
+	SELECT create_distributed_table('t1', 'a');
+ <waiting ...>
+step s4-create-table: 
+	CREATE TABLE t3 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+	SET citus.shard_replication_factor TO 1;
+	SELECT create_distributed_table('t3', 'a');
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-create-table: <... completed>
+create_distributed_table
+
+               
+step s4-create-table: <... completed>
+create_distributed_table
+
+               
+step s2-commit: 
+	COMMIT;
+
+step s4-commit: 
+	COMMIT;
+
+step s2-print-distributed-objects: 
+    -- print an overview of all distributed objects
+    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
+
+    -- print if the schema has been created
+    SELECT count(*) FROM pg_namespace where nspname = 'myschema';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
+
+    -- print if the type has been created
+	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
+
+    -- print if the function has been created
+    SELECT count(*) FROM pg_proc WHERE proname='add';
+    SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='add';$$);
+
+pg_identify_object_as_address
+
+(schema,{myschema},{})
+(schema,{myschema2},{})
 count          
 
 1              

--- a/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
+++ b/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
@@ -1,4 +1,4 @@
-Parsed test spec with 4 sessions
+Parsed test spec with 3 sessions
 
 starting permutation: s1-print-distributed-objects s1-begin s1-add-worker s2-public-schema s2-create-table s1-commit s2-print-distributed-objects
 ?column?       
@@ -911,174 +911,6 @@ master_remove_node
                
                
 
-starting permutation: s1-print-distributed-objects s2-create-schema s1-begin s2-begin s3-begin s4-begin s1-add-worker s2-create-table s3-use-schema s3-create-table s4-use-schema s4-create-table s1-commit s2-commit s3-commit s4-commit s2-print-distributed-objects
-?column?       
-
-1              
-step s1-print-distributed-objects: 
-    SELECT 1 FROM master_add_node('localhost', 57638);
-
-    -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
-
-    -- print if the schema has been created
-    SELECT count(*) FROM pg_namespace where nspname = 'myschema';
-    SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
-
-    -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
-    SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
-
-    -- print if the function has been created
-    SELECT count(*) FROM pg_proc WHERE proname='add';
-    SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='add';$$);
-
-    SELECT master_remove_node('localhost', 57638);
-
-?column?       
-
-1              
-pg_identify_object_as_address
-
-count          
-
-0              
-run_command_on_workers
-
-(localhost,57637,t,0)
-(localhost,57638,t,0)
-count          
-
-0              
-run_command_on_workers
-
-(localhost,57637,t,0)
-(localhost,57638,t,0)
-count          
-
-0              
-run_command_on_workers
-
-(localhost,57637,t,0)
-(localhost,57638,t,0)
-master_remove_node
-
-               
-step s2-create-schema: 
-    CREATE SCHEMA myschema;
-    SET search_path TO myschema;
-
-step s1-begin: 
-    BEGIN;
-
-step s2-begin: 
-	BEGIN;
-
-step s3-begin: 
-	BEGIN;
-
-step s4-begin: 
-	BEGIN;
-
-step s1-add-worker: 
-	SELECT 1 FROM master_add_node('localhost', 57638);
-
-?column?       
-
-1              
-step s2-create-table: 
-	CREATE TABLE t1 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
- <waiting ...>
-step s3-use-schema: 
-    SET search_path TO myschema;
-
-step s3-create-table: 
-	CREATE TABLE t2 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t2', 'a');
- <waiting ...>
-step s4-use-schema: 
-    SET search_path TO myschema;
-
-step s4-create-table: 
-	CREATE TABLE t3 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t3', 'a');
- <waiting ...>
-step s1-commit: 
-    COMMIT;
-
-step s2-create-table: <... completed>
-create_distributed_table
-
-               
-step s2-commit: 
-	COMMIT;
-
-step s3-create-table: <... completed>
-create_distributed_table
-
-               
-step s4-create-table: <... completed>
-create_distributed_table
-
-               
-step s3-commit: 
-	COMMIT;
-
-step s4-commit: 
-	COMMIT;
-
-step s2-print-distributed-objects: 
-    -- print an overview of all distributed objects
-    SELECT pg_identify_object_as_address(classid, objid, objsubid) FROM citus.pg_dist_object ORDER BY 1;
-
-    -- print if the schema has been created
-    SELECT count(*) FROM pg_namespace where nspname = 'myschema';
-    SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
-
-    -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
-    SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
-
-    -- print if the function has been created
-    SELECT count(*) FROM pg_proc WHERE proname='add';
-    SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='add';$$);
-
-pg_identify_object_as_address
-
-(schema,{myschema},{})
-count          
-
-1              
-run_command_on_workers
-
-(localhost,57637,t,1)
-(localhost,57638,t,1)
-count          
-
-0              
-run_command_on_workers
-
-(localhost,57637,t,0)
-(localhost,57638,t,0)
-count          
-
-0              
-run_command_on_workers
-
-(localhost,57637,t,0)
-(localhost,57638,t,0)
-master_remove_node
-
-               
-               
-
 starting permutation: s1-print-distributed-objects s1-add-worker s2-create-schema s2-begin s3-begin s3-use-schema s2-create-table s3-create-table s2-commit s3-commit s2-print-distributed-objects
 ?column?       
 
@@ -1221,7 +1053,7 @@ master_remove_node
                
                
 
-starting permutation: s1-print-distributed-objects s1-begin s2-begin s4-begin s1-add-worker s2-create-schema s4-create-schema2 s2-create-table s4-create-table s1-commit s2-commit s4-commit s2-print-distributed-objects
+starting permutation: s1-print-distributed-objects s1-begin s2-begin s3-begin s1-add-worker s2-create-schema s3-create-schema2 s2-create-table s3-create-table s1-commit s2-commit s3-commit s2-print-distributed-objects
 ?column?       
 
 1              
@@ -1280,7 +1112,7 @@ step s1-begin:
 step s2-begin: 
 	BEGIN;
 
-step s4-begin: 
+step s3-begin: 
 	BEGIN;
 
 step s1-add-worker: 
@@ -1293,7 +1125,7 @@ step s2-create-schema:
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
 
-step s4-create-schema2: 
+step s3-create-schema2: 
     CREATE SCHEMA myschema2;
     SET search_path TO myschema2;
 
@@ -1303,11 +1135,11 @@ step s2-create-table:
 	SET citus.shard_replication_factor TO 1;
 	SELECT create_distributed_table('t1', 'a');
  <waiting ...>
-step s4-create-table: 
-	CREATE TABLE t3 (a int, b int);
+step s3-create-table: 
+	CREATE TABLE t2 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
 	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t3', 'a');
+	SELECT create_distributed_table('t2', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
@@ -1316,14 +1148,14 @@ step s2-create-table: <... completed>
 create_distributed_table
 
                
-step s4-create-table: <... completed>
+step s3-create-table: <... completed>
 create_distributed_table
 
                
 step s2-commit: 
 	COMMIT;
 
-step s4-commit: 
+step s3-commit: 
 	COMMIT;
 
 step s2-print-distributed-objects: 

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-commit:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-commit s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102489"
+error in steps s1-commit s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_1400001"
 step s2-commit: 
   COMMIT;
 

--- a/src/test/regress/expected/isolation_replace_wait_function.out
+++ b/src/test/regress/expected/isolation_replace_wait_function.out
@@ -16,7 +16,7 @@ step s1-commit:
   COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-commit s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102469"
+error in steps s1-commit s2-insert: ERROR:  duplicate key value violates unique constraint "test_locking_a_key_102489"
 step s2-commit: 
   COMMIT;
 

--- a/src/test/regress/specs/isolation_citus_dist_activity.spec
+++ b/src/test/regress/specs/isolation_citus_dist_activity.spec
@@ -1,13 +1,8 @@
 setup
 {
-    -- would be great if we could SET citus.next_shard_id TO 107000;
-    -- unfortunately that will cause messages like
-    -- ERROR:  cached metadata for shard 107000 is inconsistent
-    -- to show up. This test is therefore subject to change due to
-    -- addition of tests or permutations prior to this test.
-
     SET citus.shard_replication_factor TO 1;
     SET citus.shard_count TO 4;
+    select setval('pg_dist_shardid_seq', GREATEST(1300000, nextval('pg_dist_shardid_seq')));
 
     CREATE TABLE test_table(column1 int, column2 int);
     SELECT create_distributed_table('test_table', 'column1');

--- a/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
+++ b/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
@@ -247,11 +247,9 @@ permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s2-create-sche
 
 # concurrency tests with multi schema distribution
 permutation "s1-print-distributed-objects" "s2-create-schema" "s1-begin" "s2-begin" "s3-begin" "s1-add-worker" "s2-create-table" "s3-use-schema" "s3-create-table" "s1-commit" "s2-commit" "s3-commit" "s2-print-distributed-objects"
+permutation "s1-print-distributed-objects" "s2-create-schema" "s1-begin" "s2-begin" "s3-begin" "s4-begin" "s1-add-worker" "s2-create-table" "s3-use-schema" "s3-create-table" "s4-use-schema" "s4-create-table" "s1-commit" "s2-commit" "s3-commit" "s4-commit" "s2-print-distributed-objects"
 permutation "s1-print-distributed-objects" "s1-add-worker" "s2-create-schema" "s2-begin" "s3-begin" "s3-use-schema" "s2-create-table" "s3-create-table" "s2-commit" "s3-commit" "s2-print-distributed-objects"
-
-# multiple sessions block waiting to create the same schema (temporarily disabled because too unstable)
-#permutation "s1-print-distributed-objects" "s2-create-schema" "s1-begin" "s2-begin" "s3-begin" "s4-begin" "s1-add-worker" "s2-create-table" "s3-use-schema" "s3-create-table" "s4-use-schema" "s4-create-table" "s1-commit" "s2-commit" "s3-commit" "s4-commit" "s2-print-distributed-objects"
-#permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s4-begin" "s1-add-worker" "s2-create-schema" "s4-create-schema2" "s2-create-table" "s4-create-table" "s1-commit" "s2-commit" "s4-commit" "s2-print-distributed-objects"
+permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s4-begin" "s1-add-worker" "s2-create-schema" "s4-create-schema2" "s2-create-table" "s4-create-table" "s1-commit" "s2-commit" "s4-commit" "s2-print-distributed-objects"
 
 # type and schema tests
 permutation "s1-print-distributed-objects" "s1-begin" "s1-add-worker" "s2-public-schema" "s2-create-type" "s1-commit" "s2-print-distributed-objects"

--- a/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
+++ b/src/test/regress/specs/isolation_ensure_dependency_activate_node.spec
@@ -179,17 +179,6 @@ step "s3-create-table"
 	SELECT create_distributed_table('t2', 'a');
 }
 
-step "s3-begin"
-{
-	BEGIN;
-}
-
-step "s3-commit"
-{
-	COMMIT;
-}
-
-
 step "s3-wait-for-metadata-sync"
 {
     SELECT public.wait_until_metadata_sync(5000);
@@ -200,38 +189,19 @@ step "s3-listen-channel"
    LISTEN metadata_sync;
 }
 
-session "s4"
-
-step "s4-public-schema"
-{
-    SET search_path TO public;
-}
-
-step "s4-use-schema"
-{
-    SET search_path TO myschema;
-}
-
-step "s4-create-schema2"
+step "s3-create-schema2"
 {
     CREATE SCHEMA myschema2;
     SET search_path TO myschema2;
 }
 
-step "s4-create-table"
-{
-	CREATE TABLE t3 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t3', 'a');
-}
 
-step "s4-begin"
+step "s3-begin"
 {
 	BEGIN;
 }
 
-step "s4-commit"
+step "s3-commit"
 {
 	COMMIT;
 }
@@ -247,9 +217,8 @@ permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s2-create-sche
 
 # concurrency tests with multi schema distribution
 permutation "s1-print-distributed-objects" "s2-create-schema" "s1-begin" "s2-begin" "s3-begin" "s1-add-worker" "s2-create-table" "s3-use-schema" "s3-create-table" "s1-commit" "s2-commit" "s3-commit" "s2-print-distributed-objects"
-permutation "s1-print-distributed-objects" "s2-create-schema" "s1-begin" "s2-begin" "s3-begin" "s4-begin" "s1-add-worker" "s2-create-table" "s3-use-schema" "s3-create-table" "s4-use-schema" "s4-create-table" "s1-commit" "s2-commit" "s3-commit" "s4-commit" "s2-print-distributed-objects"
 permutation "s1-print-distributed-objects" "s1-add-worker" "s2-create-schema" "s2-begin" "s3-begin" "s3-use-schema" "s2-create-table" "s3-create-table" "s2-commit" "s3-commit" "s2-print-distributed-objects"
-permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s4-begin" "s1-add-worker" "s2-create-schema" "s4-create-schema2" "s2-create-table" "s4-create-table" "s1-commit" "s2-commit" "s4-commit" "s2-print-distributed-objects"
+permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s3-begin" "s1-add-worker" "s2-create-schema" "s3-create-schema2" "s2-create-table" "s3-create-table" "s1-commit" "s2-commit" "s3-commit" "s2-print-distributed-objects"
 
 # type and schema tests
 permutation "s1-print-distributed-objects" "s1-begin" "s1-add-worker" "s2-public-schema" "s2-create-type" "s1-commit" "s2-print-distributed-objects"

--- a/src/test/regress/specs/isolation_replace_wait_function.spec
+++ b/src/test/regress/specs/isolation_replace_wait_function.spec
@@ -7,6 +7,7 @@ setup
 {
   SELECT citus_internal.replace_isolation_tester_func();
   SELECT citus_internal.refresh_isolation_tester_prepared_statement();
+  select setval('pg_dist_shardid_seq', GREATEST(1400000, nextval('pg_dist_shardid_seq')));
 
   CREATE TABLE test_locking (a int unique);
   SELECT create_distributed_table('test_locking', 'a');


### PR DESCRIPTION
This test caused random failures because it was non deterministic which of the
create_distributed_table statements finished the earliest. Locally this test
would randomly deadlock the sessions because of this. Commiting session 1
earlier fixed this. 

Example of failing test in CI:
https://circleci.com/gh/citusdata/citus/34188