### PR TITLE
Prototype: INSERT...SELECT with repartitioning

### DIFF
--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '9.0-1'
+default_version = '9.1-1'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2764,7 +2764,14 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 	{
 		const char *resultId = copyStatement->relation->relname;
 
-		ReceiveQueryResultViaCopy(resultId);
+		if (copyStatement->is_from)
+		{
+			ReceiveQueryResultViaCopy(resultId);
+		}
+		else
+		{
+			SendQueryResultViaCopy(resultId);
+		}
 
 		return NULL;
 	}

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -169,7 +169,7 @@ CitusBeginScan(CustomScanState *node, EState *estate, int eflags)
 
 	distributedPlan = scanState->distributedPlan;
 	if (distributedPlan->modLevel == ROW_MODIFY_READONLY ||
-		distributedPlan->insertSelectSubquery != NULL)
+		distributedPlan->insertSelectQuery != NULL)
 	{
 		/* no more action required */
 		return;

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -1,0 +1,835 @@
+/*-------------------------------------------------------------------------
+ *
+ * distributed_intermediate_results.c
+ *   Functions for reading and writing distributed intermediate results.
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "port.h"
+
+#include "access/hash.h"
+#include "access/nbtree.h"
+#include "access/tupdesc.h"
+#include "catalog/pg_am.h"
+#include "catalog/pg_enum.h"
+#include "catalog/pg_type.h"
+#include "commands/copy.h"
+#include "distributed/citus_ruleutils.h"
+#include "distributed/colocation_utils.h"
+#include "distributed/commands/multi_copy.h"
+#include "distributed/connection_management.h"
+#include "distributed/intermediate_results.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_executor.h"
+#include "distributed/recursive_planning.h"
+#include "distributed/remote_commands.h"
+#include "distributed/sharding.h"
+#include "distributed/transmit.h"
+#include "distributed/transaction_identifier.h"
+#include "distributed/tuplestore.h"
+#include "distributed/worker_protocol.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "storage/fd.h"
+#include "tcop/pquery.h"
+#include "tcop/tcopprot.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/portal.h"
+#include "utils/syscache.h"
+
+
+/*
+ * NodePair contains the source and destination node in a NodeToNodeFragmentsTransfer.
+ * It is a separate struct to use it as a key in a hash table.
+ */
+typedef struct NodePair
+{
+	int sourceNodeId;
+	int targetNodeId;
+} NodePair;
+
+
+/*
+ * NodeToNodeFragmentsTransfer contains all fragments that need to be fetched from
+ * the source node to the destination node in the NodePair.
+ */
+typedef struct NodeToNodeFragmentsTransfer
+{
+	NodePair nodes;
+	List *fragmentsToFetch;
+} NodeToNodeFragmentsTransfer;
+
+
+/*
+ * TargetShardFragmentStats contains statistics on the fragments that came
+ * out of predistribution using worker_predistribute_query_result.
+ */
+typedef struct TargetShardFragmentStats
+{
+	int sourceNodeId;
+	uint64 sourceShardId;
+	int targetShardIndex;
+	long byteCount;
+	long rowCount;
+} TargetShardFragmentStats;
+
+typedef struct TargetShardFragments
+{
+	int targetShardIndex;
+	List *fragments;
+} TargetShardFragments;
+
+
+/*
+ * PredistributionStats contains the statistics on individual fragments when task
+ * results are partitioned into fragments using
+ * worker_predistribute_query_result.
+ */
+typedef struct PredistributionStats
+{
+	int targetShardCount;
+	TargetShardFragments *targetShardFragments;
+} PredistributionStats;
+
+
+/*
+ * ReassembledFragmentSet represents a set of fragments that have been fetched
+ * to a particular node and when concatenated form one shard of a
+ * RedistributedQueryResult.
+ */
+typedef struct ReassembledFragmentSet
+{
+	/* node where the fragments are located */
+	int nodeId;
+
+	/* list of TargetShardFragmentStats for each fragment in a target partition */
+	List *fragments;
+} ReassembledFragmentSet;
+
+
+/*
+ * A RedistributedQueryResult represents a temporary distributed table that
+ * originated from a redistribuion operation and is therefore stored as a
+ * set of fragments per shard, which need to be concatenated at run-time.
+ */
+typedef struct RedistributedQueryResult
+{
+	/* prefix of all fragment names */
+	char *resultPrefix;
+
+	/* the partitioning between the fragment sets */
+	PartitioningScheme *partitioning;
+
+	/*
+	 * Array of reassembled fragment sets, keyed by partition index.
+	 *
+	 * The number of elements in the array is partitioning->partitionCount.
+	 */
+	ReassembledFragmentSet *reassembledFragmentSets;
+} RedistributedQueryResult;
+
+
+static RedistributedQueryResult *RedistributeDistributedQueryResult(
+											   char *distResultId, Query *query,
+											   int distributionColumnIndex,
+											   DistributionScheme *targetDistribution,
+											   bool isForWrites);
+static RedistributedQueryResult * RedistributeTaskListResult(
+									   char *distResultId, List *taskList,
+									   int distributionColumnIndex,
+									   DistributionScheme *targetDistribution,
+									   bool isForWrites);
+static void WrapTasksForPredistribution(List *taskList, char *resultPrefix,
+										int distributionColumnIndex,
+										DistributionScheme *targetDistribution);
+static ArrayType * ShardMinValueArrayForDistribution(PartitioningScheme *partitioning);
+static char * SourceShardPrefix(char *resultPrefix, uint64 shardId);
+static RedistributedQueryResult * CreateRedistributedQueryResult(char *resultPrefix,
+																 PredistributionStats *predistributionStats,
+																 DistributionScheme *targetDistribution,
+																 bool isForWrites,
+																 List **fragmentsTransferList);
+static PredistributionStats * ExecutePredistributionTasks(List *taskList, DistributionScheme *targetDistribution);
+static PredistributionStats * CreatePredistributionStats(int targetShardCount);
+static PredistributionStats * TupleStoreToPredistributionStats(Tuplestorestate *tupleStore, TupleDesc resultDescriptor, DistributionScheme *targetDistribution);
+static List * BuildFetchTaskListForFragmentTransfers(char *resultPrefix,
+													 List *fragmentsTransferList);
+static char * BuildQueryStringForFragmentsTransfer(char *resultPrefix, NodeToNodeFragmentsTransfer *fragmentsTransfer);
+static char * TargetShardFragmentName(char *resultPrefix, TargetShardFragmentStats *fragmentStats);
+static void ExecuteFetchTasks(List *fetchTaskList);
+static Tuplestorestate * ExecuteTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor);
+static Query *ReadReassembledFragmentSetQuery(char *resultPrefix, List *targetList, ReassembledFragmentSet *fragmentSet);
+
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(partition_distributed_query_result);
+
+
+/*
+ * partition_distributed_query_result executes a query and writes the results
+ * into a set of local files according to the partition scheme and the partition
+ * column.
+ */
+Datum
+partition_distributed_query_result(PG_FUNCTION_ARGS)
+{
+	text *distResultIdText = PG_GETARG_TEXT_P(0);
+	char *distResultIdString = text_to_cstring(distResultIdText);
+	text *queryText = PG_GETARG_TEXT_P(1);
+	char *queryString = text_to_cstring(queryText);
+	int distributionColumnIndex = PG_GETARG_INT32(2);
+	int colocationId = PG_GETARG_INT32(3);
+
+	TupleDesc tupleDescriptor = NULL;
+	DistributionScheme *targetDistribution = NULL;
+	Query *query = NULL;
+	RedistributedQueryResult *result = NULL;
+	int shardIndex = 0;
+	int shardCount = 0;
+
+	CheckCitusVersion(ERROR);
+	SetupTuplestore(fcinfo, &tupleDescriptor);
+
+	targetDistribution = GetDistributionSchemeForColocationId(colocationId);
+
+	/* parse the query */
+	query = ParseQueryString(queryString);
+
+	result = RedistributeDistributedQueryResult(distResultIdString, query,
+												distributionColumnIndex, targetDistribution,
+												true);
+
+	shardCount = targetDistribution->partitioning.partitionCount;
+
+	for (shardIndex = 0; shardIndex < shardCount; shardIndex++)
+	{
+		ReassembledFragmentSet *fragmentSet =
+			&(result->reassembledFragmentSets[shardIndex]);
+		Query *fragmentSetQuery = NULL;
+		StringInfo deparsedQuery = makeStringInfo();
+
+		fragmentSetQuery = ReadReassembledFragmentSetQuery(distResultIdString, query->targetList, fragmentSet);
+
+		pg_get_query_def(fragmentSetQuery, deparsedQuery);
+
+		elog(NOTICE, "on node %d: %s", fragmentSet->nodeId, deparsedQuery->data);
+	}
+
+	PG_RETURN_VOID();
+}
+
+
+/*
+ * RedistributeDistributedQueryResult executes the given query, which must
+ * be a distributed query without a merge step, and redistributes the result
+ * according to the target distribution.
+ */
+static RedistributedQueryResult *
+RedistributeDistributedQueryResult(char *distResultId, Query *query,
+								   int distributionColumnIndex,
+								   DistributionScheme *targetDistribution,
+								   bool isForWrites)
+{
+	RedistributedQueryResult *result = NULL;
+	int cursorOptions = 0;
+	ParamListInfo paramListInfo = NULL;
+	PlannedStmt *queryPlan = NULL;
+	DistributedPlan *distributedPlan = NULL;
+	List *taskList = NIL;
+
+	/* plan the query */
+	queryPlan = pg_plan_query(query, cursorOptions, paramListInfo);
+	if (!IsA(queryPlan->planTree, CustomScan))
+	{
+		/* TODO: fall back to partitioned pull-push */
+		ereport(ERROR, (errmsg("query is not a simple distributed query")));
+	}
+
+	distributedPlan = GetDistributedPlan((CustomScan *) queryPlan->planTree);
+
+	/* TODO: check for weird plans (insert select) */
+
+	taskList = distributedPlan->workerJob->taskList;
+
+	result = RedistributeTaskListResult(distResultId, taskList, distributionColumnIndex,
+										targetDistribution, isForWrites);
+
+	return result;
+}
+
+
+static RedistributedQueryResult *
+RedistributeTaskListResult(char *distResultId, List *taskList,
+						   int distributionColumnIndex,
+						   DistributionScheme *targetDistribution, bool isForWrites)
+{
+	RedistributedQueryResult *result = NULL;
+	PredistributionStats *predistributionStats = NULL;
+	List *fragmentsTransferList = NIL;
+	List *fetchTaskList = NIL;
+
+	/* make sure we have a distributed transaction ID and send BEGIN */
+	BeginOrContinueCoordinatedTransaction();
+
+	/*
+	 * Wrap tasks in worker_predistribute_query_result calls 
+	 * to generate a fragment for each shard in the target distribution.
+	 */
+	WrapTasksForPredistribution(taskList, distResultId, distributionColumnIndex,
+								targetDistribution);
+
+	/*
+	 * Execute the worker_predistribute_query_result tasks and
+	 * collect statistics to prune out empty fragments.
+	 */
+	predistributionStats = ExecutePredistributionTasks(taskList, targetDistribution);
+
+	/*
+	 * Create an object that represents redistributed query results. We
+	 * derive the fetch tasks from the result.
+	 */ 
+	result = CreateRedistributedQueryResult(distResultId, predistributionStats,
+											targetDistribution, isForWrites,
+											&fragmentsTransferList);
+
+	fetchTaskList = BuildFetchTaskListForFragmentTransfers(distResultId,
+														   fragmentsTransferList);
+
+	/*
+	 * Execute the fetch tasks, after this the result is ready to be used
+	 * in distributed queries.
+	 */
+	ExecuteFetchTasks(fetchTaskList);
+
+	return result;
+}
+
+
+/*
+ * WrapTasksForPredistribution wraps the query strings in a given list of tasks
+ * in calls to worker_predistribute_query_result, in order to generate
+ * a fragment (intermediate result) for each shard in the target distribution.
+ * Rows are written to a fragment based on the value in the distribution column
+ * of the query result.
+ */
+static void
+WrapTasksForPredistribution(List *taskList, char *resultPrefix, int distributionColumnIndex,
+							DistributionScheme *targetDistribution)
+{
+	ListCell *taskCell = NULL;
+	PartitioningScheme *partitioning = &(targetDistribution->partitioning);
+	ArrayType *splitPointObject = ShardMinValueArrayForDistribution(partitioning);
+	StringInfo splitPointString = SplitPointArrayString(splitPointObject,
+														partitioning->valueTypeId,
+														partitioning->valueTypeMod);
+
+	foreach(taskCell, taskList)
+	{
+		Task *task = (Task *) lfirst(taskCell);
+		StringInfo wrappedQuery = makeStringInfo();
+		List *shardPlacementList = task->taskPlacementList;
+		ShardPlacement *shardPlacement = NULL;
+		char *taskPrefix = NULL;
+
+		if (list_length(shardPlacementList) > 1)
+		{
+			ereport(ERROR, (errmsg("repartitioning is currently only available for "
+								   "queries on distributed tables without replication")));
+		}
+
+		shardPlacement = linitial(shardPlacementList);
+		taskPrefix = SourceShardPrefix(resultPrefix, task->anchorShardId);
+
+		appendStringInfo(wrappedQuery,
+						 "SELECT %d, " UINT64_FORMAT ", partition_index, bytes_written, rows_written "
+						 "FROM worker_predistribute_query_result"
+						 "(%s,%s,%d,%s)",
+						 shardPlacement->nodeId,
+						 task->anchorShardId,
+						 quote_literal_cstr(taskPrefix),
+						 quote_literal_cstr(task->queryString),
+						 distributionColumnIndex,
+						 splitPointString->data);
+
+		task->queryString = wrappedQuery->data;
+	}
+}
+
+
+/*
+ * ShardMinValueArrayForDistribution constructs a SQL array for the min values
+ * of the partitions.
+ */
+static ArrayType *
+ShardMinValueArrayForDistribution(PartitioningScheme *partitioning)
+{
+	ArrayType *splitPointObject = NULL;
+	uint32 partitionIndex = 0;
+	Oid typeId = partitioning->valueTypeId;
+
+	bool typeByValue = false;
+	char typeAlignment = 0;
+	int16 typeLength = 0;
+
+	uint32 minDatumCount = partitioning->partitionCount;
+	Datum *minDatumArray = palloc0(partitioning->partitionCount * sizeof(Datum));
+
+	for (partitionIndex = 0; partitionIndex < minDatumCount; partitionIndex++)
+	{
+		DatumRange *hashRange = &(partitioning->ranges[partitionIndex]);
+
+		minDatumArray[partitionIndex] = hashRange->minValue;
+	}
+
+	get_typlenbyvalalign(typeId, &typeLength, &typeByValue, &typeAlignment);
+
+	splitPointObject = construct_array(minDatumArray, minDatumCount, typeId,
+									   typeLength, typeByValue, typeAlignment);
+
+	return splitPointObject;
+
+}
+
+
+static char *
+SourceShardPrefix(char *resultPrefix, uint64 shardId)
+{
+	StringInfo taskPrefix = makeStringInfo();
+
+	appendStringInfo(taskPrefix, "%s.from." UINT64_FORMAT ".to", resultPrefix, shardId);
+
+	return taskPrefix->data;
+}
+
+
+/*
+ * ExecutePredistributionTasks executes a list of tasks that were generated using
+ * WrapTasksForPredistribution.
+ */
+static PredistributionStats *
+ExecutePredistributionTasks(List *taskList, DistributionScheme *targetDistribution)
+{
+	TupleDesc resultDescriptor = NULL;
+	Tuplestorestate *resultStore = NULL;
+	int resultColumnCount = 5;
+	Oid hasOid = false;
+	PredistributionStats *predistributionStats = NULL;
+
+	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount, hasOid);
+
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 1, "node_id",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 2, "shard_id",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 3, "partition_index",
+					   INT4OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 4, "bytes_written",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 5, "rows_written",
+					   INT8OID, -1, 0);
+
+	resultStore = ExecuteTasksIntoTupleStore(taskList, resultDescriptor);
+	predistributionStats = TupleStoreToPredistributionStats(resultStore, resultDescriptor,
+															targetDistribution);
+
+	return predistributionStats;
+}
+
+
+static PredistributionStats *
+TupleStoreToPredistributionStats(Tuplestorestate *tupleStore, TupleDesc resultDescriptor,
+								  DistributionScheme *targetDistribution)
+{
+	TupleTableSlot *slot = MakeSingleTupleTableSlot(resultDescriptor);
+	PredistributionStats *predistributionStats = NULL;
+	PartitioningScheme *partitioning = &targetDistribution->partitioning;
+	int shardCount = partitioning->partitionCount;
+
+	predistributionStats = CreatePredistributionStats(shardCount);
+
+	while (tuplestore_gettupleslot(tupleStore, true, false, slot))
+	{
+		TargetShardFragmentStats *shardFragmentStats = palloc0(sizeof(TargetShardFragmentStats));
+		TargetShardFragments *fragmentSet = NULL;
+		int sourceNodeId = 0;
+		int64 sourceShardId = 0;
+		int targetShardIndex = 0;
+		int64 rowCount = 0;
+		int64 byteCount = 0;
+		bool isNull = false;
+
+		sourceNodeId = DatumGetInt32(slot_getattr(slot, 1, &isNull));
+		sourceShardId = DatumGetInt64(slot_getattr(slot, 2, &isNull));
+		targetShardIndex = DatumGetInt32(slot_getattr(slot, 3, &isNull));
+		byteCount = DatumGetInt64(slot_getattr(slot, 4, &isNull));
+		rowCount = DatumGetInt64(slot_getattr(slot, 5, &isNull));
+
+		/* protect against garbage results */
+		if (targetShardIndex < 0 || targetShardIndex >= shardCount)
+		{
+			ereport(ERROR, (errmsg("target shard index %d out of range", targetShardIndex)));
+		}
+
+		shardFragmentStats = palloc0(sizeof(TargetShardFragmentStats));
+		shardFragmentStats->sourceNodeId = sourceNodeId;
+		shardFragmentStats->sourceShardId = sourceShardId;
+		shardFragmentStats->targetShardIndex = targetShardIndex;
+		shardFragmentStats->byteCount = byteCount;
+		shardFragmentStats->rowCount = rowCount;
+
+		fragmentSet = &(predistributionStats->targetShardFragments[targetShardIndex]);
+		fragmentSet->fragments = lappend(fragmentSet->fragments, shardFragmentStats);
+
+		ExecClearTuple(slot);
+	}
+
+	ExecDropSingleTupleTableSlot(slot);
+
+	return predistributionStats;
+}
+
+
+/*
+ * CreatePredistributionStats creates a data structure for holding the statistics
+ * returned by executing SQL tasks wrapped in worker_predistribute_query_result
+ * calls.
+ */
+static PredistributionStats *
+CreatePredistributionStats(int targetShardCount)
+{
+	PredistributionStats *predistributionStats = palloc0(sizeof(PredistributionStats));
+	int targetShardIndex = 0;
+
+	predistributionStats->targetShardCount = targetShardCount;
+	predistributionStats->targetShardFragments =
+		palloc0(targetShardCount * sizeof(TargetShardFragments));
+
+	for (targetShardIndex = 0; targetShardIndex < targetShardCount; targetShardIndex++)
+	{
+		TargetShardFragments *fragmentSet =
+			&(predistributionStats->targetShardFragments[targetShardIndex]);
+
+		fragmentSet->targetShardIndex = targetShardIndex;
+		fragmentSet->fragments = NIL;
+	}
+
+	return predistributionStats;
+}
+
+
+/*
+ * CreateRedistributedQueryResult creates a RedistributedQueryResult that contains
+ * the reassembled fragment sets which are effectively shards in the temporary
+ * distributed table that consist of smaller fragments. Empty fragments are filtered
+ * out using the pre-distribution statistics.
+ *
+ * As part of the process, we also build the list of transfers that need to happen
+ * to get the fragments to the right place, grouped by a pair of source and target
+ * nodes such that we only open one connection per node pair.
+ *
+ * TODO: maybe generate the transfer list separately
+ */
+static RedistributedQueryResult *
+CreateRedistributedQueryResult(char *resultPrefix,
+							   PredistributionStats *predistributionStats,
+							   DistributionScheme *targetDistribution,
+							   bool isForWrites,
+							   List **fragmentsTransferList)
+{
+	RedistributedQueryResult *result = NULL;
+	PartitioningScheme *partitioning = &targetDistribution->partitioning;
+	ReassembledFragmentSet *reassembledFragmentSets = NULL;
+	NodeToNodeFragmentsTransfer *fragmentsTransfer = NULL;
+	int targetShardIndex = 0;
+	int targetShardCount = partitioning->partitionCount;
+	HASHCTL info;
+	uint32 hashFlags = 0;
+	HTAB *nodeToNodeTransfers = NULL;
+	HASH_SEQ_STATUS status;
+
+	reassembledFragmentSets = palloc0(sizeof(ReassembledFragmentSet) * targetShardCount);
+
+	result = palloc0(sizeof(RedistributedQueryResult));
+	result->resultPrefix = pstrdup(resultPrefix);
+	result->partitioning = partitioning;
+	result->reassembledFragmentSets = reassembledFragmentSets;
+
+	memset(&info, 0, sizeof(info));
+	info.keysize = sizeof(NodePair);
+	info.entrysize = sizeof(NodeToNodeFragmentsTransfer);
+	info.hcxt = CurrentMemoryContext;
+	hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
+
+	nodeToNodeTransfers = hash_create("Fragment transfers", 32, &info, hashFlags);
+
+	/*
+	 * For each target shard, there is a TargetShardFragments that contains
+	 * statistics on all fragments that make up the shard from the time they
+	 * were generated on their respective source nodes.
+	 *
+	 * In this loop we transform TargetShardFragments into ReassembledFragmentSet,
+	 * which is tied to a particular (target) node and does not contain empty
+	 * fragments. This allows us to construct the appropriate fetch and read tasks.
+	 *
+	 * Effectively, TargetShardFragments represents the fragments in a target
+	 * shard before redistribution and ReassembledFragmentSet represents the
+	 * fragments in a target shard after redistribution.
+	 */
+	for (targetShardIndex = 0; targetShardIndex < targetShardCount; targetShardIndex++)
+	{
+		TargetShardFragments *targetShardFragments =
+			&(predistributionStats->targetShardFragments[targetShardIndex]);
+		ReassembledFragmentSet *reassembledFragments = 
+			&(reassembledFragmentSets[targetShardIndex]);
+
+		ListCell *fragmentCell = NULL;
+		int *nodeGroupIds = targetDistribution->groupIds[targetShardIndex];
+
+		/* TODO: consider replication */
+		int targetGroupId = nodeGroupIds[0];
+
+		/* TODO: consider follower clusters (isForWrites) */
+		WorkerNode *targetNode = PrimaryNodeForGroup(targetGroupId, NULL);
+
+		List *targetShardFragmentStatsList = NIL;
+
+		foreach(fragmentCell, targetShardFragments->fragments)
+		{
+			TargetShardFragmentStats *fragmentStats = lfirst(fragmentCell);
+			NodePair nodePair = {
+				fragmentStats->sourceNodeId,
+				targetNode->nodeId
+			};
+			bool foundPair = false;
+
+			if (fragmentStats->rowCount == 0)
+			{
+				/* no data in fragment */
+				continue;
+			}
+
+			targetShardFragmentStatsList = lappend(targetShardFragmentStatsList,
+												   fragmentStats);
+
+			if (nodePair.sourceNodeId == nodePair.targetNodeId)
+			{
+				/* fragment is already on the right node, not transfer needed */
+				continue;
+			}
+
+			fragmentsTransfer = hash_search(nodeToNodeTransfers, &nodePair, HASH_ENTER,
+											&foundPair);
+			if (!foundPair)
+			{
+				fragmentsTransfer->fragmentsToFetch = NIL;
+			}
+
+			fragmentsTransfer->fragmentsToFetch = lappend(fragmentsTransfer->fragmentsToFetch,
+														  fragmentStats);
+		}
+
+		reassembledFragments->nodeId = targetNode->nodeId;
+		reassembledFragments->fragments = targetShardFragmentStatsList;
+	}
+
+	if (fragmentsTransferList != NULL)
+	{
+		hash_seq_init(&status, nodeToNodeTransfers);
+
+		while ((fragmentsTransfer = hash_seq_search(&status)) != NULL)
+		{
+			if (list_length(fragmentsTransfer->fragmentsToFetch) == 0)
+			{
+				/* all fragments from source to target were empty */
+				continue;
+			}
+
+			*fragmentsTransferList = lappend(*fragmentsTransferList, fragmentsTransfer);
+		}
+	}
+
+	return result;
+}
+
+
+/*
+ * BuildFetchTaskListForFragmentTransfers expects a list of NodeToNodeFragmentsTransfers
+ * and for each transfer it builds an appropriate fetch_intermediate_result task to
+ * perform the transfer.
+ */
+static List *
+BuildFetchTaskListForFragmentTransfers(char *resultPrefix, List *fragmentsTransferList)
+{
+	List *fetchTaskList = NIL;
+	ListCell *fragmentsTransferCell = NULL;
+
+	foreach(fragmentsTransferCell, fragmentsTransferList)
+	{
+		NodeToNodeFragmentsTransfer *fragmentsTransfer = lfirst(fragmentsTransferCell);
+		Task *task = NULL;
+		int targetNodeId = fragmentsTransfer->nodes.targetNodeId;
+		WorkerNode *workerNode = LookupNodeByNodeId(targetNodeId);
+		ShardPlacement *targetPlacement = NULL;
+
+		if (list_length(fragmentsTransfer->fragmentsToFetch) == 0)
+		{
+			continue;
+		}
+
+		targetPlacement = CitusMakeNode(ShardPlacement);
+		targetPlacement->nodeName = workerNode->workerName;
+		targetPlacement->nodePort = workerNode->workerPort;
+		targetPlacement->groupId = workerNode->groupId;
+
+		task = CitusMakeNode(Task);
+		task->taskType = SQL_TASK;
+		task->queryString = BuildQueryStringForFragmentsTransfer(resultPrefix, fragmentsTransfer);
+		task->taskPlacementList = list_make1(targetPlacement);
+
+		fetchTaskList = lappend(fetchTaskList, task);
+	}
+
+	return fetchTaskList;
+}
+
+
+/*
+ * BuildQueryStringForFragmentsTransfer builds a fetch_intermediate_result query to
+ * perform the given node-to-node transfer by executing the query on the target
+ * node.
+ */
+static char *
+BuildQueryStringForFragmentsTransfer(char *resultPrefix,
+									 NodeToNodeFragmentsTransfer *fragmentsTransfer)
+{
+	ListCell *fragmentCell = NULL;
+	StringInfo queryString = makeStringInfo();
+	StringInfo fragmentNamesArrayString = makeStringInfo();
+	int fragmentCount = 0;
+	NodePair *nodePair = &fragmentsTransfer->nodes;
+	WorkerNode *sourceNode = LookupNodeByNodeId(nodePair->sourceNodeId);
+
+	appendStringInfoString(fragmentNamesArrayString, "ARRAY[");
+
+	foreach(fragmentCell, fragmentsTransfer->fragmentsToFetch)
+	{
+		TargetShardFragmentStats *fragmentStats = lfirst(fragmentCell);
+		char *fragmentName = TargetShardFragmentName(resultPrefix, fragmentStats);
+
+		if (fragmentCount > 0)
+		{
+			appendStringInfoString(fragmentNamesArrayString, ",");
+		}
+
+		appendStringInfoString(fragmentNamesArrayString,
+							   quote_literal_cstr(fragmentName));
+
+		fragmentCount++;
+	}
+
+	appendStringInfoString(fragmentNamesArrayString, "]::text[]");
+
+	appendStringInfo(queryString,
+					 "SELECT %d, bytes FROM fetch_intermediate_results(%s,%s,%d) bytes",
+					 nodePair->targetNodeId,
+					 fragmentNamesArrayString->data,
+					 quote_literal_cstr(sourceNode->workerName),
+					 sourceNode->workerPort);
+
+	return queryString->data;
+}
+
+
+static char *
+TargetShardFragmentName(char *resultPrefix, TargetShardFragmentStats *fragmentStats)
+{
+	char *sourceShardPrefix = NULL;
+	StringInfo fragmentName = makeStringInfo();
+	int targetShardIndex = fragmentStats->targetShardIndex;
+
+	sourceShardPrefix = SourceShardPrefix(resultPrefix, fragmentStats->sourceShardId);
+
+	appendStringInfo(fragmentName, "%s.%d", sourceShardPrefix, targetShardIndex);
+
+	return fragmentName->data;
+}
+
+
+
+/*
+ * ExecuteFetchTasks executes a list of fetch tasks and discards the results.
+ * The fetch task returns the number of bytes written, but this is currently
+ * unused.
+ */
+static void
+ExecuteFetchTasks(List *fetchTaskList)
+{
+	TupleDesc resultDescriptor = NULL;
+	int resultColumnCount = 2;
+	Oid hasOid = false;
+
+	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount, hasOid);
+
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 1, "node_id",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 2, "bytes_written",
+					   INT8OID, -1, 0);
+
+	ExecuteTasksIntoTupleStore(fetchTaskList, resultDescriptor);
+}
+
+
+static Tuplestorestate *
+ExecuteTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor)
+{
+	Tuplestorestate *resultStore = NULL;
+	bool hasReturning = true;
+	int targetPoolSize = MaxAdaptiveExecutorPoolSize;
+	bool randomAccess = true;
+	bool interTransactions = false;
+
+	resultStore = tuplestore_begin_heap(randomAccess, interTransactions, work_mem);
+
+	ExecuteTaskListExtended(ROW_MODIFY_READONLY, taskList, resultDescriptor,
+							resultStore, hasReturning, targetPoolSize);
+
+	return resultStore;
+}
+
+
+static Query *
+ReadReassembledFragmentSetQuery(char *resultPrefix, List *targetList,
+								ReassembledFragmentSet *fragmentSet)
+{
+	Query *query = NULL;
+	ListCell *fragmentCell = NULL;
+	List *fragmentNames = NIL;
+
+	foreach(fragmentCell, fragmentSet->fragments)
+	{
+		TargetShardFragmentStats *fragmentStats = lfirst(fragmentCell);
+		char *fragmentName = NULL;
+
+		fragmentName = TargetShardFragmentName(resultPrefix, fragmentStats);
+
+		fragmentNames = lappend(fragmentNames, fragmentName);
+	}
+
+	query = BuildReadIntermediateResultsArrayQuery(targetList, NIL, fragmentNames);
+
+	return query;
+}

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -207,7 +207,7 @@ partition_distributed_query_result(PG_FUNCTION_ARGS)
 	targetDistribution = GetDistributionSchemeForColocationId(colocationId);
 
 	/* parse the query */
