### PR TITLE
Clean old citus install before installing extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 citus_subdir = .
 citus_top_builddir = .
+extension_dir = $(shell $(PG_CONFIG) --sharedir)/extension
 
 # Hint that configure should be run first
 ifeq (,$(wildcard Makefile.global))
@@ -16,6 +17,7 @@ all: extension
 extension: $(citus_top_builddir)/src/include/citus_version.h
 	$(MAKE) -C src/backend/distributed/ all
 install-extension: extension
+	rm -f $(extension_dir)/citus*
 	$(MAKE) -C src/backend/distributed/ install
 install-headers: extension
 	$(MKDIR_P) '$(DESTDIR)$(includedir_server)/distributed/'


### PR DESCRIPTION
One case where this would have been useful recently was when we changed
the `citus--9.0-1--9.1-1.sql` file to `citus--9.0-2--9.1-1.sql`. If you
had the old file installed it would never be cleaned. Any changes in
the 9.0-2 version would not be applied, because postgres tries to find
the shortest migration path, so it would always run the 9.0-1--9.1-1
version, because then it could skip 9.0-1--9.0-2.