### PR TITLE
Update CircleCI codecov orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.4
+  codecov: codecov/codecov@1.0.5
 
 jobs:
   build:


### PR DESCRIPTION
Hopefully this fixes the long runtime for coverage uploads that we sometimes have (> 1 minute).