### PR TITLE
Enhance pg upgrade tests

### DIFF
--- a/src/test/regress/expected/upgrade_distributed_table_after.out
+++ b/src/test/regress/expected/upgrade_distributed_table_after.out
@@ -28,72 +28,6 @@ SELECT * FROM t WHERE a = 11;
  11
 (1 row)
 
--- test task-tracker executor
-SET citus.task_executor_type TO 'task-tracker';
-SELECT * FROM t WHERE a = 10;
- a  
-----
- 10
-(1 row)
-
-SELECT * FROM t WHERE a = 11;
- a  
-----
- 11
-(1 row)
-
-SELECT * FROM t WHERE a < 3 ORDER BY a;
- a 
----
- 1
- 2
-(2 rows)
-
-RESET citus.task_executor_type;
--- test adaptive executor
-SET citus.task_executor_type to "adaptive";
-SELECT * FROM t WHERE a = 10;
- a  
-----
- 10
-(1 row)
-
-SELECT * FROM t WHERE a = 11;
- a  
-----
- 11
-(1 row)
-
-SELECT * FROM t WHERE a < 3 ORDER BY a;
- a 
----
- 1
- 2
-(2 rows)
-
-RESET citus.task_executor_type;
--- test real-time executor
-SET citus.task_executor_type to "real-time";
-SELECT * FROM t WHERE a = 10;
- a  
-----
- 10
-(1 row)
-
-SELECT * FROM t WHERE a = 11;
- a  
-----
- 11
-(1 row)
-
-SELECT * FROM t WHERE a < 3 ORDER BY a;
- a 
----
- 1
- 2
-(2 rows)
-
-RESET citus.task_executor_type;
 -- test distributed type
 INSERT INTO t1 VALUES (1, (2,3)::tc1);
 SELECT * FROM t1;
@@ -110,8 +44,30 @@ SELECT * FROM T;
 ---
 (0 rows)
 
+-- verify that the table whose column is dropped before a pg_upgrade still works as expected.
+SELECT * FROM t_ab ORDER BY b;
+ b  
+----
+ 11
+ 22
+ 33
+(3 rows)
+
+SELECT * FROM t_ab WHERE b = 11;
+ b  
+----
+ 11
+(1 row)
+
+SELECT * FROM t_ab WHERE b = 22;
+ b  
+----
+ 22
+(1 row)
+
 DROP TABLE t;
 DROP SCHEMA upgrade_distributed_table_before CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to type tc1_newname
 drop cascades to table t1
+drop cascades to table t_ab

--- a/src/test/regress/expected/upgrade_distributed_table_after.out
+++ b/src/test/regress/expected/upgrade_distributed_table_after.out
@@ -15,5 +15,103 @@ SELECT * FROM t WHERE a = 1;
  1
 (1 row)
 
+INSERT INTO t SELECT * FROM generate_series(10, 15);
+SELECT * FROM t WHERE a = 10;
+ a  
+----
+ 10
+(1 row)
+
+SELECT * FROM t WHERE a = 11;
+ a  
+----
+ 11
+(1 row)
+
+-- test task-tracker executor
+SET citus.task_executor_type TO 'task-tracker';
+SELECT * FROM t WHERE a = 10;
+ a  
+----
+ 10
+(1 row)
+
+SELECT * FROM t WHERE a = 11;
+ a  
+----
+ 11
+(1 row)
+
+SELECT * FROM t WHERE a < 3 ORDER BY a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+RESET citus.task_executor_type;
+-- test adaptive executor
+SET citus.task_executor_type to "adaptive";
+SELECT * FROM t WHERE a = 10;
+ a  
+----
+ 10
+(1 row)
+
+SELECT * FROM t WHERE a = 11;
+ a  
+----
+ 11
+(1 row)
+
+SELECT * FROM t WHERE a < 3 ORDER BY a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+RESET citus.task_executor_type;
+-- test real-time executor
+SET citus.task_executor_type to "real-time";
+SELECT * FROM t WHERE a = 10;
+ a  
+----
+ 10
+(1 row)
+
+SELECT * FROM t WHERE a = 11;
+ a  
+----
+ 11
+(1 row)
+
+SELECT * FROM t WHERE a < 3 ORDER BY a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+RESET citus.task_executor_type;
+-- test distributed type
+INSERT INTO t1 VALUES (1, (2,3)::tc1);
+SELECT * FROM t1;
+ a |   b   
+---+-------
+ 1 | (2,3)
+(1 row)
+
+ALTER TYPE tc1 RENAME TO tc1_newname;
+INSERT INTO t1 VALUES (3, (4,5)::tc1_newname);
+TRUNCATE TABLE t;
+SELECT * FROM T;
+ a 
+---
+(0 rows)
+
+DROP TABLE t;
 DROP SCHEMA upgrade_distributed_table_before CASCADE;
