### PR TITLE
Avoid caching connections from backends that service internal connections

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -89,7 +89,7 @@ ResetConnParams()
 
 	InvalidateConnParamsHashEntries();
 
-	AddConnParam("fallback_application_name", "citus");
+	AddConnParam("fallback_application_name", CITUS_APPLICATION_NAME);
 }
 
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -27,6 +27,9 @@
 /* default notice level */
 #define DEFAULT_CITUS_NOTICE_LEVEL DEBUG1
 
+/* application name used for internal connections in Citus */
+#define CITUS_APPLICATION_NAME "citus"
+
 /* forward declare, to avoid forcing large headers on everyone */
 struct pg_conn; /* target of the PGconn typedef */
 struct MemoryContextData;


### PR DESCRIPTION
Some functions on the workers open connections on to other workers (e.g. when we do stored procedure delegation with non-local execution). We want to make sure we do not cache those connections, since we would otherwise have a quadratic number of cached connections come in to each worker, or even exponential if the other worker also ends up opening connections.

This change ensures we do not cache connections in backends that service internal connections by looking at the application_name, which is `"citus"` for all internal connections. This does not prohibit connection caching when the client connects directly to the workers (MX), but that can still be disabled separately via `citus.max_cached_conns_per_worker` if desired.