### PR TITLE
Propagate CREATE OR REPLACE FUNCTION to workers for distributed functions

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -790,7 +790,7 @@ const ObjectAddress *
 CreateFunctionStmtObjectAddress(CreateFunctionStmt *stmt, bool missing_ok)
 {
 	ObjectType objectType = OBJECT_FUNCTION;
-	ObjectWithArgs *owa = NULL;
+	ObjectWithArgs *objectWithArgs = NULL;
 	ListCell *parameterCell = NULL;
 
 #if PG_VERSION_NUM > 110000
@@ -800,16 +800,16 @@ CreateFunctionStmtObjectAddress(CreateFunctionStmt *stmt, bool missing_ok)
 	}
 #endif
 
-	owa = makeNode(ObjectWithArgs);
-	owa->objname = stmt->funcname;
+	objectWithArgs = makeNode(ObjectWithArgs);
+	objectWithArgs->objname = stmt->funcname;
 
 	foreach(parameterCell, stmt->parameters)
 	{
 		FunctionParameter *funcParam = castNode(FunctionParameter, lfirst(parameterCell));
-		owa->objargs = lappend(owa->objargs, funcParam->argType);
+		objectWithArgs->objargs = lappend(objectWithArgs->objargs, funcParam->argType);
 	}
 
-	return FunctionToObjectAddress(objectType, owa, missing_ok);
+	return FunctionToObjectAddress(objectType, objectWithArgs, missing_ok);
 }
 
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -554,6 +554,12 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 											queryString);
 		}
 
+		if (IsA(parsetree, CreateFunctionStmt))
+		{
+			ddlJobs = PlanCreateFunctionStmt(castNode(CreateFunctionStmt, parsetree),
+											 queryString);
+		}
+
 		/*
 		 * ALTER TABLE ALL IN TABLESPACE statements have their node type as
 		 * AlterTableMoveAllStmt. At the moment we do not support this functionality in
@@ -705,6 +711,13 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		if (IsA(parsetree, AlterEnumStmt))
 		{
 			ProcessAlterEnumStmt(castNode(AlterEnumStmt, parsetree), queryString);
+		}
+
+		if (IsA(parsetree, CreateFunctionStmt))
+		{
+			Assert(ddlJobs == NIL); /* jobs should not have been set before */
+			ddlJobs = ProcessCreateFunctionStmt(castNode(CreateFunctionStmt, parsetree),
+												queryString);
 		}
 	}
 

--- a/src/backend/distributed/deparser/objectaddress.c
+++ b/src/backend/distributed/deparser/objectaddress.c
@@ -82,6 +82,12 @@ GetObjectAddressFromParseTree(Node *parseTree, bool missing_ok)
 												  missing_ok);
 		}
 
+		case T_CreateFunctionStmt:
+		{
+			return CreateFunctionStmtObjectAddress(
+				castNode(CreateFunctionStmt, parseTree), missing_ok);
+		}
+
 		default:
 		{
 			/*

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -51,6 +51,11 @@ extern bool ConstraintIsAForeignKey(char *constraintName, Oid relationId);
 
 
 /* function.c - forward declarations */
+extern List * PlanCreateFunctionStmt(CreateFunctionStmt *stmt, const char *queryString);
+extern List * ProcessCreateFunctionStmt(CreateFunctionStmt *stmt, const
+										char *queryString);
+extern const ObjectAddress * CreateFunctionStmtObjectAddress(CreateFunctionStmt *stmt,
+															 bool missing_ok);
 extern List * PlanAlterFunctionStmt(AlterFunctionStmt *stmt, const char *queryString);
 extern const ObjectAddress * AlterFunctionStmtObjectAddress(AlterFunctionStmt *stmt,
 															bool missing_ok);

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -288,6 +288,19 @@ SELECT * FROM run_command_on_workers('SELECT function_tests2.add(2,3);') ORDER B
 (2 rows)
 
 ALTER FUNCTION function_tests2.add(int,int) SET SCHEMA function_tests;
+-- when a function is distributed and we create or replace the function we need to propagate the statement to the worker to keep it in sync with the coordinator
+CREATE OR REPLACE FUNCTION add(integer, integer) RETURNS integer
+AS 'select $1 * $2;' -- I know, this is not an add, but the output will tell us if the update succeeded
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
+ nodename  | nodeport | success | result 
+-----------+----------+---------+--------
+ localhost |    57637 | t       | 6
+ localhost |    57638 | t       | 6
+(2 rows)
+
 DROP FUNCTION add(int,int);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -294,6 +294,12 @@ AS 'select $1 * $2;' -- I know, this is not an add, but the output will tell us 
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
+SELECT public.verify_function_is_same_on_workers('function_tests.add(int,int)');
+ verify_function_is_same_on_workers 
+------------------------------------
+ t
+(1 row)
+
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
  nodename  | nodeport | success | result 
 -----------+----------+---------+--------

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -155,6 +155,7 @@ AS 'select $1 * $2;' -- I know, this is not an add, but the output will tell us 
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
+SELECT public.verify_function_is_same_on_workers('function_tests.add(int,int)');
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
 
 DROP FUNCTION add(int,int);

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -149,6 +149,14 @@ SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY
 SELECT * FROM run_command_on_workers('SELECT function_tests2.add(2,3);') ORDER BY 1,2;
 ALTER FUNCTION function_tests2.add(int,int) SET SCHEMA function_tests;
 
+-- when a function is distributed and we create or replace the function we need to propagate the statement to the worker to keep it in sync with the coordinator
+CREATE OR REPLACE FUNCTION add(integer, integer) RETURNS integer
+AS 'select $1 * $2;' -- I know, this is not an add, but the output will tell us if the update succeeded
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
+
 DROP FUNCTION add(int,int);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;


### PR DESCRIPTION
DESCRIPTION: Propagate CREATE OR REPLACE FUNCTION

Distributed functions could be replaced, which should be propagated to the workers to keep the function in sync between all nodes.

Due to the complexity of deparsing the `CreateFunctionStmt` we actually produce the plan during the processing phase of our utilityhook. Since the changes have already been made in the catalog tables we can reuse `pg_get_functiondef` to get us the generated `CREATE OR REPLACE` sql.