### PR TITLE
Deparsing and qualifiying {ALTER|DROP} .. {FUNCTION|PROCEDURE} queries

### DIFF
--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -166,8 +166,8 @@ DeparseAlterTableStmt(AlterTableStmt *stmt)
 /*
  * DeparseRenameStmt deparses an RenameStmt to its SQL command.
  * Contrary to its name these statements are not covering all ALTER .. RENAME
- * statements. 
- * 
+ * statements.
+ *
  * e.g. ALTER TYPE name RENAME VALUE old TO new is an AlterEnumStmt
  *
  * Currently with limited support. Check support before using, and add support for new

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -137,9 +137,10 @@ DeparseDropStmt(DropStmt *stmt)
 
 
 /*
- * DeparseAlterTableStmt aims to deparse
- * ALTER TABLE ..
- * statements.
+ * DeparseAlterTableStmt deparses an AlterTableStmt to its SQL command.
+ * Contrary to its name these statements are covering not only ALTER TABLE ...
+ * statements but are used for almost all relation-esque objects in postgres,
+ * including but not limited to, Tables, Types, ...
  *
  * Currently with limited support. Check support before using, and add support for new
  * statements as required.
@@ -163,9 +164,11 @@ DeparseAlterTableStmt(AlterTableStmt *stmt)
 
 
 /*
- * DeparseRenameStmt aims to deparse
- * ALTER .. RENAME TO ..
- * statements.
+ * DeparseRenameStmt deparses an RenameStmt to its SQL command.
+ * Contrary to its name these statements are not covering all ALTER .. RENAME
+ * statements. 
+ * 
+ * e.g. ALTER TYPE name RENAME VALUE old TO new is an AlterEnumStmt
  *
  * Currently with limited support. Check support before using, and add support for new
  * statements as required.
@@ -201,14 +204,6 @@ DeparseRenameStmt(RenameStmt *stmt)
 }
 
 
-/*
- * DeparseRenameAttributeStmt aims to deparse
- * ALTER TYPE .. RENAME ATTRIBUTE .. TO ..
- * statements.
- *
- * Currently with limited support. Check support before using, and add support for new
- * statements as required.
- */
 static const char *
 DeparseRenameAttributeStmt(RenameStmt *stmt)
 {

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -35,7 +35,11 @@ static const char * DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt);
  *  - ALTER TYPE
  *  - DROP TYPE
  *
+ *  - ALTER FUNCTION
  *  - DROP FUNCTION
+ *
+ *  - ALTER PROCEDURE
+ *  - DROP PROCEDURE
  */
 const char *
 DeparseTreeNode(Node *stmt)

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -23,7 +23,7 @@ static const char * DeparseRenameStmt(RenameStmt *stmt);
 static const char * DeparseRenameAttributeStmt(RenameStmt *stmt);
 static const char * DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt);
 static const char * DeparseAlterOwnerStmt(AlterOwnerStmt *stmt);
-
+static const char * DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt);
 
 /*
  * DeparseTreeNode aims to be the inverse of postgres' ParseTreeNode. Currently with
@@ -85,6 +85,11 @@ DeparseTreeNode(Node *stmt)
 		case T_AlterOwnerStmt:
 		{
 			return DeparseAlterOwnerStmt(castNode(AlterOwnerStmt, stmt));
+		}
+
+		case T_AlterObjectDependsStmt:
+		{
+			return DeparseAlterObjectDependsStmt(castNode(AlterObjectDependsStmt, stmt));
 		}
 
 		default:
@@ -151,6 +156,11 @@ DeparseRenameStmt(RenameStmt *stmt)
 			return DeparseRenameAttributeStmt(stmt);
 		}
 
+		case OBJECT_FUNCTION:
+		{
+			return DeparseRenameFunctionStmt(stmt);
+		}
+
 		default:
 		{
 			ereport(ERROR, (errmsg("unsupported rename statement for deparsing")));
@@ -190,6 +200,11 @@ DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 			return DeparseAlterTypeSchemaStmt(stmt);
 		}
 
+		case OBJECT_FUNCTION:
+		{
+			return DeparseAlterFunctionSchemaStmt(stmt);
+		}
+
 		default:
 		{
 			ereport(ERROR, (errmsg("unsupported rename statement for deparsing")));
@@ -208,9 +223,34 @@ DeparseAlterOwnerStmt(AlterOwnerStmt *stmt)
 			return DeparseAlterTypeOwnerStmt(stmt);
 		}
 
+		case OBJECT_FUNCTION:
+		case OBJECT_PROCEDURE:
+		{
+			return DeparseAlterFunctionOwnerStmt(stmt);
+		}
+
 		default:
 		{
 			ereport(ERROR, (errmsg("unsupported alter owner statement for deparsing")));
+		}
+	}
+}
+
+
+static const char *
+DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
+{
+	switch (stmt->objectType)
+	{
+		case OBJECT_FUNCTION:
+		case OBJECT_PROCEDURE:
+		{
+			return DeparseAlterFunctionDependsStmt(stmt);
+		}
+
+		default:
+		{
+			ereport(ERROR, (errmsg("unsupported alter depends statement for deparsing")));
 		}
 	}
 }

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -111,6 +111,9 @@ DeparseDropStmt(DropStmt *stmt)
 		}
 
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			return DeparseDropFunctionStmt(stmt);
 		}
@@ -157,6 +160,9 @@ DeparseRenameStmt(RenameStmt *stmt)
 		}
 
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			return DeparseRenameFunctionStmt(stmt);
 		}
@@ -201,6 +207,9 @@ DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 		}
 
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			return DeparseAlterFunctionSchemaStmt(stmt);
 		}
@@ -224,7 +233,9 @@ DeparseAlterOwnerStmt(AlterOwnerStmt *stmt)
 		}
 
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
+#endif
 		{
 			return DeparseAlterFunctionOwnerStmt(stmt);
 		}
@@ -243,7 +254,9 @@ DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
 	switch (stmt->objectType)
 	{
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
+#endif
 		{
 			return DeparseAlterFunctionDependsStmt(stmt);
 		}

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -120,13 +120,13 @@ DeparseDropStmt(DropStmt *stmt)
 			return DeparseDropTypeStmt(stmt);
 		}
 
-		case OBJECT_FUNCTION:
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-			{
-				return DeparseDropFunctionStmt(stmt);
-			}
+		case OBJECT_FUNCTION:
+		{
+			return DeparseDropFunctionStmt(stmt);
+		}
 
 		default:
 		{
@@ -188,13 +188,13 @@ DeparseRenameStmt(RenameStmt *stmt)
 			return DeparseRenameAttributeStmt(stmt);
 		}
 
-		case OBJECT_FUNCTION:
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-			{
-				return DeparseRenameFunctionStmt(stmt);
-			}
+		case OBJECT_FUNCTION:
+		{
+			return DeparseRenameFunctionStmt(stmt);
+		}
 
 		default:
 		{
@@ -243,13 +243,13 @@ DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 			return DeparseAlterTypeSchemaStmt(stmt);
 		}
 
-		case OBJECT_FUNCTION:
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-			{
-				return DeparseAlterFunctionSchemaStmt(stmt);
-			}
+		case OBJECT_FUNCTION:
+		{
+			return DeparseAlterFunctionSchemaStmt(stmt);
+		}
 
 		default:
 		{
@@ -277,13 +277,13 @@ DeparseAlterOwnerStmt(AlterOwnerStmt *stmt)
 			return DeparseAlterTypeOwnerStmt(stmt);
 		}
 
-		case OBJECT_FUNCTION:
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-			{
-				return DeparseAlterFunctionOwnerStmt(stmt);
-			}
+		case OBJECT_FUNCTION:
+		{
+			return DeparseAlterFunctionOwnerStmt(stmt);
+		}
 
 		default:
 		{
@@ -306,13 +306,13 @@ DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
 {
 	switch (stmt->objectType)
 	{
-		case OBJECT_FUNCTION:
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-			{
-				return DeparseAlterFunctionDependsStmt(stmt);
-			}
+		case OBJECT_FUNCTION:
+		{
+			return DeparseAlterFunctionDependsStmt(stmt);
+		}
 
 		default:
 		{

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -34,6 +34,8 @@ static const char * DeparseAlterOwnerStmt(AlterOwnerStmt *stmt);
  *  - CREATE TYPE
  *  - ALTER TYPE
  *  - DROP TYPE
+ *
+ *  - DROP FUNCTION
  */
 const char *
 DeparseTreeNode(Node *stmt)
@@ -63,6 +65,11 @@ DeparseTreeNode(Node *stmt)
 		case T_AlterEnumStmt:
 		{
 			return DeparseAlterEnumStmt(castNode(AlterEnumStmt, stmt));
+		}
+
+		case T_AlterFunctionStmt:
+		{
+			return DeparseAlterFunctionStmt(castNode(AlterFunctionStmt, stmt));
 		}
 
 		case T_RenameStmt:
@@ -96,6 +103,11 @@ DeparseDropStmt(DropStmt *stmt)
 		case OBJECT_TYPE:
 		{
 			return DeparseDropTypeStmt(stmt);
+		}
+
+		case OBJECT_FUNCTION:
+		{
+			return DeparseDropFunctionStmt(stmt);
 		}
 
 		default:

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -104,6 +104,12 @@ DeparseTreeNode(Node *stmt)
 }
 
 
+/*
+ * DeparseDropStmt aims to deparse DROP statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseDropStmt(DropStmt *stmt)
 {
@@ -130,6 +136,14 @@ DeparseDropStmt(DropStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterTableStmt aims to deparse
+ * ALTER TABLE ..
+ * statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseAlterTableStmt(AlterTableStmt *stmt)
 {
@@ -148,6 +162,14 @@ DeparseAlterTableStmt(AlterTableStmt *stmt)
 }
 
 
+/*
+ * DeparseRenameStmt aims to deparse
+ * ALTER .. RENAME TO ..
+ * statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseRenameStmt(RenameStmt *stmt)
 {
@@ -179,6 +201,14 @@ DeparseRenameStmt(RenameStmt *stmt)
 }
 
 
+/*
+ * DeparseRenameAttributeStmt aims to deparse
+ * ALTER TYPE .. RENAME ATTRIBUTE .. TO ..
+ * statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseRenameAttributeStmt(RenameStmt *stmt)
 {
@@ -200,6 +230,14 @@ DeparseRenameAttributeStmt(RenameStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterObjectSchemaStmt aims to deparse
+ * ALTER .. SET SCHEMA ..
+ * statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 {
@@ -226,6 +264,14 @@ DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterOwnerStmt aims to deparse
+ * ALTER .. OWNER TO ..
+ * statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseAlterOwnerStmt(AlterOwnerStmt *stmt)
 {
@@ -252,6 +298,14 @@ DeparseAlterOwnerStmt(AlterOwnerStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterObjectDependsStmt aims to deparse
+ * ALTER .. DEPENDS ON EXTENSION ..
+ * statements.
+ *
+ * Currently with limited support. Check support before using, and add support for new
+ * statements as required.
+ */
 static const char *
 DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
 {

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -114,9 +114,9 @@ DeparseDropStmt(DropStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			return DeparseDropFunctionStmt(stmt);
-		}
+			{
+				return DeparseDropFunctionStmt(stmt);
+			}
 
 		default:
 		{
@@ -163,9 +163,9 @@ DeparseRenameStmt(RenameStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			return DeparseRenameFunctionStmt(stmt);
-		}
+			{
+				return DeparseRenameFunctionStmt(stmt);
+			}
 
 		default:
 		{
@@ -210,9 +210,9 @@ DeparseAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			return DeparseAlterFunctionSchemaStmt(stmt);
-		}
+			{
+				return DeparseAlterFunctionSchemaStmt(stmt);
+			}
 
 		default:
 		{
@@ -236,9 +236,9 @@ DeparseAlterOwnerStmt(AlterOwnerStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			return DeparseAlterFunctionOwnerStmt(stmt);
-		}
+			{
+				return DeparseAlterFunctionOwnerStmt(stmt);
+			}
 
 		default:
 		{
@@ -257,9 +257,9 @@ DeparseAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			return DeparseAlterFunctionDependsStmt(stmt);
-		}
+			{
+				return DeparseAlterFunctionDependsStmt(stmt);
+			}
 
 		default:
 		{

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -2,7 +2,15 @@
  *
  * deparse_function_stmts.c
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ *	  All routines to deparse function and procedure statements.
+ *	  This file contains all entry points specific for function and procedure statement
+ *    deparsing
+ *
+ *	  Functions that could move later are AppendDefElem, AppendDefElemStrict, etc. These
+ *	  should be reused across multiple statements and should live in their own deparse
+ *	  file.
+ * 
+ * Copyright (c), Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -260,9 +260,23 @@ AppendDefElemSet(StringInfo buf, DefElem *def)
 			break;
 		}
 
+		/*
+		 * When we get a SET FROM CURRENT action, we capture the current config option on
+		 * the coordinator and use that value directly.
+		 *
+		 * The PG docs:
+		 * SET FROM CURRENT saves the value of the parameter that is current when
+		 * ALTER FUNCTION is executed as the value to be applied when the function
+		 * is entered.
+		 *
+		 * This logic should have been implemented in QualifyAlterFunction()
+		 */
 		case VAR_SET_CURRENT:
 		{
-			appendStringInfo(buf, " SET %s FROM CURRENT", setStmt->name);
+			char *currentValue = NULL;
+			currentValue = GetConfigOptionByName(setStmt->name, NULL, false);
+
+			appendStringInfo(buf, " SET %s TO %s", setStmt->name, currentValue);
 			break;
 		}
 

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -260,23 +260,9 @@ AppendDefElemSet(StringInfo buf, DefElem *def)
 			break;
 		}
 
-		/*
-		 * When we get a SET FROM CURRENT action, we capture the current config option on
-		 * the coordinator and use that value directly.
-		 *
-		 * The PG docs:
-		 * SET FROM CURRENT saves the value of the parameter that is current when
-		 * ALTER FUNCTION is executed as the value to be applied when the function
-		 * is entered.
-		 *
-		 * This logic should have been implemented in QualifyAlterFunction()
-		 */
 		case VAR_SET_CURRENT:
 		{
-			char *currentValue = NULL;
-			currentValue = GetConfigOptionByName(setStmt->name, NULL, false);
-
-			appendStringInfo(buf, " SET %s TO %s", setStmt->name, currentValue);
+			appendStringInfo(buf, " SET %s FROM CURRENT", setStmt->name);
 			break;
 		}
 

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -9,7 +9,7 @@
  *	  Functions that could move later are AppendDefElem, AppendDefElemStrict, etc. These
  *	  should be reused across multiple statements and should live in their own deparse
  *	  file.
- * 
+ *
  * Copyright (c), Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
@@ -36,7 +36,9 @@
 #include "utils/fmgrprotos.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/syscache.h"
+
 
 /* forward declaration for deparse functions */
 static void AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt);
@@ -59,6 +61,7 @@ static void AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt 
 static void AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt);
 static void AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt);
 
+static char * CopyAndConvertToUpperCase(const char *str);
 
 /*
  * DeparseAlterFunctionStmt builds and returns a string representing the AlterFunctionStmt
@@ -175,7 +178,7 @@ AppendDefElemStrict(StringInfo buf, DefElem *def)
 static void
 AppendDefElemVolatility(StringInfo buf, DefElem *def)
 {
-	appendStringInfo(buf, " %s", strVal(def->arg));
+	appendStringInfo(buf, " %s", CopyAndConvertToUpperCase(strVal(def->arg)));
 }
 
 
@@ -216,7 +219,7 @@ AppendDefElemSecurity(StringInfo buf, DefElem *def)
 static void
 AppendDefElemParallel(StringInfo buf, DefElem *def)
 {
-	appendStringInfo(buf, " PARALLEL %s", strVal(def->arg));
+	appendStringInfo(buf, " PARALLEL %s", CopyAndConvertToUpperCase(strVal(def->arg)));
 }
 
 
@@ -628,4 +631,23 @@ AppendFunctionName(StringInfo buf, ObjectWithArgs *func, ObjectType objtype)
 	}
 
 	appendStringInfo(buf, "(%s)", args);
+}
+
+
+/*
+ * CopyAndConvertToUpperCase copies a string and converts all characters to uppercase
+ */
+static char *
+CopyAndConvertToUpperCase(const char *str)
+{
+	char *result, *p;
+
+	result = pstrdup(str);
+
+	for (p = result; *p; p++)
+	{
+		*p = pg_toupper((unsigned char) *p);
+	}
+
+	return result;
 }

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -158,7 +158,7 @@ AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
 	ListCell *actionCell = NULL;
 
 #if (PG_VERSION_NUM < 110000)
