### PR TITLE
CALL propagation: set search_path

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -69,7 +69,6 @@ static int activeAlterTables = 0;
 
 /* Local functions forward declarations for helper functions */
 static void ExecuteDistributedDDLJob(DDLJob *ddlJob);
-static char * SetSearchPathToCurrentSearchPathCommand(void);
 static char * CurrentSearchPath(void);
 static void PostProcessUtility(Node *parsetree);
 static List * PlanRenameAttributeStmt(RenameStmt *stmt, const char *queryString);
@@ -928,7 +927,7 @@ ExecuteNodeBaseDDLCommands(List *taskList)
  * If the current search path is null (or doesn't have any valid schemas),
  * the function returns NULL.
  */
-static char *
+char *
 SetSearchPathToCurrentSearchPathCommand(void)
 {
 	StringInfo setCommand = NULL;

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -790,7 +790,7 @@ ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
 	ParamListInfo paramListInfo = NULL;
 
 	/*
-	 * The code-paths that rely on this function do not know how execute
+	 * The code-paths that rely on this function do not know how to execute
 	 * commands locally.
 	 */
 	ErrorIfLocalExecutionHappened();
@@ -3067,23 +3067,16 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 				execution->rowsProcessed += currentAffectedTupleCount;
 			}
 
-			PQclear(result);
-
-			/* no more results, break out of loop and free allocated memory */
-			fetchDone = true;
-			break;
+			continue;
 		}
 		else if (resultStatus == PGRES_TUPLES_OK)
 		{
 			/*
-			 * We've already consumed all the tuples, no more results. Break out
-			 * of loop and free allocated memory before returning.
+			 * We've already consumed all the tuples.
+			 * Continue in case there's more results.
 			 */
-			Assert(PQntuples(result) == 0);
-			PQclear(result);
 
-			fetchDone = true;
-			break;
+			continue;
 		}
 		else if (resultStatus != PGRES_SINGLE_TUPLE)
 		{
@@ -3093,7 +3086,7 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 		else if (!storeRows)
 		{
 			/*
-			 * Already receieved rows from executing on another shard placement or
+			 * Already received rows from executing on another shard placement or
 			 * doesn't need at all (e.g., DDL).
 			 */
 			PQclear(result);

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -55,6 +55,7 @@ extern void CitusProcessUtility(Node *node, const char *queryString,
 								DestReceiver *dest, char *completionTag);
 extern void MarkInvalidateForeignKeyGraph(void);
 extern void InvalidateForeignKeyGraphForDDL(void);
+extern char * SetSearchPathToCurrentSearchPathCommand(void);
 extern List * DDLTaskList(Oid relationId, const char *commandString);
 extern List * NodeDDLTaskList(TargetWorkerSet targets, List *commands);
 extern bool AlterTableInProgress(void);

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -72,7 +72,7 @@ BEGIN
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
     -- we also make sure that we can run distributed queries in the procedures
     -- that are routed to the workers.
-    y := y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id);
+    y := y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id);
 END;$$;
 -- create another procedure which verifies:
 -- 1. we work fine with multiple return columns
@@ -84,13 +84,13 @@ BEGIN
     x := (select case groupid when 0 then 'F' else 'S' end from pg_dist_local_group);
 END;$$;
 -- Test that undistributed procedures have no issue executing
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
  y  
 ----
  29
 (1 row)
 
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
  x | y 
 ---+---
  F | S
