### PR TITLE
isolation_multiuser_locking

### DIFF
--- a/src/test/regress/expected/isolation_multiuser_locking.out
+++ b/src/test/regress/expected/isolation_multiuser_locking.out
@@ -1,0 +1,284 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s2-begin s2-reindex s1-insert s2-commit s1-commit
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s2-reindex: 
+	REINDEX TABLE test_table;
+
+ERROR:  must be owner of table test_table
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s2-commit: 
+	COMMIT;
+
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-grant s1-begin s2-begin s2-reindex s1-insert s2-insert s2-commit s1-commit
+step s1-grant: 
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+
+bool_and       
+
+t              
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s2-reindex: 
+	REINDEX TABLE test_table;
+
+ERROR:  must be owner of table test_table
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s2-insert: 
+	UPDATE test_table SET column2 = 2;
+
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+step s2-commit: 
+	COMMIT;
+
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-grant s1-begin s2-begin s1-reindex s2-insert s1-insert s1-commit s2-commit
+step s1-grant: 
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+
+bool_and       
+
+t              
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s1-reindex: 
+	REINDEX TABLE test_table;
+
+step s2-insert: 
+	UPDATE test_table SET column2 = 2;
+ <waiting ...>
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s1-commit: 
+	COMMIT;
+
+step s2-insert: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s2-begin s2-index s1-insert s2-commit s1-commit s2-drop-index
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s2-index: 
+	CREATE INDEX test_index ON test_table(column1);
+
+ERROR:  must be owner of table test_table
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s2-commit: 
+	COMMIT;
+
+step s1-commit: 
+	COMMIT;
+
+step s2-drop-index: 
+	DROP INDEX IF EXISTS test_index;
+
+
+starting permutation: s1-grant s1-begin s2-begin s2-insert s1-index s2-insert s2-commit s1-commit s1-drop-index
+step s1-grant: 
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+
+bool_and       
+
+t              
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s2-insert: 
+	UPDATE test_table SET column2 = 2;
+
+step s1-index: 
+	CREATE INDEX test_index ON test_table(column1);
+ <waiting ...>
+step s2-insert: 
+	UPDATE test_table SET column2 = 2;
+
+step s2-commit: 
+	COMMIT;
+
+step s1-index: <... completed>
+step s1-commit: 
+	COMMIT;
+
+step s1-drop-index: 
+	DROP INDEX IF EXISTS test_index;
+
+
+starting permutation: s1-grant s1-begin s2-begin s1-index s2-index s1-insert s1-commit s2-commit s1-drop-index s2-drop-index
+step s1-grant: 
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+
+bool_and       
+
+t              
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s1-index: 
+	CREATE INDEX test_index ON test_table(column1);
+
+step s2-index: 
+	CREATE INDEX test_index ON test_table(column1);
+
+ERROR:  must be owner of table test_table
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s1-commit: 
+	COMMIT;
+
+step s2-commit: 
+	COMMIT;
+
+step s1-drop-index: 
+	DROP INDEX IF EXISTS test_index;
+
+step s2-drop-index: 
+	DROP INDEX IF EXISTS test_index;
+
+
+starting permutation: s1-begin s2-begin s2-truncate s1-insert s2-commit s1-commit
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s2-truncate: 
+	TRUNCATE test_table;
+
+ERROR:  permission denied for table test_table
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s2-commit: 
+	COMMIT;
+
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-grant s1-begin s2-begin s1-truncate s2-insert s1-insert s1-commit s2-commit
+step s1-grant: 
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+
+bool_and       
+
+t              
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s1-truncate: 
+	TRUNCATE test_table;
+
+step s2-insert: 
+	UPDATE test_table SET column2 = 2;
+ <waiting ...>
+step s1-insert: 
+	UPDATE test_table SET column2 = 1;
+
+step s1-commit: 
+	COMMIT;
+
+step s2-insert: <... completed>
+step s2-commit: 
+	COMMIT;
+
+
+starting permutation: s1-grant s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit
+step s1-grant: 
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+
+bool_and       
+
+t              
+step s1-begin: 
+	BEGIN;
+	SET ROLE test_user_1;
+
+step s2-begin: 
+	BEGIN;
+	SET ROLE test_user_2;
+
+step s1-truncate: 
+	TRUNCATE test_table;
+
+step s2-truncate: 
+	TRUNCATE test_table;
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-truncate: <... completed>
+step s2-commit: 
+	COMMIT;
+

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -14,7 +14,7 @@ test: isolation_cluster_management
 # the following tests depend on the distributed
 # transactionId, so should not be parallelized
 # and no tests should be added before these
