### PR TITLE
Replicate reference tables to coordinator: rename OpenConnectionToAllNodes

### DIFF
--- a/src/backend/distributed/master/citus_create_restore_point.c
+++ b/src/backend/distributed/master/citus_create_restore_point.c
@@ -30,7 +30,7 @@
 
 
 /* local functions forward declarations */
-static List * OpenConnectionsToAllNodes(LOCKMODE lockMode);
+static List * OpenConnectionsToAllWorkerNodes(LOCKMODE lockMode);
 static void BlockDistributedTransactions(void);
 static void CreateRemoteRestorePoints(char *restoreName, List *connectionList);
 
@@ -87,7 +87,7 @@ citus_create_restore_point(PG_FUNCTION_ARGS)
 	 * establish connections to all nodes before taking any locks
 	 * ShareLock prevents new nodes being added, rendering connectionList incomplete
 	 */
-	connectionList = OpenConnectionsToAllNodes(ShareLock);
+	connectionList = OpenConnectionsToAllWorkerNodes(ShareLock);
 
 	/*
 	 * Send a BEGIN to bust through pgbouncer. We won't actually commit since
@@ -114,7 +114,7 @@ citus_create_restore_point(PG_FUNCTION_ARGS)
  * of connections.
  */
 static List *
-OpenConnectionsToAllNodes(LOCKMODE lockMode)
+OpenConnectionsToAllWorkerNodes(LOCKMODE lockMode)
 {
 	List *connectionList = NIL;
 	List *workerNodeList = NIL;

--- a/src/test/regress/expected/isolation_create_restore_point.out
+++ b/src/test/regress/expected/isolation_create_restore_point.out
@@ -1,7 +1,7 @@
 Parsed test spec with 2 sessions
 
 starting permutation: s1-begin s1-create-distributed s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -27,7 +27,7 @@ step s2-create-restore: <... completed>
 1              
 
 starting permutation: s1-begin s1-insert s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -48,7 +48,7 @@ step s1-commit:
 
 
 starting permutation: s1-begin s1-modify-multiple s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -69,7 +69,7 @@ step s1-commit:
 
 
 starting permutation: s1-begin s1-ddl s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -90,7 +90,7 @@ step s1-commit:
 
 
 starting permutation: s1-begin s1-copy s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -111,7 +111,7 @@ step s1-commit:
 
 
 starting permutation: s1-begin s1-recover s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -136,7 +136,7 @@ step s2-create-restore: <... completed>
 1              
 
 starting permutation: s1-begin s1-drop s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -158,7 +158,7 @@ step s2-create-restore: <... completed>
 1              
 
 starting permutation: s1-begin s1-add-node s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -183,7 +183,7 @@ step s2-create-restore: <... completed>
 1              
 
 starting permutation: s1-begin s1-remove-node s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -208,7 +208,7 @@ step s2-create-restore: <... completed>
 1              
 
 starting permutation: s1-begin s1-create-restore s2-create-restore s1-commit
-create_distributed_table
+create_reference_table
 
                
 step s1-begin: 
@@ -233,7 +233,7 @@ step s2-create-restore: <... completed>
 1              
 
 starting permutation: s2-begin s2-create-restore s1-modify-multiple s2-commit
-create_distributed_table
+create_reference_table
 
                
 step s2-begin: 
@@ -254,7 +254,7 @@ step s2-commit:
 step s1-modify-multiple: <... completed>
 
 starting permutation: s2-begin s2-create-restore s1-ddl s2-commit
-create_distributed_table
+create_reference_table
 
                
 step s2-begin: 
@@ -275,7 +275,7 @@ step s2-commit:
 step s1-ddl: <... completed>
 
 starting permutation: s2-begin s2-create-restore s1-multi-statement s2-commit
-create_distributed_table
+create_reference_table
 
                
 step s2-begin: 
@@ -298,3 +298,203 @@ step s2-commit:
 	COMMIT;
 
 step s1-multi-statement: <... completed>
+
+starting permutation: s1-begin s1-create-reference s2-create-restore s1-commit
+create_reference_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-create-reference: 
+	CREATE TABLE test_create_reference_table (test_id integer NOT NULL, data text);
+	SELECT create_reference_table('test_create_reference_table');
+
+create_reference_table
+
+               
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-restore: <... completed>
+?column?       
+
+1              
+
+starting permutation: s1-begin s1-insert-ref s2-create-restore s1-commit
+create_reference_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-insert-ref: 
+	INSERT INTO restore_ref_table VALUES (1,'hello');
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s1-modify-multiple-ref s2-create-restore s1-commit
+create_reference_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-modify-multiple-ref: 
+	UPDATE restore_ref_table SET data = 'world';
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s1-ddl-ref s2-create-restore s1-commit
+create_reference_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-ddl-ref: 
+	ALTER TABLE restore_ref_table ADD COLUMN x int;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-restore: <... completed>
+?column?       
+
+1              
+
+starting permutation: s1-begin s1-copy-ref s2-create-restore s1-commit
+create_reference_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-copy-ref: 
+	COPY restore_ref_table FROM PROGRAM 'echo 1,hello' WITH CSV;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-commit: 
+	COMMIT;
+
+
+starting permutation: s1-begin s1-drop-ref s2-create-restore s1-commit
+create_reference_table
+
+               
+step s1-begin: 
+	BEGIN;
+	SET citus.multi_shard_commit_protocol TO '2pc';
+
+step s1-drop-ref: 
+	DROP TABLE restore_ref_table;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+ <waiting ...>
+step s1-commit: 
+	COMMIT;
+
+step s2-create-restore: <... completed>
+?column?       
+
+1              
+
+starting permutation: s2-begin s2-create-restore s1-modify-multiple-ref s2-commit
+create_reference_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-modify-multiple-ref: 
+	UPDATE restore_ref_table SET data = 'world';
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-modify-multiple-ref: <... completed>
+
+starting permutation: s2-begin s2-create-restore s1-ddl-ref s2-commit
+create_reference_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-ddl-ref: 
+	ALTER TABLE restore_ref_table ADD COLUMN x int;
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-ddl-ref: <... completed>
+
+starting permutation: s2-begin s2-create-restore s1-multi-statement-ref s2-commit
+create_reference_table
+
+               
+step s2-begin: 
+	BEGIN;
+
+step s2-create-restore: 
+	SELECT 1 FROM citus_create_restore_point('citus-test');
+
+?column?       
+
+1              
+step s1-multi-statement-ref: 
+	SET citus.multi_shard_commit_protocol TO '2pc';
+	BEGIN;
+	INSERT INTO restore_ref_table VALUES (1,'hello');
+	INSERT INTO restore_ref_table VALUES (2,'hello');
+	COMMIT;
+ <waiting ...>
+step s2-commit: 
+	COMMIT;
+
+step s1-multi-statement-ref: <... completed>

--- a/src/test/regress/specs/isolation_create_restore_point.spec
+++ b/src/test/regress/specs/isolation_create_restore_point.spec
@@ -2,12 +2,14 @@ setup
 {
 	SET citus.shard_replication_factor TO 1;
 	CREATE TABLE restore_table (test_id integer NOT NULL, data text);
+	CREATE TABLE restore_ref_table (test_id integer NOT NULL, data text);
 	SELECT create_distributed_table('restore_table', 'test_id');
+	SELECT create_reference_table('restore_ref_table');
 }
 
 teardown
 {
-	DROP TABLE IF EXISTS restore_table, test_create_distributed_table;
+	DROP TABLE IF EXISTS restore_table, restore_ref_table, test_create_distributed_table, test_create_reference_table;
 }
 
 session "s1"
@@ -16,6 +18,12 @@ step "s1-begin"
 {
 	BEGIN;
 	SET citus.multi_shard_commit_protocol TO '2pc';
+}
+
+step "s1-create-reference"
+{
+	CREATE TABLE test_create_reference_table (test_id integer NOT NULL, data text);
+	SELECT create_reference_table('test_create_reference_table');
 }
 
 step "s1-create-distributed"
@@ -29,9 +37,28 @@ step "s1-insert"
 	INSERT INTO restore_table VALUES (1,'hello');
 }
 
