### PR TITLE
Replicate reference tables to the coordinator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ function.
 Then copy the `latest.sql` file to `{version}.sql`, where `{version}` is the
 version for which this sql change is, e.g. `{9.0-1.sql}`. Now that you've
 created this stable snapshot of the function definition for your version you
-should use it in your actual sql file, .e.g.
+should use it in your actual sql file, e.g.
 `src/backend/distributed/sql/citus--8.3-1--9.0-1.sql`. You do this by using C
 style `#include` statements like this:
 ```

--- a/configure
+++ b/configure
@@ -3907,8 +3907,7 @@ if test x"$citusac_cv_prog_cc_cflags__Wno_clobbered" = x"yes"; then
   CITUS_CFLAGS="$CITUS_CFLAGS -Wno-clobbered"
 fi
 
-if test x"$GCC" = x"no" ; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-gnu-variable-sized-type-not-at-end" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-gnu-variable-sized-type-not-at-end" >&5
 $as_echo_n "checking whether $CC supports -Wno-gnu-variable-sized-type-not-at-end... " >&6; }
 if ${citusac_cv_prog_cc_cflags__Wno_gnu_variable_sized_type_not_at_end+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -3947,7 +3946,6 @@ if test x"$citusac_cv_prog_cc_cflags__Wno_gnu_variable_sized_type_not_at_end" = 
   CITUS_CFLAGS="$CITUS_CFLAGS -Wno-gnu-variable-sized-type-not-at-end"
 fi
 
-fi
 # And add a few extra warnings
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wendif-labels" >&5
 $as_echo_n "checking whether $CC supports -Wendif-labels... " >&6; }

--- a/configure
+++ b/configure
@@ -3907,7 +3907,8 @@ if test x"$citusac_cv_prog_cc_cflags__Wno_clobbered" = x"yes"; then
   CITUS_CFLAGS="$CITUS_CFLAGS -Wno-clobbered"
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-gnu-variable-sized-type-not-at-end" >&5
+if test x"$GCC" = x"no" ; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-gnu-variable-sized-type-not-at-end" >&5
 $as_echo_n "checking whether $CC supports -Wno-gnu-variable-sized-type-not-at-end... " >&6; }
 if ${citusac_cv_prog_cc_cflags__Wno_gnu_variable_sized_type_not_at_end+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -3946,6 +3947,7 @@ if test x"$citusac_cv_prog_cc_cflags__Wno_gnu_variable_sized_type_not_at_end" = 
   CITUS_CFLAGS="$CITUS_CFLAGS -Wno-gnu-variable-sized-type-not-at-end"
 fi
 
+fi
 # And add a few extra warnings
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wendif-labels" >&5
 $as_echo_n "checking whether $CC supports -Wendif-labels... " >&6; }

--- a/configure.in
+++ b/configure.in
@@ -162,9 +162,7 @@ CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-unused-parameter])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-sign-compare])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-missing-field-initializers])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-clobbered])
-if test x"$GCC" = x"no" ; then
-  CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-gnu-variable-sized-type-not-at-end])
-fi
+CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-gnu-variable-sized-type-not-at-end])
 # And add a few extra warnings
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wendif-labels])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wmissing-format-attribute])

--- a/configure.in
+++ b/configure.in
@@ -162,7 +162,9 @@ CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-unused-parameter])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-sign-compare])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-missing-field-initializers])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-clobbered])
-CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-gnu-variable-sized-type-not-at-end])
+if test x"$GCC" = x"no" ; then
+  CITUSAC_PROG_CC_CFLAGS_OPT([-Wno-gnu-variable-sized-type-not-at-end])
+fi
 # And add a few extra warnings
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wendif-labels])
 CITUSAC_PROG_CC_CFLAGS_OPT([-Wmissing-format-attribute])

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -272,7 +272,6 @@ create_reference_table(PG_FUNCTION_ARGS)
 
 	Relation relation = NULL;
 	char *colocateWithTableName = NULL;
-	List *workerNodeList = NIL;
 	int workerCount = 0;
 	Var *distributionColumn = NULL;
 	ObjectAddress tableAddress = { 0 };
@@ -306,10 +305,7 @@ create_reference_table(PG_FUNCTION_ARGS)
 	 */
 	EnsureRelationKindSupported(relationId);
 
-	workerNodeList = ActivePrimaryNodeList(ShareLock);
-	workerCount = list_length(workerNodeList);
-
-	/* if there are no workers, error out */
+	workerCount = ActivePrimaryNodeCount();
 	if (workerCount == 0)
 	{
 		char *relationName = get_rel_name(relationId);

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -65,6 +65,7 @@ bool EnableDDLPropagation = true; /* ddl propagation is enabled */
 PropSetCmdBehavior PropagateSetCommands = PROPSETCMD_NONE; /* SET prop off */
 static bool shouldInvalidateForeignKeyGraph = false;
 static int activeAlterTables = 0;
+static int activeDropSchemas = 0;
 
 
 /* Local functions forward declarations for helper functions */
@@ -76,7 +77,7 @@ static List * PlanRenameAttributeStmt(RenameStmt *stmt, const char *queryString)
 static List * PlanAlterOwnerStmt(AlterOwnerStmt *stmt, const char *queryString);
 static List * PlanAlterObjectDependsStmt(AlterObjectDependsStmt *stmt,
 										 const char *queryString);
-
+static bool IsDropSchema(Node *parsetree);
 static void ExecuteNodeBaseDDLCommands(List *taskList);
 
 
@@ -655,6 +656,11 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 			activeAlterTables++;
 		}
 
+		if (IsDropSchema(parsetree))
+		{
+			activeDropSchemas++;
+		}
+
 		standard_ProcessUtility(pstmt, queryString, context,
 								params, queryEnv, dest, completionTag);
 
@@ -678,12 +684,22 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		{
 			activeAlterTables--;
 		}
+
+		if (IsDropSchema(parsetree))
+		{
+			activeDropSchemas--;
+		}
 	}
 	PG_CATCH();
 	{
 		if (IsA(parsetree, AlterTableStmt))
 		{
 			activeAlterTables--;
+		}
+
+		if (IsDropSchema(parsetree))
+		{
+			activeDropSchemas--;
 		}
 
 		PG_RE_THROW();
@@ -793,6 +809,24 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 	 * EXTENSION. This is important to register some invalidation callbacks.
 	 */
 	CitusHasBeenLoaded();
+}
+
+
+/*
+ * IsDropSchema returns true if parsetree represents DROP SCHEMA ...
+ */
+static bool
+IsDropSchema(Node *parsetree)
+{
+	DropStmt *dropStatement = NULL;
+
+	if (!IsA(parsetree, DropStmt))
+	{
+		return false;
+	}
+
+	dropStatement = (DropStmt *) parsetree;
+	return (dropStatement->removeType == OBJECT_SCHEMA);
 }
 
 
@@ -1235,4 +1269,15 @@ bool
 AlterTableInProgress(void)
 {
 	return activeAlterTables > 0;
+}
+
+
+/*
+ * DropSchemaInProgress returns true if we're processing an DROP SCHEMA command
+ * right now.
+ */
+bool
+DropSchemaInProgress(void)
+{
+	return activeDropSchemas > 0;
 }

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -408,7 +408,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	 * load and sort the worker node list for deterministic placements
 	 * create_reference_table has already acquired pg_dist_node lock
 	 */
-	nodeList = ActiveReferenceTablePlacementNodeList(NoLock);
+	nodeList = ActiveReferenceTablePlacementNodeList(ShareLock);
 	nodeList = SortList(nodeList, CompareWorkerNodes);
 
 	replicationFactor = ReferenceTableReplicationFactor();

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -41,6 +41,7 @@
 #include "distributed/pg_dist_partition.h"
 #include "distributed/pg_dist_shard.h"
 #include "distributed/pg_dist_placement.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/relay_utility.h"
 #include "distributed/resource_lock.h"
 #include "distributed/remote_commands.h"
@@ -1292,7 +1293,7 @@ UpdateShardPlacementState(uint64 placementId, char shardState)
  * cache after updating replication factor.
  */
 void
-UpdateColocationGroupReplicationFactorForReferenceTables(int replicationFactor)
+UpdateColocationGroupReplicationFactorForReferenceTables(void)
 {
 	Relation pgDistColocation = NULL;
 	SysScanDesc scanDescriptor = NULL;
@@ -1301,6 +1302,7 @@ UpdateColocationGroupReplicationFactorForReferenceTables(int replicationFactor)
 	bool indexOK = false;
 	HeapTuple heapTuple = NULL;
 	TupleDesc tupleDescriptor = NULL;
+	int replicationFactor = ReferenceTableReplicationFactor();
 
 	/*
 	 * All reference tables share a colocation entry with:

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -402,7 +402,8 @@ ActivePrimaryShouldHaveShardsNodeList(LOCKMODE lockMode)
 {
 	bool excludeCoordinator = true;
 	EnsureModificationsCanRun();
-	return FilterActiveNodeListFunc(lockMode, WorkerNodeIsPrimaryShouldHaveShardsNode, excludeCoordinator);
+	return FilterActiveNodeListFunc(lockMode, WorkerNodeIsPrimaryShouldHaveShardsNode,
+									excludeCoordinator);
 }
 
 

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -319,6 +319,9 @@ ActiveReadableNodeCount(void)
 }
 
 
+/*
+ * NodeIsCoordinator returns true if the given node represents the coordinator.
+ */
 static bool
 NodeIsCoordinator(WorkerNode *node)
 {
@@ -384,6 +387,11 @@ ActivePrimaryNodeList(LOCKMODE lockMode)
 }
 
 
+/*
+ * ActiveReferenceTablePlacementNodeList returns the set of nodes that should
+ * have reference table placements. This includes all primaries, including the
+ * coordinator if known.
+ */
 List *
 ActiveReferenceTablePlacementNodeList(LOCKMODE lockMode)
 {

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -346,7 +346,7 @@ MetadataCreateCommands(void)
 	List *distributedTableList = DistributedTableList();
 	List *propagatedTableList = NIL;
 	bool includeNodesFromOtherClusters = true;
-	List *workerNodeList = ReadWorkerNodes(includeNodesFromOtherClusters);
+	List *workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
 	ListCell *distributedTableCell = NULL;
 	char *nodeListInsertCommand = NULL;
 	bool includeSequenceDefaults = true;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -124,6 +124,13 @@ StartMetadatSyncToNode(char *nodeNameString, int32 nodePort)
 								escapedNodeName, nodePort)));
 	}
 
+	if (workerNode->groupId == 0)
+	{
+		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						errmsg("you cannot sync metadata to the coordinator"),
+						errhint("Coordinator already should have the metadata")));
+	}
+
 	MarkNodeHasMetadata(nodeNameString, nodePort, true);
 
 	if (!WorkerNodeIsPrimary(workerNode))

--- a/src/backend/distributed/sql/citus--9.0-2--9.1-1.sql
+++ b/src/backend/distributed/sql/citus--9.0-2--9.1-1.sql
@@ -4,3 +4,5 @@ COMMENT ON COLUMN pg_catalog.pg_dist_node.shouldhaveshards IS
 
 #include "udfs/master_set_node_property/9.1-1.sql"
 #include "udfs/master_drain_node/9.1-1.sql"
+#include "udfs/master_add_node/9.1-1.sql"
+#include "udfs/master_add_inactive_node/9.1-1.sql"

--- a/src/backend/distributed/sql/udfs/master_add_inactive_node/9.1-1.sql
+++ b/src/backend/distributed/sql/udfs/master_add_inactive_node/9.1-1.sql
@@ -1,0 +1,14 @@
+DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         groupid integer default -1,
+                                         noderole noderole default 'primary',
+                                         nodecluster name default 'default')
+  RETURNS INTEGER
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text,nodeport integer,
+                                             groupid integer, noderole noderole,
+                                             nodecluster name)
+  IS 'prepare node by adding it to pg_dist_node';
+REVOKE ALL ON FUNCTION master_add_inactive_node(text,int,int,noderole,name) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/master_add_inactive_node/9.1-1.sql
+++ b/src/backend/distributed/sql/udfs/master_add_inactive_node/9.1-1.sql
@@ -1,3 +1,4 @@
+-- Update the default groupId to -1
 DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole, name);
 CREATE FUNCTION master_add_inactive_node(nodename text,
                                          nodeport integer,

--- a/src/backend/distributed/sql/udfs/master_add_inactive_node/latest.sql
+++ b/src/backend/distributed/sql/udfs/master_add_inactive_node/latest.sql
@@ -1,0 +1,14 @@
+DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_inactive_node(nodename text,
+                                         nodeport integer,
+                                         groupid integer default -1,
+                                         noderole noderole default 'primary',
+                                         nodecluster name default 'default')
+  RETURNS INTEGER
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME',$$master_add_inactive_node$$;
+COMMENT ON FUNCTION master_add_inactive_node(nodename text,nodeport integer,
+                                             groupid integer, noderole noderole,
+                                             nodecluster name)
+  IS 'prepare node by adding it to pg_dist_node';
+REVOKE ALL ON FUNCTION master_add_inactive_node(text,int,int,noderole,name) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/master_add_inactive_node/latest.sql
+++ b/src/backend/distributed/sql/udfs/master_add_inactive_node/latest.sql
@@ -1,3 +1,4 @@
+-- Update the default groupId to -1
 DROP FUNCTION master_add_inactive_node(text, integer, integer, noderole, name);
 CREATE FUNCTION master_add_inactive_node(nodename text,
                                          nodeport integer,

--- a/src/backend/distributed/sql/udfs/master_add_node/9.1-1.sql
+++ b/src/backend/distributed/sql/udfs/master_add_node/9.1-1.sql
@@ -1,0 +1,13 @@
+DROP FUNCTION master_add_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                groupid integer default -1,
+                                noderole noderole default 'primary',
+                                nodecluster name default 'default')
+  RETURNS INTEGER
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer,
+                                    groupid integer, noderole noderole, nodecluster name)
+  IS 'add node to the cluster';
+REVOKE ALL ON FUNCTION master_add_node(text,int,int,noderole,name) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/master_add_node/9.1-1.sql
+++ b/src/backend/distributed/sql/udfs/master_add_node/9.1-1.sql
@@ -1,3 +1,4 @@
+-- Update the default groupId to -1
 DROP FUNCTION master_add_node(text, integer, integer, noderole, name);
 CREATE FUNCTION master_add_node(nodename text,
                                 nodeport integer,

--- a/src/backend/distributed/sql/udfs/master_add_node/latest.sql
+++ b/src/backend/distributed/sql/udfs/master_add_node/latest.sql
@@ -1,0 +1,13 @@
+DROP FUNCTION master_add_node(text, integer, integer, noderole, name);
+CREATE FUNCTION master_add_node(nodename text,
+                                nodeport integer,
+                                groupid integer default -1,
+                                noderole noderole default 'primary',
+                                nodecluster name default 'default')
+  RETURNS INTEGER
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$master_add_node$$;
+COMMENT ON FUNCTION master_add_node(nodename text, nodeport integer,
+                                    groupid integer, noderole noderole, nodecluster name)
+  IS 'add node to the cluster';
+REVOKE ALL ON FUNCTION master_add_node(text,int,int,noderole,name) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/master_add_node/latest.sql
+++ b/src/backend/distributed/sql/udfs/master_add_node/latest.sql
@@ -1,3 +1,4 @@
+-- Update the default groupId to -1
 DROP FUNCTION master_add_node(text, integer, integer, noderole, name);
 CREATE FUNCTION master_add_node(nodename text,
                                 nodeport integer,

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -166,6 +166,11 @@ BeginCoordinatedTransaction(void)
 		ereport(ERROR, (errmsg("starting transaction in wrong state")));
 	}
 
+	if (LocalExecutionHappened)
+	{
+		ereport(WARNING, (errmsg("Local transaction has happend?!!")));
+	}
+
 	CurrentCoordinatedTransactionState = COORD_TRANS_STARTED;
 
 	AssignDistributedTransactionId();

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -166,6 +166,12 @@ BeginCoordinatedTransaction(void)
 		ereport(ERROR, (errmsg("starting transaction in wrong state")));
 	}
 
+	if (LocalPlanningHasHappened)
+	{
+		ereport(ERROR, (errmsg("cannot start a distributed transaction after "
+							   "joining reference tables and local tables.")));
+	}
+
 	CurrentCoordinatedTransactionState = COORD_TRANS_STARTED;
 
 	AssignDistributedTransactionId();
@@ -228,6 +234,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 			XactModificationLevel = XACT_MODIFICATION_NONE;
 			LocalExecutionHappened = false;
+			LocalPlanningHasHappened = false;
 			dlist_init(&InProgressTransactions);
 			activeSetStmts = NULL;
 			CoordinatedTransactionUses2PC = false;
@@ -282,6 +289,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 			XactModificationLevel = XACT_MODIFICATION_NONE;
 			LocalExecutionHappened = false;
+			LocalPlanningHasHappened = false;
 			dlist_init(&InProgressTransactions);
 			activeSetStmts = NULL;
 			CoordinatedTransactionUses2PC = false;

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -166,11 +166,6 @@ BeginCoordinatedTransaction(void)
 		ereport(ERROR, (errmsg("starting transaction in wrong state")));
 	}
 
-	if (LocalExecutionHappened)
-	{
-		ereport(WARNING, (errmsg("Local transaction has happend?!!")));
-	}
-
 	CurrentCoordinatedTransactionState = COORD_TRANS_STARTED;
 
 	AssignDistributedTransactionId();

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -119,6 +119,11 @@ TargetWorkerSetNodeList(TargetWorkerSet targetWorkerSet, LOCKMODE lockMode)
 	foreach(workerNodeCell, workerNodeList)
 	{
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
+		if (workerNode->groupId == 0)
+		{
+			continue;
+		}
+
 		if (targetWorkerSet == WORKERS_WITH_METADATA &&
 			(!workerNode->hasMetadata || !workerNode->metadataSynced))
 		{

--- a/src/backend/distributed/utils/metadata_cache.c
+++ b/src/backend/distributed/utils/metadata_cache.c
@@ -3010,7 +3010,7 @@ InitializeWorkerNodeCache(void)
 	newWorkerNodeHash = hash_create("Worker Node Hash", maxTableSize, &info, hashFlags);
 
 	/* read the list from pg_dist_node */
-	workerNodeList = ReadWorkerNodes(includeNodesFromOtherClusters);
+	workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
 
 	newWorkerNodeCount = list_length(workerNodeList);
 	newWorkerNodeArray = MemoryContextAlloc(MetadataCacheMemoryContext,

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -753,7 +753,7 @@ worker_append_table_to_shard(PG_FUNCTION_ARGS)
 	 * We lock on the shard table, but do not unlock. When the transaction ends,
 	 * this lock will automatically be released. This ensures appends to a shard
 	 * happen in a serial manner.
-	 * 
+	 *
 	 * We don't acquire lock on the shard id to avoid deadlock when doing
 	 * upgrade_to_reference_table(). upgrade_to_reference_table() acquires
 	 * a lock on shard resource on the coordinator, and opens connections

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -750,12 +750,18 @@ worker_append_table_to_shard(PG_FUNCTION_ARGS)
 							 &sourceTableName);
 
 	/*
-	 * We lock on the shardId, but do not unlock. When the function returns, and
-	 * the transaction for this function commits, this lock will automatically
-	 * be released. This ensures appends to a shard happen in a serial manner.
+	 * We lock on the shard table, but do not unlock. When the transaction ends,
+	 * this lock will automatically be released. This ensures appends to a shard
+	 * happen in a serial manner.
+	 * 
+	 * We don't acquire lock on the shard id to avoid deadlock when doing
+	 * upgrade_to_reference_table(). upgrade_to_reference_table() acquires
+	 * a lock on shard resource on the coordinator, and opens connections
+	 * to all nodes and calls worker_append_table_to_shard(). This connection
+	 * might be a connection to the coordinator.
 	 */
 	shardId = ExtractShardIdFromTableName(shardTableName, false);
-	LockShardResource(shardId, AccessExclusiveLock);
+	LockRelationOid(RelnameGetRelid(shardTableName), AccessExclusiveLock);
 
 	/* copy remote table's data to this node */
 	localFilePath = makeStringInfo();

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -122,11 +122,18 @@ RelationIsAKnownShard(Oid shardRelationId)
 	localGroupId = GetLocalGroupId();
 	if (localGroupId == 0)
 	{
-		/*
-		 * We're not interested in shards in the coordinator
-		 * or non-mx worker nodes.
-		 */
-		return false;
+		bool coordinatorIsKnown = false;
+		PrimaryNodeForGroup(0, &coordinatorIsKnown);
+
+		if (!coordinatorIsKnown)
+		{
+			/*
+			 * We're not interested in shards in the coordinator
+			 * or non-mx worker nodes, unless the coordinator is
+			 * in pg_dist_node.
+			 */
+			return false;
+		}
 	}
 
 	/* we're not interested in the relations that are not in the search path */

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -58,5 +58,6 @@ extern void InvalidateForeignKeyGraphForDDL(void);
 extern List * DDLTaskList(Oid relationId, const char *commandString);
 extern List * NodeDDLTaskList(TargetWorkerSet targets, List *commands);
 extern bool AlterTableInProgress(void);
+extern bool DropSchemaInProgress(void);
 
 #endif /* MULTI_UTILITY_H */

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -29,6 +29,8 @@
 
 #define CURSOR_OPT_FORCE_DISTRIBUTED 0x080000
 
+extern bool LocalPlanningHasHappened;
+
 typedef struct RelationRestrictionContext
 {
 	bool hasDistributedRelation;

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -127,8 +127,7 @@ extern void DeletePartitionRow(Oid distributedRelationId);
 extern void DeleteShardRow(uint64 shardId);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern void DeleteShardPlacementRow(uint64 placementId);
-extern void UpdateColocationGroupReplicationFactorForReferenceTables(int
-																	 replicationFactor);
+extern void UpdateColocationGroupReplicationFactorForReferenceTables(void);
 extern void CreateDistributedTable(Oid relationId, Var *distributionColumn,
 								   char distributionMethod, char *colocateWithTableName,
 								   bool viaDeprecatedAPI);

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -21,6 +21,7 @@ extern void ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);
 extern List * ReferenceTableOidList(void);
 extern int CompareOids(const void *leftElement, const void *rightElement);
+extern int ReferenceTableReplicationFactor(void);
 
 
 #endif /* REFERENCE_TABLE_UTILS_H_ */

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -72,15 +72,16 @@ extern WorkerNode * WorkerGetRoundRobinCandidateNode(List *workerNodeList,
 extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern uint32 ActivePrimaryNodeCount(void);
 extern List * ActivePrimaryNodeList(LOCKMODE lockMode);
+extern List * ActiveReferenceTablePlacementNodeList(LOCKMODE lockMode);
 extern List * ActivePrimaryShouldHaveShardsNodeList(LOCKMODE lockMode);
 extern uint32 ActiveReadableNodeCount(void);
 extern List * ActiveReadableNodeList(void);
 extern WorkerNode * GetWorkerNodeByNodeId(int nodeId);
 extern WorkerNode * FindWorkerNode(char *nodeName, int32 nodePort);
 extern WorkerNode * FindWorkerNodeAnyCluster(const char *nodeName, int32 nodePort);
-extern List * ReadWorkerNodes(bool includeNodesFromOtherClusters);
+extern List * ReadDistNode(bool includeNodesFromOtherClusters);
 extern void EnsureCoordinator(void);
-extern uint32 GroupForNode(char *nodeName, int32 nodePorT);
+extern uint32 GroupForNode(char *nodeName, int32 nodePort);
 extern WorkerNode * PrimaryNodeForGroup(int32 groupId, bool *groupContainsNodes);
 extern bool WorkerNodeIsPrimary(WorkerNode *worker);
 extern bool WorkerNodeIsSecondary(WorkerNode *worker);

--- a/src/test/regress/expected/add_coordinator.out
+++ b/src/test/regress/expected/add_coordinator.out
@@ -1,0 +1,28 @@
+--
+-- ADD_COORDINATOR
+--
+-- The colocation group for reference tables should have replication factor 2
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
+-- adding the same node again should return the existing nodeid
+SELECT master_add_node('localhost', :master_port, groupid => 0) = :master_nodeid;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- adding another node with groupid=0 should error out
+SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
+ERROR:  group 0 already has a primary node
+-- The colocation group for reference tables should have replication factor 3
+SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/src/test/regress/expected/add_coordinator.out
+++ b/src/test/regress/expected/add_coordinator.out
@@ -26,3 +26,7 @@ SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntyp
  t
 (1 row)
 
+-- start_metadata_sync_to_node() for coordinator should fail
+SELECT start_metadata_sync_to_node('localhost', :master_port);
+ERROR:  you cannot sync metadata to the coordinator
+HINT:  Coordinator already should have the metadata

--- a/src/test/regress/expected/foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table.out
@@ -527,12 +527,9 @@ SELECT count(*) FROM referencing_schema.referencing_table;
    800
 (1 row)
 
+DROP TABLE referenced_schema.referenced_table, referencing_schema.referencing_table;
 DROP SCHEMA referenced_schema CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table referenced_schema.referenced_table
-drop cascades to constraint fkey_ref on table referencing_schema.referencing_table
 DROP SCHEMA referencing_schema CASCADE;
-NOTICE:  drop cascades to table referencing_schema.referencing_table
 -- on delete set update cascades properly
 CREATE TABLE referenced_table(test_column int, test_column2 int, PRIMARY KEY(test_column));
 CREATE TABLE referencing_table(id int, ref_id int DEFAULT 1);
@@ -646,8 +643,8 @@ INSERT INTO referenced_table SELECT x,x FROM generate_series(1,1000) AS f(x);
 INSERT INTO referencing_table(id) SELECT x FROM generate_series(1,1000) AS f(x);
 -- Fails for non existing value inserts (serial is already incremented)
 INSERT INTO referencing_table(id) SELECT x FROM generate_series(1,10) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000190" violates foreign key constraint "fkey_ref_7000190"
-DETAIL:  Key (ref_id)=(1004) is not present in table "referenced_table_7000187".
+ERROR:  insert or update on table "referencing_table_7000193" violates foreign key constraint "fkey_ref_7000193"
+DETAIL:  Key (ref_id)=(1006) is not present in table "referenced_table_7000187".
 DROP TABLE referenced_table CASCADE;
 NOTICE:  drop cascades to constraint fkey_ref on table referencing_table
 DROP TABLE referencing_table CASCADE;
@@ -677,8 +674,8 @@ INSERT INTO referenced_table(test_column2) SELECT x FROM generate_series(1,1000)
 INSERT INTO referencing_table(id) SELECT x FROM generate_series(1,1000) AS f(x);
 -- Fails for non existing value inserts (serial is already incremented)
 INSERT INTO referencing_table(id) SELECT x FROM generate_series(1,10) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000199" violates foreign key constraint "fkey_ref_7000199"
-DETAIL:  Key (ref_id)=(1004) is not present in table "referenced_table_7000196".
+ERROR:  insert or update on table "referencing_table_7000200" violates foreign key constraint "fkey_ref_7000200"
+DETAIL:  Key (ref_id)=(1003) is not present in table "referenced_table_7000196".
 DROP TABLE referenced_table CASCADE;
 NOTICE:  drop cascades to constraint fkey_ref on table referencing_table
 DROP TABLE referencing_table CASCADE;
@@ -819,16 +816,16 @@ INSERT INTO referenced_table SELECT x, x+1 FROM generate_series(0,1000) AS f(x);
 INSERT INTO referenced_table2 SELECT x, x+1 FROM generate_series(500,1500) AS f(x);
 -- should fail
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(0,1500) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000230" violates foreign key constraint "foreign_key_2_7000230"
-DETAIL:  Key (id)=(28) is not present in table "referenced_table2_7000225".
+ERROR:  insert or update on table "referencing_table_7000229" violates foreign key constraint "foreign_key_2_7000229"
+DETAIL:  Key (id)=(0) is not present in table "referenced_table2_7000225".
 -- should fail
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(0,400) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000226" violates foreign key constraint "foreign_key_2_7000226"
-DETAIL:  Key (id)=(1) is not present in table "referenced_table2_7000225".
+ERROR:  insert or update on table "referencing_table_7000229" violates foreign key constraint "foreign_key_2_7000229"
+DETAIL:  Key (id)=(0) is not present in table "referenced_table2_7000225".
 -- should fail
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(1000,1400) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000228" violates foreign key constraint "fkey_ref_7000228"
-DETAIL:  Key (id)=(1015) is not present in table "referenced_table_7000224".
+ERROR:  insert or update on table "referencing_table_7000231" violates foreign key constraint "fkey_ref_7000231"
+DETAIL:  Key (id)=(1001) is not present in table "referenced_table_7000224".
 -- should succeed
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(600,900) AS f(x);
 SELECT count(*) FROM referencing_table;
@@ -947,13 +944,13 @@ INSERT INTO referenced_table SELECT x, x+1 FROM generate_series(0,1000) AS f(x);
 INSERT INTO referenced_table2 SELECT x, x+1 FROM generate_series(500,1500) AS f(x);
 -- should fail
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(0,1500) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000246" violates foreign key constraint "foreign_key_2_7000246"
+ERROR:  insert or update on table "referencing_table_7000249" violates foreign key constraint "foreign_key_2_7000249"
 -- should fail
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(0,400) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000246" violates foreign key constraint "foreign_key_2_7000246"
+ERROR:  insert or update on table "referencing_table_7000249" violates foreign key constraint "foreign_key_2_7000249"
 -- should fail
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(1000,1400) AS f(x);
-ERROR:  insert or update on table "referencing_table_7000248" violates foreign key constraint "fkey_ref_7000248"
+ERROR:  insert or update on table "referencing_table_7000251" violates foreign key constraint "fkey_ref_7000251"
 -- should succeed
 INSERT INTO referencing_table SELECT x, x+501 FROM generate_series(0,1000) AS f(x);
 SELECT count(*) FROM referencing_table;
@@ -1085,14 +1082,14 @@ SELECT * FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' A
 INSERT INTO referenced_table SELECT x, x+1 FROM generate_series(0,1000) AS f(x);
 -- should fail
 INSERT INTO referencing_table2 SELECT x, x+1 FROM generate_series(0,100) AS f(x);
-ERROR:  insert or update on table "referencing_table2_7000273" violates foreign key constraint "fkey_ref_to_dist_7000273"
-DETAIL:  Key (id)=(1) is not present in table "referencing_table_7000265".
+ERROR:  insert or update on table "referencing_table2_7000276" violates foreign key constraint "fkey_ref_to_dist_7000276"
+DETAIL:  Key (id)=(0) is not present in table "referencing_table_7000268".
 -- should succeed
 INSERT INTO referencing_table SELECT x, x+1 FROM generate_series(0,400) AS f(x);
 -- should fail
 INSERT INTO referencing_table2 SELECT x, x+1 FROM generate_series(200,500) AS f(x);
-ERROR:  insert or update on table "referencing_table2_7000273" violates foreign key constraint "fkey_ref_to_dist_7000273"
-DETAIL:  Key (id)=(401) is not present in table "referencing_table_7000265".
+ERROR:  insert or update on table "referencing_table2_7000274" violates foreign key constraint "fkey_ref_to_dist_7000274"
+DETAIL:  Key (id)=(403) is not present in table "referencing_table_7000266".
 -- should succeed
 INSERT INTO referencing_table2 SELECT x, x+1 FROM generate_series(0,300) AS f(x);
 DELETE FROM referenced_table WHERE test_column < 200;

--- a/src/test/regress/expected/multi_insert_select_conflict.out
+++ b/src/test/regress/expected/multi_insert_select_conflict.out
@@ -306,11 +306,12 @@ NOTICE:  truncate cascades to table "target_table"
 		col_2,
 		col_1
 	FROM source_table_1 ON CONFLICT (col_1) DO UPDATE SET col_2 = 55 RETURNING *;
-ERROR:  insert or update on table "target_table_1900000" violates foreign key constraint "fkey_1900000"
-DETAIL:  Key (col_1)=(1) is not present in table "test_ref_table_1900012".
-CONTEXT:  while executing command on localhost:57637
+ERROR:  insert or update on table "target_table_1900001" violates foreign key constraint "fkey_1900001"
+DETAIL:  Key (col_1)=(3) is not present in table "test_ref_table_1900012".
+CONTEXT:  while executing command on localhost:57638
 ROLLBACK;
 BEGIN;
+	SET LOCAL citus.enable_local_execution TO off;
 	DELETE FROM test_ref_table WHERE key > 10;
 	INSERT INTO 
 		target_table
@@ -331,6 +332,7 @@ ROLLBACK;
 -- Following two queries are supported since we no not modify but only select from
 -- the target_table after modification on test_ref_table.
 BEGIN;
+	SET LOCAL citus.enable_local_execution TO off;
 	TRUNCATE test_ref_table CASCADE;
 NOTICE:  truncate cascades to table "target_table"
 	INSERT INTO 
@@ -345,6 +347,7 @@ NOTICE:  truncate cascades to table "target_table"
 
 ROLLBACK;
 BEGIN;
+	SET LOCAL citus.enable_local_execution TO off;
 	DELETE FROM test_ref_table;
 	INSERT INTO 
  		source_table_1
@@ -526,10 +529,10 @@ SELECT * FROM target_table ORDER BY 1;
 (10 rows)
 
 RESET client_min_messages;
+DROP TABLE test_ref_table;
 DROP SCHEMA on_conflict CASCADE;
-NOTICE:  drop cascades to 7 other objects
-DETAIL:  drop cascades to table test_ref_table
-drop cascades to table source_table_3
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to table source_table_3
 drop cascades to table source_table_4
 drop cascades to table target_table_2
 drop cascades to table target_table

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1436,13 +1436,13 @@ SELECT shardid, shardstate FROM pg_dist_shard_placement WHERE placementid = :a_p
 (1 row)
 
 -- some queries that are captured in functions
-CREATE FUNCTION select_count_all() RETURNS bigint AS '
+CREATE OR REPLACE FUNCTION select_count_all() RETURNS bigint AS '
         SELECT
                 count(*)
         FROM
                 reference_table_test;
 ' LANGUAGE SQL;
-CREATE FUNCTION insert_into_ref_table(value_1 int, value_2 float, value_3 text, value_4 timestamp) 
+CREATE OR REPLACE FUNCTION insert_into_ref_table(value_1 int, value_2 float, value_3 text, value_4 timestamp) 
 RETURNS void AS '
        INSERT INTO reference_table_test VALUES ($1, $2, $3, $4);
 ' LANGUAGE SQL;
@@ -1584,9 +1584,11 @@ BEGIN;
 ALTER TABLE reference_table_test ADD COLUMN value_dummy INT;
 INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
 ROLLBACK;
--- clean up tables
+-- clean up tables, ...
 DROP SEQUENCE example_ref_value_seq;
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
 		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite,
-		   reference_schema.reference_table_test_sixth, reference_schema.reference_table_test_seventh;
+		   reference_schema.reference_table_test_sixth, reference_schema.reference_table_test_seventh,
+		   colocated_table_test, colocated_table_test_2, append_reference_tmp_table;
+DROP TYPE reference_comp_key;
 DROP SCHEMA reference_schema CASCADE;

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -34,19 +34,19 @@ WHERE
  1250000 | t                   | t
 (1 row)
 
+SELECT count(*) active_primaries FROM pg_dist_node WHERE isactive AND noderole='primary' \gset
 SELECT
-	shardid, shardstate, nodename, nodeport
+	shardid, bool_and(shardstate = 1) all_placements_healthy, COUNT(distinct nodeport) = :active_primaries replicated_to_all
 FROM
 	pg_dist_shard_placement
 WHERE
 	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'reference_table_test'::regclass)
-ORDER BY
-	placementid;
- shardid | shardstate | nodename  | nodeport 
----------+------------+-----------+----------
- 1250000 |          1 | localhost |    57637
- 1250000 |          1 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | all_placements_healthy | replicated_to_all 
+---------+------------------------+-------------------
+ 1250000 | t                      | t
+(1 row)
 
 -- check whether data was copied into distributed table
 SELECT * FROM reference_table_test;
@@ -783,18 +783,16 @@ SELECT create_reference_table('reference_table_test_fourth');
  
 (1 row)
 
+\set VERBOSITY terse
 -- insert a row
 INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '1', '2016-12-01');
 -- now get the unique key violation
 INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '1', '2016-12-01');
 ERROR:  duplicate key value violates unique constraint "reference_table_test_fourth_pkey_1250003"
-DETAIL:  Key (value_2)=(1) already exists.
-CONTEXT:  while executing command on localhost:57637
 -- now get null constraint violation due to primary key
 INSERT INTO reference_table_test_fourth (value_1, value_3, value_4) VALUES (1, '1.0', '2016-12-01');
 ERROR:  null value in column "value_2" violates not-null constraint
-DETAIL:  Failing row contains (1, null, 1.0, 2016-12-01 00:00:00).
-CONTEXT:  while executing command on localhost:57637
+\set VERBOSITY default
 -- lets run some upserts
 INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '1', '2016-12-01') ON CONFLICT DO NOTHING RETURNING *;
  value_1 | value_2 | value_3 | value_4 
@@ -820,18 +818,17 @@ INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '10', '2016-12-01') ON C
 
 -- finally see that shard healths are OK
 SELECT
-	shardid, shardstate, nodename, nodeport
+	shardid, bool_and(shardstate = 1) all_placements_healthy, COUNT(distinct nodeport) = :active_primaries replicated_to_all
 FROM
 	pg_dist_shard_placement
 WHERE
 	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'reference_table_test_fourth'::regclass)
-ORDER BY
-	placementid;
- shardid | shardstate | nodename  | nodeport 
----------+------------+-----------+----------
- 1250003 |          1 | localhost |    57637
- 1250003 |          1 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | all_placements_healthy | replicated_to_all 
+---------+------------------------+-------------------
+ 1250003 | t                      | t
+(1 row)
 
 -- let's not run some update/delete queries on arbitrary columns
 DELETE FROM
@@ -1588,9 +1585,8 @@ ALTER TABLE reference_table_test ADD COLUMN value_dummy INT;
 INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
 ROLLBACK;
 -- clean up tables
+DROP SEQUENCE example_ref_value_seq;
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
-		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite;
+		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite,
+		   reference_schema.reference_table_test_sixth, reference_schema.reference_table_test_seventh;
 DROP SCHEMA reference_schema CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table reference_schema.reference_table_test_sixth
-drop cascades to table reference_schema.reference_table_test_seventh

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -1017,7 +1017,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+        10004 |          1 |                 1 |                      0
 (1 row)
 
 \c - - - :worker_1_port

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -1017,7 +1017,7 @@ WHERE colocationid IN
      WHERE logicalrelid = 'remove_node_reference_table'::regclass);
  colocationid | shardcount | replicationfactor | distributioncolumntype 
 --------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+        10004 |          1 |                 2 |                      0
 (1 row)
 
 \c - - - :worker_1_port

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -104,20 +104,18 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -133,21 +131,19 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370001 |          1 |           0 | localhost |    57638
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 -- test add same node twice
@@ -157,21 +153,19 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370001 |          1 |           0 | localhost |    57638
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -186,21 +180,19 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370001 |          1 |           0 | localhost |    57638
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_valid;
@@ -224,20 +216,18 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 BEGIN;
@@ -255,20 +245,18 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_rollback;
@@ -286,20 +274,18 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_commit'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 BEGIN;
@@ -317,21 +303,19 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370003 |          1 |           0 | localhost |    57638
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_commit'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_commit;
@@ -373,40 +357,37 @@ WHERE
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
+SELECT colocationid AS reference_table_colocationid FROM pg_dist_colocation WHERE distributioncolumntype = 0 \gset
 SELECT
-    logicalrelid, partmethod, colocationid, repmodel
+    logicalrelid, partmethod, colocationid = :reference_table_colocationid, repmodel
 FROM
     pg_dist_partition
 WHERE
     logicalrelid IN ('replicate_reference_table_reference_one', 'replicate_reference_table_hash', 'replicate_reference_table_reference_two')
 ORDER BY logicalrelid;
-              logicalrelid               | partmethod | colocationid | repmodel 
------------------------------------------+------------+--------------+----------
- replicate_reference_table_reference_one | n          |        10004 | t
- replicate_reference_table_hash          | h          |      1360005 | c
+              logicalrelid               | partmethod | ?column? | repmodel 
+-----------------------------------------+------------+----------+----------
+ replicate_reference_table_reference_one | n          | t        | t
+ replicate_reference_table_hash          | h          | f        | c
 (2 rows)
 
 BEGIN;
+SET LOCAL client_min_messages TO ERROR;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "replicate_reference_table_reference_one" to the node localhost:57638
  ?column? 
 ----------
         1
 (1 row)
 
 SELECT upgrade_to_reference_table('replicate_reference_table_hash');
-NOTICE:  Replicating reference table "replicate_reference_table_hash" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -426,8 +407,7 @@ FROM
     pg_dist_shard_placement
 WHERE
     nodeport = :worker_2_port
-ORDER BY
-    shardid;
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370004 |          1 |           0 | localhost |    57638
@@ -435,30 +415,27 @@ ORDER BY
  1370006 |          1 |           0 | localhost |    57638
 (3 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT
-    logicalrelid, partmethod, colocationid, repmodel
+    logicalrelid, partmethod, colocationid = :reference_table_colocationid, repmodel
 FROM
     pg_dist_partition
 WHERE
     logicalrelid IN ('replicate_reference_table_reference_one', 'replicate_reference_table_hash', 'replicate_reference_table_reference_two')
 ORDER BY 
 	logicalrelid;
-              logicalrelid               | partmethod | colocationid | repmodel 
------------------------------------------+------------+--------------+----------
- replicate_reference_table_reference_one | n          |        10004 | t
- replicate_reference_table_hash          | n          |        10004 | t
- replicate_reference_table_reference_two | n          |        10004 | t
+              logicalrelid               | partmethod | ?column? | repmodel 
+-----------------------------------------+------------+----------+----------
+ replicate_reference_table_reference_one | n          | t        | t
+ replicate_reference_table_hash          | n          | t        | t
+ replicate_reference_table_reference_two | n          | t        | t
 (3 rows)
 
 DROP TABLE replicate_reference_table_reference_one;
@@ -526,20 +503,18 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_drop'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_drop'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 BEGIN;
@@ -558,7 +533,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
@@ -589,20 +565,18 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 1 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -618,21 +592,19 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370011 |          1 |           0 | localhost |    57638
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 DROP TABLE replicate_reference_table_schema.table1;
@@ -661,7 +633,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename | nodeport 
 ---------+------------+-------------+----------+----------
 (0 rows)
@@ -681,7 +654,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
  1370012 |          1 |           0 | localhost |    57638
@@ -718,7 +692,7 @@ SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
         1
 (1 row)
 
--- we should see only one shard placements
+-- we should see only one shard placements (other than coordinator)
 SELECT
     shardid, shardstate, shardlength, nodename, nodeport
 FROM
@@ -730,6 +704,7 @@ WHERE
                     pg_dist_shard 
                 WHERE 
                     logicalrelid = 'initially_not_replicated_reference_table'::regclass)
+    AND nodeport != :master_port
 ORDER BY 1,4,5;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------
@@ -755,6 +730,7 @@ WHERE
                     pg_dist_shard 
                 WHERE 
                     logicalrelid = 'initially_not_replicated_reference_table'::regclass)
+    AND nodeport != :master_port
 ORDER BY 1,4,5;
  shardid | shardstate | shardlength | nodename  | nodeport 
 ---------+------------+-------------+-----------+----------

--- a/src/test/regress/expected/multi_test_helpers.out
+++ b/src/test/regress/expected/multi_test_helpers.out
@@ -1,6 +1,6 @@
 -- File to create functions and helpers needed for subsequent tests
 -- create a helper function to create objects on each node
-CREATE FUNCTION run_command_on_master_and_workers(p_sql text)
+CREATE OR REPLACE FUNCTION run_command_on_master_and_workers(p_sql text)
 RETURNS void LANGUAGE plpgsql AS $$
 BEGIN
      EXECUTE p_sql;
@@ -12,7 +12,7 @@ END;$$;
 -- was safely accomplished by a \d invocation.
 SELECT run_command_on_master_and_workers(
 $desc_views$
-CREATE VIEW table_fkey_cols AS
+CREATE OR REPLACE VIEW table_fkey_cols AS
 SELECT rc.constraint_name AS "name",
        kcu.column_name AS "column_name",
        uc_kcu.column_name AS "refd_column_name",
@@ -27,7 +27,7 @@ WHERE rc.constraint_schema = kcu.constraint_schema AND
       rc.unique_constraint_schema = uc_kcu.constraint_schema AND
       rc.unique_constraint_name = uc_kcu.constraint_name;
 
-CREATE VIEW table_fkeys AS
+CREATE OR REPLACE VIEW table_fkeys AS
 SELECT name AS "Constraint",
        format('FOREIGN KEY (%s) REFERENCES %s(%s)',
               string_agg(DISTINCT quote_ident(column_name), ', '),
@@ -37,7 +37,7 @@ SELECT name AS "Constraint",
 FROM table_fkey_cols
 GROUP BY (name, relid);
 
-CREATE VIEW table_attrs AS
+CREATE OR REPLACE VIEW table_attrs AS
 SELECT c.column_name AS "name",
        c.data_type AS "type",
        CASE
@@ -53,7 +53,7 @@ SELECT c.column_name AS "name",
 FROM information_schema.columns AS c
 ORDER BY ordinal_position;
 
-CREATE VIEW table_desc AS
+CREATE OR REPLACE VIEW table_desc AS
 SELECT "name" AS "Column",
        "type" || "modifier" AS "Type",
        rtrim((
@@ -69,7 +69,7 @@ SELECT "name" AS "Column",
 	   "relid"
 FROM table_attrs;
 
-CREATE VIEW table_checks AS
+CREATE OR REPLACE VIEW table_checks AS
 SELECT cc.constraint_name AS "Constraint",
        ('CHECK ' || regexp_replace(check_clause, '^\((.*)\)$', '\1')) AS "Definition",
        format('%I.%I', ccu.table_schema, ccu.table_name)::regclass::oid AS relid
@@ -79,7 +79,7 @@ WHERE cc.constraint_schema = ccu.constraint_schema AND
       cc.constraint_name = ccu.constraint_name
 ORDER BY cc.constraint_name ASC;
 
-CREATE VIEW index_attrs AS
+CREATE OR REPLACE VIEW index_attrs AS
 WITH indexoid AS (
 	SELECT c.oid,
 	  n.nspname,
@@ -111,7 +111,7 @@ $desc_views$
 (1 row)
 
 -- Create a function to make sure that queries returning the same result
-CREATE FUNCTION raise_failed_execution(query text) RETURNS void AS $$
+CREATE OR REPLACE FUNCTION raise_failed_execution(query text) RETURNS void AS $$
 BEGIN
 	EXECUTE query;
 	EXCEPTION WHEN OTHERS THEN
@@ -134,7 +134,7 @@ BEGIN
   RETURN;
 END; $$ language plpgsql;
 -- helper function to quickly run SQL on the whole cluster
-CREATE FUNCTION run_command_on_coordinator_and_workers(p_sql text)
+CREATE OR REPLACE FUNCTION run_command_on_coordinator_and_workers(p_sql text)
 RETURNS void LANGUAGE plpgsql AS $$
 BEGIN
      EXECUTE p_sql;
@@ -142,7 +142,7 @@ BEGIN
 END;$$;
 -- 1. Marks the given procedure as colocated with the given table.
 -- 2. Marks the argument index with which we route the procedure.
-CREATE FUNCTION colocate_proc_with_table(procname text, tablerelid regclass, argument_index int)
+CREATE OR REPLACE FUNCTION colocate_proc_with_table(procname text, tablerelid regclass, argument_index int)
 RETURNS void LANGUAGE plpgsql AS $$
 BEGIN
     update citus.pg_dist_object
@@ -170,3 +170,9 @@ BEGIN
     RETURN true;
 END;
 $func$;
+CREATE OR REPLACE VIEW colocation_view AS
+SELECT a.logicalrelid, b.colocationid, b.shardcount, b.replicationfactor,
+       b.replicationfactor=(SELECT count(*) FROM pg_dist_node WHERE isactive AND noderole='primary') AS replicated_on_all_nodes,
+       b.distributioncolumntype
+FROM pg_dist_partition a, pg_dist_colocation b
+WHERE a.colocationid = b.colocationid;

--- a/src/test/regress/expected/multi_upgrade_reference_table.out
+++ b/src/test/regress/expected/multi_upgrade_reference_table.out
@@ -5,6 +5,7 @@
 --
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1360000;
 ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1360000;
+SET client_min_messages TO WARNING;
 -- test with not distributed table
 CREATE TABLE upgrade_reference_table_local(column1 int);
 SELECT upgrade_to_reference_table('upgrade_reference_table_local');
@@ -74,7 +75,8 @@ SELECT create_distributed_table('upgrade_reference_table_unhealthy', 'column1');
 (1 row)
 
 UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='upgrade_reference_table_unhealthy'::regclass;
-UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1360006;
+UPDATE pg_dist_shard_placement SET shardstate = 3
+   WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'upgrade_reference_table_unhealthy'::regclass::oid);
 SELECT upgrade_to_reference_table('upgrade_reference_table_unhealthy');
 ERROR:  could not find any healthy placement for shard 1360006
 DROP TABLE upgrade_reference_table_unhealthy;
@@ -91,13 +93,13 @@ SELECT create_distributed_table('upgrade_reference_table_composite', 'column1');
 
 UPDATE pg_dist_partition SET repmodel='c' WHERE logicalrelid='upgrade_reference_table_composite'::regclass;
 SELECT upgrade_to_reference_table('upgrade_reference_table_composite');
-NOTICE:  Replicating reference table "upgrade_reference_table_composite" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
 (1 row)
 
 DROP TABLE upgrade_reference_table_composite;
+DROP TYPE upgrade_test_composite_type;
 -- test with reference table
 CREATE TABLE upgrade_reference_table_reference(column1 int);
 SELECT create_reference_table('upgrade_reference_table_reference');
@@ -142,30 +144,29 @@ WHERE
  1360009 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_append'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
 (0 rows)
 
+SELECT count(*) active_primaries FROM pg_dist_node WHERE isactive AND noderole='primary' \gset
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360009 |          1 |        8192 | localhost |    57637
+     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360009 | f
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_append');
-NOTICE:  Replicating reference table "upgrade_reference_table_append" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -194,31 +195,27 @@ WHERE
  1360009 | t                   | t
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_append'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_append'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_append'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360009 |          1 |        8192 | localhost |    57637
- 1360009 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360009 | t
+(1 row)
 
     
 DROP TABLE upgrade_reference_table_append;
@@ -254,31 +251,29 @@ WHERE
  1360010 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360001 |          1 |                 1 |                     23
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+      1360001 |          1 | f                       |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360010 |          1 |           0 | localhost |    57637
+     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360010 | f
 (1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_one_worker');
-NOTICE:  Replicating reference table "upgrade_reference_table_one_worker" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -307,31 +302,27 @@ WHERE
  1360010 | t                   | t
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_one_worker'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360010 |          1 |           0 | localhost |    57637
- 1360010 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360010 | t
+(1 row)
 
     
 DROP TABLE upgrade_reference_table_one_worker;
@@ -344,7 +335,8 @@ SELECT create_distributed_table('upgrade_reference_table_one_unhealthy', 'column
  
 (1 row)
 
-UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE shardid = 1360010 AND nodeport = :worker_1_port;
+UPDATE pg_dist_shard_placement SET shardstate = 3
+WHERE shardid = (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass::oid) AND nodeport = :worker_1_port;
 -- situation before upgrade_reference_table
 SELECT
     partmethod, (partkey IS NULL) as partkeyisnull, colocationid, repmodel
@@ -368,31 +360,28 @@ WHERE
  1360011 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360002 |          1 |                 2 |                     23
+SELECT colocationid, shardcount, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass;
+ colocationid | shardcount | distributioncolumntype 
+--------------+------------+------------------------
+      1360002 |          1 |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360011 |          1 |           0 | localhost |    57637
- 1360011 |          1 |           0 | localhost |    57638
-(2 rows)
+    AND shardstate = 1
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360011 | f
+(1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_one_unhealthy');
  upgrade_to_reference_table 
@@ -423,31 +412,28 @@ WHERE
  1360011 | t                   | t
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass;
+ colocationid | shardcount | distributioncolumntype 
+--------------+------------+------------------------
+        10004 |          1 |                      0
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_one_unhealthy'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360011 |          1 |           0 | localhost |    57637
- 1360011 |          1 |           0 | localhost |    57638
-(2 rows)
+    AND shardstate = 1
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360011 | t
+(1 row)
 
     
 DROP TABLE upgrade_reference_table_one_unhealthy;
@@ -482,31 +468,27 @@ WHERE
  1360012 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360003 |          1 |                 2 |                     23
+SELECT colocationid, shardcount, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass;
+ colocationid | shardcount | distributioncolumntype 
+--------------+------------+------------------------
+      1360003 |          1 |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360012 |          1 |           0 | localhost |    57637
- 1360012 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid 
+---------
+ 1360012
+(1 row)
 
 SELECT upgrade_to_reference_table('upgrade_reference_table_both_healthy');
  upgrade_to_reference_table 
@@ -537,31 +519,27 @@ WHERE
  1360012 | t                   | t
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_both_healthy'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360012 |          1 |           0 | localhost |    57637
- 1360012 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360012 | t
+(1 row)
 
     
 DROP TABLE upgrade_reference_table_both_healthy;
@@ -598,32 +576,30 @@ WHERE
  1360013 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+      1360004 |          1 | f                       |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360013 |          1 |           0 | localhost |    57637
+     WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360013 | f
 (1 row)
 
 BEGIN;
 SELECT upgrade_to_reference_table('upgrade_reference_table_transaction_rollback');
-NOTICE:  Replicating reference table "upgrade_reference_table_transaction_rollback" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -653,27 +629,26 @@ WHERE
  1360013 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+      1360004 |          1 | f                       |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass);
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360013 |          1 |           0 | localhost |    57637
+     WHERE logicalrelid = 'upgrade_reference_table_transaction_rollback'::regclass)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360013 | f
 (1 row)
 
      
@@ -711,32 +686,30 @@ WHERE
  1360014 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360004 |          1 |                 1 |                     23
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+      1360004 |          1 | f                       |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360014 |          1 |           0 | localhost |    57637
+     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360014 | f
 (1 row)
 
 BEGIN;
 SELECT upgrade_to_reference_table('upgrade_reference_table_transaction_commit');
-NOTICE:  Replicating reference table "upgrade_reference_table_transaction_commit" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -766,31 +739,27 @@ WHERE
  1360014 | t                   | t
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_transaction_commit'::regclass)
-ORDER BY
-    nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360014 |          1 |           0 | localhost |    57637
- 1360014 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360014 | t
+(1 row)
 
 -- verify that shard is replicated to other worker
 \c - - - :worker_2_port
@@ -837,28 +806,26 @@ WHERE
  1360015 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360005 |          1 |                 1 |                     23
+SELECT colocationid, shardcount, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass;
+ colocationid | shardcount | distributioncolumntype 
+--------------+------------+------------------------
+      1360005 |          1 |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass)
-ORDER BY nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360015 |          1 |           0 | localhost |    57637
+GROUP BY shardid
+ORDER BY shardid;
+ shardid 
+---------
+ 1360015
 (1 row)
 
      
@@ -889,28 +856,26 @@ WHERE
  1360015 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360005 |          1 |                 1 |                     23
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+      1360005 |          1 | f                       |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass)
-ORDER BY nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360015 |          1 |           0 | localhost |    57637
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360015 | f
 (1 row)
 
 DROP TABLE upgrade_reference_table_mx;
@@ -958,34 +923,31 @@ WHERE
  1360016 | f                   | f
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-      1360006 |          1 |                 2 |                     23
+SELECT colocationid, shardcount, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass;
+ colocationid | shardcount | distributioncolumntype 
+--------------+------------+------------------------
+      1360006 |          1 |                     23
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass)
-ORDER BY nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360016 |          1 |           0 | localhost |    57637
- 1360016 |          3 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid 
+---------
+ 1360016
+(1 row)
 
      
+SET client_min_messages TO WARNING;
 SELECT upgrade_to_reference_table('upgrade_reference_table_mx');
-NOTICE:  Replicating reference table "upgrade_reference_table_mx" to the node localhost:57638
  upgrade_to_reference_table 
 ----------------------------
  
@@ -1015,30 +977,27 @@ WHERE
  1360016 | t                   | t
 (1 row)
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass);
- colocationid | shardcount | replicationfactor | distributioncolumntype 
---------------+------------+-------------------+------------------------
-        10004 |          1 |                 2 |                      0
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass;
+ colocationid | shardcount | replicated_on_all_nodes | distributioncolumntype 
+--------------+------------+-------------------------+------------------------
+        10004 |          1 | t                       |                      0
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass)
-ORDER BY nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360016 |          1 |           0 | localhost |    57637
- 1360016 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360016 | t
+(1 row)
 
      
 -- situation on metadata worker
@@ -1066,18 +1025,18 @@ WHERE
 (1 row)
 
 SELECT
-    shardid, shardstate, shardlength, nodename, nodeport
+    shardid, count(distinct nodeport) = :active_primaries
 FROM pg_dist_shard_placement
 WHERE shardid IN
     (SELECT shardid
      FROM pg_dist_shard
      WHERE logicalrelid = 'upgrade_reference_table_mx'::regclass)
-ORDER BY nodeport;
- shardid | shardstate | shardlength | nodename  | nodeport 
----------+------------+-------------+-----------+----------
- 1360016 |          1 |           0 | localhost |    57637
- 1360016 |          1 |           0 | localhost |    57638
-(2 rows)
+GROUP BY shardid
+ORDER BY shardid;
+ shardid | ?column? 
+---------+----------
+ 1360016 | t
+(1 row)
 
      
 \c - - - :master_port
@@ -1088,3 +1047,7 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
  
 (1 row)
 
+RESET client_min_messages TO WARNING;
+ERROR:  syntax error at or near "TO"
+LINE 1: RESET client_min_messages TO WARNING;
+                                  ^

--- a/src/test/regress/expected/remove_coordinator.out
+++ b/src/test/regress/expected/remove_coordinator.out
@@ -1,0 +1,13 @@
+-- removing coordinator from pg_dist_node should update pg_dist_colocation
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -18,66 +18,6 @@ SELECT create_reference_table('squares');
 (1 row)
 
 INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
-SELECT groupid FROM pg_dist_placement 
-WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
-ORDER BY groupid;
- groupid 
----------
-      14
-      16
-(2 rows)
-
--- should be executed on a worker
-SELECT count(*) FROM squares;
- count 
--------
-    10
-(1 row)
-
--- The colocation group for reference tables should have replication factor 2
-SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
- ?column? 
-----------
- t
-(1 row)
-
-SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
-NOTICE:  Replicating reference table "orders_reference" to the node localhost:57636
-NOTICE:  Replicating reference table "customer" to the node localhost:57636
-NOTICE:  Replicating reference table "nation" to the node localhost:57636
-NOTICE:  Replicating reference table "part" to the node localhost:57636
-NOTICE:  Replicating reference table "supplier" to the node localhost:57636
-NOTICE:  Replicating reference table "users_ref_test_table" to the node localhost:57636
-NOTICE:  Replicating reference table "events_reference_table" to the node localhost:57636
-NOTICE:  Replicating reference table "users_reference_table" to the node localhost:57636
-NOTICE:  Replicating reference table "squares" to the node localhost:57636
--- adding the same node again should return the existing nodeid
-SELECT master_add_node('localhost', :master_port, groupid => 0) = :master_nodeid;
- ?column? 
-----------
- t
-(1 row)
-
--- adding another node with groupid=0 should error out
-SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
-ERROR:  group 0 already has a primary node
--- The colocation group for reference tables should have replication factor 3
-SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;
- ?column? 
-----------
- t
-(1 row)
-
-SELECT groupid FROM pg_dist_placement 
-WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
-ORDER BY groupid;
- groupid 
----------
-       0
-      14
-      16
-(3 rows)
-
 -- should be executed locally
 SELECT count(*) FROM squares;
 LOG:  executing the command locally: SELECT count(*) AS count FROM replicate_ref_to_coordinator.squares_8000000 squares
@@ -95,6 +35,7 @@ SELECT create_reference_table('numbers');
 (1 row)
 
 INSERT INTO numbers VALUES (20), (21);
+LOG:  executing the command locally: INSERT INTO replicate_ref_to_coordinator.numbers_8000001 AS citus_table_alias (a) VALUES (20), (21)
 -- INSERT ... SELECT between reference tables
 BEGIN;
 EXPLAIN INSERT INTO squares SELECT a, a*a FROM numbers;
@@ -104,16 +45,18 @@ EXPLAIN INSERT INTO squares SELECT a, a*a FROM numbers;
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Node: host=localhost port=57637 dbname=regression
+         Node: host=localhost port=57636 dbname=regression
          ->  Insert on squares_8000000 citus_table_alias  (cost=0.00..41.88 rows=2550 width=8)
                ->  Seq Scan on numbers_8000001 numbers  (cost=0.00..41.88 rows=2550 width=8)
 (7 rows)
 
 INSERT INTO squares SELECT a, a*a FROM numbers;
 SELECT * FROM squares WHERE a >= 20 ORDER BY a;
- a | b 
----+---
-(0 rows)
+ a  |  b  
+----+-----
+ 20 | 400
+ 21 | 441
+(2 rows)
 
 ROLLBACK;
 BEGIN;
@@ -124,7 +67,7 @@ EXPLAIN INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
    Task Count: 1
    Tasks Shown: All
    ->  Task
-         Node: host=localhost port=57637 dbname=regression
+         Node: host=localhost port=57636 dbname=regression
          ->  Insert on numbers_8000001 citus_table_alias  (cost=0.00..38.25 rows=753 width=4)
                ->  Seq Scan on squares_8000000 squares  (cost=0.00..38.25 rows=753 width=4)
                      Filter: (a < 3)
@@ -132,26 +75,42 @@ EXPLAIN INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
 
 INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
 SELECT * FROM numbers ORDER BY a;
- a 
----
-(0 rows)
+ a  
+----
+  1
+  2
+ 20
+ 21
+(4 rows)
 
 ROLLBACK;
--- removing coordinator from pg_dist_node should update pg_dist_colocation
-SELECT master_remove_node('localhost', :master_port);
- master_remove_node 
---------------------
- 
-(1 row)
+-- Interact with a local table
+CREATE TABLE local_table(a int);
+INSERT INTO local_table VALUES (30), (31);
+EXPLAIN (costs off) SELECT * FROM numbers, local_table;
+             QUERY PLAN              
+-------------------------------------
+ Nested Loop
+   ->  Seq Scan on numbers_8000001
+   ->  Materialize
+         ->  Seq Scan on local_table
+(4 rows)
 
-SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
- ?column? 
-----------
- t
-(1 row)
+BEGIN;
+INSERT INTO numbers SELECT * FROM local_table;
+SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
+ a  | a  
+----+----
+ 20 | 30
+ 20 | 31
+ 21 | 30
+ 21 | 31
+(4 rows)
 
+ROLLBACK;
 -- clean-up
 SET client_min_messages TO ERROR;
+DROP TABLE squares, numbers, local_table;
 DROP SCHEMA replicate_ref_to_coordinator CASCADE;
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -99,7 +99,7 @@ EXPLAIN (costs off) SELECT * FROM numbers, local_table;
 BEGIN;
 INSERT INTO numbers SELECT * FROM local_table;
 SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
-ERROR:  cannot join reference tables with local tablesin a coordinated transaction
+ERROR:  cannot join reference tables with local tables in a coordinated transaction
 ROLLBACK;
 BEGIN;
 SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
@@ -123,7 +123,11 @@ ROLLBACK;
 
 -- clean-up
 SET client_min_messages TO ERROR;
-DROP TABLE squares, numbers, local_table;
 DROP SCHEMA replicate_ref_to_coordinator CASCADE;
+-- Make sure the shard was dropped
+ SELECT 'numbers_8000001'::regclass::oid;
+ERROR:  relation "numbers_8000001" does not exist
+LINE 1: SELECT 'numbers_8000001'::regclass::oid;
+               ^
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -108,6 +108,13 @@ SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
 (4 rows)
 
 ROLLBACK;
+-- Make sure we hide shard tables ...
+ SELECT citus_table_is_visible('numbers_8000001'::regclass::oid);
+ citus_table_is_visible 
+------------------------
+ f
+(1 row)
+
 -- clean-up
 SET client_min_messages TO ERROR;
 DROP TABLE squares, numbers, local_table;

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -1,0 +1,157 @@
+--
+-- REPLICATE_REF_TABLES_ON_COORDINATOR
+--
+CREATE SCHEMA replicate_ref_to_coordinator;
+SET search_path TO 'replicate_ref_to_coordinator';
+SET citus.shard_replication_factor TO 1;
+SET citus.shard_count TO 4;
+SET citus.next_shard_id TO 8000000;
+SET citus.next_placement_id TO 8000000;
+--- enable logging to see which tasks are executed locally
+SET client_min_messages TO LOG;
+SET citus.log_local_commands TO ON;
+CREATE TABLE squares(a int, b int);
+SELECT create_reference_table('squares');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
+SELECT groupid FROM pg_dist_placement 
+WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
+ORDER BY groupid;
+ groupid 
+---------
+      14
+      16
+(2 rows)
+
+-- should be executed on a worker
+SELECT count(*) FROM squares;
+ count 
+-------
+    10
+(1 row)
+
+-- The colocation group for reference tables should have replication factor 2
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
+NOTICE:  Replicating reference table "orders_reference" to the node localhost:57636
+NOTICE:  Replicating reference table "customer" to the node localhost:57636
+NOTICE:  Replicating reference table "nation" to the node localhost:57636
+NOTICE:  Replicating reference table "part" to the node localhost:57636
+NOTICE:  Replicating reference table "supplier" to the node localhost:57636
+NOTICE:  Replicating reference table "users_ref_test_table" to the node localhost:57636
+NOTICE:  Replicating reference table "events_reference_table" to the node localhost:57636
+NOTICE:  Replicating reference table "users_reference_table" to the node localhost:57636
+NOTICE:  Replicating reference table "squares" to the node localhost:57636
+-- adding the same node again should return the existing nodeid
+SELECT master_add_node('localhost', :master_port, groupid => 0) = :master_nodeid;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- adding another node with groupid=0 should error out
+SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
+ERROR:  group 0 already has a primary node
+-- The colocation group for reference tables should have replication factor 3
+SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT groupid FROM pg_dist_placement 
+WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
+ORDER BY groupid;
+ groupid 
+---------
+       0
+      14
+      16
+(3 rows)
+
+-- should be executed locally
+SELECT count(*) FROM squares;
+LOG:  executing the command locally: SELECT count(*) AS count FROM replicate_ref_to_coordinator.squares_8000000 squares
+ count 
+-------
+    10
+(1 row)
+
+-- create a second reference table
+CREATE TABLE numbers(a int);
+SELECT create_reference_table('numbers');
+ create_reference_table 
+------------------------
+ 
+(1 row)
+
+INSERT INTO numbers VALUES (20), (21);
+-- INSERT ... SELECT between reference tables
+BEGIN;
+EXPLAIN INSERT INTO squares SELECT a, a*a FROM numbers;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Insert on squares_8000000 citus_table_alias  (cost=0.00..41.88 rows=2550 width=8)
+               ->  Seq Scan on numbers_8000001 numbers  (cost=0.00..41.88 rows=2550 width=8)
+(7 rows)
+
+INSERT INTO squares SELECT a, a*a FROM numbers;
+SELECT * FROM squares WHERE a >= 20 ORDER BY a;
+ a | b 
+---+---
+(0 rows)
+
+ROLLBACK;
+BEGIN;
+EXPLAIN INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=57637 dbname=regression
+         ->  Insert on numbers_8000001 citus_table_alias  (cost=0.00..38.25 rows=753 width=4)
+               ->  Seq Scan on squares_8000000 squares  (cost=0.00..38.25 rows=753 width=4)
+                     Filter: (a < 3)
+(8 rows)
+
+INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+SELECT * FROM numbers ORDER BY a;
+ a 
+---
+(0 rows)
+
+ROLLBACK;
+-- removing coordinator from pg_dist_node should update pg_dist_colocation
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node 
+--------------------
+ 
+(1 row)
+
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- clean-up
+SET client_min_messages TO ERROR;
+DROP SCHEMA replicate_ref_to_coordinator CASCADE;
+SET search_path TO DEFAULT;
+RESET client_min_messages;

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -99,6 +99,10 @@ EXPLAIN (costs off) SELECT * FROM numbers, local_table;
 BEGIN;
 INSERT INTO numbers SELECT * FROM local_table;
 SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
+ERROR:  cannot join reference tables with local tablesin a coordinated transaction
+ROLLBACK;
+BEGIN;
+SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
  a  | a  
 ----+----
  20 | 30
@@ -107,6 +111,8 @@ SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
  21 | 31
 (4 rows)
 
+INSERT INTO numbers SELECT * FROM local_table;
+ERROR:  cannot start a distributed transaction after joining reference tables and local tables.
 ROLLBACK;
 -- Make sure we hide shard tables ...
  SELECT citus_table_is_visible('numbers_8000001'::regclass::oid);

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -247,7 +247,6 @@ test: multi_foreign_key multi_foreign_key_relation_graph
 # multi_upgrade_reference_table tests for upgrade_reference_table UDF
 # multi_replicate_reference_table tests replicating reference tables to new nodes after we add new nodes
 # multi_remove_node_reference_table tests metadata changes after master_remove_node
-# replicate_reference_tables_to_coordinator tests replicating reference tables to coordinator
 # ----------
 test: multi_upgrade_reference_table
 test: multi_replicate_reference_table
@@ -262,6 +261,7 @@ test: multi_upgrade_reference_table
 test: multi_replicate_reference_table
 test: multi_reference_table
 test: foreign_key_to_reference_table
+test: replicate_reference_tables_to_coordinator
 test: remove_coordinator
 
 # ----------

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -246,6 +246,7 @@ test: multi_foreign_key multi_foreign_key_relation_graph
 # multi_upgrade_reference_table tests for upgrade_reference_table UDF
 # multi_replicate_reference_table tests replicating reference tables to new nodes after we add new nodes
 # multi_remove_node_reference_table tests metadata changes after master_remove_node
+# replicate_reference_tables_to_coordinator tests replicating reference tables to coordinator
 # ----------
 test: multi_upgrade_reference_table
 test: multi_replicate_reference_table
@@ -288,3 +289,13 @@ test: distributed_procedure
 # deparsing logic tests
 # ---------
 test: multi_deparse_function multi_deparse_procedure
+
+# --------
+# Replicating reference tables to coordinator.  Add coordinator to pg_dist_node
+# and rerun some of the tests.
+# --------
+test: add_coordinator
+test: multi_upgrade_reference_table
+test: multi_replicate_reference_table
+test: multi_remove_node_reference_table
+test: remove_coordinator

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -18,8 +18,8 @@
 test: multi_extension
 test: multi_703_upgrade
 test: multi_cluster_management
-test: multi_test_helpers
 test: multi_table_ddl
+test: multi_test_helpers
 test: multi_name_lengths
 test: multi_name_resolution
 test: multi_metadata_access
@@ -202,6 +202,7 @@ test: multi_size_queries
 # multi_drop_extension makes sure we can safely drop and recreate the extension
 # ----------
 test: multi_drop_extension
+test: multi_test_helpers
 
 # ----------
 # multi_metadata_sync tests the propagation of mx-related metadata changes to metadata workers
@@ -252,6 +253,17 @@ test: multi_upgrade_reference_table
 test: multi_replicate_reference_table
 test: multi_remove_node_reference_table
 
+# --------
+# Replicating reference tables to coordinator.  Add coordinator to pg_dist_node
+# and rerun some of the tests.
+# --------
+test: add_coordinator
+test: multi_upgrade_reference_table
+test: multi_replicate_reference_table
+test: multi_reference_table
+test: foreign_key_to_reference_table
+test: remove_coordinator
+
 # ----------
 # multi_transactional_drop_shards tests for dropping shards using connection API
 # ----------
@@ -289,13 +301,3 @@ test: distributed_procedure
 # deparsing logic tests
 # ---------
 test: multi_deparse_function multi_deparse_procedure
-
-# --------
-# Replicating reference tables to coordinator.  Add coordinator to pg_dist_node
-# and rerun some of the tests.
-# --------
-test: add_coordinator
-test: multi_upgrade_reference_table
-test: multi_replicate_reference_table
-test: multi_remove_node_reference_table
-test: remove_coordinator

--- a/src/test/regress/multi_task_tracker_extra_schedule
+++ b/src/test/regress/multi_task_tracker_extra_schedule
@@ -15,8 +15,8 @@
 # ---
 test: multi_extension
 test: multi_cluster_management
-test: multi_test_helpers
 test: multi_table_ddl
+test: multi_test_helpers
 
 # ----------
 # The following distributed tests depend on creating a partitioned table and

--- a/src/test/regress/sql/add_coordinator.sql
+++ b/src/test/regress/sql/add_coordinator.sql
@@ -1,0 +1,17 @@
+--
+-- ADD_COORDINATOR
+--
+
+-- The colocation group for reference tables should have replication factor 2
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
+
+-- adding the same node again should return the existing nodeid
+SELECT master_add_node('localhost', :master_port, groupid => 0) = :master_nodeid;
+
+-- adding another node with groupid=0 should error out
+SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
+
+-- The colocation group for reference tables should have replication factor 3
+SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;

--- a/src/test/regress/sql/add_coordinator.sql
+++ b/src/test/regress/sql/add_coordinator.sql
@@ -15,3 +15,6 @@ SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
 
 -- The colocation group for reference tables should have replication factor 3
 SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+-- start_metadata_sync_to_node() for coordinator should fail
+SELECT start_metadata_sync_to_node('localhost', :master_port);

--- a/src/test/regress/sql/add_coordinator.sql.sql
+++ b/src/test/regress/sql/add_coordinator.sql.sql
@@ -1,0 +1,74 @@
+--
+-- REPLICATE_REF_TABLES_ON_COORDINATOR
+--
+
+CREATE SCHEMA replicate_ref_to_coordinator;
+SET search_path TO 'replicate_ref_to_coordinator';
+SET citus.shard_replication_factor TO 1;
+SET citus.shard_count TO 4;
+SET citus.next_shard_id TO 8000000;
+SET citus.next_placement_id TO 8000000;
+
+--- enable logging to see which tasks are executed locally
+SET client_min_messages TO LOG;
+SET citus.log_local_commands TO ON;
+
+CREATE TABLE squares(a int, b int);
+SELECT create_reference_table('squares');
+INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
+
+SELECT groupid FROM pg_dist_placement 
+WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
+ORDER BY groupid;
+
+-- should be executed on a worker
+SELECT count(*) FROM squares;
+
+-- The colocation group for reference tables should have replication factor 2
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
+
+-- adding the same node again should return the existing nodeid
+SELECT master_add_node('localhost', :master_port, groupid => 0) = :master_nodeid;
+
+-- adding another node with groupid=0 should error out
+SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
+
+-- The colocation group for reference tables should have replication factor 3
+SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+SELECT groupid FROM pg_dist_placement 
+WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
+ORDER BY groupid;
+
+-- should be executed locally
+SELECT count(*) FROM squares;
+
+-- create a second reference table
+CREATE TABLE numbers(a int);
+SELECT create_reference_table('numbers');
+INSERT INTO numbers VALUES (20), (21);
+
+-- INSERT ... SELECT between reference tables
+BEGIN;
+EXPLAIN INSERT INTO squares SELECT a, a*a FROM numbers;
+INSERT INTO squares SELECT a, a*a FROM numbers;
+SELECT * FROM squares WHERE a >= 20 ORDER BY a;
+ROLLBACK;
+
+BEGIN;
+EXPLAIN INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+SELECT * FROM numbers ORDER BY a;
+ROLLBACK;
+
+-- removing coordinator from pg_dist_node should update pg_dist_colocation
+SELECT master_remove_node('localhost', :master_port);
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+-- clean-up
+SET client_min_messages TO ERROR;
+DROP SCHEMA replicate_ref_to_coordinator CASCADE;
+SET search_path TO DEFAULT;
+RESET client_min_messages;

--- a/src/test/regress/sql/foreign_key_to_reference_table.sql
+++ b/src/test/regress/sql/foreign_key_to_reference_table.sql
@@ -249,6 +249,7 @@ INSERT INTO referencing_schema.referencing_table SELECT x, x from generate_serie
 DELETE FROM referenced_schema.referenced_table WHERE id > 800;
 SELECT count(*) FROM referencing_schema.referencing_table;
 
+DROP TABLE referenced_schema.referenced_table, referencing_schema.referencing_table;
 DROP SCHEMA referenced_schema CASCADE;
 DROP SCHEMA referencing_schema CASCADE;
 

--- a/src/test/regress/sql/multi_insert_select_conflict.sql
+++ b/src/test/regress/sql/multi_insert_select_conflict.sql
@@ -176,6 +176,7 @@ BEGIN;
 ROLLBACK;
 
 BEGIN;
+	SET LOCAL citus.enable_local_execution TO off;
 	DELETE FROM test_ref_table WHERE key > 10;
 	INSERT INTO 
 		target_table
@@ -188,6 +189,7 @@ ROLLBACK;
 -- Following two queries are supported since we no not modify but only select from
 -- the target_table after modification on test_ref_table.
 BEGIN;
+	SET LOCAL citus.enable_local_execution TO off;
 	TRUNCATE test_ref_table CASCADE;
 	INSERT INTO 
  		source_table_1
@@ -198,6 +200,7 @@ BEGIN;
 ROLLBACK;
 
 BEGIN;
+	SET LOCAL citus.enable_local_execution TO off;
 	DELETE FROM test_ref_table;
 	INSERT INTO 
  		source_table_1
@@ -297,4 +300,5 @@ INSERT INTO target_table SELECT * FROM cte_2 ON CONFLICT(col_1) DO UPDATE SET co
 SELECT * FROM target_table ORDER BY 1;
 
 RESET client_min_messages;
+DROP TABLE test_ref_table;
 DROP SCHEMA on_conflict CASCADE;

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -23,14 +23,17 @@ FROM
 	pg_dist_shard
 WHERE
 	logicalrelid = 'reference_table_test'::regclass;
+
+SELECT count(*) active_primaries FROM pg_dist_node WHERE isactive AND noderole='primary' \gset
+
 SELECT
-	shardid, shardstate, nodename, nodeport
+	shardid, bool_and(shardstate = 1) all_placements_healthy, COUNT(distinct nodeport) = :active_primaries replicated_to_all
 FROM
 	pg_dist_shard_placement
 WHERE
 	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'reference_table_test'::regclass)
-ORDER BY
-	placementid;
+GROUP BY shardid
+ORDER BY shardid;
 
 -- check whether data was copied into distributed table
 SELECT * FROM reference_table_test;
@@ -478,6 +481,8 @@ ORDER BY
 CREATE TABLE reference_table_test_fourth (value_1 int, value_2 float PRIMARY KEY, value_3 text, value_4 timestamp);
 SELECT create_reference_table('reference_table_test_fourth');
 
+\set VERBOSITY terse
+
 -- insert a row
 INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '1', '2016-12-01');
 
@@ -486,6 +491,8 @@ INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '1', '2016-12-01');
 
 -- now get null constraint violation due to primary key
 INSERT INTO reference_table_test_fourth (value_1, value_3, value_4) VALUES (1, '1.0', '2016-12-01');
+
+\set VERBOSITY default
 
 -- lets run some upserts
 INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '1', '2016-12-01') ON CONFLICT DO NOTHING RETURNING *;
@@ -499,13 +506,13 @@ INSERT INTO reference_table_test_fourth VALUES (1, 1.0, '10', '2016-12-01') ON C
 
 -- finally see that shard healths are OK
 SELECT
-	shardid, shardstate, nodename, nodeport
+	shardid, bool_and(shardstate = 1) all_placements_healthy, COUNT(distinct nodeport) = :active_primaries replicated_to_all
 FROM
 	pg_dist_shard_placement
 WHERE
 	shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid = 'reference_table_test_fourth'::regclass)
-ORDER BY
-	placementid;
+GROUP BY shardid
+ORDER BY shardid;
 
 -- let's not run some update/delete queries on arbitrary columns
 DELETE FROM
@@ -993,6 +1000,8 @@ INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
 ROLLBACK;
 
 -- clean up tables
+DROP SEQUENCE example_ref_value_seq;
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
-		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite;
+		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite,
+		   reference_schema.reference_table_test_sixth, reference_schema.reference_table_test_seventh;
 DROP SCHEMA reference_schema CASCADE;

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -916,14 +916,14 @@ SELECT master_copy_shard_placement(:a_shard_id, 'localhost', :worker_2_port, 'lo
 SELECT shardid, shardstate FROM pg_dist_shard_placement WHERE placementid = :a_placement_id;
 
 -- some queries that are captured in functions
-CREATE FUNCTION select_count_all() RETURNS bigint AS '
+CREATE OR REPLACE FUNCTION select_count_all() RETURNS bigint AS '
         SELECT
                 count(*)
         FROM
                 reference_table_test;
 ' LANGUAGE SQL;
 
-CREATE FUNCTION insert_into_ref_table(value_1 int, value_2 float, value_3 text, value_4 timestamp) 
+CREATE OR REPLACE FUNCTION insert_into_ref_table(value_1 int, value_2 float, value_3 text, value_4 timestamp) 
 RETURNS void AS '
        INSERT INTO reference_table_test VALUES ($1, $2, $3, $4);
 ' LANGUAGE SQL;
@@ -999,9 +999,11 @@ ALTER TABLE reference_table_test ADD COLUMN value_dummy INT;
 INSERT INTO reference_table_test VALUES (2, 2.0, '2', '2016-12-02');
 ROLLBACK;
 
--- clean up tables
+-- clean up tables, ...
 DROP SEQUENCE example_ref_value_seq;
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
 		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite,
-		   reference_schema.reference_table_test_sixth, reference_schema.reference_table_test_seventh;
+		   reference_schema.reference_table_test_sixth, reference_schema.reference_table_test_seventh,
+		   colocated_table_test, colocated_table_test_2, append_reference_tmp_table;
+DROP TYPE reference_comp_key;
 DROP SCHEMA reference_schema CASCADE;

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -3,7 +3,6 @@
 --
 -- Tests that check that reference tables are replicated when adding new nodes.
 
-
 SET citus.next_shard_id TO 1370000;
 ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1370000;
 ALTER SEQUENCE pg_catalog.pg_dist_groupid_seq RESTART 1370000;
@@ -71,14 +70,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
@@ -88,14 +85,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
 
 
 -- test add same node twice
@@ -106,14 +101,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
@@ -123,14 +116,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_valid'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_valid'::regclass;
 
 DROP TABLE replicate_reference_table_valid;
 
@@ -147,14 +138,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass;
 
 BEGIN;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -166,14 +155,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_rollback'::regclass;
 
 DROP TABLE replicate_reference_table_rollback;
 
@@ -188,14 +175,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_commit'::regclass;
 
 BEGIN;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -207,14 +192,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_commit'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_commit'::regclass;
 
 DROP TABLE replicate_reference_table_commit;
 
@@ -244,15 +227,14 @@ FROM
 WHERE
     nodeport = :worker_2_port;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass;
+
+SELECT colocationid AS reference_table_colocationid FROM pg_dist_colocation WHERE distributioncolumntype = 0 \gset
 
 SELECT
-    logicalrelid, partmethod, colocationid, repmodel
+    logicalrelid, partmethod, colocationid = :reference_table_colocationid, repmodel
 FROM
     pg_dist_partition
 WHERE
@@ -260,6 +242,7 @@ WHERE
 ORDER BY logicalrelid;
 
 BEGIN;
+SET LOCAL client_min_messages TO ERROR;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT upgrade_to_reference_table('replicate_reference_table_hash');
 SELECT create_reference_table('replicate_reference_table_reference_two');
@@ -272,18 +255,14 @@ FROM
     pg_dist_shard_placement
 WHERE
     nodeport = :worker_2_port
-ORDER BY
-    shardid;
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_reference_one'::regclass;
 
 SELECT
-    logicalrelid, partmethod, colocationid, repmodel
+    logicalrelid, partmethod, colocationid = :reference_table_colocationid, repmodel
 FROM
     pg_dist_partition
 WHERE
@@ -350,14 +329,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_drop'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_drop'::regclass;
 
 BEGIN;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
@@ -370,7 +347,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
 SELECT * FROM pg_dist_colocation WHERE colocationid = 1370009;
 
@@ -387,14 +365,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass;
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
@@ -404,14 +380,12 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
-SELECT *
-FROM pg_dist_colocation
-WHERE colocationid IN
-    (SELECT colocationid
-     FROM pg_dist_partition
-     WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass);
+SELECT colocationid, shardcount, replicated_on_all_nodes, distributioncolumntype
+FROM colocation_view
+WHERE logicalrelid = 'replicate_reference_table_schema.table1'::regclass;
 
 DROP TABLE replicate_reference_table_schema.table1;
 DROP SCHEMA replicate_reference_table_schema CASCADE;
@@ -434,7 +408,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
@@ -444,7 +419,8 @@ SELECT
 FROM
     pg_dist_shard_placement
 WHERE
-    nodeport = :worker_2_port;
+    nodeport = :worker_2_port
+ORDER BY shardid, nodeport;
 
 -- verify constraints have been created on the new node
 SELECT run_command_on_workers('select count(*) from pg_constraint where contype=''f'' AND conname like ''ref_table%'';');
@@ -459,7 +435,7 @@ SELECT create_reference_table('initially_not_replicated_reference_table');
 
 SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
 
--- we should see only one shard placements
+-- we should see only one shard placements (other than coordinator)
 SELECT
     shardid, shardstate, shardlength, nodename, nodeport
 FROM
@@ -471,6 +447,7 @@ WHERE
                     pg_dist_shard 
                 WHERE 
                     logicalrelid = 'initially_not_replicated_reference_table'::regclass)
+    AND nodeport != :master_port
 ORDER BY 1,4,5;
 
 -- we should see the two shard placements after activation
@@ -487,6 +464,7 @@ WHERE
                     pg_dist_shard 
                 WHERE 
                     logicalrelid = 'initially_not_replicated_reference_table'::regclass)
+    AND nodeport != :master_port
 ORDER BY 1,4,5;
 
 -- this should have no effect

--- a/src/test/regress/sql/multi_upgrade_reference_table.sql
+++ b/src/test/regress/sql/multi_upgrade_reference_table.sql
@@ -695,4 +695,3 @@ ORDER BY nodeport;
 \c - - - :master_port
 DROP TABLE upgrade_reference_table_mx;
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
-

--- a/src/test/regress/sql/remove_coordinator.sql
+++ b/src/test/regress/sql/remove_coordinator.sql
@@ -1,0 +1,3 @@
+-- removing coordinator from pg_dist_node should update pg_dist_colocation
+SELECT master_remove_node('localhost', :master_port);
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;

--- a/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
+++ b/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
@@ -48,6 +48,11 @@ INSERT INTO numbers SELECT * FROM local_table;
 SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
 ROLLBACK;
 
+BEGIN;
+SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
+INSERT INTO numbers SELECT * FROM local_table;
+ROLLBACK;
+
 -- Make sure we hide shard tables ...
  SELECT citus_table_is_visible('numbers_8000001'::regclass::oid);
 

--- a/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
+++ b/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
@@ -58,7 +58,10 @@ ROLLBACK;
 
 -- clean-up
 SET client_min_messages TO ERROR;
-DROP TABLE squares, numbers, local_table;
 DROP SCHEMA replicate_ref_to_coordinator CASCADE;
+
+-- Make sure the shard was dropped
+ SELECT 'numbers_8000001'::regclass::oid;
+
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
+++ b/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
@@ -48,6 +48,9 @@ INSERT INTO numbers SELECT * FROM local_table;
 SELECT * FROM numbers, local_table WHERE numbers.a != local_table.a;
 ROLLBACK;
 
+-- Make sure we hide shard tables ...
+ SELECT citus_table_is_visible('numbers_8000001'::regclass::oid);
+
 -- clean-up
 SET client_min_messages TO ERROR;
 DROP TABLE squares, numbers, local_table;

--- a/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
+++ b/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
@@ -1,0 +1,74 @@
+--
+-- REPLICATE_REF_TABLES_ON_COORDINATOR
+--
+
+CREATE SCHEMA replicate_ref_to_coordinator;
+SET search_path TO 'replicate_ref_to_coordinator';
+SET citus.shard_replication_factor TO 1;
+SET citus.shard_count TO 4;
+SET citus.next_shard_id TO 8000000;
+SET citus.next_placement_id TO 8000000;
+
+--- enable logging to see which tasks are executed locally
+SET client_min_messages TO LOG;
+SET citus.log_local_commands TO ON;
+
+CREATE TABLE squares(a int, b int);
+SELECT create_reference_table('squares');
+INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
+
+SELECT groupid FROM pg_dist_placement 
+WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
+ORDER BY groupid;
+
+-- should be executed on a worker
+SELECT count(*) FROM squares;
+
+-- The colocation group for reference tables should have replication factor 2
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
+
+-- adding the same node again should return the existing nodeid
+SELECT master_add_node('localhost', :master_port, groupid => 0) = :master_nodeid;
+
+-- adding another node with groupid=0 should error out
+SELECT master_add_node('localhost', 12345, groupid => 0) = :master_nodeid;
+
+-- The colocation group for reference tables should have replication factor 3
+SELECT replicationfactor = 3 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+SELECT groupid FROM pg_dist_placement 
+WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='squares'::regclass::oid)
+ORDER BY groupid;
+
+-- should be executed locally
+SELECT count(*) FROM squares;
+
+-- create a second reference table
+CREATE TABLE numbers(a int);
+SELECT create_reference_table('numbers');
+INSERT INTO numbers VALUES (20), (21);
+
+-- INSERT ... SELECT between reference tables
+BEGIN;
+EXPLAIN INSERT INTO squares SELECT a, a*a FROM numbers;
+INSERT INTO squares SELECT a, a*a FROM numbers;
+SELECT * FROM squares WHERE a >= 20 ORDER BY a;
+ROLLBACK;
+
+BEGIN;
+EXPLAIN INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+SELECT * FROM numbers ORDER BY a;
+ROLLBACK;
+
+-- removing coordinator from pg_dist_node should update pg_dist_colocation
+SELECT master_remove_node('localhost', :master_port);
+SELECT replicationfactor = 2 FROM pg_dist_colocation WHERE distributioncolumntype=0;
+
+-- clean-up
+SET client_min_messages TO ERROR;
+DROP SCHEMA replicate_ref_to_coordinator CASCADE;
+SET search_path TO DEFAULT;
+RESET client_min_messages;


### PR DESCRIPTION
After user designates the coordinator by doing a `master_add_node(hostname, port, groupId => 0)`, we will replicate all reference tables to the coordinator too. This is so users can join reference tables with local tables too.

For queries which are a SELECT query which joins reference tables and local tables, we replace the reference table with the shard table and do local planning.

To test this, we added some new tests, but also run some related tests again after adding a coordinator node.
