### PR TITLE
Set default threshold on get_rebalance_table_shards_plan to 0, like rebalance_table_shards

### DIFF
--- a/src/backend/distributed/sql/udfs/get_rebalance_table_shards_plan/9.0-1.sql
+++ b/src/backend/distributed/sql/udfs/get_rebalance_table_shards_plan/9.0-1.sql
@@ -5,7 +5,7 @@
 --
 CREATE OR REPLACE FUNCTION pg_catalog.get_rebalance_table_shards_plan(
         relation regclass,
-        threshold float4 default 0.1,
+        threshold float4 default 0,
         max_shard_moves int default 1000000,
         excluded_shard_list bigint[] default '{}')
     RETURNS TABLE (table_name regclass,

--- a/src/backend/distributed/sql/udfs/get_rebalance_table_shards_plan/latest.sql
+++ b/src/backend/distributed/sql/udfs/get_rebalance_table_shards_plan/latest.sql
@@ -5,7 +5,7 @@
 --
 CREATE OR REPLACE FUNCTION pg_catalog.get_rebalance_table_shards_plan(
         relation regclass,
-        threshold float4 default 0.1,
+        threshold float4 default 0,
         max_shard_moves int default 1000000,
         excluded_shard_list bigint[] default '{}')
     RETURNS TABLE (table_name regclass,


### PR DESCRIPTION
In this PR the default `threshold` of `rebalance_table_shards` was set to 0: https://github.com/citusdata/shard_rebalancer/pull/73
However, the default for get_rebalance_table_shards_plan was not updated. This
can cause the confusing situation where the actual steps run by
`rebalance_table_shards` are not the same as the ones returned by
`get_rebalance_table_shards_plan`.