-	query = ParseQueryString(queryString);
+	query = ParseQueryString(queryString, NULL, 0);
 
 	result = RedistributeDistributedQueryResult(distResultIdString, query,
 												distributionColumnIndex, targetDistribution,

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -11,6 +11,7 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include "distributed/citus_ruleutils.h"
 #include "distributed/commands/multi_copy.h"
 #include "distributed/insert_select_executor.h"
 #include "distributed/insert_select_planner.h"
@@ -19,7 +20,9 @@
 #include "distributed/multi_partitioning_utils.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/multi_router_executor.h"
+#include "distributed/multi_router_planner.h"
 #include "distributed/distributed_planner.h"
+#include "distributed/recursive_planning.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/resource_lock.h"
 #include "distributed/transaction_management.h"
@@ -30,11 +33,13 @@
 #include "nodes/parsenodes.h"
 #include "nodes/plannodes.h"
 #include "parser/parse_coerce.h"
+#include "parser/parse_relation.h"
 #include "parser/parsetree.h"
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"
 #include "utils/lsyscache.h"
 #include "utils/portal.h"
+#include "utils/rel.h"
 #include "utils/snapmgr.h"
 
 
@@ -43,6 +48,9 @@ static int insertSelectExecutorLevel = 0;
 
 
 static TupleTableSlot * CoordinatorInsertSelectExecScanInternal(CustomScanState *node);
+static Query * WrapSubquery(Query *subquery);
+static List * TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
+										   char *resultIdPrefix);
 static void ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
 									  Query *selectQuery, EState *executorState);
 static HTAB * ExecuteSelectIntoColocatedIntermediateResults(Oid targetRelationId,
@@ -97,12 +105,16 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 
 	if (!scanState->finishedRemoteScan)
 	{
-		EState *executorState = ScanStateGetExecutorState(scanState);
+		EState *executorState = scanState->customScanState.ss.ps.state;
 		DistributedPlan *distributedPlan = scanState->distributedPlan;
-		Query *selectQuery = distributedPlan->insertSelectSubquery;
-		List *insertTargetList = distributedPlan->insertTargetList;
-		Oid targetRelationId = distributedPlan->targetRelationId;
+		Query *insertSelectQuery = copyObject(distributedPlan->insertSelectQuery);
+		Query *selectQuery = NULL;
+		List *insertTargetList = insertSelectQuery->targetList;
+		RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertSelectQuery);
+		RangeTblEntry *insertRte = ExtractResultRelationRTE(insertSelectQuery);
+		Oid targetRelationId = insertRte->relid;
 		char *intermediateResultIdPrefix = distributedPlan->intermediateResultIdPrefix;
+		bool hasReturning = distributedPlan->hasReturning;
 		HTAB *shardStateHash = NULL;
 
 		ereport(DEBUG1, (errmsg("Collecting INSERT ... SELECT results on coordinator")));
@@ -117,6 +129,12 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 		 */
 		DisableLocalExecution();
 
+		/* select query to execute */
+		selectQuery = BuildSelectForInsertSelect(insertSelectQuery);
+
+		selectRte->subquery = selectQuery;
+		ReorderInsertSelectTargetLists(insertSelectQuery, insertRte, selectRte);
+
 		/*
 		 * If we are dealing with partitioned table, we also need to lock its
 		 * partitions. Here we only lock targetRelation, we acquire necessary
@@ -127,8 +145,9 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 			LockPartitionRelations(targetRelationId, RowExclusiveLock);
 		}
 
-		if (distributedPlan->workerJob != NULL)
+		if (insertSelectQuery->onConflict || hasReturning)
 		{
+
 			/*
 			 * If we also have a workerJob that means there is a second step
 			 * to the INSERT...SELECT. This happens when there is a RETURNING
@@ -136,11 +155,13 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 			 * distributed INSERT...SELECT from a set of intermediate results
 			 * to the target relation.
 			 */
-			Job *workerJob = distributedPlan->workerJob;
 			ListCell *taskCell = NULL;
-			List *taskList = workerJob->taskList;
+			List *taskList = NIL;
 			List *prunedTaskList = NIL;
-			bool hasReturning = distributedPlan->hasReturning;
+
+			/* generate tasks for the INSERT..SELECT phase */
+			taskList = TwoPhaseInsertSelectTaskList(targetRelationId, insertSelectQuery,
+													intermediateResultIdPrefix);
 
 			shardStateHash = ExecuteSelectIntoColocatedIntermediateResults(
 				targetRelationId,
@@ -217,6 +238,231 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 	resultSlot = ReturnTupleFromTuplestore(scanState);
 
 	return resultSlot;
+}
+
+
+/*
+ * BuildSelectForInsertSelect extracts the SELECT part from an INSERT...SELECT query.
+ * If the INSERT...SELECT has CTEs then these are added to the resulting SELECT instead.
+ */
+Query *
+BuildSelectForInsertSelect(Query *insertSelectQuery)
+{
+	RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertSelectQuery);
+	Query *selectQuery = selectRte->subquery;
+
+	/*
+	 * Wrap the SELECT as a subquery if the INSERT...SELECT has CTEs or the SELECT
+	 * has top-level set operations.
+	 *
+	 * We could simply wrap all queries, but that might create a subquery that is
+	 * not supported by the logical planner. Since the logical planner also does
+	 * not support CTEs and top-level set operations, we can wrap queries containing
+	 * those without breaking anything.
+	 */
+	if (list_length(insertSelectQuery->cteList) > 0)
+	{
+		selectQuery = WrapSubquery(selectRte->subquery);
+
+		/* copy CTEs from the INSERT ... SELECT statement into outer SELECT */
+		selectQuery->cteList = copyObject(insertSelectQuery->cteList);
+		selectQuery->hasModifyingCTE = insertSelectQuery->hasModifyingCTE;
+	}
+	else if (selectQuery->setOperations != NULL)
+	{
+		/* top-level set operations confuse the ReorderInsertSelectTargetLists logic */
+		selectQuery = WrapSubquery(selectRte->subquery);
+	}
+
+	return selectQuery;
+}
+
+
+/*
+ * WrapSubquery wraps the given query as a subquery in a newly constructed
+ * "SELECT * FROM (...subquery...) citus_insert_select_subquery" query.
+ */
+static Query *
+WrapSubquery(Query *subquery)
+{
+	Query *outerQuery = NULL;
+	ParseState *pstate = make_parsestate(NULL);
+	Alias *selectAlias = NULL;
+	RangeTblEntry *newRangeTableEntry = NULL;
+	RangeTblRef *newRangeTableRef = NULL;
+	ListCell *selectTargetCell = NULL;
+	List *newTargetList = NIL;
+
+	outerQuery = makeNode(Query);
+	outerQuery->commandType = CMD_SELECT;
+
+	/* create range table entries */
+	selectAlias = makeAlias("citus_insert_select_subquery", NIL);
+	newRangeTableEntry = addRangeTableEntryForSubquery(pstate, subquery,
+													   selectAlias, false, true);
+	outerQuery->rtable = list_make1(newRangeTableEntry);
+
+	/* set the FROM expression to the subquery */
+	newRangeTableRef = makeNode(RangeTblRef);
+	newRangeTableRef->rtindex = 1;
+	outerQuery->jointree = makeFromExpr(list_make1(newRangeTableRef), NULL);
+
+	/* create a target list that matches the SELECT */
+	foreach(selectTargetCell, subquery->targetList)
+	{
+		TargetEntry *selectTargetEntry = (TargetEntry *) lfirst(selectTargetCell);
+		Var *newSelectVar = NULL;
+		TargetEntry *newSelectTargetEntry = NULL;
+
+		/* exactly 1 entry in FROM */
+		int indexInRangeTable = 1;
+
+		if (selectTargetEntry->resjunk)
+		{
+			continue;
+		}
+
+		newSelectVar = makeVar(indexInRangeTable, selectTargetEntry->resno,
+							   exprType((Node *) selectTargetEntry->expr),
+							   exprTypmod((Node *) selectTargetEntry->expr),
+							   exprCollation((Node *) selectTargetEntry->expr), 0);
+
+		newSelectTargetEntry = makeTargetEntry((Expr *) newSelectVar,
+											   selectTargetEntry->resno,
+											   selectTargetEntry->resname,
+											   selectTargetEntry->resjunk);
+
+		newTargetList = lappend(newTargetList, newSelectTargetEntry);
+	}
+
+	outerQuery->targetList = newTargetList;
+
+	return outerQuery;
+}
+
+
+/*
+ * TwoPhaseInsertSelectTaskList generates a list of tasks for a query that
+ * inserts into a target relation and selects from a set of co-located
+ * intermediate results.
+ */
+static List *
+TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
+							 char *resultIdPrefix)
+{
+	List *taskList = NIL;
+
+	/*
+	 * Make a copy of the INSERT ... SELECT. We'll repeatedly replace the
+	 * subquery of insertResultQuery for different intermediate results and
+	 * then deparse it.
+	 */
+	Query *insertResultQuery = copyObject(insertSelectQuery);
+	RangeTblEntry *insertRte = ExtractResultRelationRTE(insertResultQuery);
+	RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertResultQuery);
+
+	DistTableCacheEntry *targetCacheEntry = DistributedTableCacheEntry(targetRelationId);
+	int shardCount = targetCacheEntry->shardIntervalArrayLength;
+	int shardOffset = 0;
+	uint32 taskIdIndex = 1;
+	uint64 jobId = INVALID_JOB_ID;
+
+	ListCell *targetEntryCell = NULL;
+	Relation distributedRelation = NULL;
+	TupleDesc destTupleDescriptor = NULL;
+
+	distributedRelation = heap_open(targetRelationId, RowExclusiveLock);
+	destTupleDescriptor = RelationGetDescr(distributedRelation);
+
+	/*
+	 * If the type of insert column and target table's column type is
+	 * different from each other. Cast insert column't type to target
+	 * table's column
+	 */
+	foreach(targetEntryCell, insertSelectQuery->targetList)
+	{
+		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
+		Var *insertColumn = (Var *) targetEntry->expr;
+		Form_pg_attribute attr = TupleDescAttr(destTupleDescriptor, targetEntry->resno -
+											   1);
+
+		if (insertColumn->vartype != attr->atttypid)
+		{
+			CoerceViaIO *coerceExpr = makeNode(CoerceViaIO);
+			coerceExpr->arg = (Expr *) copyObject(insertColumn);
+			coerceExpr->resulttype = attr->atttypid;
+			coerceExpr->resultcollid = attr->attcollation;
+			coerceExpr->coerceformat = COERCE_IMPLICIT_CAST;
+			coerceExpr->location = -1;
+
+			targetEntry->expr = (Expr *) coerceExpr;
+		}
+	}
+
+	for (shardOffset = 0; shardOffset < shardCount; shardOffset++)
+	{
+		ShardInterval *targetShardInterval =
+			targetCacheEntry->sortedShardIntervalArray[shardOffset];
+		uint64 shardId = targetShardInterval->shardId;
+		List *columnAliasList = NIL;
+		List *insertShardPlacementList = NIL;
+		Query *resultSelectQuery = NULL;
+		StringInfo queryString = makeStringInfo();
+		RelationShard *relationShard = NULL;
+		Task *modifyTask = NULL;
+		StringInfo resultId = makeStringInfo();
+
+		/* during COPY, the shard ID is appended to the result name */
+		appendStringInfo(resultId, "%s_" UINT64_FORMAT, resultIdPrefix, shardId);
+
+		/* generate the query on the intermediate result */
+		resultSelectQuery = BuildSubPlanResultQuery(insertSelectQuery->targetList,
+													columnAliasList, resultId->data);
+
+		/* put the intermediate result query in the INSERT..SELECT */
+		selectRte->subquery = resultSelectQuery;
+
+		/* setting an alias simplifies deparsing of RETURNING */
+		if (insertRte->alias == NULL)
+		{
+			Alias *alias = makeAlias(CITUS_TABLE_ALIAS, NIL);
+			insertRte->alias = alias;
+		}
+
+		/*
+		 * Generate a query string for the query that inserts into a shard and reads
+		 * from an intermediate result.
+		 *
+		 * Since CTEs have already been converted to intermediate results, they need
+		 * to removed from the query. Otherwise, worker queries include both
+		 * intermediate results and CTEs in the query.
+		 */
+		insertResultQuery->cteList = NIL;
+		deparse_shard_query(insertResultQuery, targetRelationId, shardId, queryString);
+		ereport(DEBUG2, (errmsg("distributed statement: %s", queryString->data)));
+
+		LockShardDistributionMetadata(shardId, ShareLock);
+		insertShardPlacementList = FinalizedShardPlacementList(shardId);
+
+		relationShard = CitusMakeNode(RelationShard);
+		relationShard->relationId = targetShardInterval->relationId;
+		relationShard->shardId = targetShardInterval->shardId;
+
+		modifyTask = CreateBasicTask(jobId, taskIdIndex, MODIFY_TASK, queryString->data);
+		modifyTask->dependedTaskList = NULL;
+		modifyTask->anchorShardId = shardId;
+		modifyTask->taskPlacementList = insertShardPlacementList;
+		modifyTask->relationShardList = list_make1(relationShard);
+		modifyTask->replicationModel = targetCacheEntry->replicationModel;
+
+		taskList = lappend(taskList, modifyTask);
+
+		taskIdIndex++;
+	}
+
+	heap_close(distributedRelation, NoLock);
+
+	return taskList;
 }
 
 

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -12,6 +12,7 @@
 #include "miscadmin.h"
 
 #include "distributed/citus_ruleutils.h"
