### PR TITLE
fix disable_object_propagation test for pg12

### DIFF
--- a/src/test/regress/expected/disable_object_propagation.out
+++ b/src/test/regress/expected/disable_object_propagation.out
@@ -119,7 +119,7 @@ $$);
 (2 rows)
 
 -- suppress any warnings during cleanup
-SET client_min_messages TO fatal;
+SET client_min_messages TO error;
 RESET citus.enable_object_propagation;
 DROP SCHEMA disabled_object_propagation CASCADE;
 DROP SCHEMA disabled_object_propagation2 CASCADE;

--- a/src/test/regress/sql/disable_object_propagation.sql
+++ b/src/test/regress/sql/disable_object_propagation.sql
@@ -74,7 +74,7 @@ GROUP BY pg_type.typname;
 $$);
 
 -- suppress any warnings during cleanup
-SET client_min_messages TO fatal;
+SET client_min_messages TO error;
 RESET citus.enable_object_propagation;
 DROP SCHEMA disabled_object_propagation CASCADE;
 DROP SCHEMA disabled_object_propagation2 CASCADE;


### PR DESCRIPTION
no changelog required.

adding the `disable_object_propagation` test caused failing tests for pg12, this should fix the issue.