-		appendStringInfo(buf, "ALTER FUNCTION ");
+	appendStringInfo(buf, "ALTER FUNCTION ");
 #else
 	if (stmt->objtype == OBJECT_FUNCTION)
 	{
@@ -342,7 +342,7 @@ AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
 #if (PG_VERSION_NUM < 110000)
-		appendStringInfo(buf, "ALTER FUNCTION ");
+	appendStringInfo(buf, "ALTER FUNCTION ");
 #else
 	if (stmt->renameType == OBJECT_FUNCTION)
 	{
@@ -366,7 +366,7 @@ AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
 #if (PG_VERSION_NUM < 110000)
-		appendStringInfo(buf, "ALTER FUNCTION ");
+	appendStringInfo(buf, "ALTER FUNCTION ");
 #else
 	if (stmt->objectType == OBJECT_FUNCTION)
 	{
@@ -389,7 +389,7 @@ AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
 #if (PG_VERSION_NUM < 110000)
-		appendStringInfo(buf, "ALTER FUNCTION ");
+	appendStringInfo(buf, "ALTER FUNCTION ");
 #else
 	if (stmt->objectType == OBJECT_FUNCTION)
 	{
@@ -412,7 +412,7 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
 #if (PG_VERSION_NUM < 110000)
-		appendStringInfo(buf, "ALTER FUNCTION ");
+	appendStringInfo(buf, "ALTER FUNCTION ");
 #else
 	if (stmt->objectType == OBJECT_FUNCTION)
 	{
@@ -433,7 +433,7 @@ static void
 AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt)
 {
 #if (PG_VERSION_NUM < 110000)
-		appendStringInfo(buf, "DROP FUNCTION ");
+	appendStringInfo(buf, "DROP FUNCTION ");
 #else
 	if (stmt->removeType == OBJECT_FUNCTION)
 	{

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -1,0 +1,342 @@
+/*-------------------------------------------------------------------------
+ *
+ * deparse_function_stmts.c
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_proc.h"
+#include "commands/defrem.h"
+#include "distributed/commands.h"
+#include "distributed/deparser.h"
+#include "distributed/version_compat.h"
+#include "lib/stringinfo.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodes.h"
+#include "nodes/value.h"
+#include "parser/parse_func.h"
+#include "parser/parse_type.h"
+#include "utils/builtins.h"
+#include "utils/guc.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+
+/* forward declaration for deparse functions */
+static void AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt);
+static void AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt);
+static void AppendFunctionNameList(StringInfo buf, List *objects);
+static void AppendFunctionName(StringInfo buf, ObjectWithArgs *func);
+
+static void AppendDefElem(StringInfo buf, DefElem *def);
+static void AppendDefElemStrict(StringInfo buf, DefElem *def);
+static void AppendDefElemVolatility(StringInfo buf, DefElem *def);
+static void AppendDefElemLeakproof(StringInfo buf, DefElem *def);
+static void AppendDefElemSecurity(StringInfo buf, DefElem *def);
+static void AppendDefElemParallel(StringInfo buf, DefElem *def);
+static void AppendDefElemCost(StringInfo buf, DefElem *def);
+static void AppendDefElemRows(StringInfo buf, DefElem *def);
+static void AppendDefElemSet(StringInfo buf, DefElem *def);
+
+
+const char *
+DeparseAlterFunctionStmt(AlterFunctionStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+	AppendAlterFunctionStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+const char *
+DeparseDropFunctionStmt(DropStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+	Assert(stmt->removeType == OBJECT_FUNCTION);
+
+	AppendDropFunctionStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+static void
+AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
+{
+	ListCell *actionCell = NULL;
+	appendStringInfo(buf, "ALTER FUNCTION ");
+	AppendFunctionName(buf, stmt->func);
+
+	foreach(actionCell, stmt->actions)
+	{
+		DefElem *def = castNode(DefElem, lfirst(actionCell));
+		AppendDefElem(buf, def);
+	}
+
+	/* TODO: use other attributes to deparse the query here  */
+	appendStringInfoString(buf, ";");
+}
+
+
+static void
+AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt)
+{
+	/*
+	 * TODO: Hanefi you should check that this comment is still valid.
+	 *
+	 * already tested at call site, but for future it might be collapsed in a
+	 * deparse_function_stmt so be safe and check again
+	 */
+	Assert(stmt->removeType == OBJECT_FUNCTION);
+
+	appendStringInfo(buf, "DROP FUNCTION ");
+	if (stmt->missing_ok)
+	{
+		appendStringInfoString(buf, "IF EXISTS ");
+	}
+	AppendFunctionNameList(buf, stmt->objects);
+	if (stmt->behavior == DROP_CASCADE)
+	{
+		appendStringInfoString(buf, " CASCADE");
+	}
+	appendStringInfoString(buf, ";");
+}
+
+
+static void
+AppendFunctionNameList(StringInfo buf, List *objects)
+{
+	ListCell *objectCell = NULL;
+	foreach(objectCell, objects)
+	{
+		Node *object = lfirst(objectCell);
+		ObjectWithArgs *func = NULL;
+
+		if (objectCell != list_head(objects))
+		{
+			appendStringInfo(buf, ", ");
+		}
+
+		Assert(IsA(object, ObjectWithArgs));
+		func = castNode(ObjectWithArgs, object);
+
+		AppendFunctionName(buf, func);
+	}
+}
+
+
+static void
+AppendQualifiedFunctionName(StringInfo buf, ObjectWithArgs *func)
+{
+	Oid funcid = InvalidOid;
+	HeapTuple proctup;
+	char *functionName = NULL;
+	char *schemaName = NULL;
+	char *qualifiedFunctionName;
+
+	funcid = LookupFuncWithArgs(OBJECT_FUNCTION, func, true);
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+
+	if (!HeapTupleIsValid(proctup))
+	{
+		/*
+		 * DROP FUNCTION IF EXISTS absent_function arrives here
+		 *
+		 * There is no namespace associated with the nonexistent function,
+		 * thus we return the function name as it is provided
+		 */
+		DeconstructQualifiedName(func->objname, &schemaName, &functionName);
+	}
+	else
+	{
+		Form_pg_proc procform;
+
+		procform = (Form_pg_proc) GETSTRUCT(proctup);
+		functionName = NameStr(procform->proname);
+		schemaName = get_namespace_name(procform->pronamespace);
+
+		ReleaseSysCache(proctup);
+	}
+
+	qualifiedFunctionName = quote_qualified_identifier(schemaName, functionName);
+	appendStringInfoString(buf, qualifiedFunctionName);
+}
+
+
+static void
+AppendFunctionName(StringInfo buf, ObjectWithArgs *func)
+{
+	char *args = TypeNameListToString(func->objargs);
+
+	AppendQualifiedFunctionName(buf, func);
+
+	/* append the optional arg list if provided */
+	if (args)
+	{
+		appendStringInfo(buf, "(%s)", args);
+	}
+}
+
+
+static void
+AppendDefElem(StringInfo buf, DefElem *def)
+{
+	if (strcmp(def->defname, "strict") == 0)
+	{
+		AppendDefElemStrict(buf, def);
+	}
+	else if (strcmp(def->defname, "volatility") == 0)
+	{
+		AppendDefElemVolatility(buf, def);
+	}
+	else if (strcmp(def->defname, "leakproof") == 0)
+	{
+		AppendDefElemLeakproof(buf, def);
+	}
+	else if (strcmp(def->defname, "security") == 0)
+	{
+		AppendDefElemSecurity(buf, def);
+	}
+	else if (strcmp(def->defname, "parallel") == 0)
+	{
+		AppendDefElemParallel(buf, def);
+	}
+	else if (strcmp(def->defname, "cost") == 0)
+	{
+		AppendDefElemCost(buf, def);
+	}
+	else if (strcmp(def->defname, "rows") == 0)
+	{
+		AppendDefElemRows(buf, def);
+	}
+	else if (strcmp(def->defname, "set") == 0)
+	{
+		AppendDefElemSet(buf, def);
+	}
+}
+
+
+static void
+AppendDefElemStrict(StringInfo buf, DefElem *def)
+{
+	if (intVal(def->arg) == 1)
+	{
+		appendStringInfo(buf, " STRICT");
+	}
+	else
+	{
+		appendStringInfo(buf, " CALLED ON NULL INPUT");
+	}
+}
+
+
+static void
+AppendDefElemVolatility(StringInfo buf, DefElem *def)
+{
+	appendStringInfo(buf, " %s", strVal(def->arg));
+}
+
+
+static void
+AppendDefElemLeakproof(StringInfo buf, DefElem *def)
+{
+	if (intVal(def->arg) == 0)
+	{
+		appendStringInfo(buf, " NOT");
+	}
+	appendStringInfo(buf, " LEAKPROOF");
+}
+
+
+static void
+AppendDefElemSecurity(StringInfo buf, DefElem *def)
+{
+	if (intVal(def->arg) == 0)
+	{
+		appendStringInfo(buf, " SECURITY INVOKER");
+	}
+	else
+	{
+		appendStringInfo(buf, " SECURITY DEFINER");
+	}
+}
+
+
+static void
+AppendDefElemParallel(StringInfo buf, DefElem *def)
+{
+	appendStringInfo(buf, " PARALLEL %s", strVal(def->arg));
+}
+
+
+static void
+AppendDefElemCost(StringInfo buf, DefElem *def)
+{
+	appendStringInfo(buf, " COST %lf", defGetNumeric(def));
+}
+
+
+static void
+AppendDefElemRows(StringInfo buf, DefElem *def)
+{
+	appendStringInfo(buf, " ROWS  %lf", defGetNumeric(def));
+}
+
+
+static void
+AppendDefElemSet(StringInfo buf, DefElem *def)
+{
+	VariableSetStmt *setStmt = castNode(VariableSetStmt, def->arg);
+	char *setVariableArgs = ExtractSetVariableArgs(setStmt);
+
+	switch (setStmt->kind)
+	{
+		case VAR_SET_VALUE:
+		{
+			appendStringInfo(buf, " SET %s = %s", setStmt->name, setVariableArgs);
+			break;
+		}
+
+		case VAR_SET_CURRENT:
+		{
+			appendStringInfo(buf, " SET %s FROM CURRENT", setStmt->name);
+			break;
+		}
+
+		case VAR_SET_DEFAULT:
+		{
+			appendStringInfo(buf, " SET %s TO DEFAULT", setStmt->name);
+			break;
+		}
+
+		case VAR_RESET:
+		{
+			appendStringInfo(buf, " RESET %s", setStmt->name);
+			break;
+		}
+
+		case VAR_RESET_ALL:
+		{
+			appendStringInfoString(buf, " RESET ALL");
+			break;
+		}
+
+		/* VAR_SET_MULTI is a special case for SET TRANSACTION that should not occur here */
+		case VAR_SET_MULTI:
+		default:
+		{
+			ereport(ERROR, (errmsg("Unable to deparse SET statement")));
+			break;
+		}
+	}
+}

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -70,8 +70,11 @@ DeparseRenameFunctionStmt(RenameStmt *stmt)
 	StringInfoData str = { 0 };
 	initStringInfo(&str);
 
-	/* TODO: check that OBJECT_PROCEDURE still works fine */
+#if (PG_VERSION_NUM < 110000)
 	Assert(stmt->renameType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->renameType == OBJECT_FUNCTION || stmt->renameType == OBJECT_PROCEDURE);
+#endif
 
 	AppendRenameFunctionStmt(&str, stmt);
 
@@ -99,7 +102,11 @@ DeparseAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt)
 	StringInfoData str = { 0 };
 	initStringInfo(&str);
 
+#if (PG_VERSION_NUM < 110000)
 	Assert(stmt->objectType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
+#endif
 
 	AppendAlterFunctionSchemaStmt(&str, stmt);
 
@@ -125,7 +132,11 @@ DeparseAlterFunctionOwnerStmt(AlterOwnerStmt *stmt)
 	StringInfoData str = { 0 };
 	initStringInfo(&str);
 
+#if (PG_VERSION_NUM < 110000)
 	Assert(stmt->objectType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
+#endif
 
 	AppendAlterFunctionOwnerStmt(&str, stmt);
 
@@ -151,7 +162,11 @@ DeparseAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt)
 	StringInfoData str = { 0 };
 	initStringInfo(&str);
 
+#if (PG_VERSION_NUM < 110000)
 	Assert(stmt->objectType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
+#endif
 
 	AppendAlterFunctionDependsStmt(&str, stmt);
 
@@ -176,7 +191,11 @@ DeparseDropFunctionStmt(DropStmt *stmt)
 	StringInfoData str = { 0 };
 	initStringInfo(&str);
 
+#if (PG_VERSION_NUM < 110000)
 	Assert(stmt->removeType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->removeType == OBJECT_FUNCTION || stmt->removeType == OBJECT_PROCEDURE);
+#endif
 
 	AppendDropFunctionStmt(&str, stmt);
 

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -421,7 +421,7 @@ AppendFunctionName(StringInfo buf, ObjectWithArgs *func)
 	char *qualifiedFunctionName;
 	char *args = TypeNameListToString(func->objargs);
 
-	funcid = LookupFuncWithArgs(OBJECT_FUNCTION, func, true);
+	funcid = LookupFuncWithArgsCompat(OBJECT_FUNCTION, func, true);
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 
 	if (!HeapTupleIsValid(proctup))

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -157,6 +157,9 @@ AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
 {
 	ListCell *actionCell = NULL;
 
+#if (PG_VERSION_NUM < 110000)
+		appendStringInfo(buf, "ALTER FUNCTION ");
+#else
 	if (stmt->objtype == OBJECT_FUNCTION)
 	{
 		appendStringInfo(buf, "ALTER FUNCTION ");
@@ -165,6 +168,7 @@ AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
 	{
 		appendStringInfo(buf, "ALTER PROCEDURE ");
 	}
+#endif
 
 	AppendFunctionName(buf, stmt->func);
 
@@ -337,6 +341,9 @@ AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
+#if (PG_VERSION_NUM < 110000)
+		appendStringInfo(buf, "ALTER FUNCTION ");
+#else
 	if (stmt->renameType == OBJECT_FUNCTION)
 	{
 		appendStringInfoString(buf, "ALTER FUNCTION ");
@@ -345,6 +352,7 @@ AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
 	{
 		appendStringInfoString(buf, "ALTER PROCEDURE ");
 	}
+#endif
 
 	AppendFunctionName(buf, func);
 
@@ -357,6 +365,9 @@ AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
+#if (PG_VERSION_NUM < 110000)
+		appendStringInfo(buf, "ALTER FUNCTION ");
+#else
 	if (stmt->objectType == OBJECT_FUNCTION)
 	{
 		appendStringInfoString(buf, "ALTER FUNCTION ");
@@ -365,6 +376,7 @@ AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 	{
 		appendStringInfoString(buf, "ALTER PROCEDURE ");
 	}
+#endif
 
 	AppendFunctionName(buf, func);
 	appendStringInfo(buf, " SET SCHEMA %s;", quote_identifier(stmt->newschema));
@@ -376,6 +388,9 @@ AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
+#if (PG_VERSION_NUM < 110000)
+		appendStringInfo(buf, "ALTER FUNCTION ");
+#else
 	if (stmt->objectType == OBJECT_FUNCTION)
 	{
 		appendStringInfoString(buf, "ALTER FUNCTION ");
@@ -384,6 +399,7 @@ AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 	{
 		appendStringInfoString(buf, "ALTER PROCEDURE ");
 	}
+#endif
 
 	AppendFunctionName(buf, func);
 	appendStringInfo(buf, " OWNER TO %s;", RoleSpecString(stmt->newowner));
@@ -395,6 +411,9 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
+#if (PG_VERSION_NUM < 110000)
+		appendStringInfo(buf, "ALTER FUNCTION ");
+#else
 	if (stmt->objectType == OBJECT_FUNCTION)
 	{
 		appendStringInfoString(buf, "ALTER FUNCTION ");
@@ -403,6 +422,7 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 	{
 		appendStringInfoString(buf, "ALTER PROCEDURE ");
 	}
+#endif
 
 	AppendFunctionName(buf, func);
 	appendStringInfo(buf, " DEPENDS ON EXTENSION %s;", strVal(stmt->extname));
@@ -412,14 +432,18 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 static void
 AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt)
 {
+#if (PG_VERSION_NUM < 110000)
+		appendStringInfo(buf, "DROP FUNCTION ");
+#else
 	if (stmt->removeType == OBJECT_FUNCTION)
 	{
-		appendStringInfo(buf, "DROP FUNCTION ");
+		appendStringInfoString(buf, "DROP FUNCTION ");
 	}
 	else
 	{
-		appendStringInfo(buf, "DROP PROCEDURE ");
+		appendStringInfoString(buf, "DROP PROCEDURE ");
 	}
+#endif
 
 	if (stmt->missing_ok)
 	{

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -50,6 +50,9 @@ static void AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt);
 static void AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt);
 
 
+/*
+ * DeparseAlterFunctionStmt builds and returns a string representing the AlterFunctionStmt
+ */
 const char *
 DeparseAlterFunctionStmt(AlterFunctionStmt *stmt)
 {
@@ -62,96 +65,9 @@ DeparseAlterFunctionStmt(AlterFunctionStmt *stmt)
 }
 
 
-const char *
-DeparseRenameFunctionStmt(RenameStmt *stmt)
-{
-	StringInfoData str = { 0 };
-	initStringInfo(&str);
-
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->renameType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->renameType == OBJECT_FUNCTION || stmt->renameType == OBJECT_PROCEDURE);
-#endif
-
-	AppendRenameFunctionStmt(&str, stmt);
-
-	return str.data;
-}
-
-
-const char *
-DeparseAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt)
-{
-	StringInfoData str = { 0 };
-	initStringInfo(&str);
-
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->objectType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
-#endif
-
-	AppendAlterFunctionSchemaStmt(&str, stmt);
-
-	return str.data;
-}
-
-
-const char *
-DeparseAlterFunctionOwnerStmt(AlterOwnerStmt *stmt)
-{
-	StringInfoData str = { 0 };
-	initStringInfo(&str);
-
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->objectType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
-#endif
-
-	AppendAlterFunctionOwnerStmt(&str, stmt);
-
-	return str.data;
-}
-
-
-const char *
-DeparseAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt)
-{
-	StringInfoData str = { 0 };
-	initStringInfo(&str);
-
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->objectType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
-#endif
-
-	AppendAlterFunctionDependsStmt(&str, stmt);
-
-	return str.data;
-}
-
-
-const char *
-DeparseDropFunctionStmt(DropStmt *stmt)
-{
-	StringInfoData str = { 0 };
-	initStringInfo(&str);
-
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->removeType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->removeType == OBJECT_FUNCTION || stmt->removeType == OBJECT_PROCEDURE);
-#endif
-
-	AppendDropFunctionStmt(&str, stmt);
-
-	return str.data;
-}
-
-
+/*
+ * AppendAlterFunctionStmt appends a string representing the AlterFunctionStmt to a buffer
+ */
 static void
 AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
 {
@@ -182,6 +98,9 @@ AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
 }
 
 
+/*
+ * AppendDefElem appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElem(StringInfo buf, DefElem *def)
 {
@@ -220,6 +139,9 @@ AppendDefElem(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemStrict appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemStrict(StringInfo buf, DefElem *def)
 {
@@ -234,6 +156,9 @@ AppendDefElemStrict(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemVolatility appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemVolatility(StringInfo buf, DefElem *def)
 {
@@ -241,6 +166,9 @@ AppendDefElemVolatility(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemLeakproof appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemLeakproof(StringInfo buf, DefElem *def)
 {
@@ -252,6 +180,9 @@ AppendDefElemLeakproof(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemSecurity appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemSecurity(StringInfo buf, DefElem *def)
 {
@@ -266,6 +197,9 @@ AppendDefElemSecurity(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemParallel appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemParallel(StringInfo buf, DefElem *def)
 {
@@ -273,6 +207,9 @@ AppendDefElemParallel(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemCost appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemCost(StringInfo buf, DefElem *def)
 {
@@ -280,6 +217,9 @@ AppendDefElemCost(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemRows appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemRows(StringInfo buf, DefElem *def)
 {
@@ -287,6 +227,9 @@ AppendDefElemRows(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * AppendDefElemSet appends a string representing the DefElem to a buffer
+ */
 static void
 AppendDefElemSet(StringInfo buf, DefElem *def)
 {
@@ -336,6 +279,30 @@ AppendDefElemSet(StringInfo buf, DefElem *def)
 }
 
 
+/*
+ * DeparseRenameFunctionStmt builds and returns a string representing the RenameStmt
+ */
+const char *
+DeparseRenameFunctionStmt(RenameStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+#if (PG_VERSION_NUM < 110000)
+	Assert(stmt->renameType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->renameType == OBJECT_FUNCTION || stmt->renameType == OBJECT_PROCEDURE);
+#endif
+
+	AppendRenameFunctionStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+/*
+ * AppendRenameFunctionStmt appends a string representing the RenameStmt to a buffer
+ */
 static void
 AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
 {
@@ -360,6 +327,30 @@ AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterFunctionSchemaStmt builds and returns a string representing the AlterObjectSchemaStmt
+ */
+const char *
+DeparseAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+#if (PG_VERSION_NUM < 110000)
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
+#endif
+
+	AppendAlterFunctionSchemaStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+/*
+ * AppendAlterFunctionSchemaStmt appends a string representing the AlterObjectSchemaStmt to a buffer
+ */
 static void
 AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 {
@@ -383,6 +374,30 @@ AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterFunctionOwnerStmt builds and returns a string representing the AlterOwnerStmt
+ */
+const char *
+DeparseAlterFunctionOwnerStmt(AlterOwnerStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+#if (PG_VERSION_NUM < 110000)
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
+#endif
+
+	AppendAlterFunctionOwnerStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+/*
+ * AppendAlterFunctionOwnerStmt appends a string representing the AlterOwnerStmt to a buffer
+ */
 static void
 AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 {
@@ -406,6 +421,30 @@ AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 }
 
 
+/*
+ * DeparseAlterFunctionDependsStmt builds and returns a string representing the AlterObjectDependsStmt
+ */
+const char *
+DeparseAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+#if (PG_VERSION_NUM < 110000)
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
+#endif
+
+	AppendAlterFunctionDependsStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+/*
+ * AppendAlterFunctionDependsStmt appends a string representing the AlterObjectDependsStmt to a buffer
+ */
 static void
 AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 {
@@ -429,6 +468,30 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 }
 
 
+/*
+ * DeparseDropFunctionStmt builds and returns a string representing the DropStmt
+ */
+const char *
+DeparseDropFunctionStmt(DropStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+#if (PG_VERSION_NUM < 110000)
+	Assert(stmt->removeType == OBJECT_FUNCTION);
+#else
+	Assert(stmt->removeType == OBJECT_FUNCTION || stmt->removeType == OBJECT_PROCEDURE);
+#endif
+
+	AppendDropFunctionStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+/*
+ * AppendDropFunctionStmt appends a string representing the DropStmt to a buffer
+ */
 static void
 AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt)
 {
@@ -461,6 +524,9 @@ AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt)
 }
 
 
+/*
+ * AppendFunctionNameList appends a string representing the list of function names to a buffer
+ */
 static void
 AppendFunctionNameList(StringInfo buf, List *objects)
 {
@@ -482,6 +548,9 @@ AppendFunctionNameList(StringInfo buf, List *objects)
 }
 
 
+/*
+ * AppendFunctionName appends a string representing a single function name to a buffer
+ */
 static void
 AppendFunctionName(StringInfo buf, ObjectWithArgs *func)
 {

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -13,6 +13,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_proc.h"
 #include "commands/defrem.h"
+#include "distributed/citus_ruleutils.h"
 #include "distributed/commands.h"
 #include "distributed/deparser.h"
 #include "distributed/version_compat.h"
@@ -43,6 +44,10 @@ static void AppendDefElemCost(StringInfo buf, DefElem *def);
 static void AppendDefElemRows(StringInfo buf, DefElem *def);
 static void AppendDefElemSet(StringInfo buf, DefElem *def);
 
+static void AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt);
+static void AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt);
+static void AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt);
+static void AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt);
 
 const char *
 DeparseAlterFunctionStmt(AlterFunctionStmt *stmt)
@@ -53,6 +58,118 @@ DeparseAlterFunctionStmt(AlterFunctionStmt *stmt)
 	AppendAlterFunctionStmt(&str, stmt);
 
 	return str.data;
+}
+
+
+/* TODO: implement this and add some comments here */
+const char *
+DeparseRenameFunctionStmt(RenameStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+	/* TODO: check that OBJECT_PROCEDURE still works fine */
+	Assert(stmt->renameType == OBJECT_FUNCTION);
+
+	AppendRenameFunctionStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+static void
+AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
+{
+	List *names = (List *) stmt->object;
+
+	appendStringInfo(buf, "ALTER FUNCTION %s RENAME TO %s;", NameListToQuotedString(
+						 names), quote_identifier(stmt->newname));
+}
+
+
+/* TODO: implement this and add some comments here */
+const char *
+DeparseAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+
+	AppendAlterFunctionSchemaStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+static void
+AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
+{
+	List *names = NIL;
+
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+
+	names = (List *) stmt->object;
+	appendStringInfo(buf, "ALTER FUNCTION %s SET SCHEMA %s;", NameListToQuotedString(
+						 names),
+					 quote_identifier(stmt->newschema));
+}
+
+
+/* TODO: implement this and add some comments here */
+const char *
+DeparseAlterFunctionOwnerStmt(AlterOwnerStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+
+	AppendAlterFunctionOwnerStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+static void
+AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
+{
+	List *names = NIL;
+
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+
+	names = (List *) stmt->object;
+	appendStringInfo(buf, "ALTER FUNCTION %s OWNER TO %s;", NameListToQuotedString(names),
+					 RoleSpecString(stmt->newowner));
+}
+
+
+/* TODO: implement this and add some comments here */
+const char *
+DeparseAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt)
+{
+	StringInfoData str = { 0 };
+	initStringInfo(&str);
+
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+
+	AppendAlterFunctionDependsStmt(&str, stmt);
+
+	return str.data;
+}
+
+
+static void
+AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
+{
+	List *names = NIL;
+
+	Assert(stmt->objectType == OBJECT_FUNCTION);
+
+	names = (List *) stmt->object;
+	appendStringInfo(buf, "ALTER FUNCTION %s DEPENDS ON EXTENSION %s;",
+					 NameListToQuotedString(names),
+					 strVal(stmt->extname));
 }
 
 

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -595,6 +595,7 @@ AppendFunctionName(StringInfo buf, ObjectWithArgs *func, ObjectType objtype)
 
 		procform = (Form_pg_proc) GETSTRUCT(proctup);
 		functionName = NameStr(procform->proname);
+		functionName = pstrdup(functionName); /* we release the tuple before used */
 		schemaName = get_namespace_name(procform->pronamespace);
 
 		ReleaseSysCache(proctup);

--- a/src/backend/distributed/deparser/deparse_function_stmts.c
+++ b/src/backend/distributed/deparser/deparse_function_stmts.c
@@ -156,7 +156,16 @@ static void
 AppendAlterFunctionStmt(StringInfo buf, AlterFunctionStmt *stmt)
 {
 	ListCell *actionCell = NULL;
-	appendStringInfo(buf, "ALTER FUNCTION ");
+
+	if (stmt->objtype == OBJECT_FUNCTION)
+	{
+		appendStringInfo(buf, "ALTER FUNCTION ");
+	}
+	else
+	{
+		appendStringInfo(buf, "ALTER PROCEDURE ");
+	}
+
 	AppendFunctionName(buf, stmt->func);
 
 	foreach(actionCell, stmt->actions)
@@ -328,7 +337,14 @@ AppendRenameFunctionStmt(StringInfo buf, RenameStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
-	appendStringInfoString(buf, "ALTER FUNCTION ");
+	if (stmt->renameType == OBJECT_FUNCTION)
+	{
+		appendStringInfoString(buf, "ALTER FUNCTION ");
+	}
+	else
+	{
+		appendStringInfoString(buf, "ALTER PROCEDURE ");
+	}
 
 	AppendFunctionName(buf, func);
 
@@ -341,7 +357,15 @@ AppendAlterFunctionSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
-	appendStringInfoString(buf, "ALTER FUNCTION ");
+	if (stmt->objectType == OBJECT_FUNCTION)
+	{
+		appendStringInfoString(buf, "ALTER FUNCTION ");
+	}
+	else
+	{
+		appendStringInfoString(buf, "ALTER PROCEDURE ");
+	}
+
 	AppendFunctionName(buf, func);
 	appendStringInfo(buf, " SET SCHEMA %s;", quote_identifier(stmt->newschema));
 }
@@ -352,7 +376,15 @@ AppendAlterFunctionOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
-	appendStringInfoString(buf, "ALTER FUNCTION ");
+	if (stmt->objectType == OBJECT_FUNCTION)
+	{
+		appendStringInfoString(buf, "ALTER FUNCTION ");
+	}
+	else
+	{
+		appendStringInfoString(buf, "ALTER PROCEDURE ");
+	}
+
 	AppendFunctionName(buf, func);
 	appendStringInfo(buf, " OWNER TO %s;", RoleSpecString(stmt->newowner));
 }
@@ -363,7 +395,15 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 {
 	ObjectWithArgs *func = castNode(ObjectWithArgs, stmt->object);
 
-	appendStringInfoString(buf, "ALTER FUNCTION ");
+	if (stmt->objectType == OBJECT_FUNCTION)
+	{
+		appendStringInfoString(buf, "ALTER FUNCTION ");
+	}
+	else
+	{
+		appendStringInfoString(buf, "ALTER PROCEDURE ");
+	}
+
 	AppendFunctionName(buf, func);
 	appendStringInfo(buf, " DEPENDS ON EXTENSION %s;", strVal(stmt->extname));
 }
@@ -372,7 +412,14 @@ AppendAlterFunctionDependsStmt(StringInfo buf, AlterObjectDependsStmt *stmt)
 static void
 AppendDropFunctionStmt(StringInfo buf, DropStmt *stmt)
 {
-	appendStringInfo(buf, "DROP FUNCTION ");
+	if (stmt->removeType == OBJECT_FUNCTION)
+	{
+		appendStringInfo(buf, "DROP FUNCTION ");
+	}
+	else
+	{
+		appendStringInfo(buf, "DROP PROCEDURE ");
+	}
 
 	if (stmt->missing_ok)
 	{

--- a/src/backend/distributed/deparser/qualify.c
+++ b/src/backend/distributed/deparser/qualify.c
@@ -104,6 +104,10 @@ QualifyTreeNode(Node *stmt)
 }
 
 
+/*
+ * QualifyRenameStmt transforms a RENAME statement in place and makes all (supported)
+ * statements fully qualified.
+ */
 static void
 QualifyRenameStmt(RenameStmt *stmt)
 {
@@ -138,6 +142,10 @@ QualifyRenameStmt(RenameStmt *stmt)
 }
 
 
+/*
+ * QualifyRenameAttributeStmt transforms a RENAME ATTRIBUTE statement in place and makes all (supported)
+ * statements fully qualified.
+ */
 static void
 QualifyRenameAttributeStmt(RenameStmt *stmt)
 {

--- a/src/backend/distributed/deparser/qualify.c
+++ b/src/backend/distributed/deparser/qualify.c
@@ -121,8 +121,10 @@ QualifyRenameStmt(RenameStmt *stmt)
 			return;
 		}
 
-		case OBJECT_PROCEDURE:
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			QualifyRenameFunctionStmt(stmt);
 		}
@@ -188,8 +190,10 @@ QualifyAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 			return;
 		}
 
-		case OBJECT_PROCEDURE:
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			QualifyAlterFunctionSchemaStmt(stmt);
 		}
@@ -214,8 +218,10 @@ QualifyAlterOwnerStmt(AlterOwnerStmt *stmt)
 			return;
 		}
 
-		case OBJECT_PROCEDURE:
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			QualifyAlterFunctionOwnerStmt(stmt);
 		}
@@ -233,8 +239,10 @@ QualifyAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
 {
 	switch (stmt->objectType)
 	{
-		case OBJECT_PROCEDURE:
 		case OBJECT_FUNCTION:
+#if PG_VERSION_NUM >= 110000
+		case OBJECT_PROCEDURE:
+#endif
 		{
 			QualifyAlterFunctionDependsStmt(stmt);
 		}

--- a/src/backend/distributed/deparser/qualify.c
+++ b/src/backend/distributed/deparser/qualify.c
@@ -125,9 +125,9 @@ QualifyRenameStmt(RenameStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			QualifyRenameFunctionStmt(stmt);
-		}
+			{
+				QualifyRenameFunctionStmt(stmt);
+			}
 
 		default:
 		{
@@ -194,9 +194,9 @@ QualifyAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			QualifyAlterFunctionSchemaStmt(stmt);
-		}
+			{
+				QualifyAlterFunctionSchemaStmt(stmt);
+			}
 
 		default:
 		{
@@ -222,9 +222,9 @@ QualifyAlterOwnerStmt(AlterOwnerStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			QualifyAlterFunctionOwnerStmt(stmt);
-		}
+			{
+				QualifyAlterFunctionOwnerStmt(stmt);
+			}
 
 		default:
 		{
@@ -243,9 +243,9 @@ QualifyAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
 #if PG_VERSION_NUM >= 110000
 		case OBJECT_PROCEDURE:
 #endif
-		{
-			QualifyAlterFunctionDependsStmt(stmt);
-		}
+			{
+				QualifyAlterFunctionDependsStmt(stmt);
+			}
 
 		default:
 		{

--- a/src/backend/distributed/deparser/qualify.c
+++ b/src/backend/distributed/deparser/qualify.c
@@ -29,7 +29,7 @@ static void QualifyRenameAttributeStmt(RenameStmt *stmt);
 static void QualifyAlterTableStmt(AlterTableStmt *stmt);
 static void QualifyAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt);
 static void QualifyAlterOwnerStmt(AlterOwnerStmt *stmt);
-
+static void QualifyAlterObjectDependsStmt(AlterObjectDependsStmt *stmt);
 
 /*
  * QualifyTreeNode transforms the statement in place and makes all (supported) statements
@@ -83,6 +83,18 @@ QualifyTreeNode(Node *stmt)
 			return;
 		}
 
+		case T_AlterFunctionStmt:
+		{
+			QualifyAlterFunctionStmt(castNode(AlterFunctionStmt, stmt));
+			return;
+		}
+
+		case T_AlterObjectDependsStmt:
+		{
+			QualifyAlterObjectDependsStmt(castNode(AlterObjectDependsStmt, stmt));
+			return;
+		}
+
 		default:
 		{
 			/* skip unsupported statements */
@@ -107,6 +119,12 @@ QualifyRenameStmt(RenameStmt *stmt)
 		{
 			QualifyRenameAttributeStmt(stmt);
 			return;
+		}
+
+		case OBJECT_PROCEDURE:
+		case OBJECT_FUNCTION:
+		{
+			QualifyRenameFunctionStmt(stmt);
 		}
 
 		default:
@@ -170,6 +188,12 @@ QualifyAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt)
 			return;
 		}
 
+		case OBJECT_PROCEDURE:
+		case OBJECT_FUNCTION:
+		{
+			QualifyAlterFunctionSchemaStmt(stmt);
+		}
+
 		default:
 		{
 			/* skip unsupported statements */
@@ -188,6 +212,31 @@ QualifyAlterOwnerStmt(AlterOwnerStmt *stmt)
 		{
 			QualifyAlterTypeOwnerStmt(stmt);
 			return;
+		}
+
+		case OBJECT_PROCEDURE:
+		case OBJECT_FUNCTION:
+		{
+			QualifyAlterFunctionOwnerStmt(stmt);
+		}
+
+		default:
+		{
+			return;
+		}
+	}
+}
+
+
+static void
+QualifyAlterObjectDependsStmt(AlterObjectDependsStmt *stmt)
+{
+	switch (stmt->objectType)
+	{
+		case OBJECT_PROCEDURE:
+		case OBJECT_FUNCTION:
+		{
+			QualifyAlterFunctionDependsStmt(stmt);
 		}
 
 		default:

--- a/src/backend/distributed/deparser/qualify_function_stmt.c
+++ b/src/backend/distributed/deparser/qualify_function_stmt.c
@@ -171,6 +171,7 @@ QualifyFunctionSchemaName(ObjectWithArgs *func, ObjectType type)
 		procform = (Form_pg_proc) GETSTRUCT(proctup);
 		schemaName = get_namespace_name(procform->pronamespace);
 		functionName = NameStr(procform->proname);
+		functionName = pstrdup(functionName); /* we release the tuple before used */
 
 		ReleaseSysCache(proctup);
 

--- a/src/backend/distributed/deparser/qualify_function_stmt.c
+++ b/src/backend/distributed/deparser/qualify_function_stmt.c
@@ -32,6 +32,14 @@ void QualifyFunction(ObjectWithArgs *func);
 void QualifyFunctionSchemaName(ObjectWithArgs *func);
 
 
+/*
+ * QualifyAlterFunctionStmt transforms a
+ * ALTER {FUNCTION|PROCEDURE} ..
+ * statement in place and makes all (supported) statements fully qualified.
+ *
+ * Note that not all queries of this form are valid AlterFunctionStmt
+ * (e.g. ALTER FUNCTION .. RENAME .. queries are RenameStmt )
+ */
 void
 QualifyAlterFunctionStmt(AlterFunctionStmt *stmt)
 {
@@ -39,58 +47,57 @@ QualifyAlterFunctionStmt(AlterFunctionStmt *stmt)
 }
 
 
+/*
+ * QualifyRenameFunctionStmt transforms a
+ * ALTER {FUNCTION|PROCEDURE} .. RENAME TO ..
+ * statement in place and makes the function name fully qualified.
+ */
 void
 QualifyRenameFunctionStmt(RenameStmt *stmt)
 {
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->renameType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->renameType == OBJECT_FUNCTION || stmt->renameType == OBJECT_PROCEDURE);
-#endif
-
 	QualifyFunction(castNode(ObjectWithArgs, stmt->object));
 }
 
 
+/*
+ * QualifyAlterFunctionSchemaStmt transforms a
+ * ALTER {FUNCTION|PROCEDURE} .. SET SCHEMA ..
+ * statement in place and makes the function name fully qualified.
+ */
 void
 QualifyAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt)
 {
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->objectType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
-#endif
-
 	QualifyFunction(castNode(ObjectWithArgs, stmt->object));
 }
 
 
+/*
+ * QualifyAlterFunctionOwnerStmt transforms a
+ * ALTER {FUNCTION|PROCEDURE} .. OWNER TO ..
+ * statement in place and makes the function name fully qualified.
+ */
 void
 QualifyAlterFunctionOwnerStmt(AlterOwnerStmt *stmt)
 {
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->objectType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
-#endif
-
 	QualifyFunction(castNode(ObjectWithArgs, stmt->object));
 }
 
 
+/*
+ * QualifyAlterFunctionDependsStmt transforms a
+ * ALTER {FUNCTION|PROCEDURE} .. DEPENDS ON EXTENSIOIN ..
+ * statement in place and makes the function name fully qualified.
+ */
 void
 QualifyAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt)
 {
-#if (PG_VERSION_NUM < 110000)
-	Assert(stmt->objectType == OBJECT_FUNCTION);
-#else
-	Assert(stmt->objectType == OBJECT_FUNCTION || stmt->objectType == OBJECT_PROCEDURE);
-#endif
-
 	QualifyFunction(castNode(ObjectWithArgs, stmt->object));
 }
 
 
+/*
+ * QualifyFunction transforms a function in place and makes it's name fully qualified.
+ */
 void
 QualifyFunction(ObjectWithArgs *func)
 {
@@ -108,6 +115,9 @@ QualifyFunction(ObjectWithArgs *func)
 }
 
 
+/*
+ * QualifyFunction transforms a function in place using a catalog lookup for its schema name to make it fully qualified.
+ */
 void
 QualifyFunctionSchemaName(ObjectWithArgs *func)
 {

--- a/src/backend/distributed/deparser/qualify_function_stmt.c
+++ b/src/backend/distributed/deparser/qualify_function_stmt.c
@@ -1,0 +1,50 @@
+/*-------------------------------------------------------------------------
+ *
+ * qualify_function_stmt.c
+ *	  Functions specialized in fully qualifying all function statements. These
+ *	  functions are dispatched from qualify.c
+ *
+ *	  Fully qualifying function statements consists of adding the schema name
+ *	  to the subject of the function and types as well as any other branch of
+ *    the parsetree.
+ *
+ *	  Goal would be that the deparser functions for these statements can
+ *	  serialize the statement without any external lookups.
+ *
+ * Copyright (c), Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "distributed/deparser.h"
+
+/* TODO: implement this and add some comments here */
+void
+QualifyAlterFunctionStmt(AlterFunctionStmt *stmt)
+{ }
+
+
+/* TODO: implement this and add some comments here */
+void
+QualifyRenameFunctionStmt(RenameStmt *stmt)
+{ }
+
+
+/* TODO: implement this and add some comments here */
+void
+QualifyAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt)
+{ }
+
+
+/* TODO: implement this and add some comments here */
+void
+QualifyAlterFunctionOwnerStmt(AlterOwnerStmt *stmt)
+{ }
+
+
+/* TODO: implement this and add some comments here */
+void
+QualifyAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt)
+{ }

--- a/src/backend/distributed/deparser/qualify_function_stmt.c
+++ b/src/backend/distributed/deparser/qualify_function_stmt.c
@@ -19,12 +19,13 @@
 #include "postgres.h"
 
 #include "access/htup_details.h"
-#include "distributed/deparser.h"
-#include "utils/syscache.h"
-#include "catalog/pg_proc.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_proc.h"
+#include "distributed/deparser.h"
+#include "distributed/version_compat.h"
 #include "parser/parse_func.h"
 #include "utils/lsyscache.h"
+#include "utils/syscache.h"
 
 /* forward declaration for qualify functions */
 void QualifyFunction(ObjectWithArgs *func);
@@ -116,7 +117,7 @@ QualifyFunctionSchemaName(ObjectWithArgs *func)
 	Oid funcid = InvalidOid;
 	HeapTuple proctup;
 
-	funcid = LookupFuncWithArgs(OBJECT_FUNCTION, func, true);
+	funcid = LookupFuncWithArgsCompat(OBJECT_FUNCTION, func, true);
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 
 	/*

--- a/src/backend/distributed/test/deparse_function_query.c
+++ b/src/backend/distributed/test/deparse_function_query.c
@@ -1,10 +1,10 @@
 /*-------------------------------------------------------------------------
  *
- * test/src/depase_function_query.c
+ * test/src/deparse_function_query.c
  *
  * This file contains functions to exercise deparsing of
- *  CREATE|ALTER|DROP [...] function/procedure ...
- * statements
+ *  CREATE|ALTER|DROP [...] {FUNCTION|PROCEDURE} ...
+ * queries
  *
  * Copyright (c) Citus Data, Inc.
  *
@@ -21,6 +21,12 @@
 PG_FUNCTION_INFO_V1(deparse_test);
 
 
+/*
+ * deparse_test UDF is a UDF to test deparsing in Citus.
+ *
+ * This function accepts a query string; parses, qualifies and then deparses it to create
+ * a qualified query string.
+ */
 Datum
 deparse_test(PG_FUNCTION_ARGS)
 {

--- a/src/backend/distributed/test/deparse_function_query.c
+++ b/src/backend/distributed/test/deparse_function_query.c
@@ -31,6 +31,7 @@ deparse_test(PG_FUNCTION_ARGS)
 
 	queryStringChar = text_to_cstring(queryStringText);
 	query = ParseQueryString(queryStringChar, NULL, 0);
+
 	QualifyTreeNode(query->utilityStmt);
 	deparsedQuery = DeparseTreeNode(query->utilityStmt);
 

--- a/src/backend/distributed/test/deparse_function_query.c
+++ b/src/backend/distributed/test/deparse_function_query.c
@@ -14,43 +14,25 @@
 #include "postgres.h"
 
 #include "distributed/deparser.h"
+#include "distributed/multi_executor.h"
 #include "utils/builtins.h"
-#include "tcop/tcopprot.h"
 
 /* declarations for dynamic loading */
 PG_FUNCTION_INFO_V1(deparse_test);
 
 
-/* TODO: Rewrite this using a ParseQueryString() call */
 Datum
 deparse_test(PG_FUNCTION_ARGS)
 {
 	text *queryStringText = PG_GETARG_TEXT_P(0);
-
 	char *queryStringChar = NULL;
-	List *parseTreeList = NIL;
-	ListCell *parseTreeCell = NULL;
-	StringInfo string = makeStringInfo();
+	Query *query = NULL;
+	const char *deparsedQuery = NULL;
 
 	queryStringChar = text_to_cstring(queryStringText);
-	parseTreeList = pg_parse_query(queryStringChar);
+	query = ParseQueryString(queryStringChar, NULL, 0);
+	QualifyTreeNode(query->utilityStmt);
+	deparsedQuery = DeparseTreeNode(query->utilityStmt);
 
-	foreach(parseTreeCell, parseTreeList)
-	{
-		RawStmt *parsetree = lfirst_node(RawStmt, parseTreeCell);
-		const char *deparsedQuery = NULL;
-
-		/* TODO: Do I need to call pg_analyze_and_rewrite? Do I need it to change parsetree? I guess not */
-		pg_analyze_and_rewrite(parsetree, queryStringChar, NULL, 0, NULL);
-
-		deparsedQuery = DeparseTreeNode(parsetree->stmt);
-
-		if (strcmp(string->data, "") != 0)
-		{
-			appendStringInfoString(string, "; ");
-		}
-		appendStringInfoString(string, deparsedQuery);
-	}
-
-	PG_RETURN_TEXT_P(cstring_to_text(string->data));
+	PG_RETURN_TEXT_P(cstring_to_text(deparsedQuery));
 }

--- a/src/backend/distributed/test/deparse_function_query.c
+++ b/src/backend/distributed/test/deparse_function_query.c
@@ -21,6 +21,7 @@
 PG_FUNCTION_INFO_V1(deparse_test);
 
 
+/* TODO: Rewrite this using a ParseQueryString() call */
 Datum
 deparse_test(PG_FUNCTION_ARGS)
 {
@@ -39,7 +40,7 @@ deparse_test(PG_FUNCTION_ARGS)
 		RawStmt *parsetree = lfirst_node(RawStmt, parseTreeCell);
 		const char *deparsedQuery = NULL;
 
-		/* TODO: Do I need to call pg_analyze_and_rewrite? Do I need it to change parsetree? */
+		/* TODO: Do I need to call pg_analyze_and_rewrite? Do I need it to change parsetree? I guess not */
 		pg_analyze_and_rewrite(parsetree, queryStringChar, NULL, 0, NULL);
 
 		deparsedQuery = DeparseTreeNode(parsetree->stmt);

--- a/src/backend/distributed/test/deparse_function_query.c
+++ b/src/backend/distributed/test/deparse_function_query.c
@@ -1,0 +1,55 @@
+/*-------------------------------------------------------------------------
+ *
+ * test/src/depase_function_query.c
+ *
+ * This file contains functions to exercise deparsing of
+ *  CREATE|ALTER|DROP [...] function/procedure ...
+ * statements
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "distributed/deparser.h"
+#include "utils/builtins.h"
+#include "tcop/tcopprot.h"
+
+/* declarations for dynamic loading */
+PG_FUNCTION_INFO_V1(deparse_test);
+
+
+Datum
+deparse_test(PG_FUNCTION_ARGS)
+{
+	text *queryStringText = PG_GETARG_TEXT_P(0);
+
+	char *queryStringChar = NULL;
+	List *parseTreeList = NIL;
+	ListCell *parseTreeCell = NULL;
+	StringInfo string = makeStringInfo();
+
+	queryStringChar = text_to_cstring(queryStringText);
+	parseTreeList = pg_parse_query(queryStringChar);
+
+	foreach(parseTreeCell, parseTreeList)
+	{
+		RawStmt *parsetree = lfirst_node(RawStmt, parseTreeCell);
+		const char *deparsedQuery = NULL;
+
+		/* TODO: Do I need to call pg_analyze_and_rewrite? Do I need it to change parsetree? */
+		pg_analyze_and_rewrite(parsetree, queryStringChar, NULL, 0, NULL);
+
+		deparsedQuery = DeparseTreeNode(parsetree->stmt);
+
+		if (strcmp(string->data, "") != 0)
+		{
+			appendStringInfoString(string, "; ");
+		}
+		appendStringInfoString(string, deparsedQuery);
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text(string->data));
+}

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -52,4 +52,9 @@ extern void QualifyAlterTypeOwnerStmt(AlterOwnerStmt *stmt);
 extern const ObjectAddress * GetObjectAddressFromParseTree(Node *parseTree, bool
 														   missing_ok);
 
+/* forward declarations for deparse_function_stmts.c */
+extern const char * DeparseDropFunctionStmt(DropStmt *stmt);
+extern const char * DeparseAlterFunctionStmt(AlterFunctionStmt *stmt);
+
+
 #endif /* CITUS_DEPARSER_H */

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -56,5 +56,10 @@ extern const ObjectAddress * GetObjectAddressFromParseTree(Node *parseTree, bool
 extern const char * DeparseDropFunctionStmt(DropStmt *stmt);
 extern const char * DeparseAlterFunctionStmt(AlterFunctionStmt *stmt);
 
+extern void QualifyAlterFunctionStmt(AlterFunctionStmt *stmt);
+extern void QualifyRenameFunctionStmt(RenameStmt *stmt);
+extern void QualifyAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt);
+extern void QualifyAlterFunctionOwnerStmt(AlterOwnerStmt *stmt);
+extern void QualifyAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt);
 
 #endif /* CITUS_DEPARSER_H */

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -56,6 +56,11 @@ extern const ObjectAddress * GetObjectAddressFromParseTree(Node *parseTree, bool
 extern const char * DeparseDropFunctionStmt(DropStmt *stmt);
 extern const char * DeparseAlterFunctionStmt(AlterFunctionStmt *stmt);
 
+extern const char * DeparseRenameFunctionStmt(RenameStmt *stmt);
+extern const char * DeparseAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt);
+extern const char * DeparseAlterFunctionOwnerStmt(AlterOwnerStmt *stmt);
+extern const char * DeparseAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt);
+
 extern void QualifyAlterFunctionStmt(AlterFunctionStmt *stmt);
 extern void QualifyRenameFunctionStmt(RenameStmt *stmt);
 extern void QualifyAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt);

--- a/src/include/distributed/version_compat.h
+++ b/src/include/distributed/version_compat.h
@@ -15,6 +15,7 @@
 #include "commands/explain.h"
 #include "catalog/namespace.h"
 #include "nodes/parsenodes.h"
+#include "parser/parse_func.h"
 
 #if (PG_VERSION_NUM >= 120000)
 #include "optimizer/optimizer.h"
@@ -165,6 +166,25 @@ get_expr_result_tupdesc(Node *expr, bool noError)
 	return NULL;
 }
 
