### PR TITLE
Cache whether an object is in pg_dist_object

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -54,7 +54,7 @@ CallDistributedProcedureRemotely(CallStmt *callStmt, DestReceiver *dest)
 	Oid functionId = funcExpr->funcid;
 
 	procedure = LookupDistObjectCacheEntry(ProcedureRelationId, functionId, 0);
-	if (procedure == NULL)
+	if (procedure == NULL || !procedure->isDistributed)
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -221,7 +221,7 @@ TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 
 	funcExpr = (FuncExpr *) targetEntry->expr;
 	procedure = LookupDistObjectCacheEntry(ProcedureRelationId, funcExpr->funcid, 0);
-	if (procedure == NULL)
+	if (procedure == NULL || !procedure->isDistributed)
 	{
 		/* not a distributed function call */
 		ereport(DEBUG4, (errmsg("function is not distributed")));

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -991,6 +991,7 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 						  isNullArray);
 
 		cacheEntry->isValid = true;
+		cacheEntry->isDistributed = true;
 
 		cacheEntry->distributionArgIndex =
 			DatumGetInt32(datumArray[Anum_pg_dist_object_distribution_argument_index -
@@ -1000,8 +1001,8 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 	}
 	else
 	{
-		/* return NULL, cacheEntry left invalid in hash table */
-		cacheEntry = NULL;
+		cacheEntry->isValid = true;
+		cacheEntry->isDistributed = false;
 	}
 
 	systable_endscan(pgDistObjectScan);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -110,6 +110,7 @@ typedef struct DistObjectCacheEntry
 	DistObjectCacheEntryKey key;
 
 	bool isValid;
+	bool isDistributed;
 
 	int distributionArgIndex;
 	int colocationId;


### PR DESCRIPTION
DESCRIPTION: Avoid redundant lookups for non-distributed objects

Fixes #3091