-NOTICE:  drop cascades to table t
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to type tc1_newname
+drop cascades to table t1

--- a/src/test/regress/expected/upgrade_distributed_table_before.out
+++ b/src/test/regress/expected/upgrade_distributed_table_before.out
@@ -16,3 +16,17 @@ SELECT create_distributed_table('t1','a');
  
 (1 row)
 
+-- We store the index of distribution column and here we check that the distribution
+-- column index does not change after an upgrade if we drop a column that comes before the
+-- distribution column. The index information is in partkey column of pg_dist_partition table.
+CREATE TABLE t_ab(a int, b int);
+SELECT create_distributed_table('t_ab', 'b');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO t_ab VALUES (1, 11);
+INSERT INTO t_ab VALUES (2, 22);
+INSERT INTO t_ab VALUES (3, 33);
+ALTER TABLE t_ab DROP a;

--- a/src/test/regress/expected/upgrade_distributed_table_before.out
+++ b/src/test/regress/expected/upgrade_distributed_table_before.out
@@ -8,3 +8,11 @@ SELECT create_distributed_table('t', 'a');
 (1 row)
 
 INSERT INTO t SELECT * FROM generate_series(1, 5);
+CREATE TYPE tc1 AS (a int, b int);
+CREATE TABLE t1 (a int PRIMARY KEY, b tc1);
+SELECT create_distributed_table('t1','a');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+

--- a/src/test/regress/sql/upgrade_distributed_table_after.sql
+++ b/src/test/regress/sql/upgrade_distributed_table_after.sql
@@ -8,33 +8,6 @@ INSERT INTO t SELECT * FROM generate_series(10, 15);
 SELECT * FROM t WHERE a = 10;
 SELECT * FROM t WHERE a = 11;
 
--- test task-tracker executor
-SET citus.task_executor_type TO 'task-tracker';
-
-SELECT * FROM t WHERE a = 10;
-SELECT * FROM t WHERE a = 11;
-SELECT * FROM t WHERE a < 3 ORDER BY a;
-
-RESET citus.task_executor_type;
-
--- test adaptive executor
-SET citus.task_executor_type to "adaptive";
-
-SELECT * FROM t WHERE a = 10;
-SELECT * FROM t WHERE a = 11;
-SELECT * FROM t WHERE a < 3 ORDER BY a;
-
-RESET citus.task_executor_type;
-
--- test real-time executor
-SET citus.task_executor_type to "real-time";
-
-SELECT * FROM t WHERE a = 10;
-SELECT * FROM t WHERE a = 11;
-SELECT * FROM t WHERE a < 3 ORDER BY a;
-
-RESET citus.task_executor_type;
-
 -- test distributed type
 INSERT INTO t1 VALUES (1, (2,3)::tc1);
 SELECT * FROM t1;
@@ -44,6 +17,11 @@ INSERT INTO t1 VALUES (3, (4,5)::tc1_newname);
 TRUNCATE TABLE t;
 
 SELECT * FROM T;