+
+/* following compat function and macro should be removed when we drop support for PG10 */
+static inline Oid
+LookupFuncWithArgsCompat(ObjectType objtype, ObjectWithArgs *func, bool noError)
+{
+	if (objtype == OBJECT_FUNCTION)
+	{
+		return LookupFuncWithArgs(func, noError);
+	}
+	else if (objtype == OBJECT_AGGREGATE)
+	{
+		return LookupAggWithArgs(func, noError);
+	}
+
+	return InvalidOid;
+}
+
+
+#define LookupFuncWithArgs LookupFuncWithArgsCompat
 
 #endif
 

--- a/src/include/distributed/version_compat.h
+++ b/src/include/distributed/version_compat.h
@@ -184,8 +184,6 @@ LookupFuncWithArgsCompat(ObjectType objtype, ObjectWithArgs *func, bool noError)
 }
 
 
-#define LookupFuncWithArgs LookupFuncWithArgsCompat
-
 #endif
 
 #if (PG_VERSION_NUM >= 110000)
@@ -259,6 +257,14 @@ RangeVarGetRelidInternal(const RangeVar *relation, LOCKMODE lockmode, uint32 fla
 						 RangeVarGetRelidCallback callback, void *callback_arg)
 {
 	return RangeVarGetRelidExtended(relation, lockmode, flags, callback, callback_arg);
+}
+
+
+/* following compat function and macro should be removed when we drop support for PG10 */
+static inline Oid
+LookupFuncWithArgsCompat(ObjectType objtype, ObjectWithArgs *func, bool noError)
+{
+	return LookupFuncWithArgs(objtype, func, noError);
 }
 
 

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -283,7 +283,7 @@ CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages FROM CURRENT
 $cmd$);
-INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages FROM CURRENT;
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages TO warning;
 CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
       deparse_and_run_on_workers      
 --------------------------------------

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -283,7 +283,7 @@ CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages FROM CURRENT
 $cmd$);
-INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages TO warning;
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages FROM CURRENT;
 CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
       deparse_and_run_on_workers      
 --------------------------------------

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -473,8 +473,8 @@ CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
 CREATE SCHEMA "CiTuS.TeeN";
 CREATE SCHEMA "CiTUS.TEEN2";
 SELECT run_command_on_workers($$
-    CREATE SCHEMA "CiTuS.TeeN";
-    CREATE SCHEMA "CiTUS.TEEN2";
+    CREATE SCHEMA IF NOT EXISTS "CiTuS.TeeN";
+    CREATE SCHEMA IF NOT EXISTS "CiTUS.TEEN2";
 $$);
        run_command_on_workers        
 -------------------------------------

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -411,13 +411,25 @@ CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
  (localhost,57638,t,"ALTER FUNCTION")
 (2 rows)
 
+-- make sure "any" type is correctly deparsed
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION pg_catalog.get_shard_id_for_distribution_column(table_name regclass, distribution_value "any") PARALLEL SAFE;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION pg_catalog.get_shard_id_for_distribution_column(table_name regclass, distribution_value "any") PARALLEL SAFE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
 -- Do not run valid drop queries in the workers
 SELECT deparse_test($cmd$
 DROP FUNCTION add(int,int);
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- DROP FUNCTION function_tests.add(pg_catalog.int4,pg_catalog.int4);
+                    deparse_test                     
+-----------------------------------------------------
+ DROP FUNCTION function_tests.add(integer, integer);
 (1 row)
 
 -- have multiple actions in a single query
@@ -462,6 +474,17 @@ SELECT deparse_and_run_on_workers($cmd$
 DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
 $cmd$);
 INFO:  Propagating deparsed query: DROP FUNCTION IF EXISTS missing_schema.missing_function(pg_catalog.int4,pg_catalog.float8);
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+     deparse_and_run_on_workers      
+-------------------------------------
+ (localhost,57637,t,"DROP FUNCTION")
+ (localhost,57638,t,"DROP FUNCTION")
+(2 rows)
+
+SELECT deparse_and_run_on_workers($cmd$
+DROP FUNCTION IF EXISTS missing_func_without_args;
+$cmd$);
+INFO:  Propagating deparsed query: DROP FUNCTION IF EXISTS missing_func_without_args;
 CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
      deparse_and_run_on_workers      
 -------------------------------------

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -1,7 +1,8 @@
 --
 -- Regression tests for deparsing ALTER/DROP FUNCTION Queries
 --
--- This test implements all the possible queries as of Postgres 11:
+-- This test implements all the possible queries as of Postgres 11
+-- in the order they are listed in the docs
 -- 
 -- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
 --     action [ ... ] [ RESTRICT ]
@@ -38,274 +39,646 @@ CREATE FUNCTION deparse_test(text)
 	RETURNS text
 	AS 'citus'
  	LANGUAGE C STRICT;
--- Create a simple function
+CREATE OR REPLACE FUNCTION deparse_and_run_on_workers(IN query text,
+                                                     OUT nodename text,
+                                                     OUT nodeport int,
+                                                     OUT success bool,
+                                                     OUT result text)
+    RETURNS SETOF record
+    LANGUAGE PLPGSQL AS $fnc$
+    DECLARE
+        deparsed_query character varying(255);
+    BEGIN
+        deparsed_query := ( SELECT deparse_test($1) );
+        RAISE INFO 'Propagating deparsed query: %', deparsed_query;
+        RETURN QUERY SELECT * FROM run_command_on_workers(deparsed_query);
+    END;
+    $fnc$;
+-- Create a simple function and distribute it
 CREATE FUNCTION add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
-SELECT deparse_test($cmd$
+SELECT create_distributed_function('add(int,int)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add CALLED ON NULL INPUT
 $cmd$);
-                               deparse_test                                
----------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) CALLED ON NULL INPUT;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) CALLED ON NULL INPUT;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+-- RETURNS NULL ON NULL INPUT and STRICT are synonyms and can be used interchangeably
+-- RETURNS NULL ON NULL INPUT is actually stored as STRICT in the query parse tree
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RETURNS NULL ON NULL INPUT
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) STRICT;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) STRICT;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add STRICT
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) STRICT;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) STRICT;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add IMMUTABLE
 $cmd$);
-                          deparse_test                          
-----------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) immutable;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) IMMUTABLE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add STABLE
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) stable;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) STABLE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add VOLATILE
 $cmd$);
-                         deparse_test                          
----------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) volatile;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) VOLATILE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add LEAKPROOF
 $cmd$);
-                          deparse_test                          
-----------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) LEAKPROOF;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) LEAKPROOF;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add NOT LEAKPROOF
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) NOT LEAKPROOF;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) NOT LEAKPROOF;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+-- EXTERNAL keyword is ignored by Postgres Parser. It is allowed only for SQL conformance
+-- The following queries will not have the EXTERNAL keyword after deparsing
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  FUNCTION add EXTERNAL SECURITY INVOKER
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SECURITY INVOKER;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SECURITY INVOKER;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add SECURITY INVOKER
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SECURITY INVOKER;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SECURITY INVOKER;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  FUNCTION add EXTERNAL SECURITY DEFINER
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SECURITY DEFINER;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SECURITY DEFINER;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add SECURITY DEFINER
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SECURITY DEFINER;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SECURITY DEFINER;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add PARALLEL UNSAFE
 $cmd$);
-                             deparse_test                             
-----------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) PARALLEL unsafe;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) PARALLEL UNSAFE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add PARALLEL RESTRICTED
 $cmd$);
-                               deparse_test                               
---------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) PARALLEL restricted;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) PARALLEL RESTRICTED;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add PARALLEL SAFE
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) PARALLEL safe;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) PARALLEL SAFE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
--- The COST/ROWS arguments should always be numeric
-SELECT deparse_test($cmd$
+-- The COST arguments should always be numeric
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add COST 1234
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) COST 1234.000000;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) COST 1234.000000;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  FUNCTION add COST 1234.5
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) COST 1234.500000;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) COST 1234.500000;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
-ALTER FUNCTION add ROWS 10
-$cmd$);
-                             deparse_test                             
-----------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) ROWS  10.000000;
-(1 row)
-
-SELECT deparse_test($cmd$
-ALTER  FUNCTION add ROWS 10.8
-$cmd$);
-                             deparse_test                             
-----------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) ROWS  10.800000;
-(1 row)
-
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages = ERROR
 $cmd$);
-                                   deparse_test                                    
------------------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages = error;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages = error;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages TO DEFAULT
 $cmd$);
-                                     deparse_test                                     
---------------------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages TO DEFAULT;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages TO DEFAULT;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages FROM CURRENT
 $cmd$);
-                                      deparse_test                                      
-----------------------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages FROM CURRENT;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages FROM CURRENT;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RESET log_min_messages
 $cmd$);
-                                deparse_test                                 
------------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) RESET log_min_messages;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) RESET log_min_messages;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RESET ALL
 $cmd$);
-                          deparse_test                          
-----------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) RESET ALL;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) RESET ALL;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+-- Rename the function in the workers
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RENAME TO summation
 $cmd$);
-                               deparse_test                               
---------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) RENAME TO summation;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) RENAME TO summation;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
+-- Rename the function inb the coordinator as well.
+-- This is needed so the next query is parsed on the coordinator
+ALTER FUNCTION add RENAME TO summation;
+-- Rename it back to the original so that the next tests can pass
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION summation RENAME TO add
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.summation(integer, integer) RENAME TO add;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- Rename the function back to the original name in the coordinator
+ALTER FUNCTION summation RENAME TO add;
 CREATE ROLE function_role;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-SELECT deparse_test($cmd$
+SELECT run_command_on_workers('CREATE ROLE function_role');
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add OWNER TO function_role
 $cmd$);
-                                deparse_test                                 
------------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) OWNER TO function_role;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) OWNER TO function_role;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add OWNER TO missing_role
 $cmd$);
-                                deparse_test                                
-----------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) OWNER TO missing_role;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) OWNER TO missing_role;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+                     deparse_and_run_on_workers                     
+--------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  role ""missing_role"" does not exist")
+ (localhost,57638,f,"ERROR:  role ""missing_role"" does not exist")
+(2 rows)
 
-SELECT deparse_test($cmd$
+-- SET the schema in workers as well as the coordinator so that it remains in the same schema
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add SET SCHEMA public
 $cmd$);
-                              deparse_test                              
-------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) SET SCHEMA public;
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) SET SCHEMA public;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+ALTER FUNCTION add SET SCHEMA public;
+-- Revert the schema back
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION public.add SET SCHEMA function_tests
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION public.add(integer, integer) SET SCHEMA function_tests;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+ALTER FUNCTION public.add SET SCHEMA function_tests;
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add DEPENDS ON EXTENSION citus
 $cmd$);
-                                  deparse_test                                   
----------------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add(integer, integer) DEPENDS ON EXTENSION citus;
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) DEPENDS ON EXTENSION citus;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- Do not run valid drop queries in the workers
+SELECT deparse_test($cmd$
+DROP FUNCTION add(int,int);
+$cmd$);
+                            deparse_test                            
+--------------------------------------------------------------------
+ DROP FUNCTION function_tests.add(pg_catalog.int4,pg_catalog.int4);
 (1 row)
 
-SELECT deparse_test($cmd$
-DROP FUNCTION IF EXISTS add(int,int);
+-- have multiple actions in a single query
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION add volatile leakproof SECURITY DEFINER PARALLEL unsafe;
 $cmd$);
-                                 deparse_test                                 
-------------------------------------------------------------------------------
- DROP FUNCTION IF EXISTS function_tests.add(pg_catalog.int4,pg_catalog.int4);
-(1 row)
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.add(integer, integer) VOLATILE LEAKPROOF SECURITY DEFINER PARALLEL UNSAFE;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
 -- Check that an invalid function name is still parsed correctly
-SELECT deparse_test($cmd$
+-- Test that it fails when run without IF EXISTS clause
+SELECT deparse_and_run_on_workers($cmd$
+DROP FUNCTION missing_function(int, text);
+$cmd$);
+INFO:  Propagating deparsed query: DROP FUNCTION missing_function(pg_catalog.int4,text);
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+                              deparse_and_run_on_workers                               
+---------------------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  function missing_function(integer, text) does not exist")
+ (localhost,57638,f,"ERROR:  function missing_function(integer, text) does not exist")
+(2 rows)
+
+-- Check that an invalid function name is still parsed correctly
+-- Test that it is successful when run with IF EXISTS clause
+SELECT deparse_and_run_on_workers($cmd$
 DROP FUNCTION IF EXISTS missing_function(int, text);
 $cmd$);
-                          deparse_test                           
------------------------------------------------------------------
- DROP FUNCTION IF EXISTS missing_function(pg_catalog.int4,text);
-(1 row)
+INFO:  Propagating deparsed query: DROP FUNCTION IF EXISTS missing_function(pg_catalog.int4,text);
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+     deparse_and_run_on_workers      
+-------------------------------------
+ (localhost,57637,t,"DROP FUNCTION")
+ (localhost,57638,t,"DROP FUNCTION")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
 $cmd$);
