### PR TITLE
Disallow distributed functions for functions depending on an extension

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1072,6 +1072,17 @@ PlanDropFunctionStmt(DropStmt *stmt, const char *queryString)
 }
 
 
+/*
+ * PlanAlterFunctionDependsStmt is called during the planning phase of an
+ * ALTER FUNCION ... DEPENDS ON EXTENSION ... statement. Since functions depending on
+ * extensions are assumed to be Owned by an extension we assume the extension to keep the
+ * function in sync.
+ *
+ * If we would allow users to create a dependency between a distributed function and an
+ * extension our pruning logic for which objects to distribute as dependencies of other
+ * objects will change significantly which could cause issues adding new workers. Hence we
+ * don't allow this dependency to be created.
+ */
 List *
 PlanAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt, const char *queryString)
 {
@@ -1119,6 +1130,11 @@ PlanAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt, const char *queryStri
 }
 
 
+/*
+ * AlterFunctionDependsStmtObjectAddress resolves the ObjectAddress of the function that
+ * is the subject of an ALTER FUNCTION ... DEPENS ON EXTENSION ... statement. If
+ * missing_ok is set to false the lookup will raise an error.
+ */
 const ObjectAddress *
 AlterFunctionDependsStmtObjectAddress(AlterObjectDependsStmt *stmt, bool missing_ok)
 {

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1111,11 +1111,10 @@ PlanAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt, const char *queryStri
 	 * workers
 	 */
 
-	functionName = get_func_name(address->objectId);
-
+	functionName = getObjectIdentity(address);
 	ereport(ERROR, (errmsg("distrtibuted functions are not allowed to depend on an "
 						   "extension"),
-					errdetail("function \"%s\" is already distributed. Functions from "
+					errdetail("Function \"%s\" is already distributed. Functions from "
 							  "extensions are expected to be created on the workers by "
 							  "the extension they depend on.", functionName)));
 }

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -99,6 +99,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 
 	const char *ddlCommand = NULL;
 	ObjectAddress functionAddress = { 0 };
+	ObjectAddress extensionAddress = { 0 };
 
 	int distributionArgumentIndex = -1;
 	Oid distributionArgumentOid = InvalidOid;
@@ -146,15 +147,17 @@ create_distributed_function(PG_FUNCTION_ARGS)
 
 	ObjectAddressSet(functionAddress, ProcedureRelationId, funcOid);
 
-	if (IsObjectAddressOwnedByExtension(&functionAddress))
+	if (IsObjectAddressOwnedByExtension(&functionAddress, &extensionAddress))
 	{
+		char *extensionName = getObjectIdentity(&extensionAddress);
 		char *functionName = get_func_name(funcOid);
 		ereport(ERROR, (errmsg("unable to create a distributed function from functions "
 							   "owned by an extension"),
-						errdetail("Function \"%s\" has a dependency on an extension. "
+						errdetail("Function \"%s\" has a dependency on extension \"%s\". "
 								  "Functions depending on an extension cannot be "
 								  "distributed. Create the function by creating the "
-								  "extension on the workers.", functionName)));
+								  "extension on the workers.", functionName,
+								  extensionName)));
 	}
 
 	/*

--- a/src/backend/distributed/deparser/objectaddress.c
+++ b/src/backend/distributed/deparser/objectaddress.c
@@ -24,6 +24,8 @@ static const ObjectAddress * RenameAttributeStmtObjectAddress(RenameStmt *stmt,
 															  bool missing_ok);
 static const ObjectAddress * AlterOwnerStmtObjectAddress(AlterOwnerStmt *stmt,
 														 bool missing_ok);
+static const ObjectAddress * AlterObjectDependsStmtObjectAddress(
+	AlterObjectDependsStmt *stmt, bool missing_ok);
 
 
 /*
@@ -86,6 +88,12 @@ GetObjectAddressFromParseTree(Node *parseTree, bool missing_ok)
 		{
 			return CreateFunctionStmtObjectAddress(
 				castNode(CreateFunctionStmt, parseTree), missing_ok);
+		}
+
+		case T_AlterObjectDependsStmt:
+		{
+			return AlterObjectDependsStmtObjectAddress(
+				castNode(AlterObjectDependsStmt, parseTree), missing_ok);
 		}
 
 		default:
@@ -222,6 +230,28 @@ AlterOwnerStmtObjectAddress(AlterOwnerStmt *stmt, bool missing_ok)
 		{
 			ereport(ERROR, (errmsg("unsupported alter owner statement to get object "
 								   "address for")));
+		}
+	}
+}
+
+
+static const ObjectAddress *
+AlterObjectDependsStmtObjectAddress(AlterObjectDependsStmt *stmt, bool missing_ok)
+{
+	switch (stmt->objectType)
+	{
+#if PG_VERSION_NUM > 110000
+		case OBJECT_PROCEDURE:
+#endif
+		case OBJECT_FUNCTION:
+		{
+			return AlterFunctionDependsStmtObjectAddress(stmt, missing_ok);
+		}
+
+		default:
+		{
+			ereport(ERROR, (errmsg("unsupported alter depends on extension statement to "
+								   "get object address for")));
 		}
 	}
 }

--- a/src/backend/distributed/deparser/objectaddress.c
+++ b/src/backend/distributed/deparser/objectaddress.c
@@ -235,6 +235,16 @@ AlterOwnerStmtObjectAddress(AlterOwnerStmt *stmt, bool missing_ok)
 }
 
 
+/*
+ * AlterObjectDependsStmtObjectAddress resolves the ObjectAddress for the object targeted
+ * by the AlterObjectDependStmt. This is done by dispatching the call to the object
+ * specific implementation based on the ObjectType captured in the original statement. If
+ * a specific implementation is not present an error will be raised. This is a developer
+ * error since this function should only be reachable by calls of supported types.
+ *
+ * If missing_ok is set to fails the object specific implementation is supposed to raise
+ * an error explaining the user the object is not existing.
+ */
 static const ObjectAddress *
 AlterObjectDependsStmtObjectAddress(AlterObjectDependsStmt *stmt, bool missing_ok)
 {

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -60,9 +60,6 @@ static bool FollowNewSupportedDependencies(void *context, Form_pg_depend pg_depe
 static void ApplyAddToDependencyList(void *context, Form_pg_depend pg_depend);
 static List * ExpandCitusSupportedTypes(void *context, const ObjectAddress *target);
 
-/* forward declaration of support functions to decide what to follow */
-static bool IsObjectAddressOwnedByExtension(const ObjectAddress *target);
-
 
 /*
  * GetDependenciesForObject returns a list of ObjectAddesses to be created in order
@@ -404,7 +401,7 @@ SupportedDependencyByCitus(const ObjectAddress *address)
  * extension. It is assumed that an object having a dependency on an extension is created
  * by that extension and therefore owned by that extension.
  */
-static bool
+bool
 IsObjectAddressOwnedByExtension(const ObjectAddress *target)
 {
 	Relation depRel = NULL;

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -72,6 +72,10 @@ extern const ObjectAddress * AlterFunctionSchemaStmtObjectAddress(
 extern void ProcessAlterFunctionSchemaStmt(AlterObjectSchemaStmt *stmt,
 										   const char *queryString);
 extern List * PlanDropFunctionStmt(DropStmt *stmt, const char *queryString);
+extern List * PlanAlterFunctionDependsStmt(AlterObjectDependsStmt *stmt,
+										   const char *queryString);
+extern const ObjectAddress * AlterFunctionDependsStmtObjectAddress(
+	AlterObjectDependsStmt *stmt, bool missing_ok);
 
 
 /* grant.c - forward declarations */

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -21,7 +21,8 @@ extern bool IsObjectDistributed(const ObjectAddress *address);
 extern bool ClusterHasDistributedFunctionWithDistArgument(void);
 extern void MarkObjectDistributed(const ObjectAddress *distAddress);
 extern void UnmarkObjectDistributed(const ObjectAddress *address);
-bool IsObjectAddressOwnedByExtension(const ObjectAddress *target);
+extern bool IsObjectAddressOwnedByExtension(const ObjectAddress *target,
+											ObjectAddress *extensionAddress);
 
 extern List * GetDistributedObjectAddressList(void);
 

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -21,6 +21,7 @@ extern bool IsObjectDistributed(const ObjectAddress *address);
 extern bool ClusterHasDistributedFunctionWithDistArgument(void);
 extern void MarkObjectDistributed(const ObjectAddress *distAddress);
 extern void UnmarkObjectDistributed(const ObjectAddress *address);
+bool IsObjectAddressOwnedByExtension(const ObjectAddress *target);
 
 extern List * GetDistributedObjectAddressList(void);
 

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -314,7 +314,7 @@ ERROR:  distrtibuted functions are not allowed to depend on an extension
 DETAIL:  function "add" is already distributed. Functions from extensions are expected to be created on the workers by the extension they depend on.
 SELECT create_distributed_function('pg_catalog.citus_drop_trigger()');
 ERROR:  unable to create a distributed function from functions owned by an extension
-DETAIL:  Function "citus_drop_trigger" has a dependency on extension "citus". Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.
+DETAIL:  Function "pg_catalog.citus_drop_trigger()" has a dependency on extension "citus". Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.
 DROP FUNCTION add(int,int);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -307,6 +307,14 @@ SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY
  localhost |    57638 | t       | 6
 (2 rows)
 
+-- distributed functions should not be allowed to depend on an extension, also functions
+-- that depend on an extension should not be allowed to be distributed.
+ALTER FUNCTION add(int,int) DEPENDS ON EXTENSION citus;
+ERROR:  distrtibuted functions are not allowed to depend on an extension
+DETAIL:  function "add" is already distributed. Functions from extensions are expected to be created on the workers by the extension they depend on.
+SELECT create_distributed_function('pg_catalog.citus_drop_trigger()');
+ERROR:  unable to create a distributed function from functions owned by an extension
+DETAIL:  Function "citus_drop_trigger" has a dependency on an extension. Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.
 DROP FUNCTION add(int,int);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -314,7 +314,7 @@ ERROR:  distrtibuted functions are not allowed to depend on an extension
 DETAIL:  function "add" is already distributed. Functions from extensions are expected to be created on the workers by the extension they depend on.
 SELECT create_distributed_function('pg_catalog.citus_drop_trigger()');
 ERROR:  unable to create a distributed function from functions owned by an extension
-DETAIL:  Function "citus_drop_trigger" has a dependency on an extension. Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.
+DETAIL:  Function "citus_drop_trigger" has a dependency on extension "citus". Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.
 DROP FUNCTION add(int,int);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -311,7 +311,7 @@ SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY
 -- that depend on an extension should not be allowed to be distributed.
 ALTER FUNCTION add(int,int) DEPENDS ON EXTENSION citus;
 ERROR:  distrtibuted functions are not allowed to depend on an extension
-DETAIL:  function "add" is already distributed. Functions from extensions are expected to be created on the workers by the extension they depend on.
+DETAIL:  Function "function_tests.add(integer,integer)" is already distributed. Functions from extensions are expected to be created on the workers by the extension they depend on.
 SELECT create_distributed_function('pg_catalog.citus_drop_trigger()');
 ERROR:  unable to create a distributed function from functions owned by an extension
 DETAIL:  Function "pg_catalog.citus_drop_trigger()" has a dependency on extension "citus". Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -158,6 +158,11 @@ AS 'select $1 * $2;' -- I know, this is not an add, but the output will tell us 
 SELECT public.verify_function_is_same_on_workers('function_tests.add(int,int)');
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;
 
+-- distributed functions should not be allowed to depend on an extension, also functions
+-- that depend on an extension should not be allowed to be distributed.
+ALTER FUNCTION add(int,int) DEPENDS ON EXTENSION citus;
+SELECT create_distributed_function('pg_catalog.citus_drop_trigger()');
+
 DROP FUNCTION add(int,int);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers('SELECT function_tests.add(2,3);') ORDER BY 1,2;


### PR DESCRIPTION
DESCRIPTION: Disallow distributed functions for functions depending on an extension

Functions depending on an extension cannot (yet) be distributed by citus. If we would allow this it would cause issues with our dependency following mechanism as we stop following objects depending on an extension.

By not allowing functions to be distributed when they depend on an extension as well as not allowing to make distributed functions depend on an extension we won't break the ability to add new nodes. Allowing functions depending on extensions to be distributed at the moment could cause problems in that area.