### PR TITLE
Fix assert failure in bare SELECT FROM reference table FOR UPDATE in MX

### DIFF
--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -512,3 +512,31 @@ WorkerNodeCompare(const void *lhsKey, const void *rhsKey, Size keySize)
 	portCompare = workerLhs->workerPort - workerRhs->workerPort;
 	return portCompare;
 }
+
+
+/*
+ * GetFirstPrimaryWorkerNode returns the primary worker node with the
+ * lowest rank based on CompareWorkerNodes.
+ *
+ * The ranking is arbitrary, but needs to be kept consistent with IsFirstWorkerNode.
+ */
+WorkerNode *
+GetFirstPrimaryWorkerNode(void)
+{
+	List *workerNodeList = ActivePrimaryNodeList(NoLock);
+	ListCell *workerNodeCell = NULL;
+	WorkerNode *firstWorkerNode = NULL;
+
+	foreach(workerNodeCell, workerNodeList)
+	{
+		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
+
+		if (firstWorkerNode == NULL ||
+			CompareWorkerNodes(&workerNode, &firstWorkerNode) < 0)
+		{
+			firstWorkerNode = workerNode;
+		}
+	}
+
+	return firstWorkerNode;
+}

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -69,30 +69,6 @@ SendCommandToWorkerAsUser(char *nodeName, int32 nodePort, const char *nodeUser,
 
 
 /*
- * SendCommandToFirstWorker sends the given command only to the first worker node
- * sorted by host name and port number using SendCommandToWorker.
- */
-void
-SendCommandToFirstWorker(char *command)
-{
-	List *workerNodeList = ActivePrimaryNodeList(NoLock);
-	WorkerNode *firstWorkerNode = NULL;
-
-	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
-
-	if (list_length(workerNodeList) == 0)
-	{
-		ereport(ERROR, (errmsg("cannot find a worker node")));
-	}
-
-	firstWorkerNode = (WorkerNode *) linitial(workerNodeList);
-
-	SendCommandToWorker(firstWorkerNode->workerName, firstWorkerNode->workerPort,
-						command);
-}
-
-
-/*
  * SendCommandToWorkers sends a command to all workers in
  * parallel. Commands are committed on the workers when the local
  * transaction commits. The connection are made as the extension

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -78,6 +78,7 @@ extern bool WorkerNodeIsPrimary(WorkerNode *worker);
 extern bool WorkerNodeIsSecondary(WorkerNode *worker);
 extern bool WorkerNodeIsReadable(WorkerNode *worker);
 extern uint32 CountPrimariesWithMetadata(void);
+extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 
 /* Function declarations for worker node utilities */
 extern int CompareWorkerNodes(const void *leftElement, const void *rightElement);

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -34,7 +34,6 @@ extern List * TargetWorkerSetNodeList(TargetWorkerSet targetWorkerSet, LOCKMODE 
 extern void SendCommandToWorker(char *nodeName, int32 nodePort, const char *command);
 extern void SendCommandToWorkerAsUser(char *nodeName, int32 nodePort,
 									  const char *nodeUser, const char *command);
-extern void SendCommandToFirstWorker(char *command);
 extern void SendCommandToWorkers(TargetWorkerSet targetWorkerSet, const char *command);
 extern void SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet,
 										 List *commandList);

--- a/src/test/regress/expected/multi_mx_reference_table.out
+++ b/src/test/regress/expected/multi_mx_reference_table.out
@@ -12,7 +12,37 @@ INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
 INSERT INTO reference_table_test VALUES (3, 3.0, '3', '2016-12-03');
 INSERT INTO reference_table_test VALUES (4, 4.0, '4', '2016-12-04');
 INSERT INTO reference_table_test VALUES (5, 5.0, '5', '2016-12-05');
+-- SELECT .. FOR UPDATE should work on coordinator (takes lock on first worker)
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+ value_1 | value_2 
+---------+---------
+       1 |       1
+(1 row)
+
+BEGIN;
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+ value_1 | value_2 
+---------+---------
+       1 |       1
+(1 row)
+
+END;
 \c - - - :worker_1_port
+-- SELECT .. FOR UPDATE should work on first worker (takes lock on self)
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+ value_1 | value_2 
+---------+---------
+       1 |       1
+(1 row)
+
+BEGIN;
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+ value_1 | value_2 
+---------+---------
+       1 |       1
+(1 row)
+
+END;
 -- run some queries on top of the data
 SELECT
 	*
@@ -569,6 +599,21 @@ INSERT INTO reference_table_test_second VALUES (3, 3.0, '3', '2016-12-03');
 INSERT INTO reference_table_test_third VALUES (4, 4.0, '4', '2016-12-04');
 INSERT INTO reference_table_test_third VALUES (5, 5.0, '5', '2016-12-05');
 \c - - - :worker_2_port
+-- SELECT .. FOR UPDATE should work on second worker (takes lock on first worker)
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+ value_1 | value_2 
+---------+---------
+       1 |       1
+(1 row)
+
+BEGIN;
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+ value_1 | value_2 
+---------+---------
+       1 |       1
+(1 row)
+
+END;
 -- some very basic tests
 SELECT
 	DISTINCT t1.value_1

--- a/src/test/regress/sql/multi_mx_reference_table.sql
+++ b/src/test/regress/sql/multi_mx_reference_table.sql
@@ -10,7 +10,22 @@ INSERT INTO reference_table_test VALUES (3, 3.0, '3', '2016-12-03');
 INSERT INTO reference_table_test VALUES (4, 4.0, '4', '2016-12-04');
 INSERT INTO reference_table_test VALUES (5, 5.0, '5', '2016-12-05');
 
+-- SELECT .. FOR UPDATE should work on coordinator (takes lock on first worker)
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+
+BEGIN;
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+END;
+
 \c - - - :worker_1_port
+
+-- SELECT .. FOR UPDATE should work on first worker (takes lock on self)
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+
+BEGIN;
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+END;
+
 -- run some queries on top of the data
 SELECT
 	*
@@ -339,6 +354,13 @@ INSERT INTO reference_table_test_third VALUES (4, 4.0, '4', '2016-12-04');
 INSERT INTO reference_table_test_third VALUES (5, 5.0, '5', '2016-12-05');
 
 \c - - - :worker_2_port
+
+-- SELECT .. FOR UPDATE should work on second worker (takes lock on first worker)
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+
+BEGIN;
+SELECT value_1, value_2 FROM reference_table_test ORDER BY value_1, value_2 LIMIT 1 FOR UPDATE;
+END;
 
 -- some very basic tests
 SELECT


### PR DESCRIPTION
DESCRIPTION: Fix assert failure in bare SELECT FROM reference table FOR UPDATE in MX

When a SELECT ... FROM reference_table ... FOR UPDATE in MX is not in a transaction block we end up doing a 2PC anyway because the call to `lock_shard_resource` goes via `SendCommandToWorker` which activates 2PC. 

Since the statement is not in a transaction block the adaptive executor does not treat it as a distributed transaction and therefore resets the transaction state of the connection when the `SELECT .. FOR UPDATE` completes.

When running the command as superuser, the connection used for the SELECT..FOR UPDATE is the same as the one used for the `lock_shard_resource` and therefore we end up resetting the state of a connection that is in a transaction block, hence the assertion failure when trying to PREPARE. 

It would work correctly without asserts, except for the redundant 2PC.

This issue is quite specific to locking a shard. In general, the executor knows when it is in a distributed transaction and will do the right thing, but the `lock_shard_resource` happens just after the executor determines whether it is in a distributed transaction (in `StartDistributedExecution`).