### PR TITLE
Escape transaction names

### DIFF
--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -25,11 +25,12 @@
 #include "distributed/transaction_management.h"
 #include "distributed/worker_transaction.h"
 #include "storage/lmgr.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
 
-#define LOCK_RELATION_IF_EXISTS "SELECT lock_relation_if_exists('%s', '%s');"
+#define LOCK_RELATION_IF_EXISTS "SELECT lock_relation_if_exists(%s, '%s');"
 
 
 /* Local functions forward declarations for unsupported command checks */
@@ -253,7 +254,8 @@ AcquireDistributedLockOnRelations(List *relationIdList, LOCKMODE lockMode)
 			ListCell *workerNodeCell = NULL;
 
 			appendStringInfo(lockRelationCommand, LOCK_RELATION_IF_EXISTS,
-							 qualifiedRelationName, lockModeText);
+							 quote_literal_cstr(qualifiedRelationName),
+							 lockModeText);
 
 			foreach(workerNodeCell, workerNodeList)
 			{

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -236,8 +236,8 @@ StartRemoteTransactionCommit(MultiConnection *connection)
 		StringInfoData command;
 
 		initStringInfo(&command);
-		appendStringInfo(&command, "COMMIT PREPARED '%s'",
-						 transaction->preparedName);
+		appendStringInfo(&command, "COMMIT PREPARED %s",
+						 quote_literal_cstr(transaction->preparedName));
 
 		transaction->transactionState = REMOTE_TRANS_2PC_COMMITTING;
 
@@ -371,8 +371,8 @@ StartRemoteTransactionAbort(MultiConnection *connection)
 		ForgetResults(connection);
 
 		initStringInfo(&command);
-		appendStringInfo(&command, "ROLLBACK PREPARED '%s'",
-						 transaction->preparedName);
+		appendStringInfo(&command, "ROLLBACK PREPARED %s",
+						 quote_literal_cstr(transaction->preparedName));
 
 		if (!SendRemoteCommand(connection, command.data))
 		{
@@ -497,8 +497,8 @@ StartRemoteTransactionPrepare(struct MultiConnection *connection)
 	}
 
 	initStringInfo(&command);
-	appendStringInfo(&command, "PREPARE TRANSACTION '%s'",
-					 transaction->preparedName);
+	appendStringInfo(&command, "PREPARE TRANSACTION %s",
+					 quote_literal_cstr(transaction->preparedName));
 
 	if (!SendRemoteCommand(connection, command.data))
 	{
@@ -1314,8 +1314,6 @@ CheckRemoteTransactionsHealth(void)
  * The connection number is used to distinguish connections made to a node
  * within the same transaction.
  *
- * NB: we rely on the fact that we don't need to do full escaping on the names
- * generated here.
  */
 static void
 Assign2PCIdentifier(MultiConnection *connection)
@@ -1431,13 +1429,13 @@ WarnAboutLeakedPreparedTransaction(MultiConnection *connection, bool commit)
 
 	if (commit)
 	{
-		appendStringInfo(&command, "COMMIT PREPARED '%s'",
-						 transaction->preparedName);
+		appendStringInfo(&command, "COMMIT PREPARED %s",
+						 quote_literal_cstr(transaction->preparedName));
 	}
 	else
 	{
-		appendStringInfo(&command, "ROLLBACK PREPARED '%s'",
-						 transaction->preparedName);
+		appendStringInfo(&command, "ROLLBACK PREPARED %s",
+						 quote_literal_cstr(transaction->preparedName));
 	}
 
 	/* log a warning so the user may abort the transaction later */

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -499,12 +499,14 @@ RecoverPreparedTransactionOnWorker(MultiConnection *connection, char *transactio
 	if (shouldCommit)
 	{
 		/* should have committed this prepared transaction */
-		appendStringInfo(command, "COMMIT PREPARED '%s'", transactionName);
+		appendStringInfo(command, "COMMIT PREPARED %s",
+						 quote_literal_cstr(transactionName));
 	}
 	else
 	{
 		/* should have aborted this prepared transaction */
-		appendStringInfo(command, "ROLLBACK PREPARED '%s'", transactionName);
+		appendStringInfo(command, "ROLLBACK PREPARED %s",
+						 quote_literal_cstr(transactionName));
 	}
 
 	executeCommand = ExecuteOptionalRemoteCommand(connection, command->data, &result);

--- a/src/test/regress/expected/multi_mx_truncate_from_worker.out
+++ b/src/test/regress/expected/multi_mx_truncate_from_worker.out
@@ -5,8 +5,8 @@ SET citus.next_placement_id TO 2380000;
 SET citus.shard_replication_factor TO 1;
 SET citus.shard_count TO 6;
 SET citus.replication_model TO streaming;
-CREATE TABLE referece_table(id int PRIMARY KEY);
-SELECT create_reference_table('referece_table');
+CREATE TABLE "refer'ence_table"(id int PRIMARY KEY);
+SELECT create_reference_table('refer''ence_table');
  create_reference_table 
 ------------------------
  
@@ -19,8 +19,8 @@ SELECT create_distributed_table('on_update_fkey_table', 'id');
  
 (1 row)
 
-ALTER TABLE on_update_fkey_table ADD CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES referece_table(id) ON UPDATE CASCADE;
-INSERT INTO referece_table SELECT i FROM generate_series(0, 100) i;
+ALTER TABLE on_update_fkey_table ADD CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES "refer'ence_table"(id) ON UPDATE CASCADE;
+INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 -- first, make sure that truncate from the coordinator workers as expected
 TRUNCATE on_update_fkey_table;
@@ -33,7 +33,7 @@ SELECT count(*) FROM on_update_fkey_table;
 -- fill the table again
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 -- now, show that TRUNCATE CASCADE works expected from the coordinator
-TRUNCATE referece_table CASCADE;
+TRUNCATE "refer'ence_table" CASCADE;
 NOTICE:  truncate cascades to table "on_update_fkey_table"
 SELECT count(*) FROM on_update_fkey_table;
  count 
@@ -41,14 +41,14 @@ SELECT count(*) FROM on_update_fkey_table;
      0
 (1 row)
 
-SELECT count(*) FROM referece_table;
+SELECT count(*) FROM "refer'ence_table";
  count 
 -------
      0
 (1 row)
 
 -- load some data for the next tests
-INSERT INTO referece_table SELECT i FROM generate_series(0, 100) i;
+INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 -- make sure that DDLs along with TRUNCATE worker fine
 BEGIN;
@@ -71,10 +71,10 @@ SELECT count(*) FROM on_update_fkey_table;
      0
 (1 row)
 
--- load some data 
+-- load some data
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 -- now, show that TRUNCATE CASCADE works expected from the worker
-TRUNCATE referece_table CASCADE;
+TRUNCATE "refer'ence_table" CASCADE;
 NOTICE:  truncate cascades to table "on_update_fkey_table"
 SELECT count(*) FROM on_update_fkey_table;
  count 
@@ -82,7 +82,7 @@ SELECT count(*) FROM on_update_fkey_table;
      0
 (1 row)
 
-SELECT count(*) FROM referece_table;
+SELECT count(*) FROM "refer'ence_table";
  count 
 -------
      0
@@ -94,20 +94,20 @@ BEGIN;
 ROLLBACK;
 -- test within transaction blocks
 BEGIN;
-	TRUNCATE referece_table CASCADE;
+	TRUNCATE "refer'ence_table" CASCADE;
 NOTICE:  truncate cascades to table "on_update_fkey_table"
 ROLLBACK;
 -- test with sequential mode and CASCADE
 BEGIN;
 	SET LOCAL citus.multi_shard_modify_mode TO sequential;
 	TRUNCATE on_update_fkey_table;
-	TRUNCATE referece_table CASCADE;
+	TRUNCATE "refer'ence_table" CASCADE;
 NOTICE:  truncate cascades to table "on_update_fkey_table"
 ROLLBACK;
 -- fill some data for the next test
 \c - - - :master_port
 SET search_path TO 'truncate_from_workers';
-INSERT INTO referece_table SELECT i FROM generate_series(0, 100) i;
+INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 \c - - - :worker_1_port
 SET search_path TO 'truncate_from_workers';
 -- make sure that DMLs-SELECTs works along with TRUNCATE worker fine
@@ -129,7 +129,7 @@ BEGIN;
 ROLLBACK;
 RESET client_min_messages;
 \c - - - :master_port
--- also test the infrastructure that is used for supporting 
+-- also test the infrastructure that is used for supporting
 -- TRUNCATE from worker nodes
 -- should fail since it is not in transaction block
 SELECT lock_relation_if_exists('on_update_fkey_table', 'ACCESS SHARE');
@@ -240,6 +240,6 @@ BEGIN;
 COMMIT;
 DROP SCHEMA truncate_from_workers CASCADE;
 NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table truncate_from_workers.referece_table
+DETAIL:  drop cascades to table truncate_from_workers."refer'ence_table"
 drop cascades to table truncate_from_workers.on_update_fkey_table
 SET search_path TO public;

--- a/src/test/regress/sql/multi_mx_truncate_from_worker.sql
+++ b/src/test/regress/sql/multi_mx_truncate_from_worker.sql
@@ -8,15 +8,15 @@ SET citus.shard_replication_factor TO 1;
 SET citus.shard_count TO 6;
 SET citus.replication_model TO streaming;
 
-CREATE TABLE referece_table(id int PRIMARY KEY);
-SELECT create_reference_table('referece_table');
+CREATE TABLE "refer'ence_table"(id int PRIMARY KEY);
+SELECT create_reference_table('refer''ence_table');
 
 CREATE TABLE on_update_fkey_table(id int PRIMARY KEY, value_1 int);
 SELECT create_distributed_table('on_update_fkey_table', 'id');
 
-ALTER TABLE on_update_fkey_table ADD CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES referece_table(id) ON UPDATE CASCADE;
+ALTER TABLE on_update_fkey_table ADD CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES "refer'ence_table"(id) ON UPDATE CASCADE;
 
-INSERT INTO referece_table SELECT i FROM generate_series(0, 100) i;
+INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 
 -- first, make sure that truncate from the coordinator workers as expected
@@ -27,12 +27,12 @@ SELECT count(*) FROM on_update_fkey_table;
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 
 -- now, show that TRUNCATE CASCADE works expected from the coordinator
-TRUNCATE referece_table CASCADE;
+TRUNCATE "refer'ence_table" CASCADE;
 SELECT count(*) FROM on_update_fkey_table;
-SELECT count(*) FROM referece_table;
+SELECT count(*) FROM "refer'ence_table";
 
 -- load some data for the next tests
-INSERT INTO referece_table SELECT i FROM generate_series(0, 100) i;
+INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 
 -- make sure that DDLs along with TRUNCATE worker fine
@@ -50,13 +50,13 @@ SET search_path TO 'truncate_from_workers';
 TRUNCATE on_update_fkey_table;
 SELECT count(*) FROM on_update_fkey_table;
 
--- load some data 
+-- load some data
 INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 
 -- now, show that TRUNCATE CASCADE works expected from the worker
-TRUNCATE referece_table CASCADE;
+TRUNCATE "refer'ence_table" CASCADE;
 SELECT count(*) FROM on_update_fkey_table;
-SELECT count(*) FROM referece_table;
+SELECT count(*) FROM "refer'ence_table";
 
 -- test within transaction blocks
 BEGIN;
@@ -65,20 +65,20 @@ ROLLBACK;
 
 -- test within transaction blocks
 BEGIN;
-	TRUNCATE referece_table CASCADE;
+	TRUNCATE "refer'ence_table" CASCADE;
 ROLLBACK;
 
 -- test with sequential mode and CASCADE
 BEGIN;
 	SET LOCAL citus.multi_shard_modify_mode TO sequential;
 	TRUNCATE on_update_fkey_table;
-	TRUNCATE referece_table CASCADE;
+	TRUNCATE "refer'ence_table" CASCADE;
 ROLLBACK;
 
 -- fill some data for the next test
 \c - - - :master_port
 SET search_path TO 'truncate_from_workers';
-INSERT INTO referece_table SELECT i FROM generate_series(0, 100) i;
+INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 
 \c - - - :worker_1_port
 SET search_path TO 'truncate_from_workers';
@@ -95,7 +95,7 @@ RESET client_min_messages;
 
 \c - - - :master_port
 
--- also test the infrastructure that is used for supporting 
+-- also test the infrastructure that is used for supporting
 -- TRUNCATE from worker nodes
 
 -- should fail since it is not in transaction block


### PR DESCRIPTION
While `Assign2PCIdentifier` included *NB: we rely on the fact that we don't need to do full escaping on the names*, it seems best to escape the transaction name regardless

We could end up with a quote slipping through if a user manually inserted data to `pg_dist_transaction` (ParsePreparedTransactionName would at least let it by), though users inserting data into `pg_dist_transaction` is probably outside our threat model

After noticing this, did a search for `'%s'` in codebase. Found an instance in `commands/truncate.c` that seemed suspect. Otherwise all seems fine assuming `workerNode->workerName` can't contain a quote