+#include "distributed/colocation_utils.h"
 #include "distributed/commands/multi_copy.h"
 #include "distributed/insert_select_executor.h"
 #include "distributed/insert_select_planner.h"
@@ -23,8 +24,10 @@
 #include "distributed/multi_router_planner.h"
 #include "distributed/distributed_planner.h"
 #include "distributed/recursive_planning.h"
+#include "distributed/redistribution.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/resource_lock.h"
+#include "distributed/subplan_execution.h"
 #include "distributed/transaction_management.h"
 #include "executor/executor.h"
 #include "nodes/execnodes.h"
@@ -49,8 +52,12 @@ static int insertSelectExecutorLevel = 0;
 
 static TupleTableSlot * CoordinatorInsertSelectExecScanInternal(CustomScanState *node);
 static Query * WrapSubquery(Query *subquery);
-static List * TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
-										   char *resultIdPrefix);
+static bool IsRedistributablePlan(PlannedStmt *selectPlan);
+static bool IsSupportedRedistributionTarget(Oid targetRelationId);
+static List * RedistributedInsertSelectTaskList(Query *insertSelectQuery,
+												RedistributedQueryResult *redistributionResult);
+static void AddInsertSelectCasts(List *targetList, TupleDesc destTupleDescriptor);
+static List * TwoPhaseInsertSelectTaskList(Query *insertSelectQuery, char *resultIdPrefix);
 static void ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 									PlannedStmt *selectPlan, EState *executorState);
 static HTAB * ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
