### PR TITLE
fix connect error, epoll_ctl failed: file or directory not exist.

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2122,8 +2122,30 @@ ManageWorkerPool(WorkerPool *workerPool)
 		/* create a session for the connection */
 		session = FindOrCreateWorkerSession(workerPool, connection);
 
+		pollMode = PQconnectPoll(connection->pgConn);
+		if (pollMode == PGRES_POLLING_FAILED)
+		{
+			ereport(ERROR, (errcode(ERRCODE_CONNECTION_FAILURE),
+						errmsg("could not establish any connections to the node "
+							"%s:%d", workerPool->nodeName,
+							workerPool->nodePort)));
+		}
+		else if (pollMode == PGRES_POLLING_READING)
+		{
+			waitFlags |= WL_SOCKET_READABLE;
+		}
+		else if (pollMode == PGRES_POLLING_WRITING)
+		{
+			waitFlags |= WL_SOCKET_WRITEABLE;
+		}
+		else
+		{
+			/* PGRES_POLLING_OK */
+			waitFlags |= WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE;
+		}
+
 		/* always poll the connection in the first round */
-		UpdateConnectionWaitFlags(session, WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE);
+		UpdateConnectionWaitFlags(session, waitFlags);
 	}
 
 	workerPool->lastConnectionOpenTime = GetCurrentTimestamp();


### PR DESCRIPTION
because we use async connect module. when pgStatus is CONNECTION_STARTED
then pollMode(PQconnectPoll) is PGRES_POLLING_WRITING, so we need set
the envent from pollMode. but we init it to
'WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE' when ManageWorkerPool.

see code:
GetPlacementListConnection->FinishConnectionEstablishment->
FinishConnectionListEstablishment->MultiConnectionStatePoll
the first status is get from PQconnectPoll

DESCRIPTION: PR description that will go into the change log, up to 78 characters
