### PR TITLE
Check command type in TryToDelegateFunctionCall

### DIFF
--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -141,6 +141,12 @@ TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 		return NULL;
 	}
 
+	if (query->commandType != CMD_SELECT)
+	{
+		/* not a SELECT */
+		return NULL;
+	}
+
 	joinTree = query->jointree;
 	if (joinTree == NULL)
 	{


### PR DESCRIPTION
We do a lot of checks in `TryToDelegateFunctionCall` to see if the query has the right format for a `SELECT distributed_function(...)`, but we neglect to check whether the query is actually a SELECT. 