@@ -157,7 +164,55 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 			LockPartitionRelations(targetRelationId, RowExclusiveLock);
 		}
 
-		if (insertSelectQuery->onConflict || hasReturning)
+		if (IsRedistributablePlan(selectPlan) &&
+			IsSupportedRedistributionTarget(targetRelationId))
+		{
+			DistributedPlan *distSelectPlan =
+				GetDistributedPlan((CustomScan *) selectPlan->planTree);
+			RedistributedQueryResult *result = NULL;
+			char *distResultPrefix = NULL;
+			List *columnNameList = NIL;
+			int distributionColumnIndex = 0;
+			DistributionScheme *targetDistribution = NULL;
+			bool isForWrites = true;
+			List *taskList = NIL;
+			TupleDesc tupleDescriptor = ScanStateGetTupleDescriptor(scanState);
+			bool randomAccess = true;
+			bool interTransactions = false;
+			int64 rowsInserted = 0;
+
+			ExecuteSubPlans(distSelectPlan);
+
+			distResultPrefix = "replace_this";
+
+			columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
+															   insertTargetList);
+			distributionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
+																		  columnNameList);
+
+
+			targetDistribution = GetDistributionSchemeForRelationId(targetRelationId);
+
+			result = RedistributeDistributedPlanResult(distResultPrefix,
+													   distSelectPlan,
+													   distributionColumnIndex,
+													   targetDistribution,
+													   isForWrites);
+
+			taskList = RedistributedInsertSelectTaskList(insertSelectQuery, result);
+
+			scanState->tuplestorestate =
+				tuplestore_begin_heap(randomAccess, interTransactions, work_mem);
+
+			rowsInserted = ExecuteTaskListExtended(ROW_MODIFY_COMMUTATIVE, taskList,
+												   tupleDescriptor,
+												   scanState->tuplestorestate,
+												   hasReturning,
+												   MaxAdaptiveExecutorPoolSize);		
+
+			executorState->es_processed = rowsInserted;
+		}
+		else if (insertSelectQuery->onConflict || hasReturning)
 		{
 
 			/*
@@ -179,7 +234,7 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 				intermediateResultIdPrefix);
 
 			/* generate tasks for the INSERT..SELECT phase */
-			taskList = TwoPhaseInsertSelectTaskList(targetRelationId, insertSelectQuery,
+			taskList = TwoPhaseInsertSelectTaskList(insertSelectQuery,
 													intermediateResultIdPrefix);
 
 			/*
@@ -241,7 +296,7 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 		else
 		{
 			ExecutePlanIntoRelation(targetRelationId, insertTargetList, selectPlan,
-									  executorState);
+									executorState);
 		}
 
 		scanState->finishedRemoteScan = true;
@@ -353,14 +408,60 @@ WrapSubquery(Query *subquery)
 }
 
 
+static bool
+IsRedistributablePlan(PlannedStmt *selectPlan)
+{
+	Plan *planTree = selectPlan->planTree;
+	DistributedPlan *distributedPlan = NULL;
+
+	if (!IsA(planTree, CustomScan))
+	{
+		return false;
+	}
+
+	distributedPlan = GetDistributedPlan((CustomScan *) planTree);
+	if (distributedPlan == NULL)
+	{
+		return false;
+	}
+
+	/* TODO: additional checks */
+
+	return true;
+}
+
+
 /*
- * TwoPhaseInsertSelectTaskList generates a list of tasks for a query that
- * inserts into a target relation and selects from a set of co-located
- * intermediate results.
+ * IsSupportedRedistributionTarget determines whether re-partitioning into the
+ * given target relation is supported.
+ */
+static bool
+IsSupportedRedistributionTarget(Oid targetRelationId)
+{
+	DistTableCacheEntry *tableEntry= DistributedTableCacheEntry(targetRelationId);
+
+	if (tableEntry->partitionMethod != DISTRIBUTE_BY_HASH)
+	{
+		/* only hash-distributed tables are currently supported */
+		return false;
+	}
+
+	if (tableEntry->replicationModel != REPLICATION_MODEL_STREAMING)
+	{
+		/* only single-replica tables are currently supported */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ *
  */
 static List *
-TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
-							 char *resultIdPrefix)
+RedistributedInsertSelectTaskList(Query *insertSelectQuery,
+								  RedistributedQueryResult *redistributionResult)
 {
 	List *taskList = NIL;
 
@@ -372,14 +473,16 @@ TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
 	Query *insertResultQuery = copyObject(insertSelectQuery);
 	RangeTblEntry *insertRte = ExtractResultRelationRTE(insertResultQuery);
 	RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertResultQuery);
-
+	List *selectTargetList = selectRte->subquery->targetList;
+	Oid targetRelationId = insertRte->relid;
 	DistTableCacheEntry *targetCacheEntry = DistributedTableCacheEntry(targetRelationId);
+
 	int shardCount = targetCacheEntry->shardIntervalArrayLength;
 	int shardOffset = 0;
 	uint32 taskIdIndex = 1;
 	uint64 jobId = INVALID_JOB_ID;
+	char *resultIdPrefix = redistributionResult->resultPrefix;
 
-	ListCell *targetEntryCell = NULL;
 	Relation distributedRelation = NULL;
 	TupleDesc destTupleDescriptor = NULL;
 
@@ -391,7 +494,84 @@ TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
 	 * different from each other. Cast insert column't type to target
 	 * table's column
 	 */
-	foreach(targetEntryCell, insertSelectQuery->targetList)
+	AddInsertSelectCasts(insertSelectQuery->targetList, destTupleDescriptor);
+
+	for (shardOffset = 0; shardOffset < shardCount; shardOffset++)
+	{
+		ShardInterval *targetShardInterval =
+			targetCacheEntry->sortedShardIntervalArray[shardOffset];
+		ReassembledFragmentSet *fragmentSet =
+			&(redistributionResult->reassembledFragmentSets[shardOffset]);
+		uint64 shardId = targetShardInterval->shardId;
+		List *insertShardPlacementList = NIL;
+		Query *fragmentSetQuery = NULL;
+		StringInfo queryString = makeStringInfo();
+		RelationShard *relationShard = NULL;
+		Task *modifyTask = NULL;
+
+		if (list_length(fragmentSet->fragments) == 0)
+		{
+			continue;
+		}
+
+		/* generate the query on the intermediate result */
+		fragmentSetQuery = ReadReassembledFragmentSetQuery(resultIdPrefix,
+														   selectTargetList,
+														   fragmentSet);
+
+		/* put the intermediate result query in the INSERT..SELECT */
+		selectRte->subquery = fragmentSetQuery;
+
+		/* setting an alias simplifies deparsing of RETURNING */
+		if (insertRte->alias == NULL)
+		{
+			Alias *alias = makeAlias(CITUS_TABLE_ALIAS, NIL);
+			insertRte->alias = alias;
+		}
+
+		/*
+		 * Generate a query string for the query that inserts into a shard and reads
+		 * from an intermediate result.
+		 *
+		 * Since CTEs have already been converted to intermediate results, they need
+		 * to removed from the query. Otherwise, worker queries include both
+		 * intermediate results and CTEs in the query.
+		 */
+		insertResultQuery->cteList = NIL;
+		deparse_shard_query(insertResultQuery, targetRelationId, shardId, queryString);
+		ereport(DEBUG2, (errmsg("distributed statement: %s", queryString->data)));
+
+		LockShardDistributionMetadata(shardId, ShareLock);
+		insertShardPlacementList = FinalizedShardPlacementList(shardId);
+
+		relationShard = CitusMakeNode(RelationShard);
+		relationShard->relationId = targetShardInterval->relationId;
+		relationShard->shardId = targetShardInterval->shardId;
+
+		modifyTask = CreateBasicTask(jobId, taskIdIndex, MODIFY_TASK, queryString->data);
+		modifyTask->dependedTaskList = NULL;
+		modifyTask->anchorShardId = shardId;
+		modifyTask->taskPlacementList = insertShardPlacementList;
+		modifyTask->relationShardList = list_make1(relationShard);
+		modifyTask->replicationModel = targetCacheEntry->replicationModel;
+
+		taskList = lappend(taskList, modifyTask);
+
+		taskIdIndex++;
+	}
+
+	heap_close(distributedRelation, NoLock);
+
+	return taskList;
+}
+
+
+static void
+AddInsertSelectCasts(List *targetList, TupleDesc destTupleDescriptor)
+{
+	ListCell *targetEntryCell = NULL;
+
+	foreach(targetEntryCell, targetList)
 	{
 		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
 		Var *insertColumn = (Var *) targetEntry->expr;
@@ -410,6 +590,46 @@ TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
 			targetEntry->expr = (Expr *) coerceExpr;
 		}
 	}
+}
+
+
+/*
+ * TwoPhaseInsertSelectTaskList generates a list of tasks for a query that
+ * inserts into a target relation and selects from a set of co-located
+ * intermediate results.
+ */
+static List *
+TwoPhaseInsertSelectTaskList(Query *insertSelectQuery, char *resultIdPrefix)
+{
+	List *taskList = NIL;
+
+	/*
+	 * Make a copy of the INSERT ... SELECT. We'll repeatedly replace the
+	 * subquery of insertResultQuery for different intermediate results and
+	 * then deparse it.
+	 */
+	Query *insertResultQuery = copyObject(insertSelectQuery);
+	RangeTblEntry *insertRte = ExtractResultRelationRTE(insertResultQuery);
+	RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertResultQuery);
+	Oid targetRelationId = insertRte->relid;
+	DistTableCacheEntry *targetCacheEntry = DistributedTableCacheEntry(targetRelationId);
+	int shardCount = targetCacheEntry->shardIntervalArrayLength;
+	int shardOffset = 0;
+	uint32 taskIdIndex = 1;
+	uint64 jobId = INVALID_JOB_ID;
+
+	Relation distributedRelation = NULL;
+	TupleDesc destTupleDescriptor = NULL;
+
+	distributedRelation = heap_open(targetRelationId, RowExclusiveLock);
+	destTupleDescriptor = RelationGetDescr(distributedRelation);
+
+	/*
+	 * If the type of insert column and target table's column type is
+	 * different from each other. Cast insert column't type to target
+	 * table's column
+	 */
+	AddInsertSelectCasts(insertSelectQuery->targetList, destTupleDescriptor);
 
 	for (shardOffset = 0; shardOffset < shardCount; shardOffset++)
 	{

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -844,8 +844,6 @@ fetch_intermediate_results(PG_FUNCTION_ARGS)
 							   "distributed transaction")));
 	}
 
-	CurrentCoordinatedTransactionState = COORD_TRANS_STARTED;
-
 	connection = GetNodeConnection(connectionFlags, remoteHost, remotePort);
 
 	if (PQstatus(connection->pgConn) != CONNECTION_OK)
@@ -855,7 +853,7 @@ fetch_intermediate_results(PG_FUNCTION_ARGS)
 							   remoteHost, remotePort)));
 	}
 
-	RemoteTransactionBeginIfNecessary(connection);
+	RemoteTransactionBegin(connection);
 
 	for (resultIndex = 0; resultIndex < resultCount; resultIndex++)
 	{

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -84,7 +84,7 @@ JobExecutorType(DistributedPlan *distributedPlan)
 		return MULTI_EXECUTOR_ROUTER;
 	}
 
