### PR TITLE
DEBUG only when the function is distributed

### DIFF
--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -224,8 +224,11 @@ TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 	if (procedure == NULL || !procedure->isDistributed)
 	{
 		/* not a distributed function call */
-		ereport(DEBUG4, (errmsg("function is not distributed")));
 		return NULL;
+	}
+	else
+	{
+		ereport(DEBUG4, (errmsg("function is distributed")));
 	}
 
 	if (IsMultiStatementTransaction())


### PR DESCRIPTION
Otherwise, we're seeing this message way too often doing random debugging on other topics.
