### PR TITLE
Hotfix for circleci problem where directory is owned by root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-multi)'
-          command: 'install-and-test-ext check-multi'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi'
       - codecov/upload:
           flags: 'test_10,multi'
   test-10_check-tt-van-mx:
@@ -51,7 +51,7 @@ jobs:
           at: .
       - run:
           name: 'Install and Test (check-tt-van-mx)'
-          command: 'install-and-test-ext check-multi-task-tracker-extra check-vanilla check-multi-mx'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi-task-tracker-extra check-vanilla check-multi-mx'
       - codecov/upload:
           flags: 'test_10,tracker,vanilla,mx'
   test-10_check-iso-work-fol:
@@ -63,7 +63,7 @@ jobs:
            at: .
       - run: 
           name: 'Install and Test (check-iso-work-fol)'
-          command: 'install-and-test-ext check-isolation check-worker'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation check-worker'
       - codecov/upload: 
           flags: 'test_10,isolation,worker'
   test-10_check-fol:
@@ -78,7 +78,7 @@ jobs:
           command: 'ulimit -c unlimited'
       - run: 
           name: 'Install and Test (fol)'
-          command: 'install-and-test-ext check-follower-cluster'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-follower-cluster'
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -97,7 +97,7 @@ jobs:
           at: .
       - run:
           name: 'Install and Test (check-failure)'
-          command: 'install-and-test-ext check-failure'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-failure'
   test-11_check-multi:
     docker:
       - image: 'citus/exttester-11:latest'
@@ -107,7 +107,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-multi)'
-          command: 'install-and-test-ext check-multi'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi'
       - codecov/upload: 
           flags: 'test_11,multi'
 
@@ -120,7 +120,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-non-adaptive-executors)'
-          command: 'install-and-test-ext check-multi-non-adaptive'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi-non-adaptive'
       - codecov/upload:
           flags: 'test_11,multi'
 
@@ -133,7 +133,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-non-adaptive-executors)'
-          command: 'install-and-test-ext check-failure-non-adaptive'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-failure-non-adaptive'
       - codecov/upload:
           flags: 'test_11,failure'
 
@@ -146,7 +146,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-non-adaptive-executors)'
-          command: 'install-and-test-ext check-isolation-non-adaptive'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation-non-adaptive'
       - codecov/upload: 
           flags: 'test_11,isolation'
 
@@ -160,7 +160,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-tt-van-mx)'
-          command: 'install-and-test-ext check-multi-task-tracker-extra check-vanilla check-multi-mx'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi-task-tracker-extra check-vanilla check-multi-mx'
       - codecov/upload: 
           flags: 'test_11,tracker,vanilla,mx'
   test-11_check-iso-work-fol:
@@ -172,7 +172,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-iso-work-fol)'
-          command: 'install-and-test-ext check-isolation check-worker'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation check-worker'
       - codecov/upload:
           flags: 'test_11,isolation,worker'
   test-11_check-fol:
@@ -187,7 +187,7 @@ jobs:
           command: 'ulimit -c unlimited'
       - run:
           name: 'Install and Test (fol)'
-          command: 'install-and-test-ext check-follower-cluster'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-follower-cluster'
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -206,7 +206,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and Test (check-failure)'
-          command: 'install-and-test-ext check-failure'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-failure'
   test-10-11_check-pg-upgrade:
     docker:
       - image: 'citus/pgupgradetester:latest'
@@ -216,7 +216,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and test postgres upgrade'
-          command: 'install-and-test-ext --target check-upgrade --old-pg-version 10 --new-pg-version 11'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext --target check-upgrade --old-pg-version 10 --new-pg-version 11'
   test-11-12_check-pg-upgrade:
     docker:
       - image: 'citus/pgupgradetester:latest'
@@ -226,7 +226,7 @@ jobs:
           at: .
       - run: 
           name: 'Install and test postgres upgrade'
-          command: 'install-and-test-ext --target check-upgrade --old-pg-version 11 --new-pg-version 12'        
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext --target check-upgrade --old-pg-version 11 --new-pg-version 12'
 
 workflows:
   version: 2


### PR DESCRIPTION
CircleCI seems to be having some issues where the directory is not owned by the
`circleci` user, but by root. This hopefully fixes that. Example of issue:
https://circleci.com/gh/citusdata/citus/40446