### PR TITLE
Do not assign InvalidOid for local execution while extracting parameters

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2925,8 +2925,8 @@ StartPlacementExecutionOnSession(TaskPlacementExecution *placementExecution,
 		/* force evaluation of bound params */
 		paramListInfo = copyParamList(paramListInfo);
 
-		ExtractParametersFromParamListInfo(paramListInfo, &parameterTypes,
-										   &parameterValues);
+		ExtractParametersForRemoteExecution(paramListInfo, &parameterTypes,
+											&parameterValues);
 		querySent = SendRemoteCommandParams(connection, queryString, parameterCount,
 											parameterTypes, parameterValues);
 	}

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -107,6 +107,10 @@ static uint64 ExecuteLocalTaskPlan(CitusScanState *scanState, PlannedStmt *taskP
 static bool TaskAccessesLocalNode(Task *task);
 static void LogLocalCommand(const char *command);
 
+static void
+ExtractParametersForLocalExecution(ParamListInfo paramListInfo, Oid **parameterTypes,
+								   const char ***parameterValues);
+
 
 /*
  * ExecuteLocalTasks gets a CitusScanState node and list of local tasks.
@@ -170,6 +174,19 @@ ExecuteLocalTaskList(CitusScanState *scanState, List *taskList)
 	}
 
 	return totalRowsProcessed;
+}
+
+/*
+ * ExtractParametersForLocalExecution extracts parameter types and values from
+ * the given ParamListInfo structure, and fills parameter type and value arrays.
+ * It does not change the oid of custom types, because the query will be run locally.
+ */
+static void
+ExtractParametersForLocalExecution(ParamListInfo paramListInfo, Oid **parameterTypes,
+								   const char ***parameterValues)
+{
+	ExtractParametersFromParamList(paramListInfo, parameterTypes,
+							  parameterValues, true);
 }
 
 

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -130,8 +130,8 @@ ExecuteLocalTaskList(CitusScanState *scanState, List *taskList)
 	{
 		const char **parameterValues = NULL; /* not used anywhere, so decleare here */
 
-		ExtractParametersFromParamListInfoLocal(paramListInfo, &parameterTypes,
-												&parameterValues);
+		ExtractParametersForLocalExecution(paramListInfo, &parameterTypes,
+										   &parameterValues);
 
 		numParams = paramListInfo->numParams;
 	}

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -130,7 +130,7 @@ ExecuteLocalTaskList(CitusScanState *scanState, List *taskList)
 	{
 		const char **parameterValues = NULL; /* not used anywhere, so decleare here */
 
-		ExtractParametersFromParamListInfo(paramListInfo, &parameterTypes,
+		ExtractParametersFromParamListInfoLocal(paramListInfo, &parameterTypes,
 										   &parameterValues);
 
 		numParams = paramListInfo->numParams;

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -107,9 +107,9 @@ static uint64 ExecuteLocalTaskPlan(CitusScanState *scanState, PlannedStmt *taskP
 static bool TaskAccessesLocalNode(Task *task);
 static void LogLocalCommand(const char *command);
 
-static void
-ExtractParametersForLocalExecution(ParamListInfo paramListInfo, Oid **parameterTypes,
-								   const char ***parameterValues);
+static void ExtractParametersForLocalExecution(ParamListInfo paramListInfo,
+											   Oid **parameterTypes,
+											   const char ***parameterValues);
 
 
 /*
@@ -176,6 +176,7 @@ ExecuteLocalTaskList(CitusScanState *scanState, List *taskList)
 	return totalRowsProcessed;
 }
 
+
 /*
  * ExtractParametersForLocalExecution extracts parameter types and values from
  * the given ParamListInfo structure, and fills parameter type and value arrays.
@@ -186,7 +187,7 @@ ExtractParametersForLocalExecution(ParamListInfo paramListInfo, Oid **parameterT
 								   const char ***parameterValues)
 {
 	ExtractParametersFromParamList(paramListInfo, parameterTypes,
-							  parameterValues, true);
+								   parameterValues, true);
 }
 
 

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -131,7 +131,7 @@ ExecuteLocalTaskList(CitusScanState *scanState, List *taskList)
 		const char **parameterValues = NULL; /* not used anywhere, so decleare here */
 
 		ExtractParametersFromParamListInfoLocal(paramListInfo, &parameterTypes,
-										   &parameterValues);
+												&parameterValues);
 
 		numParams = paramListInfo->numParams;
 	}

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -1767,8 +1767,9 @@ ExtractParametersForRemoteExecution(ParamListInfo paramListInfo, Oid **parameter
 									const char ***parameterValues)
 {
 	ExtractParametersFromParamList(paramListInfo, parameterTypes,
-							  parameterValues, false);
+								   parameterValues, false);
 }
+
 
 /*
  * ExtractParametersFromParamList extracts parameter types and values from
@@ -1777,9 +1778,9 @@ ExtractParametersForRemoteExecution(ParamListInfo paramListInfo, Oid **parameter
  */
 void
 ExtractParametersFromParamList(ParamListInfo paramListInfo,
-						  Oid **parameterTypes,
-						  const char ***parameterValues, bool
-						  useOriginalCustomTypeOids)
+							   Oid **parameterTypes,
+							   const char ***parameterValues, bool
+							   useOriginalCustomTypeOids)
 {
 	int parameterIndex = 0;
 	int parameterCount = paramListInfo->numParams;

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -117,8 +117,10 @@ static bool StoreQueryResult(CitusScanState *scanState, MultiConnection *connect
 static bool ConsumeQueryResult(MultiConnection *connection, bool
 							   alwaysThrowErrorOnFailure, int64 *rows);
 
-void ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo, Oid **parameterTypes,
-										const char ***parameterValues, bool isLocalExecution);
+void ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo,
+												Oid **parameterTypes,
+												const char ***parameterValues, bool
+												isLocalExecution);
 
 /*
  * AcquireMetadataLocks acquires metadata locks on each of the anchor
@@ -1763,30 +1765,39 @@ SendQueryInSingleRowMode(MultiConnection *connection, char *query,
  * ExtractParametersFromParamListInfo extracts parameter types and values from
  * the given ParamListInfo structure, and fills parameter type and value arrays.
  */
