### PR TITLE
Use -std=gnu99 (C99 + GNU extensions)

### DIFF
--- a/configure
+++ b/configure
@@ -3633,6 +3633,41 @@ POSTGRES_BUILDDIR=$(grep ^abs_top_builddir $(dirname $($PG_CONFIG --pgxs))/../Ma
 # command-line option. If it does, add the string to CFLAGS.
 # CITUSAC_PROG_CC_CFLAGS_OPT
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -std=gnu99" >&5
+$as_echo_n "checking whether $CC supports -std=gnu99... " >&6; }
+if ${citusac_cv_prog_cc_cflags__std_gnu99+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  citusac_save_CFLAGS=$CFLAGS
+CFLAGS="$citusac_save_CFLAGS -std=gnu99"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  citusac_cv_prog_cc_cflags__std_gnu99=yes
+else
+  citusac_cv_prog_cc_cflags__std_gnu99=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$citusac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $citusac_cv_prog_cc_cflags__std_gnu99" >&5
+$as_echo "$citusac_cv_prog_cc_cflags__std_gnu99" >&6; }
+if test x"$citusac_cv_prog_cc_cflags__std_gnu99" = x"yes"; then
+  CITUS_CFLAGS="$CITUS_CFLAGS -std=gnu99"
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wall" >&5
 $as_echo_n "checking whether $CC supports -Wall... " >&6; }
 if ${citusac_cv_prog_cc_cflags__Wall+:} false; then :
@@ -3880,41 +3915,6 @@ if test x"$citusac_cv_prog_cc_cflags__Wno_gnu_variable_sized_type_not_at_end" = 
 fi
 
 # And add a few extra warnings
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wdeclaration-after-statement" >&5
-$as_echo_n "checking whether $CC supports -Wdeclaration-after-statement... " >&6; }
-if ${citusac_cv_prog_cc_cflags__Wdeclaration_after_statement+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  citusac_save_CFLAGS=$CFLAGS
-CFLAGS="$citusac_save_CFLAGS -Wdeclaration-after-statement"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  citusac_cv_prog_cc_cflags__Wdeclaration_after_statement=yes
-else
-  citusac_cv_prog_cc_cflags__Wdeclaration_after_statement=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$citusac_save_CFLAGS"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $citusac_cv_prog_cc_cflags__Wdeclaration_after_statement" >&5
-$as_echo "$citusac_cv_prog_cc_cflags__Wdeclaration_after_statement" >&6; }
-if test x"$citusac_cv_prog_cc_cflags__Wdeclaration_after_statement" = x"yes"; then
-  CITUS_CFLAGS="$CITUS_CFLAGS -Wdeclaration-after-statement"
-fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wendif-labels" >&5
 $as_echo_n "checking whether $CC supports -Wendif-labels... " >&6; }
 if ${citusac_cv_prog_cc_cflags__Wendif_labels+:} false; then :

--- a/configure.in
+++ b/configure.in
@@ -150,6 +150,7 @@ fi
 undefine([Ac_cachevar])dnl
 ])# CITUSAC_PROG_CC_CFLAGS_OPT
 
+CITUSAC_PROG_CC_CFLAGS_OPT([-std=gnu99])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wall])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wextra])
 # disarm options included in the above, which are too noisy for now
@@ -159,7 +160,6 @@ CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-missing-field-initializers])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-clobbered])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-gnu-variable-sized-type-not-at-end])
 # And add a few extra warnings
-CITUSAC_PROG_CC_CFLAGS_OPT([-Wdeclaration-after-statement])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wendif-labels])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wmissing-format-attribute])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wmissing-declarations])


### PR DESCRIPTION
Everything supports this, works in clang 6 and gcc 4.7

Also removes `-Wdeclaration-after-statement`, since declarations 
after statements are only not supported in ISO C90.

Fixes #3122 