### PR TITLE
MX Isolation Tests for Foreign keys from Distributrion to Reference tables vs DML

### DIFF
--- a/src/test/regress/expected/isolation_dis2ref_foreign_keys_on_mx.out
+++ b/src/test/regress/expected/isolation_dis2ref_foreign_keys_on_mx.out
@@ -1,0 +1,544 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-delete s2-start-session-level-connection s2-begin-on-worker s2-insert s1-rollback-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-delete: 
+	SELECT run_commands_on_session_level_connection_to_node('DELETE FROM ref_table WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-insert: 
+        SELECT run_commands_on_session_level_connection_to_node('INSERT INTO dist_table VALUES (1, 1)');
+ <waiting ...>
+step s1-rollback-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('ROLLBACK');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-insert: <... completed>
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+1              10             
+2              20             
+id             value          
+
+1              1              
+1              1              
+2              2              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-delete s2-start-session-level-connection s2-begin-on-worker s2-select s1-commit-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-delete: 
+	SELECT run_commands_on_session_level_connection_to_node('DELETE FROM ref_table WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-select: 
+        SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM dist_table WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+2              20             
+id             value          
+
+2              2              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-delete s2-start-session-level-connection s2-begin-on-worker s2-insert-select s1-rollback-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-delete: 
+	SELECT run_commands_on_session_level_connection_to_node('DELETE FROM ref_table WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-insert-select: 
+        SELECT run_commands_on_session_level_connection_to_node('INSERT INTO dist_table SELECT * FROM dist_table');
+ <waiting ...>
+step s1-rollback-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('ROLLBACK');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-insert-select: <... completed>
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+1              10             
+2              20             
+id             value          
+
+1              1              
+1              1              
+2              2              
+2              2              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-update s2-start-session-level-connection s2-begin-on-worker s2-update s1-commit-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-update: 
+	SELECT run_commands_on_session_level_connection_to_node('UPDATE ref_table SET id=id+2 WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-update: 
+        SELECT run_commands_on_session_level_connection_to_node('UPDATE dist_table SET value=2 WHERE id=1');
+ <waiting ...>
+step s1-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-update: <... completed>
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+2              20             
+3              10             
+id             value          
+
+1              2              
+2              2              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-update s2-start-session-level-connection s2-begin-on-worker s2-copy s1-rollback-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-update: 
+	SELECT run_commands_on_session_level_connection_to_node('UPDATE ref_table SET id=id+2 WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-copy: 
+        SELECT run_commands_on_session_level_connection_to_node('COPY dist_table FROM PROGRAM ''echo 1, 1''WITH CSV');
+ <waiting ...>
+step s1-rollback-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('ROLLBACK');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-copy: <... completed>
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+1              10             
+2              20             
+id             value          
+
+1              1              
+1              1              
+2              2              
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-update s2-start-session-level-connection s2-begin-on-worker s2-truncate s1-commit-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-update: 
+	SELECT run_commands_on_session_level_connection_to_node('UPDATE ref_table SET id=id+2 WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-truncate: 
+        SELECT run_commands_on_session_level_connection_to_node('TRUNCATE dist_table');
+ <waiting ...>
+step s1-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-truncate: <... completed>
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+2              20             
+3              10             
+id             value          
+
+restore_isolation_tester_func
+
+               
+
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-delete s2-start-session-level-connection s2-begin-on-worker s2-select-for-udpate s1-commit-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-display
+step s1-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+
+start_session_level_connection_to_node
+
+               
+step s1-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-delete: 
+	SELECT run_commands_on_session_level_connection_to_node('DELETE FROM ref_table WHERE id=1');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-start-session-level-connection: 
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+
+start_session_level_connection_to_node
+
+               
+step s2-begin-on-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-select-for-udpate: 
+        SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM dist_table WHERE id=1 FOR UPDATE');
+ <waiting ...>
+step s1-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-select-for-udpate: <... completed>
+run_commands_on_session_level_connection_to_node
+
+               
+step s2-commit-worker: 
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+
+run_commands_on_session_level_connection_to_node
+
+               
+step s1-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s2-stop-connection: 
+	SELECT stop_session_level_connection_to_node();
+
+stop_session_level_connection_to_node
+
+               
+step s3-display: 
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+
+id             value          
+
+2              20             
+id             value          
+
+2              2              
+restore_isolation_tester_func
+
+               

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -70,3 +70,4 @@ test: isolation_drop_alter_index_select_for_update_on_mx
 test: isolation_insert_select_vs_all_on_mx
 test: isolation_ref_select_for_update_vs_all_on_mx
 test: isolation_ref_update_delete_upsert_vs_all_on_mx
+test: isolation_dis2ref_foreign_keys_on_mx

--- a/src/test/regress/specs/isolation_dis2ref_foreign_keys_on_mx.spec
+++ b/src/test/regress/specs/isolation_dis2ref_foreign_keys_on_mx.spec
@@ -1,0 +1,166 @@
+setup
+{
+	CREATE OR REPLACE FUNCTION start_session_level_connection_to_node(text, integer)
+            RETURNS void
+            LANGUAGE C STRICT VOLATILE
+            AS 'citus', $$start_session_level_connection_to_node$$;
+
+        CREATE OR REPLACE FUNCTION run_commands_on_session_level_connection_to_node(text)
+            RETURNS void
+            LANGUAGE C STRICT VOLATILE
+            AS 'citus', $$run_commands_on_session_level_connection_to_node$$;
+
+        CREATE OR REPLACE FUNCTION stop_session_level_connection_to_node()
+            RETURNS void
+            LANGUAGE C STRICT VOLATILE
+            AS 'citus', $$stop_session_level_connection_to_node$$;
+	
+
+	SELECT citus_internal.replace_isolation_tester_func();
+  	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
+
+	-- start_metadata_sync_to_node can not be run inside a transaction block.
+	-- Following is a workaround to overcome that. Port numbers are hard coded
+	-- at the moment.
+	SELECT master_run_on_worker(
+		ARRAY['localhost']::text[],
+		ARRAY[57636]::int[],
+		ARRAY[format('SELECT start_metadata_sync_to_node(''%s'', %s)', nodename, nodeport)]::text[],
+		false)
+	FROM pg_dist_node;
+
+	SET citus.replication_model to streaming;
+	SET citus.shard_replication_factor TO 1;
+	
+	CREATE TABLE ref_table(id int PRIMARY KEY, value int);
+	SELECT create_reference_table('ref_table');
+
+	CREATE TABLE dist_table(id int, value int REFERENCES ref_table(id) ON DELETE CASCADE ON UPDATE CASCADE);
+	SELECT create_distributed_table('dist_table', 'id');
+
+	INSERT INTO ref_table VALUES (1, 10), (2, 20);
+	INSERT INTO dist_table VALUES (1, 1), (2, 2);
+}
+
+teardown
+{
+	DROP TABLE ref_table, dist_table;
+	SELECT citus_internal.restore_isolation_tester_func();
+}
+
+session "s1"
+
+step "s1-start-session-level-connection"
+{
+	SELECT start_session_level_connection_to_node('localhost', 57637);
+}
+
+step "s1-begin-on-worker"
+{
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+}
+
+step "s1-delete"
+{
+	SELECT run_commands_on_session_level_connection_to_node('DELETE FROM ref_table WHERE id=1');
+}
+
+step "s1-update"
+{
+	SELECT run_commands_on_session_level_connection_to_node('UPDATE ref_table SET id=id+2 WHERE id=1');
+}
+
+step "s1-commit-worker"
+{
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+}
+
+step "s1-rollback-worker"
+{
+	SELECT run_commands_on_session_level_connection_to_node('ROLLBACK');
+}
+
+step "s1-stop-connection"
+{
+	SELECT stop_session_level_connection_to_node();
+}
+
+session "s2"
+
+step "s2-start-session-level-connection"
+{
+	SELECT start_session_level_connection_to_node('localhost', 57638);
+}
+
+step "s2-begin-on-worker"
+{
+	SELECT run_commands_on_session_level_connection_to_node('BEGIN'); 
+}
+
+step "s2-insert"
+{
+        SELECT run_commands_on_session_level_connection_to_node('INSERT INTO dist_table VALUES (1, 1)');
+}
+
+step "s2-select"
+{
+        SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM dist_table WHERE id=1');
+}
+
+step "s2-insert-select"
+{
+        SELECT run_commands_on_session_level_connection_to_node('INSERT INTO dist_table SELECT * FROM dist_table');
+}
+
+step "s2-update"
+{
+        SELECT run_commands_on_session_level_connection_to_node('UPDATE dist_table SET value=2 WHERE id=1');
+}
+
+step "s2-copy"
+{
+        SELECT run_commands_on_session_level_connection_to_node('COPY dist_table FROM PROGRAM ''echo 1, 1''WITH CSV');
+}
+
+step "s2-truncate"
+{
+        SELECT run_commands_on_session_level_connection_to_node('TRUNCATE dist_table');
+}
+
+step "s2-select-for-udpate"
+{
+        SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM dist_table WHERE id=1 FOR UPDATE');
+}
+
+step "s2-coordinator-create-index-concurrently"
+{
+        CREATE INDEX CONCURRENTLY dist_table_index ON dist_table(id);
+}
+
+step "s2-commit-worker"
+{
+	SELECT run_commands_on_session_level_connection_to_node('COMMIT');
+}
+
+step "s2-stop-connection"
+{
+	SELECT stop_session_level_connection_to_node();
+}
+
+session "s3"
+
+step "s3-display"
+{
+	SELECT * FROM ref_table ORDER BY id, value;
+	SELECT * FROM dist_table ORDER BY id, value;
+}
+
+
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-delete" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-insert" "s1-rollback-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-delete" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-delete" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-insert-select" "s1-rollback-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-update" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-update" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-copy" "s1-rollback-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-update" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-truncate" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-delete" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-udpate" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-display"
+#permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-update" "s2-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection" "s3-display"


### PR DESCRIPTION
Created isolation tests for distribution table to reference table foreign keys vs DML operations on MX.