-void ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterTypes,
-										const char ***parameterValues)
+void
+ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterTypes,
+								   const char ***parameterValues)
 {
-	ExtractParametersFromParamListInfoInternal(paramListInfo, parameterTypes, parameterValues, false);
+	ExtractParametersFromParamListInfoInternal(paramListInfo, parameterTypes,
+											   parameterValues, false);
 }
+
 
 /*
  * ExtractParametersFromParamListInfoLocal extracts parameter types and values from
  * the given ParamListInfo structure, and fills parameter type and value arrays.
  */
-void ExtractParametersFromParamListInfoLocal(ParamListInfo paramListInfo, Oid **parameterTypes,
+void
+ExtractParametersFromParamListInfoLocal(ParamListInfo paramListInfo, Oid **parameterTypes,
 										const char ***parameterValues)
 {
-	ExtractParametersFromParamListInfoInternal(paramListInfo, parameterTypes, parameterValues, true);
+	ExtractParametersFromParamListInfoInternal(paramListInfo, parameterTypes,
+											   parameterValues, true);
 }
 
-void ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo, Oid **parameterTypes,
-										const char ***parameterValues, bool isLocalExecution)
+
+void
+ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo,
+										   Oid **parameterTypes,
+										   const char ***parameterValues, bool
+										   isLocalExecution)
 {
 	int parameterIndex = 0;
 	int parameterCount = paramListInfo->numParams;
 
-	*parameterTypes = (Oid *)palloc0(parameterCount * sizeof(Oid));
-	*parameterValues = (const char **)palloc0(parameterCount * sizeof(char *));
+	*parameterTypes = (Oid *) palloc0(parameterCount * sizeof(Oid));
+	*parameterValues = (const char **) palloc0(parameterCount * sizeof(char *));
 
 	/* get parameter types and values */
 	for (parameterIndex = 0; parameterIndex < parameterCount; parameterIndex++)
@@ -1841,6 +1852,7 @@ void ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo, Oid
 																   parameterData->value);
 	}
 }
+
 
 /*
  * StoreQueryResult gets the query results from the given connection, builds

--- a/src/backend/distributed/executor/multi_router_executor.c
+++ b/src/backend/distributed/executor/multi_router_executor.c
@@ -117,6 +117,8 @@ static bool StoreQueryResult(CitusScanState *scanState, MultiConnection *connect
 static bool ConsumeQueryResult(MultiConnection *connection, bool
 							   alwaysThrowErrorOnFailure, int64 *rows);
 
+void ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo, Oid **parameterTypes,
+										const char ***parameterValues, bool isLocalExecution);
 
 /*
  * AcquireMetadataLocks acquires metadata locks on each of the anchor
@@ -1761,15 +1763,30 @@ SendQueryInSingleRowMode(MultiConnection *connection, char *query,
  * ExtractParametersFromParamListInfo extracts parameter types and values from
  * the given ParamListInfo structure, and fills parameter type and value arrays.
  */