@@ -112,20 +112,20 @@ select create_distributed_function('mx_call_proc_custom_types(mx_call_enum,mx_ca
 -- We still don't route them to the workers, because they aren't
 -- colocated with any distributed tables.
 SET client_min_messages TO DEBUG1;
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 DEBUG:  stored procedure does not have co-located tables
 DEBUG:  generating subplan 8_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 8 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('8_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
  29
 (1 row)
 
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 DEBUG:  stored procedure does not have co-located tables
  x | y 
 ---+---
@@ -133,16 +133,16 @@ DEBUG:  stored procedure does not have co-located tables
 (1 row)
 
 -- Mark them as colocated with a table. Now we should route them to workers.
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
-call multi_mx_call.mx_call_proc(2, 0);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
+call mx_call_proc(2, 0);
 DEBUG:  pushing down the procedure
  y  
 ----
  28
 (1 row)
 
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 DEBUG:  pushing down the procedure
  x | y 
 ---+---
@@ -151,13 +151,13 @@ DEBUG:  pushing down the procedure
 
 -- We don't allow distributing calls inside transactions
 begin;
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 DEBUG:  cannot push down CALL in multi-statement transaction
 DEBUG:  generating subplan 10_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 10 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('10_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
@@ -170,7 +170,7 @@ commit;
 SET client_min_messages TO NOTICE;
 drop table mx_call_dist_table_enum;
 SET client_min_messages TO DEBUG1;
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 DEBUG:  stored procedure does not have co-located tables
  x | y 
 ---+---
@@ -179,28 +179,28 @@ DEBUG:  stored procedure does not have co-located tables
 
 -- Make sure we do bounds checking on distributed argument index
 -- This also tests that we have cache invalidation for pg_dist_object updates
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
-call multi_mx_call.mx_call_proc(2, 0);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
+call mx_call_proc(2, 0);
 DEBUG:  cannot push down invalid distribution_argument_index
 DEBUG:  generating subplan 12_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 12 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('12_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
  29
 (1 row)
 
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
-call multi_mx_call.mx_call_proc(2, 0);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
+call mx_call_proc(2, 0);
 DEBUG:  cannot push down invalid distribution_argument_index
 DEBUG:  generating subplan 14_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 14 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('14_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
@@ -208,14 +208,14 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 (1 row)
 
 -- We don't currently support colocating with reference tables
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
-call multi_mx_call.mx_call_proc(2, 0);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
+call mx_call_proc(2, 0);
 DEBUG:  cannot push down CALL for reference tables
 DEBUG:  generating subplan 17_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 17 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('17_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
@@ -223,14 +223,14 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 (1 row)
 
 -- We don't currently support colocating with replicated tables
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
-call multi_mx_call.mx_call_proc(2, 0);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
+call mx_call_proc(2, 0);
 DEBUG:  cannot push down CALL for replicated distributed tables
 DEBUG:  generating subplan 19_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 19 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('19_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
@@ -240,7 +240,7 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 SET client_min_messages TO NOTICE;
 drop table mx_call_dist_table_replica;
 SET client_min_messages TO DEBUG1;
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
 -- Test that we handle transactional constructs correctly inside a procedure
 -- that is routed to the workers.
 CREATE PROCEDURE mx_call_proc_tx(x int) LANGUAGE plpgsql AS $$
@@ -253,7 +253,7 @@ BEGIN
     UPDATE mx_call_dist_table_1 SET val = val-1 WHERE id >= x;
 END;$$;
 -- before distribution ...
-CALL multi_mx_call.mx_call_proc_tx(10);
+CALL mx_call_proc_tx(10);
 -- after distribution ...
 select create_distributed_function('mx_call_proc_tx(int)', '$1', 'mx_call_dist_table_1');
 DEBUG:  switching to sequential query execution mode
@@ -265,9 +265,9 @@ DETAIL:  A distributed function is created. To make sure subsequent commands see
 
 CALL multi_mx_call.mx_call_proc_tx(20);
 DEBUG:  pushing down the procedure
-ERROR:  relation "mx_call_dist_table_1" does not exist
+ERROR:  invalid transaction termination
 CONTEXT:  while executing command on localhost:57637
-PL/pgSQL function multi_mx_call.mx_call_proc_tx(integer) line 3 at SQL statement
+PL/pgSQL function mx_call_proc_tx(integer) line 4 at COMMIT
 SELECT id, val FROM mx_call_dist_table_1 ORDER BY id, val;
  id | val 
 ----+-----
@@ -300,7 +300,7 @@ DEBUG:  warning
 DETAIL:  WARNING from localhost:57638
 ERROR:  error
 CONTEXT:  while executing command on localhost:57638
-PL/pgSQL function multi_mx_call.mx_call_proc_raise(integer) line 4 at RAISE
+PL/pgSQL function mx_call_proc_raise(integer) line 4 at RAISE
 -- Test that we don't propagate to non-metadata worker nodes
 select stop_metadata_sync_to_node('localhost', :worker_1_port);
  stop_metadata_sync_to_node 
@@ -314,13 +314,13 @@ select stop_metadata_sync_to_node('localhost', :worker_2_port);
  
 (1 row)
 
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 DEBUG:  there is no worker node with metadata
 DEBUG:  generating subplan 25_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 25 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('25_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
@@ -355,13 +355,13 @@ DETAIL:  A distributed function is created. To make sure subsequent commands see
 (1 row)
 
 -- non-const distribution parameters cannot be pushed down
-call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+call mx_call_proc(2, mx_call_add(3, 4));
 DEBUG:  distribution argument value must be a constant
 DEBUG:  generating subplan 27_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 27 query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('27_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----
@@ -369,7 +369,7 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 (1 row)
 
 -- non-const parameter can be pushed down
-call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3, 4), 2);
+call mx_call_proc(mx_call_add(3, 4), 2);
 DEBUG:  pushing down the procedure
  y  
 ----
@@ -377,13 +377,13 @@ DEBUG:  pushing down the procedure
 (1 row)
 
 -- volatile parameter cannot be pushed down
-call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+call mx_call_proc(floor(random())::int, 2);
 DEBUG:  arguments in a distributed stored procedure must be constant expressions
 DEBUG:  generating subplan 29_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 DEBUG:  Plan 29 query after replacing subqueries and CTEs: SELECT (1 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('29_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
+CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  y  
 ----

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -75,7 +75,7 @@ BEGIN
     y := x + (select case groupid when 0 then 1 else 0 end from pg_dist_local_group);
     -- we also make sure that we can run distributed queries in the procedures
     -- that are routed to the workers.
-    y := y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id);
+    y := y + (select sum(t1.val + t2.val) from mx_call_dist_table_1 t1 join mx_call_dist_table_2 t2 on t1.id = t2.id);
 END;$$;
 ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: CREATE PROCEDURE mx_call_proc(x int, INOUT y int)
@@ -93,13 +93,13 @@ ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: CREATE PROCEDURE mx_call_proc_custom_types(INOUT x mx_call_e...
                ^
 -- Test that undistributed procedures have no issue executing
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+LINE 1: call mx_call_proc_custom_types('S', 'A');
         ^
 -- Mark both procedures as distributed ...
 select create_distributed_function('mx_call_proc(int,int)');
@@ -113,36 +113,36 @@ LINE 1: select create_distributed_function('mx_call_proc_custom_type...
 -- We still don't route them to the workers, because they aren't
 -- colocated with any distributed tables.
 SET client_min_messages TO DEBUG1;
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+LINE 1: call mx_call_proc_custom_types('S', 'A');
         ^
 -- Mark them as colocated with a table. Now we should route them to workers.
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+LINE 1: call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_...
         ^
-call multi_mx_call.colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc_custom_types', 'mx_call_dist_table_enum'::regclass, 1);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc_cu...
+LINE 1: call colocate_proc_with_table('mx_call_proc_custom_types', '...
         ^
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+LINE 1: call mx_call_proc_custom_types('S', 'A');
         ^
 -- We don't allow distributing calls inside transactions
 begin;
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
 commit;
 -- Drop the table colocated with mx_call_proc_custom_types. Now it shouldn't
@@ -150,52 +150,52 @@ commit;
 SET client_min_messages TO NOTICE;
 drop table mx_call_dist_table_enum;
 SET client_min_messages TO DEBUG1;
-call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+call mx_call_proc_custom_types('S', 'A');
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc_custom_types('S', 'A');
+LINE 1: call mx_call_proc_custom_types('S', 'A');
         ^
 -- Make sure we do bounds checking on distributed argument index
 -- This also tests that we have cache invalidation for pg_dist_object updates
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, -1);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+LINE 1: call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_...
         ^
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 2);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+LINE 1: call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_...
         ^
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
 -- We don't currently support colocating with reference tables
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+LINE 1: call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_...
         ^
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
 -- We don't currently support colocating with replicated tables
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::regclass, 1);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+LINE 1: call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_...
         ^
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
 SET client_min_messages TO NOTICE;
 drop table mx_call_dist_table_replica;
 SET client_min_messages TO DEBUG1;
-call multi_mx_call.colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
+call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_1'::regclass, 1);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.colocate_proc_with_table('mx_call_proc', ...
+LINE 1: call colocate_proc_with_table('mx_call_proc', 'mx_call_dist_...
         ^
 -- Test that we handle transactional constructs correctly inside a procedure
 -- that is routed to the workers.
@@ -212,9 +212,9 @@ ERROR:  syntax error at or near "PROCEDURE"
 LINE 1: CREATE PROCEDURE mx_call_proc_tx(x int) LANGUAGE plpgsql AS ...
                ^
 -- before distribution ...
-CALL multi_mx_call.mx_call_proc_tx(10);
+CALL mx_call_proc_tx(10);
 ERROR:  syntax error at or near "CALL"
-LINE 1: CALL multi_mx_call.mx_call_proc_tx(10);
+LINE 1: CALL mx_call_proc_tx(10);
         ^
 -- after distribution ...
 select create_distributed_function('mx_call_proc_tx(int)', '$1', 'mx_call_dist_table_1');
@@ -265,9 +265,9 @@ select stop_metadata_sync_to_node('localhost', :worker_2_port);
  
 (1 row)
 
-call multi_mx_call.mx_call_proc(2, 0);
+call mx_call_proc(2, 0);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, 0);
+LINE 1: call mx_call_proc(2, 0);
         ^
 SET client_min_messages TO NOTICE;
 select start_metadata_sync_to_node('localhost', :worker_1_port);
@@ -297,19 +297,19 @@ DETAIL:  A distributed function is created. To make sure subsequent commands see
 (1 row)
 
 -- non-const distribution parameters cannot be pushed down
-call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+call mx_call_proc(2, mx_call_add(3, 4));
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(2, mx_call_add(3, 4));
+LINE 1: call mx_call_proc(2, mx_call_add(3, 4));
         ^
 -- non-const parameter can be pushed down
-call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3, 4), 2);
+call mx_call_proc(mx_call_add(3, 4), 2);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(multi_mx_call.mx_call_add(3,...
+LINE 1: call mx_call_proc(mx_call_add(3, 4), 2);
         ^
 -- volatile parameter cannot be pushed down
-call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+call mx_call_proc(floor(random())::int, 2);
 ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc(floor(random())::int, 2);
+LINE 1: call mx_call_proc(floor(random())::int, 2);
         ^
 reset client_min_messages;
 \set VERBOSITY terse


### PR DESCRIPTION
Adaptive executor also updated to not only store first resultset to tuplestore
This works in our case because SET doesn't produce any tuples
