### PR TITLE
Use citus docker repositories instead of citusdata in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: citus_indent --check
   check-sql-snapshots:
     docker:
-      - image: 'citusdata/extbuilder:werror'
+      - image: 'citus/extbuilder:latest'
     steps:
       - checkout
       - run: 


### PR DESCRIPTION
We will also need to change `stylechecker` image to use `citus` repo in all of our images. I will build that image and update it soon.