-void
-ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterTypes,
-								   const char ***parameterValues)
+void ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterTypes,
+										const char ***parameterValues)
+{
+	ExtractParametersFromParamListInfoInternal(paramListInfo, parameterTypes, parameterValues, false);
+}
+
+/*
+ * ExtractParametersFromParamListInfoLocal extracts parameter types and values from
+ * the given ParamListInfo structure, and fills parameter type and value arrays.
+ */
+void ExtractParametersFromParamListInfoLocal(ParamListInfo paramListInfo, Oid **parameterTypes,
+										const char ***parameterValues)
+{
+	ExtractParametersFromParamListInfoInternal(paramListInfo, parameterTypes, parameterValues, true);
+}
+
+void ExtractParametersFromParamListInfoInternal(ParamListInfo paramListInfo, Oid **parameterTypes,
+										const char ***parameterValues, bool isLocalExecution)
 {
 	int parameterIndex = 0;
 	int parameterCount = paramListInfo->numParams;
 
-	*parameterTypes = (Oid *) palloc0(parameterCount * sizeof(Oid));
-	*parameterValues = (const char **) palloc0(parameterCount * sizeof(char *));
+	*parameterTypes = (Oid *)palloc0(parameterCount * sizeof(Oid));
+	*parameterValues = (const char **)palloc0(parameterCount * sizeof(char *));
 
 	/* get parameter types and values */
 	for (parameterIndex = 0; parameterIndex < parameterCount; parameterIndex++)
@@ -1783,7 +1800,7 @@ ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterT
 		 * the master and worker nodes. Therefore, the worker nodes can
 		 * infer the correct oid.
 		 */
-		if (parameterData->ptype >= FirstNormalObjectId)
+		if (parameterData->ptype >= FirstNormalObjectId && !isLocalExecution)
 		{
 			(*parameterTypes)[parameterIndex] = 0;
 		}
@@ -1824,7 +1841,6 @@ ExtractParametersFromParamListInfo(ParamListInfo paramListInfo, Oid **parameterT
 																   parameterData->value);
 	}
 }
-
 
 /*
  * StoreQueryResult gets the query results from the given connection, builds

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -66,8 +66,8 @@ extern void ExtractParametersForRemoteExecution(ParamListInfo paramListInfo,
 												Oid **parameterTypes,
 												const char ***parameterValues);
 extern void ExtractParametersFromParamList(ParamListInfo paramListInfo,
-									  Oid **parameterTypes,
-									  const char ***parameterValues, bool
-									  useOriginalCustomTypeOids);
+										   Oid **parameterTypes,
+										   const char ***parameterValues, bool
+										   useOriginalCustomTypeOids);
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -65,5 +65,8 @@ extern List * BuildPlacementDDLList(int32 groupId, List *relationShardList);
 extern void ExtractParametersFromParamListInfo(ParamListInfo paramListInfo,
 											   Oid **parameterTypes,
 											   const char ***parameterValues);
+extern void ExtractParametersFromParamListInfoLocal(ParamListInfo paramListInfo,
+											   Oid **parameterTypes,
+											   const char ***parameterValues);											   
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -66,7 +66,7 @@ extern void ExtractParametersFromParamListInfo(ParamListInfo paramListInfo,
 											   Oid **parameterTypes,
 											   const char ***parameterValues);
 extern void ExtractParametersFromParamListInfoLocal(ParamListInfo paramListInfo,
-											   Oid **parameterTypes,
-											   const char ***parameterValues);											   
+													Oid **parameterTypes,
+													const char ***parameterValues);
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -65,8 +65,9 @@ extern List * BuildPlacementDDLList(int32 groupId, List *relationShardList);
 extern void ExtractParametersForRemoteExecution(ParamListInfo paramListInfo,
 												Oid **parameterTypes,
 												const char ***parameterValues);
-extern void ExtractParametersForLocalExecution(ParamListInfo paramListInfo,
-											   Oid **parameterTypes,
-											   const char ***parameterValues);
+extern void ExtractParametersFromParamList(ParamListInfo paramListInfo,
+									  Oid **parameterTypes,
+									  const char ***parameterValues, bool
+									  useOriginalCustomTypeOids);
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/include/distributed/multi_router_executor.h
+++ b/src/include/distributed/multi_router_executor.h
@@ -62,11 +62,11 @@ extern bool TaskListRequires2PC(List *taskList);
 extern bool ReadOnlyTask(TaskType taskType);
 extern List * BuildPlacementSelectList(int32 groupId, List *relationShardList);
 extern List * BuildPlacementDDLList(int32 groupId, List *relationShardList);
-extern void ExtractParametersFromParamListInfo(ParamListInfo paramListInfo,
+extern void ExtractParametersForRemoteExecution(ParamListInfo paramListInfo,
+												Oid **parameterTypes,
+												const char ***parameterValues);
+extern void ExtractParametersForLocalExecution(ParamListInfo paramListInfo,
 											   Oid **parameterTypes,
 											   const char ***parameterValues);
-extern void ExtractParametersFromParamListInfoLocal(ParamListInfo paramListInfo,
-													Oid **parameterTypes,
-													const char ***parameterValues);
 
 #endif /* MULTI_ROUTER_EXECUTOR_H_ */

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -1089,6 +1089,43 @@ LOG:  executing the command locally: INSERT INTO local_shard_execution.reference
 (1 row)
 
 \c - - - :master_port