-                                        deparse_test                                         
----------------------------------------------------------------------------------------------
- DROP FUNCTION IF EXISTS missing_schema.missing_function(pg_catalog.int4,pg_catalog.float8);
+INFO:  Propagating deparsed query: DROP FUNCTION IF EXISTS missing_schema.missing_function(pg_catalog.int4,pg_catalog.float8);
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+     deparse_and_run_on_workers      
+-------------------------------------
+ (localhost,57637,t,"DROP FUNCTION")
+ (localhost,57638,t,"DROP FUNCTION")
+(2 rows)
+
+-- create schema with weird names
+CREATE SCHEMA "CiTuS.TeeN";
+CREATE SCHEMA "CiTUS.TEEN2";
+SELECT run_command_on_workers($$
+    CREATE SCHEMA "CiTuS.TeeN";
+    CREATE SCHEMA "CiTUS.TEEN2";
+$$);
+       run_command_on_workers        
+-------------------------------------
+ (localhost,57637,t,"CREATE SCHEMA")
+ (localhost,57638,t,"CREATE SCHEMA")
+(2 rows)
+
+-- create table with weird names
+CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() RETURNS TEXT
+    AS $$ SELECT 'test function without params' $$
+    LANGUAGE SQL;
+CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text) RETURNS TEXT
+    AS $$ SELECT 'Overloaded function called with param: ' || $1 $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"()');
+ create_distributed_function 
+-----------------------------
+ 
 (1 row)
+
+SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() SET SCHEMA "CiTUS.TEEN2"
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() SET SCHEMA "CiTUS.TEEN2";
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- drop 2 functions at the same time
+SELECT deparse_and_run_on_workers($cmd$
+DROP FUNCTION "CiTUS.TEEN2"."TeeNFunCT10N.1!?!"(),"CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text);
+$cmd$);
+INFO:  Propagating deparsed query: DROP FUNCTION "CiTUS.TEEN2"."TeeNFunCT10N.1!?!"(), "CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text);
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+     deparse_and_run_on_workers      
+-------------------------------------
+ (localhost,57637,t,"DROP FUNCTION")
+ (localhost,57638,t,"DROP FUNCTION")
+(2 rows)
+
+-- a function with a default parameter
+CREATE FUNCTION func_default_param(param INT DEFAULT 0) RETURNS TEXT
+    AS $$ SELECT 'supplied param is : ' || param; $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_default_param(INT)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_default_param RENAME TO func_with_default_param;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.func_default_param(param integer) RENAME TO func_with_default_param;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- a function with IN and OUT parameters
+CREATE FUNCTION func_out_param(IN param INT, OUT result TEXT)
+    AS $$ SELECT 'supplied param is : ' || param; $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_out_param(INT)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_out_param RENAME TO func_in_and_out_param;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.func_out_param(param integer, OUT result text) RENAME TO func_in_and_out_param;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- a function with INOUT parameter
+CREATE FUNCTION square(INOUT a NUMERIC)
+AS $$
+BEGIN
+   a := a * a;
+END; $$
+LANGUAGE plpgsql;
+SELECT create_distributed_function('square(NUMERIC)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION square SET search_path TO DEFAULT;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.square(INOUT a numeric) SET search_path TO DEFAULT;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- a function with variadic input. 
+CREATE FUNCTION sum_avg(
+   VARIADIC list NUMERIC[],
+   OUT total NUMERIC,
+   OUT average NUMERIC)
+AS $$
+BEGIN
+   SELECT INTO total SUM(list[i])
+   FROM generate_subscripts(list, 1) g(i);
+ 
+   SELECT INTO average AVG(list[i])
+   FROM generate_subscripts(list, 1) g(i);
+END; $$
+LANGUAGE plpgsql;
+SELECT create_distributed_function('sum_avg(NUMERIC[])');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION sum_avg COST 10000;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.sum_avg(VARIADIC list numeric[], OUT total numeric, OUT average numeric) COST 10000.000000;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- a function with a custom type IN parameter 
+CREATE TYPE intpair AS (x int, y int);
+CREATE FUNCTION func_custom_param(IN param intpair, OUT total INT)
+    AS $$ SELECT param.x + param.y $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_custom_param(intpair)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_custom_param RENAME TO func_with_custom_param;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.func_custom_param(param function_tests.intpair, OUT total integer) RENAME TO func_with_custom_param;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
+
+-- a function that returns TABLE
+CREATE FUNCTION func_returns_table(IN count INT)
+    RETURNS TABLE (x INT, y INT)
+    AS $$ SELECT i,i FROM generate_series(1,count) i $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_returns_table(INT)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_returns_table ROWS 100;
+$cmd$);
+INFO:  Propagating deparsed query: ALTER FUNCTION function_tests.func_returns_table(count integer) ROWS  100.000000;
+CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line 6 at RAISE
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"ALTER FUNCTION")
+ (localhost,57638,t,"ALTER FUNCTION")
+(2 rows)
 
 -- clear objects
 SET client_min_messages TO WARNING; -- suppress cascading objects dropping
+DROP SCHEMA "CiTuS.TeeN" CASCADE;
+DROP SCHEMA "CiTUS.TEEN2" CASCADE;
 DROP SCHEMA function_tests CASCADE;
+SELECT run_command_on_workers($$
+    DROP SCHEMA "CiTuS.TeeN" CASCADE;
+    DROP SCHEMA "CiTUS.TEEN2" CASCADE;
+    DROP SCHEMA function_tests CASCADE;
+$$);
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"DROP SCHEMA")
+ (localhost,57638,t,"DROP SCHEMA")
+(2 rows)
+
 DROP ROLE function_role;

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -47,202 +47,202 @@ CREATE FUNCTION add(integer, integer) RETURNS integer
 SELECT deparse_test($cmd$
 ALTER FUNCTION  add CALLED ON NULL INPUT
 $cmd$);
-                       deparse_test                        
------------------------------------------------------------
- ALTER FUNCTION function_tests.add() CALLED ON NULL INPUT;
+                               deparse_test                                
+---------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) CALLED ON NULL INPUT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add RETURNS NULL ON NULL INPUT
 $cmd$);
-                deparse_test                 
----------------------------------------------
- ALTER FUNCTION function_tests.add() STRICT;
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) STRICT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add STRICT
 $cmd$);
-                deparse_test                 
----------------------------------------------
- ALTER FUNCTION function_tests.add() STRICT;
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) STRICT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add IMMUTABLE
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER FUNCTION function_tests.add() immutable;
+                          deparse_test                          
+----------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) immutable;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add STABLE
 $cmd$);
-                deparse_test                 
----------------------------------------------
- ALTER FUNCTION function_tests.add() stable;
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) stable;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add VOLATILE
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION function_tests.add() volatile;
+                         deparse_test                          
+---------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) volatile;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add LEAKPROOF
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER FUNCTION function_tests.add() LEAKPROOF;
+                          deparse_test                          
+----------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) LEAKPROOF;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add NOT LEAKPROOF
 $cmd$);
-                    deparse_test                    
-----------------------------------------------------
- ALTER FUNCTION function_tests.add() NOT LEAKPROOF;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) NOT LEAKPROOF;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  FUNCTION add EXTERNAL SECURITY INVOKER
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER FUNCTION function_tests.add() SECURITY INVOKER;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SECURITY INVOKER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add SECURITY INVOKER
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER FUNCTION function_tests.add() SECURITY INVOKER;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SECURITY INVOKER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  FUNCTION add EXTERNAL SECURITY DEFINER
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER FUNCTION function_tests.add() SECURITY DEFINER;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SECURITY DEFINER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add SECURITY DEFINER
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER FUNCTION function_tests.add() SECURITY DEFINER;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SECURITY DEFINER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add PARALLEL UNSAFE
 $cmd$);
-                     deparse_test                     
-------------------------------------------------------
- ALTER FUNCTION function_tests.add() PARALLEL unsafe;
+                             deparse_test                             
+----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) PARALLEL unsafe;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add PARALLEL RESTRICTED
 $cmd$);
-                       deparse_test                       
-----------------------------------------------------------
- ALTER FUNCTION function_tests.add() PARALLEL restricted;
+                               deparse_test                               
+--------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) PARALLEL restricted;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add PARALLEL SAFE
 $cmd$);
-                    deparse_test                    
-----------------------------------------------------
- ALTER FUNCTION function_tests.add() PARALLEL safe;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) PARALLEL safe;
 (1 row)
 
 -- The COST/ROWS arguments should always be numeric
 SELECT deparse_test($cmd$
 ALTER FUNCTION add COST 1234
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER FUNCTION function_tests.add() COST 1234.000000;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) COST 1234.000000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  FUNCTION add COST 1234.5
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER FUNCTION function_tests.add() COST 1234.500000;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) COST 1234.500000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add ROWS 10
 $cmd$);
-                     deparse_test                     
-------------------------------------------------------
- ALTER FUNCTION function_tests.add() ROWS  10.000000;
+                             deparse_test                             
+----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) ROWS  10.000000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  FUNCTION add ROWS 10.8
 $cmd$);
-                     deparse_test                     
-------------------------------------------------------
- ALTER FUNCTION function_tests.add() ROWS  10.800000;
+                             deparse_test                             
+----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) ROWS  10.800000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION  add SET log_min_messages = ERROR
 $cmd$);
-                           deparse_test                            
--------------------------------------------------------------------
- ALTER FUNCTION function_tests.add() SET log_min_messages = error;
+                                   deparse_test                                    
+-----------------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages = error;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION  add SET log_min_messages TO DEFAULT
 $cmd$);
-                             deparse_test                             
-----------------------------------------------------------------------
- ALTER FUNCTION function_tests.add() SET log_min_messages TO DEFAULT;
+                                     deparse_test                                     
+--------------------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages TO DEFAULT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION  add SET log_min_messages FROM CURRENT
 $cmd$);
-                              deparse_test                              
-------------------------------------------------------------------------
- ALTER FUNCTION function_tests.add() SET log_min_messages FROM CURRENT;
+                                      deparse_test                                      
+----------------------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SET log_min_messages FROM CURRENT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add RESET log_min_messages
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER FUNCTION function_tests.add() RESET log_min_messages;
+                                deparse_test                                 
+-----------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) RESET log_min_messages;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add RESET ALL
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER FUNCTION function_tests.add() RESET ALL;
+                          deparse_test                          
+----------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) RESET ALL;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add RENAME TO summation
 $cmd$);
-                       deparse_test                       
-----------------------------------------------------------
- ALTER FUNCTION function_tests.add() RENAME TO summation;
+                               deparse_test                               
+--------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) RENAME TO summation;
 (1 row)
 
 CREATE ROLE function_role;
@@ -251,33 +251,33 @@ HINT:  Connect to worker nodes directly to manually create all necessary users a
 SELECT deparse_test($cmd$
 ALTER FUNCTION add OWNER TO function_role
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER FUNCTION function_tests.add() OWNER TO function_role;
+                                deparse_test                                 
+-----------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) OWNER TO function_role;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add OWNER TO missing_role
 $cmd$);
-                        deparse_test                        
-------------------------------------------------------------
- ALTER FUNCTION function_tests.add() OWNER TO missing_role;
+                                deparse_test                                
+----------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) OWNER TO missing_role;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add SET SCHEMA public
 $cmd$);
-                      deparse_test                      
---------------------------------------------------------
- ALTER FUNCTION function_tests.add() SET SCHEMA public;
+                              deparse_test                              
+------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) SET SCHEMA public;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add DEPENDS ON EXTENSION citus
 $cmd$);
-                          deparse_test                           
------------------------------------------------------------------
- ALTER FUNCTION function_tests.add() DEPENDS ON EXTENSION citus;
+                                  deparse_test                                   
+---------------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add(integer, integer) DEPENDS ON EXTENSION citus;
 (1 row)
 
 SELECT deparse_test($cmd$
@@ -306,6 +306,6 @@ $cmd$);
 (1 row)
 
 -- clear objects
-SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+SET client_min_messages TO WARNING; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
 DROP ROLE function_role;

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -1,0 +1,267 @@
+--
+-- Regression tests for deparsing ALTER/DROP TABLE Queries
+--
+-- This test implements all the possible queries as of Postgres 11:
+-- 
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     action [ ... ] [ RESTRICT ]
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     RENAME TO new_name
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     OWNER TO { new_owner | CURRENT_USER | SESSION_USER }
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     SET SCHEMA new_schema
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     DEPENDS ON EXTENSION extension_name
+-- 
+-- where action is one of:
+-- 
+--     CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT
+--     IMMUTABLE | STABLE | VOLATILE | [ NOT ] LEAKPROOF
+--     [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
+--     PARALLEL { UNSAFE | RESTRICTED | SAFE }
+--     COST execution_cost
+--     ROWS result_rows
+--     SET configuration_parameter { TO | = } { value | DEFAULT }
+--     SET configuration_parameter FROM CURRENT
+--     RESET configuration_parameter
+--     RESET ALL
+-- 
+-- DROP FUNCTION [ IF EXISTS ] name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ] [, ...]
+--     [ CASCADE | RESTRICT ]
+SET citus.next_shard_id TO 20020000;
+CREATE SCHEMA function_tests;
+SET search_path TO function_tests;
+SET citus.shard_count TO 4;
+SET client_min_messages TO DEBUG;
+CREATE FUNCTION deparse_test(text)
+	RETURNS text
+	AS 'citus'
+ 	LANGUAGE C STRICT;
+-- Create a simple function
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add CALLED ON NULL INPUT
+$cmd$);
+                       deparse_test                        
+-----------------------------------------------------------
+ ALTER FUNCTION function_tests.add() CALLED ON NULL INPUT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add  RETURNS NULL ON NULL INPUT
+$cmd$);
+                deparse_test                 
+---------------------------------------------
+ ALTER FUNCTION function_tests.add() STRICT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add STRICT
+$cmd$);
+                deparse_test                 
+---------------------------------------------
+ ALTER FUNCTION function_tests.add() STRICT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add IMMUTABLE
+$cmd$);
+                  deparse_test                  
+------------------------------------------------
+ ALTER FUNCTION function_tests.add() immutable;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add STABLE
+$cmd$);
+                deparse_test                 
+---------------------------------------------
+ ALTER FUNCTION function_tests.add() stable;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add VOLATILE
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION function_tests.add() volatile;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add LEAKPROOF
+$cmd$);
+                  deparse_test                  
+------------------------------------------------
+ ALTER FUNCTION function_tests.add() LEAKPROOF;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add NOT LEAKPROOF
+$cmd$);
+                    deparse_test                    
+----------------------------------------------------
+ ALTER FUNCTION function_tests.add() NOT LEAKPROOF;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add EXTERNAL SECURITY INVOKER
+$cmd$);
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SECURITY INVOKER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add SECURITY INVOKER
+$cmd$);
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SECURITY INVOKER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add EXTERNAL SECURITY DEFINER
+$cmd$);
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SECURITY DEFINER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add SECURITY DEFINER
+$cmd$);
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SECURITY DEFINER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add PARALLEL UNSAFE
+$cmd$);
+                     deparse_test                     
+------------------------------------------------------
+ ALTER FUNCTION function_tests.add() PARALLEL unsafe;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add PARALLEL RESTRICTED
+$cmd$);
+                       deparse_test                       
+----------------------------------------------------------
+ ALTER FUNCTION function_tests.add() PARALLEL restricted;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add PARALLEL SAFE
+$cmd$);
+                    deparse_test                    
+----------------------------------------------------
+ ALTER FUNCTION function_tests.add() PARALLEL safe;
+(1 row)
+
+-- The COST/ROWS arguments should always be numeric
+SELECT deparse_test($cmd$
+ALTER FUNCTION add COST 1234
+$cmd$);
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER FUNCTION function_tests.add() COST 1234.000000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add COST 1234.5
+$cmd$);
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER FUNCTION function_tests.add() COST 1234.500000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add ROWS 10
+$cmd$);
+                     deparse_test                     
+------------------------------------------------------
+ ALTER FUNCTION function_tests.add() ROWS  10.000000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add ROWS 10.8
+$cmd$);
+                     deparse_test                     
+------------------------------------------------------
+ ALTER FUNCTION function_tests.add() ROWS  10.800000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add SET log_min_messages = ERROR
+$cmd$);
+                           deparse_test                            
+-------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SET log_min_messages = error;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add SET log_min_messages TO DEFAULT
+$cmd$);
+                             deparse_test                             
+----------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SET log_min_messages TO DEFAULT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add SET log_min_messages FROM CURRENT
+$cmd$);
+                              deparse_test                              
+------------------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SET log_min_messages FROM CURRENT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add RESET log_min_messages
+$cmd$);
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() RESET log_min_messages;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add RESET ALL
+$cmd$);
+                  deparse_test                  
+------------------------------------------------
+ ALTER FUNCTION function_tests.add() RESET ALL;
+(1 row)
+
+SELECT deparse_test($cmd$
+DROP FUNCTION IF EXISTS add(int,int);
+$cmd$);
+                                 deparse_test                                 
+------------------------------------------------------------------------------
+ DROP FUNCTION IF EXISTS function_tests.add(pg_catalog.int4,pg_catalog.int4);
+(1 row)
+
+-- Check that an invalid function name is still parsed correctly
+SELECT deparse_test($cmd$
+DROP FUNCTION IF EXISTS missing_function(int, text);
+$cmd$);
+                          deparse_test                           
+-----------------------------------------------------------------
+ DROP FUNCTION IF EXISTS missing_function(pg_catalog.int4,text);
+(1 row)
+
+SELECT deparse_test($cmd$
+DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
+$cmd$);
+                                        deparse_test                                         
+---------------------------------------------------------------------------------------------
+ DROP FUNCTION IF EXISTS missing_schema.missing_function(pg_catalog.int4,pg_catalog.float8);
+(1 row)
+
+-- clear objects
+SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+DROP SCHEMA function_tests CASCADE;

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -238,6 +238,56 @@ $cmd$);
 (1 row)
 
 SELECT deparse_test($cmd$
+ALTER FUNCTION add RENAME TO summation
+$cmd$);
+                       deparse_test                       
+----------------------------------------------------------
+ ALTER FUNCTION function_tests.add() RENAME TO summation;
+(1 row)
+
+CREATE ROLE function_role;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SELECT run_command_on_workers('CREATE ROLE function_role');
+DEBUG:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+DETAIL:  NOTICE from localhost:57637
+CONTEXT:  PL/pgSQL function run_command_on_workers(text,boolean) line 13 at RETURN QUERY
+DEBUG:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+DETAIL:  NOTICE from localhost:57638
+CONTEXT:  PL/pgSQL function run_command_on_workers(text,boolean) line 13 at RETURN QUERY
+      run_command_on_workers       
+-----------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add OWNER TO function_role
+$cmd$);
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() OWNER TO function_role;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add SET SCHEMA public
+$cmd$);
+                      deparse_test                      
+--------------------------------------------------------
+ ALTER FUNCTION function_tests.add() SET SCHEMA public;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add DEPENDS ON EXTENSION citus
+$cmd$);
+                          deparse_test                           
+-----------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() DEPENDS ON EXTENSION citus;
+(1 row)
+
+SELECT deparse_test($cmd$
 DROP FUNCTION IF EXISTS add(int,int);
 $cmd$);
                                  deparse_test                                 
@@ -265,3 +315,11 @@ $cmd$);
 -- clear objects
 SET client_min_messages TO FATAL; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
+DROP ROLE function_role;
+SELECT result FROM run_command_on_workers('DROP ROLE function_role');
+  result   
+-----------
+ DROP ROLE
+ DROP ROLE
+(2 rows)
+

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -33,7 +33,7 @@ SET citus.next_shard_id TO 20020000;
 CREATE SCHEMA function_tests;
 SET search_path TO function_tests;
 SET citus.shard_count TO 4;
-SET client_min_messages TO DEBUG;
+SET client_min_messages TO INFO;
 CREATE FUNCTION deparse_test(text)
 	RETURNS text
 	AS 'citus'
@@ -53,7 +53,7 @@ $cmd$);
 (1 row)
 
 SELECT deparse_test($cmd$
-ALTER FUNCTION add  RETURNS NULL ON NULL INPUT
+ALTER FUNCTION add RETURNS NULL ON NULL INPUT
 $cmd$);
                 deparse_test                 
 ---------------------------------------------
@@ -248,27 +248,20 @@ $cmd$);
 CREATE ROLE function_role;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-SELECT run_command_on_workers('CREATE ROLE function_role');
