### PR TITLE
(NO-MERGE, POC) Add backtrace to test outputs

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -64,6 +64,11 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 	List *activeSubXacts = NIL;
 	const char *timestamp = NULL;
 
+	char *x = 0;
+	*x = 'a';
+	(*x)++;
+	elog(WARNING, "%s", x);
+
 	Assert(transaction->transactionState == REMOTE_TRANS_INVALID);
 
 	/* remember transaction as being in-progress */

--- a/src/test/regress/bin/psql-bt.py
+++ b/src/test/regress/bin/psql-bt.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import subprocess, sys, os
+
+args = " ".join(map(lambda s: '"%s"' % s if ' ' in s else s, sys.argv[1:]))
+
+psql = subprocess.Popen([args + " 2>&1"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, env=os.environ, shell=True)
+
+psql.stdin.write("SELECT pg_backend_pid();\n")
+psql.stdout.readline() # SELECT pg_backend_pid();
+psql.stdout.readline() # pg_backend_pid
+psql.stdout.readline() # -----------------------
+pgpid = int(psql.stdout.readline().strip())
+psql.stdout.readline() # (1 row)
+psql.stdout.readline() # (empty line)
+
+gdb = subprocess.Popen(['sudo', 'gdb', '-batch', '-ex', 'c', '-ex', 'bt', '--pid', str(pgpid)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+gdb.stdout.readline()
+
+for line in sys.stdin.readlines():
+    psql.stdin.write(line)
+psql.stdin.close()
+
+while psql.returncode is None:
+    psql.poll()
+
+sys.stdout.write(''.join(psql.stdout.readlines()))
+
+ret = psql.returncode
+
+if ret:
+    sys.stdout.write(''.join(gdb.stdout.readlines()))
+    sys.stdout.write(''.join(gdb.stderr.readlines()))
+
+exit(ret)

--- a/src/test/regress/log_test_times
+++ b/src/test/regress/log_test_times
@@ -1,4 +1,4 @@
 #!/bin/bash
 export TIMEFORMAT="${PG_MAJOR}/${PGAPPNAME} %6R"
 
-{ { time "$@" 1>&3- 2>&4-; } 2>> test_times.log; } 3>&1 4>&2
+{ { time psql-bt.py "${@}" 1>&3- 2>&4-; } 2>> test_times.log; } 3>&1 4>&2


### PR DESCRIPTION
Build with `--enable-debug`, run `make -C src/test/regress check-base`, look at the end of `src/test/regress/results/multi_cluster_management.out` or `regression.diffs`. You should see the backtrace. This is what I get: https://gist.github.com/pykello/b5741b1311bf0bff7bb3f30d1826669c#file-multi_cluster_management-out-L94

Assumption is that current user is passwordless sudoer so it can run `sudo gdb`.