-	if (distributedPlan->insertSelectSubquery != NULL)
+	if (distributedPlan->insertSelectQuery != NULL)
 	{
 		/*
 		 * Even if adaptiveExecutorEnabled, we go through

--- a/src/backend/distributed/executor/partition_intermediate_results.c
+++ b/src/backend/distributed/executor/partition_intermediate_results.c
@@ -1,0 +1,643 @@
+/*-------------------------------------------------------------------------
+ *
+ * partition_intermediate_results.c
+ *   Functions for writing partitioned intermediate results.
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "port.h"
+
+#include "access/hash.h"
+#include "access/nbtree.h"
+#include "catalog/pg_am.h"
+#include "catalog/pg_enum.h"
+#include "commands/copy.h"
+#include "distributed/commands/multi_copy.h"
+#include "distributed/connection_management.h"
+#include "distributed/intermediate_results.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_executor.h"
+#include "distributed/remote_commands.h"
+#include "distributed/transmit.h"
+#include "distributed/transaction_identifier.h"
+#include "distributed/tuplestore.h"
+#include "distributed/worker_protocol.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "storage/fd.h"
+#include "tcop/pquery.h"
+#include "tcop/tcopprot.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/portal.h"
+#include "utils/syscache.h"
+
+
+struct PartitionedResultDestReceiver;
+typedef uint32 (*PartitionIdFunc)(Datum, void *);
+
+
+/* CopyDestReceiver can be used to stream results into a distributed table */
+typedef struct PartitionedResultDestReceiver
+{
+	/* public DestReceiver interface */
+	DestReceiver pub;
+
+	char *resultIdPrefix;
+
+	/* descriptor of the tuples that are sent to the worker */
+	TupleDesc tupleDescriptor;
+
+	/* EState for per-tuple memory allocation */
+	EState *executorState;
+
+	/* MemoryContext for DestReceiver session */
+	MemoryContext memoryContext;
+
+	/* partitioning logic */
+	int partitionColumnIndex;
+	PartitionIdFunc determinePartitionId;
+	void *partitionContext;
+
+	/* output files */
+	int partitionCount;
+	FileOutputStream *partitionFiles;
+
+	/* state on how to copy out data types */
+	CopyOutState copyOutState;
+	FmgrInfo *columnOutputFunctions;
+
+	/* number of tuples sent */
+	uint64 tuplesSent;
+} PartitionedResultDestReceiver;
+
+
+static DestReceiver * CreatePartitionedResultDestReceiver(char *resultId,
+														  EState *executorState,
+														  int partitionColumnIndex,
+														  int partitionCount,
+														  PartitionIdFunc partitionIdFunc,
+														  void *partitionContext);
+static HashPartitionContext * CreateHashPartitionContext(Datum *hashRangeArray,
+														 int partitionCount,
+														 Oid partitionColumnType);
+static uint32 HashPartitionId(Datum partitionValue, void *context);
+static void PartitionedResultDestReceiverStartup(DestReceiver *dest, int operation,
+												 TupleDesc inputTupleDescriptor);
+static bool PartitionedResultDestReceiverReceive(TupleTableSlot *slot,
+												 DestReceiver *dest);
+static void FileOutputStreamOpen(FileOutputStream *file);
+static void FileOutputStreamWrite(FileOutputStream *file, StringInfo dataToWrite);
+static void FileOutputStreamFlush(FileOutputStream *file);
+static void PartitionedResultDestReceiverShutdown(DestReceiver *destReceiver);
+static void PartitionedResultDestReceiverDestroy(DestReceiver *destReceiver);
+
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(create_hash_partitioned_intermediate_result);
+
+
+/*
+ * create_hash_partitioned_intermediate_result executes a query and writes the results
+ * into a set of local files according to the partition scheme and the partition
+ * column.
+ */
+Datum
+create_hash_partitioned_intermediate_result(PG_FUNCTION_ARGS)
+{
+	ReturnSetInfo *resultInfo = (ReturnSetInfo *) fcinfo->resultinfo;
+
+	text *resultIdPrefixText = PG_GETARG_TEXT_P(0);
+	char *resultIdPrefixString = text_to_cstring(resultIdPrefixText);
+	text *queryText = PG_GETARG_TEXT_P(1);
+	char *queryString = text_to_cstring(queryText);
+
+	int partitionColumnIndex = PG_GETARG_INT32(2);
+	ArrayType *hashRangeObject = PG_GETARG_ARRAYTYPE_P(3);
+
+	Query *query = NULL;
+	PlannedStmt *queryPlan = NULL;
+	Portal portal = NULL;
+	TupleDesc tupleDescriptor;
+	Oid partitionColumnType = InvalidOid;
+
+	HashPartitionContext *partitionContext = NULL;
+	Datum *hashRangeArray = DeconstructArrayObject(hashRangeObject);
+	int32 partitionCount = ArrayObjectCount(hashRangeObject);
+
+	EState *estate = NULL;
+	DestReceiver *dest = NULL;
+	PartitionedResultDestReceiver *resultDest = NULL;
+	ParamListInfo paramListInfo = NULL;
+
+	TupleDesc returnTupleDesc = NULL;
+	Tuplestorestate *tupleStore = NULL;
+	MemoryContext perQueryContext = resultInfo->econtext->ecxt_per_query_memory;
+	MemoryContext oldContext = NULL;
+	int partitionIndex = 0;
+
+	int cursorOptions = 0;
+	int eflags = 0;
+	long count = FETCH_ALL;
+
+	CheckCitusVersion(ERROR);
+
+	tupleStore = SetupTuplestore(fcinfo, &returnTupleDesc);
+
+	if (partitionCount == 0)
+	{
+		ereport(ERROR, (errmsg("number of partitions cannot be 0")));
+	}
+
+	if (partitionColumnIndex < 0)
+	{
+		ereport(ERROR, (errmsg("partition column index cannot be negative")));
+	}
+
+	/*
+	 * Make sure that this transaction has a distributed transaction ID.
+	 *
+	 * Intermediate results will be stored in a directory that is derived
+	 * from the distributed transaction ID.
+	 */
+	BeginOrContinueCoordinatedTransaction();
+
+	/* parse the query */
+	query = ParseQueryString(queryString);
+
+	/* plan the query */
+	cursorOptions = CURSOR_OPT_PARALLEL_OK;
+	queryPlan = pg_plan_query(query, cursorOptions, paramListInfo);
+
+	/* create a new portal for executing the query */
+	portal = CreateNewPortal();
+
+	/* don't display the portal in pg_cursors, it is for internal use only */
+	portal->visible = false;
+
+	/* start execution early in order to extract the tuple descriptor  */
+	PortalDefineQuery(portal, NULL, queryString, "SELECT", list_make1(queryPlan), NULL);
+	PortalStart(portal, paramListInfo, eflags, GetActiveSnapshot());
+
+	/* extract the partition column */
+	tupleDescriptor = portal->tupDesc;
+
+	if (tupleDescriptor == NULL)
+	{
+		elog(ERROR, "no tuple descriptor");
+	}
+
+	if (partitionColumnIndex >= tupleDescriptor->natts)
+	{
+		ereport(ERROR, (errmsg("partition column index cannot be greater than %d",
+							   tupleDescriptor->natts - 1)));
+	}
+
+	/* determine the partition column type */
+	partitionColumnType = TupleDescAttr(tupleDescriptor, partitionColumnIndex)->atttypid;
+
+	/* build the partition context */
+	partitionContext = CreateHashPartitionContext(hashRangeArray, partitionCount,
+												  partitionColumnType);
+
+	/* prepare the output destination */
+	estate = CreateExecutorState();
+	dest = CreatePartitionedResultDestReceiver(resultIdPrefixString, estate,
+											   partitionColumnIndex,
+											   partitionCount, HashPartitionId,
+											   partitionContext);
+
+	resultDest = (PartitionedResultDestReceiver *) dest;
+
+	/* execute the query */
+	PortalRun(portal, count, false, true, dest, dest, NULL);
+
+	oldContext = MemoryContextSwitchTo(perQueryContext);
+
+	tupleStore = tuplestore_begin_heap(true, false, work_mem);
+	resultInfo->returnMode = SFRM_Materialize;
+	resultInfo->setResult = tupleStore;
+	resultInfo->setDesc = returnTupleDesc;
+
+	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
+	{
+		FileOutputStream *partitionFile = &resultDest->partitionFiles[partitionIndex];
+		int64 bytesWritten = partitionFile->bytesWritten;
+		Datum values[2];
+		bool nulls[2];
+
+		memset(values, 0, sizeof(values));
+		memset(nulls, 0, sizeof(nulls));
+
+		values[0] = Int32GetDatum(partitionIndex);
+		values[1] = UInt64GetDatum(bytesWritten);
+
+		tuplestore_putvalues(tupleStore, returnTupleDesc, values, nulls);
+	}
+
+	tuplestore_donestoring(tupleStore);
+
+	MemoryContextSwitchTo(oldContext);
+
+	PortalDrop(portal, false);
+	FreeExecutorState(estate);
+
+	PG_RETURN_INT64(resultDest->tuplesSent);
+}
+
+
+/*
+ * CreateHashPartitionContext creates a new partition context for dividing
+ * values of type partitionColumnType into hash buckets according to the
+ * ranges whose minimum hash value is in hashRangeArray.
+ */
+static HashPartitionContext *
+CreateHashPartitionContext(Datum *hashRangeArray, int partitionCount,
+						   Oid partitionColumnType)
+{
+	HashPartitionContext *partitionContext = NULL;
+	FmgrInfo *hashFunction = NULL;
+
+	partitionContext = palloc0(sizeof(HashPartitionContext));
+	partitionContext->syntheticShardIntervalArray =
+		SyntheticShardIntervalArrayForShardMinValues(hashRangeArray, partitionCount);
+	partitionContext->hasUniformHashDistribution =
+		HasUniformHashDistribution(partitionContext->syntheticShardIntervalArray,
+								   partitionCount);
+
+	/* use column's type information to get the hashing function */
+	hashFunction = GetFunctionInfo(partitionColumnType, HASH_AM_OID, HASHSTANDARD_PROC);
+
+	partitionContext->hashFunction = hashFunction;
+	partitionContext->partitionCount = partitionCount;
+
+	/* we'll use binary search, we need the comparison function */
+	if (!partitionContext->hasUniformHashDistribution)
+	{
+		partitionContext->comparisonFunction =
+			GetFunctionInfo(partitionColumnType, BTREE_AM_OID, BTORDER_PROC);
+	}
+
+	return partitionContext;
+}
+
+
+/*
+ * HashPartitionId determines the partition number for the given data value
+ * using hash partitioning. More specifically, the function returns zero if the
+ * given data value is null. If not, the function follows the exact same approach
+ * as Citus distributed planner uses.
+ */
+static uint32
+HashPartitionId(Datum partitionValue, void *context)
+{
+	HashPartitionContext *hashPartitionContext = (HashPartitionContext *) context;
+	FmgrInfo *hashFunction = hashPartitionContext->hashFunction;
+	uint32 partitionCount = hashPartitionContext->partitionCount;
+	ShardInterval **syntheticShardIntervalArray =
+		hashPartitionContext->syntheticShardIntervalArray;
+	FmgrInfo *comparisonFunction = hashPartitionContext->comparisonFunction;
+	Datum hashDatum = FunctionCall1(hashFunction, partitionValue);
+	int32 hashResult = 0;
+	uint32 hashPartitionId = 0;
+
+	if (hashDatum == 0)
+	{
+		return hashPartitionId;
+	}
+
+	if (hashPartitionContext->hasUniformHashDistribution)
+	{
+		uint64 hashTokenIncrement = HASH_TOKEN_COUNT / partitionCount;
+
+		hashResult = DatumGetInt32(hashDatum);
+		hashPartitionId = (uint32) (hashResult - INT32_MIN) / hashTokenIncrement;
+	}
+	else
+	{
+		hashPartitionId =
+			SearchCachedShardInterval(hashDatum, syntheticShardIntervalArray,
+									  partitionCount, comparisonFunction);
+	}
+
+	return hashPartitionId;
+}
+
+
+/*
+ * CreatePartitionedResultDestReceiver creates a DestReceiver that streams results
+ * to a set of worker nodes. If the scope of the intermediate result is a
+ * distributed transaction, then it's up to the caller to ensure that a
+ * coordinated transaction is started prior to using the DestReceiver.
+ */
+static DestReceiver *
+CreatePartitionedResultDestReceiver(char *resultIdPrefix, EState *executorState,
+									int partitionColumnIndex,
+									int partitionCount, PartitionIdFunc partitionIdFunc,
+									void *partitionContext)
+{
+	PartitionedResultDestReceiver *resultDest = NULL;
+
+	resultDest = (PartitionedResultDestReceiver *) palloc0(
+		sizeof(PartitionedResultDestReceiver));
+
+	/* set up the DestReceiver function pointers */
+	resultDest->pub.receiveSlot = PartitionedResultDestReceiverReceive;
+	resultDest->pub.rStartup = PartitionedResultDestReceiverStartup;
+	resultDest->pub.rShutdown = PartitionedResultDestReceiverShutdown;
+	resultDest->pub.rDestroy = PartitionedResultDestReceiverDestroy;
+	resultDest->pub.mydest = DestCopyOut;
+
+	/* set up output parameters */
+	resultDest->resultIdPrefix = resultIdPrefix;
+	resultDest->executorState = executorState;
+	resultDest->memoryContext = CurrentMemoryContext;
+	resultDest->partitionColumnIndex = partitionColumnIndex;
+	resultDest->partitionCount = partitionCount;
+	resultDest->determinePartitionId = partitionIdFunc;
+	resultDest->partitionContext = partitionContext;
+	resultDest->partitionFiles =
+		(FileOutputStream *) palloc0(partitionCount * sizeof(FileOutputStream));
+
+	return (DestReceiver *) resultDest;
+}
+
+
+/*
+ * PartitionedResultDestReceiverStartup implements the rStartup interface of
+ * PartitionedResultDestReceiver. It opens the relation
+ */
+static void
+PartitionedResultDestReceiverStartup(DestReceiver *dest, int operation,
+									 TupleDesc inputTupleDescriptor)
+{
+	PartitionedResultDestReceiver *resultDest = (PartitionedResultDestReceiver *) dest;
+
+	const char *resultIdPrefix = resultDest->resultIdPrefix;
+
+	CopyOutState copyOutState = NULL;
+	const char *delimiterCharacter = "\t";
+	const char *nullPrintCharacter = "\\N";
+
+	int partitionCount = resultDest->partitionCount;
+	int partitionIndex = 0;
+	FileOutputStream *partitionFileArray = resultDest->partitionFiles;
+	uint32 fileBufferSize = 0;
+
+	resultDest->tupleDescriptor = inputTupleDescriptor;
+
+	/* define how tuples will be serialised */
+	copyOutState = (CopyOutState) palloc0(sizeof(CopyOutStateData));
+	copyOutState->delim = (char *) delimiterCharacter;
+	copyOutState->null_print = (char *) nullPrintCharacter;
+	copyOutState->null_print_client = (char *) nullPrintCharacter;
+	copyOutState->binary = CanUseBinaryCopyFormat(inputTupleDescriptor);
+	copyOutState->fe_msgbuf = makeStringInfo();
+	copyOutState->rowcontext = GetPerTupleMemoryContext(resultDest->executorState);
+	resultDest->copyOutState = copyOutState;
+
+	resultDest->columnOutputFunctions = ColumnOutputFunctions(inputTupleDescriptor,
+															  copyOutState->binary);
+
+	/* make sure the directory exists */
+	CreateIntermediateResultsDirectory();
+
+	fileBufferSize = (uint32) Max(16384 * 1024 / partitionCount, 1024);
+
+	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
+	{
+		char *filePath = NULL;
+		StringInfo resultId = makeStringInfo();
+		StringInfo filePathStringInfo = makeStringInfo();
+
+		appendStringInfo(resultId, "%s.%d", resultIdPrefix, partitionIndex);
+
+		filePath = QueryResultFileName(resultId->data);
+		appendStringInfoString(filePathStringInfo, filePath);
+
+		/* initialize the entry but do not create the file yet */
+		partitionFileArray[partitionIndex].fileDescriptor = 0;
+		partitionFileArray[partitionIndex].fileBuffer = makeStringInfo();
+		partitionFileArray[partitionIndex].filePath = filePathStringInfo;
+		partitionFileArray[partitionIndex].bufferSize = fileBufferSize;
+		partitionFileArray[partitionIndex].bytesWritten = 0L;
+	}
+}
+
+
+/*
+ * PartitionedResultDestReceiverReceive implements the receiveSlot function of
+ * PartitionedResultDestReceiver. It takes a TupleTableSlot and sends the contents to
+ * all worker nodes.
+ */
+static bool
+PartitionedResultDestReceiverReceive(TupleTableSlot *slot, DestReceiver *dest)
+{
+	PartitionedResultDestReceiver *resultDest = (PartitionedResultDestReceiver *) dest;
+
+	TupleDesc tupleDescriptor = resultDest->tupleDescriptor;
+
+	CopyOutState copyOutState = resultDest->copyOutState;
+	FmgrInfo *columnOutputFunctions = resultDest->columnOutputFunctions;
+	int partitionColumnIndex = resultDest->partitionColumnIndex;
+
+	Datum *columnValues = NULL;
+	bool *columnNulls = NULL;
+	StringInfo copyData = copyOutState->fe_msgbuf;
+
+	Datum partitionColumnValue = 0;
+	void *partitionContext = resultDest->partitionContext;
+	int partitionId = 0;
+	FileOutputStream *partitionFile = NULL;
+
+	EState *executorState = resultDest->executorState;
+	MemoryContext executorTupleContext = GetPerTupleMemoryContext(executorState);
+	MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
+
+	/* deform the tuple */
+	slot_getallattrs(slot);
+
+	columnValues = slot->tts_values;
+	columnNulls = slot->tts_isnull;
+
+	/* find the partition column value */
+	partitionColumnValue = columnValues[partitionColumnIndex];
+
+	/* determine the right partition */
+	partitionId = resultDest->determinePartitionId(partitionColumnValue,
+												   partitionContext);
+
+	/* find the right partition file */
+	partitionFile = &resultDest->partitionFiles[partitionId];
+	if (partitionFile->fileDescriptor == 0)
+	{
+		/* create the file */
+		FileOutputStreamOpen(partitionFile);
+
+		if (copyOutState->binary)
+		{
+			/* send headers when using binary encoding */
+			resetStringInfo(copyOutState->fe_msgbuf);
+			AppendCopyBinaryHeaders(copyOutState);
+
+			FileOutputStreamWrite(partitionFile, copyOutState->fe_msgbuf);
+		}
+	}
+
+	/* construct row in COPY format */
+	resetStringInfo(copyData);
+	AppendCopyRowData(columnValues, columnNulls, tupleDescriptor,
+					  copyOutState, columnOutputFunctions, NULL);
+
+	/* append row to the file */
+	FileOutputStreamWrite(partitionFile, copyOutState->fe_msgbuf);
+
+	resultDest->tuplesSent++;
+
+	MemoryContextSwitchTo(oldContext);
+	ResetPerTupleExprContext(executorState);
+
+	return true;
+}
+
+
+/*
+ * FileOutputStreamOpen opens the file and adds headers if necessary.
+ */
+static void
+FileOutputStreamOpen(FileOutputStream *file)
+{
+	const int fileFlags = (O_APPEND | O_CREAT | O_RDWR | O_TRUNC | PG_BINARY);
+	const int fileMode = (S_IRUSR | S_IWUSR);
+	char *filePath = file->filePath->data;
+	File fileDescriptor = 0;
+
+	fileDescriptor = PathNameOpenFilePerm(filePath, fileFlags, fileMode);
+	if (fileDescriptor < 0)
+	{
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not open file \"%s\": %m", filePath)));
+	}
+
+	file->fileDescriptor = fileDescriptor;
+}
+
+
+/*
+ * FileOutputStreamWrite appends given data to file stream's internal buffers.
+ * The function then checks if buffered data exceeds preconfigured buffer size;
+ * if so, the function flushes the buffer to the underlying file.
+ */
+static void
+FileOutputStreamWrite(FileOutputStream *file, StringInfo dataToWrite)
+{
+	StringInfo fileBuffer = file->fileBuffer;
+	uint32 newBufferSize = fileBuffer->len + dataToWrite->len;
+
+	appendBinaryStringInfo(fileBuffer, dataToWrite->data, dataToWrite->len);
+
+	file->bytesWritten += dataToWrite->len;
+
+	if (newBufferSize > file->bufferSize)
+	{
+		FileOutputStreamFlush(file);
+
+		resetStringInfo(fileBuffer);
+	}
+}
+
+
+/* Flushes data buffered in the file stream object to the underlying file. */
+static void
+FileOutputStreamFlush(FileOutputStream *file)
+{
+	StringInfo fileBuffer = file->fileBuffer;
+	int written = 0;
+
+	errno = 0;
+	written = FileWrite(file->fileDescriptor, fileBuffer->data, fileBuffer->len,
+						PG_WAIT_IO);
+	if (written != fileBuffer->len)
+	{
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not write %d bytes to partition file \"%s\"",
+							   fileBuffer->len, file->filePath->data)));
+	}
+}
+
+
+/*
+ * PartitionedResultDestReceiverShutdown implements the rShutdown interface of
+ * PartitionedResultDestReceiver. It ends the COPY on all the open connections and closes
+ * the relation.
+ */
+static void
+PartitionedResultDestReceiverShutdown(DestReceiver *destReceiver)
+{
+	PartitionedResultDestReceiver *resultDest =
+		(PartitionedResultDestReceiver *) destReceiver;
+	int partitionCount = resultDest->partitionCount;
+	int partitionIndex = 0;
+
+	CopyOutState copyOutState = resultDest->copyOutState;
+
+	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
+	{
+		FileOutputStream *partitionFile = &resultDest->partitionFiles[partitionIndex];
+
+		if (partitionFile->fileDescriptor != 0)
+		{
+			if (copyOutState->binary)
+			{
+				/* send footers when using binary encoding */
+				resetStringInfo(copyOutState->fe_msgbuf);
+				AppendCopyBinaryFooters(copyOutState);
+
+				FileOutputStreamWrite(partitionFile, copyOutState->fe_msgbuf);
+			}
+
+			FileOutputStreamFlush(partitionFile);
+			FileClose(partitionFile->fileDescriptor);
+		}
+
+		FreeStringInfo(partitionFile->fileBuffer);
+		FreeStringInfo(partitionFile->filePath);
+	}
+}
+
+
+/*
+ * PartitionedResultDestReceiverDestroy frees memory allocated as part of the
+ * PartitionedResultDestReceiver and closes file descriptors.
+ */
+static void
+PartitionedResultDestReceiverDestroy(DestReceiver *destReceiver)
+{
+	PartitionedResultDestReceiver *resultDest =
+		(PartitionedResultDestReceiver *) destReceiver;
+
+	if (resultDest->copyOutState)
+	{
+		pfree(resultDest->copyOutState);
+	}
+
+	if (resultDest->columnOutputFunctions)
+	{
+		pfree(resultDest->columnOutputFunctions);
+	}
+
+	pfree(resultDest);
+}

