### PR TITLE
Update all c-style comments in migration files

### DIFF
--- a/src/backend/distributed/sql/citus--7.0-1--7.0-2.sql
+++ b/src/backend/distributed/sql/citus--7.0-1--7.0-2.sql
@@ -1,6 +1,6 @@
-/* citus--7.0-1--7.0-2.sql */
+--  citus--7.0-1--7.0-2.sql 
 
-/* redefine shard_name as STRICT */
+--  redefine shard_name as STRICT 
 CREATE OR REPLACE FUNCTION pg_catalog.shard_name(object_name regclass, shard_id bigint)
     RETURNS text
     LANGUAGE C STABLE STRICT

--- a/src/backend/distributed/sql/citus--7.0-1.sql
+++ b/src/backend/distributed/sql/citus--7.0-1.sql
@@ -1,13 +1,12 @@
-/* citus--7.0-1.sql */
+--  citus--7.0-1.sql 
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION citus" to load this file. \quit
 
 CREATE SCHEMA citus;
 
-/*****************************************************************************
- * Enable SSL to encrypt all trafic by default
- *****************************************************************************/
+-- Enable SSL to encrypt all trafic by default
+
 -- create temporary UDF that has the power to change settings within postgres and drop it
 -- after ssl has been setup.
 CREATE FUNCTION citus_setup_ssl()
@@ -27,9 +26,8 @@ $$;
 
 DROP FUNCTION citus_setup_ssl();
 
