### PR TITLE
Make sure that functions are also listed in `SupportedDependencyByCitus`

### DIFF
--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -339,6 +339,11 @@ SupportedDependencyByCitus(const ObjectAddress *address)
 			return true;
 		}
 
+		case OCLASS_PROC:
+		{
+			return true;
+		}
+
 		case OCLASS_TYPE:
 		{
 			switch (get_typtype(address->objectId))

--- a/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
+++ b/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
@@ -1974,7 +1974,7 @@ count
 run_command_on_workers
 
 (localhost,57637,t,1)
-(localhost,57638,t,0)
+(localhost,57638,t,1)
 master_remove_node
 
                
@@ -2103,7 +2103,7 @@ count
 run_command_on_workers
 
 (localhost,57637,t,1)
-(localhost,57638,t,0)
+(localhost,57638,t,1)
 master_remove_node
 
                


### PR DESCRIPTION
We've recently merged two commits, db5d03931d1b07479707bb53e35f973056216ca2
and eccba1d4c33f31085abc2aea189110a95c4010c4, which actually operates
on the very similar places.

It turns out that we've an integration issue, where master_add_node()
fails to replicate the functions to the newly added node.