--- a/src/backend/distributed/executor/partition_intermediate_results.c
+++ b/src/backend/distributed/executor/partition_intermediate_results.c
@@ -167,16 +167,8 @@ worker_predistribute_query_result(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errmsg("partition column index cannot be negative")));
 	}
 
-	/*
-	 * Make sure that this transaction has a distributed transaction ID.
-	 *
-	 * Intermediate results will be stored in a directory that is derived
-	 * from the distributed transaction ID.
-	 */
-	//BeginOrContinueCoordinatedTransaction();
-
 	/* parse the query */
-	query = ParseQueryString(queryString);
+	query = ParseQueryString(queryString, NULL, 0);
 
 	/* plan the query */
 	cursorOptions = CURSOR_OPT_PARALLEL_OK;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1475,6 +1475,12 @@ AdjustReadIntermediateResultCost(RangeTblEntry *rangeTableEntry, RelOptInfo *rel
 		return;
 	}
 
+	if (resultIdConst->consttype != TEXTOID)
+	{
+		/* currently only handles a single result */
+		return;
+	}
+
 	resultIdDatum = resultIdConst->constvalue;
 	resultId = TextDatumGetCString(resultIdDatum);
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -23,6 +23,7 @@
 #include "distributed/citus_nodefuncs.h"
 #include "distributed/connection_management.h"
 #include "distributed/insert_select_planner.h"
+#include "distributed/insert_select_executor.h"
 #include "distributed/listutils.h"
 #include "distributed/multi_client_executor.h"
 #include "distributed/multi_executor.h"