-DEBUG:  not propagating CREATE ROLE/USER commands to worker nodes
-HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-DETAIL:  NOTICE from localhost:57637
-CONTEXT:  PL/pgSQL function run_command_on_workers(text,boolean) line 13 at RETURN QUERY
-DEBUG:  not propagating CREATE ROLE/USER commands to worker nodes
-HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-DETAIL:  NOTICE from localhost:57638
-CONTEXT:  PL/pgSQL function run_command_on_workers(text,boolean) line 13 at RETURN QUERY
-      run_command_on_workers       
------------------------------------
- (localhost,57637,t,"CREATE ROLE")
- (localhost,57638,t,"CREATE ROLE")
-(2 rows)
-
 SELECT deparse_test($cmd$
 ALTER FUNCTION add OWNER TO function_role
 $cmd$);
                         deparse_test                         
 -------------------------------------------------------------
  ALTER FUNCTION function_tests.add() OWNER TO function_role;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add OWNER TO missing_role
+$cmd$);
+                        deparse_test                        
+------------------------------------------------------------
+ ALTER FUNCTION function_tests.add() OWNER TO missing_role;
 (1 row)
 
 SELECT deparse_test($cmd$
@@ -316,10 +309,3 @@ $cmd$);
 SET client_min_messages TO FATAL; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
 DROP ROLE function_role;
-SELECT result FROM run_command_on_workers('DROP ROLE function_role');
-  result   
------------
- DROP ROLE
- DROP ROLE
-(2 rows)
-

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -1,5 +1,5 @@
 --
--- Regression tests for deparsing ALTER/DROP TABLE Queries
+-- Regression tests for deparsing ALTER/DROP FUNCTION Queries
 --
 -- This test implements all the possible queries as of Postgres 11:
 -- 

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -42,273 +42,318 @@ CREATE FUNCTION deparse_test(text)
 	RETURNS text
 	AS 'citus'
  	LANGUAGE C STRICT;
--- Create a simple PROCEDURE
+CREATE FUNCTION deparse_and_run_on_workers(text)
+    RETURNS SETOF record
+    AS $fnc$
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    $fnc$
+    LANGUAGE SQL;
+-- Create a simple PROCEDURE and distribute it
 CREATE OR REPLACE PROCEDURE raise_info(text)
 LANGUAGE PLPGSQL AS $proc$
 BEGIN
   RAISE INFO 'information message %', $1;
 END;
 $proc$;
-SELECT deparse_test($cmd$
+SELECT create_distributed_function('raise_info(text)');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);
-                              deparse_test                              
-------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) CALLED ON NULL INPUT;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
 $cmd$);
-                       deparse_test                       
-----------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) STRICT;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info STRICT
 $cmd$);
-                       deparse_test                       
-----------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) STRICT;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info IMMUTABLE
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) immutable;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info STABLE
 $cmd$);
-                       deparse_test                       
-----------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) stable;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info VOLATILE
 $cmd$);
-                        deparse_test                        
-------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) volatile;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info LEAKPROOF
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) LEAKPROOF;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info NOT LEAKPROOF
 $cmd$);
-                          deparse_test                           
------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) NOT LEAKPROOF;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY INVOKER;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SECURITY INVOKER
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY INVOKER;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY DEFINER;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SECURITY DEFINER
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY DEFINER;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL UNSAFE
 $cmd$);
-                           deparse_test                            
--------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) PARALLEL unsafe;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL RESTRICTED
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) PARALLEL restricted;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL SAFE
 $cmd$);
-                          deparse_test                           
------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) PARALLEL safe;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
 -- The COST/ROWS arguments should always be numeric
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info COST 1234
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) COST 1234.000000;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info COST 1234.5
 $cmd$);
-                            deparse_test                            
---------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) COST 1234.500000;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info ROWS 10
 $cmd$);
-                           deparse_test                            
--------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) ROWS  10.000000;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
-                           deparse_test                            
--------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) ROWS  10.800000;
-(1 row)
+                       deparse_and_run_on_workers                        
+-------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  invalid attribute in procedure definition")
+ (localhost,57638,f,"ERROR:  invalid attribute in procedure definition")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
-                                  deparse_test                                  
---------------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SET log_min_messages = error;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
 $cmd$);
-                                   deparse_test                                    
------------------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SET log_min_messages TO DEFAULT;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
 $cmd$);
-                                    deparse_test                                     
--------------------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SET log_min_messages FROM CURRENT;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RESET log_min_messages
 $cmd$);
-                               deparse_test                               
---------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) RESET log_min_messages;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RESET ALL
 $cmd$);
-                        deparse_test                         
--------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) RESET ALL;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RENAME TO summation
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) RENAME TO summation;
-(1 row)
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
 
 CREATE ROLE PROCEDURE_role;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
 $cmd$);
-                               deparse_test                                
----------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) OWNER TO procedure_role;
-(1 row)
+                      deparse_and_run_on_workers                      
+----------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  role ""procedure_role"" does not exist")
+ (localhost,57638,f,"ERROR:  role ""procedure_role"" does not exist")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info OWNER TO missing_role
 $cmd$);
-                              deparse_test                               
--------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) OWNER TO missing_role;
-(1 row)
+                     deparse_and_run_on_workers                     
+--------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  role ""missing_role"" does not exist")
+ (localhost,57638,f,"ERROR:  role ""missing_role"" does not exist")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SET SCHEMA public
 $cmd$);
-                            deparse_test                             
----------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) SET SCHEMA public;
-(1 row)
+                               deparse_and_run_on_workers                                
+-----------------------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  procedure procedure_tests.raise_info(text) does not exist")
+ (localhost,57638,f,"ERROR:  procedure procedure_tests.raise_info(text) does not exist")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
 $cmd$);
-                                 deparse_test                                 
-------------------------------------------------------------------------------
- ALTER PROCEDURE procedure_tests.raise_info(text) DEPENDS ON EXTENSION citus;
-(1 row)
+                               deparse_and_run_on_workers                                
+-----------------------------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  procedure procedure_tests.raise_info(text) does not exist")
+ (localhost,57638,f,"ERROR:  procedure procedure_tests.raise_info(text) does not exist")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS raise_info(int,int);
 $cmd$);
-                             deparse_test                              
------------------------------------------------------------------------
- DROP PROCEDURE IF EXISTS raise_info(pg_catalog.int4,pg_catalog.int4);
-(1 row)
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"DROP PROCEDURE")
+ (localhost,57638,t,"DROP PROCEDURE")
+(2 rows)
 
 -- Check that an invalid PROCEDURE name is still parsed correctly
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
 $cmd$);
-                           deparse_test                            
--------------------------------------------------------------------
- DROP PROCEDURE IF EXISTS missing_procedure(pg_catalog.int4,text);
-(1 row)
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"DROP PROCEDURE")
+ (localhost,57638,t,"DROP PROCEDURE")
+(2 rows)
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
 $cmd$);
-                                         deparse_test                                          
------------------------------------------------------------------------------------------------
- DROP PROCEDURE IF EXISTS missing_schema.missing_procedure(pg_catalog.int4,pg_catalog.float8);
-(1 row)
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"DROP PROCEDURE")
+ (localhost,57638,t,"DROP PROCEDURE")
+(2 rows)
 
 -- clear objects
 SET client_min_messages TO WARNING; -- suppress cascading objects dropping

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -52,202 +52,202 @@ $proc$;
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);
-                    deparse_test                    
-----------------------------------------------------
- ALTER PROCEDURE raise_info() CALLED ON NULL INPUT;
+                              deparse_test                              
+------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) CALLED ON NULL INPUT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
 $cmd$);
-             deparse_test             
---------------------------------------
- ALTER PROCEDURE raise_info() STRICT;
+                       deparse_test                       
+----------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) STRICT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info STRICT
 $cmd$);
-             deparse_test             
---------------------------------------
- ALTER PROCEDURE raise_info() STRICT;
+                       deparse_test                       
+----------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) STRICT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info IMMUTABLE
 $cmd$);
-              deparse_test               
------------------------------------------
- ALTER PROCEDURE raise_info() immutable;
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) immutable;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info STABLE
 $cmd$);
-             deparse_test             
---------------------------------------
- ALTER PROCEDURE raise_info() stable;
+                       deparse_test                       
+----------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) stable;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info VOLATILE
 $cmd$);
-              deparse_test              
-----------------------------------------
- ALTER PROCEDURE raise_info() volatile;
+                        deparse_test                        
+------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) volatile;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info LEAKPROOF
 $cmd$);
-              deparse_test               
------------------------------------------
- ALTER PROCEDURE raise_info() LEAKPROOF;
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) LEAKPROOF;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info NOT LEAKPROOF
 $cmd$);
-                deparse_test                 
----------------------------------------------
- ALTER PROCEDURE raise_info() NOT LEAKPROOF;
+                          deparse_test                           
+-----------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) NOT LEAKPROOF;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER PROCEDURE raise_info() SECURITY INVOKER;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY INVOKER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SECURITY INVOKER
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER PROCEDURE raise_info() SECURITY INVOKER;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY INVOKER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER PROCEDURE raise_info() SECURITY DEFINER;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY DEFINER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SECURITY DEFINER
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER PROCEDURE raise_info() SECURITY DEFINER;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SECURITY DEFINER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL UNSAFE
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER PROCEDURE raise_info() PARALLEL unsafe;
+                           deparse_test                            
+-------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) PARALLEL unsafe;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL RESTRICTED
 $cmd$);
-                   deparse_test                    
----------------------------------------------------
- ALTER PROCEDURE raise_info() PARALLEL restricted;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) PARALLEL restricted;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL SAFE
 $cmd$);
-                deparse_test                 
----------------------------------------------
- ALTER PROCEDURE raise_info() PARALLEL safe;
+                          deparse_test                           
+-----------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) PARALLEL safe;
 (1 row)
 
 -- The COST/ROWS arguments should always be numeric
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info COST 1234
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER PROCEDURE raise_info() COST 1234.000000;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) COST 1234.000000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info COST 1234.5
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER PROCEDURE raise_info() COST 1234.500000;
+                            deparse_test                            
+--------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) COST 1234.500000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info ROWS 10
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER PROCEDURE raise_info() ROWS  10.000000;
+                           deparse_test                            
+-------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) ROWS  10.000000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER PROCEDURE raise_info() ROWS  10.800000;
+                           deparse_test                            
+-------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) ROWS  10.800000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
-                        deparse_test                        
-------------------------------------------------------------
- ALTER PROCEDURE raise_info() SET log_min_messages = error;
+                                  deparse_test                                  
+--------------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SET log_min_messages = error;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
 $cmd$);
-                         deparse_test                          
----------------------------------------------------------------
- ALTER PROCEDURE raise_info() SET log_min_messages TO DEFAULT;
+                                   deparse_test                                    
+-----------------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SET log_min_messages TO DEFAULT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
 $cmd$);
-                          deparse_test                           
------------------------------------------------------------------
- ALTER PROCEDURE raise_info() SET log_min_messages FROM CURRENT;
+                                    deparse_test                                     
+-------------------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SET log_min_messages FROM CURRENT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RESET log_min_messages
 $cmd$);
-                     deparse_test                     
-------------------------------------------------------
- ALTER PROCEDURE raise_info() RESET log_min_messages;
+                               deparse_test                               
+--------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) RESET log_min_messages;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RESET ALL
 $cmd$);
-              deparse_test               
------------------------------------------
- ALTER PROCEDURE raise_info() RESET ALL;
+                        deparse_test                         
+-------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) RESET ALL;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RENAME TO summation
 $cmd$);
-                   deparse_test                    
----------------------------------------------------
- ALTER PROCEDURE raise_info() RENAME TO summation;
+                             deparse_test                              
+-----------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) RENAME TO summation;
 (1 row)
 
 CREATE ROLE PROCEDURE_role;
@@ -256,33 +256,33 @@ HINT:  Connect to worker nodes directly to manually create all necessary users a
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
 $cmd$);
-                     deparse_test                      
--------------------------------------------------------
- ALTER PROCEDURE raise_info() OWNER TO procedure_role;
+                               deparse_test                                
+---------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) OWNER TO procedure_role;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info OWNER TO missing_role
 $cmd$);
-                    deparse_test                     
------------------------------------------------------
- ALTER PROCEDURE raise_info() OWNER TO missing_role;
+                              deparse_test                               
+-------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) OWNER TO missing_role;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SET SCHEMA public
 $cmd$);
-                  deparse_test                   
--------------------------------------------------
- ALTER PROCEDURE raise_info() SET SCHEMA public;
+                            deparse_test                             
+---------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) SET SCHEMA public;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
 $cmd$);
-                       deparse_test                       
-----------------------------------------------------------
- ALTER PROCEDURE raise_info() DEPENDS ON EXTENSION citus;
+                                 deparse_test                                 
+------------------------------------------------------------------------------
+ ALTER PROCEDURE procedure_tests.raise_info(text) DEPENDS ON EXTENSION citus;
 (1 row)
 
 SELECT deparse_test($cmd$
@@ -311,6 +311,6 @@ $cmd$);
 (1 row)
 
 -- clear objects
-SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+SET client_min_messages TO WARNING; -- suppress cascading objects dropping
 DROP SCHEMA procedure_tests CASCADE;
 DROP ROLE PROCEDURE_role;

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -1,0 +1,308 @@
+--
+-- Regression tests for deparsing ALTER/DROP PROCEDURE Queries
+--
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     action [ ... ] [ RESTRICT ]
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     RENAME TO new_name
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     OWNER TO { new_owner | CURRENT_USER | SESSION_USER }
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     SET SCHEMA new_schema
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     DEPENDS ON EXTENSION extension_name
+-- where action is one of:
+--     [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
+--     SET configuration_parameter { TO | = } { value | DEFAULT }
+--     SET configuration_parameter FROM CURRENT
+--     RESET configuration_parameter
+--     RESET ALL
+-- 
+-- DROP PROCEDURE [ IF EXISTS ] name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ] [, ...]
+--     [ CASCADE | RESTRICT ]
+-- 
+-- Please note that current deparser does not return errors on some invalid queries.
+-- 
+-- For example CALLED ON NULL INPUT action is valid only for FUNCTIONS, but we still 
+-- allow deparsing them here.
+SET citus.next_shard_id TO 20030000;
+CREATE SCHEMA procedure_tests;
+SET search_path TO procedure_tests;
+SET citus.shard_count TO 4;
+SET client_min_messages TO INFO;
+CREATE FUNCTION deparse_test(text)
+	RETURNS text
+	AS 'citus'
+ 	LANGUAGE C STRICT;
+-- Create a simple PROCEDURE
+CREATE OR REPLACE PROCEDURE raise_info(text)
+LANGUAGE PLPGSQL AS $proc$
+BEGIN
+  RAISE INFO 'information message %', $1;
+END;
+$proc$;
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
+$cmd$);
+                   deparse_test                    
+---------------------------------------------------
+ ALTER FUNCTION raise_info() CALLED ON NULL INPUT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
+$cmd$);
+            deparse_test             
+-------------------------------------
+ ALTER FUNCTION raise_info() STRICT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info STRICT
+$cmd$);
+            deparse_test             
+-------------------------------------
+ ALTER FUNCTION raise_info() STRICT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info IMMUTABLE
+$cmd$);
+              deparse_test              
+----------------------------------------
+ ALTER FUNCTION raise_info() immutable;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info STABLE
+$cmd$);
+            deparse_test             
+-------------------------------------
+ ALTER FUNCTION raise_info() stable;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info VOLATILE
+$cmd$);
+             deparse_test              
+---------------------------------------
+ ALTER FUNCTION raise_info() volatile;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info LEAKPROOF
+$cmd$);
+              deparse_test              
+----------------------------------------
+ ALTER FUNCTION raise_info() LEAKPROOF;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info NOT LEAKPROOF
+$cmd$);
+                deparse_test                
+--------------------------------------------
+ ALTER FUNCTION raise_info() NOT LEAKPROOF;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION raise_info() SECURITY INVOKER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info SECURITY INVOKER
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION raise_info() SECURITY INVOKER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION raise_info() SECURITY DEFINER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info SECURITY DEFINER
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION raise_info() SECURITY DEFINER;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info PARALLEL UNSAFE
+$cmd$);
+                 deparse_test                 
+----------------------------------------------
+ ALTER FUNCTION raise_info() PARALLEL unsafe;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info PARALLEL RESTRICTED
+$cmd$);
+                   deparse_test                   
+--------------------------------------------------
+ ALTER FUNCTION raise_info() PARALLEL restricted;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info PARALLEL SAFE
+$cmd$);
+                deparse_test                
+--------------------------------------------
+ ALTER FUNCTION raise_info() PARALLEL safe;
+(1 row)
+
+-- The COST/ROWS arguments should always be numeric
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info COST 1234
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION raise_info() COST 1234.000000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info COST 1234.5
+$cmd$);
+                 deparse_test                  
+-----------------------------------------------
+ ALTER FUNCTION raise_info() COST 1234.500000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info ROWS 10
+$cmd$);
+                 deparse_test                 
+----------------------------------------------
+ ALTER FUNCTION raise_info() ROWS  10.000000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info ROWS 10.8
+$cmd$);
+                 deparse_test                 
+----------------------------------------------
+ ALTER FUNCTION raise_info() ROWS  10.800000;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
+$cmd$);
+                       deparse_test                        
+-----------------------------------------------------------
+ ALTER FUNCTION raise_info() SET log_min_messages = error;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
+$cmd$);
+                         deparse_test                         
+--------------------------------------------------------------
+ ALTER FUNCTION raise_info() SET log_min_messages TO DEFAULT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
+$cmd$);
+                          deparse_test                          
+----------------------------------------------------------------
+ ALTER FUNCTION raise_info() SET log_min_messages FROM CURRENT;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RESET log_min_messages
+$cmd$);
+                    deparse_test                     
+-----------------------------------------------------
+ ALTER FUNCTION raise_info() RESET log_min_messages;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RESET ALL
+$cmd$);
+              deparse_test              
+----------------------------------------
+ ALTER FUNCTION raise_info() RESET ALL;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RENAME TO summation
+$cmd$);
+                   deparse_test                   
+--------------------------------------------------
+ ALTER FUNCTION raise_info() RENAME TO summation;
+(1 row)
+
+CREATE ROLE PROCEDURE_role;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
+$cmd$);
+                     deparse_test                     
+------------------------------------------------------
+ ALTER FUNCTION raise_info() OWNER TO procedure_role;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info OWNER TO missing_role
+$cmd$);
+                    deparse_test                    
+----------------------------------------------------
+ ALTER FUNCTION raise_info() OWNER TO missing_role;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info SET SCHEMA public
+$cmd$);
+                  deparse_test                  
+------------------------------------------------
+ ALTER FUNCTION raise_info() SET SCHEMA public;
+(1 row)
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
+$cmd$);
+                      deparse_test                       
+---------------------------------------------------------
+ ALTER FUNCTION raise_info() DEPENDS ON EXTENSION citus;
+(1 row)
+
+SELECT deparse_test($cmd$
+DROP PROCEDURE IF EXISTS raise_info(int,int);
+$cmd$);
+                             deparse_test                             
+----------------------------------------------------------------------
+ DROP FUNCTION IF EXISTS raise_info(pg_catalog.int4,pg_catalog.int4);
+(1 row)
+
+-- Check that an invalid PROCEDURE name is still parsed correctly
+SELECT deparse_test($cmd$
+DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
+$cmd$);
+                           deparse_test                           
+------------------------------------------------------------------
+ DROP FUNCTION IF EXISTS missing_procedure(pg_catalog.int4,text);
+(1 row)
+
+SELECT deparse_test($cmd$
+DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
+$cmd$);
+                                         deparse_test                                         
+----------------------------------------------------------------------------------------------
+ DROP FUNCTION IF EXISTS missing_schema.missing_procedure(pg_catalog.int4,pg_catalog.float8);
+(1 row)
+
+-- clear objects
+SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+DROP SCHEMA procedure_tests CASCADE;
+DROP ROLE PROCEDURE_role;

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -44,202 +44,202 @@ $proc$;
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);
-                   deparse_test                    
----------------------------------------------------
- ALTER FUNCTION raise_info() CALLED ON NULL INPUT;
+                    deparse_test                    
+----------------------------------------------------
+ ALTER PROCEDURE raise_info() CALLED ON NULL INPUT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
 $cmd$);
