### PR TITLE
Make implicit declarations and wrong return types hard errors

### DIFF
--- a/configure
+++ b/configure
@@ -4181,6 +4181,123 @@ if test x"$citusac_cv_prog_cc_cflags__Werror_vla" = x"yes"; then
   CITUS_CFLAGS="$CITUS_CFLAGS -Werror=vla"
 fi
   # visual studio does not support these
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-int" >&5
+$as_echo_n "checking whether $CC supports -Werror=implicit-int... " >&6; }
+if ${citusac_cv_prog_cc_cflags__Werror_implicit_int+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  citusac_save_CFLAGS=$CFLAGS
+flag=-Werror=implicit-int
+case $flag in -Wno*)
+	 flag=-W$(echo $flag | cut -c 6-)
+esac
+CFLAGS="$citusac_save_CFLAGS $flag"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  citusac_cv_prog_cc_cflags__Werror_implicit_int=yes
+else
+  citusac_cv_prog_cc_cflags__Werror_implicit_int=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$citusac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $citusac_cv_prog_cc_cflags__Werror_implicit_int" >&5
+$as_echo "$citusac_cv_prog_cc_cflags__Werror_implicit_int" >&6; }
+if test x"$citusac_cv_prog_cc_cflags__Werror_implicit_int" = x"yes"; then
+  CITUS_CFLAGS="$CITUS_CFLAGS -Werror=implicit-int"
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=implicit-function-declaration" >&5
+$as_echo_n "checking whether $CC supports -Werror=implicit-function-declaration... " >&6; }
+if ${citusac_cv_prog_cc_cflags__Werror_implicit_function_declaration+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  citusac_save_CFLAGS=$CFLAGS
+flag=-Werror=implicit-function-declaration
+case $flag in -Wno*)
+	 flag=-W$(echo $flag | cut -c 6-)
+esac
+CFLAGS="$citusac_save_CFLAGS $flag"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  citusac_cv_prog_cc_cflags__Werror_implicit_function_declaration=yes
+else
+  citusac_cv_prog_cc_cflags__Werror_implicit_function_declaration=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$citusac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $citusac_cv_prog_cc_cflags__Werror_implicit_function_declaration" >&5
+$as_echo "$citusac_cv_prog_cc_cflags__Werror_implicit_function_declaration" >&6; }
+if test x"$citusac_cv_prog_cc_cflags__Werror_implicit_function_declaration" = x"yes"; then
+  CITUS_CFLAGS="$CITUS_CFLAGS -Werror=implicit-function-declaration"
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=return-type" >&5
+$as_echo_n "checking whether $CC supports -Werror=return-type... " >&6; }
+if ${citusac_cv_prog_cc_cflags__Werror_return_type+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  citusac_save_CFLAGS=$CFLAGS
+flag=-Werror=return-type
+case $flag in -Wno*)
+	 flag=-W$(echo $flag | cut -c 6-)
+esac
+CFLAGS="$citusac_save_CFLAGS $flag"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  citusac_cv_prog_cc_cflags__Werror_return_type=yes
+else
+  citusac_cv_prog_cc_cflags__Werror_return_type=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$citusac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $citusac_cv_prog_cc_cflags__Werror_return_type" >&5
+$as_echo "$citusac_cv_prog_cc_cflags__Werror_return_type" >&6; }
+if test x"$citusac_cv_prog_cc_cflags__Werror_return_type" = x"yes"; then
+  CITUS_CFLAGS="$CITUS_CFLAGS -Werror=return-type"
+fi
+
 
 #
 # --enable-coverage enables generation of code coverage metrics with gcov

--- a/configure.in
+++ b/configure.in
@@ -170,6 +170,9 @@ CITUSAC_PROG_CC_CFLAGS_OPT([-Wmissing-declarations])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wmissing-prototypes])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wshadow])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Werror=vla])  # visual studio does not support these
+CITUSAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-int])
+CITUSAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-function-declaration])
+CITUSAC_PROG_CC_CFLAGS_OPT([-Werror=return-type])
 
 #
 # --enable-coverage enables generation of code coverage metrics with gcov


### PR DESCRIPTION
This makes three warnings hard errors:

1. `implicit-int`
> Warn when a declaration does not specify a type.

2. `implicit-function-declaration`
> Give a warning whenever a function is used before being declared.

3. `return-type`
> Warn whenever a function is defined with a return type that defaults to
> "int".  Also warn about any "return" statement with no return value in
> a function whose return type is not "void" (falling off the end of the
> function body is considered returning without a value).
>
> For C only, warn about a "return" statement with an expression in a
> function whose return type is "void", unless the expression type is
> also "void".

The compiler behaviour when these warnings occur is not the behaviour
the developer expects. So even during development it makes sense that
they are errors.

This builds on top of #3128 