+step "s1-insert-ref"
+{
+	INSERT INTO restore_ref_table VALUES (1,'hello');
+}
+
 step "s1-modify-multiple"
 {
 	UPDATE restore_table SET data = 'world';
+}
+
+step "s1-modify-multiple-ref"
+{
+	UPDATE restore_ref_table SET data = 'world';
+}
+
+step "s1-multi-statement-ref"
+{
+	SET citus.multi_shard_commit_protocol TO '2pc';
+	BEGIN;
+	INSERT INTO restore_ref_table VALUES (1,'hello');
+	INSERT INTO restore_ref_table VALUES (2,'hello');
+	COMMIT;
 }
 
 step "s1-multi-statement"
@@ -43,9 +70,19 @@ step "s1-multi-statement"
 	COMMIT;
 }
 
+step "s1-ddl-ref"
+{
+	ALTER TABLE restore_ref_table ADD COLUMN x int;
+}
+
 step "s1-ddl"
 {
 	ALTER TABLE restore_table ADD COLUMN x int;
+}
+
+step "s1-copy-ref"
+{
+	COPY restore_ref_table FROM PROGRAM 'echo 1,hello' WITH CSV;
 }
 
 step "s1-copy"
@@ -66,6 +103,11 @@ step "s1-create-restore"
 step "s1-drop"
 {
 	DROP TABLE restore_table;
+}
+
+step "s1-drop-ref"
+{
+	DROP TABLE restore_ref_table;
 }
 
 step "s1-add-node"