+
+-- verify that the table whose column is dropped before a pg_upgrade still works as expected.
+SELECT * FROM t_ab ORDER BY b;
+SELECT * FROM t_ab WHERE b = 11;
+SELECT * FROM t_ab WHERE b = 22;
 
 DROP TABLE t;
 

--- a/src/test/regress/sql/upgrade_distributed_table_after.sql
+++ b/src/test/regress/sql/upgrade_distributed_table_after.sql
@@ -3,4 +3,48 @@ SET search_path TO upgrade_distributed_table_before, public;
 SELECT * FROM t ORDER BY a;
 SELECT * FROM t WHERE a = 1;
 
+INSERT INTO t SELECT * FROM generate_series(10, 15);
+
+SELECT * FROM t WHERE a = 10;
+SELECT * FROM t WHERE a = 11;
+
+-- test task-tracker executor
+SET citus.task_executor_type TO 'task-tracker';
+
+SELECT * FROM t WHERE a = 10;
+SELECT * FROM t WHERE a = 11;
+SELECT * FROM t WHERE a < 3 ORDER BY a;
+
+RESET citus.task_executor_type;
+
+-- test adaptive executor
+SET citus.task_executor_type to "adaptive";
+
+SELECT * FROM t WHERE a = 10;
+SELECT * FROM t WHERE a = 11;
+SELECT * FROM t WHERE a < 3 ORDER BY a;
+
+RESET citus.task_executor_type;
+
+-- test real-time executor
+SET citus.task_executor_type to "real-time";
+
+SELECT * FROM t WHERE a = 10;
+SELECT * FROM t WHERE a = 11;
+SELECT * FROM t WHERE a < 3 ORDER BY a;
+
+RESET citus.task_executor_type;
+
+-- test distributed type
+INSERT INTO t1 VALUES (1, (2,3)::tc1);
+SELECT * FROM t1;
+ALTER TYPE tc1 RENAME TO tc1_newname;
+INSERT INTO t1 VALUES (3, (4,5)::tc1_newname);
+
+TRUNCATE TABLE t;
+
+SELECT * FROM T;
+
+DROP TABLE t;
+
 DROP SCHEMA upgrade_distributed_table_before CASCADE;

--- a/src/test/regress/sql/upgrade_distributed_table_before.sql
+++ b/src/test/regress/sql/upgrade_distributed_table_before.sql
@@ -4,3 +4,7 @@ SET search_path TO upgrade_distributed_table_before, public;
 CREATE TABLE t(a int);
 SELECT create_distributed_table('t', 'a');
 INSERT INTO t SELECT * FROM generate_series(1, 5);
+
+CREATE TYPE tc1 AS (a int, b int);
+CREATE TABLE t1 (a int PRIMARY KEY, b tc1);
+SELECT create_distributed_table('t1','a');

--- a/src/test/regress/sql/upgrade_distributed_table_before.sql
+++ b/src/test/regress/sql/upgrade_distributed_table_before.sql
@@ -8,3 +8,15 @@ INSERT INTO t SELECT * FROM generate_series(1, 5);
 CREATE TYPE tc1 AS (a int, b int);
 CREATE TABLE t1 (a int PRIMARY KEY, b tc1);
 SELECT create_distributed_table('t1','a');
+
+-- We store the index of distribution column and here we check that the distribution
+-- column index does not change after an upgrade if we drop a column that comes before the
+-- distribution column. The index information is in partkey column of pg_dist_partition table.
+CREATE TABLE t_ab(a int, b int);
+SELECT create_distributed_table('t_ab', 'b');
+INSERT INTO t_ab VALUES (1, 11);
+INSERT INTO t_ab VALUES (2, 22);
+INSERT INTO t_ab VALUES (3, 33);
+
+ALTER TABLE t_ab DROP a;
+


### PR DESCRIPTION
This PR adds some more tests for pg upgrade tests:
- Basic distributed type test
- Truncate/drop table
- We store the index of distribution column, and when a column with an
index that is smaller than distribution column index is dropped before
a pg upgrade, the index should still match the distribution column after
the upgrade