-test: isolation_distributed_transaction_id 
+test: isolation_distributed_transaction_id
 test: isolation_dump_global_wait_edges
 test: isolation_citus_dist_activity
 
@@ -56,6 +56,7 @@ test: isolation_get_all_active_transactions
 test: isolation_validate_vs_insert
 test: isolation_insert_select_conflict
 test: isolation_ref2ref_foreign_keys
+test: isolation_multiuser_locking
 
 # MX tests
 test: isolation_reference_on_mx

--- a/src/test/regress/specs/isolation_multiuser_locking.spec
+++ b/src/test/regress/specs/isolation_multiuser_locking.spec
@@ -1,0 +1,134 @@
+setup
+{
+	SET citus.shard_replication_factor TO 1;
+
+	CREATE USER test_user_1;
+	SELECT run_command_on_workers('CREATE USER test_user_1');
+
+	CREATE USER test_user_2;
+	SELECT run_command_on_workers('CREATE USER test_user_2');
+
+	SET ROLE test_user_1;
+	CREATE TABLE test_table(column1 int, column2 int);
+	SELECT create_distributed_table('test_table', 'column1');
+	RESET ROLE;
+}
+
+teardown
+{
+	BEGIN;
+	DROP TABLE IF EXISTS test_table;
+	DROP USER test_user_1, test_user_2;
+	SELECT run_command_on_workers('DROP USER test_user_1, test_user_2');
+	COMMIT;
+}
+
+session "s1"
+
+# run_command_on_placements is done in a separate step because the setup is executed as a single transaction
+step "s1-grant"
+{
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+}
+
+step "s1-setrole"
+{
+	SET ROLE test_user_1;
+}
+
+step "s1-begin"
+{
+	BEGIN;
+	SET ROLE test_user_1;
+}
+
+step "s1-index"
+{
+	CREATE INDEX test_index ON test_table(column1);
+}
+
+step "s1-reindex"
+{
+	REINDEX TABLE test_table;
+}
+
+step "s1-drop-index"
+{
+	DROP INDEX IF EXISTS test_index;
+}
+
+step "s1-insert"
+{
+	UPDATE test_table SET column2 = 1;
+}
+
+step "s1-truncate"
+{
+	TRUNCATE test_table;
+}
+
+step "s1-commit"
+{
+	COMMIT;
+}
+
+session "s2"
+
+step "s2-setrole"
+{
+	SET ROLE test_user_2;
+}
+
+step "s2-begin"
+{
+	BEGIN;
+	SET ROLE test_user_2;
+}
+
+step "s2-index"
+{
+	CREATE INDEX test_index ON test_table(column1);
+}
+
+step "s2-reindex"
+{
+	REINDEX TABLE test_table;
+}
+
+step "s2-drop-index"
+{
+	DROP INDEX IF EXISTS test_index;
+}
+
+step "s2-insert"
+{
+	UPDATE test_table SET column2 = 2;
+}
+
+step "s2-truncate"
+{
+	TRUNCATE test_table;
+}
+
+step "s2-commit"
+{
+	COMMIT;
+}
+
+# REINDEX
+permutation "s1-begin" "s2-begin" "s2-reindex" "s1-insert" "s2-commit" "s1-commit"
+permutation "s1-grant" "s1-begin" "s2-begin" "s2-reindex" "s1-insert" "s2-insert" "s2-commit" "s1-commit"
+permutation "s1-grant" "s1-begin" "s2-begin" "s1-reindex" "s2-insert" "s1-insert" "s1-commit" "s2-commit"
+
+# CREATE INDEX
+permutation "s1-begin" "s2-begin" "s2-index" "s1-insert" "s2-commit" "s1-commit" "s2-drop-index"
+permutation "s1-grant" "s1-begin" "s2-begin" "s2-insert" "s1-index" "s2-insert" "s2-commit" "s1-commit" "s1-drop-index"
+permutation "s1-grant" "s1-begin" "s2-begin" "s1-index" "s2-index" "s1-insert" "s1-commit" "s2-commit" "s1-drop-index" "s2-drop-index"
+
+# TRUNCATE
+permutation "s1-begin" "s2-begin" "s2-truncate" "s1-insert" "s2-commit" "s1-commit"
+permutation "s1-grant" "s1-begin" "s2-begin" "s1-truncate" "s2-insert" "s1-insert" "s1-commit" "s2-commit"
+permutation "s1-grant" "s1-begin" "s2-begin" "s1-truncate" "s2-truncate" "s1-commit" "s2-commit"
+


### PR DESCRIPTION
Introduce a test which checks that locks are only acquired when a user has necessary permissions
Currently tests REINDEX, CREATE INDEX, TRUNCATE
