### PR TITLE
Update certifi in regress pipenv

### DIFF
--- a/src/test/regress/Pipfile.lock
+++ b/src/test/regress/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "705f2b4bd5a49fcd8d7a7d0b4f1bc90f92f8fa3640764b36689296365d41aefe"
+            "sha256": "b275a748e05be7bb653f589f10e279838e2401900af6c211a00edb1212252a1c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -67,10 +67,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "cffi": {
             "hashes": [


### PR DESCRIPTION
For some reason pipenv really wanted me to update this when I ran `pipenv install`.
To improve future `pipenv install` runs it's probably best to save this change.