@@ -136,5 +178,32 @@ permutation "s2-begin" "s2-create-restore" "s1-modify-multiple" "s2-commit"
 # verify that DDL is blocked by concurrent citus_create_restore_point
 permutation "s2-begin" "s2-create-restore" "s1-ddl" "s2-commit"
 
-# verify that multi-statement transactions is blocked by concurrent citus_create_restore_point
+# verify that multi-statement transactions are blocked by concurrent citus_create_restore_point
 permutation "s2-begin" "s2-create-restore" "s1-multi-statement" "s2-commit"
+
+# verify that citus_create_restore_point is blocked by concurrent create_reference_table
+permutation "s1-begin" "s1-create-reference" "s2-create-restore" "s1-commit"
+
+# verify that citus_create_restore_point is not blocked by concurrent reference table INSERT (only commit)
+permutation "s1-begin" "s1-insert-ref" "s2-create-restore" "s1-commit"
+
+# verify that citus_create_restore_point is not blocked by concurrent reference table UPDATE (only commit)
+permutation "s1-begin" "s1-modify-multiple-ref" "s2-create-restore" "s1-commit"
+
+# verify that citus_create_restore_point is not blocked by concurrent refence table DDL (only commit)
+permutation "s1-begin" "s1-ddl-ref" "s2-create-restore" "s1-commit"
+
+# verify that citus_create_restore_point is not blocked by concurrent COPY to reference table (only commit)
+permutation "s1-begin" "s1-copy-ref" "s2-create-restore" "s1-commit"
+
+# verify that citus_create_restore_point is blocked by concurrent DROP TABLE when table is a reference table
+permutation "s1-begin" "s1-drop-ref" "s2-create-restore" "s1-commit"
+
+# verify that reference table UPDATE is blocked by concurrent citus_create_restore_point
+permutation "s2-begin" "s2-create-restore" "s1-modify-multiple-ref" "s2-commit"
+
+# verify that reference table DDL is blocked by concurrent citus_create_restore_point
+permutation "s2-begin" "s2-create-restore" "s1-ddl-ref" "s2-commit"
+
+# verify that multi-statement transactions with reference tables are blocked by concurrent citus_create_restore_point
+permutation "s2-begin" "s2-create-restore" "s1-multi-statement-ref" "s2-commit"


### PR DESCRIPTION
create_restore_point creates a restore point on coordinator before having rest of nodes create restore point. No reason to have it create on coordinator again

This is already the case. This PR renames a function to be clear about that & adds testing reference tables with create_restore_point. Actual testing of create_restore_point is lacking