### PR TITLE
Do not try to sync metadata on standby coordinator

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -366,8 +366,9 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		}
 #endif
 
-		if (MetadataSyncTriggeredCheckAndReset(myDbData) ||
-			GetCurrentTimestamp() >= nextMetadataSyncTime)
+		if (!RecoveryInProgress() &&
+			(MetadataSyncTriggeredCheckAndReset(myDbData) ||
+			 GetCurrentTimestamp() >= nextMetadataSyncTime))
 		{
 			bool metadataSyncFailed = false;
 			int64 nextTimeout = 0;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that caused maintenance daemon to fail on standby nodes

We currently try to sync metadata on standby nodes in the maintenance daemon, which predictably fails causing the maintenance daemon to not work in a standby and log errors every 5 second.

Fixes #3144