### PR TITLE
Remove citus.worker_list_file & master_initialize_node_metadata

### DIFF
--- a/src/backend/distributed/sql/citus--7.0-1.sql
+++ b/src/backend/distributed/sql/citus--7.0-1.sql
@@ -1,4 +1,4 @@
---  citus--7.0-1.sql 
+--  citus--7.0-1.sql
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION citus" to load this file. \quit
@@ -44,7 +44,7 @@ CREATE TABLE citus.pg_dist_partition(
 	colocationid integer DEFAULT 0 NOT NULL,
 	repmodel "char" DEFAULT 'c' NOT NULL
 );
---  SELECT granted to PUBLIC in upgrade script 
+--  SELECT granted to PUBLIC in upgrade script
 CREATE UNIQUE INDEX pg_dist_partition_logical_relid_index
 ON citus.pg_dist_partition using btree(logicalrelid);
 ALTER TABLE citus.pg_dist_partition SET SCHEMA pg_catalog;
@@ -62,7 +62,7 @@ CREATE TABLE citus.pg_dist_shard(
 -- ALTER-after-CREATE to keep table tuple layout consistent
 -- with earlier versions of Citus.
 ALTER TABLE citus.pg_dist_shard DROP shardalias;
---  SELECT granted to PUBLIC in upgrade script 
+--  SELECT granted to PUBLIC in upgrade script
 CREATE UNIQUE INDEX pg_dist_shard_shardid_index
 ON citus.pg_dist_shard using btree(shardid);
 CREATE INDEX pg_dist_shard_logical_relid_index
@@ -82,7 +82,7 @@ CREATE TABLE citus.pg_dist_shard_placement(
     nodeport int8 NOT NULL,
 	placementid bigint NOT NULL DEFAULT nextval('pg_catalog.pg_dist_shard_placement_placementid_seq')
 );
---  SELECT granted to PUBLIC in upgrade script 
+--  SELECT granted to PUBLIC in upgrade script
 CREATE UNIQUE INDEX pg_dist_shard_placement_placementid_index
 ON citus.pg_dist_shard_placement using btree(placementid);
 CREATE INDEX pg_dist_shard_placement_shardid_index
@@ -105,17 +105,17 @@ ALTER SEQUENCE  citus.pg_dist_shardid_seq SET SCHEMA pg_catalog;
 -- used to identify jobs in the distributed database; and they wrap at 32-bits
 -- to allow for worker nodes to independently execute their distributed jobs.
 CREATE SEQUENCE citus.pg_dist_jobid_seq
-    MINVALUE 2 --  first jobId reserved for clean up jobs 
+    MINVALUE 2 --  first jobId reserved for clean up jobs
     MAXVALUE 4294967296;
 ALTER SEQUENCE  citus.pg_dist_jobid_seq SET SCHEMA pg_catalog;
 
 
 -- Citus functions
 
---  For backward compatibility and ease of use create functions et al. in pg_catalog 
+--  For backward compatibility and ease of use create functions et al. in pg_catalog
 SET search_path = 'pg_catalog';
 
---  master_* functions 
+--  master_* functions
 
 CREATE FUNCTION master_get_table_metadata(relation_name text, OUT logical_relid oid,
                                           OUT part_storage_type "char",
@@ -198,7 +198,7 @@ RETURNS void
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
---  task_tracker_* functions 
+--  task_tracker_* functions
 
 CREATE FUNCTION task_tracker_assign_task(bigint, integer, text)
     RETURNS void
@@ -222,7 +222,7 @@ COMMENT ON FUNCTION task_tracker_cleanup_job(bigint)
     IS 'clean up all tasks associated with a job';
 
 
---  worker_* functions 
+--  worker_* functions
 
 CREATE FUNCTION worker_fetch_partition_file(bigint, integer, integer, integer, text,
                                             integer)
@@ -284,7 +284,7 @@ CREATE FUNCTION master_drop_sequences(sequence_names text[])
 COMMENT ON FUNCTION master_drop_sequences(text[])
     IS 'drop specified sequences from the cluster';
 
---  trigger functions 
+--  trigger functions
 
 CREATE FUNCTION pg_catalog.citus_drop_trigger()
     RETURNS event_trigger
@@ -347,7 +347,7 @@ COMMENT ON FUNCTION master_dist_shard_cache_invalidate()
     IS 'register relcache invalidation for changed rows';
 
 
---  internal functions, not user accessible 
+--  internal functions, not user accessible
 
 CREATE FUNCTION citus_extradata_container(INTERNAL)
     RETURNS void
@@ -385,7 +385,7 @@ GRANT SELECT ON pg_catalog.pg_dist_partition TO public;
 GRANT SELECT ON pg_catalog.pg_dist_shard TO public;
 GRANT SELECT ON pg_catalog.pg_dist_shard_placement TO public;
 
---  empty, but required to update the extension version 
+--  empty, but required to update the extension version
 CREATE FUNCTION pg_catalog.master_modify_multiple_shards(text)
     RETURNS integer
     LANGUAGE C STRICT
@@ -462,7 +462,7 @@ CREATE SEQUENCE citus.pg_dist_node_nodeid_seq
 ALTER SEQUENCE citus.pg_dist_groupid_seq SET SCHEMA pg_catalog;
 ALTER SEQUENCE citus.pg_dist_node_nodeid_seq SET SCHEMA pg_catalog;
 
---  add pg_dist_node 
+--  add pg_dist_node
 CREATE TABLE citus.pg_dist_node(
 	nodeid int NOT NULL DEFAULT nextval('pg_dist_groupid_seq') PRIMARY KEY,
 	groupid int NOT NULL DEFAULT nextval('pg_dist_node_nodeid_seq'),
@@ -495,14 +495,6 @@ CREATE FUNCTION master_remove_node(nodename text, nodeport integer)
 	AS 'MODULE_PATHNAME', $$master_remove_node$$;
 COMMENT ON FUNCTION master_remove_node(nodename text, nodeport integer)
 	IS 'remove node from the cluster';
-
---  this only needs to run once, now. 
-CREATE FUNCTION master_initialize_node_metadata()
-    RETURNS BOOL
-    LANGUAGE C STRICT
-    AS 'MODULE_PATHNAME', $$master_initialize_node_metadata$$;
-
-SELECT master_initialize_node_metadata();
 
 RESET search_path;
 
@@ -552,7 +544,7 @@ CREATE TABLE citus.pg_dist_local_group(
     groupid int NOT NULL PRIMARY KEY)
 ;
 
---  insert the default value for being the coordinator node 
+--  insert the default value for being the coordinator node
 INSERT INTO citus.pg_dist_local_group VALUES (0);
 
 ALTER TABLE citus.pg_dist_local_group SET SCHEMA pg_catalog;
@@ -588,7 +580,7 @@ CREATE SEQUENCE citus.pg_dist_colocationid_seq
 
 ALTER SEQUENCE citus.pg_dist_colocationid_seq SET SCHEMA pg_catalog;
 
---  add pg_dist_colocation 
+--  add pg_dist_colocation
 CREATE TABLE citus.pg_dist_colocation(
 	colocationid int NOT NULL PRIMARY KEY,
 	shardcount int NOT NULL,

--- a/src/backend/distributed/sql/citus--8.0-8--8.0-9.sql
+++ b/src/backend/distributed/sql/citus--8.0-8--8.0-9.sql
@@ -1,4 +1,4 @@
---  citus--8.0-8--8.0-9 
+--  citus--8.0-8--8.0-9
 SET search_path = 'pg_catalog';
 
 REVOKE ALL ON FUNCTION master_activate_node(text,int) FROM PUBLIC;
@@ -6,7 +6,6 @@ REVOKE ALL ON FUNCTION master_add_inactive_node(text,int,int,noderole,name) FROM
 REVOKE ALL ON FUNCTION master_add_node(text,int,int,noderole,name) FROM PUBLIC;
 REVOKE ALL ON FUNCTION master_add_secondary_node(text,int,text,int,name) FROM PUBLIC;
 REVOKE ALL ON FUNCTION master_disable_node(text,int) FROM PUBLIC;
-REVOKE ALL ON FUNCTION master_initialize_node_metadata() FROM PUBLIC;
 REVOKE ALL ON FUNCTION master_remove_node(text,int) FROM PUBLIC;
 REVOKE ALL ON FUNCTION master_update_node(int,text,int) FROM PUBLIC;
 

--- a/src/backend/distributed/sql/citus--9.0-2--9.1-1.sql
+++ b/src/backend/distributed/sql/citus--9.0-2--9.1-1.sql
@@ -10,3 +10,7 @@ COMMENT ON COLUMN pg_catalog.pg_dist_node.shouldhaveshards IS
 UPDATE pg_dist_colocation SET replicationfactor = -1 WHERE distributioncolumntype = 0;
 
 #include "udfs/any_value/9.1-1.sql"
+
+-- drop function which was used for upgrading from 6.0
+-- creation was removed from citus--7.0-1.sql
+DROP FUNCTION IF EXISTS pg_catalog.master_initialize_node_metadata;

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -27,9 +27,6 @@
 /* Maximum length of worker port number (represented as string) */
 #define MAX_PORT_LENGTH 10
 
-/* default filename for citus.worker_list_file */
-#define WORKER_LIST_FILENAME "pg_worker_list.conf"
-
 /* Implementation specific definitions used in finding worker nodes */
 #define WORKER_RACK_TRIES 5
 #define WORKER_DEFAULT_RACK "default"

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -151,8 +151,6 @@ GRANT EXECUTE ON FUNCTION master_remove_node(text,int) TO node_metadata_user;
 GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool,int) TO node_metadata_user;
 -- try to manipulate node metadata via non-super user
 SET ROLE non_super_user;
-SELECT 1 FROM master_initialize_node_metadata();
-ERROR:  permission denied for function master_initialize_node_metadata
 SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port + 1);
 ERROR:  permission denied for function master_add_inactive_node
 SELECT 1 FROM master_activate_node('localhost', :worker_2_port + 1);

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -70,7 +70,6 @@ GRANT EXECUTE ON FUNCTION master_update_node(int,text,int,bool,int) TO node_meta
 
 -- try to manipulate node metadata via non-super user
 SET ROLE non_super_user;
-SELECT 1 FROM master_initialize_node_metadata();
 SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port + 1);
 SELECT 1 FROM master_activate_node('localhost', :worker_2_port + 1);
 SELECT 1 FROM master_disable_node('localhost', :worker_2_port + 1);


### PR DESCRIPTION
DESCRIPTION: remove `citus.worker_list_file` GUC

Also removes `master_initialize_node_metadata`

Not sure best way to remove a function. I've updated previous version scripts, could cause issue if someone were to upgrade to 8.1 from 7.0. Other option I thought of would be leaving an empty function definition to keep the symbol around

Fixes #848