-/*****************************************************************************
- * Citus data types
- *****************************************************************************/
+-- Citus data types
+
 CREATE TYPE citus.distribution_type AS ENUM (
    'hash',
    'range',
@@ -37,9 +35,8 @@ CREATE TYPE citus.distribution_type AS ENUM (
 );
 
 
-/*****************************************************************************
- * Citus tables & corresponding indexes
- *****************************************************************************/
+-- Citus tables & corresponding indexes
+
 CREATE TABLE citus.pg_dist_partition(
     logicalrelid regclass NOT NULL,
     partmethod "char" NOT NULL,
@@ -47,7 +44,7 @@ CREATE TABLE citus.pg_dist_partition(
 	colocationid integer DEFAULT 0 NOT NULL,
 	repmodel "char" DEFAULT 'c' NOT NULL
 );
-/* SELECT granted to PUBLIC in upgrade script */
+--  SELECT granted to PUBLIC in upgrade script 
 CREATE UNIQUE INDEX pg_dist_partition_logical_relid_index
 ON citus.pg_dist_partition using btree(logicalrelid);
 ALTER TABLE citus.pg_dist_partition SET SCHEMA pg_catalog;
@@ -65,7 +62,7 @@ CREATE TABLE citus.pg_dist_shard(
 -- ALTER-after-CREATE to keep table tuple layout consistent
 -- with earlier versions of Citus.
 ALTER TABLE citus.pg_dist_shard DROP shardalias;
-/* SELECT granted to PUBLIC in upgrade script */
+--  SELECT granted to PUBLIC in upgrade script 
 CREATE UNIQUE INDEX pg_dist_shard_shardid_index
 ON citus.pg_dist_shard using btree(shardid);
 CREATE INDEX pg_dist_shard_logical_relid_index
@@ -85,7 +82,7 @@ CREATE TABLE citus.pg_dist_shard_placement(
     nodeport int8 NOT NULL,
 	placementid bigint NOT NULL DEFAULT nextval('pg_catalog.pg_dist_shard_placement_placementid_seq')
 );
-/* SELECT granted to PUBLIC in upgrade script */
+--  SELECT granted to PUBLIC in upgrade script 
 CREATE UNIQUE INDEX pg_dist_shard_placement_placementid_index
 ON citus.pg_dist_shard_placement using btree(placementid);
 CREATE INDEX pg_dist_shard_placement_shardid_index
@@ -94,38 +91,31 @@ CREATE INDEX pg_dist_shard_placement_nodeid_index
 ON citus.pg_dist_shard_placement using btree(nodename, nodeport);
 ALTER TABLE citus.pg_dist_shard_placement SET SCHEMA pg_catalog;
 
-/*****************************************************************************
- * Citus sequences
- *****************************************************************************/
+--  Citus sequences
 
-/*
- * internal sequence to generate 64-bit shard ids. These identifiers are then
- * used to identify shards in the distributed database.
- */
+-- Internal sequence to generate 64-bit shard ids. These identifiers are then
+-- used to identify shards in the distributed database.
+
 CREATE SEQUENCE citus.pg_dist_shardid_seq
     MINVALUE 102008
     NO CYCLE;
 ALTER SEQUENCE  citus.pg_dist_shardid_seq SET SCHEMA pg_catalog;
 
-/*
- * internal sequence to generate 32-bit jobIds. These identifiers are then
- * used to identify jobs in the distributed database; and they wrap at 32-bits
- * to allow for worker nodes to independently execute their distributed jobs.
- */
+-- Internal sequence to generate 32-bit jobIds. These identifiers are then
+-- used to identify jobs in the distributed database; and they wrap at 32-bits
+-- to allow for worker nodes to independently execute their distributed jobs.
 CREATE SEQUENCE citus.pg_dist_jobid_seq
-    MINVALUE 2 /* first jobId reserved for clean up jobs */
+    MINVALUE 2 --  first jobId reserved for clean up jobs 
     MAXVALUE 4294967296;
 ALTER SEQUENCE  citus.pg_dist_jobid_seq SET SCHEMA pg_catalog;
 
 
-/*****************************************************************************
- * Citus functions
- *****************************************************************************/
+-- Citus functions
 
-/* For backward compatibility and ease of use create functions et al. in pg_catalog */
+--  For backward compatibility and ease of use create functions et al. in pg_catalog 
 SET search_path = 'pg_catalog';
 
-/* master_* functions */
+--  master_* functions 
 
 CREATE FUNCTION master_get_table_metadata(relation_name text, OUT logical_relid oid,
                                           OUT part_storage_type "char",
@@ -208,7 +198,7 @@ RETURNS void
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-/* task_tracker_* functions */
+--  task_tracker_* functions 
 
 CREATE FUNCTION task_tracker_assign_task(bigint, integer, text)
     RETURNS void
@@ -232,7 +222,7 @@ COMMENT ON FUNCTION task_tracker_cleanup_job(bigint)
     IS 'clean up all tasks associated with a job';
 
 
-/* worker_* functions */
+--  worker_* functions 
 
 CREATE FUNCTION worker_fetch_partition_file(bigint, integer, integer, integer, text,
                                             integer)
@@ -294,7 +284,7 @@ CREATE FUNCTION master_drop_sequences(sequence_names text[])
 COMMENT ON FUNCTION master_drop_sequences(text[])
     IS 'drop specified sequences from the cluster';
 
-/* trigger functions */
+--  trigger functions 
 
 CREATE FUNCTION pg_catalog.citus_drop_trigger()
     RETURNS event_trigger
@@ -357,7 +347,7 @@ COMMENT ON FUNCTION master_dist_shard_cache_invalidate()
     IS 'register relcache invalidation for changed rows';
 
 
-/* internal functions, not user accessible */
+--  internal functions, not user accessible 
 
 CREATE FUNCTION citus_extradata_container(INTERNAL)
     RETURNS void
@@ -367,9 +357,7 @@ COMMENT ON FUNCTION pg_catalog.citus_extradata_container(INTERNAL)
     IS 'placeholder function to store additional data in postgres node trees';
 
 
-/*****************************************************************************
- * Citus triggers
- *****************************************************************************/
+-- Citus triggers
 
 CREATE EVENT TRIGGER citus_cascade_to_partition
     ON SQL_DROP
@@ -386,9 +374,7 @@ CREATE TRIGGER dist_shard_cache_invalidate
     FOR EACH ROW EXECUTE PROCEDURE master_dist_shard_cache_invalidate();
 
 
-/*****************************************************************************
- * Citus aggregates
- *****************************************************************************/
+-- Citus aggregates
 CREATE AGGREGATE array_cat_agg(anyarray) (SFUNC = array_cat, STYPE = anyarray);
 COMMENT ON AGGREGATE array_cat_agg(anyarray)
     IS 'concatenate input arrays into a single array';
@@ -399,7 +385,7 @@ GRANT SELECT ON pg_catalog.pg_dist_partition TO public;
 GRANT SELECT ON pg_catalog.pg_dist_shard TO public;
 GRANT SELECT ON pg_catalog.pg_dist_shard_placement TO public;
 
-/* empty, but required to update the extension version */
+--  empty, but required to update the extension version 
 CREATE FUNCTION pg_catalog.master_modify_multiple_shards(text)
     RETURNS integer
     LANGUAGE C STRICT
@@ -476,7 +462,7 @@ CREATE SEQUENCE citus.pg_dist_node_nodeid_seq
 ALTER SEQUENCE citus.pg_dist_groupid_seq SET SCHEMA pg_catalog;
 ALTER SEQUENCE citus.pg_dist_node_nodeid_seq SET SCHEMA pg_catalog;
 
-/* add pg_dist_node */
+--  add pg_dist_node 
 CREATE TABLE citus.pg_dist_node(
 	nodeid int NOT NULL DEFAULT nextval('pg_dist_groupid_seq') PRIMARY KEY,
 	groupid int NOT NULL DEFAULT nextval('pg_dist_node_nodeid_seq'),
@@ -510,7 +496,7 @@ CREATE FUNCTION master_remove_node(nodename text, nodeport integer)
 COMMENT ON FUNCTION master_remove_node(nodename text, nodeport integer)
 	IS 'remove node from the cluster';
 
-/* this only needs to run once, now. */
+--  this only needs to run once, now. 
 CREATE FUNCTION master_initialize_node_metadata()
     RETURNS BOOL
     LANGUAGE C STRICT
@@ -566,7 +552,7 @@ CREATE TABLE citus.pg_dist_local_group(
     groupid int NOT NULL PRIMARY KEY)
 ;
 
-/* insert the default value for being the coordinator node */
+--  insert the default value for being the coordinator node 
 INSERT INTO citus.pg_dist_local_group VALUES (0);
 
 ALTER TABLE citus.pg_dist_local_group SET SCHEMA pg_catalog;
@@ -602,7 +588,7 @@ CREATE SEQUENCE citus.pg_dist_colocationid_seq
 
 ALTER SEQUENCE citus.pg_dist_colocationid_seq SET SCHEMA pg_catalog;
 
-/* add pg_dist_colocation */
+--  add pg_dist_colocation 
 CREATE TABLE citus.pg_dist_colocation(
 	colocationid int NOT NULL PRIMARY KEY,
 	shardcount int NOT NULL,

--- a/src/backend/distributed/sql/citus--7.0-10--7.0-11.sql
+++ b/src/backend/distributed/sql/citus--7.0-10--7.0-11.sql
@@ -1,4 +1,4 @@
-/* citus-7.0-10--7.0-11 */
+--  citus-7.0-10--7.0-11 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-11--7.0-12.sql
+++ b/src/backend/distributed/sql/citus--7.0-11--7.0-12.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-11--7.0-12.sql */
+--  citus--7.0-11--7.0-12.sql 
 
 CREATE OR REPLACE FUNCTION pg_catalog.citus_create_restore_point(text)
 RETURNS pg_lsn

--- a/src/backend/distributed/sql/citus--7.0-12--7.0-13.sql
+++ b/src/backend/distributed/sql/citus--7.0-12--7.0-13.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-12--7.0-13.sql */
+--  citus--7.0-12--7.0-13.sql 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-13--7.0-14.sql
+++ b/src/backend/distributed/sql/citus--7.0-13--7.0-14.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-13--7.0-14.sql */
+--  citus--7.0-13--7.0-14.sql 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-14--7.0-15.sql
+++ b/src/backend/distributed/sql/citus--7.0-14--7.0-15.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-14--7.0-15 */
+--  citus--7.0-14--7.0-15 
 
 DROP FUNCTION pg_catalog.dump_local_wait_edges(int4);
 

--- a/src/backend/distributed/sql/citus--7.0-15--7.1-1.sql
+++ b/src/backend/distributed/sql/citus--7.0-15--7.1-1.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-15--7.1-1 */
+--  citus--7.0-15--7.1-1 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-2--7.0-3.sql
+++ b/src/backend/distributed/sql/citus--7.0-2--7.0-3.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-2--7.0-3.sql */
+--  citus--7.0-2--7.0-3.sql 
 
 ALTER SEQUENCE pg_catalog.pg_dist_shard_placement_placementid_seq
   RENAME TO pg_dist_placement_placementid_seq;

--- a/src/backend/distributed/sql/citus--7.0-3--7.0-4.sql
+++ b/src/backend/distributed/sql/citus--7.0-3--7.0-4.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-3--7.0-4.sql */
+--  citus--7.0-3--7.0-4.sql 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-4--7.0-5.sql
+++ b/src/backend/distributed/sql/citus--7.0-4--7.0-5.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-4--7.0-5.sql */
+--  citus--7.0-4--7.0-5.sql 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-5--7.0-6.sql
+++ b/src/backend/distributed/sql/citus--7.0-5--7.0-6.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-5--7.0-6 */
+--  citus--7.0-5--7.0-6 
 
 CREATE FUNCTION pg_catalog.dump_local_wait_edges(
                     IN source_node_id int4,

--- a/src/backend/distributed/sql/citus--7.0-6--7.0-7.sql
+++ b/src/backend/distributed/sql/citus--7.0-6--7.0-7.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-6--7.0-7 */
+--  citus--7.0-6--7.0-7 
 
 CREATE FUNCTION citus.replace_isolation_tester_func()
 RETURNS void AS $$

--- a/src/backend/distributed/sql/citus--7.0-7--7.0-8.sql
+++ b/src/backend/distributed/sql/citus--7.0-7--7.0-8.sql
@@ -1,4 +1,4 @@
-/* citus--7.0-7--7.0-8.sql */
+--  citus--7.0-7--7.0-8.sql 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-8--7.0-9.sql
+++ b/src/backend/distributed/sql/citus--7.0-8--7.0-9.sql
@@ -1,4 +1,4 @@
-/* citus-7.0-8--7.0-9 */
+--  citus-7.0-8--7.0-9 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.0-9--7.0-10.sql
+++ b/src/backend/distributed/sql/citus--7.0-9--7.0-10.sql
@@ -1,4 +1,4 @@
-/* citus-7.0-9--7.0-10 */
+--  citus-7.0-9--7.0-10 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--7.1-1--7.1-2.sql
+++ b/src/backend/distributed/sql/citus--7.1-1--7.1-2.sql
@@ -1,4 +1,4 @@
-/* citus--7.1-1--7.1-2 */
+--  citus--7.1-1--7.1-2 
 
 CREATE OR REPLACE FUNCTION pg_catalog.citus_version()
     RETURNS text

--- a/src/backend/distributed/sql/citus--7.1-2--7.1-3.sql
+++ b/src/backend/distributed/sql/citus--7.1-2--7.1-3.sql
@@ -1,4 +1,4 @@
-/* citus--7.1-2--7.1-3 */
+--  citus--7.1-2--7.1-3 
 
 CREATE TABLE citus.pg_dist_node_metadata(
     metadata jsonb NOT NULL

--- a/src/backend/distributed/sql/citus--7.1-3--7.1-4.sql
+++ b/src/backend/distributed/sql/citus--7.1-3--7.1-4.sql
@@ -1,4 +1,4 @@
-/* citus--7.1-3--7.1-4 */
+--  citus--7.1-3--7.1-4 
 
 CREATE TYPE citus.shard_transfer_mode AS ENUM (
    'auto',

--- a/src/backend/distributed/sql/citus--7.1-4--7.2-1.sql
+++ b/src/backend/distributed/sql/citus--7.1-4--7.2-1.sql
@@ -1,4 +1,4 @@
-/* citus--7.1-4--7.2-1 */
+--  citus--7.1-4--7.2-1 
 
-/* bump version to 7.2-1 */
+--  bump version to 7.2-1 
 

--- a/src/backend/distributed/sql/citus--7.2-1--7.2-2.sql
+++ b/src/backend/distributed/sql/citus--7.2-1--7.2-2.sql
@@ -1,4 +1,4 @@
-/* citus--7.2-1--7.2-2 */
+--  citus--7.2-1--7.2-2 
 
 CREATE TYPE citus.copy_format AS ENUM ('csv', 'binary', 'text');
 

--- a/src/backend/distributed/sql/citus--7.2-2--7.2-3.sql
+++ b/src/backend/distributed/sql/citus--7.2-2--7.2-3.sql
@@ -1,4 +1,4 @@
-/* citus--7.2-2--7.2-3 */
+--  citus--7.2-2--7.2-3 
 
 DROP FUNCTION pg_catalog.read_intermediate_result(text,citus.copy_format);
 DROP TYPE citus.copy_format;

--- a/src/backend/distributed/sql/citus--7.2-3--7.3-1.sql
+++ b/src/backend/distributed/sql/citus--7.2-3--7.3-1.sql
@@ -1,4 +1,4 @@
-/* citus--7.2-3--7.3-1 */
+--  citus--7.2-3--7.3-1 
 
-/* bump version to 7.3-1 */
+--  bump version to 7.3-1 
 

--- a/src/backend/distributed/sql/citus--7.3-1--7.3-2.sql
+++ b/src/backend/distributed/sql/citus--7.3-1--7.3-2.sql
@@ -1,4 +1,4 @@
-/* citus--7.3-1--7.3-2 */
+--  citus--7.3-1--7.3-2 
 
 CREATE FUNCTION pg_catalog.citus_text_send_as_jsonb(text)
 RETURNS bytea

--- a/src/backend/distributed/sql/citus--7.3-2--7.3-3.sql
+++ b/src/backend/distributed/sql/citus--7.3-2--7.3-3.sql
@@ -1,8 +1,6 @@
-/* citus--7.3-2--7.3-3 */
+--  citus--7.3-2--7.3-3 
 
-/*****************************************************************************
- * Citus json aggregate helpers
- *****************************************************************************/
+-- Citus json aggregate helpers
 
 CREATE FUNCTION pg_catalog.citus_jsonb_concatenate(state jsonb, val jsonb)
 	RETURNS jsonb
@@ -52,9 +50,7 @@ AS $function$
 $function$;
 
 
-/*****************************************************************************
- * Citus json aggregates
- *****************************************************************************/
+-- Citus json aggregates
 
 CREATE AGGREGATE pg_catalog.jsonb_cat_agg(jsonb) (
     SFUNC = citus_jsonb_concatenate,

--- a/src/backend/distributed/sql/citus--7.3-3--7.4-1.sql
+++ b/src/backend/distributed/sql/citus--7.3-3--7.4-1.sql
@@ -1,4 +1,4 @@
-/* citus--7.3-3--7.4-1 */
+--  citus--7.3-3--7.4-1 
 
 DROP FUNCTION IF EXISTS master_expire_table_cache(regclass);
 DROP FUNCTION IF EXISTS pg_catalog.worker_fetch_regular_table(text, bigint, text[], integer[]);

--- a/src/backend/distributed/sql/citus--7.4-1--7.4-2.sql
+++ b/src/backend/distributed/sql/citus--7.4-1--7.4-2.sql
@@ -1,4 +1,4 @@
-/* citus--7.4-1--7.4-2 */
+--  citus--7.4-1--7.4-2 
 
 CREATE OR REPLACE FUNCTION pg_catalog.citus_drop_trigger()
     RETURNS event_trigger

--- a/src/backend/distributed/sql/citus--7.4-2--7.4-3.sql
+++ b/src/backend/distributed/sql/citus--7.4-2--7.4-3.sql
@@ -1,4 +1,4 @@
-/* citus--7.4-2--7.4-3 */
+--  citus--7.4-2--7.4-3 
 SET search_path = 'pg_catalog';
 
 -- note that we're not dropping the older version of the function

--- a/src/backend/distributed/sql/citus--7.4-3--7.5-1.sql
+++ b/src/backend/distributed/sql/citus--7.4-3--7.5-1.sql
@@ -1,4 +1,4 @@
-/* citus--7.4-3--7.5-1 */
+--  citus--7.4-3--7.5-1 
 
-/* bump version to 7.5-1 */
+--  bump version to 7.5-1 
 

--- a/src/backend/distributed/sql/citus--7.5-1--7.5-2.sql
+++ b/src/backend/distributed/sql/citus--7.5-1--7.5-2.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-1--7.5-2 */
+--  citus--7.5-1--7.5-2 
 SET search_path = 'pg_catalog';
 
 -- note that we're not dropping the older version of the function

--- a/src/backend/distributed/sql/citus--7.5-2--7.5-3.sql
+++ b/src/backend/distributed/sql/citus--7.5-2--7.5-3.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-2--7.5-3 */
+--  citus--7.5-2--7.5-3 
 SET search_path = 'pg_catalog';
 
 CREATE FUNCTION master_dist_authinfo_cache_invalidate()

--- a/src/backend/distributed/sql/citus--7.5-3--7.5-4.sql
+++ b/src/backend/distributed/sql/citus--7.5-3--7.5-4.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-3--7.5-4 */
+--  citus--7.5-3--7.5-4 
 
 CREATE FUNCTION pg_catalog.citus_query_stats(OUT queryid bigint,
 											 OUT userid oid,

--- a/src/backend/distributed/sql/citus--7.5-4--7.5-5.sql
+++ b/src/backend/distributed/sql/citus--7.5-4--7.5-5.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-4--7.5-5 */
+--  citus--7.5-4--7.5-5 
 CREATE FUNCTION pg_catalog.citus_executor_name(executor_type int)
 RETURNS TEXT
 LANGUAGE plpgsql

--- a/src/backend/distributed/sql/citus--7.5-5--7.5-6.sql
+++ b/src/backend/distributed/sql/citus--7.5-5--7.5-6.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-5--7.5-6 */
+--  citus--7.5-5--7.5-6 
 
 -- Don't want this to be available to non-superusers.
 REVOKE ALL ON FUNCTION pg_catalog.citus_stat_statements_reset() FROM PUBLIC;

--- a/src/backend/distributed/sql/citus--7.5-6--7.5-7.sql
+++ b/src/backend/distributed/sql/citus--7.5-6--7.5-7.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-6--7.5-7 */
+--  citus--7.5-6--7.5-7 
 SET search_path = 'pg_catalog';
 
 CREATE FUNCTION pg_catalog.poolinfo_valid(text)

--- a/src/backend/distributed/sql/citus--7.5-7--8.0-1.sql
+++ b/src/backend/distributed/sql/citus--7.5-7--8.0-1.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-7--8.0-1 */
+--  citus--7.5-7--8.0-1 
 
-/* bump version to 8.0-1 */
+--  bump version to 8.0-1 
 

--- a/src/backend/distributed/sql/citus--8.0-1--8.0-2.sql
+++ b/src/backend/distributed/sql/citus--8.0-1--8.0-2.sql
@@ -1,4 +1,4 @@
-/* citus--7.5-7--8.0-1 */
+--  citus--7.5-7--8.0-1 
 SET search_path = 'pg_catalog';
 
 CREATE OR REPLACE FUNCTION pg_catalog.relation_is_a_known_shard(regclass)

--- a/src/backend/distributed/sql/citus--8.0-10--8.0-11.sql
+++ b/src/backend/distributed/sql/citus--8.0-10--8.0-11.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-10--8.0-11 */
+--  citus--8.0-10--8.0-11 
 SET search_path = 'pg_catalog';
 
 -- Deprecated functions

--- a/src/backend/distributed/sql/citus--8.0-11--8.0-12.sql
+++ b/src/backend/distributed/sql/citus--8.0-11--8.0-12.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-11--8.0-12 */
+--  citus--8.0-11--8.0-12 
 SET search_path = 'pg_catalog';
 
 CREATE OR REPLACE FUNCTION pg_catalog.citus_stat_statements(OUT queryid bigint,

--- a/src/backend/distributed/sql/citus--8.0-12--8.0-13.sql
+++ b/src/backend/distributed/sql/citus--8.0-12--8.0-13.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-12--8.0-13 */
+--  citus--8.0-12--8.0-13 
 CREATE FUNCTION citus_check_defaults_for_sslmode()
     RETURNS void
     LANGUAGE C STRICT

--- a/src/backend/distributed/sql/citus--8.0-13--8.1-1.sql
+++ b/src/backend/distributed/sql/citus--8.0-13--8.1-1.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-13--8.1-1.sql */
+--  citus--8.0-13--8.1-1.sql 
 
-/* bump version to 8.1-1 */
+--  bump version to 8.1-1 
 

--- a/src/backend/distributed/sql/citus--8.0-2--8.0-3.sql
+++ b/src/backend/distributed/sql/citus--8.0-2--8.0-3.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-2--8.0-3 */
+--  citus--8.0-2--8.0-3 
 SET search_path = 'pg_catalog';
 
 CREATE FUNCTION master_remove_partition_metadata(logicalrelid regclass,

--- a/src/backend/distributed/sql/citus--8.0-3--8.0-4.sql
+++ b/src/backend/distributed/sql/citus--8.0-3--8.0-4.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-3--8.0-4 */
+--  citus--8.0-3--8.0-4 
 SET search_path = 'pg_catalog';
 
 CREATE OR REPLACE FUNCTION lock_relation_if_exists(table_name text, lock_mode text)

--- a/src/backend/distributed/sql/citus--8.0-4--8.0-5.sql
+++ b/src/backend/distributed/sql/citus--8.0-4--8.0-5.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-4--8.0-5.sql */
+--  citus--8.0-4--8.0-5.sql 
 SET search_path = 'pg_catalog';
 
 

--- a/src/backend/distributed/sql/citus--8.0-5--8.0-6.sql
+++ b/src/backend/distributed/sql/citus--8.0-5--8.0-6.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-5--8.0-6 */
+--  citus--8.0-5--8.0-6 
 SET search_path = 'pg_catalog';
 
 CREATE FUNCTION get_global_active_transactions(OUT datid oid, OUT process_id int, OUT initiator_node_identifier int4, OUT worker_query BOOL, OUT transaction_number int8, OUT transaction_stamp timestamptz)

--- a/src/backend/distributed/sql/citus--8.0-6--8.0-7.sql
+++ b/src/backend/distributed/sql/citus--8.0-6--8.0-7.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-6--8.0-7 */
+--  citus--8.0-6--8.0-7 
 SET search_path = 'pg_catalog';
 
 CREATE VIEW citus.citus_lock_waits AS

--- a/src/backend/distributed/sql/citus--8.0-7--8.0-8.sql
+++ b/src/backend/distributed/sql/citus--8.0-7--8.0-8.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-7--8.0-8 */
+--  citus--8.0-7--8.0-8 
 SET search_path = 'pg_catalog';
 
 DROP FUNCTION IF EXISTS pg_catalog.worker_drop_distributed_table(logicalrelid Oid);

--- a/src/backend/distributed/sql/citus--8.0-8--8.0-9.sql
+++ b/src/backend/distributed/sql/citus--8.0-8--8.0-9.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-8--8.0-9 */
+--  citus--8.0-8--8.0-9 
 SET search_path = 'pg_catalog';
 
 REVOKE ALL ON FUNCTION master_activate_node(text,int) FROM PUBLIC;

--- a/src/backend/distributed/sql/citus--8.0-9--8.0-10.sql
+++ b/src/backend/distributed/sql/citus--8.0-9--8.0-10.sql
@@ -1,4 +1,4 @@
-/* citus--8.0-9--8.0-10 */
+--  citus--8.0-9--8.0-10 
 SET search_path = 'pg_catalog';
 
 CREATE FUNCTION worker_execute_sql_task(jobid bigint, taskid integer, query text, binary bool)

--- a/src/backend/distributed/sql/citus--8.1-1--8.2-1.sql
+++ b/src/backend/distributed/sql/citus--8.1-1--8.2-1.sql
@@ -1,4 +1,4 @@
-/* citus--8.1-1--8.2-1.sql */
+--  citus--8.1-1--8.2-1.sql 
 
-/* bump version to 8.2-1 */
+--  bump version to 8.2-1 
 

--- a/src/backend/distributed/sql/citus--8.2-1--8.2-2.sql
+++ b/src/backend/distributed/sql/citus--8.2-1--8.2-2.sql
@@ -1,3 +1,3 @@
-/* citus--8.2-1--8.2-2.sql */
+--  citus--8.2-1--8.2-2.sql 
 
 DROP FUNCTION IF EXISTS pg_catalog.create_insert_proxy_for_table(regclass,regclass);

--- a/src/backend/distributed/sql/citus--8.2-2--8.2-3.sql
+++ b/src/backend/distributed/sql/citus--8.2-2--8.2-3.sql
@@ -1,4 +1,4 @@
-/* citus--8.2-2--8.2-3 */
+--  citus--8.2-2--8.2-3 
 
 SET search_path = 'pg_catalog';
 

--- a/src/backend/distributed/sql/citus--8.2-3--8.2-4.sql
+++ b/src/backend/distributed/sql/citus--8.2-3--8.2-4.sql
@@ -1,4 +1,4 @@
-/* citus--8.2-3--8.2-4 */
+--  citus--8.2-3--8.2-4 
 
 CREATE OR REPLACE FUNCTION pg_catalog.citus_executor_name(executor_type int)
 RETURNS text

--- a/src/backend/distributed/sql/citus--8.2-4--8.3-1.sql
+++ b/src/backend/distributed/sql/citus--8.2-4--8.3-1.sql
@@ -1,4 +1,4 @@
-/* citus--8.2-4--8.3-1 */
+--  citus--8.2-4--8.3-1 
 
-/* bump version to 8.3-1 */
+--  bump version to 8.3-1 
 

--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -1,4 +1,4 @@
-/* citus--8.3-1--9.0-1 */
+--  citus--8.3-1--9.0-1 
 
 SET search_path = 'pg_catalog';
 
@@ -72,14 +72,12 @@ CREATE TRIGGER dist_object_cache_invalidate
 #include "udfs/citus_prepare_pg_upgrade/9.0-1.sql"
 #include "udfs/citus_finish_pg_upgrade/9.0-1.sql"
 
-/*
- * We truncate pg_dist_node during metadata syncing, but we do not want
- * this to cascade to pg_dist_poolinfo, which is generally maintained
- * by the operator.
- */
+-- We truncate pg_dist_node during metadata syncing, but we do not want
+-- this to cascade to pg_dist_poolinfo, which is generally maintained
+-- by the operator.
 ALTER TABLE pg_dist_poolinfo DROP CONSTRAINT pg_dist_poolinfo_nodeid_fkey;
 
-/* if the rebalancer extension is still around, drop it before creating Citus functions */
+--  if the rebalancer extension is still around, drop it before creating Citus functions 
 DROP EXTENSION IF EXISTS shard_rebalancer;
 
 #include "udfs/get_rebalance_table_shards_plan/9.0-1.sql"


### PR DESCRIPTION
As we started to use C preprocessor, all C-style comments are stripped and we sometimes end up with empty migration scripts.
- Packagers do not like having empty files in packages
- We lose some of the information

see https://travis-ci.org/citusdata/packaging/jobs/599553068 for some problematic outputs like this ones below:

```
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--8.0-13--8.1-1.sql
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--8.1-1--8.2-1.sql
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--7.1-4--7.2-1.sql
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--7.5-7--8.0-1.sql
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--7.2-3--7.3-1.sql
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--8.2-4--8.3-1.sql
citus-enterprise90_11.x86_64: E: zero-length /usr/pgsql-11/share/extension/citus--7.4-3--7.5-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--8.0-13--8.1-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--7.2-3--7.3-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--7.1-4--7.2-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--8.1-1--8.2-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--7.4-3--7.5-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--7.5-7--8.0-1.sql
citus-enterprise90_12.x86_64: E: zero-length /usr/pgsql-12/share/extension/citus--8.2-4--8.3-1.sql
```