@@ -145,7 +146,8 @@ CoordinatorInsertSelectExplainScan(CustomScanState *node, List *ancestors,
 {
 	CitusScanState *scanState = (CitusScanState *) node;
 	DistributedPlan *distributedPlan = scanState->distributedPlan;
-	Query *query = distributedPlan->insertSelectSubquery;
+	Query *insertSelectQuery = distributedPlan->insertSelectQuery;
+	Query *query = BuildSelectForInsertSelect(insertSelectQuery);
 	IntoClause *into = NULL;
 	ParamListInfo params = NULL;
 	char *queryString = NULL;

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -795,7 +795,7 @@ IsReadIntermediateResultFunction(Node *node)
 	{
 		FuncExpr *funcExpr = (FuncExpr *) node;
 
-		if (funcExpr->funcid == CitusReadIntermediateResultFuncId())
+		if (IsReadIntermediateResultFunctionId(funcExpr->funcid))
 		{
 			return true;
 		}

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -128,8 +128,6 @@ static MapMergeJob * BuildMapMergeJob(Query *jobQuery, List *dependedJobList,
 									  Oid baseRelationId,
 									  BoundaryNodeJobType boundaryNodeJobType);
 static uint32 HashPartitionCount(void);
-static ArrayType * SplitPointObject(ShardInterval **shardIntervalArray,
-									uint32 shardIntervalCount);
 
 /* Local functions forward declarations for task list creation and helper functions */
 static bool DistributedPlanRouterExecutable(DistributedPlan *distributedPlan);
@@ -191,8 +189,6 @@ static void AssignDataFetchDependencies(List *taskList);
 static uint32 TaskListHighestTaskId(List *taskList);
 static List * MapTaskList(MapMergeJob *mapMergeJob, List *filterTaskList);
 static char * ColumnName(Var *column, List *rangeTableList);
-static StringInfo SplitPointArrayString(ArrayType *splitPointObject,
-										Oid columnType, int32 columnTypeMod);
 static List * MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList,
 							uint32 taskIdIndex);
 static StringInfo ColumnNameArrayString(uint32 columnCount, uint64 generatingJobId);
@@ -1923,7 +1919,7 @@ HashPartitionCount(void)
  * shard interval's minimum value, sorts and inserts these minimum values into a
  * new array. This sorted array is then used by the MapMerge job.
  */
-static ArrayType *
+ArrayType *
 SplitPointObject(ShardInterval **shardIntervalArray, uint32 shardIntervalCount)
 {
 	ArrayType *splitPointObject = NULL;
@@ -4388,7 +4384,7 @@ ColumnName(Var *column, List *rangeTableList)
  * object, and converts this array (and array's typed elements) to their string
  * representations.
  */
-static StringInfo
+StringInfo
 SplitPointArrayString(ArrayType *splitPointObject, Oid columnType, int32 columnTypeMod)
 {
 	StringInfo splitPointArrayString = NULL;

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -59,6 +59,7 @@
 #include "distributed/commands/multi_copy.h"
 #include "distributed/distributed_planner.h"
 #include "distributed/errormessage.h"
+#include "distributed/intermediate_results.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_logical_planner.h"
 #include "distributed/multi_router_planner.h"
@@ -1571,8 +1572,80 @@ ShouldTransformRTE(RangeTblEntry *rangeTableEntry)
 Query *
 BuildSubPlanResultQuery(List *targetEntryList, List *columnAliasList, char *resultId)
 {
-	Query *resultQuery = NULL;
 	Const *resultIdConst = NULL;
+
+	resultIdConst = makeNode(Const);
+	resultIdConst->consttype = TEXTOID;
+	resultIdConst->consttypmod = -1;
+	resultIdConst->constlen = -1;
+	resultIdConst->constvalue = CStringGetTextDatum(resultId);
+	resultIdConst->constbyval = false;
+	resultIdConst->constisnull = false;
+	resultIdConst->location = -1;
+
+	return BuildReadIntermediateResultsQuery(targetEntryList, columnAliasList,
+											 resultIdConst);
+}
+
+
+/*
+ * BuildSubPlanResultQuery returns a query of the form:
+ *
+ * SELECT
+ *   <target list>
+ * FROM
+ *   read_intermediate_result(ARRAY[<resultNames>], '<copy format'>)
+ *   AS res (<column definition list>);
+ *
+ * The caller can optionally supply a columnAliasList, which is useful for
+ * CTEs that have column aliases.
+ *
+ * If any of the types in the target list cannot be used in the binary copy format,
+ * then the copy format 'text' is used, otherwise 'binary' is used.
+ */
+Query *
+BuildReadIntermediateResultsArrayQuery(List *targetEntryList, List *columnAliasList,
+									   List *resultNames)
+{
+	Const *resultIdConst = NULL;
+
+	resultIdConst = makeNode(Const);
+	resultIdConst->consttype = TEXTARRAYOID;
+	resultIdConst->consttypmod = -1;
+	resultIdConst->constlen = -1;
+	resultIdConst->constvalue = PointerGetDatum(strlist_to_textarray(resultNames));
+	resultIdConst->constbyval = false;
+	resultIdConst->constisnull = false;
+	resultIdConst->location = -1;
+
+	return BuildReadIntermediateResultsQuery(targetEntryList, columnAliasList,
+											 resultIdConst);
+}
+
+
+/*
+ * BuildReadIntermediateResultsQuery returns a query of the form:
+ *
+ * SELECT
+ *   <target list>
+ * FROM
+ *   read_intermediate_result(<resultIdConst>, '<copy format'>)
+ *   AS res (<column definition list>);
+ *
+ * The caller can optionally supply a columnAliasList, which is useful for
+ * replacing CTEs that have column aliases.
+ *
+ * If any of the types in the target list cannot be used in the binary copy format,
+ * then the copy format 'text' is used, otherwise 'binary' is used.
+ *
+ * The resultIdConst can be supplied by the caller to allow both single files
+ * and arrays of files.
+ */
+Query *
+BuildReadIntermediateResultsQuery(List *targetEntryList, List *columnAliasList,
+								  Const *resultIdConst)
+{
+	Query *resultQuery = NULL;
 	Const *resultFormatConst = NULL;
 	FuncExpr *funcExpr = NULL;
 	Alias *funcAlias = NULL;
@@ -1655,15 +1728,6 @@ BuildSubPlanResultQuery(List *targetEntryList, List *columnAliasList, char *resu
 
 		columnNumber++;
 	}
-
-	resultIdConst = makeNode(Const);
-	resultIdConst->consttype = TEXTOID;
-	resultIdConst->consttypmod = -1;
-	resultIdConst->constlen = -1;
-	resultIdConst->constvalue = CStringGetTextDatum(resultId);
-	resultIdConst->constbyval = false;
-	resultIdConst->constisnull = false;
-	resultIdConst->location = -1;
 
 	/* build the citus_copy_format parameter for the call to read_intermediate_result */
 	if (!useBinaryCopyFormat)

--- a/src/backend/distributed/sql/citus--9.0-1--9.1-1.sql
+++ b/src/backend/distributed/sql/citus--9.0-1--9.1-1.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION pg_catalog.create_hash_partitioned_intermediate_result(
+    result_prefix text,
+    query text,
+    partition_column_index int,
+    hash_ranges int[],
+    OUT partition_index int,
+    OUT bytes_written bigint)
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$create_hash_partitioned_intermediate_result$$;
+COMMENT ON FUNCTION pg_catalog.create_hash_partitioned_intermediate_result(result_prefix text, query text, partition_column_index int, hash_ranges int[])
+IS 'execute a query and partitions its results in set of local result files';
+
+CREATE OR REPLACE FUNCTION pg_catalog.fetch_intermediate_results(
+    result_prefixes text[],
+    node_name text,
+    node_port int)
+RETURNS bigint
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$fetch_intermediate_results$$;
+COMMENT ON FUNCTION pg_catalog.fetch_intermediate_results(text[],text,int)
+IS 'fetch an intermediate result from a remote node';
+
+CREATE OR REPLACE FUNCTION pg_catalog.read_intermediate_result(
+    result_ids text[],
+    format pg_catalog.citus_copy_format default 'csv')
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE
+AS 'MODULE_PATHNAME', $$read_intermediate_result_array$$;
+COMMENT ON FUNCTION pg_catalog.read_intermediate_result(text[],pg_catalog.citus_copy_format)
+IS 'read a set files and return them as a set of records';
+

--- a/src/backend/distributed/sql/citus--9.0-1--9.1-1.sql
+++ b/src/backend/distributed/sql/citus--9.0-1--9.1-1.sql
@@ -1,14 +1,15 @@
-CREATE OR REPLACE FUNCTION pg_catalog.create_hash_partitioned_intermediate_result(
+CREATE OR REPLACE FUNCTION pg_catalog.worker_predistribute_query_result(
     result_prefix text,
     query text,
     partition_column_index int,
     hash_ranges int[],
     OUT partition_index int,
+    OUT rows_written bigint,
     OUT bytes_written bigint)
 RETURNS SETOF record
 LANGUAGE C STRICT VOLATILE
-AS 'MODULE_PATHNAME', $$create_hash_partitioned_intermediate_result$$;
-COMMENT ON FUNCTION pg_catalog.create_hash_partitioned_intermediate_result(result_prefix text, query text, partition_column_index int, hash_ranges int[])
+AS 'MODULE_PATHNAME', $$worker_predistribute_query_result$$;
+COMMENT ON FUNCTION pg_catalog.worker_predistribute_query_result(result_prefix text, query text, partition_column_index int, hash_ranges int[])
 IS 'execute a query and partitions its results in set of local result files';
 
 CREATE OR REPLACE FUNCTION pg_catalog.fetch_intermediate_results(
@@ -30,3 +31,17 @@ AS 'MODULE_PATHNAME', $$read_intermediate_result_array$$;
 COMMENT ON FUNCTION pg_catalog.read_intermediate_result(text[],pg_catalog.citus_copy_format)
 IS 'read a set files and return them as a set of records';
 
+CREATE OR REPLACE FUNCTION pg_catalog.partition_distributed_query_result(
+    dist_result_id text,
+    query text,
+    partition_column_index int,
+    colocation_id int,
+    OUT shard_id bigint,
+    OUT partition_index int,
+    OUT bytes_written bigint,
+    OUT rows_written bigint)
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$partition_distributed_query_result$$;
+COMMENT ON FUNCTION pg_catalog.partition_distributed_query_result(text, text, int, int)
+IS 'execute a query and partitions its results in set of local result files';

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -394,7 +394,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 		case XACT_EVENT_PARALLEL_PRE_COMMIT:
 		case XACT_EVENT_PRE_PREPARE:
 		{
-			if (CurrentCoordinatedTransactionState > COORD_TRANS_NONE)
+			if (InCoordinatedTransaction())
 			{
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								errmsg("cannot use 2PC in transactions involving "

--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -235,7 +235,7 @@ citus_evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 static bool
 CitusIsVolatileFunctionIdChecker(Oid func_id, void *context)
 {
-	if (func_id == CitusReadIntermediateResultFuncId())
+	if (IsReadIntermediateResultFunctionId(func_id))
 	{
 		return false;
 	}
@@ -274,7 +274,7 @@ CitusIsVolatileFunction(Node *node)
 static bool
 CitusIsMutableFunctionIdChecker(Oid func_id, void *context)
 {
-	if (func_id == CitusReadIntermediateResultFuncId())
+	if (IsReadIntermediateResultFunctionId(func_id))
 	{
 		return false;
 	}

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -111,10 +111,8 @@ CopyNodeDistributedPlan(COPYFUNC_ARGS)
 	COPY_NODE_FIELD(masterQuery);
 	COPY_SCALAR_FIELD(queryId);
 	COPY_NODE_FIELD(relationIdList);
-
-	COPY_NODE_FIELD(insertSelectSubquery);
-	COPY_NODE_FIELD(insertTargetList);
 	COPY_SCALAR_FIELD(targetRelationId);
+	COPY_NODE_FIELD(insertSelectQuery);
 	COPY_STRING_FIELD(intermediateResultIdPrefix);
 
 	COPY_NODE_FIELD(subPlanList);

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -188,10 +188,8 @@ OutDistributedPlan(OUTFUNC_ARGS)
 	WRITE_NODE_FIELD(masterQuery);
 	WRITE_UINT64_FIELD(queryId);
 	WRITE_NODE_FIELD(relationIdList);
-
-	WRITE_NODE_FIELD(insertSelectSubquery);
-	WRITE_NODE_FIELD(insertTargetList);
 	WRITE_OID_FIELD(targetRelationId);
+	WRITE_NODE_FIELD(insertSelectQuery);
 	WRITE_STRING_FIELD(intermediateResultIdPrefix);
 
 	WRITE_NODE_FIELD(subPlanList);

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -216,10 +216,8 @@ ReadDistributedPlan(READFUNC_ARGS)
 	READ_NODE_FIELD(masterQuery);
 	READ_UINT64_FIELD(queryId);
 	READ_NODE_FIELD(relationIdList);
-
-	READ_NODE_FIELD(insertSelectSubquery);
-	READ_NODE_FIELD(insertTargetList);
 	READ_OID_FIELD(targetRelationId);
+	READ_NODE_FIELD(insertSelectQuery);
 	READ_STRING_FIELD(intermediateResultIdPrefix);
 
 	READ_NODE_FIELD(subPlanList);

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -1136,11 +1136,6 @@ LoadPartitioningSchemeForRelationId(PartitioningScheme *partitioningScheme, Oid 
 DistributionScheme *
 GetDistributionSchemeForColocationId(int colocationId)
 {
-	DistributionScheme *distributionScheme = NULL;
-	DistTableCacheEntry *distTableCacheEntry = NULL;
-	int shardCount = 0;
-	int shardIndex = 0;
-
 	Oid relationId = ColocatedTableId(colocationId);
 	if (relationId == InvalidOid)
 	{
@@ -1148,11 +1143,23 @@ GetDistributionSchemeForColocationId(int colocationId)
 		return NULL;
 	}
 
+	return GetDistributionSchemeForRelationId(relationId);
+}
+
+
+DistributionScheme *
+GetDistributionSchemeForRelationId(Oid relationId)
+{
+	DistributionScheme *distributionScheme = NULL;
+	DistTableCacheEntry *distTableCacheEntry = NULL;
+	int shardCount = 0;
+	int shardIndex = 0;
+
 	distTableCacheEntry = DistributedTableCacheEntry(relationId);
 	shardCount = distTableCacheEntry->shardIntervalArrayLength;
 
 	distributionScheme = (DistributionScheme *) palloc0(sizeof(DistributionScheme));
-	distributionScheme->colocationId = colocationId;
+	distributionScheme->colocationId = distTableCacheEntry->colocationId;
 	distributionScheme->groupIds = (int **) palloc0(sizeof(int *) * shardCount);
 
 	LoadPartitioningSchemeForRelationId(&distributionScheme->partitioning, relationId);

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -134,6 +134,7 @@ typedef struct MetadataCacheData
 	Oid citusCatalogNamespaceId;
 	Oid copyFormatTypeId;
 	Oid readIntermediateResultFuncId;
+	Oid readIntermediateResultArrayFuncId;
 	Oid extraDataContainerFuncId;
 	Oid workerHashFunctionId;
 	Oid textSendAsJsonbFunctionId;
@@ -2129,6 +2130,38 @@ CitusReadIntermediateResultFuncId(void)
 	}
 
 	return MetadataCache.readIntermediateResultFuncId;
+}
+
+
+/* return oid of the read_intermediate_result(text[],citus_copy_format) function */
+Oid
+CitusReadIntermediateResultArrayFuncId(void)
+{
+	if (MetadataCache.readIntermediateResultArrayFuncId == InvalidOid)
+	{
+		List *functionNameList = list_make2(makeString("pg_catalog"),
+											makeString("read_intermediate_result"));
+		Oid copyFormatTypeOid = CitusCopyFormatTypeId();
+		Oid paramOids[2] = { TEXTARRAYOID, copyFormatTypeOid };
+		bool missingOK = false;
+
+		MetadataCache.readIntermediateResultArrayFuncId =
+			LookupFuncName(functionNameList, 2, paramOids, missingOK);
+	}
+
+	return MetadataCache.readIntermediateResultArrayFuncId;
+}
+
+
+/*
+ * IsReadIntermediateResultFunctionId returns whether the given OID is
+ * of a read_intermediate_result function.
+ */
+bool
+IsReadIntermediateResultFunctionId(Oid functionId)
+{
+	return functionId == CitusReadIntermediateResultFuncId() ||
+		   functionId == CitusReadIntermediateResultArrayFuncId();
 }
 
 

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -57,9 +57,6 @@ static uint32 FileBufferSizeInBytes = 0; /* file buffer size to init later */
 
 
 /* Local functions forward declarations */
-static ShardInterval ** SyntheticShardIntervalArrayForShardMinValues(
-	Datum *shardMinValues,
-	int shardCount);
 static StringInfo InitTaskAttemptDirectory(uint64 jobId, uint32 taskId);
 static uint32 FileBufferSize(int partitionBufferSizeInKB, uint32 fileCount);
 static FileOutputStream * OpenPartitionFiles(StringInfo directoryName, uint32 fileCount);
@@ -259,7 +256,7 @@ worker_hash_partition_table(PG_FUNCTION_ARGS)
  * The function only fills the min/max values of shard the intervals. Thus, should
  * not be used for general purpose operations.
  */
-static ShardInterval **
+ShardInterval **
 SyntheticShardIntervalArrayForShardMinValues(Datum *shardMinValues, int shardCount)
 {
 	int shardIndex = 0;

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -36,5 +36,6 @@ extern void CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelation
 extern void DeleteColocationGroupIfNoTablesBelong(uint32 colocationId);
 extern PartitioningScheme * GetPartitioningSchemeForColocationId(int colocationId);
 extern DistributionScheme * GetDistributionSchemeForColocationId(int colocationId);
+extern DistributionScheme * GetDistributionSchemeForRelationId(Oid relationId);
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -12,6 +12,7 @@
 #ifndef COLOCATION_UTILS_H_
 #define COLOCATION_UTILS_H_
 
+#include "distributed/sharding.h"
 #include "distributed/shardinterval_utils.h"
 #include "nodes/pg_list.h"
 
@@ -33,5 +34,7 @@ extern void CheckReplicationModel(Oid sourceRelationId, Oid targetRelationId);
 extern void CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelationId);
 
 extern void DeleteColocationGroupIfNoTablesBelong(uint32 colocationId);
+extern PartitioningScheme * GetPartitioningSchemeForColocationId(int colocationId);
+extern DistributionScheme * GetDistributionSchemeForColocationId(int colocationId);
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/include/distributed/insert_select_executor.h
+++ b/src/include/distributed/insert_select_executor.h
@@ -19,6 +19,7 @@
 
 extern TupleTableSlot * CoordinatorInsertSelectExecScan(CustomScanState *node);
 extern bool ExecutingInsertSelect(void);
+extern Query * BuildSelectForInsertSelect(Query *insertSelectQuery);
 
 
 #endif /* INSERT_SELECT_EXECUTOR_H */

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -21,9 +21,13 @@
 #include "utils/palloc.h"
 
 
+extern char * CreateIntermediateResultsDirectory(void);
+extern char * IntermediateResultsDirectory(void);
+extern char * QueryResultFileName(const char *resultId);
 extern DestReceiver * CreateRemoteFileDestReceiver(char *resultId, EState *executorState,
 												   List *initialNodeList, bool
 												   writeLocalFile);
+extern void SendQueryResultViaCopy(const char *resultId);
 extern void ReceiveQueryResultViaCopy(const char *resultId);
 extern void RemoveIntermediateResultsDirectory(void);
 extern int64 IntermediateResultSize(char *resultId);

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -15,6 +15,7 @@
 #include "fmgr.h"
 
 #include "distributed/commands/multi_copy.h"
+#include "distributed/sharding.h"
 #include "nodes/execnodes.h"
 #include "nodes/pg_list.h"
 #include "tcop/dest.h"
@@ -31,6 +32,11 @@ extern void SendQueryResultViaCopy(const char *resultId);
 extern void ReceiveQueryResultViaCopy(const char *resultId);
 extern void RemoveIntermediateResultsDirectory(void);
 extern int64 IntermediateResultSize(char *resultId);
-
+extern Query * BuildReadIntermediateResultsQuery(List *targetEntryList,
+												 List *columnAliasList,
+												 Const *resultIdConst);
+extern Query * BuildReadIntermediateResultsArrayQuery(List *targetEntryList,
+													  List *columnAliasList,
+													  List *resultNames);
 
 #endif /* INTERMEDIATE_RESULTS_H */

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -185,6 +185,8 @@ extern Oid CitusCopyFormatTypeId(void);
 
 /* function oids */
 extern Oid CitusReadIntermediateResultFuncId(void);
+extern Oid CitusReadIntermediateResultArrayFuncId(void);
+extern bool IsReadIntermediateResultFunctionId(Oid functionId);
 extern Oid CitusExtraDataContainerFuncId(void);
 extern Oid CitusWorkerHashFunctionId(void);
 extern Oid CitusTextSendAsJsonbFunctionId(void);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -272,14 +272,11 @@ typedef struct DistributedPlan
 	/* which relations are accessed by this distributed plan */
 	List *relationIdList;
 
-	/* SELECT query in an INSERT ... SELECT via the coordinator */
-	Query *insertSelectSubquery;
-
-	/* target list of an INSERT ... SELECT via the coordinator */
-	List *insertTargetList;
-
 	/* target relation of a modification */
 	Oid targetRelationId;
+
+	/* INSERT .. SELECT via the coordinator */
+	Query *insertSelectQuery;
 
 	/*
 	 * If intermediateResultIdPrefix is non-null, an INSERT ... SELECT

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -363,6 +363,10 @@ extern bool ShardIntervalsOverlap(ShardInterval *firstInterval,
 extern bool CoPartitionedTables(Oid firstRelationId, Oid secondRelationId);
 extern ShardInterval ** GenerateSyntheticShardIntervalArray(int partitionCount);
 extern RowModifyLevel RowModifyLevelForQuery(Query *query);
+extern ArrayType * SplitPointObject(ShardInterval **shardIntervalArray,
+									uint32 shardIntervalCount);
+extern StringInfo SplitPointArrayString(ArrayType *splitPointObject,
+										Oid columnType, int32 columnTypeMod);
 
 
 /* function declarations for Task and Task list operations */

--- a/src/include/distributed/redistribution.h
+++ b/src/include/distributed/redistribution.h
@@ -1,0 +1,78 @@
+/*-------------------------------------------------------------------------
+ *
+ * redistribution.h
+ *
+ * Functions for re-distributing query results.
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef REDISTRIBUTION_H
+#define REDISTRIBUTION_H
+
+
+#include "distributed/sharding.h"
+
+
+/*
+ * TargetShardFragmentStats contains statistics on the fragments that came
+ * out of predistribution using worker_predistribute_query_result.
+ */
+typedef struct TargetShardFragmentStats
+{
+	int sourceNodeId;
+	uint64 sourceShardId;
+	int targetShardIndex;
+	long byteCount;
+	long rowCount;
+} TargetShardFragmentStats;
+
+/*
+ * ReassembledFragmentSet represents a set of fragments that have been fetched
+ * to a particular node and when concatenated form one shard of a
+ * RedistributedQueryResult.
+ */
+typedef struct ReassembledFragmentSet
+{
+	/* node where the fragments are located */
+	int nodeId;
+
+	/* list of TargetShardFragmentStats for each fragment in a target partition */
+	List *fragments;
+} ReassembledFragmentSet;
+
+
+/*
+ * A RedistributedQueryResult represents a temporary distributed table that
+ * originated from a redistribuion operation and is therefore stored as a
+ * set of fragments per shard, which need to be concatenated at run-time.
+ */
+typedef struct RedistributedQueryResult
+{
+	/* prefix of all fragment names */
+	char *resultPrefix;
+
+	/* the partitioning between the fragment sets */
+	PartitioningScheme *partitioning;
+
+	/*
+	 * Array of reassembled fragment sets, keyed by partition index.
+	 *
+	 * The number of elements in the array is partitioning->partitionCount.
+	 */
+	ReassembledFragmentSet *reassembledFragmentSets;
+} RedistributedQueryResult;
+
+
+
+RedistributedQueryResult * RedistributeDistributedPlanResult(char *distResultId,
+															 DistributedPlan *distributedPlan,
+															 int distributionColumnIndex,
+															 DistributionScheme *targetDistribution,
+															 bool isForWrites);
+Query *ReadReassembledFragmentSetQuery(char *resultPrefix, List *targetList,
+									   ReassembledFragmentSet *fragmentSet);
+
+#endif

--- a/src/include/distributed/sharding.h
+++ b/src/include/distributed/sharding.h
@@ -1,0 +1,70 @@
+/*-------------------------------------------------------------------------
+ *
+ * sharding.h
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef SHARDING_H
+#define SHARDING_H
+
+
+#include "fmgr.h"
+
+
+/*
+ * DatumRange represents a range of values.
+ */
+typedef struct DatumRange
+{
+	Datum minValue;
+	Datum maxValue;
+} DatumRange;
+
+/*
+ * PartitionScheme represents a full partitioning scheme for a
+ * distributed table.
+ */
+typedef struct PartitioningScheme
+{
+	/* number of partitions */
+	int partitionCount;
+
+	/* ordered range of values for each partition */
+	DatumRange *ranges;
+
+	/* min/max value datum's typeId */
+	Oid valueTypeId;
+
+	/* min/max value datum's typeMod */
+	int32 valueTypeMod;
+
+	/* min/max value datum's typelen */
+	int valueTypeLen;
+
+	/* min/max value datum's byval */
+	bool valueByVal;
+} PartitioningScheme;
+
+/*
+ * DistributionScheme is a partitioning scheme that assigns
+ * partitions to nodes.
+ */
+typedef struct DistributionScheme
+{
+	PartitioningScheme partitioning;
+
+	/*
+	 * groupIds is an array group ID arrays, indicating where the partition
+	 * at a given index is placed.
+	 */
+	int **groupIds;
+
+	/* co-location ID for this sharding scheme (-1 if not co-located) */
+	int colocationId;
+} DistributionScheme;
+
+
+#endif /* SHARDING_H */

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -95,9 +95,12 @@ typedef struct HashPartitionContext
  */
 typedef struct FileOutputStream
 {
+	File fileDescriptor;
 	FileCompat fileCompat;
 	StringInfo fileBuffer;
 	StringInfo filePath;
+	uint32 bufferSize;
+	int64 bytesWritten;
 } FileOutputStream;
 
 
@@ -129,7 +132,9 @@ extern List * TableDDLCommandList(const char *nodeName, uint32 nodePort,
 								  const char *tableName);
 extern int64 WorkerExecuteSqlTask(Query *query, char *taskFilename,
 								  bool binaryCopyFormat);
-
+extern ShardInterval ** SyntheticShardIntervalArrayForShardMinValues(
+	Datum *shardMinValues,
+	int shardCount);
 
 /* Function declarations shared with the master planner */
 extern StringInfo TaskFilename(StringInfo directoryName, uint32 taskId);

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -101,6 +101,7 @@ typedef struct FileOutputStream
 	StringInfo filePath;
 	uint32 bufferSize;
 	int64 bytesWritten;
+	int64 recordsWritten;
 } FileOutputStream;
 
 

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -109,6 +109,7 @@ ALTER EXTENSION citus UPDATE TO '8.2-3';
 ALTER EXTENSION citus UPDATE TO '8.2-4';
 ALTER EXTENSION citus UPDATE TO '8.3-1';
 ALTER EXTENSION citus UPDATE TO '9.0-1';
+ALTER EXTENSION citus UPDATE TO '9.1-1';
 -- show running version
 SHOW citus.version;
  citus.version 

--- a/src/test/regress/expected/multi_insert_select.out
+++ b/src/test/regress/expected/multi_insert_select.out
@@ -1748,7 +1748,7 @@ BEGIN;
 ALTER TABLE reference_table ADD COLUMN z int;
 INSERT INTO raw_events_first (user_id)
 SELECT user_id FROM raw_events_second JOIN reference_table USING (user_id);
-ERROR:  cannot establish a new connection for placement 13300025, since DDL has been executed on a connection that is in use
+ERROR:  cannot establish a new connection for placement 13300024, since DDL has been executed on a connection that is in use
 ROLLBACK;
 -- the same test with sequential DDL should work fine
 BEGIN;
@@ -2239,21 +2239,21 @@ INSERT INTO raw_events_first (user_id, value_1)
 SELECT s, nextval('insert_select_test_seq') FROM generate_series(1, 5) s
 ON CONFLICT DO NOTHING;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300000'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300001 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300001'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300002'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300003 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300003'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
-DEBUG:  Collecting INSERT ... SELECT results on coordinator
 -- RETURNING is supported
 INSERT INTO raw_events_first (user_id, value_1)
 SELECT s, nextval('insert_select_test_seq') FROM generate_series(1, 5) s
 RETURNING *;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300000'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300001 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300001'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300002'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300003 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300003'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
-DEBUG:  Collecting INSERT ... SELECT results on coordinator
  user_id | time | value_1 | value_2 | value_3 | value_4 
 ---------+------+---------+---------+---------+---------
        1 |      |      11 |         |         |        

--- a/src/test/regress/expected/multi_insert_select_9.out
+++ b/src/test/regress/expected/multi_insert_select_9.out
@@ -91,7 +91,7 @@ ORDER BY
 -- see that we get unique vialitons
 \set VERBOSITY TERSE
 INSERT INTO raw_events_second  SELECT * FROM raw_events_first;
-ERROR:  duplicate key value violates unique constraint "raw_events_second_user_id_value_1_key_13300004"
+ERROR:  duplicate key value violates unique constraint "raw_events_second_user_id_value_1_key_13300005"
 \set VERBOSITY DEFAULT
 -- stable functions should be allowed
 INSERT INTO raw_events_second (user_id, time)
@@ -2237,21 +2237,21 @@ INSERT INTO raw_events_first (user_id, value_1)
 SELECT s, nextval('insert_select_test_seq') FROM generate_series(1, 5) s
 ON CONFLICT DO NOTHING;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300000'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300001 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300001'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300002'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300003 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_206_13300003'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) ON CONFLICT DO NOTHING
-DEBUG:  Collecting INSERT ... SELECT results on coordinator
 -- RETURNING is supported
 INSERT INTO raw_events_first (user_id, value_1)
 SELECT s, nextval('insert_select_test_seq') FROM generate_series(1, 5) s
 RETURNING *;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300000 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300000'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300001 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300001'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300002 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300002'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
 DEBUG:  distributed statement: INSERT INTO public.raw_events_first_13300003 AS citus_table_alias (user_id, value_1) SELECT user_id, value_1 FROM read_intermediate_result('insert_select_207_13300003'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer, value_1 integer) RETURNING citus_table_alias.user_id, citus_table_alias."time", citus_table_alias.value_1, citus_table_alias.value_2, citus_table_alias.value_3, citus_table_alias.value_4
-DEBUG:  Collecting INSERT ... SELECT results on coordinator
  user_id | time | value_1 | value_2 | value_3 | value_4 
 ---------+------+---------+---------+---------+---------
        1 |      |      11 |         |         |        

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -110,6 +110,7 @@ ALTER EXTENSION citus UPDATE TO '8.2-3';
 ALTER EXTENSION citus UPDATE TO '8.2-4';
 ALTER EXTENSION citus UPDATE TO '8.3-1';
 ALTER EXTENSION citus UPDATE TO '9.0-1';
+ALTER EXTENSION citus UPDATE TO '9.1-1';
 
 -- show running version
 SHOW citus.version;


### PR DESCRIPTION
DESCRIPTION: INSERT...SELECT with repartitioning

Opening a PR for visibility. Still very buggy, does not build on PG12.

We currently have two methods of executing an INSERT...SELECT: 
- in parallel between co-located shards, used when the distribution column value is preserved between source and target table
- via the coordinator using COPY, used in all other cases

The first method scales horizontally, but the second method can get bottlenecked on single core performance on the coordinator, and may cause the coordinator to run out of disk space.

This PR adds a third method:
- distributed repartitioning of the select result, used in cases where the SELECT is a distributed query that does not require a merge on the coordinator

The INSERT..SELECT runs in 3 phases:
1. Run SELECT tasks wrapped in worker_predistribute_query_result to partition query results into fragments which correspond to the hash ranges of the shards in the destination table
2. Fetch fragments to the corresponding destination shard using fetch_intermediate_result using one call per node pair
3. Run INSERT INTO .. SELECT .. FROM read_intermediate_result(..) into the shards of the destination table, where read_intermediate_result reads the concatenation of fragments that correspond to the hash range of the shard

In each phase, the tasks are executed by the adaptive executor. Empty tasks are pruned away during execution.