+-- local execution with custom type 
+SET citus.replication_model TO "streaming";
+SET citus.shard_replication_factor TO 1;
+CREATE TYPE invite_resp AS ENUM ('yes', 'no', 'maybe'); 
+CREATE TABLE event_responses (
+  event_id int,
+  user_id int,
+  response invite_resp,
+  primary key (event_id, user_id)
+);
+SELECT create_distributed_table('event_responses', 'event_id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+CREATE OR REPLACE PROCEDURE register_for_event(p_event_id int, p_user_id int, p_choice invite_resp)
+LANGUAGE plpgsql AS $fn$
+BEGIN
+   INSERT INTO event_responses VALUES (p_event_id, p_user_id, p_choice)
+   ON CONFLICT (event_id, user_id)
+   DO UPDATE SET response = EXCLUDED.response;
+END;
+$fn$;
+SELECT create_distributed_function('register_for_event(int,int,invite_resp)', 'p_event_id', 'event_responses');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+-- call 6 times to make sure it works after the 5th time(postgres binds values after the 5th time)
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
 SET client_min_messages TO ERROR;
 SET search_path TO public;
 DROP SCHEMA local_shard_execution CASCADE;

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -622,6 +622,40 @@ COMMIT;
 WITH distributed_local_mixed AS (INSERT INTO reference_table VALUES (1000) RETURNING *) SELECT * FROM distributed_local_mixed;
 
 \c - - - :master_port
+
+-- local execution with custom type 
+SET citus.replication_model TO "streaming";
+SET citus.shard_replication_factor TO 1;
+CREATE TYPE invite_resp AS ENUM ('yes', 'no', 'maybe'); 
+
+CREATE TABLE event_responses (
+  event_id int,
+  user_id int,
+  response invite_resp,
+  primary key (event_id, user_id)
+);
+
+SELECT create_distributed_table('event_responses', 'event_id');
+
+CREATE OR REPLACE PROCEDURE register_for_event(p_event_id int, p_user_id int, p_choice invite_resp)
+LANGUAGE plpgsql AS $fn$
+BEGIN
+   INSERT INTO event_responses VALUES (p_event_id, p_user_id, p_choice)
+   ON CONFLICT (event_id, user_id)
+   DO UPDATE SET response = EXCLUDED.response;
+END;
+$fn$;
+
+SELECT create_distributed_function('register_for_event(int,int,invite_resp)', 'p_event_id', 'event_responses');
+
+-- call 6 times to make sure it works after the 5th time(postgres binds values after the 5th time)
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+CALL register_for_event(16, 1, 'yes');
+
 SET client_min_messages TO ERROR;
 SET search_path TO public;
 DROP SCHEMA local_shard_execution CASCADE;


### PR DESCRIPTION
While extracting parameters from `ParamListInfo` we shouldnt assign 0 for custom types. 0 is an `InvalidOid` therefore when resolving the parameters, postgres sees that the parameter has an invalid oid, so it gives the error in #3084.

After running 5 times, postgres binds the parameters so the error does not happen.

Fixes #3084.


