### PR TITLE
Grant usage on schema citus to public

### DIFF
--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -17,6 +17,9 @@ ALTER FUNCTION citus.refresh_isolation_tester_prepared_statement SET SCHEMA citu
 ALTER FUNCTION citus.replace_isolation_tester_func SET SCHEMA citus_internal;
 ALTER FUNCTION citus.restore_isolation_tester_func SET SCHEMA citus_internal;
 
+-- we can now safely grant usage on the citus schema to use types
+GRANT USAGE ON SCHEMA citus TO public;
+
 #include "udfs/pg_dist_shard_placement_trigger_func/9.0-1.sql"
 
 CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statement text)

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -180,6 +180,32 @@ SELECT task_tracker_assign_task(1, 1, 'SELECT 1');
 
 -- check read permission
 SET ROLE read_access;
+-- should be allowed to run commands, as the current user
+SELECT result FROM run_command_on_workers($$SELECT current_user$$);
+   result    
+-------------
+ read_access
+ read_access
+(2 rows)
+
+SELECT result FROM run_command_on_placements('test', $$SELECT current_user$$);
+   result    
+-------------
+ read_access
+ read_access
+ read_access
+ read_access
+(4 rows)
+
+SELECT result FROM run_command_on_colocated_placements('test', 'test_coloc', $$SELECT current_user$$);
+   result    
+-------------
+ read_access
+ read_access
+ read_access
+ read_access
+(4 rows)
+
 EXECUTE prepare_insert(1);
 ERROR:  permission denied for table test
 EXECUTE prepare_select;
@@ -402,7 +428,7 @@ INSERT INTO full_access_user_schema.t1 VALUES (1),(2),(3);
 -- not allowed to create a table
 SELECT create_distributed_table('full_access_user_schema.t1', 'id');
 ERROR:  permission denied for schema full_access_user_schema
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 RESET ROLE;
 -- now we distribute the table as super user
 SELECT create_distributed_table('full_access_user_schema.t1', 'id');
@@ -536,7 +562,7 @@ ERROR:  could not receive file "base/pgsql_job_cache/job_0042/task_000001/p_0000
 -- different user should not be able to fetch partition file
 SET ROLE usage_access;
 SELECT worker_fetch_partition_file(42, 1, 1, 1, 'localhost', :worker_1_port);
-WARNING:  could not open file "base/pgsql_job_cache/job_0042/task_000001/p_00001.17981": No such file or directory
+WARNING:  could not open file "base/pgsql_job_cache/job_0042/task_000001/p_00001.17996": No such file or directory
 CONTEXT:  while executing command on localhost:57637
 ERROR:  could not receive file "base/pgsql_job_cache/job_0042/task_000001/p_00001" from localhost:57637
 -- only the user whom created the files should be able to fetch
@@ -575,7 +601,7 @@ RESET ROLE;
 -- test that the super user is unable to read the contents of the intermediate file,
 -- although it does create the table
 SELECT worker_merge_files_into_table(42, 1, ARRAY['a'], ARRAY['integer']);
-WARNING:  Task file "task_000001.17977" does not have expected suffix ".10"
+WARNING:  Task file "task_000001.17982" does not have expected suffix ".10"
  worker_merge_files_into_table 
 -------------------------------
  
@@ -617,7 +643,7 @@ SELECT worker_merge_files_and_run_query(42, 1,
     'CREATE TABLE task_000001_merge(merge_column_0 int)',
     'CREATE TABLE task_000001 (a) AS SELECT sum(merge_column_0) FROM task_000001_merge'
 );
-WARNING:  Task file "task_000001.17977" does not have expected suffix ".10"
+WARNING:  Task file "task_000001.17982" does not have expected suffix ".10"
  worker_merge_files_and_run_query 
 ----------------------------------
  

--- a/src/test/regress/sql/multi_multiuser.sql
+++ b/src/test/regress/sql/multi_multiuser.sql
@@ -128,6 +128,11 @@ SELECT task_tracker_assign_task(1, 1, 'SELECT 1');
 -- check read permission
 SET ROLE read_access;
 
+-- should be allowed to run commands, as the current user
+SELECT result FROM run_command_on_workers($$SELECT current_user$$);
+SELECT result FROM run_command_on_placements('test', $$SELECT current_user$$);
+SELECT result FROM run_command_on_colocated_placements('test', 'test_coloc', $$SELECT current_user$$);
+
 EXECUTE prepare_insert(1);
 EXECUTE prepare_select;
 


### PR DESCRIPTION
DESCRIPTION: Fix a bug that caused run_command_on_colocated_placements to fail for regular users

Since we've moved sensitive functions out, the citus schema can now be open to the public, which is necessary to use the types in there. This does not automatically grant access to the pg_dist_object table.

Fixes #1713