-            deparse_test             
--------------------------------------
- ALTER FUNCTION raise_info() STRICT;
+             deparse_test             
+--------------------------------------
+ ALTER PROCEDURE raise_info() STRICT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info STRICT
 $cmd$);
-            deparse_test             
--------------------------------------
- ALTER FUNCTION raise_info() STRICT;
+             deparse_test             
+--------------------------------------
+ ALTER PROCEDURE raise_info() STRICT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info IMMUTABLE
 $cmd$);
-              deparse_test              
-----------------------------------------
- ALTER FUNCTION raise_info() immutable;
+              deparse_test               
+-----------------------------------------
+ ALTER PROCEDURE raise_info() immutable;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info STABLE
 $cmd$);
-            deparse_test             
--------------------------------------
- ALTER FUNCTION raise_info() stable;
+             deparse_test             
+--------------------------------------
+ ALTER PROCEDURE raise_info() stable;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info VOLATILE
 $cmd$);
-             deparse_test              
----------------------------------------
- ALTER FUNCTION raise_info() volatile;
+              deparse_test              
+----------------------------------------
+ ALTER PROCEDURE raise_info() volatile;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info LEAKPROOF
 $cmd$);
-              deparse_test              
-----------------------------------------
- ALTER FUNCTION raise_info() LEAKPROOF;
+              deparse_test               
+-----------------------------------------
+ ALTER PROCEDURE raise_info() LEAKPROOF;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info NOT LEAKPROOF
 $cmd$);
-                deparse_test                
---------------------------------------------
- ALTER FUNCTION raise_info() NOT LEAKPROOF;
+                deparse_test                 
+---------------------------------------------
+ ALTER PROCEDURE raise_info() NOT LEAKPROOF;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION raise_info() SECURITY INVOKER;
+                  deparse_test                  
+------------------------------------------------
+ ALTER PROCEDURE raise_info() SECURITY INVOKER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SECURITY INVOKER
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION raise_info() SECURITY INVOKER;
+                  deparse_test                  
+------------------------------------------------
+ ALTER PROCEDURE raise_info() SECURITY INVOKER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION raise_info() SECURITY DEFINER;
+                  deparse_test                  
+------------------------------------------------
+ ALTER PROCEDURE raise_info() SECURITY DEFINER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SECURITY DEFINER
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION raise_info() SECURITY DEFINER;
+                  deparse_test                  
+------------------------------------------------
+ ALTER PROCEDURE raise_info() SECURITY DEFINER;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL UNSAFE
 $cmd$);
-                 deparse_test                 
-----------------------------------------------
- ALTER FUNCTION raise_info() PARALLEL unsafe;
+                 deparse_test                  
+-----------------------------------------------
+ ALTER PROCEDURE raise_info() PARALLEL unsafe;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL RESTRICTED
 $cmd$);
-                   deparse_test                   
---------------------------------------------------
- ALTER FUNCTION raise_info() PARALLEL restricted;
+                   deparse_test                    
+---------------------------------------------------
+ ALTER PROCEDURE raise_info() PARALLEL restricted;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL SAFE
 $cmd$);
-                deparse_test                
---------------------------------------------
- ALTER FUNCTION raise_info() PARALLEL safe;
+                deparse_test                 
+---------------------------------------------
+ ALTER PROCEDURE raise_info() PARALLEL safe;
 (1 row)
 
 -- The COST/ROWS arguments should always be numeric
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info COST 1234
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION raise_info() COST 1234.000000;
+                  deparse_test                  
+------------------------------------------------
+ ALTER PROCEDURE raise_info() COST 1234.000000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info COST 1234.5
 $cmd$);
-                 deparse_test                  
------------------------------------------------
- ALTER FUNCTION raise_info() COST 1234.500000;
+                  deparse_test                  
+------------------------------------------------
+ ALTER PROCEDURE raise_info() COST 1234.500000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info ROWS 10
 $cmd$);
-                 deparse_test                 
-----------------------------------------------
- ALTER FUNCTION raise_info() ROWS  10.000000;
+                 deparse_test                  
+-----------------------------------------------
+ ALTER PROCEDURE raise_info() ROWS  10.000000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
-                 deparse_test                 
-----------------------------------------------
- ALTER FUNCTION raise_info() ROWS  10.800000;
+                 deparse_test                  
+-----------------------------------------------
+ ALTER PROCEDURE raise_info() ROWS  10.800000;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
-                       deparse_test                        
------------------------------------------------------------
- ALTER FUNCTION raise_info() SET log_min_messages = error;
+                        deparse_test                        
+------------------------------------------------------------
+ ALTER PROCEDURE raise_info() SET log_min_messages = error;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
 $cmd$);
-                         deparse_test                         
---------------------------------------------------------------
- ALTER FUNCTION raise_info() SET log_min_messages TO DEFAULT;
+                         deparse_test                          
+---------------------------------------------------------------
+ ALTER PROCEDURE raise_info() SET log_min_messages TO DEFAULT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
 $cmd$);
-                          deparse_test                          
-----------------------------------------------------------------
- ALTER FUNCTION raise_info() SET log_min_messages FROM CURRENT;
+                          deparse_test                           
+-----------------------------------------------------------------
+ ALTER PROCEDURE raise_info() SET log_min_messages FROM CURRENT;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RESET log_min_messages
 $cmd$);
-                    deparse_test                     
------------------------------------------------------
- ALTER FUNCTION raise_info() RESET log_min_messages;
+                     deparse_test                     
+------------------------------------------------------
+ ALTER PROCEDURE raise_info() RESET log_min_messages;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RESET ALL
 $cmd$);
-              deparse_test              
-----------------------------------------
- ALTER FUNCTION raise_info() RESET ALL;
+              deparse_test               
+-----------------------------------------
+ ALTER PROCEDURE raise_info() RESET ALL;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RENAME TO summation
 $cmd$);
-                   deparse_test                   
---------------------------------------------------
- ALTER FUNCTION raise_info() RENAME TO summation;
+                   deparse_test                    
+---------------------------------------------------
+ ALTER PROCEDURE raise_info() RENAME TO summation;
 (1 row)
 
 CREATE ROLE PROCEDURE_role;
@@ -248,58 +248,58 @@ HINT:  Connect to worker nodes directly to manually create all necessary users a
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
 $cmd$);
-                     deparse_test                     
-------------------------------------------------------
- ALTER FUNCTION raise_info() OWNER TO procedure_role;
+                     deparse_test                      
+-------------------------------------------------------
+ ALTER PROCEDURE raise_info() OWNER TO procedure_role;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info OWNER TO missing_role
 $cmd$);
-                    deparse_test                    
-----------------------------------------------------
- ALTER FUNCTION raise_info() OWNER TO missing_role;
+                    deparse_test                     
+-----------------------------------------------------
+ ALTER PROCEDURE raise_info() OWNER TO missing_role;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SET SCHEMA public
 $cmd$);
-                  deparse_test                  
-------------------------------------------------
- ALTER FUNCTION raise_info() SET SCHEMA public;
+                  deparse_test                   
+-------------------------------------------------
+ ALTER PROCEDURE raise_info() SET SCHEMA public;
 (1 row)
 
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
 $cmd$);
-                      deparse_test                       
----------------------------------------------------------
- ALTER FUNCTION raise_info() DEPENDS ON EXTENSION citus;
+                       deparse_test                       
+----------------------------------------------------------
+ ALTER PROCEDURE raise_info() DEPENDS ON EXTENSION citus;
 (1 row)
 
 SELECT deparse_test($cmd$
 DROP PROCEDURE IF EXISTS raise_info(int,int);
 $cmd$);
-                             deparse_test                             
-----------------------------------------------------------------------
- DROP FUNCTION IF EXISTS raise_info(pg_catalog.int4,pg_catalog.int4);
+                             deparse_test                              
+-----------------------------------------------------------------------
+ DROP PROCEDURE IF EXISTS raise_info(pg_catalog.int4,pg_catalog.int4);
 (1 row)
 
 -- Check that an invalid PROCEDURE name is still parsed correctly
 SELECT deparse_test($cmd$
 DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
 $cmd$);
-                           deparse_test                           
-------------------------------------------------------------------
- DROP FUNCTION IF EXISTS missing_procedure(pg_catalog.int4,text);
+                           deparse_test                            
+-------------------------------------------------------------------
+ DROP PROCEDURE IF EXISTS missing_procedure(pg_catalog.int4,text);
 (1 row)
 
 SELECT deparse_test($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
 $cmd$);
-                                         deparse_test                                         
-----------------------------------------------------------------------------------------------
- DROP FUNCTION IF EXISTS missing_schema.missing_procedure(pg_catalog.int4,pg_catalog.float8);
+                                         deparse_test                                          
+-----------------------------------------------------------------------------------------------
+ DROP PROCEDURE IF EXISTS missing_schema.missing_procedure(pg_catalog.int4,pg_catalog.float8);
 (1 row)
 
 -- clear objects

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -235,6 +235,15 @@ $cmd$);
 (2 rows)
 
 SELECT deparse_and_run_on_workers($cmd$
+ALTER  PROCEDURE raise_info SECURITY INVOKER SET client_min_messages TO warning;
+$cmd$);
+      deparse_and_run_on_workers       
+---------------------------------------
+ (localhost,57637,t,"ALTER PROCEDURE")
+ (localhost,57638,t,"ALTER PROCEDURE")
+(2 rows)
+
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
       deparse_and_run_on_workers       
@@ -348,6 +357,15 @@ $cmd$);
 
 SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
+$cmd$);
+      deparse_and_run_on_workers      
+--------------------------------------
+ (localhost,57637,t,"DROP PROCEDURE")
+ (localhost,57638,t,"DROP PROCEDURE")
+(2 rows)
+
+SELECT deparse_and_run_on_workers($cmd$
+DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float) CASCADE;
 $cmd$);
       deparse_and_run_on_workers      
 --------------------------------------

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -30,6 +30,14 @@ CREATE SCHEMA procedure_tests;
 SET search_path TO procedure_tests;
 SET citus.shard_count TO 4;
 SET client_min_messages TO INFO;
+-- print whether we're using version > 10 to make version-specific tests clear
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int > 10 AS version_above_ten;
+ version_above_ten 
+-------------------
+ t
+(1 row)
+
 CREATE FUNCTION deparse_test(text)
 	RETURNS text
 	AS 'citus'

--- a/src/test/regress/expected/multi_deparse_procedure_0.out
+++ b/src/test/regress/expected/multi_deparse_procedure_0.out
@@ -42,7 +42,14 @@ CREATE FUNCTION deparse_test(text)
 	RETURNS text
 	AS 'citus'
  	LANGUAGE C STRICT;
--- Create a simple PROCEDURE
+CREATE FUNCTION deparse_and_run_on_workers(text)
+    RETURNS SETOF record
+    AS $fnc$
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    $fnc$
+    LANGUAGE SQL;
+-- Create a simple PROCEDURE and distribute it
 CREATE OR REPLACE PROCEDURE raise_info(text)
 LANGUAGE PLPGSQL AS $proc$
 BEGIN
@@ -52,203 +59,367 @@ $proc$;
 ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: CREATE OR REPLACE PROCEDURE raise_info(text)
                           ^
-SELECT deparse_test($cmd$
+SELECT create_distributed_function('raise_info(text)');
+ERROR:  function "raise_info(text)" does not exist
+LINE 1: SELECT create_distributed_function('raise_info(text)');
+                                           ^
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info STRICT
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info IMMUTABLE
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info STABLE
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info VOLATILE
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info LEAKPROOF
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info NOT LEAKPROOF
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-                ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+               ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SECURITY INVOKER
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-                ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+               ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SECURITY DEFINER
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL UNSAFE
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL RESTRICTED
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL SAFE
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
 -- The COST/ROWS arguments should always be numeric
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info COST 1234
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info COST 1234.5
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-                ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+               ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info ROWS 10
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-                ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+               ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RESET log_min_messages
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RESET ALL
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RENAME TO summation
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
 CREATE ROLE PROCEDURE_role;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info OWNER TO missing_role
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SET SCHEMA public
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-               ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+              ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS raise_info(int,int);
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-              ^
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+             ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
 -- Check that an invalid PROCEDURE name is still parsed correctly
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-              ^
-SELECT deparse_test($cmd$
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+             ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
-LINE 1: SELECT deparse_test($cmd$
-              ^
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+             ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
 -- clear objects
 SET client_min_messages TO WARNING; -- suppress cascading objects dropping
 DROP SCHEMA procedure_tests CASCADE;

--- a/src/test/regress/expected/multi_deparse_procedure_0.out
+++ b/src/test/regress/expected/multi_deparse_procedure_0.out
@@ -11,9 +11,7 @@
 --     SET SCHEMA new_schema
 -- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
 --     DEPENDS ON EXTENSION extension_name
-
 -- where action is one of:
-
 --     [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
 --     SET configuration_parameter { TO | = } { value | DEFAULT }
 --     SET configuration_parameter FROM CURRENT
@@ -27,23 +25,23 @@
 -- 
 -- For example CALLED ON NULL INPUT action is valid only for FUNCTIONS, but we still 
 -- allow deparsing them here.
-
 SET citus.next_shard_id TO 20030000;
-
 CREATE SCHEMA procedure_tests;
 SET search_path TO procedure_tests;
 SET citus.shard_count TO 4;
 SET client_min_messages TO INFO;
-
 -- print whether we're using version > 10 to make version-specific tests clear
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int > 10 AS version_above_ten;
+ version_above_ten 
+-------------------
+ f
+(1 row)
 
 CREATE FUNCTION deparse_test(text)
 	RETURNS text
 	AS 'citus'
  	LANGUAGE C STRICT;
-
 -- Create a simple PROCEDURE
 CREATE OR REPLACE PROCEDURE raise_info(text)
 LANGUAGE PLPGSQL AS $proc$
@@ -51,144 +49,206 @@ BEGIN
   RAISE INFO 'information message %', $1;
 END;
 $proc$;
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: CREATE OR REPLACE PROCEDURE raise_info(text)
+                          ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info STRICT
 $cmd$);
-
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info IMMUTABLE
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info STABLE
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info VOLATILE
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info LEAKPROOF
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info NOT LEAKPROOF
 $cmd$);
-
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+                ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SECURITY INVOKER
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+                ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SECURITY DEFINER
 $cmd$);
-
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL UNSAFE
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL RESTRICTED
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info PARALLEL SAFE
 $cmd$);
-
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 -- The COST/ROWS arguments should always be numeric
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info COST 1234
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info COST 1234.5
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+                ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info ROWS 10
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
-
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+                ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RESET log_min_messages
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RESET ALL
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info RENAME TO summation
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 CREATE ROLE PROCEDURE_role;
-
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info OWNER TO missing_role
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info SET SCHEMA public
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+               ^
 SELECT deparse_test($cmd$
 DROP PROCEDURE IF EXISTS raise_info(int,int);
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+              ^
 -- Check that an invalid PROCEDURE name is still parsed correctly
 SELECT deparse_test($cmd$
 DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+              ^
 SELECT deparse_test($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
 $cmd$);
-
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 1: SELECT deparse_test($cmd$
+              ^
 -- clear objects
 SET client_min_messages TO FATAL; -- suppress cascading objects dropping
 DROP SCHEMA procedure_tests CASCADE;

--- a/src/test/regress/expected/multi_deparse_procedure_0.out
+++ b/src/test/regress/expected/multi_deparse_procedure_0.out
@@ -250,6 +250,6 @@ ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: SELECT deparse_test($cmd$
               ^
 -- clear objects
-SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+SET client_min_messages TO WARNING; -- suppress cascading objects dropping
 DROP SCHEMA procedure_tests CASCADE;
 DROP ROLE PROCEDURE_role;

--- a/src/test/regress/expected/multi_deparse_procedure_0.out
+++ b/src/test/regress/expected/multi_deparse_procedure_0.out
@@ -274,6 +274,17 @@ QUERY:
     
 CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
 SELECT deparse_and_run_on_workers($cmd$
+ALTER  PROCEDURE raise_info SECURITY INVOKER SET client_min_messages TO warning;
+$cmd$);
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+               ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
@@ -411,6 +422,17 @@ QUERY:
 CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
 SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
+$cmd$);
+ERROR:  syntax error at or near "PROCEDURE"
+LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...
+             ^
+QUERY:  
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    
+CONTEXT:  SQL function "deparse_and_run_on_workers" statement 1
+SELECT deparse_and_run_on_workers($cmd$
+DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float) CASCADE;
 $cmd$);
 ERROR:  syntax error at or near "PROCEDURE"
 LINE 2:     WITH deparsed_query AS ( SELECT deparse_test($1) qualifi...

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -286,4 +286,4 @@ test: distributed_functions
 # ---------
 # deparsing logic tests
 # ---------
-test: multi_deparse_function
+test: multi_deparse_function test: multi_deparse_procedure

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -286,4 +286,4 @@ test: distributed_functions
 # ---------
 # deparsing logic tests
 # ---------
-test: multi_deparse_function test: multi_deparse_procedure
+test: multi_deparse_function multi_deparse_procedure

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -282,3 +282,8 @@ test: ssl_by_default
 # ---------
 test: distributed_types distributed_types_conflict disable_object_propagation
 test: distributed_functions
+
+# ---------
+# deparsing logic tests
+# ---------
+test: multi_deparse_function

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -209,6 +209,11 @@ SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add DEPENDS ON EXTENSION citus
 $cmd$);
 
+-- make sure "any" type is correctly deparsed
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION pg_catalog.get_shard_id_for_distribution_column(table_name regclass, distribution_value "any") PARALLEL SAFE;
+$cmd$);
+
 -- Do not run valid drop queries in the workers
 SELECT deparse_test($cmd$
 DROP FUNCTION add(int,int);
@@ -233,6 +238,10 @@ $cmd$);
 
 SELECT deparse_and_run_on_workers($cmd$
 DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
+$cmd$);
+
+SELECT deparse_and_run_on_workers($cmd$
+DROP FUNCTION IF EXISTS missing_func_without_args;
 $cmd$);
 
 -- create schema with weird names

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -240,8 +240,8 @@ CREATE SCHEMA "CiTuS.TeeN";
 CREATE SCHEMA "CiTUS.TEEN2";
 
 SELECT run_command_on_workers($$
-    CREATE SCHEMA "CiTuS.TeeN";
-    CREATE SCHEMA "CiTUS.TEEN2";
+    CREATE SCHEMA IF NOT EXISTS "CiTuS.TeeN";
+    CREATE SCHEMA IF NOT EXISTS "CiTUS.TEEN2";
 $$);
 
 -- create table with weird names

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -1,7 +1,8 @@
 --
 -- Regression tests for deparsing ALTER/DROP FUNCTION Queries
 --
--- This test implements all the possible queries as of Postgres 11:
+-- This test implements all the possible queries as of Postgres 11
+-- in the order they are listed in the docs
 -- 
 -- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
 --     action [ ... ] [ RESTRICT ]
@@ -42,151 +43,315 @@ CREATE FUNCTION deparse_test(text)
 	AS 'citus'
  	LANGUAGE C STRICT;
 
--- Create a simple function
+CREATE OR REPLACE FUNCTION deparse_and_run_on_workers(IN query text,
+                                                     OUT nodename text,
+                                                     OUT nodeport int,
+                                                     OUT success bool,
+                                                     OUT result text)
+    RETURNS SETOF record
+    LANGUAGE PLPGSQL AS $fnc$
+    DECLARE
+        deparsed_query character varying(255);
+    BEGIN
+        deparsed_query := ( SELECT deparse_test($1) );
+        RAISE INFO 'Propagating deparsed query: %', deparsed_query;
+        RETURN QUERY SELECT * FROM run_command_on_workers(deparsed_query);
+    END;
+    $fnc$;
+
+
+-- Create a simple function and distribute it
 CREATE FUNCTION add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
+SELECT create_distributed_function('add(int,int)');
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add CALLED ON NULL INPUT
 $cmd$);
 
