### PR TITLE
Propagate isactive to metadata nodes.

### DIFF
--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -406,8 +406,7 @@ CreateReferenceTableColocationId()
 /*
  * DeleteAllReferenceTablePlacementsFromNodeGroup function iterates over list of reference
  * tables and deletes all reference table placements from pg_dist_placement table
- * for given group. However, it does not modify replication factor of the colocation
- * group of reference tables. It is caller's responsibility to do that if it is necessary.
+ * for given group.
  */
 void
 DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId)

--- a/src/test/regress/expected/multi_mx_node_metadata.out
+++ b/src/test/regress/expected/multi_mx_node_metadata.out
@@ -210,7 +210,7 @@ SELECT nodeid, hasmetadata, metadatasynced FROM pg_dist_node;
 --------------------------------------------------------------------------
 -- Test updating a node when another node is in readonly-mode
 --------------------------------------------------------------------------
-SELECT FROM master_add_node('localhost', :worker_2_port) AS nodeid_2 \gset
+SELECT master_add_node('localhost', :worker_2_port) AS nodeid_2 \gset
 NOTICE:  Replicating reference table "ref_table" to the node localhost:57638
 SELECT 1 FROM start_metadata_sync_to_node('localhost', :worker_2_port);
  ?column? 
@@ -403,8 +403,166 @@ SELECT verify_metadata('localhost', :worker_1_port),
  t               | t
 (1 row)
 
+--------------------------------------------------------------------------
+-- Test that changes in isactive is propagated to the metadata nodes
+--------------------------------------------------------------------------
+-- Don't drop the reference table so it has shards on the nodes being disabled
+DROP TABLE dist_table_1, dist_table_2;
+SELECT 1 FROM master_disable_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port);
+ verify_metadata 
+-----------------
+ t
+(1 row)
+
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
+NOTICE:  Replicating reference table "ref_table" to the node localhost:57638
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port);
+ verify_metadata 
+-----------------
+ t
+(1 row)
+
+------------------------------------------------------------------------------------
+-- Test master_disable_node() when the node that is being disabled is actually down
+------------------------------------------------------------------------------------
+SELECT master_update_node(:nodeid_2, 'localhost', 1);
+ master_update_node 
+--------------------
+ 
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+-- set metadatasynced so we try porpagating metadata changes
+UPDATE pg_dist_node SET metadatasynced = TRUE WHERE nodeid IN (:nodeid_1, :nodeid_2);
+-- should error out
+SELECT 1 FROM master_disable_node('localhost', 1);
+ERROR:  Disabling localhost:1 failed
+DETAIL:  connection error: localhost:1
+HINT:  If you are using MX, try stop_metadata_sync_to_node(hostname, port) for nodes that are down before disabling them.
+-- try again after stopping metadata sync
+SELECT stop_metadata_sync_to_node('localhost', 1);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
+SELECT 1 FROM master_disable_node('localhost', 1);
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port);
+ verify_metadata 
+-----------------
+ t
+(1 row)
+
+SELECT master_update_node(:nodeid_2, 'localhost', :worker_2_port);
+ master_update_node 
+--------------------
+ 
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
+NOTICE:  Replicating reference table "ref_table" to the node localhost:57638
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port);
+ verify_metadata 
+-----------------
+ t
+(1 row)
+
+------------------------------------------------------------------------------------
+-- Test master_disable_node() when the other node is down
+------------------------------------------------------------------------------------
+-- node 1 is down.
+SELECT master_update_node(:nodeid_1, 'localhost', 1);
+ master_update_node 
+--------------------
+ 
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+-- set metadatasynced so we try porpagating metadata changes
+UPDATE pg_dist_node SET metadatasynced = TRUE WHERE nodeid IN (:nodeid_1, :nodeid_2);
+-- should error out
+SELECT 1 FROM master_disable_node('localhost', :worker_2_port);
+ERROR:  Disabling localhost:57638 failed
+DETAIL:  connection error: localhost:1
+HINT:  If you are using MX, try stop_metadata_sync_to_node(hostname, port) for nodes that are down before disabling them.
+-- try again after stopping metadata sync
+SELECT stop_metadata_sync_to_node('localhost', 1);
+ stop_metadata_sync_to_node 
+----------------------------
+ 
+(1 row)
+
+SELECT 1 FROM master_disable_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+-- bring up node 1
+SELECT master_update_node(:nodeid_1, 'localhost', :worker_1_port);
+ master_update_node 
+--------------------
+ 
+(1 row)
+
+SELECT wait_until_metadata_sync();
+ wait_until_metadata_sync 
+--------------------------
+ 
+(1 row)
+
+SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
+NOTICE:  Replicating reference table "ref_table" to the node localhost:57638
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT verify_metadata('localhost', :worker_1_port);
+ verify_metadata 
+-----------------
+ t
+(1 row)
+
 -- cleanup
-DROP TABLE dist_table_1, ref_table, dist_table_2;
+DROP TABLE ref_table;
 TRUNCATE pg_dist_colocation;
 SELECT count(*) FROM (SELECT master_remove_node(nodename, nodeport) FROM pg_dist_node) t;
  count 

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -14,7 +14,7 @@
 # Tests around schema changes, these are run first, so there's no preexisting objects.
 # ---
 test: multi_extension
-test: multi_mx_master_update_node
+test: multi_mx_node_metadata
 test: multi_cluster_management
 test: multi_test_helpers
 


### PR DESCRIPTION
We use `isactive` in planners, so not propagating to the worker nodes can result in wrong behaviour. Without this, we can get into replica inconsistency easily. Start metadata sync to node 1, add node 2, then insert into a reference table from node 1. We didn't replicate the change to the replica in node 2 in that case, because node 1 didn't see node 2 as active.
