### PR TITLE
Fix pg12 empty from clauses

### DIFF
--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -342,13 +342,12 @@ DETAIL:  A distributed function is created. To make sure subsequent commands see
  
 (1 row)
 
+\set VERBOSITY terse
 call multi_mx_call.mx_call_proc_raise(2);
 DEBUG:  pushing down the procedure
 DEBUG:  warning
-DETAIL:  WARNING from localhost:57638
 ERROR:  error
-CONTEXT:  while executing command on localhost:57638
-PL/pgSQL function multi_mx_call.mx_call_proc_raise(integer) line 4 at RAISE
+\set VERBOSITY default
 -- Test that we don't propagate to non-metadata worker nodes
 select stop_metadata_sync_to_node('localhost', :worker_1_port);
  stop_metadata_sync_to_node 

--- a/src/test/regress/expected/multi_mx_call_0.out
+++ b/src/test/regress/expected/multi_mx_call_0.out
@@ -263,10 +263,10 @@ select create_distributed_function('mx_call_proc_raise(int)', '$1', 'mx_call_dis
 ERROR:  function "mx_call_proc_raise(int)" does not exist
 LINE 1: select create_distributed_function('mx_call_proc_raise(int)'...
                                            ^
+\set VERBOSITY terse
 call multi_mx_call.mx_call_proc_raise(2);
-ERROR:  syntax error at or near "call"
-LINE 1: call multi_mx_call.mx_call_proc_raise(2);
-        ^
+ERROR:  syntax error at or near "call" at character 1
+\set VERBOSITY default
 -- Test that we don't propagate to non-metadata worker nodes
 select stop_metadata_sync_to_node('localhost', :worker_1_port);
  stop_metadata_sync_to_node 

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -265,11 +265,11 @@ SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_
 DELETE FROM pg_dist_node;
 \c - - - :worker_1_port
 -- DROP TABLE
+-- terse verbosity because pg10 has slightly different output
+\set VERBOSITY terse
 DROP TABLE mx_table;
 ERROR:  operation is not allowed on this node
-HINT:  Connect to the coordinator and run it again.
-CONTEXT:  SQL statement "SELECT master_remove_distributed_table_metadata_from_workers(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
-PL/pgSQL function citus_drop_trigger() line 18 at PERFORM
+\set VERBOSITY default
 SELECT count(*) FROM mx_table;
  count 
 -------

--- a/src/test/regress/sql/multi_mx_call.sql
+++ b/src/test/regress/sql/multi_mx_call.sql
@@ -143,8 +143,9 @@ BEGIN
     RAISE EXCEPTION 'error';
 END;$$;
 select create_distributed_function('mx_call_proc_raise(int)', '$1', 'mx_call_dist_table_1');
+\set VERBOSITY terse
 call multi_mx_call.mx_call_proc_raise(2);
-
+\set VERBOSITY default
 
 -- Test that we don't propagate to non-metadata worker nodes
 select stop_metadata_sync_to_node('localhost', :worker_1_port);

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -154,7 +154,10 @@ DELETE FROM pg_dist_node;
 \c - - - :worker_1_port
 
 -- DROP TABLE
+-- terse verbosity because pg10 has slightly different output
+\set VERBOSITY terse
 DROP TABLE mx_table;
+\set VERBOSITY default
 SELECT count(*) FROM mx_table;
 
 -- master_drop_distributed_table_metadata


### PR DESCRIPTION
PG12 introduced some changes in the way Query objects store the `jointree` of the query. This PR aims to take this into account and make necessary checks during processing queries without any `FROM` or `WHERE` clauses.

## Changes in tests:

Outputs of these tests are slightly different than PG11:
- multi_mx_call
- multi_mx_function_call_delegation
- multi_unsupported_worker_operations
	
I created new regression test outputs for these files and rotated all necessary test outputs. For example here are the expected regression outputs for `multi_mx_call`:

| test output         	| PG version 	|
|---------------------	|------------	|
| multi_mx_call.out   	| PG12       	|
| multi_mx_call_0.out 	| PG11       	|
| multi_mx_call_1.out 	| PG11       	|

Note: all the changes introduced in this PR is inside a `#if PG_VERSION_NUM >= 120000` block, so there is no CI job testing these commits. I ran `make check` to test citus master branch running on `PG 12rc1`