-SELECT deparse_test($cmd$
+-- RETURNS NULL ON NULL INPUT and STRICT are synonyms and can be used interchangeably
+-- RETURNS NULL ON NULL INPUT is actually stored as STRICT in the query parse tree
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RETURNS NULL ON NULL INPUT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add STRICT
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add IMMUTABLE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add STABLE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add VOLATILE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add LEAKPROOF
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add NOT LEAKPROOF
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+-- EXTERNAL keyword is ignored by Postgres Parser. It is allowed only for SQL conformance
+-- The following queries will not have the EXTERNAL keyword after deparsing
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  FUNCTION add EXTERNAL SECURITY INVOKER
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add SECURITY INVOKER
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  FUNCTION add EXTERNAL SECURITY DEFINER
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add SECURITY DEFINER
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add PARALLEL UNSAFE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add PARALLEL RESTRICTED
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add PARALLEL SAFE
 $cmd$);
 
 
--- The COST/ROWS arguments should always be numeric
-SELECT deparse_test($cmd$
+-- The COST arguments should always be numeric
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add COST 1234
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  FUNCTION add COST 1234.5
 $cmd$);
 
-SELECT deparse_test($cmd$
-ALTER FUNCTION add ROWS 10
-$cmd$);
-
-SELECT deparse_test($cmd$
-ALTER  FUNCTION add ROWS 10.8
-$cmd$);
-
-
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages = ERROR
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages TO DEFAULT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add SET log_min_messages FROM CURRENT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RESET log_min_messages
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RESET ALL
 $cmd$);
 
-SELECT deparse_test($cmd$
+-- Rename the function in the workers
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add RENAME TO summation
 $cmd$);
 
-CREATE ROLE function_role;
+-- Rename the function inb the coordinator as well.
+-- This is needed so the next query is parsed on the coordinator
+ALTER FUNCTION add RENAME TO summation;
 
-SELECT deparse_test($cmd$
+-- Rename it back to the original so that the next tests can pass
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION summation RENAME TO add
+$cmd$);
+
+-- Rename the function back to the original name in the coordinator
+ALTER FUNCTION summation RENAME TO add;
+
+CREATE ROLE function_role;
+SELECT run_command_on_workers('CREATE ROLE function_role');
+
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add OWNER TO function_role
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add OWNER TO missing_role
 $cmd$);
 
-SELECT deparse_test($cmd$
+-- SET the schema in workers as well as the coordinator so that it remains in the same schema
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add SET SCHEMA public
 $cmd$);
+ALTER FUNCTION add SET SCHEMA public;
 
-SELECT deparse_test($cmd$
+-- Revert the schema back
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION public.add SET SCHEMA function_tests
+$cmd$);
+ALTER FUNCTION public.add SET SCHEMA function_tests;
+
+SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION add DEPENDS ON EXTENSION citus
 $cmd$);
 
+-- Do not run valid drop queries in the workers
 SELECT deparse_test($cmd$
-DROP FUNCTION IF EXISTS add(int,int);
+DROP FUNCTION add(int,int);
+$cmd$);
+
+-- have multiple actions in a single query
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION add volatile leakproof SECURITY DEFINER PARALLEL unsafe;
 $cmd$);
 
 -- Check that an invalid function name is still parsed correctly
-SELECT deparse_test($cmd$
+-- Test that it fails when run without IF EXISTS clause
+SELECT deparse_and_run_on_workers($cmd$
+DROP FUNCTION missing_function(int, text);
+$cmd$);
+
+-- Check that an invalid function name is still parsed correctly
+-- Test that it is successful when run with IF EXISTS clause
+SELECT deparse_and_run_on_workers($cmd$
 DROP FUNCTION IF EXISTS missing_function(int, text);
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
+$cmd$);
+
+-- create schema with weird names
+CREATE SCHEMA "CiTuS.TeeN";
+CREATE SCHEMA "CiTUS.TEEN2";
+
+SELECT run_command_on_workers($$
+    CREATE SCHEMA "CiTuS.TeeN";
+    CREATE SCHEMA "CiTUS.TEEN2";
+$$);
+
+-- create table with weird names
+CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() RETURNS TEXT
+    AS $$ SELECT 'test function without params' $$
+    LANGUAGE SQL;
+
+CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text) RETURNS TEXT
+    AS $$ SELECT 'Overloaded function called with param: ' || $1 $$
+    LANGUAGE SQL;
+
+SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"()');
+SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text)');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() SET SCHEMA "CiTUS.TEEN2"
+$cmd$);
+
+-- drop 2 functions at the same time
+SELECT deparse_and_run_on_workers($cmd$
+DROP FUNCTION "CiTUS.TEEN2"."TeeNFunCT10N.1!?!"(),"CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text);
+$cmd$);
+
+-- a function with a default parameter
+CREATE FUNCTION func_default_param(param INT DEFAULT 0) RETURNS TEXT
+    AS $$ SELECT 'supplied param is : ' || param; $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_default_param(INT)');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_default_param RENAME TO func_with_default_param;
+$cmd$);
+
+-- a function with IN and OUT parameters
+CREATE FUNCTION func_out_param(IN param INT, OUT result TEXT)
+    AS $$ SELECT 'supplied param is : ' || param; $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_out_param(INT)');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_out_param RENAME TO func_in_and_out_param;
+$cmd$);
+
+-- a function with INOUT parameter
+CREATE FUNCTION square(INOUT a NUMERIC)
+AS $$
+BEGIN
+   a := a * a;
+END; $$
+LANGUAGE plpgsql;
+SELECT create_distributed_function('square(NUMERIC)');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION square SET search_path TO DEFAULT;
+$cmd$);
+
+-- a function with variadic input. 
+CREATE FUNCTION sum_avg(
+   VARIADIC list NUMERIC[],
+   OUT total NUMERIC,
+   OUT average NUMERIC)
+AS $$
+BEGIN
+   SELECT INTO total SUM(list[i])
+   FROM generate_subscripts(list, 1) g(i);
+ 
+   SELECT INTO average AVG(list[i])
+   FROM generate_subscripts(list, 1) g(i);
+END; $$
+LANGUAGE plpgsql;
+SELECT create_distributed_function('sum_avg(NUMERIC[])');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION sum_avg COST 10000;
+$cmd$);
+
+-- a function with a custom type IN parameter 
+CREATE TYPE intpair AS (x int, y int);
+CREATE FUNCTION func_custom_param(IN param intpair, OUT total INT)
+    AS $$ SELECT param.x + param.y $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_custom_param(intpair)');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_custom_param RENAME TO func_with_custom_param;
+$cmd$);
+
+
+-- a function that returns TABLE
+CREATE FUNCTION func_returns_table(IN count INT)
+    RETURNS TABLE (x INT, y INT)
+    AS $$ SELECT i,i FROM generate_series(1,count) i $$
+    LANGUAGE SQL;
+SELECT create_distributed_function('func_returns_table(INT)');
+
+SELECT deparse_and_run_on_workers($cmd$
+ALTER FUNCTION func_returns_table ROWS 100;
 $cmd$);
 
 -- clear objects
 SET client_min_messages TO WARNING; -- suppress cascading objects dropping
+
+DROP SCHEMA "CiTuS.TeeN" CASCADE;
+DROP SCHEMA "CiTUS.TEEN2" CASCADE;
 DROP SCHEMA function_tests CASCADE;
+
+SELECT run_command_on_workers($$
+    DROP SCHEMA "CiTuS.TeeN" CASCADE;
+    DROP SCHEMA "CiTUS.TEEN2" CASCADE;
+    DROP SCHEMA function_tests CASCADE;
+$$);
+
 DROP ROLE function_role;

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -35,7 +35,7 @@ SET citus.next_shard_id TO 20020000;
 CREATE SCHEMA function_tests;
 SET search_path TO function_tests;
 SET citus.shard_count TO 4;
-SET client_min_messages TO DEBUG;
+SET client_min_messages TO INFO;
 
 CREATE FUNCTION deparse_test(text)
 	RETURNS text
@@ -54,7 +54,7 @@ ALTER FUNCTION  add CALLED ON NULL INPUT
 $cmd$);
 
 SELECT deparse_test($cmd$
-ALTER FUNCTION add  RETURNS NULL ON NULL INPUT
+ALTER FUNCTION add RETURNS NULL ON NULL INPUT
 $cmd$);
 
 SELECT deparse_test($cmd$
@@ -156,10 +156,13 @@ ALTER FUNCTION add RENAME TO summation
 $cmd$);
 
 CREATE ROLE function_role;
-SELECT run_command_on_workers('CREATE ROLE function_role');
 
 SELECT deparse_test($cmd$
 ALTER FUNCTION add OWNER TO function_role
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add OWNER TO missing_role
 $cmd$);
 
 SELECT deparse_test($cmd$
@@ -187,4 +190,3 @@ $cmd$);
 SET client_min_messages TO FATAL; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
 DROP ROLE function_role;
-SELECT result FROM run_command_on_workers('DROP ROLE function_role');

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -151,6 +151,24 @@ SELECT deparse_test($cmd$
 ALTER FUNCTION add RESET ALL
 $cmd$);
 
+SELECT deparse_test($cmd$
+ALTER FUNCTION add RENAME TO summation
+$cmd$);
+
+CREATE ROLE function_role;
+SELECT run_command_on_workers('CREATE ROLE function_role');
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add OWNER TO function_role
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add SET SCHEMA public
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add DEPENDS ON EXTENSION citus
+$cmd$);
 
 SELECT deparse_test($cmd$
 DROP FUNCTION IF EXISTS add(int,int);
@@ -168,3 +186,5 @@ $cmd$);
 -- clear objects
 SET client_min_messages TO FATAL; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
+DROP ROLE function_role;
+SELECT result FROM run_command_on_workers('DROP ROLE function_role');

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -187,6 +187,6 @@ DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
 $cmd$);
 
 -- clear objects
-SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+SET client_min_messages TO WARNING; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
 DROP ROLE function_role;

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -1,5 +1,5 @@
 --
--- Regression tests for deparsing ALTER/DROP TABLE Queries
+-- Regression tests for deparsing ALTER/DROP FUNCTION Queries
 --
 -- This test implements all the possible queries as of Postgres 11:
 -- 

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -1,0 +1,170 @@
+--
+-- Regression tests for deparsing ALTER/DROP TABLE Queries
+--
+-- This test implements all the possible queries as of Postgres 11:
+-- 
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     action [ ... ] [ RESTRICT ]
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     RENAME TO new_name
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     OWNER TO { new_owner | CURRENT_USER | SESSION_USER }
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     SET SCHEMA new_schema
+-- ALTER FUNCTION name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     DEPENDS ON EXTENSION extension_name
+-- 
+-- where action is one of:
+-- 
+--     CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT
+--     IMMUTABLE | STABLE | VOLATILE | [ NOT ] LEAKPROOF
+--     [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
+--     PARALLEL { UNSAFE | RESTRICTED | SAFE }
+--     COST execution_cost
+--     ROWS result_rows
+--     SET configuration_parameter { TO | = } { value | DEFAULT }
+--     SET configuration_parameter FROM CURRENT
+--     RESET configuration_parameter
+--     RESET ALL
+-- 
+-- DROP FUNCTION [ IF EXISTS ] name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ] [, ...]
+--     [ CASCADE | RESTRICT ]
+
+SET citus.next_shard_id TO 20020000;
+
+CREATE SCHEMA function_tests;
+SET search_path TO function_tests;
+SET citus.shard_count TO 4;
+SET client_min_messages TO DEBUG;
+
+CREATE FUNCTION deparse_test(text)
+	RETURNS text
+	AS 'citus'
+ 	LANGUAGE C STRICT;
+
+-- Create a simple function
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    AS 'select $1 + $2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add CALLED ON NULL INPUT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add  RETURNS NULL ON NULL INPUT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add STRICT
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add IMMUTABLE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add STABLE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add VOLATILE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add LEAKPROOF
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add NOT LEAKPROOF
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add EXTERNAL SECURITY INVOKER
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add SECURITY INVOKER
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add EXTERNAL SECURITY DEFINER
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add SECURITY DEFINER
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add PARALLEL UNSAFE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add PARALLEL RESTRICTED
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add PARALLEL SAFE
+$cmd$);
+
+
+-- The COST/ROWS arguments should always be numeric
+SELECT deparse_test($cmd$
+ALTER FUNCTION add COST 1234
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add COST 1234.5
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add ROWS 10
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER  FUNCTION add ROWS 10.8
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add SET log_min_messages = ERROR
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add SET log_min_messages TO DEFAULT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION  add SET log_min_messages FROM CURRENT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add RESET log_min_messages
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER FUNCTION add RESET ALL
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+DROP FUNCTION IF EXISTS add(int,int);
+$cmd$);
+
+-- Check that an invalid function name is still parsed correctly
+SELECT deparse_test($cmd$
+DROP FUNCTION IF EXISTS missing_function(int, text);
+$cmd$);
+
+SELECT deparse_test($cmd$
+DROP FUNCTION IF EXISTS missing_schema.missing_function(int,float);
+$cmd$);
+
+-- clear objects
+SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+DROP SCHEMA function_tests CASCADE;

--- a/src/test/regress/sql/multi_deparse_procedure.sql
+++ b/src/test/regress/sql/multi_deparse_procedure.sql
@@ -44,148 +44,157 @@ CREATE FUNCTION deparse_test(text)
 	AS 'citus'
  	LANGUAGE C STRICT;
 
--- Create a simple PROCEDURE
+CREATE FUNCTION deparse_and_run_on_workers(text)
+    RETURNS SETOF record
+    AS $fnc$
+    WITH deparsed_query AS ( SELECT deparse_test($1) qualified_query )
+    SELECT run_command_on_workers(qualified_query) FROM deparsed_query d 
+    $fnc$
+    LANGUAGE SQL;
+
+-- Create a simple PROCEDURE and distribute it
 CREATE OR REPLACE PROCEDURE raise_info(text)
 LANGUAGE PLPGSQL AS $proc$
 BEGIN
   RAISE INFO 'information message %', $1;
 END;
 $proc$;
+SELECT create_distributed_function('raise_info(text)');
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info STRICT
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info IMMUTABLE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info STABLE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info VOLATILE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info LEAKPROOF
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info NOT LEAKPROOF
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SECURITY INVOKER
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SECURITY DEFINER
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL UNSAFE
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL RESTRICTED
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info PARALLEL SAFE
 $cmd$);
 
 
 -- The COST/ROWS arguments should always be numeric
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info COST 1234
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info COST 1234.5
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info ROWS 10
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
 
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RESET log_min_messages
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RESET ALL
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info RENAME TO summation
 $cmd$);
 
 CREATE ROLE PROCEDURE_role;
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info OWNER TO missing_role
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info SET SCHEMA public
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS raise_info(int,int);
 $cmd$);
 
 -- Check that an invalid PROCEDURE name is still parsed correctly
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
 $cmd$);
 
-SELECT deparse_test($cmd$
+SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
 $cmd$);
 

--- a/src/test/regress/sql/multi_deparse_procedure.sql
+++ b/src/test/regress/sql/multi_deparse_procedure.sql
@@ -190,6 +190,6 @@ DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
 $cmd$);
 
 -- clear objects
-SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+SET client_min_messages TO WARNING; -- suppress cascading objects dropping
 DROP SCHEMA procedure_tests CASCADE;
 DROP ROLE PROCEDURE_role;

--- a/src/test/regress/sql/multi_deparse_procedure.sql
+++ b/src/test/regress/sql/multi_deparse_procedure.sql
@@ -142,6 +142,10 @@ SELECT deparse_and_run_on_workers($cmd$
 ALTER  PROCEDURE raise_info ROWS 10.8
 $cmd$);
 
+SELECT deparse_and_run_on_workers($cmd$
+ALTER  PROCEDURE raise_info SECURITY INVOKER SET client_min_messages TO warning;
+$cmd$);
+
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
@@ -196,6 +200,10 @@ $cmd$);
 
 SELECT deparse_and_run_on_workers($cmd$
 DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
+$cmd$);
+
+SELECT deparse_and_run_on_workers($cmd$
+DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float) CASCADE;
 $cmd$);
 
 -- clear objects

--- a/src/test/regress/sql/multi_deparse_procedure.sql
+++ b/src/test/regress/sql/multi_deparse_procedure.sql
@@ -1,0 +1,191 @@
+--
+-- Regression tests for deparsing ALTER/DROP PROCEDURE Queries
+--
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     action [ ... ] [ RESTRICT ]
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     RENAME TO new_name
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     OWNER TO { new_owner | CURRENT_USER | SESSION_USER }
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     SET SCHEMA new_schema
+-- ALTER PROCEDURE name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ]
+--     DEPENDS ON EXTENSION extension_name
+
+-- where action is one of:
+
+--     [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
+--     SET configuration_parameter { TO | = } { value | DEFAULT }
+--     SET configuration_parameter FROM CURRENT
+--     RESET configuration_parameter
+--     RESET ALL
+-- 
+-- DROP PROCEDURE [ IF EXISTS ] name [ ( [ [ argmode ] [ argname ] argtype [, ...] ] ) ] [, ...]
+--     [ CASCADE | RESTRICT ]
+-- 
+-- Please note that current deparser does not return errors on some invalid queries.
+-- 
+-- For example CALLED ON NULL INPUT action is valid only for FUNCTIONS, but we still 
+-- allow deparsing them here.
+
+SET citus.next_shard_id TO 20030000;
+
+CREATE SCHEMA procedure_tests;
+SET search_path TO procedure_tests;
+SET citus.shard_count TO 4;
+SET client_min_messages TO INFO;
+
+CREATE FUNCTION deparse_test(text)
+	RETURNS text
+	AS 'citus'
+ 	LANGUAGE C STRICT;
+
+-- Create a simple PROCEDURE
+CREATE OR REPLACE PROCEDURE raise_info(text)
+LANGUAGE PLPGSQL AS $proc$
+BEGIN
+  RAISE INFO 'information message %', $1;
+END;
+$proc$;
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RETURNS NULL ON NULL INPUT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info STRICT
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info IMMUTABLE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info STABLE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info VOLATILE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info LEAKPROOF
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info NOT LEAKPROOF
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info EXTERNAL SECURITY INVOKER
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info SECURITY INVOKER
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info EXTERNAL SECURITY DEFINER
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info SECURITY DEFINER
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info PARALLEL UNSAFE
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info PARALLEL RESTRICTED
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info PARALLEL SAFE
+$cmd$);
+
+
+-- The COST/ROWS arguments should always be numeric
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info COST 1234
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info COST 1234.5
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info ROWS 10
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER  PROCEDURE raise_info ROWS 10.8
+$cmd$);
+
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info SET log_min_messages = ERROR
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info SET log_min_messages TO DEFAULT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE  raise_info SET log_min_messages FROM CURRENT
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RESET log_min_messages
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RESET ALL
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info RENAME TO summation
+$cmd$);
+
+CREATE ROLE PROCEDURE_role;
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info OWNER TO PROCEDURE_role
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info OWNER TO missing_role
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info SET SCHEMA public
+$cmd$);
+
+SELECT deparse_test($cmd$
+ALTER PROCEDURE raise_info DEPENDS ON EXTENSION citus
+$cmd$);
+
+SELECT deparse_test($cmd$
+DROP PROCEDURE IF EXISTS raise_info(int,int);
+$cmd$);
+
+-- Check that an invalid PROCEDURE name is still parsed correctly
+SELECT deparse_test($cmd$
+DROP PROCEDURE IF EXISTS missing_PROCEDURE(int, text);
+$cmd$);
+
+SELECT deparse_test($cmd$
+DROP PROCEDURE IF EXISTS missing_schema.missing_PROCEDURE(int,float);
+$cmd$);
+
+-- clear objects
+SET client_min_messages TO FATAL; -- suppress cascading objects dropping
+DROP SCHEMA procedure_tests CASCADE;
+DROP ROLE PROCEDURE_role;


### PR DESCRIPTION
This PR aims to add all the necessary logic to qualify and deparse all possible `{ALTER|DROP} .. {FUNCTION|PROCEDURE}` queries.

As Procedures are introduced in PG11, the code contains many PG version checks. I tried my best to make it easy to clean up once we drop PG10 support.


Here are some caveats:
- I assumed that the parse tree is a valid one. There are some queries that are not allowed, but still are parsed successfully by postgres planner. Such queries will result in errors in execution time. (e.g. `ALTER PROCEDURE p STRICT` -> `STRICT` action is valid for functions but not procedures. Postgres decides to parse them nevertheless.)