### PR TITLE
Automatically convert useless declarations using regex replace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,12 @@ jobs:
       - run:
           name: 'Check Style'
           command: citus_indent --check
+      - run:
+          name: 'Remove useless declarations'
+          command: ci/remove_useless_declarations.sh
+      - run:
+          name: 'Check if changed'
+          command: git diff --cached --exit-code
   check-sql-snapshots:
     docker:
       - image: 'citus/extbuilder:latest'

--- a/ci/remove_useless_declarations.sh
+++ b/ci/remove_useless_declarations.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+files=$(find src -iname '*.c' | git check-attr --stdin citus-style | grep -v ': unset$' | sed 's/: citus-style: set$//')
+while true; do
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t)?(?=\b(?P=variable)\b))(?<=\n\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t$+{type}$+{variable} =/sg' $files
+    # The following are simply the same regex, but repeated for different tab sizes
+    # (this is needed because variable sized backtracking is not supported in perl)
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t\t\t$+{type}$+{variable} =/sg' $files
+    git diff --quiet && break;
+    git add .;
+done

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -47,11 +47,11 @@ static bool CallFuncExprRemotely(CallStmt *callStmt,
 bool
 CallDistributedProcedureRemotely(CallStmt *callStmt, DestReceiver *dest)
 {
-	DistObjectCacheEntry *procedure = NULL;
 	FuncExpr *funcExpr = callStmt->funcexpr;
 	Oid functionId = funcExpr->funcid;
 
-	procedure = LookupDistObjectCacheEntry(ProcedureRelationId, functionId, 0);
+	DistObjectCacheEntry *procedure = LookupDistObjectCacheEntry(ProcedureRelationId,
+																 functionId, 0);
 	if (procedure == NULL || !procedure->isDistributed)
 	{
 		return false;
@@ -68,25 +68,13 @@ static bool
 CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 					 FuncExpr *funcExpr, DestReceiver *dest)
 {
-	Oid colocatedRelationId = InvalidOid;
-	Node *partitionValueNode = NULL;
-	Const *partitionValue = NULL;
-	Datum partitionValueDatum = 0;
-	ShardInterval *shardInterval = NULL;
-	List *placementList = NIL;
-	DistTableCacheEntry *distTable = NULL;
-	Var *partitionColumn = NULL;
-	ShardPlacement *placement = NULL;
-	WorkerNode *workerNode = NULL;
-	StringInfo callCommand = NULL;
-
 	if (IsMultiStatementTransaction())
 	{
 		ereport(DEBUG1, (errmsg("cannot push down CALL in multi-statement transaction")));
 		return false;
 	}
 
-	colocatedRelationId = ColocatedTableId(procedure->colocationId);
+	Oid colocatedRelationId = ColocatedTableId(procedure->colocationId);
 	if (colocatedRelationId == InvalidOid)
 	{
 		ereport(DEBUG1, (errmsg("stored procedure does not have co-located tables")));
@@ -107,8 +95,8 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		return false;
 	}
 
-	distTable = DistributedTableCacheEntry(colocatedRelationId);
-	partitionColumn = distTable->partitionColumn;
+	DistTableCacheEntry *distTable = DistributedTableCacheEntry(colocatedRelationId);
+	Var *partitionColumn = distTable->partitionColumn;
 	if (partitionColumn == NULL)
 	{
 		/* This can happen if colocated with a reference table. Punt for now. */
@@ -117,17 +105,17 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		return false;
 	}
 
-	partitionValueNode = (Node *) list_nth(funcExpr->args,
-										   procedure->distributionArgIndex);
+	Node *partitionValueNode = (Node *) list_nth(funcExpr->args,
+												 procedure->distributionArgIndex);
 	partitionValueNode = strip_implicit_coercions(partitionValueNode);
 	if (!IsA(partitionValueNode, Const))
 	{
 		ereport(DEBUG1, (errmsg("distribution argument value must be a constant")));
 		return false;
 	}
-	partitionValue = (Const *) partitionValueNode;
+	Const *partitionValue = (Const *) partitionValueNode;
 
-	partitionValueDatum = partitionValue->constvalue;
+	Datum partitionValueDatum = partitionValue->constvalue;
 	if (partitionValue->consttype != partitionColumn->vartype)
 	{
 		CopyCoercionData coercionData;
@@ -138,14 +126,14 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		partitionValueDatum = CoerceColumnValue(partitionValueDatum, &coercionData);
 	}
 
-	shardInterval = FindShardInterval(partitionValueDatum, distTable);
+	ShardInterval *shardInterval = FindShardInterval(partitionValueDatum, distTable);
 	if (shardInterval == NULL)
 	{
 		ereport(DEBUG1, (errmsg("cannot push down call, failed to find shard interval")));
 		return false;
 	}
 
-	placementList = FinalizedShardPlacementList(shardInterval->shardId);
+	List *placementList = FinalizedShardPlacementList(shardInterval->shardId);
 	if (list_length(placementList) != 1)
 	{
 		/* punt on this for now */
@@ -154,8 +142,8 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		return false;
 	}
 
-	placement = (ShardPlacement *) linitial(placementList);
-	workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
+	ShardPlacement *placement = (ShardPlacement *) linitial(placementList);
+	WorkerNode *workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
 	if (workerNode == NULL || !workerNode->hasMetadata || !workerNode->metadataSynced)
 	{
 		ereport(DEBUG1, (errmsg("there is no worker node with metadata")));
@@ -165,7 +153,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 	ereport(DEBUG1, (errmsg("pushing down the procedure")));
 
 	/* build remote command with fully qualified names */
-	callCommand = makeStringInfo();
+	StringInfo callCommand = makeStringInfo();
 	appendStringInfo(callCommand, "CALL %s", pg_get_rule_expr((Node *) funcExpr));
 
 	{

--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -28,11 +28,10 @@ PlanClusterStmt(ClusterStmt *clusterStmt, const char *clusterCommand)
 	}
 	else
 	{
-		Oid relationId = InvalidOid;
 		bool missingOK = false;
 
-		relationId = RangeVarGetRelid(clusterStmt->relation, AccessShareLock,
-									  missingOK);
+		Oid relationId = RangeVarGetRelid(clusterStmt->relation, AccessShareLock,
+										  missingOK);
 
 		if (OidIsValid(relationId))
 		{

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -50,7 +50,6 @@ void
 EnsureDependenciesExistsOnAllNodes(const ObjectAddress *target)
 {
 	/* local variables to work with dependencies */
-	List *dependencies = NIL;
 	List *dependenciesWithCommands = NIL;
 	ListCell *dependencyCell = NULL;
 
@@ -58,13 +57,12 @@ EnsureDependenciesExistsOnAllNodes(const ObjectAddress *target)
 	List *ddlCommands = NULL;
 
 	/* local variables to work with worker nodes */
-	List *workerNodeList = NULL;
 	ListCell *workerNodeCell = NULL;
 
 	/*
 	 * collect all dependencies in creation order and get their ddl commands
 	 */
-	dependencies = GetDependenciesForObject(target);
+	List *dependencies = GetDependenciesForObject(target);
 	foreach(dependencyCell, dependencies)
 	{
 		ObjectAddress *dependency = (ObjectAddress *) lfirst(dependencyCell);
@@ -94,7 +92,7 @@ EnsureDependenciesExistsOnAllNodes(const ObjectAddress *target)
 	 * either get it now, or get it in master_add_node after this transaction finishes and
 	 * the pg_dist_object record becomes visible.
 	 */
-	workerNodeList = ActivePrimaryWorkerNodeList(RowShareLock);
+	List *workerNodeList = ActivePrimaryWorkerNodeList(RowShareLock);
 
 	/*
 	 * right after we acquired the lock we mark our objects as distributed, these changes
@@ -216,13 +214,12 @@ void
 ReplicateAllDependenciesToNode(const char *nodeName, int nodePort)
 {
 	ListCell *dependencyCell = NULL;
-	List *dependencies = NIL;
 	List *ddlCommands = NIL;
 
 	/*
 	 * collect all dependencies in creation order and get their ddl commands
 	 */
-	dependencies = GetDistributedObjectAddressList();
+	List *dependencies = GetDistributedObjectAddressList();
 
 	/*
 	 * Depending on changes in the environment, such as the enable_object_propagation guc

--- a/src/backend/distributed/commands/drop_distributed_table.c
+++ b/src/backend/distributed/commands/drop_distributed_table.c
@@ -126,8 +126,6 @@ static void
 MasterRemoveDistributedTableMetadataFromWorkers(Oid relationId, char *schemaName,
 												char *tableName)
 {
-	char *deleteDistributionCommand = NULL;
-
 	/*
 	 * The SQL_DROP trigger calls this function even for tables that are
 	 * not distributed. In that case, silently ignore. This is not very
@@ -147,6 +145,6 @@ MasterRemoveDistributedTableMetadataFromWorkers(Oid relationId, char *schemaName
 	}
 
 	/* drop the distributed table metadata on the workers */
-	deleteDistributionCommand = DistributionDeleteCommand(schemaName, tableName);
+	char *deleteDistributionCommand = DistributionDeleteCommand(schemaName, tableName);
 	SendCommandToWorkers(WORKERS_WITH_METADATA, deleteDistributionCommand);
 }

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -82,8 +82,6 @@ ErrorIfUnstableCreateOrAlterExtensionStmt(Node *parseTree)
 static char *
 ExtractNewExtensionVersion(Node *parseTree)
 {
-	Value *newVersionValue = NULL;
-
 	List *optionsList = NIL;
 
 	if (IsA(parseTree, CreateExtensionStmt))
@@ -100,7 +98,7 @@ ExtractNewExtensionVersion(Node *parseTree)
 		Assert(false);
 	}
 
-	newVersionValue = GetExtensionOption(optionsList, "new_version");
+	Value *newVersionValue = GetExtensionOption(optionsList, "new_version");
 
 	/* return target string safely */
 	if (newVersionValue)
@@ -126,9 +124,6 @@ ExtractNewExtensionVersion(Node *parseTree)
 List *
 PlanCreateExtensionStmt(CreateExtensionStmt *createExtensionStmt, const char *queryString)
 {
-	List *commands = NIL;
-	const char *createExtensionStmtSql = NULL;
-
 	if (!ShouldPropagateExtensionCommand((Node *) createExtensionStmt))
 	{
 		return NIL;
@@ -168,15 +163,15 @@ PlanCreateExtensionStmt(CreateExtensionStmt *createExtensionStmt, const char *qu
 	 */
 	AddSchemaFieldIfMissing(createExtensionStmt);
 
-	createExtensionStmtSql = DeparseTreeNode((Node *) createExtensionStmt);
+	const char *createExtensionStmtSql = DeparseTreeNode((Node *) createExtensionStmt);
 
 	/*
 	 * To prevent recursive propagation in mx architecture, we disable ddl
 	 * propagation before sending the command to workers.
 	 */
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) createExtensionStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) createExtensionStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -229,8 +224,6 @@ void
 ProcessCreateExtensionStmt(CreateExtensionStmt *createExtensionStmt, const
 						   char *queryString)
 {
-	const ObjectAddress *extensionAddress = NULL;
-
 	if (!ShouldPropagateExtensionCommand((Node *) createExtensionStmt))
 	{
 		return;
@@ -246,7 +239,8 @@ ProcessCreateExtensionStmt(CreateExtensionStmt *createExtensionStmt, const
 		return;
 	}
 
-	extensionAddress = GetObjectAddressFromParseTree((Node *) createExtensionStmt, false);
+	const ObjectAddress *extensionAddress = GetObjectAddressFromParseTree(
+		(Node *) createExtensionStmt, false);
 
 	EnsureDependenciesExistsOnAllNodes(extensionAddress);
 
@@ -267,11 +261,6 @@ PlanDropExtensionStmt(DropStmt *dropStmt, const char *queryString)
 {
 	List *allDroppedExtensions = dropStmt->objects;
 
-	List *distributedExtensions = NIL;
-	List *distributedExtensionAddresses = NIL;
-
-	List *commands = NIL;
-	const char *deparsedStmt = NULL;
 
 	ListCell *addressCell = NULL;
 
@@ -281,7 +270,7 @@ PlanDropExtensionStmt(DropStmt *dropStmt, const char *queryString)
 	}
 
 	/* get distributed extensions to be dropped in worker nodes as well */
-	distributedExtensions = FilterDistributedExtensions(allDroppedExtensions);
+	List *distributedExtensions = FilterDistributedExtensions(allDroppedExtensions);
 
 	if (list_length(distributedExtensions) <= 0)
 	{
@@ -308,7 +297,7 @@ PlanDropExtensionStmt(DropStmt *dropStmt, const char *queryString)
 	 */
 	EnsureSequentialModeForExtensionDDL();
 
-	distributedExtensionAddresses = ExtensionNameListToObjectAddressList(
+	List *distributedExtensionAddresses = ExtensionNameListToObjectAddressList(
 		distributedExtensions);
 
 	/* unmark each distributed extension */
@@ -326,7 +315,7 @@ PlanDropExtensionStmt(DropStmt *dropStmt, const char *queryString)
 	 * its execution.
 	 */
 	dropStmt->objects = distributedExtensions;
-	deparsedStmt = DeparseTreeNode((Node *) dropStmt);
+	const char *deparsedStmt = DeparseTreeNode((Node *) dropStmt);
 
 	dropStmt->objects = allDroppedExtensions;
 
@@ -334,9 +323,9 @@ PlanDropExtensionStmt(DropStmt *dropStmt, const char *queryString)
 	 * To prevent recursive propagation in mx architecture, we disable ddl
 	 * propagation before sending the command to workers.
 	 */
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) deparsedStmt,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) deparsedStmt,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -425,9 +414,6 @@ List *
 PlanAlterExtensionSchemaStmt(AlterObjectSchemaStmt *alterExtensionStmt, const
 							 char *queryString)
 {
-	const char *alterExtensionStmtSql = NULL;
-	List *commands = NIL;
-
 	if (!ShouldPropagateExtensionCommand((Node *) alterExtensionStmt))
 	{
 		return NIL;
@@ -451,15 +437,15 @@ PlanAlterExtensionSchemaStmt(AlterObjectSchemaStmt *alterExtensionStmt, const
 	 */
 	EnsureSequentialModeForExtensionDDL();
 
-	alterExtensionStmtSql = DeparseTreeNode((Node *) alterExtensionStmt);
+	const char *alterExtensionStmtSql = DeparseTreeNode((Node *) alterExtensionStmt);
 
 	/*
 	 * To prevent recursive propagation in mx architecture, we disable ddl
 	 * propagation before sending the command to workers.
 	 */
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) alterExtensionStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) alterExtensionStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -474,9 +460,8 @@ void
 ProcessAlterExtensionSchemaStmt(AlterObjectSchemaStmt *alterExtensionStmt, const
 								char *queryString)
 {
-	const ObjectAddress *extensionAddress = NULL;
-
-	extensionAddress = GetObjectAddressFromParseTree((Node *) alterExtensionStmt, false);
+	const ObjectAddress *extensionAddress = GetObjectAddressFromParseTree(
+		(Node *) alterExtensionStmt, false);
 
 	if (!ShouldPropagateExtensionCommand((Node *) alterExtensionStmt))
 	{
@@ -495,9 +480,6 @@ List *
 PlanAlterExtensionUpdateStmt(AlterExtensionStmt *alterExtensionStmt, const
 							 char *queryString)
 {
-	const char *alterExtensionStmtSql = NULL;
-	List *commands = NIL;
-
 	if (!ShouldPropagateExtensionCommand((Node *) alterExtensionStmt))
 	{
 		return NIL;
@@ -522,15 +504,15 @@ PlanAlterExtensionUpdateStmt(AlterExtensionStmt *alterExtensionStmt, const
 	 */
 	EnsureSequentialModeForExtensionDDL();
 
-	alterExtensionStmtSql = DeparseTreeNode((Node *) alterExtensionStmt);
+	const char *alterExtensionStmtSql = DeparseTreeNode((Node *) alterExtensionStmt);
 
 	/*
 	 * To prevent recursive propagation in mx architecture, we disable ddl
 	 * propagation before sending the command to workers.
 	 */
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) alterExtensionStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) alterExtensionStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -711,18 +693,13 @@ IsAlterExtensionSetSchemaCitus(Node *parseTree)
 List *
 CreateExtensionDDLCommand(const ObjectAddress *extensionAddress)
 {
-	List *ddlCommands = NIL;
-	const char *ddlCommand = NULL;
-
-	Node *stmt = NULL;
-
 	/* generate a statement for creation of the extension in "if not exists" construct */
-	stmt = RecreateExtensionStmt(extensionAddress->objectId);
+	Node *stmt = RecreateExtensionStmt(extensionAddress->objectId);
 
 	/* capture ddl command for the create statement */
-	ddlCommand = DeparseTreeNode(stmt);
+	const char *ddlCommand = DeparseTreeNode(stmt);
 
-	ddlCommands = list_make1((void *) ddlCommand);
+	List *ddlCommands = list_make1((void *) ddlCommand);
 
 	return ddlCommands;
 }
@@ -747,26 +724,22 @@ RecreateExtensionStmt(Oid extensionOid)
 	}
 
 	/* schema DefElement related variables */
-	Oid extensionSchemaOid = InvalidOid;
-	char *extensionSchemaName = NULL;
-	Node *schemaNameArg = NULL;
 
 	/* set location to -1 as it is unknown */
 	int location = -1;
-	DefElem *schemaDefElement = NULL;
 
 	/* set extension name and if_not_exists fields */
 	createExtensionStmt->extname = extensionName;
 	createExtensionStmt->if_not_exists = true;
 
 	/* get schema name that extension was created on */
-	extensionSchemaOid = get_extension_schema(extensionOid);
-	extensionSchemaName = get_namespace_name(extensionSchemaOid);
+	Oid extensionSchemaOid = get_extension_schema(extensionOid);
+	char *extensionSchemaName = get_namespace_name(extensionSchemaOid);
 
 	/* make DefEleme for extensionSchemaName */
-	schemaNameArg = (Node *) makeString(extensionSchemaName);
+	Node *schemaNameArg = (Node *) makeString(extensionSchemaName);
 
-	schemaDefElement = makeDefElem("schema", schemaNameArg, location);
+	DefElem *schemaDefElement = makeDefElem("schema", schemaNameArg, location);
 
 	/* append the schema name DefElem finally */
 	createExtensionStmt->options = lappend(createExtensionStmt->options,
@@ -784,15 +757,11 @@ ObjectAddress *
 AlterExtensionSchemaStmtObjectAddress(AlterObjectSchemaStmt *alterExtensionSchemaStmt,
 									  bool missing_ok)
 {
-	ObjectAddress *extensionAddress = NULL;
-	Oid extensionOid = InvalidOid;
-	const char *extensionName = NULL;
-
 	Assert(alterExtensionSchemaStmt->objectType == OBJECT_EXTENSION);
 
-	extensionName = strVal(alterExtensionSchemaStmt->object);
+	const char *extensionName = strVal(alterExtensionSchemaStmt->object);
 
-	extensionOid = get_extension_oid(extensionName, missing_ok);
+	Oid extensionOid = get_extension_oid(extensionName, missing_ok);
 
 	if (extensionOid == InvalidOid)
 	{
@@ -801,7 +770,7 @@ AlterExtensionSchemaStmtObjectAddress(AlterObjectSchemaStmt *alterExtensionSchem
 							   extensionName)));
 	}
 
-	extensionAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddress *extensionAddress = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*extensionAddress, ExtensionRelationId, extensionOid);
 
 	return extensionAddress;
@@ -816,13 +785,9 @@ ObjectAddress *
 AlterExtensionUpdateStmtObjectAddress(AlterExtensionStmt *alterExtensionStmt,
 									  bool missing_ok)
 {
-	ObjectAddress *extensionAddress = NULL;
-	Oid extensionOid = InvalidOid;
-	const char *extensionName = NULL;
+	const char *extensionName = alterExtensionStmt->extname;
 
-	extensionName = alterExtensionStmt->extname;
-
-	extensionOid = get_extension_oid(extensionName, missing_ok);
+	Oid extensionOid = get_extension_oid(extensionName, missing_ok);
 
 	if (extensionOid == InvalidOid)
 	{
@@ -831,7 +796,7 @@ AlterExtensionUpdateStmtObjectAddress(AlterExtensionStmt *alterExtensionStmt,
 							   extensionName)));
 	}
 
-	extensionAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddress *extensionAddress = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*extensionAddress, ExtensionRelationId, extensionOid);
 
 	return extensionAddress;

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -298,8 +298,6 @@ PG_FUNCTION_INFO_V1(citus_text_send_as_jsonb);
 static void
 CitusCopyFrom(CopyStmt *copyStatement, char *completionTag)
 {
-	bool isCopyFromWorker = false;
-
 	BeginOrContinueCoordinatedTransaction();
 
 	/* disallow COPY to/from file or program except for superusers */
@@ -324,7 +322,7 @@ CitusCopyFrom(CopyStmt *copyStatement, char *completionTag)
 	}
 
 	masterConnection = NULL; /* reset, might still be set after error */
-	isCopyFromWorker = IsCopyFromWorker(copyStatement);
+	bool isCopyFromWorker = IsCopyFromWorker(copyStatement);
 	if (isCopyFromWorker)
 	{
 		CopyFromWorkerNode(copyStatement, completionTag);
@@ -387,9 +385,6 @@ CopyFromWorkerNode(CopyStmt *copyStatement, char *completionTag)
 	NodeAddress *masterNodeAddress = MasterNodeAddress(copyStatement);
 	char *nodeName = masterNodeAddress->nodeName;
 	int32 nodePort = masterNodeAddress->nodePort;
-	Oid relationId = InvalidOid;
-	char partitionMethod = 0;
-	char *schemaName = NULL;
 	uint32 connectionFlags = FOR_DML;
 
 	masterConnection = GetNodeConnection(connectionFlags, nodeName, nodePort);
@@ -399,14 +394,14 @@ CopyFromWorkerNode(CopyStmt *copyStatement, char *completionTag)
 	RemoteTransactionBeginIfNecessary(masterConnection);
 
 	/* strip schema name for local reference */
-	schemaName = copyStatement->relation->schemaname;
+	char *schemaName = copyStatement->relation->schemaname;
 	copyStatement->relation->schemaname = NULL;
 
-	relationId = RangeVarGetRelid(copyStatement->relation, NoLock, false);
+	Oid relationId = RangeVarGetRelid(copyStatement->relation, NoLock, false);
 
 	/* put schema name back */
 	copyStatement->relation->schemaname = schemaName;
-	partitionMethod = MasterPartitionMethod(copyStatement->relation);
+	char partitionMethod = MasterPartitionMethod(copyStatement->relation);
 	if (partitionMethod != DISTRIBUTE_BY_APPEND)
 	{
 		ereport(ERROR, (errmsg("copy from worker nodes is only supported "
@@ -439,18 +434,10 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 	CitusCopyDestReceiver *copyDest = NULL;
 	DestReceiver *dest = NULL;
 
-	Relation distributedRelation = NULL;
 	Relation copiedDistributedRelation = NULL;
 	Form_pg_class copiedDistributedRelationTuple = NULL;
-	TupleDesc tupleDescriptor = NULL;
-	uint32 columnCount = 0;
-	Datum *columnValues = NULL;
-	bool *columnNulls = NULL;
-	int columnIndex = 0;
 	List *columnNameList = NIL;
-	Var *partitionColumn = NULL;
 	int partitionColumnIndex = INVALID_PARTITION_COLUMN_INDEX;
-	TupleTableSlot *tupleTableSlot = NULL;
 
 	EState *executorState = NULL;
 	MemoryContext executorTupleContext = NULL;
@@ -465,27 +452,28 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 	ErrorContextCallback errorCallback;
 
 	/* allocate column values and nulls arrays */
-	distributedRelation = heap_open(tableId, RowExclusiveLock);
-	tupleDescriptor = RelationGetDescr(distributedRelation);
-	columnCount = tupleDescriptor->natts;
-	columnValues = palloc0(columnCount * sizeof(Datum));
-	columnNulls = palloc0(columnCount * sizeof(bool));
+	Relation distributedRelation = heap_open(tableId, RowExclusiveLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
+	uint32 columnCount = tupleDescriptor->natts;
+	Datum *columnValues = palloc0(columnCount * sizeof(Datum));
+	bool *columnNulls = palloc0(columnCount * sizeof(bool));
 
 	/* set up a virtual tuple table slot */
-	tupleTableSlot = MakeSingleTupleTableSlotCompat(tupleDescriptor, &TTSOpsVirtual);
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(tupleDescriptor,
+																	&TTSOpsVirtual);
 	tupleTableSlot->tts_nvalid = columnCount;
 	tupleTableSlot->tts_values = columnValues;
 	tupleTableSlot->tts_isnull = columnNulls;
 
 	/* determine the partition column index in the tuple descriptor */
-	partitionColumn = PartitionColumn(tableId, 0);
+	Var *partitionColumn = PartitionColumn(tableId, 0);
 	if (partitionColumn != NULL)
 	{
 		partitionColumnIndex = partitionColumn->varattno - 1;
 	}
 
 	/* build the list of column names for remote COPY statements */
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		Form_pg_attribute currentColumn = TupleDescAttr(tupleDescriptor, columnIndex);
 		char *columnName = NameStr(currentColumn->attname);
@@ -566,16 +554,13 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 
 	while (true)
 	{
-		bool nextRowFound = false;
-		MemoryContext oldContext = NULL;
-
 		ResetPerTupleExprContext(executorState);
 
-		oldContext = MemoryContextSwitchTo(executorTupleContext);
+		MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
 
 		/* parse a row from the input */
-		nextRowFound = NextCopyFromCompat(copyState, executorExpressionContext,
-										  columnValues, columnNulls);
+		bool nextRowFound = NextCopyFromCompat(copyState, executorExpressionContext,
+											   columnValues, columnNulls);
 
 		if (!nextRowFound)
 		{
@@ -625,8 +610,6 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 static void
 CopyToNewShards(CopyStmt *copyStatement, char *completionTag, Oid relationId)
 {
-	FmgrInfo *columnOutputFunctions = NULL;
-
 	/* allocate column values and nulls arrays */
 	Relation distributedRelation = heap_open(relationId, RowExclusiveLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
@@ -668,7 +651,8 @@ CopyToNewShards(CopyStmt *copyStatement, char *completionTag, Oid relationId)
 	copyOutState->fe_msgbuf = makeStringInfo();
 	copyOutState->rowcontext = executorTupleContext;
 
-	columnOutputFunctions = ColumnOutputFunctions(tupleDescriptor, copyOutState->binary);
+	FmgrInfo *columnOutputFunctions = ColumnOutputFunctions(tupleDescriptor,
+															copyOutState->binary);
 
 	/* set up callback to identify error line number */
 	errorCallback.callback = CopyFromErrorCallback;
@@ -684,19 +668,15 @@ CopyToNewShards(CopyStmt *copyStatement, char *completionTag, Oid relationId)
 
 	while (true)
 	{
-		bool nextRowFound = false;
-		MemoryContext oldContext = NULL;
-		uint64 messageBufferSize = 0;
-
 		ResetPerTupleExprContext(executorState);
 
 		/* switch to tuple memory context and start showing line number in errors */
 		error_context_stack = &errorCallback;
-		oldContext = MemoryContextSwitchTo(executorTupleContext);
+		MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
 
 		/* parse a row from the input */
-		nextRowFound = NextCopyFromCompat(copyState, executorExpressionContext,
-										  columnValues, columnNulls);
+		bool nextRowFound = NextCopyFromCompat(copyState, executorExpressionContext,
+											   columnValues, columnNulls);
 
 		if (!nextRowFound)
 		{
@@ -739,7 +719,7 @@ CopyToNewShards(CopyStmt *copyStatement, char *completionTag, Oid relationId)
 		SendCopyDataToAll(copyOutState->fe_msgbuf, currentShardId,
 						  shardConnections->connectionList);
 
-		messageBufferSize = copyOutState->fe_msgbuf->len;
+		uint64 messageBufferSize = copyOutState->fe_msgbuf->len;
 		copiedDataSizeInBytes = copiedDataSizeInBytes + messageBufferSize;
 
 		/*
@@ -841,7 +821,6 @@ static char
 MasterPartitionMethod(RangeVar *relation)
 {
 	char partitionMethod = '\0';
-	PGresult *queryResult = NULL;
 	bool raiseInterrupts = true;
 
 	char *relationName = relation->relname;
@@ -855,7 +834,7 @@ MasterPartitionMethod(RangeVar *relation)
 	{
 		ReportConnectionError(masterConnection, ERROR);
 	}
-	queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
+	PGresult *queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
 	if (PQresultStatus(queryResult) == PGRES_TUPLES_OK)
 	{
 		char *partitionMethodString = PQgetvalue((PGresult *) queryResult, 0, 0);
@@ -923,7 +902,6 @@ OpenCopyConnectionsForNewShards(CopyStmt *copyStatement,
 								ShardConnections *shardConnections,
 								bool stopOnFailure, bool useBinaryCopyFormat)
 {
-	List *finalizedPlacementList = NIL;
 	int failedPlacementCount = 0;
 	ListCell *placementCell = NULL;
 	List *connectionList = NULL;
@@ -940,7 +918,7 @@ OpenCopyConnectionsForNewShards(CopyStmt *copyStatement,
 	/* release finalized placement list at the end of this function */
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
-	finalizedPlacementList = MasterShardPlacementList(shardId);
+	List *finalizedPlacementList = MasterShardPlacementList(shardId);
 
 	MemoryContextSwitchTo(oldContext);
 
@@ -948,10 +926,7 @@ OpenCopyConnectionsForNewShards(CopyStmt *copyStatement,
 	{
 		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);
 		char *nodeUser = CurrentUserName();
-		MultiConnection *connection = NULL;
 		uint32 connectionFlags = FOR_DML;
-		StringInfo copyCommand = NULL;
-		PGresult *result = NULL;
 
 		/*
 		 * For hash partitioned tables, connection establishment happens in
@@ -959,7 +934,8 @@ OpenCopyConnectionsForNewShards(CopyStmt *copyStatement,
 		 */
 		Assert(placement->partitionMethod != DISTRIBUTE_BY_HASH);
 
-		connection = GetPlacementConnection(connectionFlags, placement, nodeUser);
+		MultiConnection *connection = GetPlacementConnection(connectionFlags, placement,
+															 nodeUser);
 
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
 		{
@@ -987,14 +963,15 @@ OpenCopyConnectionsForNewShards(CopyStmt *copyStatement,
 		ClaimConnectionExclusively(connection);
 		RemoteTransactionBeginIfNecessary(connection);
 
-		copyCommand = ConstructCopyStatement(copyStatement, shardConnections->shardId,
-											 useBinaryCopyFormat);
+		StringInfo copyCommand = ConstructCopyStatement(copyStatement,
+														shardConnections->shardId,
+														useBinaryCopyFormat);
 
 		if (!SendRemoteCommand(connection, copyCommand->data))
 		{
 			ReportConnectionError(connection, ERROR);
 		}
-		result = GetRemoteCommandResult(connection, raiseInterrupts);
+		PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 		if (PQresultStatus(result) != PGRES_COPY_IN)
 		{
 			ReportResultError(connection, result, ERROR);
@@ -1035,9 +1012,8 @@ CanUseBinaryCopyFormat(TupleDesc tupleDescription)
 {
 	bool useBinaryCopyFormat = true;
 	int totalColumnCount = tupleDescription->natts;
-	int columnIndex = 0;
 
-	for (columnIndex = 0; columnIndex < totalColumnCount; columnIndex++)
+	for (int columnIndex = 0; columnIndex < totalColumnCount; columnIndex++)
 	{
 		Form_pg_attribute currentColumn = TupleDescAttr(tupleDescription, columnIndex);
 		Oid typeId = InvalidOid;
@@ -1149,7 +1125,6 @@ static List *
 RemoteFinalizedShardPlacementList(uint64 shardId)
 {
 	List *finalizedPlacementList = NIL;
-	PGresult *queryResult = NULL;
 	bool raiseInterrupts = true;
 
 	StringInfo shardPlacementsCommand = makeStringInfo();
@@ -1159,13 +1134,12 @@ RemoteFinalizedShardPlacementList(uint64 shardId)
 	{
 		ReportConnectionError(masterConnection, ERROR);
 	}
-	queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
+	PGresult *queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
 	if (PQresultStatus(queryResult) == PGRES_TUPLES_OK)
 	{
 		int rowCount = PQntuples(queryResult);
-		int rowIndex = 0;
 
-		for (rowIndex = 0; rowIndex < rowCount; rowIndex++)
+		for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
 		{
 			char *placementIdString = PQgetvalue(queryResult, rowIndex, 0);
 			char *nodeName = pstrdup(PQgetvalue(queryResult, rowIndex, 1));
@@ -1236,11 +1210,10 @@ ConstructCopyStatement(CopyStmt *copyStatement, int64 shardId, bool useBinaryCop
 	char *relationName = copyStatement->relation->relname;
 
 	char *shardName = pstrdup(relationName);
-	char *shardQualifiedName = NULL;
 
 	AppendShardIdToName(&shardName, shardId);
 
-	shardQualifiedName = quote_qualified_identifier(schemaName, shardName);
+	char *shardQualifiedName = quote_qualified_identifier(schemaName, shardName);
 
 	appendStringInfo(command, "COPY %s ", shardQualifiedName);
 
@@ -1331,7 +1304,6 @@ EndRemoteCopy(int64 shardId, List *connectionList)
 	foreach(connectionCell, connectionList)
 	{
 		MultiConnection *connection = (MultiConnection *) lfirst(connectionCell);
-		PGresult *result = NULL;
 		bool raiseInterrupts = true;
 
 		/* end the COPY input */
@@ -1343,7 +1315,7 @@ EndRemoteCopy(int64 shardId, List *connectionList)
 		}
 
 		/* check whether there were any COPY errors */
-		result = GetRemoteCommandResult(connection, raiseInterrupts);
+		PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 		if (PQresultStatus(result) != PGRES_COMMAND_OK)
 		{
 			ReportCopyError(connection, result);
@@ -1487,14 +1459,13 @@ static Oid
 TypeForColumnName(Oid relationId, TupleDesc tupleDescriptor, char *columnName)
 {
 	AttrNumber destAttrNumber = get_attnum(relationId, columnName);
-	Form_pg_attribute attr = NULL;
 
 	if (destAttrNumber == InvalidAttrNumber)
 	{
 		ereport(ERROR, (errmsg("invalid attr? %s", columnName)));
 	}
 
-	attr = TupleDescAttr(tupleDescriptor, destAttrNumber - 1);
+	Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, destAttrNumber - 1);
 	return attr->atttypid;
 }
 
@@ -1508,9 +1479,8 @@ TypeArrayFromTupleDescriptor(TupleDesc tupleDescriptor)
 {
 	int columnCount = tupleDescriptor->natts;
 	Oid *typeArray = palloc0(columnCount * sizeof(Oid));
-	int columnIndex = 0;
 
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, columnIndex);
 		if (attr->attisdropped)
@@ -1537,15 +1507,13 @@ ColumnCoercionPaths(TupleDesc destTupleDescriptor, TupleDesc inputTupleDescripto
 					Oid destRelId, List *columnNameList,
 					Oid *finalColumnTypeArray)
 {
-	int columnIndex = 0;
 	int columnCount = inputTupleDescriptor->natts;
 	CopyCoercionData *coercePaths = palloc0(columnCount * sizeof(CopyCoercionData));
 	Oid *inputTupleTypes = TypeArrayFromTupleDescriptor(inputTupleDescriptor);
 	ListCell *currentColumnName = list_head(columnNameList);
 
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
-		Oid destTupleType = InvalidOid;
 		Oid inputTupleType = inputTupleTypes[columnIndex];
 		char *columnName = lfirst(currentColumnName);
 
@@ -1555,7 +1523,7 @@ ColumnCoercionPaths(TupleDesc destTupleDescriptor, TupleDesc inputTupleDescripto
 			continue;
 		}
 
-		destTupleType = TypeForColumnName(destRelId, destTupleDescriptor, columnName);
+		Oid destTupleType = TypeForColumnName(destRelId, destTupleDescriptor, columnName);
 
 		finalColumnTypeArray[columnIndex] = destTupleType;
 
@@ -1584,8 +1552,7 @@ TypeOutputFunctions(uint32 columnCount, Oid *typeIdArray, bool binaryFormat)
 {
 	FmgrInfo *columnOutputFunctions = palloc0(columnCount * sizeof(FmgrInfo));
 
-	uint32 columnIndex = 0;
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (uint32 columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		FmgrInfo *currentOutputFunction = &columnOutputFunctions[columnIndex];
 		Oid columnTypeId = typeIdArray[columnIndex];
@@ -1665,7 +1632,6 @@ AppendCopyRowData(Datum *valueArray, bool *isNullArray, TupleDesc rowDescriptor,
 	uint32 totalColumnCount = (uint32) rowDescriptor->natts;
 	uint32 availableColumnCount = AvailableColumnCount(rowDescriptor);
 	uint32 appendedColumnCount = 0;
-	uint32 columnIndex = 0;
 
 	MemoryContext oldContext = MemoryContextSwitchTo(rowOutputState->rowcontext);
 
@@ -1673,7 +1639,7 @@ AppendCopyRowData(Datum *valueArray, bool *isNullArray, TupleDesc rowDescriptor,
 	{
 		CopySendInt16(rowOutputState, availableColumnCount);
 	}
-	for (columnIndex = 0; columnIndex < totalColumnCount; columnIndex++)
+	for (uint32 columnIndex = 0; columnIndex < totalColumnCount; columnIndex++)
 	{
 		Form_pg_attribute currentColumn = TupleDescAttr(rowDescriptor, columnIndex);
 		Datum value = valueArray[columnIndex];
@@ -1803,9 +1769,8 @@ static uint32
 AvailableColumnCount(TupleDesc tupleDescriptor)
 {
 	uint32 columnCount = 0;
-	uint32 columnIndex = 0;
 
-	for (columnIndex = 0; columnIndex < tupleDescriptor->natts; columnIndex++)
+	for (uint32 columnIndex = 0; columnIndex < tupleDescriptor->natts; columnIndex++)
 	{
 		Form_pg_attribute currentColumn = TupleDescAttr(tupleDescriptor, columnIndex);
 
@@ -1916,13 +1881,11 @@ MasterCreateEmptyShard(char *relationName)
 static int64
 CreateEmptyShard(char *relationName)
 {
-	int64 shardId = 0;
-
 	text *relationNameText = cstring_to_text(relationName);
 	Datum relationNameDatum = PointerGetDatum(relationNameText);
 	Datum shardIdDatum = DirectFunctionCall1(master_create_empty_shard,
 											 relationNameDatum);
-	shardId = DatumGetInt64(shardIdDatum);
+	int64 shardId = DatumGetInt64(shardIdDatum);
 
 	return shardId;
 }
@@ -1936,7 +1899,6 @@ static int64
 RemoteCreateEmptyShard(char *relationName)
 {
 	int64 shardId = 0;
-	PGresult *queryResult = NULL;
 	bool raiseInterrupts = true;
 
 	StringInfo createEmptyShardCommand = makeStringInfo();
@@ -1946,7 +1908,7 @@ RemoteCreateEmptyShard(char *relationName)
 	{
 		ReportConnectionError(masterConnection, ERROR);
 	}
-	queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
+	PGresult *queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
 	if (PQresultStatus(queryResult) == PGRES_TUPLES_OK)
 	{
 		char *shardIdString = PQgetvalue((PGresult *) queryResult, 0, 0);
@@ -1991,7 +1953,6 @@ MasterUpdateShardStatistics(uint64 shardId)
 static void
 RemoteUpdateShardStatistics(uint64 shardId)
 {
-	PGresult *queryResult = NULL;
 	bool raiseInterrupts = true;
 
 	StringInfo updateShardStatisticsCommand = makeStringInfo();
@@ -2002,7 +1963,7 @@ RemoteUpdateShardStatistics(uint64 shardId)
 	{
 		ReportConnectionError(masterConnection, ERROR);
 	}
-	queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
+	PGresult *queryResult = GetRemoteCommandResult(masterConnection, raiseInterrupts);
 	if (PQresultStatus(queryResult) != PGRES_TUPLES_OK)
 	{
 		ereport(ERROR, (errmsg("could not update shard statistics")));
@@ -2067,7 +2028,6 @@ static void
 CopyAttributeOutText(CopyOutState cstate, char *string)
 {
 	char *pointer = NULL;
-	char *start = NULL;
 	char c = '\0';
 	char delimc = cstate->delim[0];
 
@@ -2092,7 +2052,7 @@ CopyAttributeOutText(CopyOutState cstate, char *string)
 	 * skip doing pg_encoding_mblen(), because in valid backend encodings,
 	 * extra bytes of a multibyte character never look like ASCII.
 	 */
-	start = pointer;
+	char *start = pointer;
 	while ((c = *pointer) != '\0')
 	{
 		if ((unsigned char) c < (unsigned char) 0x20)
@@ -2184,9 +2144,8 @@ CreateCitusCopyDestReceiver(Oid tableId, List *columnNameList, int partitionColu
 							EState *executorState, bool stopOnFailure,
 							char *intermediateResultIdPrefix)
 {
-	CitusCopyDestReceiver *copyDest = NULL;
-
-	copyDest = (CitusCopyDestReceiver *) palloc0(sizeof(CitusCopyDestReceiver));
+	CitusCopyDestReceiver *copyDest = (CitusCopyDestReceiver *) palloc0(
+		sizeof(CitusCopyDestReceiver));
 
 	/* set up the DestReceiver function pointers */
 	copyDest->pub.receiveSlot = CitusCopyDestReceiverReceive;
@@ -2225,20 +2184,14 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	Oid schemaOid = get_rel_namespace(tableId);
 	char *schemaName = get_namespace_name(schemaOid);
 
-	Relation distributedRelation = NULL;
 	List *columnNameList = copyDest->columnNameList;
 	List *quotedColumnNameList = NIL;
 
 	ListCell *columnNameCell = NULL;
 
 	char partitionMethod = '\0';
-	DistTableCacheEntry *cacheEntry = NULL;
 
-	CopyStmt *copyStatement = NULL;
 
-	List *shardIntervalList = NULL;
-
-	CopyOutState copyOutState = NULL;
 	const char *delimiterCharacter = "\t";
 	const char *nullPrintCharacter = "\\N";
 
@@ -2246,15 +2199,15 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	ErrorIfLocalExecutionHappened();
 
 	/* look up table properties */
-	distributedRelation = heap_open(tableId, RowExclusiveLock);
-	cacheEntry = DistributedTableCacheEntry(tableId);
+	Relation distributedRelation = heap_open(tableId, RowExclusiveLock);
+	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(tableId);
 	partitionMethod = cacheEntry->partitionMethod;
 
 	copyDest->distributedRelation = distributedRelation;
 	copyDest->tupleDescriptor = inputTupleDescriptor;
 
 	/* load the list of shards and verify that we have shards to copy into */
-	shardIntervalList = LoadShardIntervalList(tableId);
+	List *shardIntervalList = LoadShardIntervalList(tableId);
 	if (shardIntervalList == NIL)
 	{
 		if (partitionMethod == DISTRIBUTE_BY_HASH)
@@ -2307,7 +2260,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	}
 
 	/* define how tuples will be serialised */
-	copyOutState = (CopyOutState) palloc0(sizeof(CopyOutStateData));
+	CopyOutState copyOutState = (CopyOutState) palloc0(sizeof(CopyOutStateData));
 	copyOutState->delim = (char *) delimiterCharacter;
 	copyOutState->null_print = (char *) nullPrintCharacter;
 	copyOutState->null_print_client = (char *) nullPrintCharacter;
@@ -2349,15 +2302,15 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	}
 
 	/* define the template for the COPY statement that is sent to workers */
-	copyStatement = makeNode(CopyStmt);
+	CopyStmt *copyStatement = makeNode(CopyStmt);
 
 	if (copyDest->intermediateResultIdPrefix != NULL)
 	{
-		DefElem *formatResultOption = NULL;
 		copyStatement->relation = makeRangeVar(NULL, copyDest->intermediateResultIdPrefix,
 											   -1);
 
-		formatResultOption = makeDefElem("format", (Node *) makeString("result"), -1);
+		DefElem *formatResultOption = makeDefElem("format", (Node *) makeString("result"),
+												  -1);
 		copyStatement->options = list_make1(formatResultOption);
 	}
 	else
@@ -2422,7 +2375,6 @@ CitusSendTupleToPlacements(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest
 	TupleDesc tupleDescriptor = copyDest->tupleDescriptor;
 	CopyStmt *copyStatement = copyDest->copyStatement;
 
-	CopyShardState *shardState = NULL;
 	CopyOutState copyOutState = copyDest->copyOutState;
 	FmgrInfo *columnOutputFunctions = copyDest->columnOutputFunctions;
 	CopyCoercionData *columnCoercionPaths = copyDest->columnCoercionPaths;
@@ -2432,10 +2384,6 @@ CitusSendTupleToPlacements(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest
 
 	bool stopOnFailure = copyDest->stopOnFailure;
 
-	Datum *columnValues = NULL;
-	bool *columnNulls = NULL;
-
-	int64 shardId = 0;
 
 	EState *executorState = copyDest->executorState;
 	MemoryContext executorTupleContext = GetPerTupleMemoryContext(executorState);
@@ -2443,17 +2391,18 @@ CitusSendTupleToPlacements(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest
 
 	slot_getallattrs(slot);
 
-	columnValues = slot->tts_values;
-	columnNulls = slot->tts_isnull;
+	Datum *columnValues = slot->tts_values;
+	bool *columnNulls = slot->tts_isnull;
 
-	shardId = ShardIdForTuple(copyDest, columnValues, columnNulls);
+	int64 shardId = ShardIdForTuple(copyDest, columnValues, columnNulls);
 
 	/* connections hash is kept in memory context */
 	MemoryContextSwitchTo(copyDest->memoryContext);
 
-	shardState = GetShardState(shardId, copyDest->shardStateHash,
-							   copyDest->connectionStateHash, stopOnFailure,
-							   &cachedShardStateFound);
+	CopyShardState *shardState = GetShardState(shardId, copyDest->shardStateHash,
+											   copyDest->connectionStateHash,
+											   stopOnFailure,
+											   &cachedShardStateFound);
 	if (!cachedShardStateFound)
 	{
 		firstTupleInShard = true;
@@ -2564,7 +2513,6 @@ ShardIdForTuple(CitusCopyDestReceiver *copyDest, Datum *columnValues, bool *colu
 	int partitionColumnIndex = copyDest->partitionColumnIndex;
 	Datum partitionColumnValue = 0;
 	CopyCoercionData *columnCoercionPaths = copyDest->columnCoercionPaths;
-	ShardInterval *shardInterval = NULL;
 
 	/*
 	 * Find the partition column value and corresponding shard interval
@@ -2605,7 +2553,8 @@ ShardIdForTuple(CitusCopyDestReceiver *copyDest, Datum *columnValues, bool *colu
 	 * For reference table, this function blindly returns the tables single
 	 * shard.
 	 */
-	shardInterval = FindShardInterval(partitionColumnValue, copyDest->tableMetadata);
+	ShardInterval *shardInterval = FindShardInterval(partitionColumnValue,
+													 copyDest->tableMetadata);
 	if (shardInterval == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
@@ -2628,11 +2577,10 @@ CitusCopyDestReceiverShutdown(DestReceiver *destReceiver)
 	CitusCopyDestReceiver *copyDest = (CitusCopyDestReceiver *) destReceiver;
 
 	HTAB *connectionStateHash = copyDest->connectionStateHash;
-	List *connectionStateList = NIL;
 	ListCell *connectionStateCell = NULL;
 	Relation distributedRelation = copyDest->distributedRelation;
 
-	connectionStateList = ConnectionStateList(connectionStateHash);
+	List *connectionStateList = ConnectionStateList(connectionStateHash);
 
 	PG_TRY();
 	{
@@ -2820,21 +2768,20 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 		else
 		{
 			bool isFrom = copyStatement->is_from;
-			Relation copiedRelation = NULL;
-			char *schemaName = NULL;
-			MemoryContext relationContext = NULL;
 
 			/* consider using RangeVarGetRelidExtended to check perms before locking */
-			copiedRelation = heap_openrv(copyStatement->relation,
-										 isFrom ? RowExclusiveLock : AccessShareLock);
+			Relation copiedRelation = heap_openrv(copyStatement->relation,
+												  isFrom ? RowExclusiveLock :
+												  AccessShareLock);
 
 			isDistributedRelation = IsDistributedTable(RelationGetRelid(copiedRelation));
 
 			/* ensure future lookups hit the same relation */
-			schemaName = get_namespace_name(RelationGetNamespace(copiedRelation));
+			char *schemaName = get_namespace_name(RelationGetNamespace(copiedRelation));
 
 			/* ensure we copy string into proper context */
-			relationContext = GetMemoryChunkContext(copyStatement->relation);
+			MemoryContext relationContext = GetMemoryChunkContext(
+				copyStatement->relation);
 			schemaName = MemoryContextStrdup(relationContext, schemaName);
 			copyStatement->relation->schemaname = schemaName;
 
@@ -2906,16 +2853,15 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 			!copyStatement->is_from && !is_absolute_path(filename))
 		{
 			bool binaryCopyFormat = CopyStatementHasFormat(copyStatement, "binary");
-			int64 tuplesSent = 0;
 			Query *query = NULL;
 			Node *queryNode = copyStatement->query;
-			List *queryTreeList = NIL;
 			StringInfo userFilePath = makeStringInfo();
 
 			RawStmt *rawStmt = makeNode(RawStmt);
 			rawStmt->stmt = queryNode;
 
-			queryTreeList = pg_analyze_and_rewrite(rawStmt, queryString, NULL, 0, NULL);
+			List *queryTreeList = pg_analyze_and_rewrite(rawStmt, queryString, NULL, 0,
+														 NULL);
 
 			if (list_length(queryTreeList) != 1)
 			{
@@ -2931,7 +2877,7 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 			 */
 			appendStringInfo(userFilePath, "%s.%u", filename, GetUserId());
 
-			tuplesSent = WorkerExecuteSqlTask(query, filename, binaryCopyFormat);
+			int64 tuplesSent = WorkerExecuteSqlTask(query, filename, binaryCopyFormat);
 
 			snprintf(completionTag, COMPLETION_TAG_BUFSIZE,
 					 "COPY " UINT64_FORMAT, tuplesSent);
@@ -2952,7 +2898,6 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 static void
 CreateLocalTable(RangeVar *relation, char *nodeName, int32 nodePort)
 {
-	List *ddlCommandList = NIL;
 	ListCell *ddlCommandCell = NULL;
 
 	char *relationName = relation->relname;
@@ -2964,7 +2909,7 @@ CreateLocalTable(RangeVar *relation, char *nodeName, int32 nodePort)
 	 * enough; therefore, we just throw an error which says that we could not
 	 * run the copy operation.
 	 */
-	ddlCommandList = TableDDLCommandList(nodeName, nodePort, qualifiedRelationName);
+	List *ddlCommandList = TableDDLCommandList(nodeName, nodePort, qualifiedRelationName);
 	if (ddlCommandList == NIL)
 	{
 		ereport(ERROR, (errmsg("could not run copy from the worker node")));
@@ -3045,14 +2990,13 @@ CheckCopyPermissions(CopyStmt *copyStatement)
 	AclMode		required_access = (is_from ? ACL_INSERT : ACL_SELECT);
 	List	   *attnums;
 	ListCell   *cur;
-	RangeTblEntry *rte;
 
 	rel = heap_openrv(copyStatement->relation,
 	                  is_from ? RowExclusiveLock : AccessShareLock);
 
 	relid = RelationGetRelid(rel);
 
-	rte = makeNode(RangeTblEntry);
+	RangeTblEntry *rte = makeNode(RangeTblEntry);
 	rte->rtekind = RTE_RELATION;
 	rte->relid = relid;
 	rte->relkind = rel->rd_rel->relkind;
@@ -3166,18 +3110,16 @@ CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 static HTAB *
 CreateConnectionStateHash(MemoryContext memoryContext)
 {
-	HTAB *connectionStateHash = NULL;
-	int hashFlags = 0;
 	HASHCTL info;
 
 	memset(&info, 0, sizeof(info));
 	info.keysize = sizeof(int);
 	info.entrysize = sizeof(CopyConnectionState);
 	info.hcxt = memoryContext;
-	hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
+	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
 
-	connectionStateHash = hash_create("Copy Connection State Hash", 128, &info,
-									  hashFlags);
+	HTAB *connectionStateHash = hash_create("Copy Connection State Hash", 128, &info,
+											hashFlags);
 
 	return connectionStateHash;
 }
@@ -3191,17 +3133,15 @@ CreateConnectionStateHash(MemoryContext memoryContext)
 static HTAB *
 CreateShardStateHash(MemoryContext memoryContext)
 {
-	HTAB *shardStateHash = NULL;
-	int hashFlags = 0;
 	HASHCTL info;
 
 	memset(&info, 0, sizeof(info));
 	info.keysize = sizeof(uint64);
 	info.entrysize = sizeof(CopyShardState);
 	info.hcxt = memoryContext;
-	hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
+	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
 
-	shardStateHash = hash_create("Copy Shard State Hash", 128, &info, hashFlags);
+	HTAB *shardStateHash = hash_create("Copy Shard State Hash", 128, &info, hashFlags);
 
 	return shardStateHash;
 }
@@ -3214,14 +3154,15 @@ CreateShardStateHash(MemoryContext memoryContext)
 static CopyConnectionState *
 GetConnectionState(HTAB *connectionStateHash, MultiConnection *connection)
 {
-	CopyConnectionState *connectionState = NULL;
 	bool found = false;
 
 	int sock = PQsocket(connection->pgConn);
 	Assert(sock != -1);
 
-	connectionState = (CopyConnectionState *) hash_search(connectionStateHash, &sock,
-														  HASH_ENTER, &found);
+	CopyConnectionState *connectionState = (CopyConnectionState *) hash_search(
+		connectionStateHash, &sock,
+		HASH_ENTER,
+		&found);
 	if (!found)
 	{
 		connectionState->socket = sock;
@@ -3243,11 +3184,11 @@ ConnectionStateList(HTAB *connectionStateHash)
 {
 	List *connectionStateList = NIL;
 	HASH_SEQ_STATUS status;
-	CopyConnectionState *connectionState = NULL;
 
 	hash_seq_init(&status, connectionStateHash);
 
-	connectionState = (CopyConnectionState *) hash_seq_search(&status);
+	CopyConnectionState *connectionState = (CopyConnectionState *) hash_seq_search(
+		&status);
 	while (connectionState != NULL)
 	{
 		connectionStateList = lappend(connectionStateList, connectionState);
@@ -3268,10 +3209,8 @@ static CopyShardState *
 GetShardState(uint64 shardId, HTAB *shardStateHash,
 			  HTAB *connectionStateHash, bool stopOnFailure, bool *found)
 {
-	CopyShardState *shardState = NULL;
-
-	shardState = (CopyShardState *) hash_search(shardStateHash, &shardId,
-												HASH_ENTER, found);
+	CopyShardState *shardState = (CopyShardState *) hash_search(shardStateHash, &shardId,
+																HASH_ENTER, found);
 	if (!*found)
 	{
 		InitializeCopyShardState(shardState, connectionStateHash,
@@ -3292,7 +3231,6 @@ InitializeCopyShardState(CopyShardState *shardState,
 						 HTAB *connectionStateHash, uint64 shardId,
 						 bool stopOnFailure)
 {
-	List *finalizedPlacementList = NIL;
 	ListCell *placementCell = NULL;
 	int failedPlacementCount = 0;
 
@@ -3306,7 +3244,7 @@ InitializeCopyShardState(CopyShardState *shardState,
 	/* release finalized placement list at the end of this function */
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
-	finalizedPlacementList = MasterShardPlacementList(shardId);
+	List *finalizedPlacementList = MasterShardPlacementList(shardId);
 
 	MemoryContextSwitchTo(oldContext);
 
@@ -3316,8 +3254,6 @@ InitializeCopyShardState(CopyShardState *shardState,
 	foreach(placementCell, finalizedPlacementList)
 	{
 		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);
-		CopyConnectionState *connectionState = NULL;
-		CopyPlacementState *placementState = NULL;
 
 		MultiConnection *connection =
 			CopyGetPlacementConnection(placement, stopOnFailure);
@@ -3327,7 +3263,8 @@ InitializeCopyShardState(CopyShardState *shardState,
 			continue;
 		}
 
-		connectionState = GetConnectionState(connectionStateHash, connection);
+		CopyConnectionState *connectionState = GetConnectionState(connectionStateHash,
+																  connection);
 
 		/*
 		 * If this is the first time we are using this connection for copying a
@@ -3338,7 +3275,7 @@ InitializeCopyShardState(CopyShardState *shardState,
 			RemoteTransactionBeginIfNecessary(connection);
 		}
 
-		placementState = palloc0(sizeof(CopyPlacementState));
+		CopyPlacementState *placementState = palloc0(sizeof(CopyPlacementState));
 		placementState->shardState = shardState;
 		placementState->data = makeStringInfo();
 		placementState->connectionState = connectionState;
@@ -3380,19 +3317,19 @@ InitializeCopyShardState(CopyShardState *shardState,
 static MultiConnection *
 CopyGetPlacementConnection(ShardPlacement *placement, bool stopOnFailure)
 {
-	MultiConnection *connection = NULL;
 	uint32 connectionFlags = FOR_DML;
 	char *nodeUser = CurrentUserName();
-	ShardPlacementAccess *placementAccess = NULL;
 
 	/*
 	 * Determine whether the task has to be assigned to a particular connection
 	 * due to a preceding access to the placement in the same transaction.
 	 */
-	placementAccess = CreatePlacementAccess(placement, PLACEMENT_ACCESS_DML);
-	connection = GetConnectionIfPlacementAccessedInXact(connectionFlags,
-														list_make1(placementAccess),
-														NULL);
+	ShardPlacementAccess *placementAccess = CreatePlacementAccess(placement,
+																  PLACEMENT_ACCESS_DML);
+	MultiConnection *connection = GetConnectionIfPlacementAccessedInXact(connectionFlags,
+																		 list_make1(
+																			 placementAccess),
+																		 NULL);
 	if (connection != NULL)
 	{
 		return connection;
@@ -3451,21 +3388,19 @@ static void
 StartPlacementStateCopyCommand(CopyPlacementState *placementState,
 							   CopyStmt *copyStatement, CopyOutState copyOutState)
 {
-	StringInfo copyCommand = NULL;
-	PGresult *result = NULL;
 	MultiConnection *connection = placementState->connectionState->connection;
 	uint64 shardId = placementState->shardState->shardId;
 	bool raiseInterrupts = true;
 	bool binaryCopy = copyOutState->binary;
 
-	copyCommand = ConstructCopyStatement(copyStatement, shardId, binaryCopy);
+	StringInfo copyCommand = ConstructCopyStatement(copyStatement, shardId, binaryCopy);
 
 	if (!SendRemoteCommand(connection, copyCommand->data))
 	{
 		ReportConnectionError(connection, ERROR);
 	}
 
-	result = GetRemoteCommandResult(connection, raiseInterrupts);
+	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 	if (PQresultStatus(result) != PGRES_COPY_IN)
 	{
 		ReportResultError(connection, result, ERROR);

--- a/src/backend/distributed/commands/rename.c
+++ b/src/backend/distributed/commands/rename.c
@@ -30,8 +30,6 @@ PlanRenameStmt(RenameStmt *renameStmt, const char *renameCommand)
 {
 	Oid objectRelationId = InvalidOid; /* SQL Object OID */
 	Oid tableRelationId = InvalidOid; /* Relation OID, maybe not the same. */
-	bool isDistributedRelation = false;
-	DDLJob *ddlJob = NULL;
 
 	/*
 	 * We only support some of the PostgreSQL supported RENAME statements, and
@@ -97,7 +95,7 @@ PlanRenameStmt(RenameStmt *renameStmt, const char *renameCommand)
 			return NIL;
 	}
 
-	isDistributedRelation = IsDistributedTable(tableRelationId);
+	bool isDistributedRelation = IsDistributedTable(tableRelationId);
 	if (!isDistributedRelation)
 	{
 		return NIL;
@@ -110,7 +108,7 @@ PlanRenameStmt(RenameStmt *renameStmt, const char *renameCommand)
 	 */
 	ErrorIfUnsupportedRenameStmt(renameStmt);
 
-	ddlJob = palloc0(sizeof(DDLJob));
+	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ddlJob->targetRelationId = tableRelationId;
 	ddlJob->concurrentIndexCmd = false;
 	ddlJob->commandString = renameCommand;

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -158,16 +158,14 @@ PlanAlterObjectSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 List *
 PlanAlterTableSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 {
-	Oid relationId = InvalidOid;
-
 	if (stmt->relation == NULL)
 	{
 		return NIL;
 	}
 
-	relationId = RangeVarGetRelid(stmt->relation,
-								  AccessExclusiveLock,
-								  stmt->missing_ok);
+	Oid relationId = RangeVarGetRelid(stmt->relation,
+									  AccessExclusiveLock,
+									  stmt->missing_ok);
 
 	/* first check whether a distributed relation is affected */
 	if (!OidIsValid(relationId) || !IsDistributedTable(relationId))

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -56,7 +56,6 @@ ErrorIfDistributedAlterSeqOwnedBy(AlterSeqStmt *alterSeqStmt)
 {
 	Oid sequenceId = RangeVarGetRelid(alterSeqStmt->sequence, AccessShareLock,
 									  alterSeqStmt->missing_ok);
-	bool sequenceOwned = false;
 	Oid ownedByTableId = InvalidOid;
 	Oid newOwnedByTableId = InvalidOid;
 	int32 ownedByColumnId = 0;
@@ -68,8 +67,8 @@ ErrorIfDistributedAlterSeqOwnedBy(AlterSeqStmt *alterSeqStmt)
 		return;
 	}
 
-	sequenceOwned = sequenceIsOwned(sequenceId, DEPENDENCY_AUTO, &ownedByTableId,
-									&ownedByColumnId);
+	bool sequenceOwned = sequenceIsOwned(sequenceId, DEPENDENCY_AUTO, &ownedByTableId,
+										 &ownedByColumnId);
 	if (!sequenceOwned)
 	{
 		sequenceOwned = sequenceIsOwned(sequenceId, DEPENDENCY_INTERNAL, &ownedByTableId,

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -180,8 +180,6 @@ LockTruncatedRelationMetadataInWorkers(TruncateStmt *truncateStatement)
 	{
 		RangeVar *rangeVar = (RangeVar *) lfirst(relationCell);
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
-		DistTableCacheEntry *cacheEntry = NULL;
-		List *referencingTableList = NIL;
 		Oid referencingRelationId = InvalidOid;
 
 		if (!IsDistributedTable(relationId))
@@ -196,10 +194,10 @@ LockTruncatedRelationMetadataInWorkers(TruncateStmt *truncateStatement)
 
 		distributedRelationList = lappend_oid(distributedRelationList, relationId);
 
-		cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 		Assert(cacheEntry != NULL);
 
-		referencingTableList = cacheEntry->referencingRelationsViaForeignKey;
+		List *referencingTableList = cacheEntry->referencingRelationsViaForeignKey;
 		foreach_oid(referencingRelationId, referencingTableList)
 		{
 			distributedRelationList = list_append_unique_oid(distributedRelationList,

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -114,9 +114,6 @@ static bool ShouldPropagateTypeCreate(void);
 List *
 PlanCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 {
-	const char *compositeTypeStmtSql = NULL;
-	List *commands = NIL;
-
 	if (!ShouldPropagateTypeCreate())
 	{
 		return NIL;
@@ -149,7 +146,7 @@ PlanCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 	 * type previously has been attempted to be created in a transaction which did not
 	 * commit on the coordinator.
 	 */
-	compositeTypeStmtSql = DeparseCompositeTypeStmt(stmt);
+	const char *compositeTypeStmtSql = DeparseCompositeTypeStmt(stmt);
 	compositeTypeStmtSql = WrapCreateOrReplace(compositeTypeStmtSql);
 
 	/*
@@ -158,9 +155,9 @@ PlanCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 	 */
 	EnsureSequentialModeForTypeDDL();
 
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) compositeTypeStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) compositeTypeStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -174,8 +171,6 @@ PlanCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 void
 ProcessCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 {
-	const ObjectAddress *typeAddress = NULL;
-
 	/* same check we perform during planning of the statement */
 	if (!ShouldPropagateTypeCreate())
 	{
@@ -186,7 +181,8 @@ ProcessCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 	 * find object address of the just created object, because the type has been created
 	 * locally it can't be missing
 	 */
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	EnsureDependenciesExistsOnAllNodes(typeAddress);
 
 	MarkObjectDistributed(typeAddress);
@@ -202,13 +198,10 @@ ProcessCompositeTypeStmt(CompositeTypeStmt *stmt, const char *queryString)
 List *
 PlanAlterTypeStmt(AlterTableStmt *stmt, const char *queryString)
 {
-	const char *alterTypeStmtSql = NULL;
-	const ObjectAddress *typeAddress = NULL;
-	List *commands = NIL;
-
 	Assert(stmt->relkind == OBJECT_TYPE);
 
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return NIL;
@@ -218,7 +211,7 @@ PlanAlterTypeStmt(AlterTableStmt *stmt, const char *queryString)
 
 	/* reconstruct alter statement in a portable fashion */
 	QualifyTreeNode((Node *) stmt);
-	alterTypeStmtSql = DeparseTreeNode((Node *) stmt);
+	const char *alterTypeStmtSql = DeparseTreeNode((Node *) stmt);
 
 	/*
 	 * all types that are distributed will need their alter statements propagated
@@ -227,9 +220,9 @@ PlanAlterTypeStmt(AlterTableStmt *stmt, const char *queryString)
 	 */
 	EnsureSequentialModeForTypeDDL();
 
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) alterTypeStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) alterTypeStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -248,9 +241,6 @@ PlanAlterTypeStmt(AlterTableStmt *stmt, const char *queryString)
 List *
 PlanCreateEnumStmt(CreateEnumStmt *stmt, const char *queryString)
 {
-	const char *createEnumStmtSql = NULL;
-	List *commands = NIL;
-
 	if (!ShouldPropagateTypeCreate())
 	{
 		return NIL;
@@ -266,7 +256,7 @@ PlanCreateEnumStmt(CreateEnumStmt *stmt, const char *queryString)
 	QualifyTreeNode((Node *) stmt);
 
 	/* reconstruct creation statement in a portable fashion */
-	createEnumStmtSql = DeparseCreateEnumStmt(stmt);
+	const char *createEnumStmtSql = DeparseCreateEnumStmt(stmt);
 	createEnumStmtSql = WrapCreateOrReplace(createEnumStmtSql);
 
 	/*
@@ -276,9 +266,9 @@ PlanCreateEnumStmt(CreateEnumStmt *stmt, const char *queryString)
 	EnsureSequentialModeForTypeDDL();
 
 	/* to prevent recursion with mx we disable ddl propagation */
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) createEnumStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) createEnumStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -295,15 +285,14 @@ PlanCreateEnumStmt(CreateEnumStmt *stmt, const char *queryString)
 void
 ProcessCreateEnumStmt(CreateEnumStmt *stmt, const char *queryString)
 {
-	const ObjectAddress *typeAddress = NULL;
-
 	if (!ShouldPropagateTypeCreate())
 	{
 		return;
 	}
 
 	/* lookup type address of just created type */
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	EnsureDependenciesExistsOnAllNodes(typeAddress);
 
 	/*
@@ -326,11 +315,10 @@ ProcessCreateEnumStmt(CreateEnumStmt *stmt, const char *queryString)
 List *
 PlanAlterEnumStmt(AlterEnumStmt *stmt, const char *queryString)
 {
-	const char *alterEnumStmtSql = NULL;
-	const ObjectAddress *typeAddress = NULL;
 	List *commands = NIL;
 
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return NIL;
@@ -351,7 +339,7 @@ PlanAlterEnumStmt(AlterEnumStmt *stmt, const char *queryString)
 	EnsureCoordinator();
 
 	QualifyTreeNode((Node *) stmt);
-	alterEnumStmtSql = DeparseTreeNode((Node *) stmt);
+	const char *alterEnumStmtSql = DeparseTreeNode((Node *) stmt);
 
 	/*
 	 * Before pg12 ALTER ENUM ... ADD VALUE could not be within a xact block. Instead of
@@ -396,9 +384,8 @@ PlanAlterEnumStmt(AlterEnumStmt *stmt, const char *queryString)
 void
 ProcessAlterEnumStmt(AlterEnumStmt *stmt, const char *queryString)
 {
-	const ObjectAddress *typeAddress = NULL;
-
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return;
@@ -422,25 +409,22 @@ ProcessAlterEnumStmt(AlterEnumStmt *stmt, const char *queryString)
 		 * might already be added to some nodes, but not all.
 		 */
 
-		int result = 0;
-		List *commands = NIL;
-		const char *alterEnumStmtSql = NULL;
 
 		/* qualification of the stmt happened during planning */
-		alterEnumStmtSql = DeparseTreeNode((Node *) stmt);
+		const char *alterEnumStmtSql = DeparseTreeNode((Node *) stmt);
 
-		commands = list_make2(DISABLE_DDL_PROPAGATION, (void *) alterEnumStmtSql);
+		List *commands = list_make2(DISABLE_DDL_PROPAGATION, (void *) alterEnumStmtSql);
 
-		result = SendBareOptionalCommandListToWorkersAsUser(ALL_WORKERS, commands, NULL);
+		int result = SendBareOptionalCommandListToWorkersAsUser(ALL_WORKERS, commands,
+																NULL);
 
 		if (result != RESPONSE_OKAY)
 		{
-			const char *alterEnumStmtIfNotExistsSql = NULL;
 			bool oldSkipIfNewValueExists = stmt->skipIfNewValExists;
 
 			/* deparse the query with IF NOT EXISTS */
 			stmt->skipIfNewValExists = true;
-			alterEnumStmtIfNotExistsSql = DeparseTreeNode((Node *) stmt);
+			const char *alterEnumStmtIfNotExistsSql = DeparseTreeNode((Node *) stmt);
 			stmt->skipIfNewValExists = oldSkipIfNewValueExists;
 
 			ereport(WARNING, (errmsg("not all workers applied change to enum"),
@@ -466,18 +450,15 @@ PlanDropTypeStmt(DropStmt *stmt, const char *queryString)
 	 * the old list to put back
 	 */
 	List *oldTypes = stmt->objects;
-	List *distributedTypes = NIL;
-	const char *dropStmtSql = NULL;
 	ListCell *addressCell = NULL;
-	List *distributedTypeAddresses = NIL;
-	List *commands = NIL;
 
 	if (!ShouldPropagate())
 	{
 		return NIL;
 	}
 
-	distributedTypes = FilterNameListForDistributedTypes(oldTypes, stmt->missing_ok);
+	List *distributedTypes = FilterNameListForDistributedTypes(oldTypes,
+															   stmt->missing_ok);
 	if (list_length(distributedTypes) <= 0)
 	{
 		/* no distributed types to drop */
@@ -494,7 +475,7 @@ PlanDropTypeStmt(DropStmt *stmt, const char *queryString)
 	/*
 	 * remove the entries for the distributed objects on dropping
 	 */
-	distributedTypeAddresses = TypeNameListToObjectAddresses(distributedTypes);
+	List *distributedTypeAddresses = TypeNameListToObjectAddresses(distributedTypes);
 	foreach(addressCell, distributedTypeAddresses)
 	{
 		ObjectAddress *address = (ObjectAddress *) lfirst(addressCell);
@@ -506,15 +487,15 @@ PlanDropTypeStmt(DropStmt *stmt, const char *queryString)
 	 * deparse to an executable sql statement for the workers
 	 */
 	stmt->objects = distributedTypes;
-	dropStmtSql = DeparseTreeNode((Node *) stmt);
+	const char *dropStmtSql = DeparseTreeNode((Node *) stmt);
 	stmt->objects = oldTypes;
 
 	/* to prevent recursion with mx we disable ddl propagation */
 	EnsureSequentialModeForTypeDDL();
 
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) dropStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) dropStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -531,11 +512,8 @@ PlanDropTypeStmt(DropStmt *stmt, const char *queryString)
 List *
 PlanRenameTypeStmt(RenameStmt *stmt, const char *queryString)
 {
-	const char *renameStmtSql = NULL;
-	const ObjectAddress *typeAddress = NULL;
-	List *commands = NIL;
-
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return NIL;
@@ -545,14 +523,14 @@ PlanRenameTypeStmt(RenameStmt *stmt, const char *queryString)
 	QualifyTreeNode((Node *) stmt);
 
 	/* deparse sql*/
-	renameStmtSql = DeparseTreeNode((Node *) stmt);
+	const char *renameStmtSql = DeparseTreeNode((Node *) stmt);
 
 	/* to prevent recursion with mx we disable ddl propagation */
 	EnsureSequentialModeForTypeDDL();
 
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) renameStmtSql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) renameStmtSql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -568,14 +546,11 @@ PlanRenameTypeStmt(RenameStmt *stmt, const char *queryString)
 List *
 PlanRenameTypeAttributeStmt(RenameStmt *stmt, const char *queryString)
 {
-	const char *sql = NULL;
-	const ObjectAddress *typeAddress = NULL;
-	List *commands = NIL;
-
 	Assert(stmt->renameType == OBJECT_ATTRIBUTE);
 	Assert(stmt->relationType == OBJECT_TYPE);
 
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return NIL;
@@ -583,12 +558,12 @@ PlanRenameTypeAttributeStmt(RenameStmt *stmt, const char *queryString)
 
 	QualifyTreeNode((Node *) stmt);
 
-	sql = DeparseTreeNode((Node *) stmt);
+	const char *sql = DeparseTreeNode((Node *) stmt);
 
 	EnsureSequentialModeForTypeDDL();
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) sql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) sql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -603,13 +578,10 @@ PlanRenameTypeAttributeStmt(RenameStmt *stmt, const char *queryString)
 List *
 PlanAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 {
-	const char *sql = NULL;
-	const ObjectAddress *typeAddress = NULL;
-	List *commands = NIL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return NIL;
@@ -618,13 +590,13 @@ PlanAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 	EnsureCoordinator();
 
 	QualifyTreeNode((Node *) stmt);
-	sql = DeparseTreeNode((Node *) stmt);
+	const char *sql = DeparseTreeNode((Node *) stmt);
 
 	EnsureSequentialModeForTypeDDL();
 
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) sql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) sql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -638,11 +610,10 @@ PlanAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 void
 ProcessAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 {
-	const ObjectAddress *typeAddress = NULL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return;
@@ -663,13 +634,10 @@ ProcessAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt, const char *queryString)
 List *
 PlanAlterTypeOwnerStmt(AlterOwnerStmt *stmt, const char *queryString)
 {
-	const ObjectAddress *typeAddress = NULL;
-	const char *sql = NULL;
-	List *commands = NULL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	const ObjectAddress *typeAddress = GetObjectAddressFromParseTree((Node *) stmt,
+																	 false);
 	if (!ShouldPropagateObject(typeAddress))
 	{
 		return NIL;
@@ -678,12 +646,12 @@ PlanAlterTypeOwnerStmt(AlterOwnerStmt *stmt, const char *queryString)
 	EnsureCoordinator();
 
 	QualifyTreeNode((Node *) stmt);
-	sql = DeparseTreeNode((Node *) stmt);
+	const char *sql = DeparseTreeNode((Node *) stmt);
 
 	EnsureSequentialModeForTypeDDL();
-	commands = list_make3(DISABLE_DDL_PROPAGATION,
-						  (void *) sql,
-						  ENABLE_DDL_PROPAGATION);
+	List *commands = list_make3(DISABLE_DDL_PROPAGATION,
+								(void *) sql,
+								ENABLE_DDL_PROPAGATION);
 
 	return NodeDDLTaskList(ALL_WORKERS, commands);
 }
@@ -726,13 +694,10 @@ CreateTypeStmtByObjectAddress(const ObjectAddress *address)
 static CompositeTypeStmt *
 RecreateCompositeTypeStmt(Oid typeOid)
 {
-	CompositeTypeStmt *stmt = NULL;
-	List *names = NIL;
-
 	Assert(get_typtype(typeOid) == TYPTYPE_COMPOSITE);
 
-	stmt = makeNode(CompositeTypeStmt);
-	names = stringToQualifiedNameList(format_type_be_qualified(typeOid));
+	CompositeTypeStmt *stmt = makeNode(CompositeTypeStmt);
+	List *names = stringToQualifiedNameList(format_type_be_qualified(typeOid));
 	stmt->typevar = makeRangeVarFromNameList(names);
 	stmt->coldeflist = CompositeTypeColumnDefList(typeOid);
 
@@ -763,17 +728,14 @@ attributeFormToColumnDef(Form_pg_attribute attributeForm)
 static List *
 CompositeTypeColumnDefList(Oid typeOid)
 {
-	Relation relation = NULL;
-	Oid relationId = InvalidOid;
-	TupleDesc tupleDescriptor = NULL;
-	int attributeIndex = 0;
 	List *columnDefs = NIL;
 
-	relationId = typeidTypeRelid(typeOid);
-	relation = relation_open(relationId, AccessShareLock);
+	Oid relationId = typeidTypeRelid(typeOid);
+	Relation relation = relation_open(relationId, AccessShareLock);
 
-	tupleDescriptor = RelationGetDescr(relation);
-	for (attributeIndex = 0; attributeIndex < tupleDescriptor->natts; attributeIndex++)
+	TupleDesc tupleDescriptor = RelationGetDescr(relation);
+	for (int attributeIndex = 0; attributeIndex < tupleDescriptor->natts;
+		 attributeIndex++)
 	{
 		Form_pg_attribute attributeForm = TupleDescAttr(tupleDescriptor, attributeIndex);
 
@@ -799,11 +761,9 @@ CompositeTypeColumnDefList(Oid typeOid)
 static CreateEnumStmt *
 RecreateEnumStmt(Oid typeOid)
 {
-	CreateEnumStmt *stmt = NULL;
-
 	Assert(get_typtype(typeOid) == TYPTYPE_ENUM);
 
-	stmt = makeNode(CreateEnumStmt);
+	CreateEnumStmt *stmt = makeNode(CreateEnumStmt);
 	stmt->typeName = stringToQualifiedNameList(format_type_be_qualified(typeOid));
 	stmt->vals = EnumValsList(typeOid);
 
@@ -818,8 +778,6 @@ RecreateEnumStmt(Oid typeOid)
 static List *
 EnumValsList(Oid typeOid)
 {
-	Relation enum_rel = NULL;
-	SysScanDesc enum_scan = NULL;
 	HeapTuple enum_tuple = NULL;
 	ScanKeyData skey = { 0 };
 
@@ -831,11 +789,11 @@ EnumValsList(Oid typeOid)
 				BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(typeOid));
 
-	enum_rel = heap_open(EnumRelationId, AccessShareLock);
-	enum_scan = systable_beginscan(enum_rel,
-								   EnumTypIdSortOrderIndexId,
-								   true, NULL,
-								   1, &skey);
+	Relation enum_rel = heap_open(EnumRelationId, AccessShareLock);
+	SysScanDesc enum_scan = systable_beginscan(enum_rel,
+											   EnumTypIdSortOrderIndexId,
+											   true, NULL,
+											   1, &skey);
 
 	/* collect all value names in CREATE TYPE ... AS ENUM stmt */
 	while (HeapTupleIsValid(enum_tuple = systable_getnext(enum_scan)))
@@ -861,13 +819,9 @@ EnumValsList(Oid typeOid)
 ObjectAddress *
 CompositeTypeStmtObjectAddress(CompositeTypeStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
-	typeName = MakeTypeNameFromRangeVar(stmt->typevar);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->typevar);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -885,13 +839,9 @@ CompositeTypeStmtObjectAddress(CompositeTypeStmt *stmt, bool missing_ok)
 ObjectAddress *
 CreateEnumStmtObjectAddress(CreateEnumStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
-	typeName = makeTypeNameFromNameList(stmt->typeName);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = makeTypeNameFromNameList(stmt->typeName);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -909,15 +859,11 @@ CreateEnumStmtObjectAddress(CreateEnumStmt *stmt, bool missing_ok)
 ObjectAddress *
 AlterTypeStmtObjectAddress(AlterTableStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
 	Assert(stmt->relkind == OBJECT_TYPE);
 
-	typeName = MakeTypeNameFromRangeVar(stmt->relation);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->relation);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -931,13 +877,9 @@ AlterTypeStmtObjectAddress(AlterTableStmt *stmt, bool missing_ok)
 ObjectAddress *
 AlterEnumStmtObjectAddress(AlterEnumStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
-	typeName = makeTypeNameFromNameList(stmt->typeName);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = makeTypeNameFromNameList(stmt->typeName);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -951,15 +893,11 @@ AlterEnumStmtObjectAddress(AlterEnumStmt *stmt, bool missing_ok)
 ObjectAddress *
 RenameTypeStmtObjectAddress(RenameStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
 	Assert(stmt->renameType == OBJECT_TYPE);
 
-	typeName = makeTypeNameFromNameList((List *) stmt->object);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = makeTypeNameFromNameList((List *) stmt->object);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -978,21 +916,16 @@ RenameTypeStmtObjectAddress(RenameStmt *stmt, bool missing_ok)
 ObjectAddress *
 AlterTypeSchemaStmtObjectAddress(AlterObjectSchemaStmt *stmt, bool missing_ok)
 {
-	ObjectAddress *address = NULL;
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	List *names = NIL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	names = (List *) stmt->object;
+	List *names = (List *) stmt->object;
 
 	/*
 	 * we hardcode missing_ok here during LookupTypeNameOid because if we can't find it it
 	 * might have already been moved in this transaction.
 	 */
-	typeName = makeTypeNameFromNameList(names);
-	typeOid = LookupTypeNameOid(NULL, typeName, true);
+	TypeName *typeName = makeTypeNameFromNameList(names);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, true);
 
 	if (typeOid == InvalidOid)
 	{
@@ -1024,7 +957,7 @@ AlterTypeSchemaStmtObjectAddress(AlterObjectSchemaStmt *stmt, bool missing_ok)
 		}
 	}
 
-	address = palloc0(sizeof(ObjectAddress));
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -1042,16 +975,12 @@ AlterTypeSchemaStmtObjectAddress(AlterObjectSchemaStmt *stmt, bool missing_ok)
 ObjectAddress *
 RenameTypeAttributeStmtObjectAddress(RenameStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
 	Assert(stmt->renameType == OBJECT_ATTRIBUTE);
 	Assert(stmt->relationType == OBJECT_TYPE);
 
-	typeName = MakeTypeNameFromRangeVar(stmt->relation);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->relation);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -1065,15 +994,11 @@ RenameTypeAttributeStmtObjectAddress(RenameStmt *stmt, bool missing_ok)
 ObjectAddress *
 AlterTypeOwnerObjectAddress(AlterOwnerStmt *stmt, bool missing_ok)
 {
-	TypeName *typeName = NULL;
-	Oid typeOid = InvalidOid;
-	ObjectAddress *address = NULL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	typeName = makeTypeNameFromNameList((List *) stmt->object);
-	typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	address = palloc0(sizeof(ObjectAddress));
+	TypeName *typeName = makeTypeNameFromNameList((List *) stmt->object);
+	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
 	return address;
@@ -1088,10 +1013,7 @@ List *
 CreateTypeDDLCommandsIdempotent(const ObjectAddress *typeAddress)
 {
 	List *ddlCommands = NIL;
-	const char *ddlCommand = NULL;
-	Node *stmt = NULL;
 	StringInfoData buf = { 0 };
-	const char *username = NULL;
 
 	Assert(typeAddress->classId == TypeRelationId);
 
@@ -1106,15 +1028,15 @@ CreateTypeDDLCommandsIdempotent(const ObjectAddress *typeAddress)
 		return NIL;
 	}
 
-	stmt = CreateTypeStmtByObjectAddress(typeAddress);
+	Node *stmt = CreateTypeStmtByObjectAddress(typeAddress);
 
 	/* capture ddl command for recreation and wrap in create if not exists construct */
-	ddlCommand = DeparseTreeNode(stmt);
+	const char *ddlCommand = DeparseTreeNode(stmt);
 	ddlCommand = WrapCreateOrReplace(ddlCommand);
 	ddlCommands = lappend(ddlCommands, (void *) ddlCommand);
 
 	/* add owner ship change so the creation command can be run as a different user */
-	username = GetUserNameFromId(GetTypeOwner(typeAddress->objectId), false);
+	const char *username = GetUserNameFromId(GetTypeOwner(typeAddress->objectId), false);
 	initStringInfo(&buf);
 	appendStringInfo(&buf, ALTER_TYPE_OWNER_COMMAND, getObjectIdentity(typeAddress),
 					 quote_identifier(username));
@@ -1145,8 +1067,6 @@ GenerateBackupNameForTypeCollision(const ObjectAddress *address)
 	{
 		int suffixLength = snprintf(suffix, NAMEDATALEN - 1, "(citus_backup_%d)",
 									count);
-		TypeName *newTypeName = NULL;
-		Oid typeOid = InvalidOid;
 
 		/* trim the base name at the end to leave space for the suffix and trailing \0 */
 		baseLength = Min(baseLength, NAMEDATALEN - suffixLength - 1);
@@ -1157,9 +1077,9 @@ GenerateBackupNameForTypeCollision(const ObjectAddress *address)
 		strncpy(newName + baseLength, suffix, suffixLength);
 
 		rel->relname = newName;
-		newTypeName = makeTypeNameFromNameList(MakeNameListFromRangeVar(rel));
+		TypeName *newTypeName = makeTypeNameFromNameList(MakeNameListFromRangeVar(rel));
 
-		typeOid = LookupTypeNameOid(NULL, newTypeName, true);
+		Oid typeOid = LookupTypeNameOid(NULL, newTypeName, true);
 		if (typeOid == InvalidOid)
 		{
 			return newName;
@@ -1235,9 +1155,8 @@ static Oid
 GetTypeOwner(Oid typeOid)
 {
 	Oid result = InvalidOid;
-	HeapTuple tp = NULL;
 
-	tp = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typeOid));
+	HeapTuple tp = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typeOid));
 	if (HeapTupleIsValid(tp))
 	{
 		Form_pg_type typtup = (Form_pg_type) GETSTRUCT(tp);

--- a/src/backend/distributed/commands/variableset.c
+++ b/src/backend/distributed/commands/variableset.c
@@ -96,9 +96,8 @@ IsSettingSafeToPropagate(char *name)
 		"exit_on_error",
 		"max_stack_depth"
 	};
-	Index settingIndex = 0;
 
-	for (settingIndex = 0; settingIndex < lengthof(skipSettings); settingIndex++)
+	for (Index settingIndex = 0; settingIndex < lengthof(skipSettings); settingIndex++)
 	{
 		if (pg_strcasecmp(skipSettings[settingIndex], name) == 0)
 		{
@@ -138,9 +137,8 @@ ProcessVariableSetStmt(VariableSetStmt *setStmt, const char *setStmtString)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
-		RemoteTransaction *transaction = NULL;
 
-		transaction = &connection->remoteTransaction;
+		RemoteTransaction *transaction = &connection->remoteTransaction;
 		if (transaction->transactionFailed)
 		{
 			continue;
@@ -162,10 +160,9 @@ ProcessVariableSetStmt(VariableSetStmt *setStmt, const char *setStmtString)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
-		RemoteTransaction *transaction = NULL;
 		const bool raiseErrors = true;
 
-		transaction = &connection->remoteTransaction;
+		RemoteTransaction *transaction = &connection->remoteTransaction;
 		if (transaction->transactionFailed)
 		{
 			continue;

--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -76,8 +76,7 @@ InitConnParams()
 void
 ResetConnParams()
 {
-	Index paramIdx = 0;
-	for (paramIdx = 0; paramIdx < ConnParams.size; paramIdx++)
+	for (Index paramIdx = 0; paramIdx < ConnParams.size; paramIdx++)
 	{
 		free((void *) ConnParams.keywords[paramIdx]);
 		free((void *) ConnParams.values[paramIdx]);
@@ -135,7 +134,6 @@ bool
 CheckConninfo(const char *conninfo, const char **whitelist,
 			  Size whitelistLength, char **errorMsg)
 {
-	PQconninfoOption *optionArray = NULL;
 	PQconninfoOption *option = NULL;
 	Index whitelistIdx PG_USED_FOR_ASSERTS_ONLY = 0;
 	char *errorMsgString = NULL;
@@ -165,7 +163,7 @@ CheckConninfo(const char *conninfo, const char **whitelist,
 	}
 
 	/* this should at least parse */
-	optionArray = PQconninfoParse(conninfo, NULL);
+	PQconninfoOption *optionArray = PQconninfoParse(conninfo, NULL);
 	if (optionArray == NULL)
 	{
 		*errorMsg = "Provided string is not a valid libpq connection info string";
@@ -187,15 +185,13 @@ CheckConninfo(const char *conninfo, const char **whitelist,
 
 	for (option = optionArray; option->keyword != NULL; option++)
 	{
-		void *matchingKeyword = NULL;
-
 		if (option->val == NULL || option->val[0] == '\0')
 		{
 			continue;
 		}
 
-		matchingKeyword = bsearch(&option->keyword, whitelist, whitelistLength,
-								  sizeof(char *), pg_qsort_strcmp);
+		void *matchingKeyword = bsearch(&option->keyword, whitelist, whitelistLength,
+										sizeof(char *), pg_qsort_strcmp);
 		if (matchingKeyword == NULL)
 		{
 			/* the whitelist lacks this keyword; error out! */
@@ -283,8 +279,6 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	/* auth keywords will begin after global and runtime ones are appended */
 	Index authParamsIdx = ConnParams.size + lengthof(runtimeKeywords);
 
-	Index paramIndex = 0;
-	Index runtimeParamIndex = 0;
 
 	if (ConnParams.size + lengthof(runtimeKeywords) >= ConnParams.maxSize)
 	{
@@ -296,7 +290,7 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	pg_ltoa(key->port, nodePortString); /* populate node port string with port */
 
 	/* first step: copy global parameters to beginning of array */
-	for (paramIndex = 0; paramIndex < ConnParams.size; paramIndex++)
+	for (Index paramIndex = 0; paramIndex < ConnParams.size; paramIndex++)
 	{
 		/* copy the keyword&value pointers to the new array */
 		connKeywords[paramIndex] = ConnParams.keywords[paramIndex];
@@ -311,7 +305,7 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	*runtimeParamStart = ConnParams.size;
 
 	/* second step: begin after global params and copy runtime params into our context */
-	for (runtimeParamIndex = 0;
+	for (Index runtimeParamIndex = 0;
 		 runtimeParamIndex < lengthof(runtimeKeywords);
 		 runtimeParamIndex++)
 	{
@@ -334,9 +328,7 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 const char *
 GetConnParam(const char *keyword)
 {
-	Index i = 0;
-
-	for (i = 0; i < ConnParams.size; i++)
+	for (Index i = 0; i < ConnParams.size; i++)
 	{
 		if (strcmp(keyword, ConnParams.keywords[i]) == 0)
 		{
@@ -357,10 +349,9 @@ static Size
 CalculateMaxSize()
 {
 	PQconninfoOption *defaults = PQconndefaults();
-	PQconninfoOption *option = NULL;
 	Size maxSize = 0;
 
-	for (option = defaults;
+	for (PQconninfoOption *option = defaults;
 		 option->keyword != NULL;
 		 option++, maxSize++)
 	{

--- a/src/backend/distributed/deparser/deparse_extension_stmts.c
+++ b/src/backend/distributed/deparser/deparse_extension_stmts.c
@@ -270,11 +270,9 @@ static void
 AppendAlterExtensionSchemaStmt(StringInfo buf,
 							   AlterObjectSchemaStmt *alterExtensionSchemaStmt)
 {
-	const char *extensionName = NULL;
-
 	Assert(alterExtensionSchemaStmt->objectType == OBJECT_EXTENSION);
 
-	extensionName = strVal(alterExtensionSchemaStmt->object);
+	const char *extensionName = strVal(alterExtensionSchemaStmt->object);
 	appendStringInfo(buf, "ALTER EXTENSION %s SET SCHEMA %s;", extensionName,
 					 quote_identifier(alterExtensionSchemaStmt->newschema));
 }

--- a/src/backend/distributed/deparser/deparse_type_stmts.c
+++ b/src/backend/distributed/deparser/deparse_type_stmts.c
@@ -137,14 +137,12 @@ AppendAlterTypeStmt(StringInfo buf, AlterTableStmt *stmt)
 	appendStringInfo(buf, "ALTER TYPE %s", identifier);
 	foreach(cmdCell, stmt->cmds)
 	{
-		AlterTableCmd *alterTableCmd = NULL;
-
 		if (cmdCell != list_head(stmt->cmds))
 		{
 			appendStringInfoString(buf, ", ");
 		}
 
-		alterTableCmd = castNode(AlterTableCmd, lfirst(cmdCell));
+		AlterTableCmd *alterTableCmd = castNode(AlterTableCmd, lfirst(cmdCell));
 		AppendAlterTypeCmd(buf, alterTableCmd);
 	}
 
@@ -317,13 +315,11 @@ AppendCompositeTypeStmt(StringInfo str, CompositeTypeStmt *stmt)
 static void
 AppendCreateEnumStmt(StringInfo str, CreateEnumStmt *stmt)
 {
-	RangeVar *typevar = NULL;
-	const char *identifier = NULL;
-
-	typevar = makeRangeVarFromNameList(stmt->typeName);
+	RangeVar *typevar = makeRangeVarFromNameList(stmt->typeName);
 
 	/* create the identifier from the fully qualified rangevar */
-	identifier = quote_qualified_identifier(typevar->schemaname, typevar->relname);
+	const char *identifier = quote_qualified_identifier(typevar->schemaname,
+														typevar->relname);
 
 	appendStringInfo(str, "CREATE TYPE %s AS ENUM (", identifier);
 	AppendStringList(str, stmt->vals);
@@ -472,11 +468,9 @@ DeparseAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt)
 static void
 AppendAlterTypeSchemaStmt(StringInfo buf, AlterObjectSchemaStmt *stmt)
 {
-	List *names = NIL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	names = (List *) stmt->object;
+	List *names = (List *) stmt->object;
 	appendStringInfo(buf, "ALTER TYPE %s SET SCHEMA %s;", NameListToQuotedString(names),
 					 quote_identifier(stmt->newschema));
 }
@@ -499,11 +493,9 @@ DeparseAlterTypeOwnerStmt(AlterOwnerStmt *stmt)
 static void
 AppendAlterTypeOwnerStmt(StringInfo buf, AlterOwnerStmt *stmt)
 {
-	List *names = NIL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	names = (List *) stmt->object;
+	List *names = (List *) stmt->object;
 	appendStringInfo(buf, "ALTER TYPE %s OWNER TO %s;", NameListToQuotedString(names),
 					 RoleSpecString(stmt->newowner, true));
 }

--- a/src/backend/distributed/deparser/format_collate.c
+++ b/src/backend/distributed/deparser/format_collate.c
@@ -60,18 +60,14 @@ FormatCollateBEQualified(Oid collate_oid)
 char *
 FormatCollateExtended(Oid collid, bits16 flags)
 {
-	HeapTuple tuple = NULL;
-	Form_pg_collation collform = NULL;
-	char *buf = NULL;
 	char *nspname = NULL;
-	char *typname = NULL;
 
 	if (collid == InvalidOid && (flags & FORMAT_COLLATE_ALLOW_INVALID) != 0)
 	{
 		return pstrdup("-");
 	}
 
-	tuple = SearchSysCache1(COLLOID, ObjectIdGetDatum(collid));
+	HeapTuple tuple = SearchSysCache1(COLLOID, ObjectIdGetDatum(collid));
 	if (!HeapTupleIsValid(tuple))
 	{
 		if ((flags & FORMAT_COLLATE_ALLOW_INVALID) != 0)
@@ -83,7 +79,7 @@ FormatCollateExtended(Oid collid, bits16 flags)
 			elog(ERROR, "cache lookup failed for collate %u", collid);
 		}
 	}
-	collform = (Form_pg_collation) GETSTRUCT(tuple);
+	Form_pg_collation collform = (Form_pg_collation) GETSTRUCT(tuple);
 
 	if ((flags & FORMAT_COLLATE_FORCE_QUALIFY) == 0 && CollationIsVisible(collid))
 	{
@@ -94,9 +90,9 @@ FormatCollateExtended(Oid collid, bits16 flags)
 		nspname = get_namespace_name_or_temp(collform->collnamespace);
 	}
 
-	typname = NameStr(collform->collname);
+	char *typname = NameStr(collform->collname);
 
-	buf = quote_qualified_identifier(nspname, typname);
+	char *buf = quote_qualified_identifier(nspname, typname);
 
 	ReleaseSysCache(tuple);
 

--- a/src/backend/distributed/deparser/qualify_function_stmt.c
+++ b/src/backend/distributed/deparser/qualify_function_stmt.c
@@ -143,11 +143,9 @@ QualifyFunctionSchemaName(ObjectWithArgs *func, ObjectType type)
 {
 	char *schemaName = NULL;
 	char *functionName = NULL;
-	Oid funcid = InvalidOid;
-	HeapTuple proctup;
 
-	funcid = LookupFuncWithArgs(type, func, true);
-	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	Oid funcid = LookupFuncWithArgs(type, func, true);
+	HeapTuple proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 
 	/*
 	 * We can not qualify the function if the catalogs do not have any records.
@@ -156,9 +154,7 @@ QualifyFunctionSchemaName(ObjectWithArgs *func, ObjectType type)
 	 */
 	if (HeapTupleIsValid(proctup))
 	{
-		Form_pg_proc procform;
-
-		procform = (Form_pg_proc) GETSTRUCT(proctup);
+		Form_pg_proc procform = (Form_pg_proc) GETSTRUCT(proctup);
 		schemaName = get_namespace_name(procform->pronamespace);
 		functionName = NameStr(procform->proname);
 		functionName = pstrdup(functionName); /* we release the tuple before used */

--- a/src/backend/distributed/deparser/qualify_type_stmt.c
+++ b/src/backend/distributed/deparser/qualify_type_stmt.c
@@ -53,17 +53,15 @@ GetTypeNamespaceNameByNameList(List *names)
 static Oid
 TypeOidGetNamespaceOid(Oid typeOid)
 {
-	Form_pg_type typeData = NULL;
 	HeapTuple typeTuple = SearchSysCache1(TYPEOID, typeOid);
-	Oid typnamespace = InvalidOid;
 
 	if (!HeapTupleIsValid(typeTuple))
 	{
 		elog(ERROR, "citus cache lookup failed");
 		return InvalidOid;
 	}
-	typeData = (Form_pg_type) GETSTRUCT(typeTuple);
-	typnamespace = typeData->typnamespace;
+	Form_pg_type typeData = (Form_pg_type) GETSTRUCT(typeTuple);
+	Oid typnamespace = typeData->typnamespace;
 
 	ReleaseSysCache(typeTuple);
 
@@ -161,11 +159,9 @@ QualifyCreateEnumStmt(CreateEnumStmt *stmt)
 void
 QualifyAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt)
 {
-	List *names = NIL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	names = (List *) stmt->object;
+	List *names = (List *) stmt->object;
 	if (list_length(names) == 1)
 	{
 		/* not qualified with schema, lookup type and its schema s*/
@@ -179,11 +175,9 @@ QualifyAlterTypeSchemaStmt(AlterObjectSchemaStmt *stmt)
 void
 QualifyAlterTypeOwnerStmt(AlterOwnerStmt *stmt)
 {
-	List *names = NIL;
-
 	Assert(stmt->objectType == OBJECT_TYPE);
 
-	names = (List *) stmt->object;
+	List *names = (List *) stmt->object;
 	if (list_length(names) == 1)
 	{
 		/* not qualified with schema, lookup type and its schema s*/

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -119,12 +119,11 @@ RegisterCitusCustomScanMethods(void)
 static void
 CitusBeginScan(CustomScanState *node, EState *estate, int eflags)
 {
-	CitusScanState *scanState = NULL;
 	DistributedPlan *distributedPlan = NULL;
 
 	MarkCitusInitiatedCoordinatorBackend();
 
-	scanState = (CitusScanState *) node;
+	CitusScanState *scanState = (CitusScanState *) node;
 
 #if PG_VERSION_NUM >= 120000
 	ExecInitResultSlot(&scanState->customScanState.ss.ps, &TTSOpsMinimalTuple);
@@ -152,7 +151,6 @@ TupleTableSlot *
 CitusExecScan(CustomScanState *node)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
-	TupleTableSlot *resultSlot = NULL;
 
 	if (!scanState->finishedRemoteScan)
 	{
@@ -161,7 +159,7 @@ CitusExecScan(CustomScanState *node)
 		scanState->finishedRemoteScan = true;
 	}
 
-	resultSlot = ReturnTupleFromTuplestore(scanState);
+	TupleTableSlot *resultSlot = ReturnTupleFromTuplestore(scanState);
 
 	return resultSlot;
 }
@@ -179,21 +177,18 @@ static void
 CitusModifyBeginScan(CustomScanState *node, EState *estate, int eflags)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
-	DistributedPlan *distributedPlan = NULL;
-	Job *workerJob = NULL;
-	Query *jobQuery = NULL;
-	List *taskList = NIL;
 
 	/*
 	 * We must not change the distributed plan since it may be reused across multiple
 	 * executions of a prepared statement. Instead we create a deep copy that we only
 	 * use for the current execution.
 	 */
-	distributedPlan = scanState->distributedPlan = copyObject(scanState->distributedPlan);
+	DistributedPlan *distributedPlan = scanState->distributedPlan = copyObject(
+		scanState->distributedPlan);
 
-	workerJob = distributedPlan->workerJob;
-	jobQuery = workerJob->jobQuery;
-	taskList = workerJob->taskList;
+	Job *workerJob = distributedPlan->workerJob;
+	Query *jobQuery = workerJob->jobQuery;
+	List *taskList = workerJob->taskList;
 
 	if (workerJob->requiresMasterEvaluation)
 	{
@@ -407,8 +402,6 @@ ScanStateGetExecutorState(CitusScanState *scanState)
 CustomScan *
 FetchCitusCustomScanIfExists(Plan *plan)
 {
-	CustomScan *customScan = NULL;
-
 	if (plan == NULL)
 	{
 		return NULL;
@@ -419,7 +412,7 @@ FetchCitusCustomScanIfExists(Plan *plan)
 		return (CustomScan *) plan;
 	}
 
-	customScan = FetchCitusCustomScanIfExists(plan->lefttree);
+	CustomScan *customScan = FetchCitusCustomScanIfExists(plan->lefttree);
 
 	if (customScan == NULL)
 	{
@@ -457,9 +450,6 @@ IsCitusPlan(Plan *plan)
 bool
 IsCitusCustomScan(Plan *plan)
 {
-	CustomScan *customScan = NULL;
-	Node *privateNode = NULL;
-
 	if (plan == NULL)
 	{
 		return false;
@@ -470,13 +460,13 @@ IsCitusCustomScan(Plan *plan)
 		return false;
 	}
 
-	customScan = (CustomScan *) plan;
+	CustomScan *customScan = (CustomScan *) plan;
 	if (list_length(customScan->custom_private) == 0)
 	{
 		return false;
 	}
 
-	privateNode = (Node *) linitial(customScan->custom_private);
+	Node *privateNode = (Node *) linitial(customScan->custom_private);
 	if (!CitusIsA(privateNode, DistributedPlan))
 	{
 		return false;

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -93,7 +93,6 @@ static TupleTableSlot *
 CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
-	TupleTableSlot *resultSlot = NULL;
 
 	if (!scanState->finishedRemoteScan)
 	{
@@ -197,7 +196,7 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 		scanState->finishedRemoteScan = true;
 	}
 
-	resultSlot = ReturnTupleFromTuplestore(scanState);
+	TupleTableSlot *resultSlot = ReturnTupleFromTuplestore(scanState);
 
 	return resultSlot;
 }
@@ -217,36 +216,34 @@ ExecuteSelectIntoColocatedIntermediateResults(Oid targetRelationId,
 											  char *intermediateResultIdPrefix)
 {
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
-	int partitionColumnIndex = -1;
-	List *columnNameList = NIL;
 	bool stopOnFailure = false;
-	char partitionMethod = 0;
-	CitusCopyDestReceiver *copyDest = NULL;
-	Query *queryCopy = NULL;
 
-	partitionMethod = PartitionMethod(targetRelationId);
+	char partitionMethod = PartitionMethod(targetRelationId);
 	if (partitionMethod == DISTRIBUTE_BY_NONE)
 	{
 		stopOnFailure = true;
 	}
 
 	/* Get column name list and partition column index for the target table */
-	columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
-													   insertTargetList);
-	partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
-															  columnNameList);
+	List *columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
+															 insertTargetList);
+	int partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
+																  columnNameList);
 
 	/* set up a DestReceiver that copies into the intermediate table */
-	copyDest = CreateCitusCopyDestReceiver(targetRelationId, columnNameList,
-										   partitionColumnIndex, executorState,
-										   stopOnFailure, intermediateResultIdPrefix);
+	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
+																  columnNameList,
+																  partitionColumnIndex,
+																  executorState,
+																  stopOnFailure,
+																  intermediateResultIdPrefix);
 
 	/*
 	 * Make a copy of the query, since ExecuteQueryIntoDestReceiver may scribble on it
 	 * and we want it to be replanned every time if it is stored in a prepared
 	 * statement.
 	 */
-	queryCopy = copyObject(selectQuery);
+	Query *queryCopy = copyObject(selectQuery);
 
 	ExecuteQueryIntoDestReceiver(queryCopy, paramListInfo, (DestReceiver *) copyDest);
 
@@ -268,36 +265,33 @@ ExecuteSelectIntoRelation(Oid targetRelationId, List *insertTargetList,
 						  Query *selectQuery, EState *executorState)
 {
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
-	int partitionColumnIndex = -1;
-	List *columnNameList = NIL;
 	bool stopOnFailure = false;
-	char partitionMethod = 0;
-	CitusCopyDestReceiver *copyDest = NULL;
-	Query *queryCopy = NULL;
 
-	partitionMethod = PartitionMethod(targetRelationId);
+	char partitionMethod = PartitionMethod(targetRelationId);
 	if (partitionMethod == DISTRIBUTE_BY_NONE)
 	{
 		stopOnFailure = true;
 	}
 
 	/* Get column name list and partition column index for the target table */
-	columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
-													   insertTargetList);
-	partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
-															  columnNameList);
+	List *columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
+															 insertTargetList);
+	int partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
+																  columnNameList);
 
 	/* set up a DestReceiver that copies into the distributed table */
-	copyDest = CreateCitusCopyDestReceiver(targetRelationId, columnNameList,
-										   partitionColumnIndex, executorState,
-										   stopOnFailure, NULL);
+	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
+																  columnNameList,
+																  partitionColumnIndex,
+																  executorState,
+																  stopOnFailure, NULL);
 
 	/*
 	 * Make a copy of the query, since ExecuteQueryIntoDestReceiver may scribble on it
 	 * and we want it to be replanned every time if it is stored in a prepared
 	 * statement.
 	 */
-	queryCopy = copyObject(selectQuery);
+	Query *queryCopy = copyObject(selectQuery);
 
 	ExecuteQueryIntoDestReceiver(queryCopy, paramListInfo, (DestReceiver *) copyDest);
 

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -170,7 +170,6 @@ InitTaskExecution(Task *task, TaskExecStatus initialTaskExecStatus)
 {
 	/* each task placement (assignment) corresponds to one worker node */
 	uint32 nodeCount = list_length(task->taskPlacementList);
-	uint32 nodeIndex = 0;
 
 	TaskExecution *taskExecution = CitusMakeNode(TaskExecution);
 
@@ -185,7 +184,7 @@ InitTaskExecution(Task *task, TaskExecStatus initialTaskExecStatus)
 	taskExecution->connectionIdArray = palloc0(nodeCount * sizeof(int32));
 	taskExecution->fileDescriptorArray = palloc0(nodeCount * sizeof(int32));
 
-	for (nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
+	for (uint32 nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
 	{
 		taskExecution->taskStatusArray[nodeIndex] = initialTaskExecStatus;
 		taskExecution->transmitStatusArray[nodeIndex] = EXEC_TRANSMIT_UNASSIGNED;
@@ -205,8 +204,7 @@ InitTaskExecution(Task *task, TaskExecStatus initialTaskExecStatus)
 void
 CleanupTaskExecution(TaskExecution *taskExecution)
 {
-	uint32 nodeIndex = 0;
-	for (nodeIndex = 0; nodeIndex < taskExecution->nodeCount; nodeIndex++)
+	for (uint32 nodeIndex = 0; nodeIndex < taskExecution->nodeCount; nodeIndex++)
 	{
 		int32 connectionId = taskExecution->connectionIdArray[nodeIndex];
 		int32 fileDescriptor = taskExecution->fileDescriptorArray[nodeIndex];
@@ -284,14 +282,12 @@ AdjustStateForFailure(TaskExecution *taskExecution)
 bool
 CheckIfSizeLimitIsExceeded(DistributedExecutionStats *executionStats)
 {
-	uint64 maxIntermediateResultInBytes = 0;
-
 	if (!SubPlanLevel || MaxIntermediateResult < 0)
 	{
 		return false;
 	}
 
-	maxIntermediateResultInBytes = MaxIntermediateResult * 1024L;
+	uint64 maxIntermediateResultInBytes = MaxIntermediateResult * 1024L;
 	if (executionStats->totalIntermediateResultSize < maxIntermediateResultInBytes)
 	{
 		return false;

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -158,9 +158,7 @@ void
 MultiTaskTrackerExecute(Job *job)
 {
 	List *jobTaskList = job->taskList;
-	List *taskAndExecutionList = NIL;
 	ListCell *taskAndExecutionCell = NULL;
-	uint32 taskTrackerCount = 0;
 	uint32 topLevelTaskCount = 0;
 	uint32 failedTaskId = 0;
 	bool allTasksCompleted = false;
@@ -170,13 +168,9 @@ MultiTaskTrackerExecute(Job *job)
 	bool sizeLimitIsExceeded = false;
 
 	DistributedExecutionStats executionStats = { 0 };
-	List *workerNodeList = NIL;
-	HTAB *taskTrackerHash = NULL;
-	HTAB *transmitTrackerHash = NULL;
 	char *extensionOwner = CitusExtensionOwnerName();
 	const char *taskTrackerHashName = "Task Tracker Hash";
 	const char *transmitTrackerHashName = "Transmit Tracker Hash";
-	List *jobIdList = NIL;
 
 	if (ReadFromSecondaries == USE_SECONDARY_NODES_ALWAYS)
 	{
@@ -189,7 +183,7 @@ MultiTaskTrackerExecute(Job *job)
 	 * We walk over the task tree, and create a task execution struct for each
 	 * task. We then associate the task with its execution and get back a list.
 	 */
-	taskAndExecutionList = TaskAndExecutionList(jobTaskList);
+	List *taskAndExecutionList = TaskAndExecutionList(jobTaskList);
 
 	/*
 	 * We now count the number of "top level" tasks in the query tree. Once they
@@ -212,15 +206,15 @@ MultiTaskTrackerExecute(Job *job)
 	 * assigning and checking the status of tasks. The second (temporary) hash
 	 * helps us in fetching results data from worker nodes to the master node.
 	 */
-	workerNodeList = ActivePrimaryWorkerNodeList(NoLock);
-	taskTrackerCount = (uint32) list_length(workerNodeList);
+	List *workerNodeList = ActivePrimaryWorkerNodeList(NoLock);
+	uint32 taskTrackerCount = (uint32) list_length(workerNodeList);
 
 	/* connect as the current user for running queries */
-	taskTrackerHash = TrackerHash(taskTrackerHashName, workerNodeList, NULL);
+	HTAB *taskTrackerHash = TrackerHash(taskTrackerHashName, workerNodeList, NULL);
 
 	/* connect as the superuser for fetching result files */
-	transmitTrackerHash = TrackerHash(transmitTrackerHashName, workerNodeList,
-									  extensionOwner);
+	HTAB *transmitTrackerHash = TrackerHash(transmitTrackerHashName, workerNodeList,
+											extensionOwner);
 
 	TrackerHashConnect(taskTrackerHash);
 	TrackerHashConnect(transmitTrackerHash);
@@ -243,7 +237,6 @@ MultiTaskTrackerExecute(Job *job)
 		{
 			Task *task = (Task *) lfirst(taskAndExecutionCell);
 			TaskExecution *taskExecution = task->taskExecution;
-			TaskExecStatus taskExecutionStatus = 0;
 
 			TaskTracker *execTaskTracker = ResolveTaskTracker(taskTrackerHash,
 															  task, taskExecution);
@@ -252,8 +245,9 @@ MultiTaskTrackerExecute(Job *job)
 			Assert(execTaskTracker != NULL);
 
 			/* call the function that performs the core task execution logic */
-			taskExecutionStatus = ManageTaskExecution(execTaskTracker, mapTaskTracker,
-													  task, taskExecution);
+			TaskExecStatus taskExecutionStatus = ManageTaskExecution(execTaskTracker,
+																	 mapTaskTracker,
+																	 task, taskExecution);
 
 			/*
 			 * If task cannot execute on this task/map tracker, we fail over all
@@ -261,8 +255,6 @@ MultiTaskTrackerExecute(Job *job)
 			 */
 			if (taskExecutionStatus == EXEC_TASK_TRACKER_FAILED)
 			{
-				List *taskList = NIL;
-
 				/* mark task tracker as failed, in case it isn't marked already */
 				execTaskTracker->trackerFailureCount = MAX_TRACKER_FAILURE_COUNT;
 
@@ -275,22 +267,20 @@ MultiTaskTrackerExecute(Job *job)
 													 task, taskExecution);
 				transmitTracker->trackerFailureCount = MAX_TRACKER_FAILURE_COUNT;
 
-				taskList = ConstrainedTaskList(taskAndExecutionList, task);
+				List *taskList = ConstrainedTaskList(taskAndExecutionList, task);
 				ReassignTaskList(taskList);
 			}
 			else if (taskExecutionStatus == EXEC_SOURCE_TASK_TRACKER_FAILED)
 			{
-				List *mapFetchTaskList = NIL;
-				List *mapTaskList = NIL;
-
 				/* first resolve the map task this map fetch task depends on */
 				Task *mapTask = (Task *) linitial(task->dependedTaskList);
 				Assert(task->taskType == MAP_OUTPUT_FETCH_TASK);
 
-				mapFetchTaskList = UpstreamDependencyList(taskAndExecutionList, mapTask);
+				List *mapFetchTaskList = UpstreamDependencyList(taskAndExecutionList,
+																mapTask);
 				ReassignMapFetchTaskList(mapFetchTaskList);
 
-				mapTaskList = ConstrainedTaskList(taskAndExecutionList, mapTask);
+				List *mapTaskList = ConstrainedTaskList(taskAndExecutionList, mapTask);
 				ReassignTaskList(mapTaskList);
 			}
 
@@ -313,10 +303,7 @@ MultiTaskTrackerExecute(Job *job)
 		{
 			Task *task = (Task *) lfirst(taskAndExecutionCell);
 			TaskExecution *taskExecution = task->taskExecution;
-			TransmitExecStatus transmitExecutionStatus = 0;
 
-			TaskTracker *execTransmitTracker = NULL;
-			bool transmitCompleted = false;
 
 			/*
 			 * We find the tasks that appear in the top level of the query tree,
@@ -328,14 +315,17 @@ MultiTaskTrackerExecute(Job *job)
 				continue;
 			}
 
-			execTransmitTracker = ResolveTaskTracker(transmitTrackerHash,
-													 task, taskExecution);
+			TaskTracker *execTransmitTracker = ResolveTaskTracker(transmitTrackerHash,
+																  task, taskExecution);
 			Assert(execTransmitTracker != NULL);
 
 			/* call the function that fetches results for completed SQL tasks */
-			transmitExecutionStatus = ManageTransmitExecution(execTransmitTracker,
-															  task, taskExecution,
-															  &executionStats);
+			TransmitExecStatus transmitExecutionStatus = ManageTransmitExecution(
+				execTransmitTracker,
+				task,
+				taskExecution,
+				&
+				executionStats);
 
 			/*
 			 * If we cannot transmit SQL task's results to the master, we first
@@ -344,13 +334,11 @@ MultiTaskTrackerExecute(Job *job)
 			 */
 			if (transmitExecutionStatus == EXEC_TRANSMIT_TRACKER_FAILED)
 			{
-				List *taskList = NIL;
-
 				taskTracker = ResolveTaskTracker(taskTrackerHash,
 												 task, taskExecution);
 				taskTracker->trackerFailureCount = MAX_TRACKER_FAILURE_COUNT;
 
-				taskList = ConstrainedTaskList(taskAndExecutionList, task);
+				List *taskList = ConstrainedTaskList(taskAndExecutionList, task);
 				ReassignTaskList(taskList);
 			}
 
@@ -362,7 +350,7 @@ MultiTaskTrackerExecute(Job *job)
 				break;
 			}
 
-			transmitCompleted = TransmitExecutionCompleted(taskExecution);
+			bool transmitCompleted = TransmitExecutionCompleted(taskExecution);
 			if (transmitCompleted)
 			{
 				completedTransmitCount++;
@@ -430,7 +418,7 @@ MultiTaskTrackerExecute(Job *job)
 	 */
 	HOLD_INTERRUPTS();
 
-	jobIdList = JobIdList(job);
+	List *jobIdList = JobIdList(job);
 
 	TrackerCleanupResources(taskTrackerHash, transmitTrackerHash,
 							jobIdList, taskAndExecutionList);
@@ -470,7 +458,6 @@ static List *
 TaskAndExecutionList(List *jobTaskList)
 {
 	List *taskAndExecutionList = NIL;
-	List *taskQueue = NIL;
 	const int topLevelTaskHashSize = 32;
 	int taskHashSize = list_length(jobTaskList) * topLevelTaskHashSize;
 	HTAB *taskHash = TaskHashCreate(taskHashSize);
@@ -479,11 +466,9 @@ TaskAndExecutionList(List *jobTaskList)
 	 * We walk over the task tree using breadth-first search. For the search, we
 	 * first queue top level tasks in the task tree.
 	 */
-	taskQueue = list_copy(jobTaskList);
+	List *taskQueue = list_copy(jobTaskList);
 	while (taskQueue != NIL)
 	{
-		TaskExecution *taskExecution = NULL;
-		List *dependendTaskList = NIL;
 		ListCell *dependedTaskCell = NULL;
 
 		/* pop first element from the task queue */
@@ -491,12 +476,12 @@ TaskAndExecutionList(List *jobTaskList)
 		taskQueue = list_delete_first(taskQueue);
 
 		/* create task execution and associate it with task */
-		taskExecution = InitTaskExecution(task, EXEC_TASK_UNASSIGNED);
+		TaskExecution *taskExecution = InitTaskExecution(task, EXEC_TASK_UNASSIGNED);
 		task->taskExecution = taskExecution;
 
 		taskAndExecutionList = lappend(taskAndExecutionList, task);
 
-		dependendTaskList = task->dependedTaskList;
+		List *dependendTaskList = task->dependedTaskList;
 
 		/*
 		 * Push task node's children into the task queue, if and only if
@@ -552,8 +537,6 @@ TaskHashCreate(uint32 taskHashSize)
 {
 	HASHCTL info;
 	const char *taskHashName = "Task Hash";
-	int hashFlags = 0;
-	HTAB *taskHash = NULL;
 
 	/*
 	 * Can't create a hashtable of size 0. Normally that shouldn't happen, but
@@ -569,9 +552,9 @@ TaskHashCreate(uint32 taskHashSize)
 	info.entrysize = sizeof(TaskMapEntry);
 	info.hash = tag_hash;
 	info.hcxt = CurrentMemoryContext;
-	hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+	int hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 
-	taskHash = hash_create(taskHashName, taskHashSize, &info, hashFlags);
+	HTAB *taskHash = hash_create(taskHashName, taskHashSize, &info, hashFlags);
 
 	return taskHash;
 }
@@ -584,8 +567,6 @@ TaskHashCreate(uint32 taskHashSize)
 static Task *
 TaskHashEnter(HTAB *taskHash, Task *task)
 {
-	void *hashKey = NULL;
-	TaskMapEntry *taskInTheHash = NULL;
 	bool handleFound = false;
 
 	TaskMapKey taskKey;
@@ -595,9 +576,10 @@ TaskHashEnter(HTAB *taskHash, Task *task)
 	taskKey.jobId = task->jobId;
 	taskKey.taskId = task->taskId;
 
-	hashKey = (void *) &taskKey;
-	taskInTheHash = (TaskMapEntry *) hash_search(taskHash, hashKey, HASH_ENTER,
-												 &handleFound);
+	void *hashKey = (void *) &taskKey;
+	TaskMapEntry *taskInTheHash = (TaskMapEntry *) hash_search(taskHash, hashKey,
+															   HASH_ENTER,
+															   &handleFound);
 
 	/* if same node appears twice, we error-out */
 	if (handleFound)
@@ -620,9 +602,7 @@ TaskHashEnter(HTAB *taskHash, Task *task)
 static Task *
 TaskHashLookup(HTAB *taskHash, TaskType taskType, uint64 jobId, uint32 taskId)
 {
-	TaskMapEntry *taskEntry = NULL;
 	Task *task = NULL;
-	void *hashKey = NULL;
 	bool handleFound = false;
 
 	TaskMapKey taskKey;
@@ -632,8 +612,9 @@ TaskHashLookup(HTAB *taskHash, TaskType taskType, uint64 jobId, uint32 taskId)
 	taskKey.jobId = jobId;
 	taskKey.taskId = taskId;
 
-	hashKey = (void *) &taskKey;
-	taskEntry = (TaskMapEntry *) hash_search(taskHash, hashKey, HASH_FIND, &handleFound);
+	void *hashKey = (void *) &taskKey;
+	TaskMapEntry *taskEntry = (TaskMapEntry *) hash_search(taskHash, hashKey, HASH_FIND,
+														   &handleFound);
 
 	if (taskEntry != NULL)
 	{
@@ -672,9 +653,8 @@ static bool
 TransmitExecutionCompleted(TaskExecution *taskExecution)
 {
 	bool completed = false;
-	uint32 nodeIndex = 0;
 
-	for (nodeIndex = 0; nodeIndex < taskExecution->nodeCount; nodeIndex++)
+	for (uint32 nodeIndex = 0; nodeIndex < taskExecution->nodeCount; nodeIndex++)
 	{
 		TransmitExecStatus *transmitStatusArray = taskExecution->transmitStatusArray;
 
@@ -710,15 +690,12 @@ TrackerHash(const char *taskTrackerHashName, List *workerNodeList, char *userNam
 		char *nodeName = workerNode->workerName;
 		uint32 nodePort = workerNode->workerPort;
 
-		TaskTracker *taskTracker = NULL;
 		char taskStateHashName[MAXPGPATH];
-		HTAB *taskStateHash = NULL;
 		uint32 taskStateCount = 32;
-		int hashFlags = 0;
 		HASHCTL info;
 
 		/* insert task tracker into the tracker hash */
-		taskTracker = TrackerHashEnter(taskTrackerHash, nodeName, nodePort);
+		TaskTracker *taskTracker = TrackerHashEnter(taskTrackerHash, nodeName, nodePort);
 
 		/* for each task tracker, create hash to track its assigned tasks */
 		snprintf(taskStateHashName, MAXPGPATH,
@@ -729,9 +706,10 @@ TrackerHash(const char *taskTrackerHashName, List *workerNodeList, char *userNam
 		info.entrysize = sizeof(TrackerTaskState);
 		info.hash = tag_hash;
 		info.hcxt = CurrentMemoryContext;
-		hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+		int hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 
-		taskStateHash = hash_create(taskStateHashName, taskStateCount, &info, hashFlags);
+		HTAB *taskStateHash = hash_create(taskStateHashName, taskStateCount, &info,
+										  hashFlags);
 		if (taskStateHash == NULL)
 		{
 			ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
@@ -754,18 +732,16 @@ static HTAB *
 TrackerHashCreate(const char *taskTrackerHashName, uint32 taskTrackerHashSize)
 {
 	HASHCTL info;
-	int hashFlags = 0;
-	HTAB *taskTrackerHash = NULL;
 
 	memset(&info, 0, sizeof(info));
 	info.keysize = WORKER_LENGTH + sizeof(uint32);
 	info.entrysize = sizeof(TaskTracker);
 	info.hash = tag_hash;
 	info.hcxt = CurrentMemoryContext;
-	hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+	int hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 
-	taskTrackerHash = hash_create(taskTrackerHashName, taskTrackerHashSize,
-								  &info, hashFlags);
+	HTAB *taskTrackerHash = hash_create(taskTrackerHashName, taskTrackerHashSize,
+										&info, hashFlags);
 	if (taskTrackerHash == NULL)
 	{
 		ereport(FATAL, (errcode(ERRCODE_OUT_OF_MEMORY),
@@ -784,8 +760,6 @@ TrackerHashCreate(const char *taskTrackerHashName, uint32 taskTrackerHashSize)
 static TaskTracker *
 TrackerHashEnter(HTAB *taskTrackerHash, char *nodeName, uint32 nodePort)
 {
-	TaskTracker *taskTracker = NULL;
-	void *hashKey = NULL;
 	bool handleFound = false;
 
 	TaskTracker taskTrackerKey;
@@ -793,9 +767,9 @@ TrackerHashEnter(HTAB *taskTrackerHash, char *nodeName, uint32 nodePort)
 	strlcpy(taskTrackerKey.workerName, nodeName, WORKER_LENGTH);
 	taskTrackerKey.workerPort = nodePort;
 
-	hashKey = (void *) &taskTrackerKey;
-	taskTracker = (TaskTracker *) hash_search(taskTrackerHash, hashKey,
-											  HASH_ENTER, &handleFound);
+	void *hashKey = (void *) &taskTrackerKey;
+	TaskTracker *taskTracker = (TaskTracker *) hash_search(taskTrackerHash, hashKey,
+														   HASH_ENTER, &handleFound);
 
 	/* if same node appears twice, we overwrite previous entry */
 	if (handleFound)
@@ -829,15 +803,13 @@ TrackerHashConnect(HTAB *taskTrackerHash)
 	/* loop until we tried to connect to all task trackers */
 	while (triedTrackerCount < taskTrackerCount)
 	{
-		TaskTracker *taskTracker = NULL;
 		HASH_SEQ_STATUS status;
-		long sleepIntervalPerCycle = 0;
 
 		/* loop over the task tracker hash, and poll all trackers again */
 		triedTrackerCount = 0;
 		hash_seq_init(&status, taskTrackerHash);
 
-		taskTracker = (TaskTracker *) hash_seq_search(&status);
+		TaskTracker *taskTracker = (TaskTracker *) hash_seq_search(&status);
 		while (taskTracker != NULL)
 		{
 			TrackerStatus trackerStatus = TrackerConnectPoll(taskTracker);
@@ -851,7 +823,7 @@ TrackerHashConnect(HTAB *taskTrackerHash)
 		}
 
 		/* sleep to avoid tight loop */
-		sleepIntervalPerCycle = RemoteTaskCheckInterval * 1000L;
+		long sleepIntervalPerCycle = RemoteTaskCheckInterval * 1000L;
 		pg_usleep(sleepIntervalPerCycle);
 	}
 }
@@ -988,10 +960,6 @@ ResolveTaskTracker(HTAB *trackerHash, Task *task, TaskExecution *taskExecution)
 static TaskTracker *
 ResolveMapTaskTracker(HTAB *trackerHash, Task *task, TaskExecution *taskExecution)
 {
-	TaskTracker *mapTaskTracker = NULL;
-	Task *mapTask = NULL;
-	TaskExecution *mapTaskExecution = NULL;
-
 	/* we only resolve source (map) task tracker for map output fetch tasks */
 	if (task->taskType != MAP_OUTPUT_FETCH_TASK)
 	{
@@ -999,10 +967,11 @@ ResolveMapTaskTracker(HTAB *trackerHash, Task *task, TaskExecution *taskExecutio
 	}
 
 	Assert(task->dependedTaskList != NIL);
-	mapTask = (Task *) linitial(task->dependedTaskList);
-	mapTaskExecution = mapTask->taskExecution;
+	Task *mapTask = (Task *) linitial(task->dependedTaskList);
+	TaskExecution *mapTaskExecution = mapTask->taskExecution;
 
-	mapTaskTracker = ResolveTaskTracker(trackerHash, mapTask, mapTaskExecution);
+	TaskTracker *mapTaskTracker = ResolveTaskTracker(trackerHash, mapTask,
+													 mapTaskExecution);
 	Assert(mapTaskTracker != NULL);
 
 	return mapTaskTracker;
@@ -1016,8 +985,6 @@ ResolveMapTaskTracker(HTAB *trackerHash, Task *task, TaskExecution *taskExecutio
 static TaskTracker *
 TrackerHashLookup(HTAB *trackerHash, const char *nodeName, uint32 nodePort)
 {
-	TaskTracker *taskTracker = NULL;
-	void *hashKey = NULL;
 	bool handleFound = false;
 
 	TaskTracker taskTrackerKey;
@@ -1025,9 +992,9 @@ TrackerHashLookup(HTAB *trackerHash, const char *nodeName, uint32 nodePort)
 	strlcpy(taskTrackerKey.workerName, nodeName, WORKER_LENGTH);
 	taskTrackerKey.workerPort = nodePort;
 
-	hashKey = (void *) &taskTrackerKey;
-	taskTracker = (TaskTracker *) hash_search(trackerHash, hashKey,
-											  HASH_FIND, &handleFound);
+	void *hashKey = (void *) &taskTrackerKey;
+	TaskTracker *taskTracker = (TaskTracker *) hash_search(trackerHash, hashKey,
+														   HASH_FIND, &handleFound);
 	if (taskTracker == NULL || !handleFound)
 	{
 		ereport(ERROR, (errmsg("could not find task tracker for node \"%s:%u\"",
@@ -1056,7 +1023,6 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 {
 	TaskExecStatus *taskStatusArray = taskExecution->taskStatusArray;
 	uint32 currentNodeIndex = taskExecution->currentNodeIndex;
-	uint32 nextNodeIndex = 0;
 
 	TaskExecStatus currentExecutionStatus = taskStatusArray[currentNodeIndex];
 	TaskExecStatus nextExecutionStatus = EXEC_TASK_INVALID_FIRST;
@@ -1065,9 +1031,6 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 	{
 		case EXEC_TASK_UNASSIGNED:
 		{
-			bool taskExecutionsCompleted = true;
-			TaskType taskType = TASK_TYPE_INVALID_FIRST;
-
 			bool trackerHealthy = TrackerHealthy(taskTracker);
 			if (!trackerHealthy)
 			{
@@ -1079,7 +1042,8 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 			 * We first retrieve this task's downstream dependencies, and then check
 			 * if these dependencies' executions have completed.
 			 */
-			taskExecutionsCompleted = TaskExecutionsCompleted(task->dependedTaskList);
+			bool taskExecutionsCompleted = TaskExecutionsCompleted(
+				task->dependedTaskList);
 			if (!taskExecutionsCompleted)
 			{
 				nextExecutionStatus = EXEC_TASK_UNASSIGNED;
@@ -1087,14 +1051,14 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 			}
 
 			/* if map fetch task, create query string from completed map task */
-			taskType = task->taskType;
+			TaskType taskType = task->taskType;
 			if (taskType == MAP_OUTPUT_FETCH_TASK)
 			{
-				StringInfo mapFetchTaskQueryString = NULL;
 				Task *mapTask = (Task *) linitial(task->dependedTaskList);
 				TaskExecution *mapTaskExecution = mapTask->taskExecution;
 
-				mapFetchTaskQueryString = MapFetchTaskQueryString(task, mapTask);
+				StringInfo mapFetchTaskQueryString = MapFetchTaskQueryString(task,
+																			 mapTask);
 				task->queryString = mapFetchTaskQueryString->data;
 				taskExecution->querySourceNodeIndex = mapTaskExecution->currentNodeIndex;
 			}
@@ -1118,8 +1082,6 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 
 		case EXEC_TASK_QUEUED:
 		{
-			TaskStatus remoteTaskStatus = TASK_STATUS_INVALID_FIRST;
-
 			bool trackerHealthy = TrackerHealthy(taskTracker);
 			if (!trackerHealthy)
 			{
@@ -1127,7 +1089,7 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 				break;
 			}
 
-			remoteTaskStatus = TrackerTaskStatus(taskTracker, task);
+			TaskStatus remoteTaskStatus = TrackerTaskStatus(taskTracker, task);
 			if (remoteTaskStatus == TASK_SUCCEEDED)
 			{
 				nextExecutionStatus = EXEC_TASK_DONE;
@@ -1165,22 +1127,19 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 
 		case EXEC_TASK_TRACKER_RETRY:
 		{
-			bool trackerHealthy = false;
-			bool trackerConnectionUp = false;
-
 			/*
 			 * This case statement usually handles connection related issues. Some
 			 * edge cases however, like a user sending a SIGTERM to the worker node,
 			 * keep the connection open but disallow task assignments. We therefore
 			 * need to track those as intermittent tracker failures here.
 			 */
-			trackerConnectionUp = TrackerConnectionUp(taskTracker);
+			bool trackerConnectionUp = TrackerConnectionUp(taskTracker);
 			if (trackerConnectionUp)
 			{
 				taskTracker->trackerFailureCount++;
 			}
 
-			trackerHealthy = TrackerHealthy(taskTracker);
+			bool trackerHealthy = TrackerHealthy(taskTracker);
 			if (trackerHealthy)
 			{
 				TaskStatus remoteTaskStatus = TrackerTaskStatus(taskTracker, task);
@@ -1207,7 +1166,6 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 			TaskExecution *mapTaskExecution = mapTask->taskExecution;
 			uint32 sourceNodeIndex = mapTaskExecution->currentNodeIndex;
 
-			bool sourceTrackerHealthy = false;
 			Assert(sourceTaskTracker != NULL);
 			Assert(task->taskType == MAP_OUTPUT_FETCH_TASK);
 
@@ -1227,7 +1185,7 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 				}
 			}
 
-			sourceTrackerHealthy = TrackerHealthy(sourceTaskTracker);
+			bool sourceTrackerHealthy = TrackerHealthy(sourceTaskTracker);
 			if (sourceTrackerHealthy)
 			{
 				/*
@@ -1274,7 +1232,7 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 	}
 
 	/* update task execution's status for most recent task tracker */
-	nextNodeIndex = taskExecution->currentNodeIndex;
+	uint32 nextNodeIndex = taskExecution->currentNodeIndex;
 	taskStatusArray[nextNodeIndex] = nextExecutionStatus;
 
 	return nextExecutionStatus;
@@ -1295,7 +1253,6 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 {
 	int32 *fileDescriptorArray = taskExecution->fileDescriptorArray;
 	uint32 currentNodeIndex = taskExecution->currentNodeIndex;
-	uint32 nextNodeIndex = 0;
 
 	TransmitExecStatus *transmitStatusArray = taskExecution->transmitStatusArray;
 	TransmitExecStatus currentTransmitStatus = transmitStatusArray[currentNodeIndex];
@@ -1308,7 +1265,6 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 		{
 			TaskExecStatus *taskStatusArray = taskExecution->taskStatusArray;
 			TaskExecStatus currentExecutionStatus = taskStatusArray[currentNodeIndex];
-			bool trackerHealthy = false;
 
 			/* if top level task's in progress, nothing to do */
 			if (currentExecutionStatus != EXEC_TASK_DONE)
@@ -1317,7 +1273,7 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 				break;
 			}
 
-			trackerHealthy = TrackerHealthy(transmitTracker);
+			bool trackerHealthy = TrackerHealthy(transmitTracker);
 			if (!trackerHealthy)
 			{
 				nextTransmitStatus = EXEC_TRANSMIT_TRACKER_FAILED;
@@ -1331,10 +1287,6 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 
 		case EXEC_TRANSMIT_QUEUED:
 		{
-			QueryStatus queryStatus = CLIENT_INVALID_QUERY;
-			int32 connectionId = INVALID_CONNECTION_ID;
-			TaskStatus taskStatus = TASK_STATUS_INVALID_FIRST;
-
 			bool trackerHealthy = TrackerHealthy(transmitTracker);
 			if (!trackerHealthy)
 			{
@@ -1342,7 +1294,7 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 				break;
 			}
 
-			taskStatus = TrackerTaskStatus(transmitTracker, task);
+			TaskStatus taskStatus = TrackerTaskStatus(transmitTracker, task);
 			if (taskStatus == TASK_FILE_TRANSMIT_QUEUED)
 			{
 				/* remain in queued status until tracker assigns this task */
@@ -1356,12 +1308,12 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 			}
 
 			/* the open connection belongs to this task */
-			connectionId = TransmitTrackerConnectionId(transmitTracker, task);
+			int32 connectionId = TransmitTrackerConnectionId(transmitTracker, task);
 			Assert(connectionId != INVALID_CONNECTION_ID);
 			Assert(taskStatus == TASK_ASSIGNED);
 
 			/* start copy protocol */
-			queryStatus = MultiClientQueryStatus(connectionId);
+			QueryStatus queryStatus = MultiClientQueryStatus(connectionId);
 			if (queryStatus == CLIENT_QUERY_COPY)
 			{
 				StringInfo jobDirectoryName = MasterJobDirectoryName(task->jobId);
@@ -1413,7 +1365,6 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 		case EXEC_TRANSMIT_COPYING:
 		{
 			int32 fileDescriptor = fileDescriptorArray[currentNodeIndex];
-			CopyStatus copyStatus = CLIENT_INVALID_COPY;
 			int closed = -1;
 			uint64 bytesReceived = 0;
 
@@ -1421,8 +1372,8 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 			int32 connectionId = TransmitTrackerConnectionId(transmitTracker, task);
 			Assert(connectionId != INVALID_CONNECTION_ID);
 
-			copyStatus = MultiClientCopyData(connectionId, fileDescriptor,
-											 &bytesReceived);
+			CopyStatus copyStatus = MultiClientCopyData(connectionId, fileDescriptor,
+														&bytesReceived);
 
 			if (SubPlanLevel > 0)
 			{
@@ -1481,21 +1432,18 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 
 		case EXEC_TRANSMIT_TRACKER_RETRY:
 		{
-			bool trackerHealthy = false;
-			bool trackerConnectionUp = false;
-
 			/*
 			 * The task tracker proxy handles connection errors. On the off chance
 			 * that our connection is still up and the transmit tracker misbehaved,
 			 * we capture this as an intermittent tracker failure.
 			 */
-			trackerConnectionUp = TrackerConnectionUp(transmitTracker);
+			bool trackerConnectionUp = TrackerConnectionUp(transmitTracker);
 			if (trackerConnectionUp)
 			{
 				transmitTracker->trackerFailureCount++;
 			}
 
-			trackerHealthy = TrackerHealthy(transmitTracker);
+			bool trackerHealthy = TrackerHealthy(transmitTracker);
 			if (trackerHealthy)
 			{
 				nextTransmitStatus = EXEC_TRANSMIT_UNASSIGNED;
@@ -1536,7 +1484,7 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 	}
 
 	/* update file transmit status for most recent transmit tracker */
-	nextNodeIndex = taskExecution->currentNodeIndex;
+	uint32 nextNodeIndex = taskExecution->currentNodeIndex;
 	transmitStatusArray[nextNodeIndex] = nextTransmitStatus;
 
 	return nextTransmitStatus;
@@ -1583,7 +1531,6 @@ TaskExecutionsCompleted(List *taskList)
 static StringInfo
 MapFetchTaskQueryString(Task *mapFetchTask, Task *mapTask)
 {
-	StringInfo mapFetchQueryString = NULL;
 	uint32 partitionFileId = mapFetchTask->partitionId;
 	uint32 mergeTaskId = mapFetchTask->upstreamTaskId;
 
@@ -1599,7 +1546,7 @@ MapFetchTaskQueryString(Task *mapFetchTask, Task *mapTask)
 	Assert(mapFetchTask->taskType == MAP_OUTPUT_FETCH_TASK);
 	Assert(mapTask->taskType == MAP_TASK);
 
-	mapFetchQueryString = makeStringInfo();
+	StringInfo mapFetchQueryString = makeStringInfo();
 	appendStringInfo(mapFetchQueryString, MAP_OUTPUT_FETCH_COMMAND,
 					 mapTask->jobId, mapTask->taskId, partitionFileId,
 					 mergeTaskId, /* fetch results to merge task */
@@ -1619,8 +1566,6 @@ static void
 TrackerQueueSqlTask(TaskTracker *taskTracker, Task *task)
 {
 	HTAB *taskStateHash = taskTracker->taskStateHash;
-	TrackerTaskState *taskState = NULL;
-	StringInfo taskAssignmentQuery = NULL;
 
 	/*
 	 * We first wrap the original query string in a worker_execute_sql_task
@@ -1644,9 +1589,10 @@ TrackerQueueSqlTask(TaskTracker *taskTracker, Task *task)
 	}
 
 	/* wrap a task assignment query outside the copy out query */
-	taskAssignmentQuery = TaskAssignmentQuery(task, sqlTaskQueryString->data);
+	StringInfo taskAssignmentQuery = TaskAssignmentQuery(task, sqlTaskQueryString->data);
 
-	taskState = TaskStateHashEnter(taskStateHash, task->jobId, task->taskId);
+	TrackerTaskState *taskState = TaskStateHashEnter(taskStateHash, task->jobId,
+													 task->taskId);
 	taskState->status = TASK_CLIENT_SIDE_QUEUED;
 	taskState->taskAssignmentQuery = taskAssignmentQuery;
 }
@@ -1662,13 +1608,12 @@ static void
 TrackerQueueTask(TaskTracker *taskTracker, Task *task)
 {
 	HTAB *taskStateHash = taskTracker->taskStateHash;
-	TrackerTaskState *taskState = NULL;
-	StringInfo taskAssignmentQuery = NULL;
 
 	/* wrap a task assignment query outside the original query */
-	taskAssignmentQuery = TaskAssignmentQuery(task, task->queryString);
+	StringInfo taskAssignmentQuery = TaskAssignmentQuery(task, task->queryString);
 
-	taskState = TaskStateHashEnter(taskStateHash, task->jobId, task->taskId);
+	TrackerTaskState *taskState = TaskStateHashEnter(taskStateHash, task->jobId,
+													 task->taskId);
 	taskState->status = TASK_CLIENT_SIDE_QUEUED;
 	taskState->taskAssignmentQuery = taskAssignmentQuery;
 }
@@ -1682,12 +1627,10 @@ TrackerQueueTask(TaskTracker *taskTracker, Task *task)
 static StringInfo
 TaskAssignmentQuery(Task *task, char *queryString)
 {
-	StringInfo taskAssignmentQuery = NULL;
-
 	/* quote the original query as a string literal */
 	char *escapedQueryString = quote_literal_cstr(queryString);
 
-	taskAssignmentQuery = makeStringInfo();
+	StringInfo taskAssignmentQuery = makeStringInfo();
 	appendStringInfo(taskAssignmentQuery, TASK_ASSIGNMENT_QUERY,
 					 task->jobId, task->taskId, escapedQueryString);
 
@@ -1728,17 +1671,16 @@ TrackerTaskStatus(TaskTracker *taskTracker, Task *task)
 static TrackerTaskState *
 TrackerTaskStateHashLookup(HTAB *taskStateHash, Task *task)
 {
-	TrackerTaskState *taskState = NULL;
-	void *hashKey = NULL;
 	bool handleFound = false;
 
 	TrackerTaskState taskStateKey;
 	taskStateKey.jobId = task->jobId;
 	taskStateKey.taskId = task->taskId;
 
-	hashKey = (void *) &taskStateKey;
-	taskState = (TrackerTaskState *) hash_search(taskStateHash, hashKey,
-												 HASH_FIND, &handleFound);
+	void *hashKey = (void *) &taskStateKey;
+	TrackerTaskState *taskState = (TrackerTaskState *) hash_search(taskStateHash, hashKey,
+																   HASH_FIND,
+																   &handleFound);
 
 	return taskState;
 }
@@ -1768,9 +1710,9 @@ static void
 TrackerQueueFileTransmit(TaskTracker *transmitTracker, Task *task)
 {
 	HTAB *transmitStateHash = transmitTracker->taskStateHash;
-	TrackerTaskState *transmitState = NULL;
 
-	transmitState = TaskStateHashEnter(transmitStateHash, task->jobId, task->taskId);
+	TrackerTaskState *transmitState = TaskStateHashEnter(transmitStateHash, task->jobId,
+														 task->taskId);
 	transmitState->status = TASK_FILE_TRANSMIT_QUEUED;
 }
 
@@ -1782,17 +1724,16 @@ TrackerQueueFileTransmit(TaskTracker *transmitTracker, Task *task)
 static TrackerTaskState *
 TaskStateHashEnter(HTAB *taskStateHash, uint64 jobId, uint32 taskId)
 {
-	TrackerTaskState *taskState = NULL;
-	void *hashKey = NULL;
 	bool handleFound = false;
 
 	TrackerTaskState taskStateKey;
 	taskStateKey.jobId = jobId;
 	taskStateKey.taskId = taskId;
 
-	hashKey = (void *) &taskStateKey;
-	taskState = (TrackerTaskState *) hash_search(taskStateHash, hashKey,
-												 HASH_ENTER, &handleFound);
+	void *hashKey = (void *) &taskStateKey;
+	TrackerTaskState *taskState = (TrackerTaskState *) hash_search(taskStateHash, hashKey,
+																   HASH_ENTER,
+																   &handleFound);
 
 	/* if same task queued twice, we overwrite previous entry */
 	if (handleFound)
@@ -1847,17 +1788,14 @@ static List *
 ConstrainedTaskList(List *taskAndExecutionList, Task *task)
 {
 	List *constrainedTaskList = NIL;
-	Task *constrainingTask = NULL;
-	List *mergeTaskList = NIL;
 	ListCell *mergeTaskCell = NULL;
-	List *upstreamTaskList = NIL;
 	ListCell *upstreamTaskCell = NULL;
 
 	/*
 	 * We first check if this task depends on any merge tasks. If it does *not*,
 	 * the task's dependency list becomes our tiny constraint group.
 	 */
-	mergeTaskList = ConstrainedMergeTaskList(taskAndExecutionList, task);
+	List *mergeTaskList = ConstrainedMergeTaskList(taskAndExecutionList, task);
 	if (mergeTaskList == NIL)
 	{
 		constrainedTaskList = ConstrainedNonMergeTaskList(taskAndExecutionList, task);
@@ -1882,9 +1820,10 @@ ConstrainedTaskList(List *taskAndExecutionList, Task *task)
 	 * we walk over all the tasks. If we want to optimize this later on, we can
 	 * precompute a task list that excludes map fetch tasks.
 	 */
-	constrainingTask = (Task *) linitial(mergeTaskList);
+	Task *constrainingTask = (Task *) linitial(mergeTaskList);
 
-	upstreamTaskList = UpstreamDependencyList(taskAndExecutionList, constrainingTask);
+	List *upstreamTaskList = UpstreamDependencyList(taskAndExecutionList,
+													constrainingTask);
 	Assert(upstreamTaskList != NIL);
 
 	foreach(upstreamTaskCell, upstreamTaskList)
@@ -1912,7 +1851,6 @@ ConstrainedTaskList(List *taskAndExecutionList, Task *task)
 static List *
 ConstrainedNonMergeTaskList(List *taskAndExecutionList, Task *task)
 {
-	List *constrainedTaskList = NIL;
 	Task *upstreamTask = NULL;
 	List *dependedTaskList = NIL;
 
@@ -1924,7 +1862,7 @@ ConstrainedNonMergeTaskList(List *taskAndExecutionList, Task *task)
 	}
 	Assert(upstreamTask != NULL);
 
-	constrainedTaskList = list_make1(upstreamTask);
+	List *constrainedTaskList = list_make1(upstreamTask);
 	constrainedTaskList = list_concat(constrainedTaskList, dependedTaskList);
 
 	return constrainedTaskList;
@@ -2015,7 +1953,6 @@ ConstrainedMergeTaskList(List *taskAndExecutionList, Task *task)
 	}
 	else if (taskType == MERGE_TASK)
 	{
-		Task *upstreamTask = NULL;
 		List *upstreamTaskList = UpstreamDependencyList(taskAndExecutionList, task);
 
 		/*
@@ -2024,7 +1961,7 @@ ConstrainedMergeTaskList(List *taskAndExecutionList, Task *task)
 		 * merge task besides us.
 		 */
 		Assert(upstreamTaskList != NIL);
-		upstreamTask = (Task *) linitial(upstreamTaskList);
+		Task *upstreamTask = (Task *) linitial(upstreamTaskList);
 
 		constrainedMergeTaskList = MergeTaskList(upstreamTask->dependedTaskList);
 	}
@@ -2145,16 +2082,13 @@ ReassignMapFetchTaskList(List *mapFetchTaskList)
 static void
 ManageTaskTracker(TaskTracker *taskTracker)
 {
-	bool trackerConnectionUp = false;
-	bool trackerHealthy = false;
-
-	trackerHealthy = TrackerHealthy(taskTracker);
+	bool trackerHealthy = TrackerHealthy(taskTracker);
 	if (!trackerHealthy)
 	{
 		return;
 	}
 
-	trackerConnectionUp = TrackerConnectionUp(taskTracker);
+	bool trackerConnectionUp = TrackerConnectionUp(taskTracker);
 	if (!trackerConnectionUp)
 	{
 		TrackerReconnectPoll(taskTracker);  /* try an async reconnect */
@@ -2185,12 +2119,11 @@ ManageTaskTracker(TaskTracker *taskTracker)
 		if (taskStatusBatchList)
 		{
 			int32 connectionId = taskTracker->connectionId;
-			StringInfo taskStatusBatchQuery = NULL;
-			bool querySent = false;
 
-			taskStatusBatchQuery = TaskStatusBatchQuery(taskStatusBatchList);
+			StringInfo taskStatusBatchQuery = TaskStatusBatchQuery(taskStatusBatchList);
 
-			querySent = MultiClientSendQuery(connectionId, taskStatusBatchQuery->data);
+			bool querySent = MultiClientSendQuery(connectionId,
+												  taskStatusBatchQuery->data);
 			if (querySent)
 			{
 				taskTracker->connectionBusy = true;
@@ -2219,10 +2152,9 @@ ManageTaskTracker(TaskTracker *taskTracker)
 	if (taskTracker->connectionBusy)
 	{
 		int32 connectionId = taskTracker->connectionId;
-		ResultStatus resultStatus = CLIENT_INVALID_RESULT_STATUS;
 
 		/* if connection is available, update task status accordingly */
-		resultStatus = MultiClientResultStatus(connectionId);
+		ResultStatus resultStatus = MultiClientResultStatus(connectionId);
 		if (resultStatus == CLIENT_RESULT_READY)
 		{
 			ReceiveTaskStatusBatchQueryResponse(taskTracker);
@@ -2323,10 +2255,9 @@ AssignQueuedTasks(TaskTracker *taskTracker)
 	int32 connectionId = taskTracker->connectionId;
 
 	HASH_SEQ_STATUS status;
-	TrackerTaskState *taskState = NULL;
 	hash_seq_init(&status, taskStateHash);
 
-	taskState = (TrackerTaskState *) hash_seq_search(&status);
+	TrackerTaskState *taskState = (TrackerTaskState *) hash_seq_search(&status);
 	while (taskState != NULL)
 	{
 		if (taskState->status == TASK_CLIENT_SIDE_QUEUED)
@@ -2359,8 +2290,6 @@ AssignQueuedTasks(TaskTracker *taskTracker)
 
 		foreach(taskCell, tasksToAssignList)
 		{
-			BatchQueryStatus queryStatus = CLIENT_INVALID_BATCH_QUERY;
-
 			taskState = (TrackerTaskState *) lfirst(taskCell);
 
 			if (!batchSuccess)
@@ -2369,8 +2298,10 @@ AssignQueuedTasks(TaskTracker *taskTracker)
 				continue;
 			}
 
-			queryStatus = MultiClientBatchResult(connectionId, &queryResult,
-												 &rowCount, &columnCount);
+			BatchQueryStatus queryStatus = MultiClientBatchResult(connectionId,
+																  &queryResult,
+																  &rowCount,
+																  &columnCount);
 			if (queryStatus == CLIENT_BATCH_QUERY_CONTINUE)
 			{
 				taskState->status = TASK_ASSIGNED;
@@ -2410,22 +2341,19 @@ AssignQueuedTasks(TaskTracker *taskTracker)
 static List *
 TaskStatusBatchList(TaskTracker *taskTracker)
 {
-	int32 assignedTaskCount = 0;
 	int32 assignedTaskIndex = 0;
 	List *assignedTaskList = taskTracker->assignedTaskList;
 	List *taskStatusBatchList = NIL;
 	ListCell *taskCell = NULL;
-	int32 currentTaskIndex = 0;
-	int32 lastTaskIndex = 0;
 
-	assignedTaskCount = list_length(assignedTaskList);
+	int32 assignedTaskCount = list_length(assignedTaskList);
 	if (assignedTaskCount == 0)
 	{
 		return NIL;
 	}
 
-	lastTaskIndex = (assignedTaskCount - 1);
-	currentTaskIndex = taskTracker->currentTaskIndex;
+	int32 lastTaskIndex = (assignedTaskCount - 1);
+	int32 currentTaskIndex = taskTracker->currentTaskIndex;
 	if (currentTaskIndex >= lastTaskIndex)
 	{
 		currentTaskIndex = -1;
@@ -2562,17 +2490,13 @@ ReceiveTaskStatusBatchQueryResponse(TaskTracker *taskTracker)
 static void
 ManageTransmitTracker(TaskTracker *transmitTracker)
 {
-	TrackerTaskState *transmitState = NULL;
-	bool trackerHealthy = false;
-	bool trackerConnectionUp = false;
-
-	trackerHealthy = TrackerHealthy(transmitTracker);
+	bool trackerHealthy = TrackerHealthy(transmitTracker);
 	if (!trackerHealthy)
 	{
 		return;
 	}
 
-	trackerConnectionUp = TrackerConnectionUp(transmitTracker);
+	bool trackerConnectionUp = TrackerConnectionUp(transmitTracker);
 	if (!trackerConnectionUp)
 	{
 		TrackerReconnectPoll(transmitTracker);  /* try an async reconnect */
@@ -2585,10 +2509,10 @@ ManageTransmitTracker(TaskTracker *transmitTracker)
 		return;
 	}
 
-	transmitState = NextQueuedFileTransmit(transmitTracker->taskStateHash);
+	TrackerTaskState *transmitState = NextQueuedFileTransmit(
+		transmitTracker->taskStateHash);
 	if (transmitState != NULL)
 	{
-		bool fileTransmitStarted = false;
 		int32 connectionId = transmitTracker->connectionId;
 		StringInfo jobDirectoryName = JobDirectoryName(transmitState->jobId);
 		StringInfo taskFilename = TaskFilename(jobDirectoryName, transmitState->taskId);
@@ -2598,7 +2522,8 @@ ManageTransmitTracker(TaskTracker *transmitTracker)
 		appendStringInfo(fileTransmitQuery, TRANSMIT_WITH_USER_COMMAND,
 						 taskFilename->data, quote_literal_cstr(userName));
 
-		fileTransmitStarted = MultiClientSendQuery(connectionId, fileTransmitQuery->data);
+		bool fileTransmitStarted = MultiClientSendQuery(connectionId,
+														fileTransmitQuery->data);
 		if (fileTransmitStarted)
 		{
 			transmitState->status = TASK_ASSIGNED;
@@ -2625,10 +2550,9 @@ static TrackerTaskState *
 NextQueuedFileTransmit(HTAB *taskStateHash)
 {
 	HASH_SEQ_STATUS status;
-	TrackerTaskState *taskState = NULL;
 	hash_seq_init(&status, taskStateHash);
 
-	taskState = (TrackerTaskState *) hash_seq_search(&status);
+	TrackerTaskState *taskState = (TrackerTaskState *) hash_seq_search(&status);
 	while (taskState != NULL)
 	{
 		if (taskState->status == TASK_FILE_TRANSMIT_QUEUED)
@@ -2653,17 +2577,15 @@ static List *
 JobIdList(Job *job)
 {
 	List *jobIdList = NIL;
-	List *jobQueue = NIL;
 
 	/*
 	 * We walk over the job tree using breadth-first search. For this, we first
 	 * queue the root node, and then start traversing our search space.
 	 */
-	jobQueue = list_make1(job);
+	List *jobQueue = list_make1(job);
 	while (jobQueue != NIL)
 	{
 		uint64 *jobIdPointer = (uint64 *) palloc0(sizeof(uint64));
-		List *jobChildrenList = NIL;
 
 		Job *currJob = (Job *) linitial(jobQueue);
 		jobQueue = list_delete_first(jobQueue);
@@ -2672,7 +2594,7 @@ JobIdList(Job *job)
 		jobIdList = lappend(jobIdList, jobIdPointer);
 
 		/* prevent dependedJobList being modified on list_concat() call */
-		jobChildrenList = list_copy(currJob->dependedJobList);
+		List *jobChildrenList = list_copy(currJob->dependedJobList);
 		if (jobChildrenList != NIL)
 		{
 			jobQueue = list_concat(jobQueue, jobChildrenList);
@@ -2740,11 +2662,10 @@ TrackerCleanupResources(HTAB *taskTrackerHash, HTAB *transmitTrackerHash,
 static void
 TrackerHashWaitActiveRequest(HTAB *taskTrackerHash)
 {
-	TaskTracker *taskTracker = NULL;
 	HASH_SEQ_STATUS status;
 	hash_seq_init(&status, taskTrackerHash);
 
-	taskTracker = (TaskTracker *) hash_seq_search(&status);
+	TaskTracker *taskTracker = (TaskTracker *) hash_seq_search(&status);
 	while (taskTracker != NULL)
 	{
 		bool trackerConnectionUp = TrackerConnectionUp(taskTracker);
@@ -2774,11 +2695,10 @@ TrackerHashWaitActiveRequest(HTAB *taskTrackerHash)
 static void
 TrackerHashCancelActiveRequest(HTAB *taskTrackerHash)
 {
-	TaskTracker *taskTracker = NULL;
 	HASH_SEQ_STATUS status;
 	hash_seq_init(&status, taskTrackerHash);
 
-	taskTracker = (TaskTracker *) hash_seq_search(&status);
+	TaskTracker *taskTracker = (TaskTracker *) hash_seq_search(&status);
 	while (taskTracker != NULL)
 	{
 		bool trackerConnectionUp = TrackerConnectionUp(taskTracker);
@@ -2801,13 +2721,10 @@ TrackerHashCancelActiveRequest(HTAB *taskTrackerHash)
 static Task *
 JobCleanupTask(uint64 jobId)
 {
-	Task *jobCleanupTask = NULL;
-	StringInfo jobCleanupQuery = NULL;
-
-	jobCleanupQuery = makeStringInfo();
+	StringInfo jobCleanupQuery = makeStringInfo();
 	appendStringInfo(jobCleanupQuery, JOB_CLEANUP_QUERY, jobId);
 
-	jobCleanupTask = CitusMakeNode(Task);
+	Task *jobCleanupTask = CitusMakeNode(Task);
 	jobCleanupTask->jobId = jobId;
 	jobCleanupTask->taskId = JOB_CLEANUP_TASK_ID;
 	jobCleanupTask->replicationModel = REPLICATION_MODEL_INVALID;
@@ -2828,17 +2745,14 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 {
 	uint64 jobId = jobCleanupTask->jobId;
 	List *taskTrackerList = NIL;
-	List *remainingTaskTrackerList = NIL;
 	const long statusCheckInterval = 10000; /* microseconds */
 	bool timedOut = false;
-	TimestampTz startTime = 0;
-	TaskTracker *taskTracker = NULL;
 	HASH_SEQ_STATUS status;
 
 	hash_seq_init(&status, taskTrackerHash);
 
 	/* walk over task trackers and try to issue job clean up requests */
-	taskTracker = (TaskTracker *) hash_seq_search(&status);
+	TaskTracker *taskTracker = (TaskTracker *) hash_seq_search(&status);
 	while (taskTracker != NULL)
 	{
 		bool trackerConnectionUp = TrackerConnectionUp(taskTracker);
@@ -2849,11 +2763,10 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 			/* if we have a clear connection, send cleanup job */
 			if (!taskTracker->connectionBusy)
 			{
-				StringInfo jobCleanupQuery = NULL;
-
 				/* assign through task tracker to manage resource utilization */
-				jobCleanupQuery = TaskAssignmentQuery(jobCleanupTask,
-													  jobCleanupTask->queryString);
+				StringInfo jobCleanupQuery = TaskAssignmentQuery(jobCleanupTask,
+																 jobCleanupTask->
+																 queryString);
 
 				jobCleanupQuerySent = MultiClientSendQuery(taskTracker->connectionId,
 														   jobCleanupQuery->data);
@@ -2883,7 +2796,7 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 	}
 
 	/* record the time when we start waiting for cleanup jobs to be sent */
-	startTime = GetCurrentTimestamp();
+	TimestampTz startTime = GetCurrentTimestamp();
 
 	/*
 	 * Walk over task trackers to which we sent clean up requests. Perform
@@ -2893,33 +2806,27 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 	 * we iterate one more time after time out occurs. This is necessary to report
 	 * warning messages for timed out cleanup jobs.
 	 */
-	remainingTaskTrackerList = taskTrackerList;
+	List *remainingTaskTrackerList = taskTrackerList;
 	while (list_length(remainingTaskTrackerList) > 0 && !timedOut)
 	{
 		List *activeTackTrackerList = remainingTaskTrackerList;
 		ListCell *activeTaskTrackerCell = NULL;
-		TimestampTz currentTime = 0;
 
 		remainingTaskTrackerList = NIL;
 
 		pg_usleep(statusCheckInterval);
-		currentTime = GetCurrentTimestamp();
+		TimestampTz currentTime = GetCurrentTimestamp();
 		timedOut = TimestampDifferenceExceeds(startTime, currentTime,
 											  NodeConnectionTimeout);
 
 		foreach(activeTaskTrackerCell, activeTackTrackerList)
 		{
-			int32 connectionId = 0;
-			char *nodeName = NULL;
-			uint32 nodePort = 0;
-			ResultStatus resultStatus = CLIENT_INVALID_RESULT_STATUS;
-
 			taskTracker = (TaskTracker *) lfirst(activeTaskTrackerCell);
-			connectionId = taskTracker->connectionId;
-			nodeName = taskTracker->workerName;
-			nodePort = taskTracker->workerPort;
+			int32 connectionId = taskTracker->connectionId;
+			char *nodeName = taskTracker->workerName;
+			uint32 nodePort = taskTracker->workerPort;
 
-			resultStatus = MultiClientResultStatus(connectionId);
+			ResultStatus resultStatus = MultiClientResultStatus(connectionId);
 			if (resultStatus == CLIENT_RESULT_READY)
 			{
 				QueryStatus queryStatus = MultiClientQueryStatus(connectionId);
@@ -2976,11 +2883,10 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 static void
 TrackerHashDisconnect(HTAB *taskTrackerHash)
 {
-	TaskTracker *taskTracker = NULL;
 	HASH_SEQ_STATUS status;
 	hash_seq_init(&status, taskTrackerHash);
 
-	taskTracker = (TaskTracker *) hash_seq_search(&status);
+	TaskTracker *taskTracker = (TaskTracker *) hash_seq_search(&status);
 	while (taskTracker != NULL)
 	{
 		if (taskTracker->connectionId != INVALID_CONNECTION_ID)
@@ -3004,7 +2910,6 @@ TupleTableSlot *
 TaskTrackerExecScan(CustomScanState *node)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
-	TupleTableSlot *resultSlot = NULL;
 
 	if (!scanState->finishedRemoteScan)
 	{
@@ -3032,7 +2937,7 @@ TaskTrackerExecScan(CustomScanState *node)
 		scanState->finishedRemoteScan = true;
 	}
 
-	resultSlot = ReturnTupleFromTuplestore(scanState);
+	TupleTableSlot *resultSlot = ReturnTupleFromTuplestore(scanState);
 
 	return resultSlot;
 }

--- a/src/backend/distributed/executor/placement_access.c
+++ b/src/backend/distributed/executor/placement_access.c
@@ -128,16 +128,16 @@ BuildPlacementAccessList(int32 groupId, List *relationShardList,
 	foreach(relationShardCell, relationShardList)
 	{
 		RelationShard *relationShard = (RelationShard *) lfirst(relationShardCell);
-		ShardPlacement *placement = NULL;
-		ShardPlacementAccess *placementAccess = NULL;
 
-		placement = FindShardPlacementOnGroup(groupId, relationShard->shardId);
+		ShardPlacement *placement = FindShardPlacementOnGroup(groupId,
+															  relationShard->shardId);
 		if (placement == NULL)
 		{
 			continue;
 		}
 
-		placementAccess = CreatePlacementAccess(placement, accessType);
+		ShardPlacementAccess *placementAccess = CreatePlacementAccess(placement,
+																	  accessType);
 		placementAccessList = lappend(placementAccessList, placementAccess);
 	}
 
@@ -152,9 +152,8 @@ BuildPlacementAccessList(int32 groupId, List *relationShardList,
 ShardPlacementAccess *
 CreatePlacementAccess(ShardPlacement *placement, ShardPlacementAccessType accessType)
 {
-	ShardPlacementAccess *placementAccess = NULL;
-
-	placementAccess = (ShardPlacementAccess *) palloc0(sizeof(ShardPlacementAccess));
+	ShardPlacementAccess *placementAccess = (ShardPlacementAccess *) palloc0(
+		sizeof(ShardPlacementAccess));
 	placementAccess->placement = placement;
 	placementAccess->accessType = accessType;
 

--- a/src/backend/distributed/master/citus_create_restore_point.c
+++ b/src/backend/distributed/master/citus_create_restore_point.c
@@ -49,9 +49,6 @@ Datum
 citus_create_restore_point(PG_FUNCTION_ARGS)
 {
 	text *restoreNameText = PG_GETARG_TEXT_P(0);
-	char *restoreNameString = NULL;
-	XLogRecPtr localRestorePoint = InvalidXLogRecPtr;
-	List *connectionList = NIL;
 
 	CheckCitusVersion(ERROR);
 	EnsureSuperUser();
@@ -74,7 +71,7 @@ citus_create_restore_point(PG_FUNCTION_ARGS)
 						 "start.")));
 	}
 
-	restoreNameString = text_to_cstring(restoreNameText);
+	char *restoreNameString = text_to_cstring(restoreNameText);
 	if (strlen(restoreNameString) >= MAXFNAMELEN)
 	{
 		ereport(ERROR,
@@ -87,7 +84,7 @@ citus_create_restore_point(PG_FUNCTION_ARGS)
 	 * establish connections to all nodes before taking any locks
 	 * ShareLock prevents new nodes being added, rendering connectionList incomplete
 	 */
-	connectionList = OpenConnectionsToAllWorkerNodes(ShareLock);
+	List *connectionList = OpenConnectionsToAllWorkerNodes(ShareLock);
 
 	/*
 	 * Send a BEGIN to bust through pgbouncer. We won't actually commit since
@@ -100,7 +97,7 @@ citus_create_restore_point(PG_FUNCTION_ARGS)
 	BlockDistributedTransactions();
 
 	/* do local restore point first to bail out early if something goes wrong */
-	localRestorePoint = XLogRestorePoint(restoreNameString);
+	XLogRecPtr localRestorePoint = XLogRestorePoint(restoreNameString);
 
 	/* run pg_create_restore_point on all nodes */
 	CreateRemoteRestorePoints(restoreNameString, connectionList);
@@ -117,19 +114,18 @@ static List *
 OpenConnectionsToAllWorkerNodes(LOCKMODE lockMode)
 {
 	List *connectionList = NIL;
-	List *workerNodeList = NIL;
 	ListCell *workerNodeCell = NULL;
 	int connectionFlags = FORCE_NEW_CONNECTION;
 
-	workerNodeList = ActivePrimaryWorkerNodeList(lockMode);
+	List *workerNodeList = ActivePrimaryWorkerNodeList(lockMode);
 
 	foreach(workerNodeCell, workerNodeList)
 	{
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
-		MultiConnection *connection = NULL;
 
-		connection = StartNodeConnection(connectionFlags, workerNode->workerName,
-										 workerNode->workerPort);
+		MultiConnection *connection = StartNodeConnection(connectionFlags,
+														  workerNode->workerName,
+														  workerNode->workerPort);
 		MarkRemoteTransactionCritical(connection);
 
 		connectionList = lappend(connectionList, connection);

--- a/src/backend/distributed/master/master_citus_tools.c
+++ b/src/backend/distributed/master/master_citus_tools.c
@@ -72,18 +72,10 @@ Datum
 master_run_on_worker(PG_FUNCTION_ARGS)
 {
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
-	MemoryContext per_query_ctx = NULL;
-	MemoryContext oldcontext = NULL;
-	TupleDesc tupleDescriptor = NULL;
-	Tuplestorestate *tupleStore = NULL;
 	bool parallelExecution = false;
 	StringInfo *nodeNameArray = NULL;
 	int *nodePortArray = NULL;
 	StringInfo *commandStringArray = NULL;
-	bool *statusArray = NULL;
-	StringInfo *resultArray = NULL;
-	int commandIndex = 0;
-	int commandCount = 0;
 
 	CheckCitusVersion(ERROR);
 
@@ -96,14 +88,14 @@ master_run_on_worker(PG_FUNCTION_ARGS)
 						"allowed in this context")));
 	}
 
-	commandCount = ParseCommandParameters(fcinfo, &nodeNameArray, &nodePortArray,
-										  &commandStringArray, &parallelExecution);
+	int commandCount = ParseCommandParameters(fcinfo, &nodeNameArray, &nodePortArray,
+											  &commandStringArray, &parallelExecution);
 
-	per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
-	oldcontext = MemoryContextSwitchTo(per_query_ctx);
+	MemoryContext per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+	MemoryContext oldcontext = MemoryContextSwitchTo(per_query_ctx);
 
 	/* get the requested return tuple description */
-	tupleDescriptor = CreateTupleDescCopy(rsinfo->expectedDesc);
+	TupleDesc tupleDescriptor = CreateTupleDescCopy(rsinfo->expectedDesc);
 
 	/*
 	 * Check to make sure we have correct tuple descriptor
@@ -121,9 +113,9 @@ master_run_on_worker(PG_FUNCTION_ARGS)
 	}
 
 	/* prepare storage for status and result values */
-	statusArray = palloc0(commandCount * sizeof(bool));
-	resultArray = palloc0(commandCount * sizeof(StringInfo));
-	for (commandIndex = 0; commandIndex < commandCount; commandIndex++)
+	bool *statusArray = palloc0(commandCount * sizeof(bool));
+	StringInfo *resultArray = palloc0(commandCount * sizeof(StringInfo));
+	for (int commandIndex = 0; commandIndex < commandCount; commandIndex++)
 	{
 		resultArray[commandIndex] = makeStringInfo();
 	}
@@ -142,9 +134,10 @@ master_run_on_worker(PG_FUNCTION_ARGS)
 
 	/* let the caller know we're sending back a tuplestore */
 	rsinfo->returnMode = SFRM_Materialize;
-	tupleStore = CreateTupleStore(tupleDescriptor,
-								  nodeNameArray, nodePortArray, statusArray,
-								  resultArray, commandCount);
+	Tuplestorestate *tupleStore = CreateTupleStore(tupleDescriptor,
+												   nodeNameArray, nodePortArray,
+												   statusArray,
+												   resultArray, commandCount);
 	rsinfo->setResult = tupleStore;
 	rsinfo->setDesc = tupleDescriptor;
 
@@ -170,10 +163,6 @@ ParseCommandParameters(FunctionCallInfo fcinfo, StringInfo **nodeNameArray,
 	Datum *nodeNameDatumArray = DeconstructArrayObject(nodeNameArrayObject);
 	Datum *nodePortDatumArray = DeconstructArrayObject(nodePortArrayObject);
 	Datum *commandStringDatumArray = DeconstructArrayObject(commandStringArrayObject);
-	int index = 0;
-	StringInfo *nodeNames = NULL;
-	int *nodePorts = NULL;
-	StringInfo *commandStrings = NULL;
 
 	if (nodeNameCount != nodePortCount || nodeNameCount != commandStringCount)
 	{
@@ -182,11 +171,11 @@ ParseCommandParameters(FunctionCallInfo fcinfo, StringInfo **nodeNameArray,
 				 errmsg("expected same number of node name, port, and query string")));
 	}
 
-	nodeNames = palloc0(nodeNameCount * sizeof(StringInfo));
-	nodePorts = palloc0(nodeNameCount * sizeof(int));
-	commandStrings = palloc0(nodeNameCount * sizeof(StringInfo));
+	StringInfo *nodeNames = palloc0(nodeNameCount * sizeof(StringInfo));
+	int *nodePorts = palloc0(nodeNameCount * sizeof(int));
+	StringInfo *commandStrings = palloc0(nodeNameCount * sizeof(StringInfo));
 
-	for (index = 0; index < nodeNameCount; index++)
+	for (int index = 0; index < nodeNameCount; index++)
 	{
 		text *nodeNameText = DatumGetTextP(nodeNameDatumArray[index]);
 		char *nodeName = text_to_cstring(nodeNameText);
@@ -224,13 +213,12 @@ ExecuteCommandsInParallelAndStoreResults(StringInfo *nodeNameArray, int *nodePor
 										 bool *statusArray, StringInfo *resultStringArray,
 										 int commmandCount)
 {
-	int commandIndex = 0;
 	MultiConnection **connectionArray =
 		palloc0(commmandCount * sizeof(MultiConnection *));
 	int finishedCount = 0;
 
 	/* start connections asynchronously */
-	for (commandIndex = 0; commandIndex < commmandCount; commandIndex++)
+	for (int commandIndex = 0; commandIndex < commmandCount; commandIndex++)
 	{
 		char *nodeName = nodeNameArray[commandIndex]->data;
 		int nodePort = nodePortArray[commandIndex];
@@ -240,7 +228,7 @@ ExecuteCommandsInParallelAndStoreResults(StringInfo *nodeNameArray, int *nodePor
 	}
 
 	/* establish connections */
-	for (commandIndex = 0; commandIndex < commmandCount; commandIndex++)
+	for (int commandIndex = 0; commandIndex < commmandCount; commandIndex++)
 	{
 		MultiConnection *connection = connectionArray[commandIndex];
 		StringInfo queryResultString = resultStringArray[commandIndex];
@@ -264,9 +252,8 @@ ExecuteCommandsInParallelAndStoreResults(StringInfo *nodeNameArray, int *nodePor
 	}
 
 	/* send queries at once */
-	for (commandIndex = 0; commandIndex < commmandCount; commandIndex++)
+	for (int commandIndex = 0; commandIndex < commmandCount; commandIndex++)
 	{
-		int querySent = 0;
 		MultiConnection *connection = connectionArray[commandIndex];
 		char *queryString = commandStringArray[commandIndex]->data;
 		StringInfo queryResultString = resultStringArray[commandIndex];
@@ -280,7 +267,7 @@ ExecuteCommandsInParallelAndStoreResults(StringInfo *nodeNameArray, int *nodePor
 			continue;
 		}
 
-		querySent = SendRemoteCommand(connection, queryString);
+		int querySent = SendRemoteCommand(connection, queryString);
 		if (querySent == 0)
 		{
 			StoreErrorMessage(connection, queryResultString);
@@ -294,20 +281,19 @@ ExecuteCommandsInParallelAndStoreResults(StringInfo *nodeNameArray, int *nodePor
 	/* check for query results */
 	while (finishedCount < commmandCount)
 	{
-		for (commandIndex = 0; commandIndex < commmandCount; commandIndex++)
+		for (int commandIndex = 0; commandIndex < commmandCount; commandIndex++)
 		{
 			MultiConnection *connection = connectionArray[commandIndex];
 			StringInfo queryResultString = resultStringArray[commandIndex];
 			bool success = false;
-			bool queryFinished = false;
 
 			if (connection == NULL)
 			{
 				continue;
 			}
 
-			queryFinished = GetConnectionStatusAndResult(connection, &success,
-														 queryResultString);
+			bool queryFinished = GetConnectionStatusAndResult(connection, &success,
+															  queryResultString);
 
 			if (queryFinished)
 			{
@@ -343,9 +329,6 @@ GetConnectionStatusAndResult(MultiConnection *connection, bool *resultStatus,
 {
 	bool finished = true;
 	ConnStatusType connectionStatus = PQstatus(connection->pgConn);
-	int consumeInput = 0;
-	PGresult *queryResult = NULL;
-	bool success = false;
 
 	*resultStatus = false;
 	resetStringInfo(queryResultString);
@@ -356,7 +339,7 @@ GetConnectionStatusAndResult(MultiConnection *connection, bool *resultStatus,
 		return finished;
 	}
 
-	consumeInput = PQconsumeInput(connection->pgConn);
+	int consumeInput = PQconsumeInput(connection->pgConn);
 	if (consumeInput == 0)
 	{
 		appendStringInfo(queryResultString, "query result unavailable");
@@ -371,8 +354,8 @@ GetConnectionStatusAndResult(MultiConnection *connection, bool *resultStatus,
 	}
 
 	/* query result is available at this point */
-	queryResult = PQgetResult(connection->pgConn);
-	success = EvaluateQueryResult(connection, queryResult, queryResultString);
+	PGresult *queryResult = PQgetResult(connection->pgConn);
+	bool success = EvaluateQueryResult(connection, queryResult, queryResultString);
 	PQclear(queryResult);
 
 	*resultStatus = success;
@@ -449,12 +432,10 @@ StoreErrorMessage(MultiConnection *connection, StringInfo queryResultString)
 	char *errorMessage = PQerrorMessage(connection->pgConn);
 	if (errorMessage != NULL)
 	{
-		char *firstNewlineIndex = NULL;
-
 		/* copy the error message to a writable memory */
 		errorMessage = pnstrdup(errorMessage, strlen(errorMessage));
 
-		firstNewlineIndex = strchr(errorMessage, '\n');
+		char *firstNewlineIndex = strchr(errorMessage, '\n');
 
 		/* trim the error message at the line break */
 		if (firstNewlineIndex != NULL)
@@ -484,17 +465,15 @@ ExecuteCommandsAndStoreResults(StringInfo *nodeNameArray, int *nodePortArray,
 							   StringInfo *commandStringArray, bool *statusArray,
 							   StringInfo *resultStringArray, int commmandCount)
 {
-	int commandIndex = 0;
-	for (commandIndex = 0; commandIndex < commmandCount; commandIndex++)
+	for (int commandIndex = 0; commandIndex < commmandCount; commandIndex++)
 	{
 		char *nodeName = nodeNameArray[commandIndex]->data;
 		int32 nodePort = nodePortArray[commandIndex];
-		bool success = false;
 		char *queryString = commandStringArray[commandIndex]->data;
 		StringInfo queryResultString = resultStringArray[commandIndex];
 
-		success = ExecuteRemoteQueryOrCommand(nodeName, nodePort, queryString,
-											  queryResultString);
+		bool success = ExecuteRemoteQueryOrCommand(nodeName, nodePort, queryString,
+												   queryResultString);
 
 		statusArray[commandIndex] = success;
 
@@ -516,8 +495,6 @@ ExecuteRemoteQueryOrCommand(char *nodeName, uint32 nodePort, char *queryString,
 	int connectionFlags = FORCE_NEW_CONNECTION;
 	MultiConnection *connection =
 		GetNodeConnection(connectionFlags, nodeName, nodePort);
-	bool success = false;
-	PGresult *queryResult = NULL;
 	bool raiseInterrupts = true;
 
 	if (PQstatus(connection->pgConn) != CONNECTION_OK)
@@ -528,8 +505,8 @@ ExecuteRemoteQueryOrCommand(char *nodeName, uint32 nodePort, char *queryString,
 	}
 
 	SendRemoteCommand(connection, queryString);
-	queryResult = GetRemoteCommandResult(connection, raiseInterrupts);
-	success = EvaluateQueryResult(connection, queryResult, queryResultString);
+	PGresult *queryResult = GetRemoteCommandResult(connection, raiseInterrupts);
+	bool success = EvaluateQueryResult(connection, queryResult, queryResultString);
 
 	PQclear(queryResult);
 
@@ -547,13 +524,11 @@ CreateTupleStore(TupleDesc tupleDescriptor,
 				 StringInfo *resultArray, int commandCount)
 {
 	Tuplestorestate *tupleStore = tuplestore_begin_heap(true, false, work_mem);
-	int commandIndex = 0;
 	bool nulls[4] = { false, false, false, false };
 
-	for (commandIndex = 0; commandIndex < commandCount; commandIndex++)
+	for (int commandIndex = 0; commandIndex < commandCount; commandIndex++)
 	{
 		Datum values[4];
-		HeapTuple tuple = NULL;
 		StringInfo nodeNameString = nodeNameArray[commandIndex];
 		StringInfo resultString = resultArray[commandIndex];
 		text *nodeNameText = cstring_to_text_with_len(nodeNameString->data,
@@ -566,7 +541,7 @@ CreateTupleStore(TupleDesc tupleDescriptor,
 		values[2] = BoolGetDatum(statusArray[commandIndex]);
 		values[3] = PointerGetDatum(resultText);
 
-		tuple = heap_form_tuple(tupleDescriptor, values, nulls);
+		HeapTuple tuple = heap_form_tuple(tupleDescriptor, values, nulls);
 		tuplestore_puttuple(tupleStore, tuple);
 
 		heap_freetuple(tuple);

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -103,23 +103,10 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 {
 	text *queryText = PG_GETARG_TEXT_P(0);
 	char *queryString = text_to_cstring(queryText);
-	char *relationName = NULL;
-	char *schemaName = NULL;
-	Oid relationId = InvalidOid;
-	List *shardIntervalList = NIL;
 	List *deletableShardIntervalList = NIL;
-	List *queryTreeList = NIL;
-	Query *deleteQuery = NULL;
-	Node *whereClause = NULL;
-	Node *deleteCriteria = NULL;
-	Node *queryTreeNode = NULL;
-	DeleteStmt *deleteStatement = NULL;
-	int droppedShardCount = 0;
-	LOCKMODE lockMode = 0;
-	char partitionMethod = 0;
 	bool failOK = false;
 	RawStmt *rawStmt = (RawStmt *) ParseTreeRawStmt(queryString);
-	queryTreeNode = rawStmt->stmt;
+	Node *queryTreeNode = rawStmt->stmt;
 
 	EnsureCoordinator();
 	CheckCitusVersion(ERROR);
@@ -130,19 +117,19 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 							   ApplyLogRedaction(queryString))));
 	}
 
-	deleteStatement = (DeleteStmt *) queryTreeNode;
+	DeleteStmt *deleteStatement = (DeleteStmt *) queryTreeNode;
 
-	schemaName = deleteStatement->relation->schemaname;
-	relationName = deleteStatement->relation->relname;
+	char *schemaName = deleteStatement->relation->schemaname;
+	char *relationName = deleteStatement->relation->relname;
 
 	/*
 	 * We take an exclusive lock while dropping shards to prevent concurrent
 	 * writes. We don't want to block SELECTs, which means queries might fail
 	 * if they access a shard that has just been dropped.
 	 */
-	lockMode = ExclusiveLock;
+	LOCKMODE lockMode = ExclusiveLock;
 
-	relationId = RangeVarGetRelid(deleteStatement->relation, lockMode, failOK);
+	Oid relationId = RangeVarGetRelid(deleteStatement->relation, lockMode, failOK);
 
 	/* schema-prefix if it is not specified already */
 	if (schemaName == NULL)
@@ -154,15 +141,15 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 	CheckDistributedTable(relationId);
 	EnsureTablePermissions(relationId, ACL_DELETE);
 
-	queryTreeList = pg_analyze_and_rewrite(rawStmt, queryString, NULL, 0, NULL);
-	deleteQuery = (Query *) linitial(queryTreeList);
+	List *queryTreeList = pg_analyze_and_rewrite(rawStmt, queryString, NULL, 0, NULL);
+	Query *deleteQuery = (Query *) linitial(queryTreeList);
 	CheckTableCount(deleteQuery);
 
 	/* get where clause and flatten it */
-	whereClause = (Node *) deleteQuery->jointree->quals;
-	deleteCriteria = eval_const_expressions(NULL, whereClause);
+	Node *whereClause = (Node *) deleteQuery->jointree->quals;
+	Node *deleteCriteria = eval_const_expressions(NULL, whereClause);
 
-	partitionMethod = PartitionMethod(relationId);
+	char partitionMethod = PartitionMethod(relationId);
 	if (partitionMethod == DISTRIBUTE_BY_HASH)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -184,7 +171,7 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 	CheckDeleteCriteria(deleteCriteria);
 	CheckPartitionColumn(relationId, deleteCriteria);
 
-	shardIntervalList = LoadShardIntervalList(relationId);
+	List *shardIntervalList = LoadShardIntervalList(relationId);
 
 	/* drop all shards if where clause is not present */
 	if (deleteCriteria == NULL)
@@ -199,8 +186,8 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 																  deleteCriteria);
 	}
 
-	droppedShardCount = DropShards(relationId, schemaName, relationName,
-								   deletableShardIntervalList);
+	int droppedShardCount = DropShards(relationId, schemaName, relationName,
+									   deletableShardIntervalList);
 
 	PG_RETURN_INT32(droppedShardCount);
 }
@@ -218,8 +205,6 @@ master_drop_all_shards(PG_FUNCTION_ARGS)
 	text *schemaNameText = PG_GETARG_TEXT_P(1);
 	text *relationNameText = PG_GETARG_TEXT_P(2);
 
-	List *shardIntervalList = NIL;
-	int droppedShardCount = 0;
 
 	char *schemaName = text_to_cstring(schemaNameText);
 	char *relationName = text_to_cstring(relationNameText);
@@ -246,9 +231,9 @@ master_drop_all_shards(PG_FUNCTION_ARGS)
 	 */
 	LockRelationOid(relationId, AccessExclusiveLock);
 
-	shardIntervalList = LoadShardIntervalList(relationId);
-	droppedShardCount = DropShards(relationId, schemaName, relationName,
-								   shardIntervalList);
+	List *shardIntervalList = LoadShardIntervalList(relationId);
+	int droppedShardCount = DropShards(relationId, schemaName, relationName,
+									   shardIntervalList);
 
 	PG_RETURN_INT32(droppedShardCount);
 }
@@ -265,7 +250,6 @@ Datum
 master_drop_sequences(PG_FUNCTION_ARGS)
 {
 	ArrayType *sequenceNamesArray = PG_GETARG_ARRAYTYPE_P(0);
-	ArrayIterator sequenceIterator = NULL;
 	Datum sequenceNameDatum = 0;
 	bool isNull = false;
 	StringInfo dropSeqCommand = makeStringInfo();
@@ -291,20 +275,17 @@ master_drop_sequences(PG_FUNCTION_ARGS)
 	}
 
 	/* iterate over sequence names to build single command to DROP them all */
-	sequenceIterator = array_create_iterator(sequenceNamesArray, 0, NULL);
+	ArrayIterator sequenceIterator = array_create_iterator(sequenceNamesArray, 0, NULL);
 	while (array_iterate(sequenceIterator, &sequenceNameDatum, &isNull))
 	{
-		text *sequenceNameText = NULL;
-		Oid sequenceOid = InvalidOid;
-
 		if (isNull)
 		{
 			ereport(ERROR, (errmsg("unexpected NULL sequence name"),
 							errcode(ERRCODE_INVALID_PARAMETER_VALUE)));
 		}
 
-		sequenceNameText = DatumGetTextP(sequenceNameDatum);
-		sequenceOid = ResolveRelationId(sequenceNameText, true);
+		text *sequenceNameText = DatumGetTextP(sequenceNameDatum);
+		Oid sequenceOid = ResolveRelationId(sequenceNameText, true);
 		if (OidIsValid(sequenceOid))
 		{
 			/*
@@ -379,7 +360,6 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 		   List *deletableShardIntervalList)
 {
 	ListCell *shardIntervalCell = NULL;
-	int droppedShardCount = 0;
 
 	BeginOrContinueCoordinatedTransaction();
 
@@ -391,20 +371,18 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 
 	foreach(shardIntervalCell, deletableShardIntervalList)
 	{
-		List *shardPlacementList = NIL;
 		ListCell *shardPlacementCell = NULL;
 		ShardInterval *shardInterval = (ShardInterval *) lfirst(shardIntervalCell);
 		uint64 shardId = shardInterval->shardId;
-		char *quotedShardName = NULL;
 		char *shardRelationName = pstrdup(relationName);
 
 		Assert(shardInterval->relationId == relationId);
 
 		/* Build shard relation name. */
 		AppendShardIdToName(&shardRelationName, shardId);
-		quotedShardName = quote_qualified_identifier(schemaName, shardRelationName);
+		char *quotedShardName = quote_qualified_identifier(schemaName, shardRelationName);
 
-		shardPlacementList = ShardPlacementList(shardId);
+		List *shardPlacementList = ShardPlacementList(shardId);
 		foreach(shardPlacementCell, shardPlacementList)
 		{
 			ShardPlacement *shardPlacement =
@@ -412,7 +390,6 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 			char *workerName = shardPlacement->nodeName;
 			uint32 workerPort = shardPlacement->nodePort;
 			StringInfo workerDropQuery = makeStringInfo();
-			MultiConnection *connection = NULL;
 			uint32 connectionFlags = FOR_DDL;
 
 			char storageType = shardInterval->storageType;
@@ -441,8 +418,9 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 				continue;
 			}
 
-			connection = GetPlacementConnection(connectionFlags, shardPlacement,
-												NULL);
+			MultiConnection *connection = GetPlacementConnection(connectionFlags,
+																 shardPlacement,
+																 NULL);
 
 			RemoteTransactionBeginIfNecessary(connection);
 
@@ -471,7 +449,7 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 		DeleteShardRow(shardId);
 	}
 
-	droppedShardCount = list_length(deletableShardIntervalList);
+	int droppedShardCount = list_length(deletableShardIntervalList);
 
 	return droppedShardCount;
 }
@@ -573,7 +551,6 @@ ShardsMatchingDeleteCriteria(Oid relationId, List *shardIntervalList,
 							 Node *deleteCriteria)
 {
 	List *dropShardIntervalList = NIL;
-	List *deleteCriteriaList = NIL;
 	ListCell *shardIntervalCell = NULL;
 
 	/* build the base expression for constraint */
@@ -582,7 +559,7 @@ ShardsMatchingDeleteCriteria(Oid relationId, List *shardIntervalList,
 	Node *baseConstraint = BuildBaseConstraint(partitionColumn);
 
 	Assert(deleteCriteria != NULL);
-	deleteCriteriaList = list_make1(deleteCriteria);
+	List *deleteCriteriaList = list_make1(deleteCriteria);
 
 	/* walk over shard list and check if shards can be dropped */
 	foreach(shardIntervalCell, shardIntervalList)
@@ -591,27 +568,23 @@ ShardsMatchingDeleteCriteria(Oid relationId, List *shardIntervalList,
 		if (shardInterval->minValueExists && shardInterval->maxValueExists)
 		{
 			List *restrictInfoList = NIL;
-			bool dropShard = false;
-			BoolExpr *andExpr = NULL;
-			Expr *lessThanExpr = NULL;
-			Expr *greaterThanExpr = NULL;
-			RestrictInfo *lessThanRestrictInfo = NULL;
-			RestrictInfo *greaterThanRestrictInfo = NULL;
 
 			/* set the min/max values in the base constraint */
 			UpdateConstraint(baseConstraint, shardInterval);
 
-			andExpr = (BoolExpr *) baseConstraint;
-			lessThanExpr = (Expr *) linitial(andExpr->args);
-			greaterThanExpr = (Expr *) lsecond(andExpr->args);
+			BoolExpr *andExpr = (BoolExpr *) baseConstraint;
+			Expr *lessThanExpr = (Expr *) linitial(andExpr->args);
+			Expr *greaterThanExpr = (Expr *) lsecond(andExpr->args);
 
-			lessThanRestrictInfo = make_simple_restrictinfo(lessThanExpr);
-			greaterThanRestrictInfo = make_simple_restrictinfo(greaterThanExpr);
+			RestrictInfo *lessThanRestrictInfo = make_simple_restrictinfo(lessThanExpr);
+			RestrictInfo *greaterThanRestrictInfo = make_simple_restrictinfo(
+				greaterThanExpr);
 
 			restrictInfoList = lappend(restrictInfoList, lessThanRestrictInfo);
 			restrictInfoList = lappend(restrictInfoList, greaterThanRestrictInfo);
 
-			dropShard = predicate_implied_by(deleteCriteriaList, restrictInfoList, false);
+			bool dropShard = predicate_implied_by(deleteCriteriaList, restrictInfoList,
+												  false);
 			if (dropShard)
 			{
 				dropShardIntervalList = lappend(dropShardIntervalList, shardInterval);

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -94,26 +94,20 @@ master_get_table_metadata(PG_FUNCTION_ARGS)
 	text *relationName = PG_GETARG_TEXT_P(0);
 	Oid relationId = ResolveRelationId(relationName, false);
 
-	DistTableCacheEntry *partitionEntry = NULL;
-	char *partitionKeyString = NULL;
-	TypeFuncClass resultTypeClass = 0;
 	Datum partitionKeyExpr = 0;
 	Datum partitionKey = 0;
-	Datum metadataDatum = 0;
-	HeapTuple metadataTuple = NULL;
 	TupleDesc metadataDescriptor = NULL;
-	uint64 shardMaxSizeInBytes = 0;
-	char shardStorageType = 0;
 	Datum values[TABLE_METADATA_FIELDS];
 	bool isNulls[TABLE_METADATA_FIELDS];
 
 	CheckCitusVersion(ERROR);
 
 	/* find partition tuple for partitioned relation */
-	partitionEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *partitionEntry = DistributedTableCacheEntry(relationId);
 
 	/* create tuple descriptor for return value */
-	resultTypeClass = get_call_result_type(fcinfo, NULL, &metadataDescriptor);
+	TypeFuncClass resultTypeClass = get_call_result_type(fcinfo, NULL,
+														 &metadataDescriptor);
 	if (resultTypeClass != TYPEFUNC_COMPOSITE)
 	{
 		ereport(ERROR, (errmsg("return type must be a row type")));
@@ -123,7 +117,7 @@ master_get_table_metadata(PG_FUNCTION_ARGS)
 	memset(values, 0, sizeof(values));
 	memset(isNulls, false, sizeof(isNulls));
 
-	partitionKeyString = partitionEntry->partitionKeyString;
+	char *partitionKeyString = partitionEntry->partitionKeyString;
 
 	/* reference tables do not have partition key */
 	if (partitionKeyString == NULL)
@@ -140,10 +134,10 @@ master_get_table_metadata(PG_FUNCTION_ARGS)
 										   ObjectIdGetDatum(relationId));
 	}
 
-	shardMaxSizeInBytes = (int64) ShardMaxSize * 1024L;
+	uint64 shardMaxSizeInBytes = (int64) ShardMaxSize * 1024L;
 
 	/* get storage type */
-	shardStorageType = ShardStorageType(relationId);
+	char shardStorageType = ShardStorageType(relationId);
 
 	values[0] = ObjectIdGetDatum(relationId);
 	values[1] = shardStorageType;
@@ -153,8 +147,8 @@ master_get_table_metadata(PG_FUNCTION_ARGS)
 	values[5] = Int64GetDatum(shardMaxSizeInBytes);
 	values[6] = Int32GetDatum(ShardPlacementPolicy);
 
-	metadataTuple = heap_form_tuple(metadataDescriptor, values, isNulls);
-	metadataDatum = HeapTupleGetDatum(metadataTuple);
+	HeapTuple metadataTuple = heap_form_tuple(metadataDescriptor, values, isNulls);
+	Datum metadataDatum = HeapTupleGetDatum(metadataTuple);
 
 	PG_RETURN_DATUM(metadataDatum);
 }
@@ -212,17 +206,16 @@ master_get_table_ddl_events(PG_FUNCTION_ARGS)
 		Oid relationId = ResolveRelationId(relationName, false);
 		bool includeSequenceDefaults = true;
 
-		MemoryContext oldContext = NULL;
-		List *tableDDLEventList = NIL;
 
 		/* create a function context for cross-call persistence */
 		functionContext = SRF_FIRSTCALL_INIT();
 
 		/* switch to memory context appropriate for multiple function calls */
-		oldContext = MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
+		MemoryContext oldContext = MemoryContextSwitchTo(
+			functionContext->multi_call_memory_ctx);
 
 		/* allocate DDL statements, and then save position in DDL statements */
-		tableDDLEventList = GetTableDDLEvents(relationId, includeSequenceDefaults);
+		List *tableDDLEventList = GetTableDDLEvents(relationId, includeSequenceDefaults);
 		tableDDLEventCell = list_head(tableDDLEventList);
 
 		functionContext->user_fctx = tableDDLEventCell;
@@ -266,14 +259,11 @@ master_get_table_ddl_events(PG_FUNCTION_ARGS)
 Datum
 master_get_new_shardid(PG_FUNCTION_ARGS)
 {
-	uint64 shardId = 0;
-	Datum shardIdDatum = 0;
-
 	EnsureCoordinator();
 	CheckCitusVersion(ERROR);
 
-	shardId = GetNextShardId();
-	shardIdDatum = Int64GetDatum(shardId);
+	uint64 shardId = GetNextShardId();
+	Datum shardIdDatum = Int64GetDatum(shardId);
 
 	PG_RETURN_DATUM(shardIdDatum);
 }
@@ -290,12 +280,8 @@ master_get_new_shardid(PG_FUNCTION_ARGS)
 uint64
 GetNextShardId()
 {
-	text *sequenceName = NULL;
-	Oid sequenceId = InvalidOid;
-	Datum sequenceIdDatum = 0;
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
-	Datum shardIdDatum = 0;
 	uint64 shardId = 0;
 
 	/*
@@ -313,15 +299,15 @@ GetNextShardId()
 		return shardId;
 	}
 
-	sequenceName = cstring_to_text(SHARDID_SEQUENCE_NAME);
-	sequenceId = ResolveRelationId(sequenceName, false);
-	sequenceIdDatum = ObjectIdGetDatum(sequenceId);
+	text *sequenceName = cstring_to_text(SHARDID_SEQUENCE_NAME);
+	Oid sequenceId = ResolveRelationId(sequenceName, false);
+	Datum sequenceIdDatum = ObjectIdGetDatum(sequenceId);
 
 	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
 	SetUserIdAndSecContext(CitusExtensionOwner(), SECURITY_LOCAL_USERID_CHANGE);
 
 	/* generate new and unique shardId from sequence */
-	shardIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
+	Datum shardIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
@@ -343,14 +329,11 @@ GetNextShardId()
 Datum
 master_get_new_placementid(PG_FUNCTION_ARGS)
 {
-	uint64 placementId = 0;
-	Datum placementIdDatum = 0;
-
 	EnsureCoordinator();
 	CheckCitusVersion(ERROR);
 
-	placementId = GetNextPlacementId();
-	placementIdDatum = Int64GetDatum(placementId);
+	uint64 placementId = GetNextPlacementId();
+	Datum placementIdDatum = Int64GetDatum(placementId);
 
 	PG_RETURN_DATUM(placementIdDatum);
 }
@@ -369,12 +352,8 @@ master_get_new_placementid(PG_FUNCTION_ARGS)
 uint64
 GetNextPlacementId(void)
 {
-	text *sequenceName = NULL;
-	Oid sequenceId = InvalidOid;
-	Datum sequenceIdDatum = 0;
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
-	Datum placementIdDatum = 0;
 	uint64 placementId = 0;
 
 	/*
@@ -392,15 +371,15 @@ GetNextPlacementId(void)
 		return placementId;
 	}
 
-	sequenceName = cstring_to_text(PLACEMENTID_SEQUENCE_NAME);
-	sequenceId = ResolveRelationId(sequenceName, false);
-	sequenceIdDatum = ObjectIdGetDatum(sequenceId);
+	text *sequenceName = cstring_to_text(PLACEMENTID_SEQUENCE_NAME);
+	Oid sequenceId = ResolveRelationId(sequenceName, false);
+	Datum sequenceIdDatum = ObjectIdGetDatum(sequenceId);
 
 	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
 	SetUserIdAndSecContext(CitusExtensionOwner(), SECURITY_LOCAL_USERID_CHANGE);
 
 	/* generate new and unique placement id from sequence */
-	placementIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
+	Datum placementIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
@@ -465,17 +444,16 @@ master_get_active_worker_nodes(PG_FUNCTION_ARGS)
 
 	if (SRF_IS_FIRSTCALL())
 	{
-		MemoryContext oldContext = NULL;
-		List *workerNodeList = NIL;
 		TupleDesc tupleDescriptor = NULL;
 
 		/* create a function context for cross-call persistence */
 		functionContext = SRF_FIRSTCALL_INIT();
 
 		/* switch to memory context appropriate for multiple function calls */
-		oldContext = MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
+		MemoryContext oldContext = MemoryContextSwitchTo(
+			functionContext->multi_call_memory_ctx);
 
-		workerNodeList = ActiveReadableWorkerNodeList();
+		List *workerNodeList = ActiveReadableWorkerNodeList();
 		workerNodeCount = (uint32) list_length(workerNodeList);
 
 		functionContext->user_fctx = workerNodeList;
@@ -525,14 +503,10 @@ master_get_active_worker_nodes(PG_FUNCTION_ARGS)
 Oid
 ResolveRelationId(text *relationName, bool missingOk)
 {
-	List *relationNameList = NIL;
-	RangeVar *relation = NULL;
-	Oid relationId = InvalidOid;
-
 	/* resolve relationId from passed in schema and relation name */
-	relationNameList = textToQualifiedNameList(relationName);
-	relation = makeRangeVarFromNameList(relationNameList);
-	relationId = RangeVarGetRelid(relation, NoLock, missingOk);
+	List *relationNameList = textToQualifiedNameList(relationName);
+	RangeVar *relation = makeRangeVarFromNameList(relationNameList);
+	Oid relationId = RangeVarGetRelid(relation, NoLock, missingOk);
 
 	return relationId;
 }
@@ -551,22 +525,18 @@ List *
 GetTableDDLEvents(Oid relationId, bool includeSequenceDefaults)
 {
 	List *tableDDLEventList = NIL;
-	List *tableCreationCommandList = NIL;
-	List *indexAndConstraintCommandList = NIL;
-	List *replicaIdentityEvents = NIL;
-	List *policyCommands = NIL;
 
-	tableCreationCommandList = GetTableCreationCommands(relationId,
-														includeSequenceDefaults);
+	List *tableCreationCommandList = GetTableCreationCommands(relationId,
+															  includeSequenceDefaults);
 	tableDDLEventList = list_concat(tableDDLEventList, tableCreationCommandList);
 
-	indexAndConstraintCommandList = GetTableIndexAndConstraintCommands(relationId);
+	List *indexAndConstraintCommandList = GetTableIndexAndConstraintCommands(relationId);
 	tableDDLEventList = list_concat(tableDDLEventList, indexAndConstraintCommandList);
 
-	replicaIdentityEvents = GetTableReplicaIdentityCommand(relationId);
+	List *replicaIdentityEvents = GetTableReplicaIdentityCommand(relationId);
 	tableDDLEventList = list_concat(tableDDLEventList, replicaIdentityEvents);
 
-	policyCommands = CreatePolicyCommands(relationId);
+	List *policyCommands = CreatePolicyCommands(relationId);
 	tableDDLEventList = list_concat(tableDDLEventList, policyCommands);
 
 	return tableDDLEventList;
@@ -581,7 +551,6 @@ static List *
 GetTableReplicaIdentityCommand(Oid relationId)
 {
 	List *replicaIdentityCreateCommandList = NIL;
-	char *replicaIdentityCreateCommand = NULL;
 
 	/*
 	 * We skip non-relations because postgres does not support
@@ -593,7 +562,7 @@ GetTableReplicaIdentityCommand(Oid relationId)
 		return NIL;
 	}
 
-	replicaIdentityCreateCommand = pg_get_replica_identity_command(relationId);
+	char *replicaIdentityCreateCommand = pg_get_replica_identity_command(relationId);
 
 	if (replicaIdentityCreateCommand)
 	{
@@ -614,10 +583,6 @@ List *
 GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 {
 	List *tableDDLEventList = NIL;
-	char tableType = 0;
-	char *tableSchemaDef = NULL;
-	char *tableColumnOptionsDef = NULL;
-	char *tableOwnerDef = NULL;
 
 	/*
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
@@ -630,7 +595,7 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 	PushOverrideSearchPath(overridePath);
 
 	/* if foreign table, fetch extension and server definitions */
-	tableType = get_rel_relkind(relationId);
+	char tableType = get_rel_relkind(relationId);
 	if (tableType == RELKIND_FOREIGN_TABLE)
 	{
 		char *extensionDef = pg_get_extensiondef_string(relationId);
@@ -644,8 +609,9 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 	}
 
 	/* fetch table schema and column option definitions */
-	tableSchemaDef = pg_get_tableschemadef_string(relationId, includeSequenceDefaults);
-	tableColumnOptionsDef = pg_get_tablecolumnoptionsdef_string(relationId);
+	char *tableSchemaDef = pg_get_tableschemadef_string(relationId,
+														includeSequenceDefaults);
+	char *tableColumnOptionsDef = pg_get_tablecolumnoptionsdef_string(relationId);
 
 	tableDDLEventList = lappend(tableDDLEventList, tableSchemaDef);
 	if (tableColumnOptionsDef != NULL)
@@ -653,7 +619,7 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 		tableDDLEventList = lappend(tableDDLEventList, tableColumnOptionsDef);
 	}
 
-	tableOwnerDef = TableOwnerResetCommand(relationId);
+	char *tableOwnerDef = TableOwnerResetCommand(relationId);
 	if (tableOwnerDef != NULL)
 	{
 		tableDDLEventList = lappend(tableDDLEventList, tableOwnerDef);
@@ -674,11 +640,8 @@ List *
 GetTableIndexAndConstraintCommands(Oid relationId)
 {
 	List *indexDDLEventList = NIL;
-	Relation pgIndex = NULL;
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 1;
-	HeapTuple heapTuple = NULL;
 
 	/*
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
@@ -691,16 +654,16 @@ GetTableIndexAndConstraintCommands(Oid relationId)
 	PushOverrideSearchPath(overridePath);
 
 	/* open system catalog and scan all indexes that belong to this table */
-	pgIndex = heap_open(IndexRelationId, AccessShareLock);
+	Relation pgIndex = heap_open(IndexRelationId, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_index_indrelid,
 				BTEqualStrategyNumber, F_OIDEQ, relationId);
 
-	scanDescriptor = systable_beginscan(pgIndex,
-										IndexIndrelidIndexId, true, /* indexOK */
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgIndex,
+													IndexIndrelidIndexId, true, /* indexOK */
+													NULL, scanKeyCount, scanKey);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(heapTuple))
 	{
 		Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(heapTuple);
@@ -824,8 +787,6 @@ WorkerNodeGetDatum(WorkerNode *workerNode, TupleDesc tupleDescriptor)
 {
 	Datum values[WORKER_NODE_FIELDS];
 	bool isNulls[WORKER_NODE_FIELDS];
-	HeapTuple workerNodeTuple = NULL;
-	Datum workerNodeDatum = 0;
 
 	memset(values, 0, sizeof(values));
 	memset(isNulls, false, sizeof(isNulls));
@@ -833,8 +794,8 @@ WorkerNodeGetDatum(WorkerNode *workerNode, TupleDesc tupleDescriptor)
 	values[0] = CStringGetTextDatum(workerNode->workerName);
 	values[1] = Int64GetDatum((int64) workerNode->workerPort);
 
-	workerNodeTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
-	workerNodeDatum = HeapTupleGetDatum(workerNodeTuple);
+	HeapTuple workerNodeTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
+	Datum workerNodeDatum = HeapTupleGetDatum(workerNodeTuple);
 
 	return workerNodeDatum;
 }

--- a/src/backend/distributed/master/master_split_shards.c
+++ b/src/backend/distributed/master/master_split_shards.c
@@ -62,16 +62,13 @@ Datum
 worker_hash(PG_FUNCTION_ARGS)
 {
 	Datum valueDatum = PG_GETARG_DATUM(0);
-	Datum hashedValueDatum = 0;
-	TypeCacheEntry *typeEntry = NULL;
-	FmgrInfo *hashFunction = NULL;
-	Oid valueDataType = InvalidOid;
 
 	CheckCitusVersion(ERROR);
 
 	/* figure out hash function from the data type */
-	valueDataType = get_fn_expr_argtype(fcinfo->flinfo, 0);
-	typeEntry = lookup_type_cache(valueDataType, TYPECACHE_HASH_PROC_FINFO);
+	Oid valueDataType = get_fn_expr_argtype(fcinfo->flinfo, 0);
+	TypeCacheEntry *typeEntry = lookup_type_cache(valueDataType,
+												  TYPECACHE_HASH_PROC_FINFO);
 
 	if (typeEntry->hash_proc_finfo.fn_oid == InvalidOid)
 	{
@@ -80,11 +77,12 @@ worker_hash(PG_FUNCTION_ARGS)
 						errhint("Cast input to a data type with a hash function.")));
 	}
 
-	hashFunction = palloc0(sizeof(FmgrInfo));
+	FmgrInfo *hashFunction = palloc0(sizeof(FmgrInfo));
 	fmgr_info_copy(hashFunction, &(typeEntry->hash_proc_finfo), CurrentMemoryContext);
 
 	/* calculate hash value */
-	hashedValueDatum = FunctionCall1Coll(hashFunction, PG_GET_COLLATION(), valueDatum);
+	Datum hashedValueDatum = FunctionCall1Coll(hashFunction, PG_GET_COLLATION(),
+											   valueDatum);
 
 	PG_RETURN_INT32(hashedValueDatum);
 }

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -80,21 +80,17 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 {
 	text *relationNameText = PG_GETARG_TEXT_P(0);
 	char *relationName = text_to_cstring(relationNameText);
-	uint64 shardId = INVALID_SHARD_ID;
 	uint32 attemptableNodeCount = 0;
 	ObjectAddress tableAddress = { 0 };
 
 	uint32 candidateNodeIndex = 0;
 	List *candidateNodeList = NIL;
-	List *workerNodeList = NIL;
 	text *nullMinValue = NULL;
 	text *nullMaxValue = NULL;
-	char partitionMethod = 0;
 	char storageType = SHARD_STORAGE_TABLE;
 
 	Oid relationId = ResolveRelationId(relationNameText, false);
 	char relationKind = get_rel_relkind(relationId);
-	char replicationModel = REPLICATION_MODEL_INVALID;
 
 	CheckCitusVersion(ERROR);
 
@@ -136,7 +132,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 		}
 	}
 
-	partitionMethod = PartitionMethod(relationId);
+	char partitionMethod = PartitionMethod(relationId);
 	if (partitionMethod == DISTRIBUTE_BY_HASH)
 	{
 		ereport(ERROR, (errmsg("relation \"%s\" is a hash partitioned table",
@@ -152,15 +148,15 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 								  "on reference tables")));
 	}
 
-	replicationModel = TableReplicationModel(relationId);
+	char replicationModel = TableReplicationModel(relationId);
 
 	EnsureReplicationSettings(relationId, replicationModel);
 
 	/* generate new and unique shardId from sequence */
-	shardId = GetNextShardId();
+	uint64 shardId = GetNextShardId();
 
 	/* if enough live groups, add an extra candidate node as backup */
-	workerNodeList = DistributedTablePlacementNodeList(NoLock);
+	List *workerNodeList = DistributedTablePlacementNodeList(NoLock);
 
 	if (list_length(workerNodeList) > ShardReplicationFactor)
 	{
@@ -232,33 +228,20 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 	char *sourceTableName = text_to_cstring(sourceTableNameText);
 	char *sourceNodeName = text_to_cstring(sourceNodeNameText);
 
-	Oid shardSchemaOid = 0;
-	char *shardSchemaName = NULL;
-	char *shardTableName = NULL;
-	char *shardQualifiedName = NULL;
-	List *shardPlacementList = NIL;
 	ListCell *shardPlacementCell = NULL;
-	uint64 newShardSize = 0;
-	uint64 shardMaxSizeInBytes = 0;
 	float4 shardFillLevel = 0.0;
-	char partitionMethod = 0;
 
-	ShardInterval *shardInterval = NULL;
-	Oid relationId = InvalidOid;
-	bool cstoreTable = false;
-
-	char storageType = 0;
 
 	CheckCitusVersion(ERROR);
 
-	shardInterval = LoadShardInterval(shardId);
-	relationId = shardInterval->relationId;
+	ShardInterval *shardInterval = LoadShardInterval(shardId);
+	Oid relationId = shardInterval->relationId;
 
 	/* don't allow the table to be dropped */
 	LockRelationOid(relationId, AccessShareLock);
 
-	cstoreTable = CStoreTable(relationId);
-	storageType = shardInterval->storageType;
+	bool cstoreTable = CStoreTable(relationId);
+	char storageType = shardInterval->storageType;
 
 	EnsureTablePermissions(relationId, ACL_INSERT);
 
@@ -268,7 +251,7 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 						errdetail("The underlying shard is not a regular table")));
 	}
 
-	partitionMethod = PartitionMethod(relationId);
+	char partitionMethod = PartitionMethod(relationId);
 	if (partitionMethod == DISTRIBUTE_BY_HASH || partitionMethod == DISTRIBUTE_BY_NONE)
 	{
 		ereport(ERROR, (errmsg("cannot append to shardId " UINT64_FORMAT, shardId),
@@ -283,16 +266,17 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 	LockShardResource(shardId, ExclusiveLock);
 
 	/* get schame name of the target shard */
-	shardSchemaOid = get_rel_namespace(relationId);
-	shardSchemaName = get_namespace_name(shardSchemaOid);
+	Oid shardSchemaOid = get_rel_namespace(relationId);
+	char *shardSchemaName = get_namespace_name(shardSchemaOid);
 
 	/* Build shard table name. */
-	shardTableName = get_rel_name(relationId);
+	char *shardTableName = get_rel_name(relationId);
 	AppendShardIdToName(&shardTableName, shardId);
 
-	shardQualifiedName = quote_qualified_identifier(shardSchemaName, shardTableName);
+	char *shardQualifiedName = quote_qualified_identifier(shardSchemaName,
+														  shardTableName);
 
-	shardPlacementList = FinalizedShardPlacementList(shardId);
+	List *shardPlacementList = FinalizedShardPlacementList(shardId);
 	if (shardPlacementList == NIL)
 	{
 		ereport(ERROR, (errmsg("could not find any shard placements for shardId "
@@ -309,7 +293,6 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 		MultiConnection *connection = GetPlacementConnection(FOR_DML, shardPlacement,
 															 NULL);
 		PGresult *queryResult = NULL;
-		int executeResult = 0;
 
 		StringInfo workerAppendQuery = makeStringInfo();
 		appendStringInfo(workerAppendQuery, WORKER_APPEND_TABLE_TO_SHARD,
@@ -319,8 +302,9 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 
 		RemoteTransactionBeginIfNecessary(connection);
 
-		executeResult = ExecuteOptionalRemoteCommand(connection, workerAppendQuery->data,
-													 &queryResult);
+		int executeResult = ExecuteOptionalRemoteCommand(connection,
+														 workerAppendQuery->data,
+														 &queryResult);
 		PQclear(queryResult);
 		ForgetResults(connection);
 
@@ -333,10 +317,10 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 	MarkFailedShardPlacements();
 
 	/* update shard statistics and get new shard size */
-	newShardSize = UpdateShardStatistics(shardId);
+	uint64 newShardSize = UpdateShardStatistics(shardId);
 
 	/* calculate ratio of current shard size compared to shard max size */
-	shardMaxSizeInBytes = (int64) ShardMaxSize * 1024L;
+	uint64 shardMaxSizeInBytes = (int64) ShardMaxSize * 1024L;
 	shardFillLevel = ((float4) newShardSize / (float4) shardMaxSizeInBytes);
 
 	PG_RETURN_FLOAT4(shardFillLevel);
@@ -351,11 +335,10 @@ Datum
 master_update_shard_statistics(PG_FUNCTION_ARGS)
 {
 	int64 shardId = PG_GETARG_INT64(0);
-	uint64 shardSize = 0;
 
 	CheckCitusVersion(ERROR);
 
-	shardSize = UpdateShardStatistics(shardId);
+	uint64 shardSize = UpdateShardStatistics(shardId);
 
 	PG_RETURN_INT64(shardSize);
 }
@@ -393,7 +376,6 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 	int attemptCount = replicationFactor;
 	int workerNodeCount = list_length(workerNodeList);
 	int placementsCreated = 0;
-	int attemptNumber = 0;
 	List *foreignConstraintCommandList = GetTableForeignConstraintCommands(relationId);
 	bool includeSequenceDefaults = false;
 	List *ddlCommandList = GetTableDDLEvents(relationId, includeSequenceDefaults);
@@ -406,7 +388,7 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 		attemptCount++;
 	}
 
-	for (attemptNumber = 0; attemptNumber < attemptCount; attemptNumber++)
+	for (int attemptNumber = 0; attemptNumber < attemptCount; attemptNumber++)
 	{
 		int workerNodeIndex = attemptNumber % workerNodeCount;
 		WorkerNode *workerNode = (WorkerNode *) list_nth(workerNodeList, workerNodeIndex);
@@ -419,7 +401,6 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 		MultiConnection *connection =
 			GetNodeUserDatabaseConnection(connectionFlag, nodeName, nodePort,
 										  relationOwner, NULL);
-		List *commandList = NIL;
 
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
 		{
@@ -429,9 +410,9 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 			continue;
 		}
 
-		commandList = WorkerCreateShardCommandList(relationId, shardIndex, shardId,
-												   ddlCommandList,
-												   foreignConstraintCommandList);
+		List *commandList = WorkerCreateShardCommandList(relationId, shardIndex, shardId,
+														 ddlCommandList,
+														 foreignConstraintCommandList);
 
 		ExecuteCriticalRemoteCommandList(connection, commandList);
 
@@ -463,23 +444,21 @@ InsertShardPlacementRows(Oid relationId, int64 shardId, List *workerNodeList,
 						 int workerStartIndex, int replicationFactor)
 {
 	int workerNodeCount = list_length(workerNodeList);
-	int attemptNumber = 0;
 	int placementsInserted = 0;
 	List *insertedShardPlacements = NIL;
 
-	for (attemptNumber = 0; attemptNumber < replicationFactor; attemptNumber++)
+	for (int attemptNumber = 0; attemptNumber < replicationFactor; attemptNumber++)
 	{
 		int workerNodeIndex = (workerStartIndex + attemptNumber) % workerNodeCount;
 		WorkerNode *workerNode = (WorkerNode *) list_nth(workerNodeList, workerNodeIndex);
 		uint32 nodeGroupId = workerNode->groupId;
 		const RelayFileState shardState = FILE_FINALIZED;
 		const uint64 shardSize = 0;
-		uint64 shardPlacementId = 0;
-		ShardPlacement *shardPlacement = NULL;
 
-		shardPlacementId = InsertShardPlacementRow(shardId, INVALID_PLACEMENT_ID,
-												   shardState, shardSize, nodeGroupId);
-		shardPlacement = LoadShardPlacement(shardId, shardPlacementId);
+		uint64 shardPlacementId = InsertShardPlacementRow(shardId, INVALID_PLACEMENT_ID,
+														  shardState, shardSize,
+														  nodeGroupId);
+		ShardPlacement *shardPlacement = LoadShardPlacement(shardId, shardPlacementId);
 		insertedShardPlacements = lappend(insertedShardPlacements, shardPlacement);
 
 		placementsInserted++;
@@ -519,8 +498,6 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 		uint64 shardId = shardPlacement->shardId;
 		ShardInterval *shardInterval = LoadShardInterval(shardId);
 		int shardIndex = -1;
-		List *commandList = NIL;
-		Task *task = NULL;
 		List *relationShardList = RelationShardListForShardCreate(shardInterval);
 
 		if (colocatedShard)
@@ -528,11 +505,12 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 			shardIndex = ShardIndex(shardInterval);
 		}
 
-		commandList = WorkerCreateShardCommandList(distributedRelationId, shardIndex,
-												   shardId, ddlCommandList,
-												   foreignConstraintCommandList);
+		List *commandList = WorkerCreateShardCommandList(distributedRelationId,
+														 shardIndex,
+														 shardId, ddlCommandList,
+														 foreignConstraintCommandList);
 
-		task = CitusMakeNode(Task);
+		Task *task = CitusMakeNode(Task);
 		task->jobId = INVALID_JOB_ID;
 		task->taskId = taskId++;
 		task->taskType = DDL_TASK;
@@ -580,26 +558,23 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 static List *
 RelationShardListForShardCreate(ShardInterval *shardInterval)
 {
-	List *relationShardList = NIL;
-	RelationShard *relationShard = NULL;
 	Oid relationId = shardInterval->relationId;
 	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 	List *referencedRelationList = cacheEntry->referencedRelationsViaForeignKey;
 	List *referencingRelationList = cacheEntry->referencingRelationsViaForeignKey;
-	List *allForeignKeyRelations = NIL;
 	int shardIndex = -1;
 	ListCell *fkeyRelationIdCell = NULL;
 
 	/* list_concat_*() modifies the first arg, so make a copy first */
-	allForeignKeyRelations = list_copy(referencedRelationList);
+	List *allForeignKeyRelations = list_copy(referencedRelationList);
 	allForeignKeyRelations = list_concat_unique_oid(allForeignKeyRelations,
 													referencingRelationList);
 
 	/* record the placement access of the shard itself */
-	relationShard = CitusMakeNode(RelationShard);
+	RelationShard *relationShard = CitusMakeNode(RelationShard);
 	relationShard->relationId = relationId;
 	relationShard->shardId = shardInterval->shardId;
-	relationShardList = list_make1(relationShard);
+	List *relationShardList = list_make1(relationShard);
 
 	if (cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH &&
 		cacheEntry->colocationId != INVALID_COLOCATION_ID)
@@ -612,7 +587,6 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 	foreach(fkeyRelationIdCell, allForeignKeyRelations)
 	{
 		Oid fkeyRelationid = lfirst_oid(fkeyRelationIdCell);
-		RelationShard *fkeyRelationShard = NULL;
 		uint64 fkeyShardId = INVALID_SHARD_ID;
 
 		if (!IsDistributedTable(fkeyRelationid))
@@ -645,7 +619,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 			continue;
 		}
 
-		fkeyRelationShard = CitusMakeNode(RelationShard);
+		RelationShard *fkeyRelationShard = CitusMakeNode(RelationShard);
 		fkeyRelationShard->relationId = fkeyRelationid;
 		fkeyRelationShard->shardId = fkeyShardId;
 
@@ -714,16 +688,12 @@ WorkerCreateShardCommandList(Oid relationId, int shardIndex, uint64 shardId,
 		char *command = (char *) lfirst(foreignConstraintCommandCell);
 		char *escapedCommand = quote_literal_cstr(command);
 
-		Oid referencedRelationId = InvalidOid;
-		Oid referencedSchemaId = InvalidOid;
-		char *referencedSchemaName = NULL;
-		char *escapedReferencedSchemaName = NULL;
 		uint64 referencedShardId = INVALID_SHARD_ID;
 
 		StringInfo applyForeignConstraintCommand = makeStringInfo();
 
 		/* we need to parse the foreign constraint command to get referencing table id */
-		referencedRelationId = ForeignConstraintGetReferencedTableId(command);
+		Oid referencedRelationId = ForeignConstraintGetReferencedTableId(command);
 		if (referencedRelationId == InvalidOid)
 		{
 			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -731,9 +701,9 @@ WorkerCreateShardCommandList(Oid relationId, int shardIndex, uint64 shardId,
 							errdetail("Referenced relation cannot be found.")));
 		}
 
-		referencedSchemaId = get_rel_namespace(referencedRelationId);
-		referencedSchemaName = get_namespace_name(referencedSchemaId);
-		escapedReferencedSchemaName = quote_literal_cstr(referencedSchemaName);
+		Oid referencedSchemaId = get_rel_namespace(referencedRelationId);
+		char *referencedSchemaName = get_namespace_name(referencedSchemaId);
+		char *escapedReferencedSchemaName = quote_literal_cstr(referencedSchemaName);
 
 		/*
 		 * In case of self referencing shards, relation itself might not be distributed
@@ -792,8 +762,6 @@ UpdateShardStatistics(int64 shardId)
 	Oid relationId = shardInterval->relationId;
 	char storageType = shardInterval->storageType;
 	char partitionType = PartitionMethod(relationId);
-	char *shardQualifiedName = NULL;
-	List *shardPlacementList = NIL;
 	ListCell *shardPlacementCell = NULL;
 	bool statsOK = false;
 	uint64 shardSize = 0;
@@ -807,9 +775,9 @@ UpdateShardStatistics(int64 shardId)
 
 	AppendShardIdToName(&shardName, shardId);
 
-	shardQualifiedName = quote_qualified_identifier(schemaName, shardName);
+	char *shardQualifiedName = quote_qualified_identifier(schemaName, shardName);
 
-	shardPlacementList = FinalizedShardPlacementList(shardId);
+	List *shardPlacementList = FinalizedShardPlacementList(shardId);
 
 	/* get shard's statistics from a shard placement */
 	foreach(shardPlacementCell, shardPlacementList)
@@ -881,28 +849,19 @@ static bool
 WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 				 uint64 *shardSize, text **shardMinValue, text **shardMaxValue)
 {
-	char *quotedShardName = NULL;
-	bool cstoreTable = false;
 	StringInfo tableSizeQuery = makeStringInfo();
 
 	const uint32 unusedTableId = 1;
 	char partitionType = PartitionMethod(relationId);
-	Var *partitionColumn = NULL;
-	char *partitionColumnName = NULL;
 	StringInfo partitionValueQuery = makeStringInfo();
 
 	PGresult *queryResult = NULL;
 	const int minValueIndex = 0;
 	const int maxValueIndex = 1;
 
-	uint64 tableSize = 0;
-	char *tableSizeString = NULL;
 	char *tableSizeStringEnd = NULL;
-	bool minValueIsNull = false;
-	bool maxValueIsNull = false;
 
 	int connectionFlags = 0;
-	int executeCommand = 0;
 
 	MultiConnection *connection = GetPlacementConnection(connectionFlags, placement,
 														 NULL);
@@ -911,9 +870,9 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 	*shardMinValue = NULL;
 	*shardMaxValue = NULL;
 
-	quotedShardName = quote_literal_cstr(shardName);
+	char *quotedShardName = quote_literal_cstr(shardName);
 
-	cstoreTable = CStoreTable(relationId);
+	bool cstoreTable = CStoreTable(relationId);
 	if (cstoreTable)
 	{
 		appendStringInfo(tableSizeQuery, SHARD_CSTORE_TABLE_SIZE_QUERY, quotedShardName);
@@ -923,14 +882,14 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 		appendStringInfo(tableSizeQuery, SHARD_TABLE_SIZE_QUERY, quotedShardName);
 	}
 
-	executeCommand = ExecuteOptionalRemoteCommand(connection, tableSizeQuery->data,
-												  &queryResult);
+	int executeCommand = ExecuteOptionalRemoteCommand(connection, tableSizeQuery->data,
+													  &queryResult);
 	if (executeCommand != 0)
 	{
 		return false;
 	}
 
-	tableSizeString = PQgetvalue(queryResult, 0, 0);
+	char *tableSizeString = PQgetvalue(queryResult, 0, 0);
 	if (tableSizeString == NULL)
 	{
 		PQclear(queryResult);
@@ -939,7 +898,7 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 	}
 
 	errno = 0;
-	tableSize = pg_strtouint64(tableSizeString, &tableSizeStringEnd, 0);
+	uint64 tableSize = pg_strtouint64(tableSizeString, &tableSizeStringEnd, 0);
 	if (errno != 0 || (*tableSizeStringEnd) != '\0')
 	{
 		PQclear(queryResult);
@@ -959,8 +918,8 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 	}
 
 	/* fill in the partition column name and shard name in the query. */
-	partitionColumn = PartitionColumn(relationId, unusedTableId);
-	partitionColumnName = get_attname(relationId, partitionColumn->varattno, false);
+	Var *partitionColumn = PartitionColumn(relationId, unusedTableId);
+	char *partitionColumnName = get_attname(relationId, partitionColumn->varattno, false);
 	appendStringInfo(partitionValueQuery, SHARD_RANGE_QUERY,
 					 partitionColumnName, partitionColumnName, shardName);
 
@@ -971,8 +930,8 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, char *shardName,
 		return false;
 	}
 
-	minValueIsNull = PQgetisnull(queryResult, 0, minValueIndex);
-	maxValueIsNull = PQgetisnull(queryResult, 0, maxValueIndex);
+	bool minValueIsNull = PQgetisnull(queryResult, 0, minValueIndex);
+	bool maxValueIsNull = PQgetisnull(queryResult, 0, maxValueIndex);
 
 	if (!minValueIsNull && !maxValueIsNull)
 	{

--- a/src/backend/distributed/master/master_truncate.c
+++ b/src/backend/distributed/master/master_truncate.c
@@ -41,21 +41,16 @@ PG_FUNCTION_INFO_V1(citus_truncate_trigger);
 Datum
 citus_truncate_trigger(PG_FUNCTION_ARGS)
 {
-	TriggerData *triggerData = NULL;
-	Relation truncatedRelation = NULL;
-	Oid relationId = InvalidOid;
-	char partitionMethod = 0;
-
 	if (!CALLED_AS_TRIGGER(fcinfo))
 	{
 		ereport(ERROR, (errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
 						errmsg("must be called as trigger")));
 	}
 
-	triggerData = (TriggerData *) fcinfo->context;
-	truncatedRelation = triggerData->tg_relation;
-	relationId = RelationGetRelid(truncatedRelation);
-	partitionMethod = PartitionMethod(relationId);
+	TriggerData *triggerData = (TriggerData *) fcinfo->context;
+	Relation truncatedRelation = triggerData->tg_relation;
+	Oid relationId = RelationGetRelid(truncatedRelation);
+	char partitionMethod = PartitionMethod(relationId);
 
 	if (!EnableDDLPropagation)
 	{
@@ -110,7 +105,6 @@ TruncateTaskList(Oid relationId)
 		ShardInterval *shardInterval = (ShardInterval *) lfirst(shardIntervalCell);
 		uint64 shardId = shardInterval->shardId;
 		StringInfo shardQueryString = makeStringInfo();
-		Task *task = NULL;
 		char *shardName = pstrdup(relationName);
 
 		AppendShardIdToName(&shardName, shardId);
@@ -118,7 +112,7 @@ TruncateTaskList(Oid relationId)
 		appendStringInfo(shardQueryString, "TRUNCATE TABLE %s CASCADE",
 						 quote_qualified_identifier(schemaName, shardName));
 
-		task = CitusMakeNode(Task);
+		Task *task = CitusMakeNode(Task);
 		task->jobId = INVALID_JOB_ID;
 		task->taskId = taskId++;
 		task->taskType = DDL_TASK;

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -67,7 +67,6 @@ WorkerGetRandomCandidateNode(List *currentNodeList)
 	WorkerNode *workerNode = NULL;
 	bool wantSameRack = false;
 	uint32 tryCount = WORKER_RACK_TRIES;
-	uint32 tryIndex = 0;
 
 	uint32 currentNodeCount = list_length(currentNodeList);
 	List *candidateWorkerNodeList = PrimaryNodesNotInList(currentNodeList);
@@ -104,17 +103,15 @@ WorkerGetRandomCandidateNode(List *currentNodeList)
 	 * If after a predefined number of tries, we still cannot find such a node,
 	 * we simply give up and return the last worker node we found.
 	 */
-	for (tryIndex = 0; tryIndex < tryCount; tryIndex++)
+	for (uint32 tryIndex = 0; tryIndex < tryCount; tryIndex++)
 	{
 		WorkerNode *firstNode = (WorkerNode *) linitial(currentNodeList);
 		char *firstRack = firstNode->workerRack;
-		char *workerRack = NULL;
-		bool sameRack = false;
 
 		workerNode = FindRandomNodeFromList(candidateWorkerNodeList);
-		workerRack = workerNode->workerRack;
+		char *workerRack = workerNode->workerRack;
 
-		sameRack = (strncmp(workerRack, firstRack, WORKER_LENGTH) == 0);
+		bool sameRack = (strncmp(workerRack, firstRack, WORKER_LENGTH) == 0);
 		if ((sameRack && wantSameRack) || (!sameRack && !wantSameRack))
 		{
 			break;
@@ -171,7 +168,6 @@ WorkerGetLocalFirstCandidateNode(List *currentNodeList)
 	if (currentNodeCount == 0)
 	{
 		StringInfo clientHostStringInfo = makeStringInfo();
-		char *clientHost = NULL;
 		char *errorMessage = ClientHostAddress(clientHostStringInfo);
 
 		if (errorMessage != NULL)
@@ -184,7 +180,7 @@ WorkerGetLocalFirstCandidateNode(List *currentNodeList)
 		}
 
 		/* if hostname is localhost.localdomain, change it to localhost */
-		clientHost = clientHostStringInfo->data;
+		char *clientHost = clientHostStringInfo->data;
 		if (strncmp(clientHost, "localhost.localdomain", WORKER_LENGTH) == 0)
 		{
 			clientHost = pstrdup("localhost");
@@ -343,7 +339,6 @@ FilterActiveNodeListFunc(LOCKMODE lockMode, bool (*checkFunction)(WorkerNode *))
 {
 	List *workerNodeList = NIL;
 	WorkerNode *workerNode = NULL;
-	HTAB *workerNodeHash = NULL;
 	HASH_SEQ_STATUS status;
 
 	Assert(checkFunction != NULL);
@@ -353,7 +348,7 @@ FilterActiveNodeListFunc(LOCKMODE lockMode, bool (*checkFunction)(WorkerNode *))
 		LockRelationOid(DistNodeRelationId(), lockMode);
 	}
 
-	workerNodeHash = GetWorkerNodeHash();
+	HTAB *workerNodeHash = GetWorkerNodeHash();
 	hash_seq_init(&status, workerNodeHash);
 
 	while ((workerNode = hash_seq_search(&status)) != NULL)
@@ -568,10 +563,9 @@ CompareWorkerNodes(const void *leftElement, const void *rightElement)
 {
 	const void *leftWorker = *((const void **) leftElement);
 	const void *rightWorker = *((const void **) rightElement);
-	int compare = 0;
 	Size ignoredKeySize = 0;
 
-	compare = WorkerNodeCompare(leftWorker, rightWorker, ignoredKeySize);
+	int compare = WorkerNodeCompare(leftWorker, rightWorker, ignoredKeySize);
 
 	return compare;
 }
@@ -588,16 +582,15 @@ WorkerNodeCompare(const void *lhsKey, const void *rhsKey, Size keySize)
 	const WorkerNode *workerLhs = (const WorkerNode *) lhsKey;
 	const WorkerNode *workerRhs = (const WorkerNode *) rhsKey;
 
-	int nameCompare = 0;
-	int portCompare = 0;
 
-	nameCompare = strncmp(workerLhs->workerName, workerRhs->workerName, WORKER_LENGTH);
+	int nameCompare = strncmp(workerLhs->workerName, workerRhs->workerName,
+							  WORKER_LENGTH);
 	if (nameCompare != 0)
 	{
 		return nameCompare;
 	}
 
-	portCompare = workerLhs->workerPort - workerRhs->workerPort;
+	int portCompare = workerLhs->workerPort - workerRhs->workerPort;
 	return portCompare;
 }
 

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -278,9 +278,7 @@ EnsureModificationsCanRun(void)
 bool
 IsDistributedTable(Oid relationId)
 {
-	DistTableCacheEntry *cacheEntry = NULL;
-
-	cacheEntry = LookupDistTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = LookupDistTableCacheEntry(relationId);
 
 	/*
 	 * If extension hasn't been created, or has the wrong version and the
@@ -310,8 +308,6 @@ IsDistributedTable(Oid relationId)
 static bool
 IsDistributedTableViaCatalog(Oid relationId)
 {
-	HeapTuple partitionTuple = NULL;
-	SysScanDesc scanDescriptor = NULL;
 	const int scanKeyCount = 1;
 	ScanKeyData scanKey[1];
 	bool indexOK = true;
@@ -321,11 +317,11 @@ IsDistributedTableViaCatalog(Oid relationId)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_partition_logicalrelid,
 				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(relationId));
 
-	scanDescriptor = systable_beginscan(pgDistPartition,
-										DistPartitionLogicalRelidIndexId(),
-										indexOK, NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistPartition,
+													DistPartitionLogicalRelidIndexId(),
+													indexOK, NULL, scanKeyCount, scanKey);
 
-	partitionTuple = systable_getnext(scanDescriptor);
+	HeapTuple partitionTuple = systable_getnext(scanDescriptor);
 	systable_endscan(scanDescriptor);
 	heap_close(pgDistPartition, AccessShareLock);
 
@@ -340,21 +336,19 @@ IsDistributedTableViaCatalog(Oid relationId)
 List *
 DistributedTableList(void)
 {
-	List *distTableOidList = NIL;
 	List *distributedTableList = NIL;
 	ListCell *distTableOidCell = NULL;
 
 	Assert(CitusHasBeenLoaded() && CheckCitusVersion(WARNING));
 
 	/* first, we need to iterate over pg_dist_partition */
-	distTableOidList = DistTableOidList();
+	List *distTableOidList = DistTableOidList();
 
 	foreach(distTableOidCell, distTableOidList)
 	{
-		DistTableCacheEntry *cacheEntry = NULL;
 		Oid relationId = lfirst_oid(distTableOidCell);
 
-		cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 
 		distributedTableList = lappend(distributedTableList, cacheEntry);
 	}
@@ -372,24 +366,20 @@ DistributedTableList(void)
 ShardInterval *
 LoadShardInterval(uint64 shardId)
 {
-	ShardInterval *shardInterval = NULL;
-	ShardInterval *sourceShardInterval = NULL;
-	ShardCacheEntry *shardEntry = NULL;
-	DistTableCacheEntry *tableEntry = NULL;
+	ShardCacheEntry *shardEntry = LookupShardCacheEntry(shardId);
 
-	shardEntry = LookupShardCacheEntry(shardId);
-
-	tableEntry = shardEntry->tableEntry;
+	DistTableCacheEntry *tableEntry = shardEntry->tableEntry;
 
 	Assert(tableEntry->isDistributedTable);
 
 	/* the offset better be in a valid range */
 	Assert(shardEntry->shardIndex < tableEntry->shardIntervalArrayLength);
 
-	sourceShardInterval = tableEntry->sortedShardIntervalArray[shardEntry->shardIndex];
+	ShardInterval *sourceShardInterval =
+		tableEntry->sortedShardIntervalArray[shardEntry->shardIndex];
 
 	/* copy value to return */
-	shardInterval = (ShardInterval *) palloc0(sizeof(ShardInterval));
+	ShardInterval *shardInterval = (ShardInterval *) palloc0(sizeof(ShardInterval));
 	CopyShardInterval(sourceShardInterval, shardInterval);
 
 	return shardInterval;
@@ -403,12 +393,9 @@ LoadShardInterval(uint64 shardId)
 Oid
 RelationIdForShard(uint64 shardId)
 {
-	ShardCacheEntry *shardEntry = NULL;
-	DistTableCacheEntry *tableEntry = NULL;
+	ShardCacheEntry *shardEntry = LookupShardCacheEntry(shardId);
 
-	shardEntry = LookupShardCacheEntry(shardId);
-
-	tableEntry = shardEntry->tableEntry;
+	DistTableCacheEntry *tableEntry = shardEntry->tableEntry;
 
 	Assert(tableEntry->isDistributedTable);
 
@@ -439,24 +426,18 @@ ReferenceTableShardId(uint64 shardId)
 GroupShardPlacement *
 LoadGroupShardPlacement(uint64 shardId, uint64 placementId)
 {
-	ShardCacheEntry *shardEntry = NULL;
-	DistTableCacheEntry *tableEntry = NULL;
-
-	GroupShardPlacement *placementArray = NULL;
-	int numberOfPlacements = 0;
-
-	int i = 0;
-
-	shardEntry = LookupShardCacheEntry(shardId);
-	tableEntry = shardEntry->tableEntry;
+	ShardCacheEntry *shardEntry = LookupShardCacheEntry(shardId);
+	DistTableCacheEntry *tableEntry = shardEntry->tableEntry;
 
 	/* the offset better be in a valid range */
 	Assert(shardEntry->shardIndex < tableEntry->shardIntervalArrayLength);
 
-	placementArray = tableEntry->arrayOfPlacementArrays[shardEntry->shardIndex];
-	numberOfPlacements = tableEntry->arrayOfPlacementArrayLengths[shardEntry->shardIndex];
+	GroupShardPlacement *placementArray =
+		tableEntry->arrayOfPlacementArrays[shardEntry->shardIndex];
+	int numberOfPlacements =
+		tableEntry->arrayOfPlacementArrayLengths[shardEntry->shardIndex];
 
-	for (i = 0; i < numberOfPlacements; i++)
+	for (int i = 0; i < numberOfPlacements; i++)
 	{
 		if (placementArray[i].placementId == placementId)
 		{
@@ -479,13 +460,10 @@ LoadGroupShardPlacement(uint64 shardId, uint64 placementId)
 ShardPlacement *
 LoadShardPlacement(uint64 shardId, uint64 placementId)
 {
-	ShardCacheEntry *shardEntry = NULL;
-	GroupShardPlacement *groupPlacement = NULL;
-	ShardPlacement *nodePlacement = NULL;
-
-	shardEntry = LookupShardCacheEntry(shardId);
-	groupPlacement = LoadGroupShardPlacement(shardId, placementId);
-	nodePlacement = ResolveGroupShardPlacement(groupPlacement, shardEntry);
+	ShardCacheEntry *shardEntry = LookupShardCacheEntry(shardId);
+	GroupShardPlacement *groupPlacement = LoadGroupShardPlacement(shardId, placementId);
+	ShardPlacement *nodePlacement = ResolveGroupShardPlacement(groupPlacement,
+															   shardEntry);
 
 	return nodePlacement;
 }
@@ -499,19 +477,16 @@ LoadShardPlacement(uint64 shardId, uint64 placementId)
 ShardPlacement *
 FindShardPlacementOnGroup(int32 groupId, uint64 shardId)
 {
-	ShardCacheEntry *shardEntry = NULL;
-	DistTableCacheEntry *tableEntry = NULL;
-	GroupShardPlacement *placementArray = NULL;
-	int numberOfPlacements = 0;
 	ShardPlacement *placementOnNode = NULL;
-	int placementIndex = 0;
 
-	shardEntry = LookupShardCacheEntry(shardId);
-	tableEntry = shardEntry->tableEntry;
-	placementArray = tableEntry->arrayOfPlacementArrays[shardEntry->shardIndex];
-	numberOfPlacements = tableEntry->arrayOfPlacementArrayLengths[shardEntry->shardIndex];
+	ShardCacheEntry *shardEntry = LookupShardCacheEntry(shardId);
+	DistTableCacheEntry *tableEntry = shardEntry->tableEntry;
+	GroupShardPlacement *placementArray =
+		tableEntry->arrayOfPlacementArrays[shardEntry->shardIndex];
+	int numberOfPlacements =
+		tableEntry->arrayOfPlacementArrayLengths[shardEntry->shardIndex];
 
-	for (placementIndex = 0; placementIndex < numberOfPlacements; placementIndex++)
+	for (int placementIndex = 0; placementIndex < numberOfPlacements; placementIndex++)
 	{
 		GroupShardPlacement *placement = &placementArray[placementIndex];
 
@@ -583,11 +558,9 @@ ResolveGroupShardPlacement(GroupShardPlacement *groupShardPlacement,
 WorkerNode *
 LookupNodeByNodeId(uint32 nodeId)
 {
-	int workerNodeIndex = 0;
-
 	PrepareWorkerNodeCache();
 
-	for (workerNodeIndex = 0; workerNodeIndex < WorkerNodeCount; workerNodeIndex++)
+	for (int workerNodeIndex = 0; workerNodeIndex < WorkerNodeCount; workerNodeIndex++)
 	{
 		WorkerNode *workerNode = WorkerNodeArray[workerNodeIndex];
 		if (workerNode->nodeId == nodeId)
@@ -613,11 +586,10 @@ WorkerNode *
 LookupNodeForGroup(int32 groupId)
 {
 	bool foundAnyNodes = false;
-	int workerNodeIndex = 0;
 
 	PrepareWorkerNodeCache();
 
-	for (workerNodeIndex = 0; workerNodeIndex < WorkerNodeCount; workerNodeIndex++)
+	for (int workerNodeIndex = 0; workerNodeIndex < WorkerNodeCount; workerNodeIndex++)
 	{
 		WorkerNode *workerNode = WorkerNodeArray[workerNodeIndex];
 		int32 workerNodeGroupId = workerNode->groupId;
@@ -675,23 +647,20 @@ LookupNodeForGroup(int32 groupId)
 List *
 ShardPlacementList(uint64 shardId)
 {
-	ShardCacheEntry *shardEntry = NULL;
-	DistTableCacheEntry *tableEntry = NULL;
-	GroupShardPlacement *placementArray = NULL;
-	int numberOfPlacements = 0;
 	List *placementList = NIL;
-	int i = 0;
 
-	shardEntry = LookupShardCacheEntry(shardId);
-	tableEntry = shardEntry->tableEntry;
+	ShardCacheEntry *shardEntry = LookupShardCacheEntry(shardId);
+	DistTableCacheEntry *tableEntry = shardEntry->tableEntry;
 
 	/* the offset better be in a valid range */
 	Assert(shardEntry->shardIndex < tableEntry->shardIntervalArrayLength);
 
-	placementArray = tableEntry->arrayOfPlacementArrays[shardEntry->shardIndex];
-	numberOfPlacements = tableEntry->arrayOfPlacementArrayLengths[shardEntry->shardIndex];
+	GroupShardPlacement *placementArray =
+		tableEntry->arrayOfPlacementArrays[shardEntry->shardIndex];
+	int numberOfPlacements =
+		tableEntry->arrayOfPlacementArrayLengths[shardEntry->shardIndex];
 
-	for (i = 0; i < numberOfPlacements; i++)
+	for (int i = 0; i < numberOfPlacements; i++)
 	{
 		GroupShardPlacement *groupShardPlacement = &placementArray[i];
 		ShardPlacement *shardPlacement = ResolveGroupShardPlacement(groupShardPlacement,
@@ -718,7 +687,6 @@ ShardPlacementList(uint64 shardId)
 static ShardCacheEntry *
 LookupShardCacheEntry(int64 shardId)
 {
-	ShardCacheEntry *shardEntry = NULL;
 	bool foundInCache = false;
 	bool recheck = false;
 
@@ -727,7 +695,8 @@ LookupShardCacheEntry(int64 shardId)
 	InitializeCaches();
 
 	/* lookup cache entry */
-	shardEntry = hash_search(DistShardCacheHash, &shardId, HASH_FIND, &foundInCache);
+	ShardCacheEntry *shardEntry = hash_search(DistShardCacheHash, &shardId, HASH_FIND,
+											  &foundInCache);
 
 	if (!foundInCache)
 	{
@@ -822,7 +791,6 @@ DistributedTableCacheEntry(Oid distributedRelationId)
 static DistTableCacheEntry *
 LookupDistTableCacheEntry(Oid relationId)
 {
-	DistTableCacheEntry *cacheEntry = NULL;
 	bool foundInCache = false;
 	void *hashKey = (void *) &relationId;
 
@@ -865,7 +833,8 @@ LookupDistTableCacheEntry(Oid relationId)
 		}
 	}
 
-	cacheEntry = hash_search(DistTableCacheHash, hashKey, HASH_ENTER, &foundInCache);
+	DistTableCacheEntry *cacheEntry = hash_search(DistTableCacheHash, hashKey, HASH_ENTER,
+												  &foundInCache);
 
 	/* return valid matches */
 	if (foundInCache)
@@ -916,14 +885,9 @@ LookupDistTableCacheEntry(Oid relationId)
 DistObjectCacheEntry *
 LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 {
-	DistObjectCacheEntry *cacheEntry = NULL;
 	bool foundInCache = false;
 	DistObjectCacheEntryKey hashKey;
-	Relation pgDistObjectRel = NULL;
-	TupleDesc pgDistObjectTupleDesc = NULL;
 	ScanKeyData pgDistObjectKey[3];
-	SysScanDesc pgDistObjectScan = NULL;
-	HeapTuple pgDistObjectTup = NULL;
 
 	memset(&hashKey, 0, sizeof(DistObjectCacheEntryKey));
 	hashKey.classid = classid;
@@ -942,7 +906,8 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 
 	InitializeCaches();
 
-	cacheEntry = hash_search(DistObjectCacheHash, &hashKey, HASH_ENTER, &foundInCache);
+	DistObjectCacheEntry *cacheEntry = hash_search(DistObjectCacheHash, &hashKey,
+												   HASH_ENTER, &foundInCache);
 
 	/* return valid matches */
 	if (foundInCache)
@@ -970,8 +935,8 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 	cacheEntry->key.objid = objid;
 	cacheEntry->key.objsubid = objsubid;
 
-	pgDistObjectRel = heap_open(DistObjectRelationId(), AccessShareLock);
-	pgDistObjectTupleDesc = RelationGetDescr(pgDistObjectRel);
+	Relation pgDistObjectRel = heap_open(DistObjectRelationId(), AccessShareLock);
+	TupleDesc pgDistObjectTupleDesc = RelationGetDescr(pgDistObjectRel);
 
 	ScanKeyInit(&pgDistObjectKey[0], Anum_pg_dist_object_classid,
 				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(classid));
@@ -980,9 +945,10 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 	ScanKeyInit(&pgDistObjectKey[2], Anum_pg_dist_object_objsubid,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(objsubid));
 
-	pgDistObjectScan = systable_beginscan(pgDistObjectRel, DistObjectPrimaryKeyIndexId(),
-										  true, NULL, 3, pgDistObjectKey);
-	pgDistObjectTup = systable_getnext(pgDistObjectScan);
+	SysScanDesc pgDistObjectScan = systable_beginscan(pgDistObjectRel,
+													  DistObjectPrimaryKeyIndexId(),
+													  true, NULL, 3, pgDistObjectKey);
+	HeapTuple pgDistObjectTup = systable_getnext(pgDistObjectScan);
 
 	if (HeapTupleIsValid(pgDistObjectTup))
 	{
@@ -1021,18 +987,12 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 static void
 BuildDistTableCacheEntry(DistTableCacheEntry *cacheEntry)
 {
-	HeapTuple distPartitionTuple = NULL;
-	Relation pgDistPartition = NULL;
-	Datum partitionKeyDatum = 0;
-	Datum replicationModelDatum = 0;
 	MemoryContext oldContext = NULL;
-	TupleDesc tupleDescriptor = NULL;
-	bool partitionKeyIsNull = false;
 	Datum datumArray[Natts_pg_dist_partition];
 	bool isNullArray[Natts_pg_dist_partition];
 
-	pgDistPartition = heap_open(DistPartitionRelationId(), AccessShareLock);
-	distPartitionTuple =
+	Relation pgDistPartition = heap_open(DistPartitionRelationId(), AccessShareLock);
+	HeapTuple distPartitionTuple =
 		LookupDistPartitionTuple(pgDistPartition, cacheEntry->relationId);
 
 	/* not a distributed table, done */
@@ -1045,25 +1005,23 @@ BuildDistTableCacheEntry(DistTableCacheEntry *cacheEntry)
 
 	cacheEntry->isDistributedTable = true;
 
-	tupleDescriptor = RelationGetDescr(pgDistPartition);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPartition);
 	heap_deform_tuple(distPartitionTuple, tupleDescriptor, datumArray, isNullArray);
 
 	cacheEntry->partitionMethod = datumArray[Anum_pg_dist_partition_partmethod - 1];
-	partitionKeyDatum = datumArray[Anum_pg_dist_partition_partkey - 1];
-	partitionKeyIsNull = isNullArray[Anum_pg_dist_partition_partkey - 1];
+	Datum partitionKeyDatum = datumArray[Anum_pg_dist_partition_partkey - 1];
+	bool partitionKeyIsNull = isNullArray[Anum_pg_dist_partition_partkey - 1];
 
 	/* note that for reference tables partitionKeyisNull is true */
 	if (!partitionKeyIsNull)
 	{
-		Node *partitionNode = NULL;
-
 		oldContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
 
 		/* get the string representation of the partition column Var */
 		cacheEntry->partitionKeyString = TextDatumGetCString(partitionKeyDatum);
 
 		/* convert the string to a Node and ensure it is a Var */
-		partitionNode = stringToNode(cacheEntry->partitionKeyString);
+		Node *partitionNode = stringToNode(cacheEntry->partitionKeyString);
 		Assert(IsA(partitionNode, Var));
 
 		cacheEntry->partitionColumn = (Var *) partitionNode;
@@ -1081,7 +1039,7 @@ BuildDistTableCacheEntry(DistTableCacheEntry *cacheEntry)
 		cacheEntry->colocationId = INVALID_COLOCATION_ID;
 	}
 
-	replicationModelDatum = datumArray[Anum_pg_dist_partition_repmodel - 1];
+	Datum replicationModelDatum = datumArray[Anum_pg_dist_partition_repmodel - 1];
 	if (isNullArray[Anum_pg_dist_partition_repmodel - 1])
 	{
 		/*
@@ -1102,15 +1060,13 @@ BuildDistTableCacheEntry(DistTableCacheEntry *cacheEntry)
 	/* we only need hash functions for hash distributed tables */
 	if (cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH)
 	{
-		TypeCacheEntry *typeEntry = NULL;
-		FmgrInfo *hashFunction = NULL;
 		Var *partitionColumn = cacheEntry->partitionColumn;
 
-		typeEntry = lookup_type_cache(partitionColumn->vartype,
-									  TYPECACHE_HASH_PROC_FINFO);
+		TypeCacheEntry *typeEntry = lookup_type_cache(partitionColumn->vartype,
+													  TYPECACHE_HASH_PROC_FINFO);
 
-		hashFunction = MemoryContextAllocZero(MetadataCacheMemoryContext,
-											  sizeof(FmgrInfo));
+		FmgrInfo *hashFunction = MemoryContextAllocZero(MetadataCacheMemoryContext,
+														sizeof(FmgrInfo));
 
 		fmgr_info_copy(hashFunction, &(typeEntry->hash_proc_finfo),
 					   MetadataCacheMemoryContext);
@@ -1151,9 +1107,6 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 	ShardInterval **sortedShardIntervalArray = NULL;
 	FmgrInfo *shardIntervalCompareFunction = NULL;
 	FmgrInfo *shardColumnCompareFunction = NULL;
-	List *distShardTupleList = NIL;
-	int shardIntervalArrayLength = 0;
-	int shardIndex = 0;
 	Oid columnTypeId = InvalidOid;
 	int32 columnTypeMod = -1;
 	Oid intervalTypeId = InvalidOid;
@@ -1166,8 +1119,8 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 							  &intervalTypeId,
 							  &intervalTypeMod);
 
-	distShardTupleList = LookupDistShardTuples(cacheEntry->relationId);
-	shardIntervalArrayLength = list_length(distShardTupleList);
+	List *distShardTupleList = LookupDistShardTuples(cacheEntry->relationId);
+	int shardIntervalArrayLength = list_length(distShardTupleList);
 	if (shardIntervalArrayLength > 0)
 	{
 		Relation distShardRelation = heap_open(DistShardRelationId(), AccessShareLock);
@@ -1195,10 +1148,10 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 																distShardTupleDesc,
 																intervalTypeId,
 																intervalTypeMod);
-			ShardInterval *newShardInterval = NULL;
 			MemoryContext oldContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
 
-			newShardInterval = (ShardInterval *) palloc0(sizeof(ShardInterval));
+			ShardInterval *newShardInterval = (ShardInterval *) palloc0(
+				sizeof(ShardInterval));
 			CopyShardInterval(shardInterval, newShardInterval);
 			shardIntervalArray[arrayIndex] = newShardInterval;
 
@@ -1315,20 +1268,16 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 	cacheEntry->shardIntervalArrayLength = 0;
 
 	/* maintain shardId->(table,ShardInterval) cache */
-	for (shardIndex = 0; shardIndex < shardIntervalArrayLength; shardIndex++)
+	for (int shardIndex = 0; shardIndex < shardIntervalArrayLength; shardIndex++)
 	{
-		ShardCacheEntry *shardEntry = NULL;
 		ShardInterval *shardInterval = sortedShardIntervalArray[shardIndex];
 		bool foundInCache = false;
-		List *placementList = NIL;
-		MemoryContext oldContext = NULL;
 		ListCell *placementCell = NULL;
-		GroupShardPlacement *placementArray = NULL;
 		int placementOffset = 0;
-		int numberOfPlacements = 0;
 
-		shardEntry = hash_search(DistShardCacheHash, &shardInterval->shardId, HASH_ENTER,
-								 &foundInCache);
+		ShardCacheEntry *shardEntry = hash_search(DistShardCacheHash,
+												  &shardInterval->shardId, HASH_ENTER,
+												  &foundInCache);
 		if (foundInCache)
 		{
 			ereport(ERROR, (errmsg("cached metadata for shard " UINT64_FORMAT
@@ -1348,12 +1297,13 @@ BuildCachedShardList(DistTableCacheEntry *cacheEntry)
 		shardEntry->tableEntry = cacheEntry;
 
 		/* build list of shard placements */
-		placementList = BuildShardPlacementList(shardInterval);
-		numberOfPlacements = list_length(placementList);
+		List *placementList = BuildShardPlacementList(shardInterval);
+		int numberOfPlacements = list_length(placementList);
 
 		/* and copy that list into the cache entry */
-		oldContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
-		placementArray = palloc0(numberOfPlacements * sizeof(GroupShardPlacement));
+		MemoryContext oldContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
+		GroupShardPlacement *placementArray = palloc0(numberOfPlacements *
+													  sizeof(GroupShardPlacement));
 		foreach(placementCell, placementList)
 		{
 			GroupShardPlacement *srcPlacement =
@@ -1408,9 +1358,6 @@ bool
 HasUniformHashDistribution(ShardInterval **shardIntervalArray,
 						   int shardIntervalArrayLength)
 {
-	uint64 hashTokenIncrement = 0;
-	int shardIndex = 0;
-
 	/* if there are no shards, there is no uniform distribution */
 	if (shardIntervalArrayLength == 0)
 	{
@@ -1418,9 +1365,9 @@ HasUniformHashDistribution(ShardInterval **shardIntervalArray,
 	}
 
 	/* calculate the hash token increment */
-	hashTokenIncrement = HASH_TOKEN_COUNT / shardIntervalArrayLength;
+	uint64 hashTokenIncrement = HASH_TOKEN_COUNT / shardIntervalArrayLength;
 
-	for (shardIndex = 0; shardIndex < shardIntervalArrayLength; shardIndex++)
+	for (int shardIndex = 0; shardIndex < shardIntervalArrayLength; shardIndex++)
 	{
 		ShardInterval *shardInterval = shardIntervalArray[shardIndex];
 		int32 shardMinHashToken = INT32_MIN + (shardIndex * hashTokenIncrement);
@@ -1452,7 +1399,6 @@ static bool
 HasUninitializedShardInterval(ShardInterval **sortedShardIntervalArray, int shardCount)
 {
 	bool hasUninitializedShardInterval = false;
-	ShardInterval *lastShardInterval = NULL;
 
 	if (shardCount == 0)
 	{
@@ -1465,7 +1411,7 @@ HasUninitializedShardInterval(ShardInterval **sortedShardIntervalArray, int shar
 	 * Since the shard interval array is sorted, and uninitialized ones stored
 	 * in the end of the array, checking the last element is enough.
 	 */
-	lastShardInterval = sortedShardIntervalArray[shardCount - 1];
+	ShardInterval *lastShardInterval = sortedShardIntervalArray[shardCount - 1];
 	if (!lastShardInterval->minValueExists || !lastShardInterval->maxValueExists)
 	{
 		hasUninitializedShardInterval = true;
@@ -1484,8 +1430,6 @@ HasOverlappingShardInterval(ShardInterval **shardIntervalArray,
 							int shardIntervalArrayLength,
 							FmgrInfo *shardIntervalSortCompareFunction)
 {
-	int shardIndex = 0;
-	ShardInterval *lastShardInterval = NULL;
 	Datum comparisonDatum = 0;
 	int comparisonResult = 0;
 
@@ -1495,8 +1439,8 @@ HasOverlappingShardInterval(ShardInterval **shardIntervalArray,
 		return false;
 	}
 
-	lastShardInterval = shardIntervalArray[0];
-	for (shardIndex = 1; shardIndex < shardIntervalArrayLength; shardIndex++)
+	ShardInterval *lastShardInterval = shardIntervalArray[0];
+	for (int shardIndex = 1; shardIndex < shardIntervalArrayLength; shardIndex++)
 	{
 		ShardInterval *curShardInterval = shardIntervalArray[shardIndex];
 
@@ -1586,15 +1530,13 @@ CitusHasBeenLoaded(void)
 static bool
 CitusHasBeenLoadedInternal(void)
 {
-	Oid citusExtensionOid = InvalidOid;
-
 	if (IsBinaryUpgrade)
 	{
 		/* never use Citus logic during pg_upgrade */
 		return false;
 	}
 
-	citusExtensionOid = get_extension_oid("citus", true);
+	Oid citusExtensionOid = get_extension_oid("citus", true);
 	if (citusExtensionOid == InvalidOid)
 	{
 		/* Citus extension does not exist yet */
@@ -1654,14 +1596,12 @@ CheckCitusVersion(int elevel)
 bool
 CheckAvailableVersion(int elevel)
 {
-	char *availableVersion = NULL;
-
 	if (!EnableVersionChecks)
 	{
 		return true;
 	}
 
-	availableVersion = AvailableExtensionVersion();
+	char *availableVersion = AvailableExtensionVersion();
 
 	if (!MajorVersionsCompatible(availableVersion, CITUS_EXTENSIONVERSION))
 	{
@@ -1688,12 +1628,10 @@ CheckAvailableVersion(int elevel)
 static bool
 CheckInstalledVersion(int elevel)
 {
-	char *installedVersion = NULL;
-
 	Assert(CitusHasBeenLoaded());
 	Assert(EnableVersionChecks);
 
-	installedVersion = InstalledExtensionVersion();
+	char *installedVersion = InstalledExtensionVersion();
 
 	if (!MajorVersionsCompatible(installedVersion, CITUS_EXTENSIONVERSION))
 	{
@@ -1761,21 +1699,17 @@ MajorVersionsCompatible(char *leftVersion, char *rightVersion)
 static char *
 AvailableExtensionVersion(void)
 {
-	ReturnSetInfo *extensionsResultSet = NULL;
-	TupleTableSlot *tupleTableSlot = NULL;
 	LOCAL_FCINFO(fcinfo, 0);
 	FmgrInfo flinfo;
-	EState *estate = NULL;
 
-	bool hasTuple = false;
 	bool goForward = true;
 	bool doCopy = false;
 	char *availableExtensionVersion;
 
 	InitializeCaches();
 
-	estate = CreateExecutorState();
-	extensionsResultSet = makeNode(ReturnSetInfo);
+	EState *estate = CreateExecutorState();
+	ReturnSetInfo *extensionsResultSet = makeNode(ReturnSetInfo);
 	extensionsResultSet->econtext = GetPerTupleExprContext(estate);
 	extensionsResultSet->allowedModes = SFRM_Materialize;
 
@@ -1786,25 +1720,25 @@ AvailableExtensionVersion(void)
 	/* pg_available_extensions returns result set containing all available extensions */
 	(*pg_available_extensions)(fcinfo);
 
-	tupleTableSlot = MakeSingleTupleTableSlotCompat(extensionsResultSet->setDesc,
-													&TTSOpsMinimalTuple);
-	hasTuple = tuplestore_gettupleslot(extensionsResultSet->setResult, goForward, doCopy,
-									   tupleTableSlot);
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(
+		extensionsResultSet->setDesc,
+		&TTSOpsMinimalTuple);
+	bool hasTuple = tuplestore_gettupleslot(extensionsResultSet->setResult, goForward,
+											doCopy,
+											tupleTableSlot);
 	while (hasTuple)
 	{
-		Datum extensionNameDatum = 0;
-		char *extensionName = NULL;
 		bool isNull = false;
 
-		extensionNameDatum = slot_getattr(tupleTableSlot, 1, &isNull);
-		extensionName = NameStr(*DatumGetName(extensionNameDatum));
+		Datum extensionNameDatum = slot_getattr(tupleTableSlot, 1, &isNull);
+		char *extensionName = NameStr(*DatumGetName(extensionNameDatum));
 		if (strcmp(extensionName, "citus") == 0)
 		{
-			MemoryContext oldMemoryContext = NULL;
 			Datum availableVersion = slot_getattr(tupleTableSlot, 2, &isNull);
 
 			/* we will cache the result of citus version to prevent catalog access */
-			oldMemoryContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
+			MemoryContext oldMemoryContext = MemoryContextSwitchTo(
+				MetadataCacheMemoryContext);
 
 			availableExtensionVersion = text_to_cstring(DatumGetTextPP(availableVersion));
 
@@ -1836,28 +1770,24 @@ AvailableExtensionVersion(void)
 static char *
 InstalledExtensionVersion(void)
 {
-	Relation relation = NULL;
-	SysScanDesc scandesc;
 	ScanKeyData entry[1];
-	HeapTuple extensionTuple = NULL;
 	char *installedExtensionVersion = NULL;
 
 	InitializeCaches();
 
-	relation = heap_open(ExtensionRelationId, AccessShareLock);
+	Relation relation = heap_open(ExtensionRelationId, AccessShareLock);
 
 	ScanKeyInit(&entry[0], Anum_pg_extension_extname, BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum("citus"));
 
-	scandesc = systable_beginscan(relation, ExtensionNameIndexId, true,
-								  NULL, 1, entry);
+	SysScanDesc scandesc = systable_beginscan(relation, ExtensionNameIndexId, true,
+											  NULL, 1, entry);
 
-	extensionTuple = systable_getnext(scandesc);
+	HeapTuple extensionTuple = systable_getnext(scandesc);
 
 	/* We assume that there can be at most one matching tuple */
 	if (HeapTupleIsValid(extensionTuple))
 	{
-		MemoryContext oldMemoryContext = NULL;
 		int extensionIndex = Anum_pg_extension_extversion;
 		TupleDesc tupleDescriptor = RelationGetDescr(relation);
 		bool isNull = false;
@@ -1872,7 +1802,8 @@ InstalledExtensionVersion(void)
 		}
 
 		/* we will cache the result of citus version to prevent catalog access */
-		oldMemoryContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
+		MemoryContext oldMemoryContext = MemoryContextSwitchTo(
+			MetadataCacheMemoryContext);
 
 		installedExtensionVersion = text_to_cstring(DatumGetTextPP(installedVersion));
 
@@ -2340,10 +2271,7 @@ CurrentDatabaseName(void)
 extern Oid
 CitusExtensionOwner(void)
 {
-	Relation relation = NULL;
-	SysScanDesc scandesc;
 	ScanKeyData entry[1];
-	HeapTuple extensionTuple = NULL;
 	Form_pg_extension extensionForm = NULL;
 
 	if (MetadataCache.extensionOwner != InvalidOid)
@@ -2351,17 +2279,17 @@ CitusExtensionOwner(void)
 		return MetadataCache.extensionOwner;
 	}
 
-	relation = heap_open(ExtensionRelationId, AccessShareLock);
+	Relation relation = heap_open(ExtensionRelationId, AccessShareLock);
 
 	ScanKeyInit(&entry[0],
 				Anum_pg_extension_extname,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum("citus"));
 
-	scandesc = systable_beginscan(relation, ExtensionNameIndexId, true,
-								  NULL, 1, entry);
+	SysScanDesc scandesc = systable_beginscan(relation, ExtensionNameIndexId, true,
+											  NULL, 1, entry);
 
-	extensionTuple = systable_getnext(scandesc);
+	HeapTuple extensionTuple = systable_getnext(scandesc);
 
 	/* We assume that there can be at most one matching tuple */
 	if (HeapTupleIsValid(extensionTuple))
@@ -2540,8 +2468,6 @@ Datum
 master_dist_partition_cache_invalidate(PG_FUNCTION_ARGS)
 {
 	TriggerData *triggerData = (TriggerData *) fcinfo->context;
-	HeapTuple newTuple = NULL;
-	HeapTuple oldTuple = NULL;
 	Oid oldLogicalRelationId = InvalidOid;
 	Oid newLogicalRelationId = InvalidOid;
 
@@ -2553,8 +2479,8 @@ master_dist_partition_cache_invalidate(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
-	newTuple = triggerData->tg_newtuple;
-	oldTuple = triggerData->tg_trigtuple;
+	HeapTuple newTuple = triggerData->tg_newtuple;
+	HeapTuple oldTuple = triggerData->tg_trigtuple;
 
 	/* collect logicalrelid for OLD and NEW tuple */
 	if (oldTuple != NULL)
@@ -2603,8 +2529,6 @@ Datum
 master_dist_shard_cache_invalidate(PG_FUNCTION_ARGS)
 {
 	TriggerData *triggerData = (TriggerData *) fcinfo->context;
-	HeapTuple newTuple = NULL;
-	HeapTuple oldTuple = NULL;
 	Oid oldLogicalRelationId = InvalidOid;
 	Oid newLogicalRelationId = InvalidOid;
 
@@ -2616,8 +2540,8 @@ master_dist_shard_cache_invalidate(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
-	newTuple = triggerData->tg_newtuple;
-	oldTuple = triggerData->tg_trigtuple;
+	HeapTuple newTuple = triggerData->tg_newtuple;
+	HeapTuple oldTuple = triggerData->tg_trigtuple;
 
 	/* collect logicalrelid for OLD and NEW tuple */
 	if (oldTuple != NULL)
@@ -2666,8 +2590,6 @@ Datum
 master_dist_placement_cache_invalidate(PG_FUNCTION_ARGS)
 {
 	TriggerData *triggerData = (TriggerData *) fcinfo->context;
-	HeapTuple newTuple = NULL;
-	HeapTuple oldTuple = NULL;
 	Oid oldShardId = InvalidOid;
 	Oid newShardId = InvalidOid;
 
@@ -2679,8 +2601,8 @@ master_dist_placement_cache_invalidate(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
-	newTuple = triggerData->tg_newtuple;
-	oldTuple = triggerData->tg_trigtuple;
+	HeapTuple newTuple = triggerData->tg_newtuple;
+	HeapTuple oldTuple = triggerData->tg_trigtuple;
 
 	/* collect shardid for OLD and NEW tuple */
 	if (oldTuple != NULL)
@@ -3030,15 +2952,10 @@ PrepareWorkerNodeCache(void)
 static void
 InitializeWorkerNodeCache(void)
 {
-	HTAB *newWorkerNodeHash = NULL;
-	List *workerNodeList = NIL;
 	ListCell *workerNodeCell = NULL;
 	HASHCTL info;
-	int hashFlags = 0;
 	long maxTableSize = (long) MaxWorkerNodesTracked;
 	bool includeNodesFromOtherClusters = false;
-	int newWorkerNodeCount = 0;
-	WorkerNode **newWorkerNodeArray = NULL;
 	int workerNodeIndex = 0;
 
 	InitializeCaches();
@@ -3054,29 +2971,29 @@ InitializeWorkerNodeCache(void)
 	info.hcxt = MetadataCacheMemoryContext;
 	info.hash = WorkerNodeHashCode;
 	info.match = WorkerNodeCompare;
-	hashFlags = HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT | HASH_COMPARE;
+	int hashFlags = HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT | HASH_COMPARE;
 
-	newWorkerNodeHash = hash_create("Worker Node Hash", maxTableSize, &info, hashFlags);
+	HTAB *newWorkerNodeHash = hash_create("Worker Node Hash", maxTableSize, &info,
+										  hashFlags);
 
 	/* read the list from pg_dist_node */
-	workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
+	List *workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
 
-	newWorkerNodeCount = list_length(workerNodeList);
-	newWorkerNodeArray = MemoryContextAlloc(MetadataCacheMemoryContext,
-											sizeof(WorkerNode *) * newWorkerNodeCount);
+	int newWorkerNodeCount = list_length(workerNodeList);
+	WorkerNode **newWorkerNodeArray = MemoryContextAlloc(MetadataCacheMemoryContext,
+														 sizeof(WorkerNode *) *
+														 newWorkerNodeCount);
 
 	/* iterate over the worker node list */
 	foreach(workerNodeCell, workerNodeList)
 	{
-		WorkerNode *workerNode = NULL;
 		WorkerNode *currentNode = lfirst(workerNodeCell);
-		void *hashKey = NULL;
 		bool handleFound = false;
 
 		/* search for the worker node in the hash, and then insert the values */
-		hashKey = (void *) currentNode;
-		workerNode = (WorkerNode *) hash_search(newWorkerNodeHash, hashKey,
-												HASH_ENTER, &handleFound);
+		void *hashKey = (void *) currentNode;
+		WorkerNode *workerNode = (WorkerNode *) hash_search(newWorkerNodeHash, hashKey,
+															HASH_ENTER, &handleFound);
 
 		/* fill the newly allocated workerNode in the cache */
 		strlcpy(workerNode->workerName, currentNode->workerName, WORKER_LENGTH);
@@ -3153,14 +3070,9 @@ RegisterWorkerNodeCacheCallbacks(void)
 int32
 GetLocalGroupId(void)
 {
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 0;
-	HeapTuple heapTuple = NULL;
-	TupleDesc tupleDescriptor = NULL;
 	int32 groupId = 0;
-	Relation pgDistLocalGroupId = NULL;
-	Oid localGroupTableOid = InvalidOid;
 
 	InitializeCaches();
 
@@ -3172,21 +3084,22 @@ GetLocalGroupId(void)
 		return LocalGroupId;
 	}
 
-	localGroupTableOid = get_relname_relid("pg_dist_local_group", PG_CATALOG_NAMESPACE);
+	Oid localGroupTableOid = get_relname_relid("pg_dist_local_group",
+											   PG_CATALOG_NAMESPACE);
 	if (localGroupTableOid == InvalidOid)
 	{
 		return 0;
 	}
 
-	pgDistLocalGroupId = heap_open(localGroupTableOid, AccessShareLock);
+	Relation pgDistLocalGroupId = heap_open(localGroupTableOid, AccessShareLock);
 
-	scanDescriptor = systable_beginscan(pgDistLocalGroupId,
-										InvalidOid, false,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistLocalGroupId,
+													InvalidOid, false,
+													NULL, scanKeyCount, scanKey);
 
-	tupleDescriptor = RelationGetDescr(pgDistLocalGroupId);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistLocalGroupId);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 
 	if (HeapTupleIsValid(heapTuple))
 	{
@@ -3258,8 +3171,6 @@ WorkerNodeHashCode(const void *key, Size keySize)
 static void
 ResetDistTableCacheEntry(DistTableCacheEntry *cacheEntry)
 {
-	int shardIndex = 0;
-
 	if (cacheEntry->partitionKeyString != NULL)
 	{
 		pfree(cacheEntry->partitionKeyString);
@@ -3289,7 +3200,7 @@ ResetDistTableCacheEntry(DistTableCacheEntry *cacheEntry)
 		return;
 	}
 
-	for (shardIndex = 0; shardIndex < cacheEntry->shardIntervalArrayLength;
+	for (int shardIndex = 0; shardIndex < cacheEntry->shardIntervalArrayLength;
 		 shardIndex++)
 	{
 		ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[shardIndex];
@@ -3555,30 +3466,26 @@ InvalidateMetadataSystemCache(void)
 List *
 DistTableOidList(void)
 {
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 0;
-	HeapTuple heapTuple = NULL;
 	List *distTableOidList = NIL;
-	TupleDesc tupleDescriptor = NULL;
 
 	Relation pgDistPartition = heap_open(DistPartitionRelationId(), AccessShareLock);
 
-	scanDescriptor = systable_beginscan(pgDistPartition,
-										InvalidOid, false,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistPartition,
+													InvalidOid, false,
+													NULL, scanKeyCount, scanKey);
 
-	tupleDescriptor = RelationGetDescr(pgDistPartition);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPartition);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(heapTuple))
 	{
 		bool isNull = false;
-		Oid relationId = InvalidOid;
 		Datum relationIdDatum = heap_getattr(heapTuple,
 											 Anum_pg_dist_partition_logicalrelid,
 											 tupleDescriptor, &isNull);
-		relationId = DatumGetObjectId(relationIdDatum);
+		Oid relationId = DatumGetObjectId(relationIdDatum);
 		distTableOidList = lappend_oid(distTableOidList, relationId);
 
 		heapTuple = systable_getnext(scanDescriptor);
@@ -3630,8 +3537,6 @@ static HeapTuple
 LookupDistPartitionTuple(Relation pgDistPartition, Oid relationId)
 {
 	HeapTuple distPartitionTuple = NULL;
-	HeapTuple currentPartitionTuple = NULL;
-	SysScanDesc scanDescriptor;
 	ScanKeyData scanKey[1];
 
 	/* copy scankey to local copy, it will be modified during the scan */
@@ -3640,11 +3545,11 @@ LookupDistPartitionTuple(Relation pgDistPartition, Oid relationId)
 	/* set scan arguments */
 	scanKey[0].sk_argument = ObjectIdGetDatum(relationId);
 
-	scanDescriptor = systable_beginscan(pgDistPartition,
-										DistPartitionLogicalRelidIndexId(),
-										true, NULL, 1, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistPartition,
+													DistPartitionLogicalRelidIndexId(),
+													true, NULL, 1, scanKey);
 
-	currentPartitionTuple = systable_getnext(scanDescriptor);
+	HeapTuple currentPartitionTuple = systable_getnext(scanDescriptor);
 	if (HeapTupleIsValid(currentPartitionTuple))
 	{
 		distPartitionTuple = heap_copytuple(currentPartitionTuple);
@@ -3663,13 +3568,10 @@ LookupDistPartitionTuple(Relation pgDistPartition, Oid relationId)
 static List *
 LookupDistShardTuples(Oid relationId)
 {
-	Relation pgDistShard = NULL;
 	List *distShardTupleList = NIL;
-	HeapTuple currentShardTuple = NULL;
-	SysScanDesc scanDescriptor;
 	ScanKeyData scanKey[1];
 
-	pgDistShard = heap_open(DistShardRelationId(), AccessShareLock);
+	Relation pgDistShard = heap_open(DistShardRelationId(), AccessShareLock);
 
 	/* copy scankey to local copy, it will be modified during the scan */
 	memcpy(scanKey, DistShardScanKey, sizeof(DistShardScanKey));
@@ -3677,11 +3579,11 @@ LookupDistShardTuples(Oid relationId)
 	/* set scan arguments */
 	scanKey[0].sk_argument = ObjectIdGetDatum(relationId);
 
-	scanDescriptor = systable_beginscan(pgDistShard,
-										DistShardLogicalRelidIndexId(), true,
-										NULL, 1, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistShard,
+													DistShardLogicalRelidIndexId(), true,
+													NULL, 1, scanKey);
 
-	currentShardTuple = systable_getnext(scanDescriptor);
+	HeapTuple currentShardTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(currentShardTuple))
 	{
 		HeapTuple shardTupleCopy = heap_copytuple(currentShardTuple);
@@ -3706,10 +3608,8 @@ LookupDistShardTuples(Oid relationId)
 Oid
 LookupShardRelation(int64 shardId, bool missingOk)
 {
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 1;
-	HeapTuple heapTuple = NULL;
 	Form_pg_dist_shard shardForm = NULL;
 	Relation pgDistShard = heap_open(DistShardRelationId(), AccessShareLock);
 	Oid relationId = InvalidOid;
@@ -3717,11 +3617,11 @@ LookupShardRelation(int64 shardId, bool missingOk)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_shard_shardid,
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(shardId));
 
-	scanDescriptor = systable_beginscan(pgDistShard,
-										DistShardShardidIndexId(), true,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistShard,
+													DistShardShardidIndexId(), true,
+													NULL, scanKeyCount, scanKey);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	if (!HeapTupleIsValid(heapTuple) && !missingOk)
 	{
 		ereport(ERROR, (errmsg("could not find valid entry for shard "
@@ -3811,18 +3711,10 @@ TupleToShardInterval(HeapTuple heapTuple, TupleDesc tupleDescriptor, Oid
 					 intervalTypeId,
 					 int32 intervalTypeMod)
 {
-	ShardInterval *shardInterval = NULL;
-	bool minValueNull = false;
-	bool maxValueNull = false;
 	Oid inputFunctionId = InvalidOid;
 	Oid typeIoParam = InvalidOid;
 	Datum datumArray[Natts_pg_dist_shard];
 	bool isNullArray[Natts_pg_dist_shard];
-	Datum minValueTextDatum = 0;
-	Datum maxValueTextDatum = 0;
-	Oid relationId = InvalidOid;
-	int64 shardId = InvalidOid;
-	char storageType = InvalidOid;
 	Datum minValue = 0;
 	Datum maxValue = 0;
 	bool minValueExists = false;
@@ -3838,15 +3730,15 @@ TupleToShardInterval(HeapTuple heapTuple, TupleDesc tupleDescriptor, Oid
 	 */
 	heap_deform_tuple(heapTuple, tupleDescriptor, datumArray, isNullArray);
 
-	relationId = DatumGetObjectId(datumArray[Anum_pg_dist_shard_logicalrelid -
-											 1]);
-	shardId = DatumGetInt64(datumArray[Anum_pg_dist_shard_shardid - 1]);
-	storageType = DatumGetChar(datumArray[Anum_pg_dist_shard_shardstorage - 1]);
-	minValueTextDatum = datumArray[Anum_pg_dist_shard_shardminvalue - 1];
-	maxValueTextDatum = datumArray[Anum_pg_dist_shard_shardmaxvalue - 1];
+	Oid relationId = DatumGetObjectId(datumArray[Anum_pg_dist_shard_logicalrelid -
+												 1]);
+	int64 shardId = DatumGetInt64(datumArray[Anum_pg_dist_shard_shardid - 1]);
+	char storageType = DatumGetChar(datumArray[Anum_pg_dist_shard_shardstorage - 1]);
+	Datum minValueTextDatum = datumArray[Anum_pg_dist_shard_shardminvalue - 1];
+	Datum maxValueTextDatum = datumArray[Anum_pg_dist_shard_shardmaxvalue - 1];
 
-	minValueNull = isNullArray[Anum_pg_dist_shard_shardminvalue - 1];
-	maxValueNull = isNullArray[Anum_pg_dist_shard_shardmaxvalue - 1];
+	bool minValueNull = isNullArray[Anum_pg_dist_shard_shardminvalue - 1];
+	bool maxValueNull = isNullArray[Anum_pg_dist_shard_shardmaxvalue - 1];
 
 	if (!minValueNull && !maxValueNull)
 	{
@@ -3869,7 +3761,7 @@ TupleToShardInterval(HeapTuple heapTuple, TupleDesc tupleDescriptor, Oid
 		maxValueExists = true;
 	}
 
-	shardInterval = CitusMakeNode(ShardInterval);
+	ShardInterval *shardInterval = CitusMakeNode(ShardInterval);
 	shardInterval->relationId = relationId;
 	shardInterval->storageType = storageType;
 	shardInterval->valueTypeId = intervalTypeId;
@@ -3970,10 +3862,8 @@ CitusInvalidateRelcacheByRelid(Oid relationId)
 void
 CitusInvalidateRelcacheByShardId(int64 shardId)
 {
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 1;
-	HeapTuple heapTuple = NULL;
 	Form_pg_dist_shard shardForm = NULL;
 	Relation pgDistShard = heap_open(DistShardRelationId(), AccessShareLock);
 
@@ -3987,11 +3877,11 @@ CitusInvalidateRelcacheByShardId(int64 shardId)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_shard_shardid,
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(shardId));
 
-	scanDescriptor = systable_beginscan(pgDistShard,
-										DistShardShardidIndexId(), true,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistShard,
+													DistShardShardidIndexId(), true,
+													NULL, scanKeyCount, scanKey);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	if (HeapTupleIsValid(heapTuple))
 	{
 		shardForm = (Form_pg_dist_shard) GETSTRUCT(heapTuple);
@@ -4033,28 +3923,23 @@ Datum
 DistNodeMetadata(void)
 {
 	Datum metadata = 0;
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	const int scanKeyCount = 0;
-	HeapTuple heapTuple = NULL;
-	Oid metadataTableOid = InvalidOid;
-	Relation pgDistNodeMetadata = NULL;
-	TupleDesc tupleDescriptor = NULL;
 
-	metadataTableOid = get_relname_relid("pg_dist_node_metadata",
-										 PG_CATALOG_NAMESPACE);
+	Oid metadataTableOid = get_relname_relid("pg_dist_node_metadata",
+											 PG_CATALOG_NAMESPACE);
 	if (metadataTableOid == InvalidOid)
 	{
 		ereport(ERROR, (errmsg("pg_dist_node_metadata was not found")));
 	}
 
-	pgDistNodeMetadata = heap_open(metadataTableOid, AccessShareLock);
-	scanDescriptor = systable_beginscan(pgDistNodeMetadata,
-										InvalidOid, false,
-										NULL, scanKeyCount, scanKey);
-	tupleDescriptor = RelationGetDescr(pgDistNodeMetadata);
+	Relation pgDistNodeMetadata = heap_open(metadataTableOid, AccessShareLock);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistNodeMetadata,
+													InvalidOid, false,
+													NULL, scanKeyCount, scanKey);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistNodeMetadata);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	if (HeapTupleIsValid(heapTuple))
 	{
 		bool isNull = false;

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -128,7 +128,6 @@ master_add_node(PG_FUNCTION_ARGS)
 	text *nodeName = PG_GETARG_TEXT_P(0);
 	int32 nodePort = PG_GETARG_INT32(1);
 	char *nodeNameString = text_to_cstring(nodeName);
-	int nodeId = 0;
 
 	NodeMetadata nodeMetadata = DefaultNodeMetadata();
 	bool nodeAlreadyExists = false;
@@ -153,8 +152,8 @@ master_add_node(PG_FUNCTION_ARGS)
 		nodeMetadata.nodeRole = PG_GETARG_OID(3);
 	}
 
-	nodeId = AddNodeMetadata(nodeNameString, nodePort, &nodeMetadata,
-							 &nodeAlreadyExists);
+	int nodeId = AddNodeMetadata(nodeNameString, nodePort, &nodeMetadata,
+								 &nodeAlreadyExists);
 
 	/*
 	 * After adding new node, if the node did not already exist, we will activate
@@ -185,15 +184,14 @@ master_add_inactive_node(PG_FUNCTION_ARGS)
 
 	NodeMetadata nodeMetadata = DefaultNodeMetadata();
 	bool nodeAlreadyExists = false;
-	int nodeId = 0;
 	nodeMetadata.groupId = PG_GETARG_INT32(2);
 	nodeMetadata.nodeRole = PG_GETARG_OID(3);
 	nodeMetadata.nodeCluster = NameStr(*nodeClusterName);
 
 	CheckCitusVersion(ERROR);
 
-	nodeId = AddNodeMetadata(nodeNameString, nodePort, &nodeMetadata,
-							 &nodeAlreadyExists);
+	int nodeId = AddNodeMetadata(nodeNameString, nodePort, &nodeMetadata,
+								 &nodeAlreadyExists);
 
 	PG_RETURN_INT32(nodeId);
 }
@@ -217,7 +215,6 @@ master_add_secondary_node(PG_FUNCTION_ARGS)
 	Name nodeClusterName = PG_GETARG_NAME(4);
 	NodeMetadata nodeMetadata = DefaultNodeMetadata();
 	bool nodeAlreadyExists = false;
-	int nodeId = 0;
 
 	nodeMetadata.groupId = GroupForNode(primaryNameString, primaryPort);
 	nodeMetadata.nodeCluster = NameStr(*nodeClusterName);
@@ -226,8 +223,8 @@ master_add_secondary_node(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
-	nodeId = AddNodeMetadata(nodeNameString, nodePort, &nodeMetadata,
-							 &nodeAlreadyExists);
+	int nodeId = AddNodeMetadata(nodeNameString, nodePort, &nodeMetadata,
+								 &nodeAlreadyExists);
 
 	PG_RETURN_INT32(nodeId);
 }
@@ -307,11 +304,9 @@ master_disable_node(PG_FUNCTION_ARGS)
 	}
 	PG_CATCH();
 	{
-		ErrorData *edata = NULL;
-
 		/* CopyErrorData() requires (CurrentMemoryContext != ErrorContext) */
 		MemoryContextSwitchTo(savedContext);
-		edata = CopyErrorData();
+		ErrorData *edata = CopyErrorData();
 
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 						errmsg("Disabling %s:%d failed", workerNode->workerName,
@@ -397,14 +392,12 @@ SetUpDistributedTableDependencies(WorkerNode *newWorkerNode)
 static void
 PropagateRolesToNewNode(WorkerNode *newWorkerNode)
 {
-	List *ddlCommands = NIL;
-
 	if (!EnableAlterRolePropagation)
 	{
 		return;
 	}
 
-	ddlCommands = GenerateAlterRoleIfExistsCommandAllRoles();
+	List *ddlCommands = GenerateAlterRoleIfExistsCommandAllRoles();
 
 	SendCommandListToWorkerInSingleTransaction(newWorkerNode->workerName,
 											   newWorkerNode->workerPort,
@@ -419,8 +412,6 @@ PropagateRolesToNewNode(WorkerNode *newWorkerNode)
 static WorkerNode *
 ModifiableWorkerNode(const char *nodeName, int32 nodePort)
 {
-	WorkerNode *workerNode = NULL;
-
 	CheckCitusVersion(ERROR);
 
 	EnsureCoordinator();
@@ -428,7 +419,7 @@ ModifiableWorkerNode(const char *nodeName, int32 nodePort)
 	/* take an exclusive lock on pg_dist_node to serialize pg_dist_node changes */
 	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
 
-	workerNode = FindWorkerNodeAnyCluster(nodeName, nodePort);
+	WorkerNode *workerNode = FindWorkerNodeAnyCluster(nodeName, nodePort);
 	if (workerNode == NULL)
 	{
 		ereport(ERROR, (errmsg("node at \"%s:%u\" does not exist", nodeName, nodePort)));
@@ -581,13 +572,12 @@ PrimaryNodeForGroup(int32 groupId, bool *groupContainsNodes)
 static int
 ActivateNode(char *nodeName, int nodePort)
 {
-	WorkerNode *newWorkerNode = NULL;
 	bool isActive = true;
 
 	/* take an exclusive lock on pg_dist_node to serialize pg_dist_node changes */
 	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
 
-	newWorkerNode = SetNodeState(nodeName, nodePort, isActive);
+	WorkerNode *newWorkerNode = SetNodeState(nodeName, nodePort, isActive);
 
 	PropagateRolesToNewNode(newWorkerNode);
 	SetUpDistributedTableDependencies(newWorkerNode);
@@ -621,14 +611,13 @@ master_update_node(PG_FUNCTION_ARGS)
 	int32 lock_cooldown = PG_GETARG_INT32(4);
 
 	char *newNodeNameString = text_to_cstring(newNodeName);
-	WorkerNode *workerNode = NULL;
-	WorkerNode *workerNodeWithSameAddress = NULL;
 	List *placementList = NIL;
 	BackgroundWorkerHandle *handle = NULL;
 
 	CheckCitusVersion(ERROR);
 
-	workerNodeWithSameAddress = FindWorkerNodeAnyCluster(newNodeNameString, newNodePort);
+	WorkerNode *workerNodeWithSameAddress = FindWorkerNodeAnyCluster(newNodeNameString,
+																	 newNodePort);
 	if (workerNodeWithSameAddress != NULL)
 	{
 		/* a node with the given hostname and port already exists in the metadata */
@@ -646,7 +635,7 @@ master_update_node(PG_FUNCTION_ARGS)
 		}
 	}
 
-	workerNode = LookupNodeByNodeId(nodeId);
+	WorkerNode *workerNode = LookupNodeByNodeId(nodeId);
 	if (workerNode == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_NO_DATA_FOUND),
@@ -734,25 +723,22 @@ UpdateNodeLocation(int32 nodeId, char *newNodeName, int32 newNodePort)
 {
 	const bool indexOK = true;
 
-	Relation pgDistNode = NULL;
-	TupleDesc tupleDescriptor = NULL;
 	ScanKeyData scanKey[1];
-	SysScanDesc scanDescriptor = NULL;
-	HeapTuple heapTuple = NULL;
 	Datum values[Natts_pg_dist_node];
 	bool isnull[Natts_pg_dist_node];
 	bool replace[Natts_pg_dist_node];
 
-	pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
-	tupleDescriptor = RelationGetDescr(pgDistNode);
+	Relation pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistNode);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_node_nodeid,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(nodeId));
 
-	scanDescriptor = systable_beginscan(pgDistNode, DistNodeNodeIdIndexId(), indexOK,
-										NULL, 1, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistNode, DistNodeNodeIdIndexId(),
+													indexOK,
+													NULL, 1, scanKey);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	if (!HeapTupleIsValid(heapTuple))
 	{
 		ereport(ERROR, (errmsg("could not find valid entry for node \"%s:%d\"",
@@ -791,8 +777,6 @@ Datum
 get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 {
 	ShardInterval *shardInterval = NULL;
-	char distributionMethod = 0;
-	Oid relationId = InvalidOid;
 
 	CheckCitusVersion(ERROR);
 
@@ -806,7 +790,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 						errmsg("relation cannot be NULL")));
 	}
 
-	relationId = PG_GETARG_OID(0);
+	Oid relationId = PG_GETARG_OID(0);
 	EnsureTablePermissions(relationId, ACL_SELECT);
 
 	if (!IsDistributedTable(relationId))
@@ -815,7 +799,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 						errmsg("relation is not distributed")));
 	}
 
-	distributionMethod = PartitionMethod(relationId);
+	char distributionMethod = PartitionMethod(relationId);
 	if (distributionMethod == DISTRIBUTE_BY_NONE)
 	{
 		List *shardIntervalList = LoadShardIntervalList(relationId);
@@ -829,12 +813,6 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 	else if (distributionMethod == DISTRIBUTE_BY_HASH ||
 			 distributionMethod == DISTRIBUTE_BY_RANGE)
 	{
-		Var *distributionColumn = NULL;
-		Oid distributionDataType = InvalidOid;
-		Oid inputDataType = InvalidOid;
-		char *distributionValueString = NULL;
-		Datum inputDatum = 0;
-		Datum distributionValueDatum = 0;
 		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 
 		/* if given table is not reference table, distributionValue cannot be NULL */
@@ -845,15 +823,15 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 								   "than reference tables.")));
 		}
 
-		inputDatum = PG_GETARG_DATUM(1);
-		inputDataType = get_fn_expr_argtype(fcinfo->flinfo, 1);
-		distributionValueString = DatumToString(inputDatum, inputDataType);
+		Datum inputDatum = PG_GETARG_DATUM(1);
+		Oid inputDataType = get_fn_expr_argtype(fcinfo->flinfo, 1);
+		char *distributionValueString = DatumToString(inputDatum, inputDataType);
 
-		distributionColumn = DistPartitionKey(relationId);
-		distributionDataType = distributionColumn->vartype;
+		Var *distributionColumn = DistPartitionKey(relationId);
+		Oid distributionDataType = distributionColumn->vartype;
 
-		distributionValueDatum = StringToDatum(distributionValueString,
-											   distributionDataType);
+		Datum distributionValueDatum = StringToDatum(distributionValueString,
+													 distributionDataType);
 
 		shardInterval = FindShardInterval(distributionValueDatum, cacheEntry);
 	}
@@ -881,18 +859,17 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 WorkerNode *
 FindWorkerNode(char *nodeName, int32 nodePort)
 {
-	WorkerNode *cachedWorkerNode = NULL;
 	HTAB *workerNodeHash = GetWorkerNodeHash();
 	bool handleFound = false;
-	void *hashKey = NULL;
 
 	WorkerNode *searchedNode = (WorkerNode *) palloc0(sizeof(WorkerNode));
 	strlcpy(searchedNode->workerName, nodeName, WORKER_LENGTH);
 	searchedNode->workerPort = nodePort;
 
-	hashKey = (void *) searchedNode;
-	cachedWorkerNode = (WorkerNode *) hash_search(workerNodeHash, hashKey, HASH_FIND,
-												  &handleFound);
+	void *hashKey = (void *) searchedNode;
+	WorkerNode *cachedWorkerNode = (WorkerNode *) hash_search(workerNodeHash, hashKey,
+															  HASH_FIND,
+															  &handleFound);
 	if (handleFound)
 	{
 		WorkerNode *workerNode = (WorkerNode *) palloc(sizeof(WorkerNode));
@@ -939,22 +916,19 @@ FindWorkerNodeAnyCluster(const char *nodeName, int32 nodePort)
 List *
 ReadDistNode(bool includeNodesFromOtherClusters)
 {
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 0;
-	HeapTuple heapTuple = NULL;
 	List *workerNodeList = NIL;
-	TupleDesc tupleDescriptor = NULL;
 
 	Relation pgDistNode = heap_open(DistNodeRelationId(), AccessShareLock);
 
-	scanDescriptor = systable_beginscan(pgDistNode,
-										InvalidOid, false,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistNode,
+													InvalidOid, false,
+													NULL, scanKeyCount, scanKey);
 
-	tupleDescriptor = RelationGetDescr(pgDistNode);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistNode);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	while (HeapTupleIsValid(heapTuple))
 	{
 		WorkerNode *workerNode = TupleToWorkerNode(tupleDescriptor, heapTuple);
@@ -989,7 +963,6 @@ ReadDistNode(bool includeNodesFromOtherClusters)
 static void
 RemoveNodeFromCluster(char *nodeName, int32 nodePort)
 {
-	char *nodeDeleteCommand = NULL;
 	WorkerNode *workerNode = ModifiableWorkerNode(nodeName, nodePort);
 
 	if (NodeIsPrimary(workerNode))
@@ -1012,7 +985,7 @@ RemoveNodeFromCluster(char *nodeName, int32 nodePort)
 
 	DeleteNodeRow(workerNode->workerName, nodePort);
 
-	nodeDeleteCommand = NodeDeleteCommand(workerNode->nodeId);
+	char *nodeDeleteCommand = NodeDeleteCommand(workerNode->nodeId);
 
 	/* make sure we don't have any lingering session lifespan connections */
 	CloseNodeConnectionsAfterTransaction(workerNode->workerName, nodePort);
@@ -1059,11 +1032,6 @@ AddNodeMetadata(char *nodeName, int32 nodePort,
 				NodeMetadata *nodeMetadata,
 				bool *nodeAlreadyExists)
 {
-	int nextNodeIdInt = 0;
-	WorkerNode *workerNode = NULL;
-	char *nodeDeleteCommand = NULL;
-	uint32 primariesWithMetadata = 0;
-
 	EnsureCoordinator();
 
 	*nodeAlreadyExists = false;
@@ -1075,7 +1043,7 @@ AddNodeMetadata(char *nodeName, int32 nodePort,
 	 */
 	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
 
-	workerNode = FindWorkerNodeAnyCluster(nodeName, nodePort);
+	WorkerNode *workerNode = FindWorkerNodeAnyCluster(nodeName, nodePort);
 	if (workerNode != NULL)
 	{
 		/* fill return data and return */
@@ -1122,18 +1090,18 @@ AddNodeMetadata(char *nodeName, int32 nodePort,
 	}
 
 	/* generate the new node id from the sequence */
-	nextNodeIdInt = GetNextNodeId();
+	int nextNodeIdInt = GetNextNodeId();
 
 	InsertNodeRow(nextNodeIdInt, nodeName, nodePort, nodeMetadata);
 
 	workerNode = FindWorkerNodeAnyCluster(nodeName, nodePort);
 
 	/* send the delete command to all primary nodes with metadata */
-	nodeDeleteCommand = NodeDeleteCommand(workerNode->nodeId);
+	char *nodeDeleteCommand = NodeDeleteCommand(workerNode->nodeId);
 	SendCommandToWorkers(WORKERS_WITH_METADATA, nodeDeleteCommand);
 
 	/* finally prepare the insert command and send it to all primary nodes */
-	primariesWithMetadata = CountPrimariesWithMetadata();
+	uint32 primariesWithMetadata = CountPrimariesWithMetadata();
 	if (primariesWithMetadata != 0)
 	{
 		List *workerNodeList = list_make1(workerNode);
@@ -1157,7 +1125,6 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 	Relation pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistNode);
 	HeapTuple heapTuple = GetNodeTuple(workerNode->workerName, workerNode->workerPort);
-	WorkerNode *newWorkerNode = NULL;
 
 	Datum values[Natts_pg_dist_node];
 	bool isnull[Natts_pg_dist_node];
@@ -1206,7 +1173,7 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 	CitusInvalidateRelcacheByRelid(DistNodeRelationId());
 	CommandCounterIncrement();
 
-	newWorkerNode = TupleToWorkerNode(tupleDescriptor, heapTuple);
+	WorkerNode *newWorkerNode = TupleToWorkerNode(tupleDescriptor, heapTuple);
 
 	heap_close(pgDistNode, NoLock);
 
@@ -1257,18 +1224,16 @@ GetNodeTuple(const char *nodeName, int32 nodePort)
 	const bool indexOK = false;
 
 	ScanKeyData scanKey[2];
-	SysScanDesc scanDescriptor = NULL;
-	HeapTuple heapTuple = NULL;
 	HeapTuple nodeTuple = NULL;
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_node_nodename,
 				BTEqualStrategyNumber, F_TEXTEQ, CStringGetTextDatum(nodeName));
 	ScanKeyInit(&scanKey[1], Anum_pg_dist_node_nodeport,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(nodePort));
-	scanDescriptor = systable_beginscan(pgDistNode, InvalidOid, indexOK,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistNode, InvalidOid, indexOK,
+													NULL, scanKeyCount, scanKey);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	if (HeapTupleIsValid(heapTuple))
 	{
 		nodeTuple = heap_copytuple(heapTuple);
@@ -1298,18 +1263,16 @@ GetNextGroupId()
 	Datum sequenceIdDatum = ObjectIdGetDatum(sequenceId);
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
-	Datum groupIdDatum = 0;
-	int32 groupId = 0;
 
 	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
 	SetUserIdAndSecContext(CitusExtensionOwner(), SECURITY_LOCAL_USERID_CHANGE);
 
 	/* generate new and unique shardId from sequence */
-	groupIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
+	Datum groupIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
-	groupId = DatumGetInt32(groupIdDatum);
+	int32 groupId = DatumGetInt32(groupIdDatum);
 
 	return groupId;
 }
@@ -1332,18 +1295,16 @@ GetNextNodeId()
 	Datum sequenceIdDatum = ObjectIdGetDatum(sequenceId);
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
-	Datum nextNodeIdDatum;
-	int nextNodeId = 0;
 
 	GetUserIdAndSecContext(&savedUserId, &savedSecurityContext);
 	SetUserIdAndSecContext(CitusExtensionOwner(), SECURITY_LOCAL_USERID_CHANGE);
 
 	/* generate new and unique shardId from sequence */
-	nextNodeIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
+	Datum nextNodeIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
-	nextNodeId = DatumGetUInt32(nextNodeIdDatum);
+	int nextNodeId = DatumGetUInt32(nextNodeIdDatum);
 
 	return nextNodeId;
 }
@@ -1377,9 +1338,6 @@ EnsureCoordinator(void)
 static void
 InsertNodeRow(int nodeid, char *nodeName, int32 nodePort, NodeMetadata *nodeMetadata)
 {
-	Relation pgDistNode = NULL;
-	TupleDesc tupleDescriptor = NULL;
-	HeapTuple heapTuple = NULL;
 	Datum values[Natts_pg_dist_node];
 	bool isNulls[Natts_pg_dist_node];
 
@@ -1404,10 +1362,10 @@ InsertNodeRow(int nodeid, char *nodeName, int32 nodePort, NodeMetadata *nodeMeta
 	values[Anum_pg_dist_node_shouldhaveshards - 1] = BoolGetDatum(
 		nodeMetadata->shouldHaveShards);
 
-	pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
+	Relation pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
 
-	tupleDescriptor = RelationGetDescr(pgDistNode);
-	heapTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistNode);
+	HeapTuple heapTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
 
 	CatalogTupleInsert(pgDistNode, heapTuple);
 
@@ -1430,8 +1388,6 @@ DeleteNodeRow(char *nodeName, int32 nodePort)
 	const int scanKeyCount = 2;
 	bool indexOK = false;
 
-	HeapTuple heapTuple = NULL;
-	SysScanDesc heapScan = NULL;
 	ScanKeyData scanKey[2];
 	Relation pgDistNode = heap_open(DistNodeRelationId(), RowExclusiveLock);
 
@@ -1447,10 +1403,10 @@ DeleteNodeRow(char *nodeName, int32 nodePort)
 	ScanKeyInit(&scanKey[1], Anum_pg_dist_node_nodeport,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(nodePort));
 
-	heapScan = systable_beginscan(pgDistNode, InvalidOid, indexOK,
-								  NULL, scanKeyCount, scanKey);
+	SysScanDesc heapScan = systable_beginscan(pgDistNode, InvalidOid, indexOK,
+											  NULL, scanKeyCount, scanKey);
 
-	heapTuple = systable_getnext(heapScan);
+	HeapTuple heapTuple = systable_getnext(heapScan);
 
 	if (!HeapTupleIsValid(heapTuple))
 	{
@@ -1481,11 +1437,8 @@ DeleteNodeRow(char *nodeName, int32 nodePort)
 static WorkerNode *
 TupleToWorkerNode(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 {
-	WorkerNode *workerNode = NULL;
 	Datum datumArray[Natts_pg_dist_node];
 	bool isNullArray[Natts_pg_dist_node];
-	char *nodeName = NULL;
-	char *nodeRack = NULL;
 
 	Assert(!HeapTupleHasNulls(heapTuple));
 
@@ -1502,10 +1455,10 @@ TupleToWorkerNode(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	 */
 	heap_deform_tuple(heapTuple, tupleDescriptor, datumArray, isNullArray);
 
-	nodeName = DatumGetCString(datumArray[Anum_pg_dist_node_nodename - 1]);
-	nodeRack = DatumGetCString(datumArray[Anum_pg_dist_node_noderack - 1]);
+	char *nodeName = DatumGetCString(datumArray[Anum_pg_dist_node_nodename - 1]);
+	char *nodeRack = DatumGetCString(datumArray[Anum_pg_dist_node_noderack - 1]);
 
-	workerNode = (WorkerNode *) palloc0(sizeof(WorkerNode));
+	WorkerNode *workerNode = (WorkerNode *) palloc0(sizeof(WorkerNode));
 	workerNode->nodeId = DatumGetUInt32(datumArray[Anum_pg_dist_node_nodeid - 1]);
 	workerNode->workerPort = DatumGetUInt32(datumArray[Anum_pg_dist_node_nodeport - 1]);
 	workerNode->groupId = DatumGetInt32(datumArray[Anum_pg_dist_node_groupid - 1]);
@@ -1546,12 +1499,11 @@ StringToDatum(char *inputString, Oid dataType)
 	Oid typIoFunc = InvalidOid;
 	Oid typIoParam = InvalidOid;
 	int32 typeModifier = -1;
-	Datum datum = 0;
 
 	getTypeInputInfo(dataType, &typIoFunc, &typIoParam);
 	getBaseTypeAndTypmod(dataType, &typeModifier);
 
-	datum = OidInputFunctionCall(typIoFunc, inputString, typIoParam, typeModifier);
+	Datum datum = OidInputFunctionCall(typIoFunc, inputString, typIoParam, typeModifier);
 
 	return datum;
 }
@@ -1563,12 +1515,11 @@ StringToDatum(char *inputString, Oid dataType)
 char *
 DatumToString(Datum datum, Oid dataType)
 {
-	char *outputString = NULL;
 	Oid typIoFunc = InvalidOid;
 	bool typIsVarlena = false;
 
 	getTypeOutputInfo(dataType, &typIoFunc, &typIsVarlena);
-	outputString = OidOutputFunctionCall(typIoFunc, datum);
+	char *outputString = OidOutputFunctionCall(typIoFunc, datum);
 
 	return outputString;
 }
@@ -1582,34 +1533,29 @@ static bool
 UnsetMetadataSyncedForAll(void)
 {
 	bool updatedAtLeastOne = false;
-	Relation relation = NULL;
-	SysScanDesc scanDescriptor = NULL;
 	ScanKeyData scanKey[2];
 	int scanKeyCount = 2;
 	bool indexOK = false;
-	HeapTuple heapTuple = NULL;
-	TupleDesc tupleDescriptor = NULL;
-	CatalogIndexState indstate;
 
 	/*
 	 * Concurrent master_update_node() calls might iterate and try to update
 	 * pg_dist_node in different orders. To protect against deadlock, we
 	 * get an exclusive lock here.
 	 */
-	relation = heap_open(DistNodeRelationId(), ExclusiveLock);
-	tupleDescriptor = RelationGetDescr(relation);
+	Relation relation = heap_open(DistNodeRelationId(), ExclusiveLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(relation);
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_node_hasmetadata,
 				BTEqualStrategyNumber, F_BOOLEQ, BoolGetDatum(true));
 	ScanKeyInit(&scanKey[1], Anum_pg_dist_node_metadatasynced,
 				BTEqualStrategyNumber, F_BOOLEQ, BoolGetDatum(true));
 
-	indstate = CatalogOpenIndexes(relation);
+	CatalogIndexState indstate = CatalogOpenIndexes(relation);
 
-	scanDescriptor = systable_beginscan(relation,
-										InvalidOid, indexOK,
-										NULL, scanKeyCount, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(relation,
+													InvalidOid, indexOK,
+													NULL, scanKeyCount, scanKey);
 
-	heapTuple = systable_getnext(scanDescriptor);
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	if (HeapTupleIsValid(heapTuple))
 	{
 		updatedAtLeastOne = true;
@@ -1617,7 +1563,6 @@ UnsetMetadataSyncedForAll(void)
 
 	while (HeapTupleIsValid(heapTuple))
 	{
-		HeapTuple newHeapTuple = NULL;
 		Datum values[Natts_pg_dist_node];
 		bool isnull[Natts_pg_dist_node];
 		bool replace[Natts_pg_dist_node];
@@ -1629,8 +1574,9 @@ UnsetMetadataSyncedForAll(void)
 		values[Anum_pg_dist_node_metadatasynced - 1] = BoolGetDatum(false);
 		replace[Anum_pg_dist_node_metadatasynced - 1] = true;
 
-		newHeapTuple = heap_modify_tuple(heapTuple, tupleDescriptor, values, isnull,
-										 replace);
+		HeapTuple newHeapTuple = heap_modify_tuple(heapTuple, tupleDescriptor, values,
+												   isnull,
+												   replace);
 
 		CatalogTupleUpdateWithInfo(relation, &newHeapTuple->t_self, newHeapTuple,
 								   indstate);

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -61,21 +61,17 @@ RebuildQueryStrings(Query *originalQuery, List *taskList)
 		else if (query->commandType == CMD_INSERT && task->modifyWithSubquery)
 		{
 			/* for INSERT..SELECT, adjust shard names in SELECT part */
-			RangeTblEntry *copiedInsertRte = NULL;
-			RangeTblEntry *copiedSubqueryRte = NULL;
-			Query *copiedSubquery = NULL;
 			List *relationShardList = task->relationShardList;
 			ShardInterval *shardInterval = LoadShardInterval(task->anchorShardId);
-			char partitionMethod = 0;
 
 			query = copyObject(originalQuery);
 
-			copiedInsertRte = ExtractResultRelationRTE(query);
-			copiedSubqueryRte = ExtractSelectRangeTableEntry(query);
-			copiedSubquery = copiedSubqueryRte->subquery;
+			RangeTblEntry *copiedInsertRte = ExtractResultRelationRTE(query);
+			RangeTblEntry *copiedSubqueryRte = ExtractSelectRangeTableEntry(query);
+			Query *copiedSubquery = copiedSubqueryRte->subquery;
 
 			/* there are no restrictions to add for reference tables */
-			partitionMethod = PartitionMethod(shardInterval->relationId);
+			char partitionMethod = PartitionMethod(shardInterval->relationId);
 			if (partitionMethod != DISTRIBUTE_BY_NONE)
 			{
 				AddShardIntervalRestrictionToSelect(copiedSubquery, shardInterval);
@@ -95,14 +91,12 @@ RebuildQueryStrings(Query *originalQuery, List *taskList)
 		else if (query->commandType == CMD_INSERT && (query->onConflict != NULL ||
 													  valuesRTE != NULL))
 		{
-			RangeTblEntry *rangeTableEntry = NULL;
-
 			/*
 			 * Always an alias in UPSERTs and multi-row INSERTs to avoid
 			 * deparsing issues (e.g. RETURNING might reference the original
 			 * table name, which has been replaced by a shard name).
 			 */
-			rangeTableEntry = linitial(query->rtable);
+			RangeTblEntry *rangeTableEntry = linitial(query->rtable);
 			if (rangeTableEntry->alias == NULL)
 			{
 				Alias *alias = makeAlias(CITUS_TABLE_ALIAS, NIL);
@@ -184,13 +178,8 @@ UpdateTaskQueryString(Query *query, Oid distributedTableId, RangeTblEntry *value
 bool
 UpdateRelationToShardNames(Node *node, List *relationShardList)
 {
-	RangeTblEntry *newRte = NULL;
 	uint64 shardId = INVALID_SHARD_ID;
 	Oid relationId = InvalidOid;
-	Oid schemaId = InvalidOid;
-	char *relationName = NULL;
-	char *schemaName = NULL;
-	bool replaceRteWithNullValues = false;
 	ListCell *relationShardCell = NULL;
 	RelationShard *relationShard = NULL;
 
@@ -212,7 +201,7 @@ UpdateRelationToShardNames(Node *node, List *relationShardList)
 									  relationShardList);
 	}
 
-	newRte = (RangeTblEntry *) node;
+	RangeTblEntry *newRte = (RangeTblEntry *) node;
 
 	if (newRte->rtekind != RTE_RELATION)
 	{
@@ -238,8 +227,8 @@ UpdateRelationToShardNames(Node *node, List *relationShardList)
 		relationShard = NULL;
 	}
 
-	replaceRteWithNullValues = relationShard == NULL ||
-							   relationShard->shardId == INVALID_SHARD_ID;
+	bool replaceRteWithNullValues = relationShard == NULL ||
+									relationShard->shardId == INVALID_SHARD_ID;
 	if (replaceRteWithNullValues)
 	{
 		ConvertRteToSubqueryWithEmptyResult(newRte);
@@ -249,11 +238,11 @@ UpdateRelationToShardNames(Node *node, List *relationShardList)
 	shardId = relationShard->shardId;
 	relationId = relationShard->relationId;
 
-	relationName = get_rel_name(relationId);
+	char *relationName = get_rel_name(relationId);
 	AppendShardIdToName(&relationName, shardId);
 
-	schemaId = get_rel_namespace(relationId);
-	schemaName = get_namespace_name(schemaId);
+	Oid schemaId = get_rel_namespace(relationId);
+	char *schemaName = get_namespace_name(schemaId);
 
 	ModifyRangeTblExtraData(newRte, CITUS_RTE_SHARD, schemaName, relationName, NIL);
 
@@ -271,31 +260,26 @@ ConvertRteToSubqueryWithEmptyResult(RangeTblEntry *rte)
 	Relation relation = heap_open(rte->relid, NoLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(relation);
 	int columnCount = tupleDescriptor->natts;
-	int columnIndex = 0;
-	Query *subquery = NULL;
 	List *targetList = NIL;
-	FromExpr *joinTree = NULL;
 
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		FormData_pg_attribute *attributeForm = TupleDescAttr(tupleDescriptor,
 															 columnIndex);
-		TargetEntry *targetEntry = NULL;
-		StringInfo resname = NULL;
-		Const *constValue = NULL;
 
 		if (attributeForm->attisdropped)
 		{
 			continue;
 		}
 
-		resname = makeStringInfo();
-		constValue = makeNullConst(attributeForm->atttypid, attributeForm->atttypmod,
-								   attributeForm->attcollation);
+		StringInfo resname = makeStringInfo();
+		Const *constValue = makeNullConst(attributeForm->atttypid,
+										  attributeForm->atttypmod,
+										  attributeForm->attcollation);
 
 		appendStringInfo(resname, "%s", attributeForm->attname.data);
 
-		targetEntry = makeNode(TargetEntry);
+		TargetEntry *targetEntry = makeNode(TargetEntry);
 		targetEntry->expr = (Expr *) constValue;
 		targetEntry->resno = columnIndex;
 		targetEntry->resname = resname->data;
@@ -305,10 +289,10 @@ ConvertRteToSubqueryWithEmptyResult(RangeTblEntry *rte)
 
 	heap_close(relation, NoLock);
 
-	joinTree = makeNode(FromExpr);
+	FromExpr *joinTree = makeNode(FromExpr);
 	joinTree->quals = makeBoolConst(false, false);
 
-	subquery = makeNode(Query);
+	Query *subquery = makeNode(Query);
 	subquery->commandType = CMD_SELECT;
 	subquery->querySource = QSRC_ORIGINAL;
 	subquery->canSetTag = true;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -113,7 +113,6 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	PlannedStmt *result = NULL;
 	bool needsDistributedPlanning = false;
 	Query *originalQuery = NULL;
-	PlannerRestrictionContext *plannerRestrictionContext = NULL;
 	bool setPartitionedTablesInherited = false;
 	List *rangeTableList = ExtractRangeTableEntryList(parse);
 
@@ -181,7 +180,8 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	ReplaceTableVisibleFunction((Node *) parse);
 
 	/* create a restriction context and put it at the end if context list */
-	plannerRestrictionContext = CreateAndPushPlannerRestrictionContext();
+	PlannerRestrictionContext *plannerRestrictionContext =
+		CreateAndPushPlannerRestrictionContext();
 
 	PG_TRY();
 	{
@@ -519,8 +519,6 @@ CreateDistributedPlannedStmt(uint64 planId, PlannedStmt *localPlan, Query *origi
 							 Query *query, ParamListInfo boundParams,
 							 PlannerRestrictionContext *plannerRestrictionContext)
 {
-	DistributedPlan *distributedPlan = NULL;
-	PlannedStmt *resultPlan = NULL;
 	bool hasUnresolvedParams = false;
 	JoinRestrictionContext *joinRestrictionContext =
 		plannerRestrictionContext->joinRestrictionContext;
@@ -533,7 +531,7 @@ CreateDistributedPlannedStmt(uint64 planId, PlannedStmt *localPlan, Query *origi
 	plannerRestrictionContext->joinRestrictionContext =
 		RemoveDuplicateJoinRestrictions(joinRestrictionContext);
 
-	distributedPlan =
+	DistributedPlan *distributedPlan =
 		CreateDistributedPlan(planId, originalQuery, query, boundParams,
 							  hasUnresolvedParams, plannerRestrictionContext);
 
@@ -580,7 +578,7 @@ CreateDistributedPlannedStmt(uint64 planId, PlannedStmt *localPlan, Query *origi
 	distributedPlan->planId = planId;
 
 	/* create final plan by combining local plan with distributed plan */
-	resultPlan = FinalizePlan(localPlan, distributedPlan);
+	PlannedStmt *resultPlan = FinalizePlan(localPlan, distributedPlan);
 
 	/*
 	 * As explained above, force planning costs to be unrealistically high if
@@ -617,17 +615,14 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 					  PlannerRestrictionContext *plannerRestrictionContext)
 {
 	DistributedPlan *distributedPlan = NULL;
-	MultiTreeRoot *logicalPlan = NULL;
-	List *subPlanList = NIL;
 	bool hasCtes = originalQuery->cteList != NIL;
 
 
 	if (IsModifyCommand(originalQuery))
 	{
-		Oid targetRelationId = InvalidOid;
 		EnsureModificationsCanRun();
 
-		targetRelationId = ModifyQueryResultRelationId(query);
+		Oid targetRelationId = ModifyQueryResultRelationId(query);
 		EnsurePartitionTableNotReplicated(targetRelationId);
 
 		if (InsertSelectIntoDistributedTable(originalQuery))
@@ -722,8 +717,8 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 	 * Plan subqueries and CTEs that cannot be pushed down by recursively
 	 * calling the planner and return the resulting plans to subPlanList.
 	 */
-	subPlanList = GenerateSubplansForSubqueriesAndCTEs(planId, originalQuery,
-													   plannerRestrictionContext);
+	List *subPlanList = GenerateSubplansForSubqueriesAndCTEs(planId, originalQuery,
+															 plannerRestrictionContext);
 
 	/*
 	 * If subqueries were recursively planned then we need to replan the query
@@ -798,8 +793,8 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 	query->cteList = NIL;
 	Assert(originalQuery->cteList == NIL);
 
-	logicalPlan = MultiLogicalPlanCreate(originalQuery, query,
-										 plannerRestrictionContext);
+	MultiTreeRoot *logicalPlan = MultiLogicalPlanCreate(originalQuery, query,
+														plannerRestrictionContext);
 	MultiLogicalPlanOptimize(logicalPlan);
 
 	/*
@@ -937,14 +932,11 @@ ResolveExternalParams(Node *inputNode, ParamListInfo boundParams)
 	if (IsA(inputNode, Param))
 	{
 		Param *paramToProcess = (Param *) inputNode;
-		ParamExternData *correspondingParameterData = NULL;
 		int numberOfParameters = boundParams->numParams;
 		int parameterId = paramToProcess->paramid;
 		int16 typeLength = 0;
 		bool typeByValue = false;
 		Datum constValue = 0;
-		bool paramIsNull = false;
-		int parameterIndex = 0;
 
 		if (paramToProcess->paramkind != PARAM_EXTERN)
 		{
@@ -957,13 +949,14 @@ ResolveExternalParams(Node *inputNode, ParamListInfo boundParams)
 		}
 
 		/* parameterId starts from 1 */
-		parameterIndex = parameterId - 1;
+		int parameterIndex = parameterId - 1;
 		if (parameterIndex >= numberOfParameters)
 		{
 			return inputNode;
 		}
 
-		correspondingParameterData = &boundParams->params[parameterIndex];
+		ParamExternData *correspondingParameterData =
+			&boundParams->params[parameterIndex];
 
 		if (!(correspondingParameterData->pflags & PARAM_FLAG_CONST))
 		{
@@ -972,7 +965,7 @@ ResolveExternalParams(Node *inputNode, ParamListInfo boundParams)
 
 		get_typlenbyval(paramToProcess->paramtype, &typeLength, &typeByValue);
 
-		paramIsNull = correspondingParameterData->isnull;
+		bool paramIsNull = correspondingParameterData->isnull;
 		if (paramIsNull)
 		{
 			constValue = 0;
@@ -1015,17 +1008,14 @@ ResolveExternalParams(Node *inputNode, ParamListInfo boundParams)
 DistributedPlan *
 GetDistributedPlan(CustomScan *customScan)
 {
-	Node *node = NULL;
-	DistributedPlan *distributedPlan = NULL;
-
 	Assert(list_length(customScan->custom_private) == 1);
 
-	node = (Node *) linitial(customScan->custom_private);
+	Node *node = (Node *) linitial(customScan->custom_private);
 	Assert(CitusIsA(node, DistributedPlan));
 
 	CheckNodeCopyAndSerialization(node);
 
-	distributedPlan = (DistributedPlan *) node;
+	DistributedPlan *distributedPlan = (DistributedPlan *) node;
 
 	return distributedPlan;
 }
@@ -1040,7 +1030,6 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
 {
 	PlannedStmt *finalPlan = NULL;
 	CustomScan *customScan = makeNode(CustomScan);
-	Node *distributedPlanData = NULL;
 	MultiExecutorType executorType = MULTI_EXECUTOR_INVALID_FIRST;
 
 	if (!distributedPlan->planningError)
@@ -1092,7 +1081,7 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
 	distributedPlan->relationIdList = localPlan->relationOids;
 	distributedPlan->queryId = localPlan->queryId;
 
-	distributedPlanData = (Node *) distributedPlan;
+	Node *distributedPlanData = (Node *) distributedPlan;
 
 	customScan->custom_private = list_make1(distributedPlanData);
 	customScan->flags = CUSTOMPATH_SUPPORT_BACKWARD_SCAN;
@@ -1119,9 +1108,7 @@ static PlannedStmt *
 FinalizeNonRouterPlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 					  CustomScan *customScan)
 {
-	PlannedStmt *finalPlan = NULL;
-
-	finalPlan = MasterNodeSelectPlan(distributedPlan, customScan);
+	PlannedStmt *finalPlan = MasterNodeSelectPlan(distributedPlan, customScan);
 	finalPlan->queryId = localPlan->queryId;
 	finalPlan->utilityStmt = localPlan->utilityStmt;
 
@@ -1141,8 +1128,6 @@ FinalizeNonRouterPlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 static PlannedStmt *
 FinalizeRouterPlan(PlannedStmt *localPlan, CustomScan *customScan)
 {
-	PlannedStmt *routerPlan = NULL;
-	RangeTblEntry *remoteScanRangeTableEntry = NULL;
 	ListCell *targetEntryCell = NULL;
 	List *targetList = NIL;
 	List *columnNameList = NIL;
@@ -1154,9 +1139,6 @@ FinalizeRouterPlan(PlannedStmt *localPlan, CustomScan *customScan)
 	foreach(targetEntryCell, localPlan->planTree->targetlist)
 	{
 		TargetEntry *targetEntry = lfirst(targetEntryCell);
-		TargetEntry *newTargetEntry = NULL;
-		Var *newVar = NULL;
-		Value *columnName = NULL;
 
 		Assert(IsA(targetEntry, TargetEntry));
 
@@ -1171,7 +1153,7 @@ FinalizeRouterPlan(PlannedStmt *localPlan, CustomScan *customScan)
 		}
 
 		/* build target entry pointing to remote scan range table entry */
-		newVar = makeVarFromTargetEntry(customScanRangeTableIndex, targetEntry);
+		Var *newVar = makeVarFromTargetEntry(customScanRangeTableIndex, targetEntry);
 
 		if (newVar->vartype == RECORDOID)
 		{
@@ -1184,20 +1166,20 @@ FinalizeRouterPlan(PlannedStmt *localPlan, CustomScan *customScan)
 			newVar->vartypmod = BlessRecordExpression(targetEntry->expr);
 		}
 
-		newTargetEntry = flatCopyTargetEntry(targetEntry);
+		TargetEntry *newTargetEntry = flatCopyTargetEntry(targetEntry);
 		newTargetEntry->expr = (Expr *) newVar;
 		targetList = lappend(targetList, newTargetEntry);
 
-		columnName = makeString(targetEntry->resname);
+		Value *columnName = makeString(targetEntry->resname);
 		columnNameList = lappend(columnNameList, columnName);
 	}
 
 	customScan->scan.plan.targetlist = targetList;
 
-	routerPlan = makeNode(PlannedStmt);
+	PlannedStmt *routerPlan = makeNode(PlannedStmt);
 	routerPlan->planTree = (Plan *) customScan;
 
-	remoteScanRangeTableEntry = RemoteScanRangeTableEntry(columnNameList);
+	RangeTblEntry *remoteScanRangeTableEntry = RemoteScanRangeTableEntry(columnNameList);
 	routerPlan->rtable = list_make1(remoteScanRangeTableEntry);
 
 	/* add original range table list for access permission checks */
@@ -1236,11 +1218,10 @@ BlessRecordExpression(Expr *expr)
 		 */
 		Oid resultTypeId = InvalidOid;
 		TupleDesc resultTupleDesc = NULL;
-		TypeFuncClass typeClass;
 
 		/* get_expr_result_type blesses the tuple descriptor */
-		typeClass = get_expr_result_type((Node *) expr, &resultTypeId,
-										 &resultTupleDesc);
+		TypeFuncClass typeClass = get_expr_result_type((Node *) expr, &resultTypeId,
+													   &resultTupleDesc);
 		if (typeClass == TYPEFUNC_COMPOSITE)
 		{
 			typeMod = resultTupleDesc->tdtypmod;
@@ -1368,32 +1349,27 @@ multi_join_restriction_hook(PlannerInfo *root,
 							JoinType jointype,
 							JoinPathExtraData *extra)
 {
-	PlannerRestrictionContext *plannerRestrictionContext = NULL;
-	JoinRestrictionContext *joinRestrictionContext = NULL;
-	JoinRestriction *joinRestriction = NULL;
-	MemoryContext restrictionsMemoryContext = NULL;
-	MemoryContext oldMemoryContext = NULL;
-	List *restrictInfoList = NIL;
-
 	/*
 	 * Use a memory context that's guaranteed to live long enough, could be
 	 * called in a more shorted lived one (e.g. with GEQO).
 	 */
-	plannerRestrictionContext = CurrentPlannerRestrictionContext();
-	restrictionsMemoryContext = plannerRestrictionContext->memoryContext;
-	oldMemoryContext = MemoryContextSwitchTo(restrictionsMemoryContext);
+	PlannerRestrictionContext *plannerRestrictionContext =
+		CurrentPlannerRestrictionContext();
+	MemoryContext restrictionsMemoryContext = plannerRestrictionContext->memoryContext;
+	MemoryContext oldMemoryContext = MemoryContextSwitchTo(restrictionsMemoryContext);
 
 	/*
 	 * We create a copy of restrictInfoList because it may be created in a memory
 	 * context which will be deleted when we still need it, thus we create a copy
 	 * of it in our memory context.
 	 */
-	restrictInfoList = copyObject(extra->restrictlist);
+	List *restrictInfoList = copyObject(extra->restrictlist);
 
-	joinRestrictionContext = plannerRestrictionContext->joinRestrictionContext;
+	JoinRestrictionContext *joinRestrictionContext =
+		plannerRestrictionContext->joinRestrictionContext;
 	Assert(joinRestrictionContext != NULL);
 
-	joinRestriction = palloc0(sizeof(JoinRestriction));
+	JoinRestriction *joinRestriction = palloc0(sizeof(JoinRestriction));
 	joinRestriction->joinType = jointype;
 	joinRestriction->joinRestrictInfoList = restrictInfoList;
 	joinRestriction->plannerInfo = root;
@@ -1424,14 +1400,7 @@ void
 multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 								Index restrictionIndex, RangeTblEntry *rte)
 {
-	PlannerRestrictionContext *plannerRestrictionContext = NULL;
-	RelationRestrictionContext *relationRestrictionContext = NULL;
-	MemoryContext restrictionsMemoryContext = NULL;
-	MemoryContext oldMemoryContext = NULL;
-	RelationRestriction *relationRestriction = NULL;
 	DistTableCacheEntry *cacheEntry = NULL;
-	bool distributedTable = false;
-	bool localTable = false;
 
 	AdjustReadIntermediateResultCost(rte, relOptInfo);
 
@@ -1444,14 +1413,15 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 	 * Use a memory context that's guaranteed to live long enough, could be
 	 * called in a more shorted lived one (e.g. with GEQO).
 	 */
-	plannerRestrictionContext = CurrentPlannerRestrictionContext();
-	restrictionsMemoryContext = plannerRestrictionContext->memoryContext;
-	oldMemoryContext = MemoryContextSwitchTo(restrictionsMemoryContext);
+	PlannerRestrictionContext *plannerRestrictionContext =
+		CurrentPlannerRestrictionContext();
+	MemoryContext restrictionsMemoryContext = plannerRestrictionContext->memoryContext;
+	MemoryContext oldMemoryContext = MemoryContextSwitchTo(restrictionsMemoryContext);
 
-	distributedTable = IsDistributedTable(rte->relid);
-	localTable = !distributedTable;
+	bool distributedTable = IsDistributedTable(rte->relid);
+	bool localTable = !distributedTable;
 
-	relationRestriction = palloc0(sizeof(RelationRestriction));
+	RelationRestriction *relationRestriction = palloc0(sizeof(RelationRestriction));
 	relationRestriction->index = restrictionIndex;
 	relationRestriction->relationId = rte->relid;
 	relationRestriction->rte = rte;
@@ -1463,7 +1433,8 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 	/* see comments on GetVarFromAssignedParam() */
 	relationRestriction->outerPlanParamsList = OuterPlanParamsList(root);
 
-	relationRestrictionContext = plannerRestrictionContext->relationRestrictionContext;
+	RelationRestrictionContext *relationRestrictionContext =
+		plannerRestrictionContext->relationRestrictionContext;
 	relationRestrictionContext->hasDistributedRelation |= distributedTable;
 	relationRestrictionContext->hasLocalRelation |= localTable;
 
@@ -1644,9 +1615,8 @@ static List *
 OuterPlanParamsList(PlannerInfo *root)
 {
 	List *planParamsList = NIL;
-	PlannerInfo *outerNodeRoot = NULL;
 
-	for (outerNodeRoot = root->parent_root; outerNodeRoot != NULL;
+	for (PlannerInfo *outerNodeRoot = root->parent_root; outerNodeRoot != NULL;
 		 outerNodeRoot = outerNodeRoot->parent_root)
 	{
 		RootPlanParams *rootPlanParams = palloc0(sizeof(RootPlanParams));
@@ -1729,11 +1699,9 @@ CreateAndPushPlannerRestrictionContext(void)
 static PlannerRestrictionContext *
 CurrentPlannerRestrictionContext(void)
 {
-	PlannerRestrictionContext *plannerRestrictionContext = NULL;
-
 	Assert(plannerRestrictionContextList != NIL);
 
-	plannerRestrictionContext =
+	PlannerRestrictionContext *plannerRestrictionContext =
 		(PlannerRestrictionContext *) linitial(plannerRestrictionContextList);
 
 	if (plannerRestrictionContext == NULL)
@@ -1804,7 +1772,6 @@ HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams)
 		if (boundParams && paramId > 0 && paramId <= boundParams->numParams)
 		{
 			ParamExternData *externParam = NULL;
-			Oid paramType = InvalidOid;
 
 			/* give hook a chance in case parameter is dynamic */
 			if (boundParams->paramFetch != NULL)
@@ -1818,7 +1785,7 @@ HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams)
 				externParam = &boundParams->params[paramId - 1];
 			}
 
-			paramType = externParam->ptype;
+			Oid paramType = externParam->ptype;
 			if (OidIsValid(paramType))
 			{
 				return false;
@@ -1890,7 +1857,6 @@ IsLocalReferenceTableJoin(Query *parse, List *rangeTableList)
 	foreach(rangeTableCell, rangeTableList)
 	{
 		RangeTblEntry *rangeTableEntry = (RangeTblEntry *) lfirst(rangeTableCell);
-		DistTableCacheEntry *cacheEntry = NULL;
 
 		if (rangeTableEntry->rtekind == RTE_FUNCTION)
 		{
@@ -1909,7 +1875,8 @@ IsLocalReferenceTableJoin(Query *parse, List *rangeTableList)
 			continue;
 		}
 
-		cacheEntry = DistributedTableCacheEntry(rangeTableEntry->relid);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(
+			rangeTableEntry->relid);
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{
 			hasReferenceTable = true;
@@ -1931,14 +1898,12 @@ IsLocalReferenceTableJoin(Query *parse, List *rangeTableList)
 static bool
 QueryIsNotSimpleSelect(Node *node)
 {
-	Query *query = NULL;
-
 	if (!IsA(node, Query))
 	{
 		return false;
 	}
 
-	query = (Query *) node;
+	Query *query = (Query *) node;
 	return (query->commandType != CMD_SELECT) || (query->rowMarks != NIL);
 }
 
@@ -1950,14 +1915,6 @@ QueryIsNotSimpleSelect(Node *node)
 static bool
 UpdateReferenceTablesWithShard(Node *node, void *context)
 {
-	RangeTblEntry *newRte = NULL;
-	uint64 shardId = INVALID_SHARD_ID;
-	Oid relationId = InvalidOid;
-	Oid schemaId = InvalidOid;
-	char *relationName = NULL;
-	DistTableCacheEntry *cacheEntry = NULL;
-	ShardInterval *shardInterval = NULL;
-
 	if (node == NULL)
 	{
 		return false;
@@ -1976,32 +1933,32 @@ UpdateReferenceTablesWithShard(Node *node, void *context)
 									  NULL);
 	}
 
-	newRte = (RangeTblEntry *) node;
+	RangeTblEntry *newRte = (RangeTblEntry *) node;
 
 	if (newRte->rtekind != RTE_RELATION)
 	{
 		return false;
 	}
 
-	relationId = newRte->relid;
+	Oid relationId = newRte->relid;
 	if (!IsDistributedTable(relationId))
 	{
 		return false;
 	}
 
-	cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 	if (cacheEntry->partitionMethod != DISTRIBUTE_BY_NONE)
 	{
 		return false;
 	}
 
-	shardInterval = cacheEntry->sortedShardIntervalArray[0];
-	shardId = shardInterval->shardId;
+	ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[0];
+	uint64 shardId = shardInterval->shardId;
 
-	relationName = get_rel_name(relationId);
+	char *relationName = get_rel_name(relationId);
 	AppendShardIdToName(&relationName, shardId);
 
-	schemaId = get_rel_namespace(relationId);
+	Oid schemaId = get_rel_namespace(relationId);
 	newRte->relid = get_relname_relid(relationName, schemaId);
 
 	/*

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -98,7 +98,6 @@ contain_param_walker(Node *node, void *context)
 DistributedPlan *
 TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 {
-	FromExpr *joinTree = NULL;
 	List *targetList = NIL;
 	TargetEntry *targetEntry = NULL;
 	FuncExpr *funcExpr = NULL;
@@ -116,7 +115,6 @@ TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 	Task *task = NULL;
 	Job *job = NULL;
 	DistributedPlan *distributedPlan = NULL;
-	int32 groupId = 0;
 	struct ParamWalkerContext walkerParamContext = { 0 };
 
 	/* set hasExternParam now in case of early exit */
@@ -128,7 +126,7 @@ TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 		return NULL;
 	}
 
-	groupId = GetLocalGroupId();
+	int32 groupId = GetLocalGroupId();
 	if (groupId != 0 || groupId == GROUP_ID_UPGRADING)
 	{
 		/* do not delegate from workers, or while upgrading */
@@ -147,7 +145,7 @@ TryToDelegateFunctionCall(Query *query, bool *hasExternParam)
 		return NULL;
 	}
 
-	joinTree = query->jointree;
+	FromExpr *joinTree = query->jointree;
 	if (joinTree == NULL)
 	{
 		/* no join tree (mostly here to be defensive) */

--- a/src/backend/distributed/planner/intermediate_result_pruning.c
+++ b/src/backend/distributed/planner/intermediate_result_pruning.c
@@ -52,7 +52,6 @@ FindSubPlansUsedInNode(Node *node)
 		{
 			char *resultId =
 				FindIntermediateResultIdIfExists(rangeTableEntry);
-			Value *resultIdValue = NULL;
 
 			if (resultId == NULL)
 			{
@@ -63,7 +62,7 @@ FindSubPlansUsedInNode(Node *node)
 			 * Use a Value to be able to use list_append_unique and store
 			 * the result ID in the DistributedPlan.
 			 */
-			resultIdValue = makeString(resultId);
+			Value *resultIdValue = makeString(resultId);
 			subPlanList = list_append_unique(subPlanList, resultIdValue);
 		}
 	}
@@ -185,8 +184,6 @@ AppendAllAccessedWorkerNodes(List *workerNodeList, DistributedPlan *distributedP
 HTAB *
 MakeIntermediateResultHTAB()
 {
-	HTAB *intermediateResultsHash = NULL;
-	uint32 hashFlags = 0;
 	HASHCTL info = { 0 };
 	int initialNumberOfElements = 16;
 
@@ -194,10 +191,11 @@ MakeIntermediateResultHTAB()
 	info.entrysize = sizeof(IntermediateResultsHashEntry);
 	info.hash = string_hash;
 	info.hcxt = CurrentMemoryContext;
-	hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 
-	intermediateResultsHash = hash_create("Intermediate results hash",
-										  initialNumberOfElements, &info, hashFlags);
+	HTAB *intermediateResultsHash = hash_create("Intermediate results hash",
+												initialNumberOfElements, &info,
+												hashFlags);
 
 	return intermediateResultsHash;
 }
@@ -243,10 +241,10 @@ FindAllWorkerNodesUsingSubplan(HTAB *intermediateResultsHash,
 static IntermediateResultsHashEntry *
 SearchIntermediateResult(HTAB *intermediateResultsHash, char *resultId)
 {
-	IntermediateResultsHashEntry *entry = NULL;
 	bool found = false;
 
-	entry = hash_search(intermediateResultsHash, resultId, HASH_ENTER, &found);
+	IntermediateResultsHashEntry *entry = hash_search(intermediateResultsHash, resultId,
+													  HASH_ENTER, &found);
 
 	/* use sane defaults */
 	if (!found)

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -343,9 +343,8 @@ ExplainTaskList(List *taskList, ExplainState *es)
 	foreach(taskCell, taskList)
 	{
 		Task *task = (Task *) lfirst(taskCell);
-		RemoteExplainPlan *remoteExplain = NULL;
 
-		remoteExplain = RemoteExplain(task, es);
+		RemoteExplainPlan *remoteExplain = RemoteExplain(task, es);
 		remoteExplainList = lappend(remoteExplainList, remoteExplain);
 
 		if (!ExplainAllTasks)
@@ -374,14 +373,12 @@ ExplainTaskList(List *taskList, ExplainState *es)
 static RemoteExplainPlan *
 RemoteExplain(Task *task, ExplainState *es)
 {
-	StringInfo explainQuery = NULL;
 	List *taskPlacementList = task->taskPlacementList;
 	int placementCount = list_length(taskPlacementList);
-	int placementIndex = 0;
-	RemoteExplainPlan *remotePlan = NULL;
 
-	remotePlan = (RemoteExplainPlan *) palloc0(sizeof(RemoteExplainPlan));
-	explainQuery = BuildRemoteExplainQuery(task->queryString, es);
+	RemoteExplainPlan *remotePlan = (RemoteExplainPlan *) palloc0(
+		sizeof(RemoteExplainPlan));
+	StringInfo explainQuery = BuildRemoteExplainQuery(task->queryString, es);
 
 	/*
 	 * Use a coordinated transaction to ensure that we open a transaction block
@@ -389,17 +386,16 @@ RemoteExplain(Task *task, ExplainState *es)
 	 */
 	BeginOrContinueCoordinatedTransaction();
 
-	for (placementIndex = 0; placementIndex < placementCount; placementIndex++)
+	for (int placementIndex = 0; placementIndex < placementCount; placementIndex++)
 	{
 		ShardPlacement *taskPlacement = list_nth(taskPlacementList, placementIndex);
-		MultiConnection *connection = NULL;
 		PGresult *queryResult = NULL;
 		int connectionFlags = 0;
-		int executeResult = 0;
 
 		remotePlan->placementIndex = placementIndex;
 
-		connection = GetPlacementConnection(connectionFlags, taskPlacement, NULL);
+		MultiConnection *connection = GetPlacementConnection(connectionFlags,
+															 taskPlacement, NULL);
 
 		/* try other placements if we fail to connect this one */
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
@@ -417,8 +413,8 @@ RemoteExplain(Task *task, ExplainState *es)
 		ExecuteCriticalRemoteCommand(connection, "SAVEPOINT citus_explain_savepoint");
 
 		/* run explain query */
-		executeResult = ExecuteOptionalRemoteCommand(connection, explainQuery->data,
-													 &queryResult);
+		int executeResult = ExecuteOptionalRemoteCommand(connection, explainQuery->data,
+														 &queryResult);
 		if (executeResult != 0)
 		{
 			PQclear(queryResult);
@@ -517,11 +513,9 @@ ExplainTaskPlacement(ShardPlacement *taskPlacement, List *explainOutputList,
 	foreach(explainOutputCell, explainOutputList)
 	{
 		StringInfo rowString = (StringInfo) lfirst(explainOutputCell);
-		int rowLength = 0;
-		char *lineStart = NULL;
 
-		rowLength = strlen(rowString->data);
-		lineStart = rowString->data;
+		int rowLength = strlen(rowString->data);
+		char *lineStart = rowString->data;
 
 		/* parse the lines in the remote EXPLAIN for proper indentation */
 		while (lineStart < rowString->data + rowLength)
@@ -646,14 +640,13 @@ ExplainOneQuery(Query *query, int cursorOptions,
 	}
 	else
 	{
-		PlannedStmt *plan;
 		instr_time	planstart,
 					planduration;
 
 		INSTR_TIME_SET_CURRENT(planstart);
 
 		/* plan the query */
-		plan = pg_plan_query(query, cursorOptions, params);
+		PlannedStmt *plan = pg_plan_query(query, cursorOptions, params);
 
 		INSTR_TIME_SET_CURRENT(planduration);
 		INSTR_TIME_SUBTRACT(planduration, planstart);

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -217,22 +217,17 @@ DistributedPlan *
 CreatePhysicalDistributedPlan(MultiTreeRoot *multiTree,
 							  PlannerRestrictionContext *plannerRestrictionContext)
 {
-	DistributedPlan *distributedPlan = NULL;
-	Job *workerJob = NULL;
-	Query *masterQuery = NULL;
-	List *masterDependedJobList = NIL;
-
 	/* build the worker job tree and check that we only one job in the tree */
-	workerJob = BuildJobTree(multiTree);
+	Job *workerJob = BuildJobTree(multiTree);
 
 	/* create the tree of executable tasks for the worker job */
 	workerJob = BuildJobTreeTaskList(workerJob, plannerRestrictionContext);
 
 	/* build the final merge query to execute on the master */
-	masterDependedJobList = list_make1(workerJob);
-	masterQuery = BuildJobQuery((MultiNode *) multiTree, masterDependedJobList);
+	List *masterDependedJobList = list_make1(workerJob);
+	Query *masterQuery = BuildJobQuery((MultiNode *) multiTree, masterDependedJobList);
 
-	distributedPlan = CitusMakeNode(DistributedPlan);
+	DistributedPlan *distributedPlan = CitusMakeNode(DistributedPlan);
 	distributedPlan->workerJob = workerJob;
 	distributedPlan->masterQuery = masterQuery;
 	distributedPlan->routerExecutable = DistributedPlanRouterExecutable(distributedPlan);
@@ -258,7 +253,6 @@ DistributedPlanRouterExecutable(DistributedPlan *distributedPlan)
 	List *workerTaskList = job->taskList;
 	int taskCount = list_length(workerTaskList);
 	int dependedJobCount = list_length(job->dependedJobList);
-	bool masterQueryHasAggregates = false;
 
 	if (!EnableRouterExecution)
 	{
@@ -292,7 +286,7 @@ DistributedPlanRouterExecutable(DistributedPlan *distributedPlan)
 	 * have either an aggregate or a function expression which has to be executed for
 	 * the correct results.
 	 */
-	masterQueryHasAggregates = job->jobQuery->hasAggs;
+	bool masterQueryHasAggregates = job->jobQuery->hasAggs;
 	if (masterQueryHasAggregates)
 	{
 		return false;
@@ -521,9 +515,6 @@ static Oid
 RangePartitionJoinBaseRelationId(MultiJoin *joinNode)
 {
 	MultiPartition *partitionNode = NULL;
-	MultiTable *baseTable = NULL;
-	Index baseTableId = 0;
-	Oid baseRelationId = InvalidOid;
 
 	MultiNode *leftChildNode = joinNode->binaryNode.leftChildNode;
 	MultiNode *rightChildNode = joinNode->binaryNode.rightChildNode;
@@ -537,9 +528,9 @@ RangePartitionJoinBaseRelationId(MultiJoin *joinNode)
 		partitionNode = (MultiPartition *) rightChildNode;
 	}
 
-	baseTableId = partitionNode->splitPointTableId;
-	baseTable = FindTableNode((MultiNode *) joinNode, baseTableId);
-	baseRelationId = baseTable->relationId;
+	Index baseTableId = partitionNode->splitPointTableId;
+	MultiTable *baseTable = FindTableNode((MultiNode *) joinNode, baseTableId);
+	Oid baseRelationId = baseTable->relationId;
 
 	return baseRelationId;
 }
@@ -580,19 +571,11 @@ FindTableNode(MultiNode *multiNode, int rangeTableId)
 static Query *
 BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 {
-	Query *jobQuery = NULL;
-	MultiNode *parentNode = NULL;
 	bool updateColumnAttributes = false;
-	List *rangeTableList = NIL;
 	List *targetList = NIL;
-	List *extendedOpNodeList = NIL;
 	List *sortClauseList = NIL;
-	List *groupClauseList = NIL;
-	List *selectClauseList = NIL;
 	Node *limitCount = NULL;
 	Node *limitOffset = NULL;
-	FromExpr *joinTree = NULL;
-	Node *joinRoot = NULL;
 	Node *havingQual = NULL;
 	bool hasDistinctOn = false;
 	List *distinctClause = NIL;
@@ -611,7 +594,7 @@ BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 	 * Note that we don't do this for master queries, as column attributes for
 	 * master target entries are already set during the master/worker split.
 	 */
-	parentNode = ParentNode(multiNode);
+	MultiNode *parentNode = ParentNode(multiNode);
 	if (parentNode != NULL)
 	{
 		updateColumnAttributes = true;
@@ -640,7 +623,7 @@ BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 	 * Otherwise, we use the target list based on the MultiProject node at this
 	 * level in the query tree.
 	 */
-	extendedOpNodeList = FindNodesOfType(multiNode, T_MultiExtendedOp);
+	List *extendedOpNodeList = FindNodesOfType(multiNode, T_MultiExtendedOp);
 	if (extendedOpNodeList != NIL)
 	{
 		MultiExtendedOp *extendedOp = (MultiExtendedOp *) linitial(extendedOpNodeList);
@@ -654,8 +637,8 @@ BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 	}
 
 	/* build the join tree and the range table list */
-	rangeTableList = BaseRangeTableList(multiNode);
-	joinRoot = QueryJoinTree(multiNode, dependedJobList, &rangeTableList);
+	List *rangeTableList = BaseRangeTableList(multiNode);
+	Node *joinRoot = QueryJoinTree(multiNode, dependedJobList, &rangeTableList);
 
 	/* update the column attributes for target entries */
 	if (updateColumnAttributes)
@@ -675,11 +658,11 @@ BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 	}
 
 	/* build group clauses */
-	groupClauseList = QueryGroupClauseList(multiNode);
+	List *groupClauseList = QueryGroupClauseList(multiNode);
 
 
 	/* build the where clause list using select predicates */
-	selectClauseList = QuerySelectClauseList(multiNode);
+	List *selectClauseList = QuerySelectClauseList(multiNode);
 
 	/* set correct column attributes for select and having clauses */
 	if (updateColumnAttributes)
@@ -711,12 +694,12 @@ BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 	 * AND'd, since both partition and join pruning depends on the clauses being
 	 * expressed as a list.
 	 */
-	joinTree = makeNode(FromExpr);
+	FromExpr *joinTree = makeNode(FromExpr);
 	joinTree->quals = (Node *) list_copy(selectClauseList);
 	joinTree->fromlist = list_make1(joinRoot);
 
 	/* build the query structure for this job */
-	jobQuery = makeNode(Query);
+	Query *jobQuery = makeNode(Query);
 	jobQuery->commandType = CMD_SELECT;
 	jobQuery->querySource = QSRC_ORIGINAL;
 	jobQuery->canSetTag = true;
@@ -745,44 +728,35 @@ BuildJobQuery(MultiNode *multiNode, List *dependedJobList)
 static Query *
 BuildReduceQuery(MultiExtendedOp *extendedOpNode, List *dependedJobList)
 {
-	Query *reduceQuery = NULL;
 	MultiNode *multiNode = (MultiNode *) extendedOpNode;
 	List *derivedRangeTableList = NIL;
 	List *targetList = NIL;
-	List *whereClauseList = NIL;
-	List *selectClauseList = NIL;
-	List *joinClauseList = NIL;
-	List *columnList = NIL;
 	ListCell *columnCell = NULL;
-	FromExpr *joinTree = NULL;
 	List *columnNameList = NIL;
-	RangeTblEntry *rangeTableEntry = NULL;
 
 	Job *dependedJob = linitial(dependedJobList);
 	List *dependedTargetList = dependedJob->jobQuery->targetList;
 	uint32 columnCount = (uint32) list_length(dependedTargetList);
-	uint32 columnIndex = 0;
 
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (uint32 columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
-		Value *columnValue = NULL;
 		StringInfo columnNameString = makeStringInfo();
 
 		appendStringInfo(columnNameString, MERGE_COLUMN_FORMAT, columnIndex);
 
-		columnValue = makeString(columnNameString->data);
+		Value *columnValue = makeString(columnNameString->data);
 		columnNameList = lappend(columnNameList, columnValue);
 	}
 
 	/* create a derived range table for the subtree below the collect */
-	rangeTableEntry = DerivedRangeTableEntry(multiNode, columnNameList,
-											 OutputTableIdList(multiNode));
+	RangeTblEntry *rangeTableEntry = DerivedRangeTableEntry(multiNode, columnNameList,
+															OutputTableIdList(multiNode));
 	rangeTableEntry->eref->colnames = columnNameList;
 	ModifyRangeTblExtraData(rangeTableEntry, CITUS_RTE_SHARD, NULL, NULL, NULL);
 	derivedRangeTableList = lappend(derivedRangeTableList, rangeTableEntry);
 
 	targetList = copyObject(extendedOpNode->targetList);
-	columnList = pull_var_clause_default((Node *) targetList);
+	List *columnList = pull_var_clause_default((Node *) targetList);
 
 	foreach(columnCell, columnList)
 	{
@@ -795,21 +769,21 @@ BuildReduceQuery(MultiExtendedOp *extendedOpNode, List *dependedJobList)
 	}
 
 	/* build the where clause list using select and join predicates */
-	selectClauseList = QuerySelectClauseList((MultiNode *) extendedOpNode);
-	joinClauseList = QueryJoinClauseList((MultiNode *) extendedOpNode);
-	whereClauseList = list_concat(selectClauseList, joinClauseList);
+	List *selectClauseList = QuerySelectClauseList((MultiNode *) extendedOpNode);
+	List *joinClauseList = QueryJoinClauseList((MultiNode *) extendedOpNode);
+	List *whereClauseList = list_concat(selectClauseList, joinClauseList);
 
 	/*
 	 * Build the From/Where construct. We keep the where-clause list implicitly
 	 * AND'd, since both partition and join pruning depends on the clauses being
 	 * expressed as a list.
 	 */
-	joinTree = makeNode(FromExpr);
+	FromExpr *joinTree = makeNode(FromExpr);
 	joinTree->quals = (Node *) whereClauseList;
 	joinTree->fromlist = QueryFromList(derivedRangeTableList);
 
 	/* build the query structure for this job */
-	reduceQuery = makeNode(Query);
+	Query *reduceQuery = makeNode(Query);
 	reduceQuery->commandType = CMD_SELECT;
 	reduceQuery->querySource = QSRC_ORIGINAL;
 	reduceQuery->canSetTag = true;
@@ -908,18 +882,16 @@ static List *
 DerivedColumnNameList(uint32 columnCount, uint64 generatingJobId)
 {
 	List *columnNameList = NIL;
-	uint32 columnIndex = 0;
 
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (uint32 columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		StringInfo columnName = makeStringInfo();
-		Value *columnValue = NULL;
 
 		appendStringInfo(columnName, "intermediate_column_");
 		appendStringInfo(columnName, UINT64_FORMAT "_", generatingJobId);
 		appendStringInfo(columnName, "%u", columnIndex);
 
-		columnValue = makeString(columnName->data);
+		Value *columnValue = makeString(columnName->data);
 		columnNameList = lappend(columnNameList, columnValue);
 	}
 
@@ -938,16 +910,12 @@ DerivedColumnNameList(uint32 columnCount, uint64 generatingJobId)
 static List *
 QueryTargetList(MultiNode *multiNode)
 {
-	MultiProject *topProjectNode = NULL;
-	List *columnList = NIL;
-	List *queryTargetList = NIL;
-
 	List *projectNodeList = FindNodesOfType(multiNode, T_MultiProject);
 	Assert(list_length(projectNodeList) > 0);
 
-	topProjectNode = (MultiProject *) linitial(projectNodeList);
-	columnList = topProjectNode->columnList;
-	queryTargetList = TargetEntryList(columnList);
+	MultiProject *topProjectNode = (MultiProject *) linitial(projectNodeList);
+	List *columnList = topProjectNode->columnList;
+	List *queryTargetList = TargetEntryList(columnList);
 
 	Assert(queryTargetList != NIL);
 	return queryTargetList;
@@ -1163,9 +1131,7 @@ QueryJoinTree(MultiNode *multiNode, List *dependedJobList, List **rangeTableList
 		{
 			MultiJoin *joinNode = (MultiJoin *) multiNode;
 			MultiBinaryNode *binaryNode = (MultiBinaryNode *) multiNode;
-			List *columnList = NIL;
 			ListCell *columnCell = NULL;
-			RangeTblEntry *rangeTableEntry = NULL;
 			JoinExpr *joinExpr = makeNode(JoinExpr);
 			joinExpr->jointype = joinNode->joinType;
 			joinExpr->isNatural = false;
@@ -1194,12 +1160,13 @@ QueryJoinTree(MultiNode *multiNode, List *dependedJobList, List **rangeTableList
 				joinExpr->jointype = JOIN_LEFT;
 			}
 
-			rangeTableEntry = JoinRangeTableEntry(joinExpr, dependedJobList,
-												  *rangeTableList);
+			RangeTblEntry *rangeTableEntry = JoinRangeTableEntry(joinExpr,
+																 dependedJobList,
+																 *rangeTableList);
 			*rangeTableList = lappend(*rangeTableList, rangeTableEntry);
 
 			/* fix the column attributes in ON (...) clauses */
-			columnList = pull_var_clause_default((Node *) joinNode->joinClauseList);
+			List *columnList = pull_var_clause_default((Node *) joinNode->joinClauseList);
 			foreach(columnCell, columnList)
 			{
 				Var *column = (Var *) lfirst(columnCell);
@@ -1263,7 +1230,6 @@ QueryJoinTree(MultiNode *multiNode, List *dependedJobList, List **rangeTableList
 		case T_MultiCartesianProduct:
 		{
 			MultiBinaryNode *binaryNode = (MultiBinaryNode *) multiNode;
-			RangeTblEntry *rangeTableEntry = NULL;
 
 			JoinExpr *joinExpr = makeNode(JoinExpr);
 			joinExpr->jointype = JOIN_INNER;
@@ -1277,8 +1243,9 @@ QueryJoinTree(MultiNode *multiNode, List *dependedJobList, List **rangeTableList
 			joinExpr->quals = NULL;
 			joinExpr->rtindex = list_length(*rangeTableList) + 1;
 
-			rangeTableEntry = JoinRangeTableEntry(joinExpr, dependedJobList,
-												  *rangeTableList);
+			RangeTblEntry *rangeTableEntry = JoinRangeTableEntry(joinExpr,
+																 dependedJobList,
+																 *rangeTableList);
 			*rangeTableList = lappend(*rangeTableList, rangeTableEntry);
 
 			return (Node *) joinExpr;
@@ -1291,12 +1258,11 @@ QueryJoinTree(MultiNode *multiNode, List *dependedJobList, List **rangeTableList
 		case T_MultiPartition:
 		{
 			MultiUnaryNode *unaryNode = (MultiUnaryNode *) multiNode;
-			Node *childNode = NULL;
 
 			Assert(UnaryOperator(multiNode));
 
-			childNode = QueryJoinTree(unaryNode->childNode, dependedJobList,
-									  rangeTableList);
+			Node *childNode = QueryJoinTree(unaryNode->childNode, dependedJobList,
+											rangeTableList);
 
 			return childNode;
 		}
@@ -1444,10 +1410,9 @@ static List *
 QueryFromList(List *rangeTableList)
 {
 	List *fromList = NIL;
-	Index rangeTableIndex = 1;
 	int rangeTableCount = list_length(rangeTableList);
 
-	for (rangeTableIndex = 1; rangeTableIndex <= rangeTableCount; rangeTableIndex++)
+	for (Index rangeTableIndex = 1; rangeTableIndex <= rangeTableCount; rangeTableIndex++)
 	{
 		RangeTblRef *rangeTableReference = makeNode(RangeTblRef);
 		rangeTableReference->rtindex = rangeTableIndex;
@@ -1479,21 +1444,11 @@ QueryFromList(List *rangeTableList)
 static Query *
 BuildSubqueryJobQuery(MultiNode *multiNode)
 {
-	Query *jobQuery = NULL;
-	Query *subquery = NULL;
-	MultiTable *multiTable = NULL;
-	RangeTblEntry *rangeTableEntry = NULL;
-	List *subqueryMultiTableList = NIL;
-	List *rangeTableList = NIL;
 	List *targetList = NIL;
-	List *extendedOpNodeList = NIL;
 	List *sortClauseList = NIL;
-	List *groupClauseList = NIL;
-	List *whereClauseList = NIL;
 	Node *havingQual = NULL;
 	Node *limitCount = NULL;
 	Node *limitOffset = NULL;
-	FromExpr *joinTree = NULL;
 	bool hasAggregates = false;
 	List *distinctClause = NIL;
 	bool hasDistinctOn = false;
@@ -1503,28 +1458,28 @@ BuildSubqueryJobQuery(MultiNode *multiNode)
 	/* we start building jobs from below the collect node */
 	Assert(!CitusIsA(multiNode, MultiCollect));
 
-	subqueryMultiTableList = SubqueryMultiTableList(multiNode);
+	List *subqueryMultiTableList = SubqueryMultiTableList(multiNode);
 	Assert(list_length(subqueryMultiTableList) == 1);
 
-	multiTable = (MultiTable *) linitial(subqueryMultiTableList);
-	subquery = multiTable->subquery;
+	MultiTable *multiTable = (MultiTable *) linitial(subqueryMultiTableList);
+	Query *subquery = multiTable->subquery;
 
 	/*  build subquery range table list */
-	rangeTableEntry = makeNode(RangeTblEntry);
+	RangeTblEntry *rangeTableEntry = makeNode(RangeTblEntry);
 	rangeTableEntry->rtekind = RTE_SUBQUERY;
 	rangeTableEntry->inFromCl = true;
 	rangeTableEntry->eref = multiTable->referenceNames;
 	rangeTableEntry->alias = multiTable->alias;
 	rangeTableEntry->subquery = subquery;
 
-	rangeTableList = list_make1(rangeTableEntry);
+	List *rangeTableList = list_make1(rangeTableEntry);
 
 	/*
 	 * If we have an extended operator, then we copy the operator's target list.
 	 * Otherwise, we use the target list based on the MultiProject node at this
 	 * level in the query tree.
 	 */
-	extendedOpNodeList = FindNodesOfType(multiNode, T_MultiExtendedOp);
+	List *extendedOpNodeList = FindNodesOfType(multiNode, T_MultiExtendedOp);
 	if (extendedOpNodeList != NIL)
 	{
 		MultiExtendedOp *extendedOp = (MultiExtendedOp *) linitial(extendedOpNodeList);
@@ -1551,10 +1506,10 @@ BuildSubqueryJobQuery(MultiNode *multiNode)
 	}
 
 	/* build group clauses */
-	groupClauseList = QueryGroupClauseList(multiNode);
+	List *groupClauseList = QueryGroupClauseList(multiNode);
 
 	/* build the where clause list using select predicates */
-	whereClauseList = QuerySelectClauseList(multiNode);
+	List *whereClauseList = QuerySelectClauseList(multiNode);
 
 	if (contain_agg_clause((Node *) targetList) ||
 		contain_agg_clause((Node *) havingQual))
@@ -1575,12 +1530,12 @@ BuildSubqueryJobQuery(MultiNode *multiNode)
 	 * AND'd, since both partition and join pruning depends on the clauses being
 	 * expressed as a list.
 	 */
-	joinTree = makeNode(FromExpr);
+	FromExpr *joinTree = makeNode(FromExpr);
 	joinTree->quals = (Node *) whereClauseList;
 	joinTree->fromlist = QueryFromList(rangeTableList);
 
 	/* build the query structure for this job */
-	jobQuery = makeNode(Query);
+	Query *jobQuery = makeNode(Query);
 	jobQuery->commandType = CMD_SELECT;
 	jobQuery->querySource = QSRC_ORIGINAL;
 	jobQuery->canSetTag = true;
@@ -1665,11 +1620,10 @@ NewTableId(Index originalTableId, List *rangeTableList)
 	{
 		RangeTblEntry *rangeTableEntry = (RangeTblEntry *) lfirst(rangeTableCell);
 		List *originalTableIdList = NIL;
-		bool listMember = false;
 
 		ExtractRangeTblExtraData(rangeTableEntry, NULL, NULL, NULL, &originalTableIdList);
 
-		listMember = list_member_int(originalTableIdList, originalTableId);
+		bool listMember = list_member_int(originalTableIdList, originalTableId);
 		if (listMember)
 		{
 			return rangeTableIndex;
@@ -1740,7 +1694,6 @@ NewColumnId(Index originalTableId, AttrNumber originalColumnId,
 static Job *
 JobForRangeTable(List *jobList, RangeTblEntry *rangeTableEntry)
 {
-	Job *searchedJob = NULL;
 	List *searchedTableIdList = NIL;
 	CitusRTEKind rangeTableKind;
 
@@ -1749,7 +1702,7 @@ JobForRangeTable(List *jobList, RangeTblEntry *rangeTableEntry)
 
 	Assert(rangeTableKind == CITUS_RTE_REMOTE_QUERY);
 
-	searchedJob = JobForTableIdList(jobList, searchedTableIdList);
+	Job *searchedJob = JobForTableIdList(jobList, searchedTableIdList);
 
 	return searchedJob;
 }
@@ -1773,8 +1726,6 @@ JobForTableIdList(List *jobList, List *searchedTableIdList)
 		List *jobRangeTableList = job->jobQuery->rtable;
 		List *jobTableIdList = NIL;
 		ListCell *jobRangeTableCell = NULL;
-		List *lhsDiff = NIL;
-		List *rhsDiff = NIL;
 
 		foreach(jobRangeTableCell, jobRangeTableList)
 		{
@@ -1792,8 +1743,8 @@ JobForTableIdList(List *jobList, List *searchedTableIdList)
 		 * Check if the searched range table's tableIds and the current job's
 		 * tableIds are the same.
 		 */
-		lhsDiff = list_difference_int(jobTableIdList, searchedTableIdList);
-		rhsDiff = list_difference_int(searchedTableIdList, jobTableIdList);
+		List *lhsDiff = list_difference_int(jobTableIdList, searchedTableIdList);
+		List *rhsDiff = list_difference_int(searchedTableIdList, jobTableIdList);
 		if (lhsDiff == NIL && rhsDiff == NIL)
 		{
 			searchedJob = job;
@@ -1855,7 +1806,6 @@ UniqueJobId(void)
 	static uint32 jobIdCounter = 0;
 
 	uint64 jobId = 0;
-	uint64 jobIdNumber = 0;
 	uint64 processId = 0;
 	uint64 localGroupId = 0;
 
@@ -1893,7 +1843,7 @@ UniqueJobId(void)
 	 * Use the remaining 23 bits to distinguish jobs by the
 	 * same backend.
 	 */
-	jobIdNumber = jobIdCounter & 0x1FFFFFF;
+	uint64 jobIdNumber = jobIdCounter & 0x1FFFFFF;
 	jobId = jobId | jobIdNumber;
 
 	return jobId;
@@ -1925,7 +1875,6 @@ BuildMapMergeJob(Query *jobQuery, List *dependedJobList, Var *partitionKey,
 				 PartitionType partitionType, Oid baseRelationId,
 				 BoundaryNodeJobType boundaryNodeJobType)
 {
-	MapMergeJob *mapMergeJob = NULL;
 	List *rangeTableList = jobQuery->rtable;
 	Var *partitionColumn = copyObject(partitionKey);
 
@@ -1935,7 +1884,7 @@ BuildMapMergeJob(Query *jobQuery, List *dependedJobList, Var *partitionKey,
 		UpdateColumnAttributes(partitionColumn, rangeTableList, dependedJobList);
 	}
 
-	mapMergeJob = CitusMakeNode(MapMergeJob);
+	MapMergeJob *mapMergeJob = CitusMakeNode(MapMergeJob);
 	mapMergeJob->job.jobId = UniqueJobId();
 	mapMergeJob->job.jobQuery = jobQuery;
 	mapMergeJob->job.dependedJobList = dependedJobList;
@@ -1960,11 +1909,10 @@ BuildMapMergeJob(Query *jobQuery, List *dependedJobList, Var *partitionKey,
 			 RANGE_PARTITION_TYPE)
 	{
 		DistTableCacheEntry *cache = DistributedTableCacheEntry(baseRelationId);
-		bool hasUninitializedShardInterval = false;
 		uint32 shardCount = cache->shardIntervalArrayLength;
 		ShardInterval **sortedShardIntervalArray = cache->sortedShardIntervalArray;
 
-		hasUninitializedShardInterval = cache->hasUninitializedShardInterval;
+		bool hasUninitializedShardInterval = cache->hasUninitializedShardInterval;
 		if (hasUninitializedShardInterval)
 		{
 			ereport(ERROR, (errmsg("cannot range repartition shard with "
@@ -2007,8 +1955,6 @@ HashPartitionCount(void)
 static ArrayType *
 SplitPointObject(ShardInterval **shardIntervalArray, uint32 shardIntervalCount)
 {
-	ArrayType *splitPointObject = NULL;
-	uint32 intervalIndex = 0;
 	Oid typeId = InvalidOid;
 	bool typeByValue = false;
 	char typeAlignment = 0;
@@ -2018,7 +1964,7 @@ SplitPointObject(ShardInterval **shardIntervalArray, uint32 shardIntervalCount)
 	uint32 minDatumCount = shardIntervalCount;
 	Datum *minDatumArray = palloc0(minDatumCount * sizeof(Datum));
 
-	for (intervalIndex = 0; intervalIndex < shardIntervalCount; intervalIndex++)
+	for (uint32 intervalIndex = 0; intervalIndex < shardIntervalCount; intervalIndex++)
 	{
 		ShardInterval *shardInterval = shardIntervalArray[intervalIndex];
 		minDatumArray[intervalIndex] = shardInterval->minValue;
@@ -2033,8 +1979,8 @@ SplitPointObject(ShardInterval **shardIntervalArray, uint32 shardIntervalCount)
 
 	/* construct the split point object from the sorted array */
 	get_typlenbyvalalign(typeId, &typeLength, &typeByValue, &typeAlignment);
-	splitPointObject = construct_array(minDatumArray, minDatumCount, typeId,
-									   typeLength, typeByValue, typeAlignment);
+	ArrayType *splitPointObject = construct_array(minDatumArray, minDatumCount, typeId,
+												  typeLength, typeByValue, typeAlignment);
 
 	return splitPointObject;
 }
@@ -2055,8 +2001,6 @@ static Job *
 BuildJobTreeTaskList(Job *jobTree, PlannerRestrictionContext *plannerRestrictionContext)
 {
 	List *flattenedJobList = NIL;
-	uint32 flattenedJobCount = 0;
-	int32 jobIndex = 0;
 
 	/*
 	 * We traverse the job tree in preorder, and append each visited job to our
@@ -2079,12 +2023,11 @@ BuildJobTreeTaskList(Job *jobTree, PlannerRestrictionContext *plannerRestriction
 	 * we can create dependencies between tasks bottom up, and assign them to
 	 * worker nodes accordingly.
 	 */
-	flattenedJobCount = (int32) list_length(flattenedJobList);
-	for (jobIndex = (flattenedJobCount - 1); jobIndex >= 0; jobIndex--)
+	uint32 flattenedJobCount = (int32) list_length(flattenedJobList);
+	for (int32 jobIndex = (flattenedJobCount - 1); jobIndex >= 0; jobIndex--)
 	{
 		Job *job = (Job *) list_nth(flattenedJobList, jobIndex);
 		List *sqlTaskList = NIL;
-		List *assignedSqlTaskList = NIL;
 		ListCell *assignedSqlTaskCell = NULL;
 
 		/* create sql tasks for the job, and prune redundant data fetch tasks */
@@ -2113,7 +2056,7 @@ BuildJobTreeTaskList(Job *jobTree, PlannerRestrictionContext *plannerRestriction
 		 * We first assign sql and merge tasks to worker nodes. Next, we assign
 		 * sql tasks' data fetch dependencies.
 		 */
-		assignedSqlTaskList = AssignTaskList(sqlTaskList);
+		List *assignedSqlTaskList = AssignTaskList(sqlTaskList);
 		AssignDataFetchDependencies(assignedSqlTaskList);
 
 		/* now assign merge task's data fetch dependencies */
@@ -2167,9 +2110,6 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 	ListCell *restrictionCell = NULL;
 	uint32 taskIdIndex = 1; /* 0 is reserved for invalid taskId */
 	int shardCount = 0;
-	int shardOffset = 0;
-	int minShardOffset = 0;
-	int maxShardOffset = 0;
 	bool *taskRequiredForShardIndex = NULL;
 	ListCell *prunedRelationShardCell = NULL;
 
@@ -2183,8 +2123,8 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 	}
 
 	/* defaults to be used if this is a reference table-only query */
-	minShardOffset = 0;
-	maxShardOffset = 0;
+	int minShardOffset = 0;
+	int maxShardOffset = 0;
 
 	forboth(prunedRelationShardCell, prunedRelationShardList,
 			restrictionCell, relationRestrictionContext->relationRestrictionList)
@@ -2194,9 +2134,8 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		Oid relationId = relationRestriction->relationId;
 		List *prunedShardList = (List *) lfirst(prunedRelationShardCell);
 		ListCell *shardIntervalCell = NULL;
-		DistTableCacheEntry *cacheEntry = NULL;
 
-		cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{
 			continue;
@@ -2249,19 +2188,19 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 	 * given that hash-distributed tables typically only have a few shards the
 	 * iteration is still very fast.
 	 */
-	for (shardOffset = minShardOffset; shardOffset <= maxShardOffset; shardOffset++)
+	for (int shardOffset = minShardOffset; shardOffset <= maxShardOffset; shardOffset++)
 	{
-		Task *subqueryTask = NULL;
-
 		if (taskRequiredForShardIndex != NULL && !taskRequiredForShardIndex[shardOffset])
 		{
 			/* this shard index is pruned away for all relations */
 			continue;
 		}
 
-		subqueryTask = QueryPushdownTaskCreate(query, shardOffset,
-											   relationRestrictionContext, taskIdIndex,
-											   taskType, modifyRequiresMasterEvaluation);
+		Task *subqueryTask = QueryPushdownTaskCreate(query, shardOffset,
+													 relationRestrictionContext,
+													 taskIdIndex,
+													 taskType,
+													 modifyRequiresMasterEvaluation);
 		subqueryTask->jobId = jobId;
 		sqlTaskList = lappend(sqlTaskList, subqueryTask);
 
@@ -2367,7 +2306,6 @@ ErrorIfUnsupportedShardDistribution(Query *query)
 	foreach(relationIdCell, nonReferenceRelations)
 	{
 		Oid relationId = lfirst_oid(relationIdCell);
-		bool coPartitionedTables = false;
 		Oid currentRelationId = relationId;
 
 		/* get shard list of first relation and continue for the next relation */
@@ -2380,8 +2318,8 @@ ErrorIfUnsupportedShardDistribution(Query *query)
 		}
 
 		/* check if this table has 1-1 shard partitioning with first table */
-		coPartitionedTables = CoPartitionedTables(firstTableRelationId,
-												  currentRelationId);
+		bool coPartitionedTables = CoPartitionedTables(firstTableRelationId,
+													   currentRelationId);
 		if (!coPartitionedTables)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2406,10 +2344,8 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 
 	StringInfo queryString = makeStringInfo();
 	ListCell *restrictionCell = NULL;
-	Task *subqueryTask = NULL;
 	List *taskShardList = NIL;
 	List *relationShardList = NIL;
-	List *selectPlacementList = NIL;
 	uint64 jobId = INVALID_JOB_ID;
 	uint64 anchorShardId = INVALID_SHARD_ID;
 	bool modifyWithSubselect = false;
@@ -2435,11 +2371,9 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 		RelationRestriction *relationRestriction =
 			(RelationRestriction *) lfirst(restrictionCell);
 		Oid relationId = relationRestriction->relationId;
-		DistTableCacheEntry *cacheEntry = NULL;
 		ShardInterval *shardInterval = NULL;
-		RelationShard *relationShard = NULL;
 
-		cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{
 			/* reference table only has one shard */
@@ -2469,7 +2403,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 
 		taskShardList = lappend(taskShardList, list_make1(shardInterval));
 
-		relationShard = CitusMakeNode(RelationShard);
+		RelationShard *relationShard = CitusMakeNode(RelationShard);
 		relationShard->relationId = shardInterval->relationId;
 		relationShard->shardId = shardInterval->shardId;
 
@@ -2478,7 +2412,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 
 	Assert(anchorShardId != INVALID_SHARD_ID);
 
-	selectPlacementList = WorkersContainingAllShards(taskShardList);
+	List *selectPlacementList = WorkersContainingAllShards(taskShardList);
 	if (list_length(selectPlacementList) == 0)
 	{
 		ereport(ERROR, (errmsg("cannot find a worker that has active placements for all "
@@ -2502,7 +2436,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 			(List *) taskQuery->jointree->quals);
 	}
 
-	subqueryTask = CreateBasicTask(jobId, taskId, taskType, NULL);
+	Task *subqueryTask = CreateBasicTask(jobId, taskId, taskType, NULL);
 
 	if ((taskType == MODIFY_TASK && !modifyRequiresMasterEvaluation) ||
 		taskType == SQL_TASK)
@@ -2534,7 +2468,6 @@ bool
 CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
 {
 	bool coPartitionedTables = true;
-	uint32 intervalIndex = 0;
 	DistTableCacheEntry *firstTableCache = DistributedTableCacheEntry(firstRelationId);
 	DistTableCacheEntry *secondTableCache = DistributedTableCacheEntry(secondRelationId);
 	ShardInterval **sortedFirstIntervalArray = firstTableCache->sortedShardIntervalArray;
@@ -2588,7 +2521,7 @@ CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
 	 * and if any pair of shard intervals are not equal or they are not located
 	 * in the same node it returns false.
 	 */
-	for (intervalIndex = 0; intervalIndex < firstListShardCount; intervalIndex++)
+	for (uint32 intervalIndex = 0; intervalIndex < firstListShardCount; intervalIndex++)
 	{
 		ShardInterval *firstInterval = sortedFirstIntervalArray[intervalIndex];
 		ShardInterval *secondInterval = sortedSecondIntervalArray[intervalIndex];
@@ -2654,15 +2587,11 @@ ShardIntervalsEqual(FmgrInfo *comparisonFunction, ShardInterval *firstInterval,
 					ShardInterval *secondInterval)
 {
 	bool shardIntervalsEqual = false;
-	Datum firstMin = 0;
-	Datum firstMax = 0;
-	Datum secondMin = 0;
-	Datum secondMax = 0;
 
-	firstMin = firstInterval->minValue;
-	firstMax = firstInterval->maxValue;
-	secondMin = secondInterval->minValue;
-	secondMax = secondInterval->maxValue;
+	Datum firstMin = firstInterval->minValue;
+	Datum firstMax = firstInterval->maxValue;
+	Datum secondMin = secondInterval->minValue;
+	Datum secondMax = secondInterval->maxValue;
 
 	if (firstInterval->minValueExists && firstInterval->maxValueExists &&
 		secondInterval->minValueExists && secondInterval->maxValueExists)
@@ -2698,10 +2627,6 @@ SqlTaskList(Job *job)
 	uint64 jobId = job->jobId;
 	bool anchorRangeTableBasedAssignment = false;
 	uint32 anchorRangeTableId = 0;
-	Node *whereClauseTree = NULL;
-	List *rangeTableFragmentsList = NIL;
-	List *fragmentCombinationList = NIL;
-	ListCell *fragmentCombinationCell = NULL;
 
 	Query *jobQuery = job->jobQuery;
 	List *rangeTableList = jobQuery->rtable;
@@ -2732,7 +2657,8 @@ SqlTaskList(Job *job)
 	 * that the query string is generated as (...) AND (...) as opposed to
 	 * (...), (...).
 	 */
-	whereClauseTree = (Node *) make_ands_explicit((List *) jobQuery->jointree->quals);
+	Node *whereClauseTree = (Node *) make_ands_explicit(
+		(List *) jobQuery->jointree->quals);
 	jobQuery->jointree->quals = whereClauseTree;
 
 	/*
@@ -2740,8 +2666,9 @@ SqlTaskList(Job *job)
 	 * We also apply partition pruning based on the selection criteria. If all
 	 * range table fragments are pruned away, we return an empty task list.
 	 */
-	rangeTableFragmentsList = RangeTableFragmentsList(rangeTableList, whereClauseList,
-													  dependedJobList);
+	List *rangeTableFragmentsList = RangeTableFragmentsList(rangeTableList,
+															whereClauseList,
+															dependedJobList);
 	if (rangeTableFragmentsList == NIL)
 	{
 		return NIL;
@@ -2752,35 +2679,31 @@ SqlTaskList(Job *job)
 	 * with each other (and apply join pruning). Each fragment combination then
 	 * represents one SQL task's dependencies.
 	 */
-	fragmentCombinationList = FragmentCombinationList(rangeTableFragmentsList,
-													  jobQuery, dependedJobList);
+	List *fragmentCombinationList = FragmentCombinationList(rangeTableFragmentsList,
+															jobQuery, dependedJobList);
 
-	fragmentCombinationCell = NULL;
+	ListCell *fragmentCombinationCell = NULL;
 	foreach(fragmentCombinationCell, fragmentCombinationList)
 	{
 		List *fragmentCombination = (List *) lfirst(fragmentCombinationCell);
-		List *dataFetchTaskList = NIL;
-		int32 dataFetchTaskCount = 0;
-		StringInfo sqlQueryString = NULL;
-		Task *sqlTask = NULL;
-		Query *taskQuery = NULL;
-		List *fragmentRangeTableList = NIL;
 
 		/* create tasks to fetch fragments required for the sql task */
-		dataFetchTaskList = DataFetchTaskList(jobId, taskIdIndex, fragmentCombination);
-		dataFetchTaskCount = list_length(dataFetchTaskList);
+		List *dataFetchTaskList = DataFetchTaskList(jobId, taskIdIndex,
+													fragmentCombination);
+		int32 dataFetchTaskCount = list_length(dataFetchTaskList);
 		taskIdIndex += dataFetchTaskCount;
 
 		/* update range table entries with fragment aliases (in place) */
-		taskQuery = copyObject(jobQuery);
-		fragmentRangeTableList = taskQuery->rtable;
+		Query *taskQuery = copyObject(jobQuery);
+		List *fragmentRangeTableList = taskQuery->rtable;
 		UpdateRangeTableAlias(fragmentRangeTableList, fragmentCombination);
 
 		/* transform the updated task query to a SQL query string */
-		sqlQueryString = makeStringInfo();
+		StringInfo sqlQueryString = makeStringInfo();
 		pg_get_query_def(taskQuery, sqlQueryString);
 
-		sqlTask = CreateBasicTask(jobId, taskIdIndex, SQL_TASK, sqlQueryString->data);
+		Task *sqlTask = CreateBasicTask(jobId, taskIdIndex, SQL_TASK,
+										sqlQueryString->data);
 		sqlTask->dependedTaskList = dataFetchTaskList;
 		sqlTask->relationShardList = BuildRelationShardList(fragmentRangeTableList,
 															fragmentCombination);
@@ -3049,16 +2972,14 @@ RangeTableFragmentsList(List *rangeTableList, List *whereClauseList,
 		}
 		else if (rangeTableKind == CITUS_RTE_REMOTE_QUERY)
 		{
-			MapMergeJob *dependedMapMergeJob = NULL;
 			List *mergeTaskFragmentList = NIL;
-			List *mergeTaskList = NIL;
 			ListCell *mergeTaskCell = NULL;
 
 			Job *dependedJob = JobForRangeTable(dependedJobList, rangeTableEntry);
 			Assert(CitusIsA(dependedJob, MapMergeJob));
 
-			dependedMapMergeJob = (MapMergeJob *) dependedJob;
-			mergeTaskList = dependedMapMergeJob->mergeTaskList;
+			MapMergeJob *dependedMapMergeJob = (MapMergeJob *) dependedJob;
+			List *mergeTaskList = dependedMapMergeJob->mergeTaskList;
 
 			/* if there are no tasks for the depended job, just return NIL */
 			if (mergeTaskList == NIL)
@@ -3099,16 +3020,12 @@ RangeTableFragmentsList(List *rangeTableList, List *whereClauseList,
 Node *
 BuildBaseConstraint(Var *column)
 {
-	Node *baseConstraint = NULL;
-	OpExpr *lessThanExpr = NULL;
-	OpExpr *greaterThanExpr = NULL;
-
 	/* Build these expressions with only one argument for now */
-	lessThanExpr = MakeOpExpression(column, BTLessEqualStrategyNumber);
-	greaterThanExpr = MakeOpExpression(column, BTGreaterEqualStrategyNumber);
+	OpExpr *lessThanExpr = MakeOpExpression(column, BTLessEqualStrategyNumber);
+	OpExpr *greaterThanExpr = MakeOpExpression(column, BTGreaterEqualStrategyNumber);
 
 	/* Build base constaint as an and of two qual conditions */
-	baseConstraint = make_and_qual((Node *) lessThanExpr, (Node *) greaterThanExpr);
+	Node *baseConstraint = make_and_qual((Node *) lessThanExpr, (Node *) greaterThanExpr);
 
 	return baseConstraint;
 }
@@ -3126,19 +3043,14 @@ MakeOpExpression(Var *variable, int16 strategyNumber)
 	Oid typeModId = variable->vartypmod;
 	Oid collationId = variable->varcollid;
 
-	OperatorCacheEntry *operatorCacheEntry = NULL;
 	Oid accessMethodId = BTREE_AM_OID;
-	Oid operatorId = InvalidOid;
-	Oid operatorClassInputType = InvalidOid;
-	Const *constantValue = NULL;
-	OpExpr *expression = NULL;
-	char typeType = 0;
 
-	operatorCacheEntry = LookupOperatorByType(typeId, accessMethodId, strategyNumber);
+	OperatorCacheEntry *operatorCacheEntry = LookupOperatorByType(typeId, accessMethodId,
+																  strategyNumber);
 
-	operatorId = operatorCacheEntry->operatorId;
-	operatorClassInputType = operatorCacheEntry->operatorClassInputType;
-	typeType = operatorCacheEntry->typeType;
+	Oid operatorId = operatorCacheEntry->operatorId;
+	Oid operatorClassInputType = operatorCacheEntry->operatorClassInputType;
+	char typeType = operatorCacheEntry->typeType;
 
 	/*
 	 * Relabel variable if input type of default operator class is not equal to
@@ -3151,15 +3063,15 @@ MakeOpExpression(Var *variable, int16 strategyNumber)
 										   -1, collationId, COERCE_IMPLICIT_CAST);
 	}
 
-	constantValue = makeNullConst(operatorClassInputType, typeModId, collationId);
+	Const *constantValue = makeNullConst(operatorClassInputType, typeModId, collationId);
 
 	/* Now make the expression with the given variable and a null constant */
-	expression = (OpExpr *) make_opclause(operatorId,
-										  InvalidOid, /* no result type yet */
-										  false,      /* no return set */
-										  (Expr *) variable,
-										  (Expr *) constantValue,
-										  InvalidOid, collationId);
+	OpExpr *expression = (OpExpr *) make_opclause(operatorId,
+												  InvalidOid, /* no result type yet */
+												  false, /* no return set */
+												  (Expr *) variable,
+												  (Expr *) constantValue,
+												  InvalidOid, collationId);
 
 	/* Set implementing function id and result type */
 	expression->opfuncid = get_opcode(operatorId);
@@ -3200,11 +3112,7 @@ LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
 	/* if not found in the cache, call GetOperatorByType and put the result in cache */
 	if (matchingCacheEntry == NULL)
 	{
-		MemoryContext oldContext = NULL;
 		Oid operatorClassId = GetDefaultOpClass(typeId, accessMethodId);
-		Oid operatorId = InvalidOid;
-		Oid operatorClassInputType = InvalidOid;
-		char typeType = InvalidOid;
 
 		if (operatorClassId == InvalidOid)
 		{
@@ -3214,9 +3122,9 @@ LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
 		}
 
 		/* fill the other fields to the cache */
-		operatorId = GetOperatorByType(typeId, accessMethodId, strategyNumber);
-		operatorClassInputType = get_opclass_input_type(operatorClassId);
-		typeType = get_typtype(operatorClassInputType);
+		Oid operatorId = GetOperatorByType(typeId, accessMethodId, strategyNumber);
+		Oid operatorClassInputType = get_opclass_input_type(operatorClassId);
+		char typeType = get_typtype(operatorClassInputType);
 
 		/* make sure we've initialized CacheMemoryContext */
 		if (CacheMemoryContext == NULL)
@@ -3224,7 +3132,7 @@ LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
 			CreateCacheMemoryContext();
 		}
 
-		oldContext = MemoryContextSwitchTo(CacheMemoryContext);
+		MemoryContext oldContext = MemoryContextSwitchTo(CacheMemoryContext);
 
 		matchingCacheEntry = palloc0(sizeof(OperatorCacheEntry));
 		matchingCacheEntry->typeId = typeId;
@@ -3392,8 +3300,6 @@ UpdateConstraint(Node *baseConstraint, ShardInterval *shardInterval)
 
 	Node *minNode = get_rightop((Expr *) greaterThanExpr); /* right op */
 	Node *maxNode = get_rightop((Expr *) lessThanExpr);    /* right op */
-	Const *minConstant = NULL;
-	Const *maxConstant = NULL;
 
 	Assert(shardInterval != NULL);
 	Assert(shardInterval->minValueExists);
@@ -3401,8 +3307,8 @@ UpdateConstraint(Node *baseConstraint, ShardInterval *shardInterval)
 	Assert(IsA(minNode, Const));
 	Assert(IsA(maxNode, Const));
 
-	minConstant = (Const *) minNode;
-	maxConstant = (Const *) maxNode;
+	Const *minConstant = (Const *) minNode;
+	Const *maxConstant = (Const *) maxNode;
 
 	minConstant->constvalue = shardInterval->minValue;
 	maxConstant->constvalue = shardInterval->maxValue;
@@ -3425,13 +3331,13 @@ FragmentCombinationList(List *rangeTableFragmentsList, Query *jobQuery,
 						List *dependedJobList)
 {
 	List *fragmentCombinationList = NIL;
-	JoinSequenceNode *joinSequenceArray = NULL;
 	List *fragmentCombinationQueue = NIL;
 	List *emptyList = NIL;
 
 	/* find a sequence that joins the range tables in the list */
-	joinSequenceArray = JoinSequenceArray(rangeTableFragmentsList, jobQuery,
-										  dependedJobList);
+	JoinSequenceNode *joinSequenceArray = JoinSequenceArray(rangeTableFragmentsList,
+															jobQuery,
+															dependedJobList);
 
 	/*
 	 * We use breadth-first search with pruning to create fragment combinations.
@@ -3441,25 +3347,19 @@ FragmentCombinationList(List *rangeTableFragmentsList, Query *jobQuery,
 	fragmentCombinationQueue = lappend(fragmentCombinationQueue, emptyList);
 	while (fragmentCombinationQueue != NIL)
 	{
-		List *fragmentCombination = NIL;
-		int32 joinSequenceIndex = 0;
-		uint32 tableId = 0;
-		List *tableFragments = NIL;
 		ListCell *tableFragmentCell = NULL;
-		int32 joiningTableId = NON_PRUNABLE_JOIN;
 		int32 joiningTableSequenceIndex = -1;
-		int32 rangeTableCount = 0;
 
 		/* pop first element from the fragment queue */
-		fragmentCombination = linitial(fragmentCombinationQueue);
+		List *fragmentCombination = linitial(fragmentCombinationQueue);
 		fragmentCombinationQueue = list_delete_first(fragmentCombinationQueue);
 
 		/*
 		 * If this combination covered all range tables in a join sequence, add
 		 * this combination to our result set.
 		 */
-		joinSequenceIndex = list_length(fragmentCombination);
-		rangeTableCount = list_length(rangeTableFragmentsList);
+		int32 joinSequenceIndex = list_length(fragmentCombination);
+		int32 rangeTableCount = list_length(rangeTableFragmentsList);
 		if (joinSequenceIndex == rangeTableCount)
 		{
 			fragmentCombinationList = lappend(fragmentCombinationList,
@@ -3468,15 +3368,16 @@ FragmentCombinationList(List *rangeTableFragmentsList, Query *jobQuery,
 		}
 
 		/* find the next range table to add to our search space */
-		tableId = joinSequenceArray[joinSequenceIndex].rangeTableId;
-		tableFragments = FindRangeTableFragmentsList(rangeTableFragmentsList, tableId);
+		uint32 tableId = joinSequenceArray[joinSequenceIndex].rangeTableId;
+		List *tableFragments = FindRangeTableFragmentsList(rangeTableFragmentsList,
+														   tableId);
 
 		/* resolve sequence index for the previous range table we join against */
-		joiningTableId = joinSequenceArray[joinSequenceIndex].joiningRangeTableId;
+		int32 joiningTableId = joinSequenceArray[joinSequenceIndex].joiningRangeTableId;
 		if (joiningTableId != NON_PRUNABLE_JOIN)
 		{
-			int32 sequenceIndex = 0;
-			for (sequenceIndex = 0; sequenceIndex < rangeTableCount; sequenceIndex++)
+			for (int32 sequenceIndex = 0; sequenceIndex < rangeTableCount;
+				 sequenceIndex++)
 			{
 				JoinSequenceNode *joinSequenceNode = &joinSequenceArray[sequenceIndex];
 				if (joinSequenceNode->rangeTableId == joiningTableId)
@@ -3537,12 +3438,11 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *depended
 	uint32 rangeTableCount = (uint32) list_length(rangeTableList);
 	uint32 sequenceNodeSize = sizeof(JoinSequenceNode);
 	uint32 joinedTableCount = 0;
-	List *joinExprList = NIL;
 	ListCell *joinExprCell = NULL;
 	uint32 firstRangeTableId = 1;
 	JoinSequenceNode *joinSequenceArray = palloc0(rangeTableCount * sequenceNodeSize);
 
-	joinExprList = JoinExprList(jobQuery->jointree);
+	List *joinExprList = JoinExprList(jobQuery->jointree);
 
 	/* pick first range table as starting table for the join sequence */
 	if (list_length(joinExprList) > 0)
@@ -3565,7 +3465,6 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *depended
 	{
 		JoinExpr *joinExpr = (JoinExpr *) lfirst(joinExprCell);
 		RangeTblRef *rightTableRef = (RangeTblRef *) joinExpr->rarg;
-		JoinSequenceNode *nextJoinSequenceNode = NULL;
 		uint32 nextRangeTableId = rightTableRef->rtindex;
 		ListCell *nextJoinClauseCell = NULL;
 		Index existingRangeTableId = 0;
@@ -3591,27 +3490,21 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *depended
 		foreach(nextJoinClauseCell, nextJoinClauseList)
 		{
 			OpExpr *nextJoinClause = (OpExpr *) lfirst(nextJoinClauseCell);
-			Var *leftColumn = NULL;
-			Var *rightColumn = NULL;
-			Index leftRangeTableId = 0;
-			Index rightRangeTableId = 0;
-			bool leftPartitioned = false;
-			bool rightPartitioned = false;
 
 			if (!IsJoinClause((Node *) nextJoinClause))
 			{
 				continue;
 			}
 
-			leftColumn = LeftColumnOrNULL(nextJoinClause);
-			rightColumn = RightColumnOrNULL(nextJoinClause);
+			Var *leftColumn = LeftColumnOrNULL(nextJoinClause);
+			Var *rightColumn = RightColumnOrNULL(nextJoinClause);
 			if (leftColumn == NULL || rightColumn == NULL)
 			{
 				continue;
 			}
 
-			leftRangeTableId = leftColumn->varno;
-			rightRangeTableId = rightColumn->varno;
+			Index leftRangeTableId = leftColumn->varno;
+			Index rightRangeTableId = rightColumn->varno;
 
 			/*
 			 * We have a table from the existing join list joining with the next
@@ -3636,10 +3529,10 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *depended
 				continue;
 			}
 
-			leftPartitioned = PartitionedOnColumn(leftColumn, rangeTableList,
-												  dependedJobList);
-			rightPartitioned = PartitionedOnColumn(rightColumn, rangeTableList,
-												   dependedJobList);
+			bool leftPartitioned = PartitionedOnColumn(leftColumn, rangeTableList,
+													   dependedJobList);
+			bool rightPartitioned = PartitionedOnColumn(rightColumn, rangeTableList,
+														dependedJobList);
 			if (leftPartitioned && rightPartitioned)
 			{
 				/* make sure this join clause references only simple columns */
@@ -3651,7 +3544,7 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *depended
 		}
 
 		/* set next joining range table's info in the join sequence */
-		nextJoinSequenceNode = &joinSequenceArray[joinedTableCount];
+		JoinSequenceNode *nextJoinSequenceNode = &joinSequenceArray[joinedTableCount];
 		if (applyJoinPruning)
 		{
 			nextJoinSequenceNode->rangeTableId = nextRangeTableId;
@@ -3707,9 +3600,6 @@ PartitionedOnColumn(Var *column, List *rangeTableList, List *dependedJobList)
 	{
 		Job *job = JobForRangeTable(dependedJobList, rangeTableEntry);
 		MapMergeJob *mapMergeJob = (MapMergeJob *) job;
-		Var *partitionColumn = NULL;
-		Var *remoteRelationColumn = NULL;
-		TargetEntry *targetEntry = NULL;
 
 		/*
 		 * The column's current attribute number is it's location in the target
@@ -3722,12 +3612,12 @@ PartitionedOnColumn(Var *column, List *rangeTableList, List *dependedJobList)
 		Assert(columnIndex >= 0);
 		Assert(columnIndex < list_length(targetEntryList));
 
-		targetEntry = (TargetEntry *) list_nth(targetEntryList, columnIndex);
-		remoteRelationColumn = (Var *) targetEntry->expr;
+		TargetEntry *targetEntry = (TargetEntry *) list_nth(targetEntryList, columnIndex);
+		Var *remoteRelationColumn = (Var *) targetEntry->expr;
 		Assert(IsA(remoteRelationColumn, Var));
 
 		/* retrieve the partition column for the job */
-		partitionColumn = mapMergeJob->partitionColumn;
+		Var *partitionColumn = mapMergeJob->partitionColumn;
 		if (partitionColumn->varattno == remoteRelationColumn->varattno)
 		{
 			partitionedOnColumn = true;
@@ -3800,9 +3690,6 @@ static bool
 JoinPrunable(RangeTableFragment *leftFragment, RangeTableFragment *rightFragment)
 {
 	bool joinPrunable = false;
-	bool overlap = false;
-	ShardInterval *leftFragmentInterval = NULL;
-	ShardInterval *rightFragmentInterval = NULL;
 
 	/*
 	 * If both range tables are remote queries, we then have a hash repartition
@@ -3834,10 +3721,10 @@ JoinPrunable(RangeTableFragment *leftFragment, RangeTableFragment *rightFragment
 	 * We have a single (re)partition join. We now get shard intervals for both
 	 * fragments, and then check if these intervals overlap.
 	 */
-	leftFragmentInterval = FragmentInterval(leftFragment);
-	rightFragmentInterval = FragmentInterval(rightFragment);
+	ShardInterval *leftFragmentInterval = FragmentInterval(leftFragment);
+	ShardInterval *rightFragmentInterval = FragmentInterval(rightFragment);
 
-	overlap = ShardIntervalsOverlap(leftFragmentInterval, rightFragmentInterval);
+	bool overlap = ShardIntervalsOverlap(leftFragmentInterval, rightFragmentInterval);
 	if (!overlap)
 	{
 		if (IsLoggableLevel(DEBUG2))
@@ -3871,11 +3758,9 @@ FragmentInterval(RangeTableFragment *fragment)
 	}
 	else if (fragment->fragmentType == CITUS_RTE_REMOTE_QUERY)
 	{
-		Task *mergeTask = NULL;
-
 		Assert(CitusIsA(fragment->fragmentReference, Task));
 
-		mergeTask = (Task *) fragment->fragmentReference;
+		Task *mergeTask = (Task *) fragment->fragmentReference;
 		fragmentInterval = mergeTask->shardInterval;
 	}
 
@@ -3892,16 +3777,11 @@ ShardIntervalsOverlap(ShardInterval *firstInterval, ShardInterval *secondInterva
 		DistributedTableCacheEntry(firstInterval->relationId);
 	FmgrInfo *comparisonFunction = intervalRelation->shardIntervalCompareFunction;
 
-	Datum firstMin = 0;
-	Datum firstMax = 0;
-	Datum secondMin = 0;
-	Datum secondMax = 0;
 
-
-	firstMin = firstInterval->minValue;
-	firstMax = firstInterval->maxValue;
-	secondMin = secondInterval->minValue;
-	secondMax = secondInterval->maxValue;
+	Datum firstMin = firstInterval->minValue;
+	Datum firstMax = firstInterval->maxValue;
+	Datum secondMin = secondInterval->minValue;
+	Datum secondMax = secondInterval->maxValue;
 
 	/*
 	 * We need to have min/max values for both intervals first. Then, we assume
@@ -3934,25 +3814,21 @@ ShardIntervalsOverlap(ShardInterval *firstInterval, ShardInterval *secondInterva
 static StringInfo
 FragmentIntervalString(ShardInterval *fragmentInterval)
 {
-	StringInfo fragmentIntervalString = NULL;
 	Oid typeId = fragmentInterval->valueTypeId;
 	Oid outputFunctionId = InvalidOid;
 	bool typeVariableLength = false;
-	FmgrInfo *outputFunction = NULL;
-	char *minValueString = NULL;
-	char *maxValueString = NULL;
 
 	Assert(fragmentInterval->minValueExists);
 	Assert(fragmentInterval->maxValueExists);
 
-	outputFunction = (FmgrInfo *) palloc0(sizeof(FmgrInfo));
+	FmgrInfo *outputFunction = (FmgrInfo *) palloc0(sizeof(FmgrInfo));
 	getTypeOutputInfo(typeId, &outputFunctionId, &typeVariableLength);
 	fmgr_info(outputFunctionId, outputFunction);
 
-	minValueString = OutputFunctionCall(outputFunction, fragmentInterval->minValue);
-	maxValueString = OutputFunctionCall(outputFunction, fragmentInterval->maxValue);
+	char *minValueString = OutputFunctionCall(outputFunction, fragmentInterval->minValue);
+	char *maxValueString = OutputFunctionCall(outputFunction, fragmentInterval->maxValue);
 
-	fragmentIntervalString = makeStringInfo();
+	StringInfo fragmentIntervalString = makeStringInfo();
 	appendStringInfo(fragmentIntervalString, "[%s,%s]", minValueString, maxValueString);
 
 	return fragmentIntervalString;
@@ -3996,30 +3872,24 @@ DataFetchTaskList(uint64 jobId, uint32 taskIdIndex, List *fragmentList)
 static StringInfo
 DatumArrayString(Datum *datumArray, uint32 datumCount, Oid datumTypeId)
 {
-	StringInfo arrayStringInfo = NULL;
-	FmgrInfo *arrayOutFunction = NULL;
-	ArrayType *arrayObject = NULL;
-	Datum arrayObjectDatum = 0;
-	Datum arrayStringDatum = 0;
-	char *arrayString = NULL;
 	int16 typeLength = 0;
 	bool typeByValue = false;
 	char typeAlignment = 0;
 
 	/* construct the array object from the given array */
 	get_typlenbyvalalign(datumTypeId, &typeLength, &typeByValue, &typeAlignment);
-	arrayObject = construct_array(datumArray, datumCount, datumTypeId,
-								  typeLength, typeByValue, typeAlignment);
-	arrayObjectDatum = PointerGetDatum(arrayObject);
+	ArrayType *arrayObject = construct_array(datumArray, datumCount, datumTypeId,
+											 typeLength, typeByValue, typeAlignment);
+	Datum arrayObjectDatum = PointerGetDatum(arrayObject);
 
 	/* convert the array object to its string representation */
-	arrayOutFunction = (FmgrInfo *) palloc0(sizeof(FmgrInfo));
+	FmgrInfo *arrayOutFunction = (FmgrInfo *) palloc0(sizeof(FmgrInfo));
 	fmgr_info(ARRAY_OUT_FUNC_ID, arrayOutFunction);
 
-	arrayStringDatum = FunctionCall1(arrayOutFunction, arrayObjectDatum);
-	arrayString = DatumGetCString(arrayStringDatum);
+	Datum arrayStringDatum = FunctionCall1(arrayOutFunction, arrayObjectDatum);
+	char *arrayString = DatumGetCString(arrayStringDatum);
 
-	arrayStringInfo = makeStringInfo();
+	StringInfo arrayStringInfo = makeStringInfo();
 	appendStringInfo(arrayStringInfo, "%s", arrayString);
 
 	return arrayStringInfo;
@@ -4108,7 +3978,6 @@ UpdateRangeTableAlias(List *rangeTableList, List *fragmentList)
 static Alias *
 FragmentAlias(RangeTblEntry *rangeTableEntry, RangeTableFragment *fragment)
 {
-	Alias *alias = NULL;
 	char *aliasName = NULL;
 	char *schemaName = NULL;
 	char *fragmentName = NULL;
@@ -4163,7 +4032,7 @@ FragmentAlias(RangeTblEntry *rangeTableEntry, RangeTableFragment *fragment)
 	 * We need to set the aliasname to relation name, as pg_get_query_def() uses
 	 * the relation name to disambiguate column names from different tables.
 	 */
-	alias = rangeTableEntry->alias;
+	Alias *alias = rangeTableEntry->alias;
 	if (alias == NULL)
 	{
 		alias = makeNode(Alias);
@@ -4194,12 +4063,10 @@ AnchorShardId(List *fragmentList, uint32 anchorRangeTableId)
 		RangeTableFragment *fragment = (RangeTableFragment *) lfirst(fragmentCell);
 		if (fragment->rangeTableId == anchorRangeTableId)
 		{
-			ShardInterval *shardInterval = NULL;
-
 			Assert(fragment->fragmentType == CITUS_RTE_RELATION);
 			Assert(CitusIsA(fragment->fragmentReference, ShardInterval));
 
-			shardInterval = (ShardInterval *) fragment->fragmentReference;
+			ShardInterval *shardInterval = (ShardInterval *) fragment->fragmentReference;
 			anchorShardId = shardInterval->shardId;
 			break;
 		}
@@ -4237,11 +4104,10 @@ PruneSqlTaskDependencies(List *sqlTaskList)
 			 */
 			if (dataFetchTask->taskType == MERGE_FETCH_TASK)
 			{
-				Task *mergeTaskReference = NULL;
 				List *mergeFetchDependencyList = dataFetchTask->dependedTaskList;
 				Assert(list_length(mergeFetchDependencyList) == 1);
 
-				mergeTaskReference = (Task *) linitial(mergeFetchDependencyList);
+				Task *mergeTaskReference = (Task *) linitial(mergeFetchDependencyList);
 				prunedDependedTaskList = lappend(prunedDependedTaskList,
 												 mergeTaskReference);
 
@@ -4298,7 +4164,6 @@ MapTaskList(MapMergeJob *mapMergeJob, List *filterTaskList)
 		Task *filterTask = (Task *) lfirst(filterTaskCell);
 		uint64 jobId = filterTask->jobId;
 		uint32 taskId = filterTask->taskId;
-		Task *mapTask = NULL;
 
 		/* wrap repartition query string around filter query string */
 		StringInfo mapQueryString = makeStringInfo();
@@ -4349,7 +4214,7 @@ MapTaskList(MapMergeJob *mapMergeJob, List *filterTaskList)
 		}
 
 		/* convert filter query task into map task */
-		mapTask = filterTask;
+		Task *mapTask = filterTask;
 		mapTask->queryString = mapQueryString->data;
 		mapTask->taskType = MAP_TASK;
 
@@ -4373,9 +4238,8 @@ GenerateSyntheticShardIntervalArray(int partitionCount)
 	ShardInterval **shardIntervalArray = palloc0(partitionCount *
 												 sizeof(ShardInterval *));
 	uint64 hashTokenIncrement = HASH_TOKEN_COUNT / partitionCount;
-	int shardIndex = 0;
 
-	for (shardIndex = 0; shardIndex < partitionCount; ++shardIndex)
+	for (int shardIndex = 0; shardIndex < partitionCount; ++shardIndex)
 	{
 		ShardInterval *shardInterval = CitusMakeNode(ShardInterval);
 
@@ -4477,14 +4341,9 @@ ColumnName(Var *column, List *rangeTableList)
 static StringInfo
 SplitPointArrayString(ArrayType *splitPointObject, Oid columnType, int32 columnTypeMod)
 {
-	StringInfo splitPointArrayString = NULL;
 	Datum splitPointDatum = PointerGetDatum(splitPointObject);
 	Oid outputFunctionId = InvalidOid;
 	bool typeVariableLength = false;
-	FmgrInfo *arrayOutFunction = NULL;
-	char *arrayOutputText = NULL;
-	char *arrayOutputEscapedText = NULL;
-	char *arrayOutTypeName = NULL;
 
 	Oid arrayOutType = get_array_type(columnType);
 	if (arrayOutType == InvalidOid)
@@ -4494,17 +4353,17 @@ SplitPointArrayString(ArrayType *splitPointObject, Oid columnType, int32 columnT
 							   columnTypeName)));
 	}
 
-	arrayOutFunction = (FmgrInfo *) palloc0(sizeof(FmgrInfo));
+	FmgrInfo *arrayOutFunction = (FmgrInfo *) palloc0(sizeof(FmgrInfo));
 	getTypeOutputInfo(arrayOutType, &outputFunctionId, &typeVariableLength);
 	fmgr_info(outputFunctionId, arrayOutFunction);
 
-	arrayOutputText = OutputFunctionCall(arrayOutFunction, splitPointDatum);
-	arrayOutputEscapedText = quote_literal_cstr(arrayOutputText);
+	char *arrayOutputText = OutputFunctionCall(arrayOutFunction, splitPointDatum);
+	char *arrayOutputEscapedText = quote_literal_cstr(arrayOutputText);
 
 	/* add an explicit cast to array's string representation */
-	arrayOutTypeName = format_type_with_typemod(arrayOutType, columnTypeMod);
+	char *arrayOutTypeName = format_type_with_typemod(arrayOutType, columnTypeMod);
 
-	splitPointArrayString = makeStringInfo();
+	StringInfo splitPointArrayString = makeStringInfo();
 	appendStringInfo(splitPointArrayString, "%s::%s",
 					 arrayOutputEscapedText, arrayOutTypeName);
 
@@ -4523,8 +4382,6 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 	List *mergeTaskList = NIL;
 	uint64 jobId = mapMergeJob->job.jobId;
 	uint32 partitionCount = mapMergeJob->partitionCount;
-	uint32 partitionId = 0;
-	uint32 initialPartitionId = 0;
 
 	/* build column name and column type arrays (table schema) */
 	Query *filterQuery = mapMergeJob->job.jobQuery;
@@ -4543,7 +4400,7 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 	 * range re-partitioned OUTER joins, we will need these rows for the
 	 * relation whose rows are retained in the OUTER join.
 	 */
-	initialPartitionId = 0;
+	uint32 initialPartitionId = 0;
 	if (mapMergeJob->partitionType == RANGE_PARTITION_TYPE)
 	{
 		initialPartitionId = 1;
@@ -4555,7 +4412,8 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 	}
 
 	/* build merge tasks and their associated "map output fetch" tasks */
-	for (partitionId = initialPartitionId; partitionId < partitionCount; partitionId++)
+	for (uint32 partitionId = initialPartitionId; partitionId < partitionCount;
+		 partitionId++)
 	{
 		Task *mergeTask = NULL;
 		List *mapOutputFetchTaskList = NIL;
@@ -4652,7 +4510,6 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 static StringInfo
 ColumnNameArrayString(uint32 columnCount, uint64 generatingJobId)
 {
-	StringInfo columnNameArrayString = NULL;
 	Datum *columnNameArray = palloc0(columnCount * sizeof(Datum));
 	uint32 columnNameIndex = 0;
 
@@ -4670,7 +4527,8 @@ ColumnNameArrayString(uint32 columnCount, uint64 generatingJobId)
 		columnNameIndex++;
 	}
 
-	columnNameArrayString = DatumArrayString(columnNameArray, columnCount, CSTRINGOID);
+	StringInfo columnNameArrayString = DatumArrayString(columnNameArray, columnCount,
+														CSTRINGOID);
 
 	return columnNameArrayString;
 }
@@ -4683,7 +4541,6 @@ ColumnNameArrayString(uint32 columnCount, uint64 generatingJobId)
 static StringInfo
 ColumnTypeArrayString(List *targetEntryList)
 {
-	StringInfo columnTypeArrayString = NULL;
 	ListCell *targetEntryCell = NULL;
 
 	uint32 columnCount = (uint32) list_length(targetEntryList);
@@ -4704,7 +4561,8 @@ ColumnTypeArrayString(List *targetEntryList)
 		columnTypeIndex++;
 	}
 
-	columnTypeArrayString = DatumArrayString(columnTypeArray, columnCount, CSTRINGOID);
+	StringInfo columnTypeArrayString = DatumArrayString(columnTypeArray, columnCount,
+														CSTRINGOID);
 
 	return columnTypeArrayString;
 }
@@ -4721,13 +4579,10 @@ static List *
 AssignTaskList(List *sqlTaskList)
 {
 	List *assignedSqlTaskList = NIL;
-	Task *firstSqlTask = NULL;
 	bool hasAnchorShardId = false;
-	bool hasMergeTaskDependencies = false;
 	ListCell *sqlTaskCell = NULL;
 	List *primarySqlTaskList = NIL;
 	ListCell *primarySqlTaskCell = NULL;
-	List *constrainedSqlTaskList = NIL;
 	ListCell *constrainedSqlTaskCell = NULL;
 
 	/* no tasks to assign */
@@ -4736,7 +4591,7 @@ AssignTaskList(List *sqlTaskList)
 		return NIL;
 	}
 
-	firstSqlTask = (Task *) linitial(sqlTaskList);
+	Task *firstSqlTask = (Task *) linitial(sqlTaskList);
 	if (firstSqlTask->anchorShardId != INVALID_SHARD_ID)
 	{
 		hasAnchorShardId = true;
@@ -4747,7 +4602,7 @@ AssignTaskList(List *sqlTaskList)
 	 * one independently of the other. We therefore go ahead and assign these
 	 * SQL tasks using the "anchor shard based" assignment algorithms.
 	 */
-	hasMergeTaskDependencies = HasMergeTaskDependencies(sqlTaskList);
+	bool hasMergeTaskDependencies = HasMergeTaskDependencies(sqlTaskList);
 	if (!hasMergeTaskDependencies)
 	{
 		Assert(hasAnchorShardId);
@@ -4812,7 +4667,7 @@ AssignTaskList(List *sqlTaskList)
 	 * primary's task assignment. We propagate the primary's task assignment in
 	 * each set to the remaining (constrained) tasks.
 	 */
-	constrainedSqlTaskList = TaskListDifference(sqlTaskList, primarySqlTaskList);
+	List *constrainedSqlTaskList = TaskListDifference(sqlTaskList, primarySqlTaskList);
 
 	foreach(constrainedSqlTaskCell, constrainedSqlTaskList)
 	{
@@ -5024,7 +4879,6 @@ static List *
 GreedyAssignTaskList(List *taskList)
 {
 	List *assignedTaskList = NIL;
-	List *activeShardPlacementLists = NIL;
 	uint32 assignedTaskCount = 0;
 	uint32 taskCount = list_length(taskList);
 
@@ -5039,7 +4893,7 @@ GreedyAssignTaskList(List *taskList)
 	 * their insertion time, and append them to a new list.
 	 */
 	taskList = SortList(taskList, CompareTasksByShardId);
-	activeShardPlacementLists = ActiveShardPlacementLists(taskList);
+	List *activeShardPlacementLists = ActiveShardPlacementLists(taskList);
 
 	while (assignedTaskCount < taskCount)
 	{
@@ -5105,8 +4959,6 @@ GreedyAssignTask(WorkerNode *workerNode, List *taskList, List *activeShardPlacem
 		{
 			Task *task = (Task *) lfirst(taskCell);
 			List *placementList = (List *) lfirst(placementListCell);
-			ShardPlacement *placement = NULL;
-			uint32 placementCount = 0;
 
 			/* check if we already assigned this task */
 			if (task == NULL)
@@ -5115,13 +4967,14 @@ GreedyAssignTask(WorkerNode *workerNode, List *taskList, List *activeShardPlacem
 			}
 
 			/* check if we have enough replicas */
-			placementCount = list_length(placementList);
+			uint32 placementCount = list_length(placementList);
 			if (placementCount <= replicaIndex)
 			{
 				continue;
 			}
 
-			placement = (ShardPlacement *) list_nth(placementList, replicaIndex);
+			ShardPlacement *placement = (ShardPlacement *) list_nth(placementList,
+																	replicaIndex);
 			if ((strncmp(placement->nodeName, workerName, WORKER_LENGTH) == 0) &&
 				(placement->nodePort == workerPort))
 			{
@@ -5233,7 +5086,6 @@ static List *
 ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(Task *, List *))
 {
 	List *assignedTaskList = NIL;
-	List *activeShardPlacementLists = NIL;
 	ListCell *taskCell = NULL;
 	ListCell *placementListCell = NULL;
 	uint32 unAssignedTaskCount = 0;
@@ -5244,7 +5096,7 @@ ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(Task *, List 
 	 * these lists just to make our policy more deterministic.
 	 */
 	taskList = SortList(taskList, CompareTasksByShardId);
-	activeShardPlacementLists = ActiveShardPlacementLists(taskList);
+	List *activeShardPlacementLists = ActiveShardPlacementLists(taskList);
 
 	forboth(taskCell, taskList, placementListCell, activeShardPlacementLists)
 	{
@@ -5255,15 +5107,14 @@ ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(Task *, List 
 		uint32 activePlacementCount = list_length(placementList);
 		if (activePlacementCount > 0)
 		{
-			ShardPlacement *primaryPlacement = NULL;
-
 			if (reorderFunction != NULL)
 			{
 				placementList = reorderFunction(task, placementList);
 			}
 			task->taskPlacementList = placementList;
 
-			primaryPlacement = (ShardPlacement *) linitial(task->taskPlacementList);
+			ShardPlacement *primaryPlacement = (ShardPlacement *) linitial(
+				task->taskPlacementList);
 			ereport(DEBUG3, (errmsg("assigned task %u to node %s:%u", task->taskId,
 									primaryPlacement->nodeName,
 									primaryPlacement->nodePort)));
@@ -5395,10 +5246,9 @@ ActivePlacementList(List *placementList)
 	foreach(placementCell, placementList)
 	{
 		ShardPlacement *placement = (ShardPlacement *) lfirst(placementCell);
-		WorkerNode *workerNode = NULL;
 
 		/* check if the worker node for this shard placement is active */
-		workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
+		WorkerNode *workerNode = FindWorkerNode(placement->nodeName, placement->nodePort);
 		if (workerNode != NULL && workerNode->isActive)
 		{
 			activePlacementList = lappend(activePlacementList, placement);
@@ -5420,8 +5270,7 @@ LeftRotateList(List *list, uint32 rotateCount)
 {
 	List *rotatedList = list_copy(list);
 
-	uint32 rotateIndex = 0;
-	for (rotateIndex = 0; rotateIndex < rotateCount; rotateIndex++)
+	for (uint32 rotateIndex = 0; rotateIndex < rotateCount; rotateIndex++)
 	{
 		void *firstElement = linitial(rotatedList);
 
@@ -5489,10 +5338,9 @@ AssignDualHashTaskList(List *taskList)
 	{
 		Task *task = (Task *) lfirst(taskCell);
 		List *taskPlacementList = NIL;
-		ShardPlacement *primaryPlacement = NULL;
 
-		uint32 replicaIndex = 0;
-		for (replicaIndex = 0; replicaIndex < ShardReplicationFactor; replicaIndex++)
+		for (uint32 replicaIndex = 0; replicaIndex < ShardReplicationFactor;
+			 replicaIndex++)
 		{
 			uint32 assignmentOffset = beginningNodeIndex + assignedTaskIndex +
 									  replicaIndex;
@@ -5509,7 +5357,8 @@ AssignDualHashTaskList(List *taskList)
 
 		task->taskPlacementList = taskPlacementList;
 
-		primaryPlacement = (ShardPlacement *) linitial(task->taskPlacementList);
+		ShardPlacement *primaryPlacement = (ShardPlacement *) linitial(
+			task->taskPlacementList);
 		ereport(DEBUG3, (errmsg("assigned task %u to node %s:%u", task->taskId,
 								primaryPlacement->nodeName,
 								primaryPlacement->nodePort)));
@@ -5606,12 +5455,11 @@ MergeTableQueryString(uint32 taskIdIndex, List *targetEntryList)
 	StringInfo mergeTableName = makeStringInfo();
 	StringInfo columnsString = makeStringInfo();
 	ListCell *targetEntryCell = NULL;
-	uint32 columnCount = 0;
 	uint32 columnIndex = 0;
 
 	appendStringInfo(mergeTableName, "%s%s", taskTableName->data, MERGE_TABLE_SUFFIX);
 
-	columnCount = (uint32) list_length(targetEntryList);
+	uint32 columnCount = (uint32) list_length(targetEntryList);
 
 	foreach(targetEntryCell, targetEntryList)
 	{
@@ -5619,14 +5467,12 @@ MergeTableQueryString(uint32 taskIdIndex, List *targetEntryList)
 		Node *columnExpression = (Node *) targetEntry->expr;
 		Oid columnTypeId = exprType(columnExpression);
 		int32 columnTypeMod = exprTypmod(columnExpression);
-		char *columnName = NULL;
-		char *columnType = NULL;
 
 		StringInfo columnNameString = makeStringInfo();
 		appendStringInfo(columnNameString, MERGE_COLUMN_FORMAT, columnIndex);
 
-		columnName = columnNameString->data;
-		columnType = format_type_with_typemod(columnTypeId, columnTypeMod);
+		char *columnName = columnNameString->data;
+		char *columnType = format_type_with_typemod(columnTypeId, columnTypeMod);
 
 		appendStringInfo(columnsString, "%s %s", columnName, columnType);
 
@@ -5657,16 +5503,11 @@ IntermediateTableQueryString(uint64 jobId, uint32 taskIdIndex, Query *reduceQuer
 	StringInfo columnsString = makeStringInfo();
 	StringInfo taskReduceQueryString = makeStringInfo();
 	Query *taskReduceQuery = copyObject(reduceQuery);
-	RangeTblEntry *rangeTableEntry = NULL;
-	Alias *referenceNames = NULL;
-	List *columnNames = NIL;
-	List *rangeTableList = NIL;
 	ListCell *columnNameCell = NULL;
-	uint32 columnCount = 0;
 	uint32 columnIndex = 0;
 
-	columnCount = FinalTargetEntryCount(reduceQuery->targetList);
-	columnNames = DerivedColumnNameList(columnCount, jobId);
+	uint32 columnCount = FinalTargetEntryCount(reduceQuery->targetList);
+	List *columnNames = DerivedColumnNameList(columnCount, jobId);
 
 	foreach(columnNameCell, columnNames)
 	{
@@ -5684,9 +5525,9 @@ IntermediateTableQueryString(uint64 jobId, uint32 taskIdIndex, Query *reduceQuer
 
 	appendStringInfo(mergeTableName, "%s%s", taskTableName->data, MERGE_TABLE_SUFFIX);
 
-	rangeTableList = taskReduceQuery->rtable;
-	rangeTableEntry = (RangeTblEntry *) linitial(rangeTableList);
-	referenceNames = rangeTableEntry->eref;
+	List *rangeTableList = taskReduceQuery->rtable;
+	RangeTblEntry *rangeTableEntry = (RangeTblEntry *) linitial(rangeTableList);
+	Alias *referenceNames = rangeTableEntry->eref;
 	referenceNames->aliasname = mergeTableName->data;
 
 	rangeTableEntry->alias = rangeTableEntry->eref;

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -260,13 +260,11 @@ CreateSingleTaskRouterPlan(DistributedPlan *distributedPlan, Query *originalQuer
 						   Query *query,
 						   PlannerRestrictionContext *plannerRestrictionContext)
 {
-	Job *job = NULL;
-
 	distributedPlan->modLevel = RowModifyLevelForQuery(query);
 
 	/* we cannot have multi shard update/delete query via this code path */
-	job = RouterJob(originalQuery, plannerRestrictionContext,
-					&distributedPlan->planningError);
+	Job *job = RouterJob(originalQuery, plannerRestrictionContext,
+						 &distributedPlan->planningError);
 
 	if (distributedPlan->planningError != NULL)
 	{
@@ -302,7 +300,6 @@ ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
 	Oid relationId = shardInterval->relationId;
 	char partitionMethod = PartitionMethod(shardInterval->relationId);
 	Var *partitionColumn = NULL;
-	Node *baseConstraint = NULL;
 
 	if (partitionMethod == DISTRIBUTE_BY_HASH)
 	{
@@ -321,7 +318,7 @@ ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
 	}
 
 	/* build the base expression for constraint */
-	baseConstraint = BuildBaseConstraint(partitionColumn);
+	Node *baseConstraint = BuildBaseConstraint(partitionColumn);
 
 	/* walk over shard list and check if shards can be pruned */
 	if (shardInterval->minValueExists && shardInterval->maxValueExists)
@@ -349,14 +346,7 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 	List *targetList = subqery->targetList;
 	ListCell *targetEntryCell = NULL;
 	Var *targetPartitionColumnVar = NULL;
-	Oid integer4GEoperatorId = InvalidOid;
-	Oid integer4LEoperatorId = InvalidOid;
-	TypeCacheEntry *typeEntry = NULL;
-	FuncExpr *hashFunctionExpr = NULL;
-	OpExpr *greaterThanAndEqualsBoundExpr = NULL;
-	OpExpr *lessThanAndEqualsBoundExpr = NULL;
 	List *boundExpressionList = NIL;
-	Expr *andedBoundExpressions = NULL;
 
 	/* iterate through the target entries */
 	foreach(targetEntryCell, targetList)
@@ -374,20 +364,20 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 	/* we should have found target partition column */
 	Assert(targetPartitionColumnVar != NULL);
 
-	integer4GEoperatorId = get_opfamily_member(INTEGER_BTREE_FAM_OID, INT4OID,
-											   INT4OID,
-											   BTGreaterEqualStrategyNumber);
-	integer4LEoperatorId = get_opfamily_member(INTEGER_BTREE_FAM_OID, INT4OID,
-											   INT4OID,
-											   BTLessEqualStrategyNumber);
+	Oid integer4GEoperatorId = get_opfamily_member(INTEGER_BTREE_FAM_OID, INT4OID,
+												   INT4OID,
+												   BTGreaterEqualStrategyNumber);
+	Oid integer4LEoperatorId = get_opfamily_member(INTEGER_BTREE_FAM_OID, INT4OID,
+												   INT4OID,
+												   BTLessEqualStrategyNumber);
 
 	/* ensure that we find the correct operators */
 	Assert(integer4GEoperatorId != InvalidOid);
 	Assert(integer4LEoperatorId != InvalidOid);
 
 	/* look up the type cache */
-	typeEntry = lookup_type_cache(targetPartitionColumnVar->vartype,
-								  TYPECACHE_HASH_PROC_FINFO);
+	TypeCacheEntry *typeEntry = lookup_type_cache(targetPartitionColumnVar->vartype,
+												  TYPECACHE_HASH_PROC_FINFO);
 
 	/* probable never possible given that the tables are already hash partitioned */
 	if (!OidIsValid(typeEntry->hash_proc_finfo.fn_oid))
@@ -398,7 +388,7 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 	}
 
 	/* generate hashfunc(partCol) expression */
-	hashFunctionExpr = makeNode(FuncExpr);
+	FuncExpr *hashFunctionExpr = makeNode(FuncExpr);
 	hashFunctionExpr->funcid = CitusWorkerHashFunctionId();
 	hashFunctionExpr->args = list_make1(targetPartitionColumnVar);
 
@@ -406,7 +396,7 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 	hashFunctionExpr->funcresulttype = INT4OID;
 
 	/* generate hashfunc(partCol) >= shardMinValue OpExpr */
-	greaterThanAndEqualsBoundExpr =
+	OpExpr *greaterThanAndEqualsBoundExpr =
 		(OpExpr *) make_opclause(integer4GEoperatorId,
 								 InvalidOid, false,
 								 (Expr *) hashFunctionExpr,
@@ -421,7 +411,7 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 		get_func_rettype(greaterThanAndEqualsBoundExpr->opfuncid);
 
 	/* generate hashfunc(partCol) <= shardMinValue OpExpr */
-	lessThanAndEqualsBoundExpr =
+	OpExpr *lessThanAndEqualsBoundExpr =
 		(OpExpr *) make_opclause(integer4LEoperatorId,
 								 InvalidOid, false,
 								 (Expr *) hashFunctionExpr,
@@ -438,7 +428,7 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 	boundExpressionList = lappend(boundExpressionList, greaterThanAndEqualsBoundExpr);
 	boundExpressionList = lappend(boundExpressionList, lessThanAndEqualsBoundExpr);
 
-	andedBoundExpressions = make_ands_explicit(boundExpressionList);
+	Expr *andedBoundExpressions = make_ands_explicit(boundExpressionList);
 
 	/* finally add the quals */
 	if (subqery->jointree->quals == NULL)
@@ -461,19 +451,15 @@ AddShardIntervalRestrictionToSelect(Query *subqery, ShardInterval *shardInterval
 RangeTblEntry *
 ExtractSelectRangeTableEntry(Query *query)
 {
-	List *fromList = NULL;
-	RangeTblRef *reference = NULL;
-	RangeTblEntry *subqueryRte = NULL;
-
 	Assert(InsertSelectIntoDistributedTable(query));
 
 	/*
 	 * Since we already asserted InsertSelectIntoDistributedTable() it is safe to access
 	 * both lists
 	 */
-	fromList = query->jointree->fromlist;
-	reference = linitial(fromList);
-	subqueryRte = rt_fetch(reference->rtindex, query->rtable);
+	List *fromList = query->jointree->fromlist;
+	RangeTblRef *reference = linitial(fromList);
+	RangeTblEntry *subqueryRte = rt_fetch(reference->rtindex, query->rtable);
 
 	return subqueryRte;
 }
@@ -490,8 +476,6 @@ ExtractSelectRangeTableEntry(Query *query)
 Oid
 ModifyQueryResultRelationId(Query *query)
 {
-	RangeTblEntry *resultRte = NULL;
-
 	/* only modify queries have result relations */
 	if (!IsModifyCommand(query))
 	{
@@ -499,7 +483,7 @@ ModifyQueryResultRelationId(Query *query)
 						errmsg("input query is not a modification query")));
 	}
 
-	resultRte = ExtractResultRelationRTE(query);
+	RangeTblEntry *resultRte = ExtractResultRelationRTE(query);
 	Assert(OidIsValid(resultRte->relid));
 
 	return resultRte->relid;
@@ -562,7 +546,6 @@ DeferredErrorMessage *
 ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuery,
 					 PlannerRestrictionContext *plannerRestrictionContext)
 {
-	DeferredErrorMessage *deferredError = NULL;
 	Oid distributedTableId = ExtractFirstDistributedTableId(queryTree);
 	uint32 rangeTableId = 1;
 	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
@@ -571,7 +554,7 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 	uint32 queryTableCount = 0;
 	CmdType commandType = queryTree->commandType;
 
-	deferredError = DeferErrorIfModifyView(queryTree);
+	DeferredErrorMessage *deferredError = DeferErrorIfModifyView(queryTree);
 	if (deferredError != NULL)
 	{
 		return deferredError;
@@ -624,7 +607,6 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 		{
 			CommonTableExpr *cte = (CommonTableExpr *) lfirst(cteCell);
 			Query *cteQuery = (Query *) cte->ctequery;
-			DeferredErrorMessage *cteError = NULL;
 
 			if (cteQuery->commandType != CMD_SELECT)
 			{
@@ -649,7 +631,7 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 									 NULL, NULL);
 			}
 
-			cteError = MultiRouterPlannableQuery(cteQuery);
+			DeferredErrorMessage *cteError = MultiRouterPlannableQuery(cteQuery);
 			if (cteError)
 			{
 				return cteError;
@@ -957,12 +939,7 @@ DeferErrorIfModifyView(Query *queryTree)
 DeferredErrorMessage *
 ErrorIfOnConflictNotSupported(Query *queryTree)
 {
-	Oid distributedTableId = InvalidOid;
 	uint32 rangeTableId = 1;
-	Var *partitionColumn = NULL;
-	List *onConflictSet = NIL;
-	Node *arbiterWhere = NULL;
-	Node *onConflictWhere = NULL;
 	ListCell *setTargetCell = NULL;
 	bool specifiesPartitionValue = false;
 
@@ -972,12 +949,12 @@ ErrorIfOnConflictNotSupported(Query *queryTree)
 		return NULL;
 	}
 
-	distributedTableId = ExtractFirstDistributedTableId(queryTree);
-	partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
+	Oid distributedTableId = ExtractFirstDistributedTableId(queryTree);
+	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
 
-	onConflictSet = queryTree->onConflict->onConflictSet;
-	arbiterWhere = queryTree->onConflict->arbiterWhere;
-	onConflictWhere = queryTree->onConflict->onConflictWhere;
+	List *onConflictSet = queryTree->onConflict->onConflictSet;
+	Node *arbiterWhere = queryTree->onConflict->arbiterWhere;
+	Node *onConflictWhere = queryTree->onConflict->onConflictWhere;
 
 	/*
 	 * onConflictSet is expanded via expand_targetlist() on the standard planner.
@@ -1207,11 +1184,10 @@ UpdateOrDeleteQuery(Query *query)
 static bool
 MasterIrreducibleExpression(Node *expression, bool *varArgument, bool *badCoalesce)
 {
-	bool result;
 	WalkerState data;
 	data.containsVar = data.varArgument = data.badCoalesce = false;
 
-	result = MasterIrreducibleExpressionWalker(expression, &data);
+	bool result = MasterIrreducibleExpressionWalker(expression, &data);
 
 	*varArgument |= data.varArgument;
 	*badCoalesce |= data.badCoalesce;
@@ -1379,14 +1355,13 @@ TargetEntryChangesValue(TargetEntry *targetEntry, Var *column, FromExpr *joinTre
 		List *restrictClauseList = WhereClauseList(joinTree);
 		OpExpr *equalityExpr = MakeOpExpression(column, BTEqualStrategyNumber);
 		Const *rightConst = (Const *) get_rightop((Expr *) equalityExpr);
-		bool predicateIsImplied = false;
 
 		rightConst->constvalue = newValue->constvalue;
 		rightConst->constisnull = newValue->constisnull;
 		rightConst->constbyval = newValue->constbyval;
 
-		predicateIsImplied = predicate_implied_by(list_make1(equalityExpr),
-												  restrictClauseList, false);
+		bool predicateIsImplied = predicate_implied_by(list_make1(equalityExpr),
+													   restrictClauseList, false);
 		if (predicateIsImplied)
 		{
 			/* target entry of the form SET col = <x> WHERE col = <x> AND ... */
@@ -1408,7 +1383,6 @@ RouterInsertJob(Query *originalQuery, Query *query, DeferredErrorMessage **plann
 {
 	Oid distributedTableId = ExtractFirstDistributedTableId(query);
 	List *taskList = NIL;
-	Job *job = NULL;
 	bool requiresMasterEvaluation = false;
 	bool deferredPruning = false;
 	Const *partitionKeyValue = NULL;
@@ -1459,7 +1433,7 @@ RouterInsertJob(Query *originalQuery, Query *query, DeferredErrorMessage **plann
 		partitionKeyValue = ExtractInsertPartitionKeyValue(originalQuery);
 	}
 
-	job = CreateJob(originalQuery);
+	Job *job = CreateJob(originalQuery);
 	job->taskList = taskList;
 	job->requiresMasterEvaluation = requiresMasterEvaluation;
 	job->deferredPruning = deferredPruning;
@@ -1475,9 +1449,7 @@ RouterInsertJob(Query *originalQuery, Query *query, DeferredErrorMessage **plann
 static Job *
 CreateJob(Query *query)
 {
-	Job *job = NULL;
-
-	job = CitusMakeNode(Job);
+	Job *job = CitusMakeNode(Job);
 	job->jobId = UniqueJobId();
 	job->jobQuery = query;
 	job->taskList = NIL;
@@ -1498,8 +1470,6 @@ static bool
 CanShardPrune(Oid distributedTableId, Query *query)
 {
 	uint32 rangeTableId = 1;
-	Var *partitionColumn = NULL;
-	List *insertValuesList = NIL;
 	ListCell *insertValuesCell = NULL;
 
 	if (query->commandType != CMD_INSERT)
@@ -1508,7 +1478,7 @@ CanShardPrune(Oid distributedTableId, Query *query)
 		return true;
 	}
 
-	partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
+	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
 	if (partitionColumn == NULL)
 	{
 		/* can always do shard pruning for reference tables */
@@ -1516,7 +1486,7 @@ CanShardPrune(Oid distributedTableId, Query *query)
 	}
 
 	/* get full list of partition values and ensure they are all Consts */
-	insertValuesList = ExtractInsertValuesList(query, partitionColumn);
+	List *insertValuesList = ExtractInsertValuesList(query, partitionColumn);
 	foreach(insertValuesCell, insertValuesList)
 	{
 		InsertValues *insertValues = (InsertValues *) lfirst(insertValuesCell);
@@ -1561,7 +1531,6 @@ List *
 RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError)
 {
 	List *insertTaskList = NIL;
-	List *modifyRouteList = NIL;
 	ListCell *modifyRouteCell = NULL;
 
 	Oid distributedTableId = ExtractFirstDistributedTableId(query);
@@ -1571,7 +1540,7 @@ RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError)
 
 	Assert(query->commandType == CMD_INSERT);
 
-	modifyRouteList = BuildRoutesForInsert(query, planningError);
+	List *modifyRouteList = BuildRoutesForInsert(query, planningError);
 	if (*planningError != NULL)
 	{
 		return NIL;
@@ -1599,9 +1568,7 @@ RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError)
 static Task *
 CreateTask(TaskType taskType)
 {
-	Task *task = NULL;
-
-	task = CitusMakeNode(Task);
+	Task *task = CitusMakeNode(Task);
 	task->taskType = taskType;
 	task->jobId = INVALID_JOB_ID;
 	task->taskId = INVALID_TASK_ID;
@@ -1666,22 +1633,18 @@ static Job *
 RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionContext,
 		  DeferredErrorMessage **planningError)
 {
-	Job *job = NULL;
 	uint64 shardId = INVALID_SHARD_ID;
 	List *placementList = NIL;
 	List *relationShardList = NIL;
 	List *prunedShardIntervalListList = NIL;
-	bool replacePrunedQueryWithDummy = false;
-	bool requiresMasterEvaluation = false;
-	RangeTblEntry *updateOrDeleteRTE = NULL;
 	bool isMultiShardModifyQuery = false;
 	Const *partitionKeyValue = NULL;
 
 	/* router planner should create task even if it doesn't hit a shard at all */
-	replacePrunedQueryWithDummy = true;
+	bool replacePrunedQueryWithDummy = true;
 
 	/* check if this query requires master evaluation */
-	requiresMasterEvaluation = RequiresMasterEvaluation(originalQuery);
+	bool requiresMasterEvaluation = RequiresMasterEvaluation(originalQuery);
 
 	(*planningError) = PlanRouterQuery(originalQuery, plannerRestrictionContext,
 									   &placementList, &shardId, &relationShardList,
@@ -1694,10 +1657,10 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 		return NULL;
 	}
 
-	job = CreateJob(originalQuery);
+	Job *job = CreateJob(originalQuery);
 	job->partitionKeyValue = partitionKeyValue;
 
-	updateOrDeleteRTE = GetUpdateOrDeleteRTE(originalQuery);
+	RangeTblEntry *updateOrDeleteRTE = GetUpdateOrDeleteRTE(originalQuery);
 
 	/*
 	 * If all of the shards are pruned, we replace the relation RTE into
@@ -1770,16 +1733,12 @@ ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 {
 	if (taskAssignmentPolicy == TASK_ASSIGNMENT_ROUND_ROBIN)
 	{
-		Task *task = NULL;
-		List *reorderedPlacementList = NIL;
-		ShardPlacement *primaryPlacement = NULL;
-
 		/*
 		 * We hit a single shard on router plans, and there should be only
 		 * one task in the task list
 		 */
 		Assert(list_length(job->taskList) == 1);
-		task = (Task *) linitial(job->taskList);
+		Task *task = (Task *) linitial(job->taskList);
 
 		/*
 		 * For round-robin SELECT queries, we don't want to include the coordinator
@@ -1796,10 +1755,11 @@ ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 		placementList = RemoveCoordinatorPlacement(placementList);
 
 		/* reorder the placement list */
-		reorderedPlacementList = RoundRobinReorder(task, placementList);
+		List *reorderedPlacementList = RoundRobinReorder(task, placementList);
 		task->taskPlacementList = reorderedPlacementList;
 
-		primaryPlacement = (ShardPlacement *) linitial(reorderedPlacementList);
+		ShardPlacement *primaryPlacement = (ShardPlacement *) linitial(
+			reorderedPlacementList);
 		ereport(DEBUG3, (errmsg("assigned task %u to node %s:%u", task->taskId,
 								primaryPlacement->nodeName,
 								primaryPlacement->nodePort)));
@@ -1916,16 +1876,14 @@ SingleShardModifyTaskList(Query *query, uint64 jobId, List *relationShardList,
 {
 	Task *task = CreateTask(MODIFY_TASK);
 	StringInfo queryString = makeStringInfo();
-	DistTableCacheEntry *modificationTableCacheEntry = NULL;
-	char modificationPartitionMethod = 0;
 	List *rangeTableList = NIL;
-	RangeTblEntry *updateOrDeleteRTE = NULL;
 
 	ExtractRangeTableEntryWalker((Node *) query, &rangeTableList);
-	updateOrDeleteRTE = GetUpdateOrDeleteRTE(query);
+	RangeTblEntry *updateOrDeleteRTE = GetUpdateOrDeleteRTE(query);
 
-	modificationTableCacheEntry = DistributedTableCacheEntry(updateOrDeleteRTE->relid);
-	modificationPartitionMethod = modificationTableCacheEntry->partitionMethod;
+	DistTableCacheEntry *modificationTableCacheEntry = DistributedTableCacheEntry(
+		updateOrDeleteRTE->relid);
+	char modificationPartitionMethod = modificationTableCacheEntry->partitionMethod;
 
 	if (modificationPartitionMethod == DISTRIBUTE_BY_NONE &&
 		SelectsFromDistributedTable(rangeTableList, query))
@@ -1983,14 +1941,14 @@ SelectsFromDistributedTable(List *rangeTableList, Query *query)
 	foreach(rangeTableCell, rangeTableList)
 	{
 		RangeTblEntry *rangeTableEntry = (RangeTblEntry *) lfirst(rangeTableCell);
-		DistTableCacheEntry *cacheEntry = NULL;
 
 		if (rangeTableEntry->relid == InvalidOid)
 		{
 			continue;
 		}
 
-		cacheEntry = DistributedTableCacheEntry(rangeTableEntry->relid);
+		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(
+			rangeTableEntry->relid);
 		if (cacheEntry->partitionMethod != DISTRIBUTE_BY_NONE &&
 			(resultRangeTableEntry == NULL || resultRangeTableEntry->relid !=
 			 rangeTableEntry->relid))
@@ -2242,7 +2200,6 @@ GetAnchorShardId(List *prunedShardIntervalListList)
 	foreach(prunedShardIntervalListCell, prunedShardIntervalListList)
 	{
 		List *prunedShardIntervalList = (List *) lfirst(prunedShardIntervalListCell);
-		ShardInterval *shardInterval = NULL;
 
 		/* no shard is present or all shards are pruned out case will be handled later */
 		if (prunedShardIntervalList == NIL)
@@ -2250,7 +2207,7 @@ GetAnchorShardId(List *prunedShardIntervalListList)
 			continue;
 		}
 
-		shardInterval = linitial(prunedShardIntervalList);
+		ShardInterval *shardInterval = linitial(prunedShardIntervalList);
 
 		if (ReferenceTableShardId(shardInterval->shardId))
 		{
@@ -2341,7 +2298,6 @@ TargetShardIntervalsForRestrictInfo(RelationRestrictionContext *restrictionConte
 		List *prunedShardIntervalList = NIL;
 		List *joinInfoList = relationRestriction->relOptInfo->joininfo;
 		List *pseudoRestrictionList = extract_actual_clauses(joinInfoList, true);
-		bool whereFalseQuery = false;
 
 		relationRestriction->prunedShardIntervalList = NIL;
 
@@ -2351,7 +2307,7 @@ TargetShardIntervalsForRestrictInfo(RelationRestrictionContext *restrictionConte
 		 * inside relOptInfo->joininfo list. We treat such cases as if all
 		 * shards of the table are pruned out.
 		 */
-		whereFalseQuery = ContainsFalseClause(pseudoRestrictionList);
+		bool whereFalseQuery = ContainsFalseClause(pseudoRestrictionList);
 		if (!whereFalseQuery && shardCount > 0)
 		{
 			Const *restrictionPartitionValueConst = NULL;
@@ -2445,9 +2401,6 @@ WorkersContainingAllShards(List *prunedShardIntervalsList)
 	foreach(prunedShardIntervalCell, prunedShardIntervalsList)
 	{
 		List *shardIntervalList = (List *) lfirst(prunedShardIntervalCell);
-		ShardInterval *shardInterval = NULL;
-		uint64 shardId = INVALID_SHARD_ID;
-		List *newPlacementList = NIL;
 
 		if (shardIntervalList == NIL)
 		{
@@ -2456,11 +2409,11 @@ WorkersContainingAllShards(List *prunedShardIntervalsList)
 
 		Assert(list_length(shardIntervalList) == 1);
 
-		shardInterval = (ShardInterval *) linitial(shardIntervalList);
-		shardId = shardInterval->shardId;
+		ShardInterval *shardInterval = (ShardInterval *) linitial(shardIntervalList);
+		uint64 shardId = shardInterval->shardId;
 
 		/* retrieve all active shard placements for this shard */
-		newPlacementList = FinalizedShardPlacementList(shardId);
+		List *newPlacementList = FinalizedShardPlacementList(shardId);
 
 		if (firstShard)
 		{
@@ -2506,8 +2459,6 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
 	char partitionMethod = cacheEntry->partitionMethod;
 	uint32 rangeTableId = 1;
-	Var *partitionColumn = NULL;
-	List *insertValuesList = NIL;
 	List *modifyRouteList = NIL;
 	ListCell *insertValuesCell = NULL;
 
@@ -2516,24 +2467,20 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 	/* reference tables can only have one shard */
 	if (partitionMethod == DISTRIBUTE_BY_NONE)
 	{
-		int shardCount = 0;
 		List *shardIntervalList = LoadShardIntervalList(distributedTableId);
-		RangeTblEntry *valuesRTE = NULL;
-		ShardInterval *shardInterval = NULL;
-		ModifyRoute *modifyRoute = NULL;
 
-		shardCount = list_length(shardIntervalList);
+		int shardCount = list_length(shardIntervalList);
 		if (shardCount != 1)
 		{
 			ereport(ERROR, (errmsg("reference table cannot have %d shards", shardCount)));
 		}
 
-		shardInterval = linitial(shardIntervalList);
-		modifyRoute = palloc(sizeof(ModifyRoute));
+		ShardInterval *shardInterval = linitial(shardIntervalList);
+		ModifyRoute *modifyRoute = palloc(sizeof(ModifyRoute));
 
 		modifyRoute->shardId = shardInterval->shardId;
 
-		valuesRTE = ExtractDistributedInsertValuesRTE(query);
+		RangeTblEntry *valuesRTE = ExtractDistributedInsertValuesRTE(query);
 		if (valuesRTE != NULL)
 		{
 			/* add the values list for a multi-row INSERT */
@@ -2549,18 +2496,15 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 		return modifyRouteList;
 	}
 
-	partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
+	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
 
 	/* get full list of insert values and iterate over them to prune */
-	insertValuesList = ExtractInsertValuesList(query, partitionColumn);
+	List *insertValuesList = ExtractInsertValuesList(query, partitionColumn);
 
 	foreach(insertValuesCell, insertValuesList)
 	{
 		InsertValues *insertValues = (InsertValues *) lfirst(insertValuesCell);
-		Const *partitionValueConst = NULL;
 		List *prunedShardIntervalList = NIL;
-		int prunedShardIntervalCount = 0;
-		ShardInterval *targetShard = NULL;
 
 		if (!IsA(insertValues->partitionValueExpr, Const))
 		{
@@ -2568,7 +2512,7 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 			return NIL;
 		}
 
-		partitionValueConst = (Const *) insertValues->partitionValueExpr;
+		Const *partitionValueConst = (Const *) insertValues->partitionValueExpr;
 		if (partitionValueConst->constisnull)
 		{
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
@@ -2580,10 +2524,9 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 			DISTRIBUTE_BY_RANGE)
 		{
 			Datum partitionValue = partitionValueConst->constvalue;
-			ShardInterval *shardInterval = NULL;
 
 			cacheEntry = DistributedTableCacheEntry(distributedTableId);
-			shardInterval = FindShardInterval(partitionValue, cacheEntry);
+			ShardInterval *shardInterval = FindShardInterval(partitionValue, cacheEntry);
 			if (shardInterval != NULL)
 			{
 				prunedShardIntervalList = list_make1(shardInterval);
@@ -2591,7 +2534,6 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 		}
 		else
 		{
-			List *restrictClauseList = NIL;
 			Index tableId = 1;
 			OpExpr *equalityExpr = MakeOpExpression(partitionColumn,
 													BTEqualStrategyNumber);
@@ -2604,13 +2546,13 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 			rightConst->constisnull = partitionValueConst->constisnull;
 			rightConst->constbyval = partitionValueConst->constbyval;
 
-			restrictClauseList = list_make1(equalityExpr);
+			List *restrictClauseList = list_make1(equalityExpr);
 
 			prunedShardIntervalList = PruneShards(distributedTableId, tableId,
 												  restrictClauseList, NULL);
 		}
 
-		prunedShardIntervalCount = list_length(prunedShardIntervalList);
+		int prunedShardIntervalCount = list_length(prunedShardIntervalList);
 		if (prunedShardIntervalCount != 1)
 		{
 			char *partitionKeyString = cacheEntry->partitionKeyString;
@@ -2651,7 +2593,7 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 			return NIL;
 		}
 
-		targetShard = (ShardInterval *) linitial(prunedShardIntervalList);
+		ShardInterval *targetShard = (ShardInterval *) linitial(prunedShardIntervalList);
 		insertValues->shardId = targetShard->shardId;
 	}
 
@@ -2768,19 +2710,15 @@ NormalizeMultiRowInsertTargetList(Query *query)
 	{
 		TargetEntry *targetEntry = lfirst(targetEntryCell);
 		Node *targetExprNode = (Node *) targetEntry->expr;
-		Oid targetType = InvalidOid;
-		int32 targetTypmod = -1;
-		Oid targetColl = InvalidOid;
-		Var *syntheticVar = NULL;
 
 		/* RTE_VALUES comes 2nd, after destination table */
 		Index valuesVarno = 2;
 
 		targetEntryNo++;
 
-		targetType = exprType(targetExprNode);
-		targetTypmod = exprTypmod(targetExprNode);
-		targetColl = exprCollation(targetExprNode);
+		Oid targetType = exprType(targetExprNode);
+		int32 targetTypmod = exprTypmod(targetExprNode);
+		Oid targetColl = exprCollation(targetExprNode);
 
 		valuesRTE->coltypes = lappend_oid(valuesRTE->coltypes, targetType);
 		valuesRTE->coltypmods = lappend_int(valuesRTE->coltypmods, targetTypmod);
@@ -2794,8 +2732,8 @@ NormalizeMultiRowInsertTargetList(Query *query)
 		}
 
 		/* replace the original expression with a Var referencing values_lists */
-		syntheticVar = makeVar(valuesVarno, targetEntryNo, targetType, targetTypmod,
-							   targetColl, 0);
+		Var *syntheticVar = makeVar(valuesVarno, targetEntryNo, targetType, targetTypmod,
+									targetColl, 0);
 		targetEntry->expr = (Expr *) syntheticVar;
 	}
 }
@@ -2935,11 +2873,10 @@ ExtractInsertValuesList(Query *query, Var *partitionColumn)
 	if (IsA(targetEntry->expr, Var))
 	{
 		Var *partitionVar = (Var *) targetEntry->expr;
-		RangeTblEntry *referencedRTE = NULL;
 		ListCell *valuesListCell = NULL;
 		Index ivIndex = 0;
 
-		referencedRTE = rt_fetch(partitionVar->varno, query->rtable);
+		RangeTblEntry *referencedRTE = rt_fetch(partitionVar->varno, query->rtable);
 		foreach(valuesListCell, referencedRTE->values_lists)
 		{
 			InsertValues *insertValues = (InsertValues *) palloc(sizeof(InsertValues));
@@ -2980,10 +2917,7 @@ ExtractInsertPartitionKeyValue(Query *query)
 {
 	Oid distributedTableId = ExtractFirstDistributedTableId(query);
 	uint32 rangeTableId = 1;
-	Var *partitionColumn = NULL;
-	TargetEntry *targetEntry = NULL;
 	Const *singlePartitionValueConst = NULL;
-	Node *targetExpression = NULL;
 
 	char partitionMethod = PartitionMethod(distributedTableId);
 	if (partitionMethod == DISTRIBUTE_BY_NONE)
@@ -2991,15 +2925,16 @@ ExtractInsertPartitionKeyValue(Query *query)
 		return NULL;
 	}
 
-	partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
-	targetEntry = get_tle_by_resno(query->targetList, partitionColumn->varattno);
+	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
+	TargetEntry *targetEntry = get_tle_by_resno(query->targetList,
+												partitionColumn->varattno);
 	if (targetEntry == NULL)
 	{
 		/* partition column value not specified */
 		return NULL;
 	}
 
-	targetExpression = strip_implicit_coercions((Node *) targetEntry->expr);
+	Node *targetExpression = strip_implicit_coercions((Node *) targetEntry->expr);
 
 	/*
 	 * Multi-row INSERTs have a Var in the target list that points to
@@ -3008,10 +2943,9 @@ ExtractInsertPartitionKeyValue(Query *query)
 	if (IsA(targetExpression, Var))
 	{
 		Var *partitionVar = (Var *) targetExpression;
-		RangeTblEntry *referencedRTE = NULL;
 		ListCell *valuesListCell = NULL;
 
-		referencedRTE = rt_fetch(partitionVar->varno, query->rtable);
+		RangeTblEntry *referencedRTE = rt_fetch(partitionVar->varno, query->rtable);
 
 		foreach(valuesListCell, referencedRTE->values_lists)
 		{
@@ -3019,7 +2953,6 @@ ExtractInsertPartitionKeyValue(Query *query)
 			Node *partitionValueNode = list_nth(rowValues, partitionVar->varattno - 1);
 			Expr *partitionValueExpr = (Expr *) strip_implicit_coercions(
 				partitionValueNode);
-			Const *partitionValueConst = NULL;
 
 			if (!IsA(partitionValueExpr, Const))
 			{
@@ -3028,7 +2961,7 @@ ExtractInsertPartitionKeyValue(Query *query)
 				break;
 			}
 
-			partitionValueConst = (Const *) partitionValueExpr;
+			Const *partitionValueConst = (Const *) partitionValueExpr;
 
 			if (singlePartitionValueConst == NULL)
 			{
@@ -3098,7 +3031,6 @@ MultiRouterPlannableQuery(Query *query)
 		{
 			/* only hash partitioned tables are supported */
 			Oid distributedTableId = rte->relid;
-			char partitionMethod = 0;
 
 			if (!IsDistributedTable(distributedTableId))
 			{
@@ -3109,7 +3041,7 @@ MultiRouterPlannableQuery(Query *query)
 					NULL, NULL);
 			}
 
-			partitionMethod = PartitionMethod(distributedTableId);
+			char partitionMethod = PartitionMethod(distributedTableId);
 			if (!(partitionMethod == DISTRIBUTE_BY_HASH || partitionMethod ==
 				  DISTRIBUTE_BY_NONE || partitionMethod == DISTRIBUTE_BY_RANGE))
 			{

--- a/src/backend/distributed/planner/postgres_planning_functions.c
+++ b/src/backend/distributed/planner/postgres_planning_functions.c
@@ -43,9 +43,6 @@ make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
 	Plan *plan = &node->plan;
 	int numCols = list_length(distinctList);
 	int keyno = 0;
-	AttrNumber *uniqColIdx;
-	Oid *uniqOperators;
-	Oid *uniqCollations;
 	ListCell *slitem;
 
 	plan->targetlist = lefttree->targetlist;
@@ -58,9 +55,9 @@ make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
 	 * operators, as wanted by executor
 	 */
 	Assert(numCols > 0);
-	uniqColIdx = (AttrNumber *) palloc(sizeof(AttrNumber) * numCols);
-	uniqOperators = (Oid *) palloc(sizeof(Oid) * numCols);
-	uniqCollations = (Oid *) palloc(sizeof(Oid) * numCols);
+	AttrNumber *uniqColIdx = (AttrNumber *) palloc(sizeof(AttrNumber) * numCols);
+	Oid *uniqOperators = (Oid *) palloc(sizeof(Oid) * numCols);
+	Oid *uniqCollations = (Oid *) palloc(sizeof(Oid) * numCols);
 
 	foreach(slitem, distinctList)
 	{
@@ -97,8 +94,6 @@ make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
 	Plan *plan = &node->plan;
 	int numCols = list_length(distinctList);
 	int keyno = 0;
-	AttrNumber *uniqColIdx;
-	Oid *uniqOperators;
 	ListCell *slitem;
 
 	plan->targetlist = lefttree->targetlist;
@@ -111,8 +106,8 @@ make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
 	 * operators, as wanted by executor
 	 */
 	Assert(numCols > 0);
-	uniqColIdx = (AttrNumber *) palloc(sizeof(AttrNumber) * numCols);
-	uniqOperators = (Oid *) palloc(sizeof(Oid) * numCols);
+	AttrNumber *uniqColIdx = (AttrNumber *) palloc(sizeof(AttrNumber) * numCols);
+	Oid *uniqOperators = (Oid *) palloc(sizeof(Oid) * numCols);
 
 	foreach(slitem, distinctList)
 	{

--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -49,14 +49,10 @@ CreateColocatedJoinChecker(Query *subquery, PlannerRestrictionContext *restricti
 {
 	ColocatedJoinChecker colocatedJoinChecker;
 
-	RangeTblEntry *anchorRangeTblEntry = NULL;
 	Query *anchorSubquery = NULL;
-	PlannerRestrictionContext *anchorPlannerRestrictionContext = NULL;
-	RelationRestrictionContext *anchorRelationRestrictionContext = NULL;
-	List *anchorRestrictionEquivalences = NIL;
 
 	/* we couldn't pick an anchor subquery, no need to continue */
-	anchorRangeTblEntry = AnchorRte(subquery);
+	RangeTblEntry *anchorRangeTblEntry = AnchorRte(subquery);
 	if (anchorRangeTblEntry == NULL)
 	{
 		colocatedJoinChecker.anchorRelationRestrictionList = NIL;
@@ -84,11 +80,11 @@ CreateColocatedJoinChecker(Query *subquery, PlannerRestrictionContext *restricti
 		pg_unreachable();
 	}
 
-	anchorPlannerRestrictionContext =
+	PlannerRestrictionContext *anchorPlannerRestrictionContext =
 		FilterPlannerRestrictionForQuery(restrictionContext, anchorSubquery);
-	anchorRelationRestrictionContext =
+	RelationRestrictionContext *anchorRelationRestrictionContext =
 		anchorPlannerRestrictionContext->relationRestrictionContext;
-	anchorRestrictionEquivalences =
+	List *anchorRestrictionEquivalences =
 		GenerateAllAttributeEquivalences(anchorPlannerRestrictionContext);
 
 	/* fill the non colocated planning context */
@@ -191,9 +187,6 @@ SubqueryColocated(Query *subquery, ColocatedJoinChecker *checker)
 	List *filteredRestrictionList =
 		filteredPlannerContext->relationRestrictionContext->relationRestrictionList;
 
-	List *unionedRelationRestrictionList = NULL;
-	RelationRestrictionContext *unionedRelationRestrictionContext = NULL;
-	PlannerRestrictionContext *unionedPlannerRestrictionContext = NULL;
 
 	/*
 	 * There are no relations in the input subquery, such as a subquery
@@ -213,7 +206,7 @@ SubqueryColocated(Query *subquery, ColocatedJoinChecker *checker)
 	 * forming this temporary context is to check whether the context contains
 	 * distribution key equality or not.
 	 */
-	unionedRelationRestrictionList =
+	List *unionedRelationRestrictionList =
 		UnionRelationRestrictionLists(anchorRelationRestrictionList,
 									  filteredRestrictionList);
 
@@ -224,11 +217,13 @@ SubqueryColocated(Query *subquery, ColocatedJoinChecker *checker)
 	 * join restrictions, we're already relying on the attributeEquivalances
 	 * provided by the context.
 	 */
-	unionedRelationRestrictionContext = palloc0(sizeof(RelationRestrictionContext));
+	RelationRestrictionContext *unionedRelationRestrictionContext = palloc0(
+		sizeof(RelationRestrictionContext));
 	unionedRelationRestrictionContext->relationRestrictionList =
 		unionedRelationRestrictionList;
 
-	unionedPlannerRestrictionContext = palloc0(sizeof(PlannerRestrictionContext));
+	PlannerRestrictionContext *unionedPlannerRestrictionContext = palloc0(
+		sizeof(PlannerRestrictionContext));
 	unionedPlannerRestrictionContext->relationRestrictionContext =
 		unionedRelationRestrictionContext;
 
@@ -256,14 +251,11 @@ WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation)
 {
 	Query *subquery = makeNode(Query);
 	RangeTblRef *newRangeTableRef = makeNode(RangeTblRef);
-	RangeTblEntry *newRangeTableEntry = NULL;
-	Var *targetColumn = NULL;
-	TargetEntry *targetEntry = NULL;
 
 	subquery->commandType = CMD_SELECT;
 
 	/* we copy the input rteRelation to preserve the rteIdentity */
-	newRangeTableEntry = copyObject(rteRelation);
+	RangeTblEntry *newRangeTableEntry = copyObject(rteRelation);
 	subquery->rtable = list_make1(newRangeTableEntry);
 
 	/* set the FROM expression to the subquery */
@@ -272,11 +264,12 @@ WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation)
 	subquery->jointree = makeFromExpr(list_make1(newRangeTableRef), NULL);
 
 	/* Need the whole row as a junk var */
-	targetColumn = makeWholeRowVar(newRangeTableEntry, newRangeTableRef->rtindex, 0,
-								   false);
+	Var *targetColumn = makeWholeRowVar(newRangeTableEntry, newRangeTableRef->rtindex, 0,
+										false);
 
 	/* create a dummy target entry */
-	targetEntry = makeTargetEntry((Expr *) targetColumn, 1, "wholerow", true);
+	TargetEntry *targetEntry = makeTargetEntry((Expr *) targetColumn, 1, "wholerow",
+											   true);
 
 	subquery->targetList = lappend(subquery->targetList, targetEntry);
 
@@ -292,15 +285,13 @@ WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation)
 static List *
 UnionRelationRestrictionLists(List *firstRelationList, List *secondRelationList)
 {
-	RelationRestrictionContext *unionedRestrictionContext = NULL;
 	List *unionedRelationRestrictionList = NULL;
 	ListCell *relationRestrictionCell = NULL;
 	Relids rteIdentities = NULL;
-	List *allRestrictionList = NIL;
 
 	/* list_concat destructively modifies the first list, thus copy it */
 	firstRelationList = list_copy(firstRelationList);
-	allRestrictionList = list_concat(firstRelationList, secondRelationList);
+	List *allRestrictionList = list_concat(firstRelationList, secondRelationList);
 
 	foreach(relationRestrictionCell, allRestrictionList)
 	{
@@ -320,7 +311,8 @@ UnionRelationRestrictionLists(List *firstRelationList, List *secondRelationList)
 		rteIdentities = bms_add_member(rteIdentities, rteIdentity);
 	}
 
-	unionedRestrictionContext = palloc0(sizeof(RelationRestrictionContext));
+	RelationRestrictionContext *unionedRestrictionContext = palloc0(
+		sizeof(RelationRestrictionContext));
 	unionedRestrictionContext->relationRestrictionList = unionedRelationRestrictionList;
 
 	return unionedRelationRestrictionList;

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -107,7 +107,6 @@ bool
 ShouldUseSubqueryPushDown(Query *originalQuery, Query *rewrittenQuery,
 						  PlannerRestrictionContext *plannerRestrictionContext)
 {
-	List *qualifierList = NIL;
 	StringInfo errorMessage = NULL;
 
 	/*
@@ -183,7 +182,7 @@ ShouldUseSubqueryPushDown(Query *originalQuery, Query *rewrittenQuery,
 	 * Some unsupported join clauses in logical planner
 	 * may be supported by subquery pushdown planner.
 	 */
-	qualifierList = QualifierList(rewrittenQuery->jointree);
+	List *qualifierList = QualifierList(rewrittenQuery->jointree);
 	if (DeferErrorIfUnsupportedClause(qualifierList) != NULL)
 	{
 		return true;
@@ -283,7 +282,6 @@ bool
 WhereOrHavingClauseContainsSubquery(Query *query)
 {
 	FromExpr *joinTree = query->jointree;
-	Node *queryQuals = NULL;
 
 	if (FindNodeCheck(query->havingQual, IsNodeSubquery))
 	{
@@ -295,7 +293,7 @@ WhereOrHavingClauseContainsSubquery(Query *query)
 		return false;
 	}
 
-	queryQuals = joinTree->quals;
+	Node *queryQuals = joinTree->quals;
 
 	return FindNodeCheck(queryQuals, IsNodeSubquery);
 }
@@ -450,15 +448,13 @@ WindowPartitionOnDistributionColumn(Query *query)
 	foreach(windowClauseCell, windowClauseList)
 	{
 		WindowClause *windowClause = lfirst(windowClauseCell);
-		List *groupTargetEntryList = NIL;
-		bool partitionOnDistributionColumn = false;
 		List *partitionClauseList = windowClause->partitionClause;
 		List *targetEntryList = query->targetList;
 
-		groupTargetEntryList =
+		List *groupTargetEntryList =
 			GroupTargetEntryList(partitionClauseList, targetEntryList);
 
-		partitionOnDistributionColumn =
+		bool partitionOnDistributionColumn =
 			TargetListOnPartitionColumn(query, groupTargetEntryList);
 
 		if (!partitionOnDistributionColumn)
@@ -495,14 +491,13 @@ SubqueryMultiNodeTree(Query *originalQuery, Query *queryTree,
 					  PlannerRestrictionContext *plannerRestrictionContext)
 {
 	MultiNode *multiQueryNode = NULL;
-	DeferredErrorMessage *subqueryPushdownError = NULL;
-	DeferredErrorMessage *unsupportedQueryError = NULL;
 
 	/*
 	 * This is a generic error check that applies to both subquery pushdown
 	 * and single table repartition subquery.
 	 */
-	unsupportedQueryError = DeferErrorIfQueryNotSupported(originalQuery);
+	DeferredErrorMessage *unsupportedQueryError = DeferErrorIfQueryNotSupported(
+		originalQuery);
 	if (unsupportedQueryError != NULL)
 	{
 		RaiseDeferredError(unsupportedQueryError, ERROR);
@@ -513,38 +508,35 @@ SubqueryMultiNodeTree(Query *originalQuery, Query *queryTree,
 	 * to create a logical plan, continue with trying the single table
 	 * repartition subquery planning.
 	 */
-	subqueryPushdownError = DeferErrorIfUnsupportedSubqueryPushdown(originalQuery,
-																	plannerRestrictionContext);
+	DeferredErrorMessage *subqueryPushdownError = DeferErrorIfUnsupportedSubqueryPushdown(
+		originalQuery,
+		plannerRestrictionContext);
 	if (!subqueryPushdownError)
 	{
 		multiQueryNode = SubqueryPushdownMultiNodeTree(originalQuery);
 	}
 	else if (subqueryPushdownError)
 	{
-		bool singleRelationRepartitionSubquery = false;
-		RangeTblEntry *subqueryRangeTableEntry = NULL;
-		Query *subqueryTree = NULL;
-		DeferredErrorMessage *repartitionQueryError = NULL;
-		List *subqueryEntryList = NULL;
-
 		/*
 		 * If not eligible for single relation repartition query, we should raise
 		 * subquery pushdown error.
 		 */
-		singleRelationRepartitionSubquery =
+		bool singleRelationRepartitionSubquery =
 			SingleRelationRepartitionSubquery(originalQuery);
 		if (!singleRelationRepartitionSubquery)
 		{
 			RaiseDeferredErrorInternal(subqueryPushdownError, ERROR);
 		}
 
-		subqueryEntryList = SubqueryEntryList(queryTree);
-		subqueryRangeTableEntry = (RangeTblEntry *) linitial(subqueryEntryList);
+		List *subqueryEntryList = SubqueryEntryList(queryTree);
+		RangeTblEntry *subqueryRangeTableEntry = (RangeTblEntry *) linitial(
+			subqueryEntryList);
 		Assert(subqueryRangeTableEntry->rtekind == RTE_SUBQUERY);
 
-		subqueryTree = subqueryRangeTableEntry->subquery;
+		Query *subqueryTree = subqueryRangeTableEntry->subquery;
 
-		repartitionQueryError = DeferErrorIfUnsupportedSubqueryRepartition(subqueryTree);
+		DeferredErrorMessage *repartitionQueryError =
+			DeferErrorIfUnsupportedSubqueryRepartition(subqueryTree);
 		if (repartitionQueryError)
 		{
 			RaiseDeferredErrorInternal(repartitionQueryError, ERROR);
@@ -574,7 +566,6 @@ DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
 	bool outerMostQueryHasLimit = false;
 	ListCell *subqueryCell = NULL;
 	List *subqueryList = NIL;
-	DeferredErrorMessage *error = NULL;
 
 	if (originalQuery->limitCount != NULL)
 	{
@@ -610,7 +601,7 @@ DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
 	}
 
 	/* we shouldn't allow reference tables in the FROM clause when the query has sublinks */
-	error = DeferErrorIfFromClauseRecurs(originalQuery);
+	DeferredErrorMessage *error = DeferErrorIfFromClauseRecurs(originalQuery);
 	if (error)
 	{
 		return error;
@@ -666,14 +657,12 @@ DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
 static DeferredErrorMessage *
 DeferErrorIfFromClauseRecurs(Query *queryTree)
 {
-	RecurringTuplesType recurType = RECURRING_TUPLES_INVALID;
-
 	if (!queryTree->hasSubLinks)
 	{
 		return NULL;
 	}
 
-	recurType = FromClauseRecurringTupleType(queryTree);
+	RecurringTuplesType recurType = FromClauseRecurringTupleType(queryTree);
 	if (recurType == RECURRING_TUPLES_REFERENCE_TABLE)
 	{
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
@@ -892,9 +881,9 @@ DeferErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLi
 	bool preconditionsSatisfied = true;
 	char *errorDetail = NULL;
 	StringInfo errorInfo = NULL;
-	DeferredErrorMessage *deferredError = NULL;
 
-	deferredError = DeferErrorIfUnsupportedTableCombination(subqueryTree);
+	DeferredErrorMessage *deferredError = DeferErrorIfUnsupportedTableCombination(
+		subqueryTree);
 	if (deferredError)
 	{
 		return deferredError;
@@ -1187,9 +1176,8 @@ DeferErrorIfUnsupportedUnionQuery(Query *subqueryTree)
 
 		if (IsA(leftArg, RangeTblRef))
 		{
-			Query *leftArgSubquery = NULL;
 			leftArgRTI = ((RangeTblRef *) leftArg)->rtindex;
-			leftArgSubquery = rt_fetch(leftArgRTI, subqueryTree->rtable)->subquery;
+			Query *leftArgSubquery = rt_fetch(leftArgRTI, subqueryTree->rtable)->subquery;
 			recurType = FromClauseRecurringTupleType(leftArgSubquery);
 			if (recurType != RECURRING_TUPLES_INVALID)
 			{
@@ -1199,9 +1187,9 @@ DeferErrorIfUnsupportedUnionQuery(Query *subqueryTree)
 
 		if (IsA(rightArg, RangeTblRef))
 		{
-			Query *rightArgSubquery = NULL;
 			rightArgRTI = ((RangeTblRef *) rightArg)->rtindex;
-			rightArgSubquery = rt_fetch(rightArgRTI, subqueryTree->rtable)->subquery;
+			Query *rightArgSubquery = rt_fetch(rightArgRTI,
+											   subqueryTree->rtable)->subquery;
 			recurType = FromClauseRecurringTupleType(rightArgSubquery);
 			if (recurType != RECURRING_TUPLES_INVALID)
 			{
@@ -1251,7 +1239,6 @@ DeferErrorIfUnsupportedUnionQuery(Query *subqueryTree)
 static bool
 ExtractSetOperationStatmentWalker(Node *node, List **setOperationList)
 {
-	bool walkerResult = false;
 	if (node == NULL)
 	{
 		return false;
@@ -1264,8 +1251,8 @@ ExtractSetOperationStatmentWalker(Node *node, List **setOperationList)
 		(*setOperationList) = lappend(*setOperationList, setOperation);
 	}
 
-	walkerResult = expression_tree_walker(node, ExtractSetOperationStatmentWalker,
-										  setOperationList);
+	bool walkerResult = expression_tree_walker(node, ExtractSetOperationStatmentWalker,
+											   setOperationList);
 
 	return walkerResult;
 }
@@ -1522,21 +1509,11 @@ static MultiNode *
 SubqueryPushdownMultiNodeTree(Query *queryTree)
 {
 	List *targetEntryList = queryTree->targetList;
-	List *columnList = NIL;
-	List *flattenedExprList = NIL;
-	List *targetColumnList = NIL;
 	MultiCollect *subqueryCollectNode = CitusMakeNode(MultiCollect);
-	MultiTable *subqueryNode = NULL;
-	MultiProject *projectNode = NULL;
-	MultiExtendedOp *extendedOpNode = NULL;
-	MultiNode *currentTopNode = NULL;
-	Query *pushedDownQuery = NULL;
-	List *subqueryTargetEntryList = NIL;
-	List *havingClauseColumnList = NIL;
-	DeferredErrorMessage *unsupportedQueryError = NULL;
 
 	/* verify we can perform distributed planning on this query */
-	unsupportedQueryError = DeferErrorIfQueryNotSupported(queryTree);
+	DeferredErrorMessage *unsupportedQueryError = DeferErrorIfQueryNotSupported(
+		queryTree);
 	if (unsupportedQueryError != NULL)
 	{
 		RaiseDeferredError(unsupportedQueryError, ERROR);
@@ -1588,14 +1565,14 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 	 * columnList. Columns mentioned in multiProject node and multiExtendedOp
 	 * node are indexed with their respective position in columnList.
 	 */
-	targetColumnList = pull_var_clause_default((Node *) targetEntryList);
-	havingClauseColumnList = pull_var_clause_default(queryTree->havingQual);
-	columnList = list_concat(targetColumnList, havingClauseColumnList);
+	List *targetColumnList = pull_var_clause_default((Node *) targetEntryList);
+	List *havingClauseColumnList = pull_var_clause_default(queryTree->havingQual);
+	List *columnList = list_concat(targetColumnList, havingClauseColumnList);
 
-	flattenedExprList = FlattenJoinVars(columnList, queryTree);
+	List *flattenedExprList = FlattenJoinVars(columnList, queryTree);
 
 	/* create a target entry for each unique column */
-	subqueryTargetEntryList = CreateSubqueryTargetEntryList(flattenedExprList);
+	List *subqueryTargetEntryList = CreateSubqueryTargetEntryList(flattenedExprList);
 
 	/*
 	 * Update varno/varattno fields of columns in columnList to
@@ -1605,7 +1582,7 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 									   subqueryTargetEntryList);
 
 	/* new query only has target entries, join tree, and rtable*/
-	pushedDownQuery = makeNode(Query);
+	Query *pushedDownQuery = makeNode(Query);
 	pushedDownQuery->commandType = queryTree->commandType;
 	pushedDownQuery->targetList = subqueryTargetEntryList;
 	pushedDownQuery->jointree = copyObject(queryTree->jointree);
@@ -1614,13 +1591,13 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 	pushedDownQuery->querySource = queryTree->querySource;
 	pushedDownQuery->hasSubLinks = queryTree->hasSubLinks;
 
-	subqueryNode = MultiSubqueryPushdownTable(pushedDownQuery);
+	MultiTable *subqueryNode = MultiSubqueryPushdownTable(pushedDownQuery);
 
 	SetChild((MultiUnaryNode *) subqueryCollectNode, (MultiNode *) subqueryNode);
-	currentTopNode = (MultiNode *) subqueryCollectNode;
+	MultiNode *currentTopNode = (MultiNode *) subqueryCollectNode;
 
 	/* build project node for the columns to project */
-	projectNode = MultiProjectNode(targetEntryList);
+	MultiProject *projectNode = MultiProjectNode(targetEntryList);
 	SetChild((MultiUnaryNode *) projectNode, currentTopNode);
 	currentTopNode = (MultiNode *) projectNode;
 
@@ -1630,7 +1607,7 @@ SubqueryPushdownMultiNodeTree(Query *queryTree)
 	 * distinguish between aggregates and expressions; and we address this later
 	 * in the logical optimizer.
 	 */
-	extendedOpNode = MultiExtendedOpNode(queryTree);
+	MultiExtendedOp *extendedOpNode = MultiExtendedOpNode(queryTree);
 
 	/*
 	 * Postgres standard planner converts having qual node to a list of and
@@ -1724,8 +1701,6 @@ FlattenJoinVarsMutator(Node *node, Query *queryTree)
 		RangeTblEntry *rte = rt_fetch(column->varno, queryTree->rtable);
 		if (rte->rtekind == RTE_JOIN)
 		{
-			Node *newColumn = NULL;
-
 			/*
 			 * if join has an alias, it is copied over join RTE. We should
 			 * reference this RTE.
@@ -1737,7 +1712,7 @@ FlattenJoinVarsMutator(Node *node, Query *queryTree)
 
 			/* join RTE does not have and alias defined at this level, deeper look is needed */
 			Assert(column->varattno > 0);
-			newColumn = (Node *) list_nth(rte->joinaliasvars, column->varattno - 1);
+			Node *newColumn = (Node *) list_nth(rte->joinaliasvars, column->varattno - 1);
 			Assert(newColumn != NULL);
 
 			/*
@@ -1894,7 +1869,6 @@ UpdateColumnToMatchingTargetEntry(Var *column, Node *flattenedExpr, List *target
 static MultiTable *
 MultiSubqueryPushdownTable(Query *subquery)
 {
-	MultiTable *subqueryTableNode = NULL;
 	StringInfo rteName = makeStringInfo();
 	List *columnNamesList = NIL;
 	ListCell *targetEntryCell = NULL;
@@ -1907,7 +1881,7 @@ MultiSubqueryPushdownTable(Query *subquery)
 		columnNamesList = lappend(columnNamesList, makeString(targetEntry->resname));
 	}
 
-	subqueryTableNode = CitusMakeNode(MultiTable);
+	MultiTable *subqueryTableNode = CitusMakeNode(MultiTable);
 	subqueryTableNode->subquery = subquery;
 	subqueryTableNode->relationId = SUBQUERY_PUSHDOWN_RELATION_ID;
 	subqueryTableNode->rangeTableId = SUBQUERY_RANGE_TABLE_ID;

--- a/src/backend/distributed/progress/multi_progress.c
+++ b/src/backend/distributed/progress/multi_progress.c
@@ -39,11 +39,6 @@ ProgressMonitorData *
 CreateProgressMonitor(uint64 progressTypeMagicNumber, int stepCount, Size stepSize,
 					  Oid relationId)
 {
-	dsm_segment *dsmSegment = NULL;
-	dsm_handle dsmHandle = 0;
-	ProgressMonitorData *monitor = NULL;
-	Size monitorSize = 0;
-
 	if (stepSize <= 0 || stepCount <= 0)
 	{
 		ereport(ERROR,
@@ -51,8 +46,8 @@ CreateProgressMonitor(uint64 progressTypeMagicNumber, int stepCount, Size stepSi
 						"positive values")));
 	}
 
-	monitorSize = sizeof(ProgressMonitorData) + stepSize * stepCount;
-	dsmSegment = dsm_create(monitorSize, DSM_CREATE_NULL_IF_MAXSEGMENTS);
+	Size monitorSize = sizeof(ProgressMonitorData) + stepSize * stepCount;
+	dsm_segment *dsmSegment = dsm_create(monitorSize, DSM_CREATE_NULL_IF_MAXSEGMENTS);
 
 	if (dsmSegment == NULL)
 	{
@@ -62,9 +57,9 @@ CreateProgressMonitor(uint64 progressTypeMagicNumber, int stepCount, Size stepSi
 		return NULL;
 	}
 
-	dsmHandle = dsm_segment_handle(dsmSegment);
+	dsm_handle dsmHandle = dsm_segment_handle(dsmSegment);
 
-	monitor = MonitorDataFromDSMHandle(dsmHandle, &dsmSegment);
+	ProgressMonitorData *monitor = MonitorDataFromDSMHandle(dsmHandle, &dsmSegment);
 
 	monitor->stepCount = stepCount;
 	monitor->processId = MyProcPid;
@@ -143,42 +138,38 @@ ProgressMonitorList(uint64 commandTypeMagicNumber, List **attachedDSMSegments)
 	 */
 	text *commandTypeText = cstring_to_text("VACUUM");
 	Datum commandTypeDatum = PointerGetDatum(commandTypeText);
-	Oid getProgressInfoFunctionOid = InvalidOid;
-	TupleTableSlot *tupleTableSlot = NULL;
-	ReturnSetInfo *progressResultSet = NULL;
 	List *monitorList = NIL;
 
-	getProgressInfoFunctionOid = FunctionOid("pg_catalog",
-											 "pg_stat_get_progress_info",
-											 1);
+	Oid getProgressInfoFunctionOid = FunctionOid("pg_catalog",
+												 "pg_stat_get_progress_info",
+												 1);
 
-	progressResultSet = FunctionCallGetTupleStore1(pg_stat_get_progress_info,
-												   getProgressInfoFunctionOid,
-												   commandTypeDatum);
+	ReturnSetInfo *progressResultSet = FunctionCallGetTupleStore1(
+		pg_stat_get_progress_info,
+		getProgressInfoFunctionOid,
+		commandTypeDatum);
 
-	tupleTableSlot = MakeSingleTupleTableSlotCompat(progressResultSet->setDesc,
-													&TTSOpsMinimalTuple);
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(
+		progressResultSet->setDesc,
+		&TTSOpsMinimalTuple);
 
 	/* iterate over tuples in tuple store, and send them to destination */
 	for (;;)
 	{
-		bool nextTuple = false;
 		bool isNull = false;
-		Datum magicNumberDatum = 0;
-		uint64 magicNumber = 0;
 
-		nextTuple = tuplestore_gettupleslot(progressResultSet->setResult,
-											true,
-											false,
-											tupleTableSlot);
+		bool nextTuple = tuplestore_gettupleslot(progressResultSet->setResult,
+												 true,
+												 false,
+												 tupleTableSlot);
 
 		if (!nextTuple)
 		{
 			break;
 		}
 
-		magicNumberDatum = slot_getattr(tupleTableSlot, magicNumberIndex, &isNull);
-		magicNumber = DatumGetUInt64(magicNumberDatum);
+		Datum magicNumberDatum = slot_getattr(tupleTableSlot, magicNumberIndex, &isNull);
+		uint64 magicNumber = DatumGetUInt64(magicNumberDatum);
 
 		if (!isNull && magicNumber == commandTypeMagicNumber)
 		{

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -273,10 +273,9 @@ static void
 ResizeStackToMaximumDepth(void)
 {
 #ifndef WIN32
-	volatile char *stack_resizer = NULL;
 	long max_stack_depth_bytes = max_stack_depth * 1024L;
 
-	stack_resizer = alloca(max_stack_depth_bytes);
+	volatile char *stack_resizer = alloca(max_stack_depth_bytes);
 
 	/*
 	 * Different architectures might have different directions while
@@ -345,14 +344,13 @@ StartupCitusBackend(void)
 static void
 CreateRequiredDirectories(void)
 {
-	int dirNo = 0;
 	const char *subdirs[] = {
 		"pg_foreign_file",
 		"pg_foreign_file/cached",
 		"base/" PG_JOB_CACHE_DIR
 	};
 
-	for (dirNo = 0; dirNo < lengthof(subdirs); dirNo++)
+	for (int dirNo = 0; dirNo < lengthof(subdirs); dirNo++)
 	{
 		int ret = mkdir(subdirs[dirNo], S_IRWXU);
 
@@ -1380,15 +1378,12 @@ NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source)
 static void
 NodeConninfoGucAssignHook(const char *newval, void *extra)
 {
-	PQconninfoOption *optionArray = NULL;
-	PQconninfoOption *option = NULL;
-
 	if (newval == NULL)
 	{
 		newval = "";
 	}
 
-	optionArray = PQconninfoParse(newval, NULL);
+	PQconninfoOption *optionArray = PQconninfoParse(newval, NULL);
 	if (optionArray == NULL)
 	{
 		ereport(FATAL, (errmsg("cannot parse node_conninfo value"),
@@ -1398,7 +1393,7 @@ NodeConninfoGucAssignHook(const char *newval, void *extra)
 
 	ResetConnParams();
 
-	for (option = optionArray; option->keyword != NULL; option++)
+	for (PQconninfoOption *option = optionArray; option->keyword != NULL; option++)
 	{
 		if (option->val == NULL || option->val[0] == '\0')
 		{

--- a/src/backend/distributed/test/colocation_utils.c
+++ b/src/backend/distributed/test/colocation_utils.c
@@ -83,7 +83,6 @@ get_colocated_table_array(PG_FUNCTION_ARGS)
 {
 	Oid distributedTableId = PG_GETARG_OID(0);
 
-	ArrayType *colocatedTablesArrayType = NULL;
 	List *colocatedTableList = ColocatedTableList(distributedTableId);
 	ListCell *colocatedTableCell = NULL;
 	int colocatedTableCount = list_length(colocatedTableList);
@@ -100,8 +99,9 @@ get_colocated_table_array(PG_FUNCTION_ARGS)
 		colocatedTableIndex++;
 	}
 
-	colocatedTablesArrayType = DatumArrayToArrayType(colocatedTablesDatumArray,
-													 colocatedTableCount, arrayTypeId);
+	ArrayType *colocatedTablesArrayType = DatumArrayToArrayType(colocatedTablesDatumArray,
+																colocatedTableCount,
+																arrayTypeId);
 
 	PG_RETURN_ARRAYTYPE_P(colocatedTablesArrayType);
 }

--- a/src/backend/distributed/test/deparse_function_query.c
+++ b/src/backend/distributed/test/deparse_function_query.c
@@ -31,15 +31,12 @@ Datum
 deparse_test(PG_FUNCTION_ARGS)
 {
 	text *queryStringText = PG_GETARG_TEXT_P(0);
-	char *queryStringChar = NULL;
-	Query *query = NULL;
-	const char *deparsedQuery = NULL;
 
-	queryStringChar = text_to_cstring(queryStringText);
-	query = ParseQueryString(queryStringChar, NULL, 0);
+	char *queryStringChar = text_to_cstring(queryStringText);
+	Query *query = ParseQueryString(queryStringChar, NULL, 0);
 
 	QualifyTreeNode(query->utilityStmt);
-	deparsedQuery = DeparseTreeNode(query->utilityStmt);
+	const char *deparsedQuery = DeparseTreeNode(query->utilityStmt);
 
 	PG_RETURN_TEXT_P(cstring_to_text(deparsedQuery));
 }

--- a/src/backend/distributed/test/deparse_shard_query.c
+++ b/src/backend/distributed/test/deparse_shard_query.c
@@ -50,10 +50,10 @@ deparse_shard_query_test(PG_FUNCTION_ARGS)
 	{
 		Node *parsetree = (Node *) lfirst(parseTreeCell);
 		ListCell *queryTreeCell = NULL;
-		List *queryTreeList = NIL;
 
-		queryTreeList = pg_analyze_and_rewrite((RawStmt *) parsetree, queryStringChar,
-											   NULL, 0, NULL);
+		List *queryTreeList = pg_analyze_and_rewrite((RawStmt *) parsetree,
+													 queryStringChar,
+													 NULL, 0, NULL);
 
 		foreach(queryTreeCell, queryTreeList)
 		{

--- a/src/backend/distributed/test/distributed_deadlock_detection.c
+++ b/src/backend/distributed/test/distributed_deadlock_detection.c
@@ -40,10 +40,7 @@ Datum
 get_adjacency_list_wait_graph(PG_FUNCTION_ARGS)
 {
 	TupleDesc tupleDescriptor = NULL;
-	Tuplestorestate *tupleStore = NULL;
 
-	WaitGraph *waitGraph = NULL;
-	HTAB *adjacencyList = NULL;
 	HASH_SEQ_STATUS status;
 	TransactionNode *transactionNode = NULL;
 
@@ -52,9 +49,9 @@ get_adjacency_list_wait_graph(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 
-	tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
-	waitGraph = BuildGlobalWaitGraph();
-	adjacencyList = BuildAdjacencyListsForWaitGraph(waitGraph);
+	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
+	WaitGraph *waitGraph = BuildGlobalWaitGraph();
+	HTAB *adjacencyList = BuildAdjacencyListsForWaitGraph(waitGraph);
 
 	/* iterate on all nodes */
 	hash_seq_init(&status, adjacencyList);

--- a/src/backend/distributed/test/distribution_metadata.c
+++ b/src/backend/distributed/test/distribution_metadata.c
@@ -62,17 +62,14 @@ Datum
 load_shard_id_array(PG_FUNCTION_ARGS)
 {
 	Oid distributedTableId = PG_GETARG_OID(0);
-	ArrayType *shardIdArrayType = NULL;
 	ListCell *shardCell = NULL;
 	int shardIdIndex = 0;
 	Oid shardIdTypeId = INT8OID;
 
-	int shardIdCount = -1;
-	Datum *shardIdDatumArray = NULL;
 	List *shardList = LoadShardIntervalList(distributedTableId);
 
-	shardIdCount = list_length(shardList);
-	shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
+	int shardIdCount = list_length(shardList);
+	Datum *shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
 
 	foreach(shardCell, shardList)
 	{
@@ -83,8 +80,8 @@ load_shard_id_array(PG_FUNCTION_ARGS)
 		shardIdIndex++;
 	}
 
-	shardIdArrayType = DatumArrayToArrayType(shardIdDatumArray, shardIdCount,
-											 shardIdTypeId);
+	ArrayType *shardIdArrayType = DatumArrayToArrayType(shardIdDatumArray, shardIdCount,
+														shardIdTypeId);
 
 	PG_RETURN_ARRAYTYPE_P(shardIdArrayType);
 }
@@ -103,12 +100,11 @@ load_shard_interval_array(PG_FUNCTION_ARGS)
 	Oid expectedType PG_USED_FOR_ASSERTS_ONLY = get_fn_expr_argtype(fcinfo->flinfo, 1);
 	ShardInterval *shardInterval = LoadShardInterval(shardId);
 	Datum shardIntervalArray[] = { shardInterval->minValue, shardInterval->maxValue };
-	ArrayType *shardIntervalArrayType = NULL;
 
 	Assert(expectedType == shardInterval->valueTypeId);
 
-	shardIntervalArrayType = DatumArrayToArrayType(shardIntervalArray, 2,
-												   shardInterval->valueTypeId);
+	ArrayType *shardIntervalArrayType = DatumArrayToArrayType(shardIntervalArray, 2,
+															  shardInterval->valueTypeId);
 
 	PG_RETURN_ARRAYTYPE_P(shardIntervalArrayType);
 }
@@ -126,12 +122,9 @@ load_shard_placement_array(PG_FUNCTION_ARGS)
 {
 	int64 shardId = PG_GETARG_INT64(0);
 	bool onlyFinalized = PG_GETARG_BOOL(1);
-	ArrayType *placementArrayType = NULL;
 	List *placementList = NIL;
 	ListCell *placementCell = NULL;
-	int placementCount = -1;
 	int placementIndex = 0;
-	Datum *placementDatumArray = NULL;
 	Oid placementTypeId = TEXTOID;
 	StringInfo placementInfo = makeStringInfo();
 
@@ -146,8 +139,8 @@ load_shard_placement_array(PG_FUNCTION_ARGS)
 
 	placementList = SortList(placementList, CompareShardPlacementsByWorker);
 
-	placementCount = list_length(placementList);
-	placementDatumArray = palloc0(placementCount * sizeof(Datum));
+	int placementCount = list_length(placementList);
+	Datum *placementDatumArray = palloc0(placementCount * sizeof(Datum));
 
 	foreach(placementCell, placementList)
 	{
@@ -160,8 +153,9 @@ load_shard_placement_array(PG_FUNCTION_ARGS)
 		resetStringInfo(placementInfo);
 	}
 
-	placementArrayType = DatumArrayToArrayType(placementDatumArray, placementCount,
-											   placementTypeId);
+	ArrayType *placementArrayType = DatumArrayToArrayType(placementDatumArray,
+														  placementCount,
+														  placementTypeId);
 
 	PG_RETURN_ARRAYTYPE_P(placementArrayType);
 }
@@ -224,14 +218,12 @@ create_monolithic_shard_row(PG_FUNCTION_ARGS)
 	StringInfo minInfo = makeStringInfo();
 	StringInfo maxInfo = makeStringInfo();
 	uint64 newShardId = GetNextShardId();
-	text *maxInfoText = NULL;
-	text *minInfoText = NULL;
 
 	appendStringInfo(minInfo, "%d", INT32_MIN);
 	appendStringInfo(maxInfo, "%d", INT32_MAX);
 
-	minInfoText = cstring_to_text(minInfo->data);
-	maxInfoText = cstring_to_text(maxInfo->data);
+	text *minInfoText = cstring_to_text(minInfo->data);
+	text *maxInfoText = cstring_to_text(maxInfo->data);
 
 	InsertShardRow(distributedTableId, newShardId, SHARD_STORAGE_TABLE, minInfoText,
 				   maxInfoText);
@@ -270,10 +262,10 @@ relation_count_in_query(PG_FUNCTION_ARGS)
 	{
 		Node *parsetree = (Node *) lfirst(parseTreeCell);
 		ListCell *queryTreeCell = NULL;
-		List *queryTreeList = NIL;
 
-		queryTreeList = pg_analyze_and_rewrite((RawStmt *) parsetree, queryStringChar,
-											   NULL, 0, NULL);
+		List *queryTreeList = pg_analyze_and_rewrite((RawStmt *) parsetree,
+													 queryStringChar,
+													 NULL, 0, NULL);
 
 		foreach(queryTreeCell, queryTreeList)
 		{

--- a/src/backend/distributed/test/progress_utils.c
+++ b/src/backend/distributed/test/progress_utils.c
@@ -95,8 +95,7 @@ show_progress(PG_FUNCTION_ARGS)
 		ProgressMonitorData *monitor = lfirst(monitorCell);
 		uint64 *steps = monitor->steps;
 
-		int stepIndex = 0;
-		for (stepIndex = 0; stepIndex < monitor->stepCount; stepIndex++)
+		for (int stepIndex = 0; stepIndex < monitor->stepCount; stepIndex++)
 		{
 			uint64 step = steps[stepIndex];
 

--- a/src/backend/distributed/test/prune_shard_list.c
+++ b/src/backend/distributed/test/prune_shard_list.c
@@ -202,20 +202,16 @@ MakeTextPartitionExpression(Oid distributedTableId, text *value)
 static ArrayType *
 PrunedShardIdsForTable(Oid distributedTableId, List *whereClauseList)
 {
-	ArrayType *shardIdArrayType = NULL;
 	ListCell *shardCell = NULL;
 	int shardIdIndex = 0;
 	Oid shardIdTypeId = INT8OID;
 	Index tableId = 1;
 
-	List *shardList = NIL;
-	int shardIdCount = -1;
-	Datum *shardIdDatumArray = NULL;
 
-	shardList = PruneShards(distributedTableId, tableId, whereClauseList, NULL);
+	List *shardList = PruneShards(distributedTableId, tableId, whereClauseList, NULL);
 
-	shardIdCount = list_length(shardList);
-	shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
+	int shardIdCount = list_length(shardList);
+	Datum *shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
 
 	foreach(shardCell, shardList)
 	{
@@ -226,8 +222,8 @@ PrunedShardIdsForTable(Oid distributedTableId, List *whereClauseList)
 		shardIdIndex++;
 	}
 
-	shardIdArrayType = DatumArrayToArrayType(shardIdDatumArray, shardIdCount,
-											 shardIdTypeId);
+	ArrayType *shardIdArrayType = DatumArrayToArrayType(shardIdDatumArray, shardIdCount,
+														shardIdTypeId);
 
 	return shardIdArrayType;
 }
@@ -240,8 +236,6 @@ PrunedShardIdsForTable(Oid distributedTableId, List *whereClauseList)
 static ArrayType *
 SortedShardIntervalArray(Oid distributedTableId)
 {
-	ArrayType *shardIdArrayType = NULL;
-	int shardIndex = 0;
 	Oid shardIdTypeId = INT8OID;
 
 	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
@@ -249,7 +243,7 @@ SortedShardIntervalArray(Oid distributedTableId)
 	int shardIdCount = cacheEntry->shardIntervalArrayLength;
 	Datum *shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
 
-	for (shardIndex = 0; shardIndex < shardIdCount; ++shardIndex)
+	for (int shardIndex = 0; shardIndex < shardIdCount; ++shardIndex)
 	{
 		ShardInterval *shardId = shardIntervalArray[shardIndex];
 		Datum shardIdDatum = Int64GetDatum(shardId->shardId);
@@ -257,8 +251,8 @@ SortedShardIntervalArray(Oid distributedTableId)
 		shardIdDatumArray[shardIndex] = shardIdDatum;
 	}
 
-	shardIdArrayType = DatumArrayToArrayType(shardIdDatumArray, shardIdCount,
-											 shardIdTypeId);
+	ArrayType *shardIdArrayType = DatumArrayToArrayType(shardIdDatumArray, shardIdCount,
+														shardIdTypeId);
 
 	return shardIdArrayType;
 }

--- a/src/backend/distributed/test/run_from_same_connection.c
+++ b/src/backend/distributed/test/run_from_same_connection.c
@@ -136,7 +136,6 @@ run_commands_on_session_level_connection_to_node(PG_FUNCTION_ARGS)
 	StringInfo workerProcessStringInfo = makeStringInfo();
 	MultiConnection *localConnection = GetNodeConnection(0, LOCAL_HOST_NAME,
 														 PostPortNumber);
-	Oid pgReloadConfOid = InvalidOid;
 
 	if (!singleConnection)
 	{
@@ -160,7 +159,7 @@ run_commands_on_session_level_connection_to_node(PG_FUNCTION_ARGS)
 	CloseConnection(localConnection);
 
 	/* Call pg_reload_conf UDF to update changed GUCs above on each backend */
-	pgReloadConfOid = FunctionOid("pg_catalog", "pg_reload_conf", 0);
+	Oid pgReloadConfOid = FunctionOid("pg_catalog", "pg_reload_conf", 0);
 	OidFunctionCall0(pgReloadConfOid);
 
 
@@ -197,21 +196,19 @@ GetRemoteProcessId()
 {
 	StringInfo queryStringInfo = makeStringInfo();
 	PGresult *result = NULL;
-	int64 rowCount = 0;
-	int64 resultValue = 0;
 
 	appendStringInfo(queryStringInfo, GET_PROCESS_ID);
 
 	ExecuteOptionalRemoteCommand(singleConnection, queryStringInfo->data, &result);
 
-	rowCount = PQntuples(result);
+	int64 rowCount = PQntuples(result);
 
 	if (rowCount != 1)
 	{
 		PG_RETURN_VOID();
 	}
 
-	resultValue = ParseIntField(result, 0, 0);
+	int64 resultValue = ParseIntField(result, 0, 0);
 
 	PQclear(result);
 	ClearResults(singleConnection, false);

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -155,12 +155,10 @@ Datum
 get_current_transaction_id(PG_FUNCTION_ARGS)
 {
 	TupleDesc tupleDescriptor = NULL;
-	HeapTuple heapTuple = NULL;
 
 	Datum values[5];
 	bool isNulls[5];
 
-	DistributedTransactionId *distributedTransctionId = NULL;
 
 	CheckCitusVersion(ERROR);
 
@@ -176,7 +174,8 @@ get_current_transaction_id(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errmsg("backend is not ready for distributed transactions")));
 	}
 
-	distributedTransctionId = GetCurrentDistributedTransactionId();
+	DistributedTransactionId *distributedTransctionId =
+		GetCurrentDistributedTransactionId();
 
 	memset(values, 0, sizeof(values));
 	memset(isNulls, false, sizeof(isNulls));
@@ -198,7 +197,7 @@ get_current_transaction_id(PG_FUNCTION_ARGS)
 		isNulls[4] = true;
 	}
 
-	heapTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
+	HeapTuple heapTuple = heap_form_tuple(tupleDescriptor, values, isNulls);
 
 	PG_RETURN_DATUM(HeapTupleGetDatum(heapTuple));
 }
@@ -215,7 +214,6 @@ Datum
 get_global_active_transactions(PG_FUNCTION_ARGS)
 {
 	TupleDesc tupleDescriptor = NULL;
-	Tuplestorestate *tupleStore = NULL;
 	List *workerNodeList = ActivePrimaryWorkerNodeList(NoLock);
 	ListCell *workerNodeCell = NULL;
 	List *connectionList = NIL;
@@ -223,7 +221,7 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 	StringInfo queryToSend = makeStringInfo();
 
 	CheckCitusVersion(ERROR);
-	tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
+	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
 
 	appendStringInfo(queryToSend, GET_ACTIVE_TRANSACTION_QUERY);
 
@@ -236,7 +234,6 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
 		char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
-		MultiConnection *connection = NULL;
 		int connectionFlags = 0;
 
 		if (workerNode->groupId == GetLocalGroupId())
@@ -245,7 +242,8 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 			continue;
 		}
 
-		connection = StartNodeConnection(connectionFlags, nodeName, nodePort);
+		MultiConnection *connection = StartNodeConnection(connectionFlags, nodeName,
+														  nodePort);
 
 		connectionList = lappend(connectionList, connection);
 	}
@@ -256,9 +254,8 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 	foreach(connectionCell, connectionList)
 	{
 		MultiConnection *connection = (MultiConnection *) lfirst(connectionCell);
-		int querySent = false;
 
-		querySent = SendRemoteCommand(connection, queryToSend->data);
+		int querySent = SendRemoteCommand(connection, queryToSend->data);
 		if (querySent == 0)
 		{
 			ReportConnectionError(connection, WARNING);
@@ -269,28 +266,24 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 	foreach(connectionCell, connectionList)
 	{
 		MultiConnection *connection = (MultiConnection *) lfirst(connectionCell);
-		PGresult *result = NULL;
 		bool raiseInterrupts = true;
 		Datum values[ACTIVE_TRANSACTION_COLUMN_COUNT];
 		bool isNulls[ACTIVE_TRANSACTION_COLUMN_COUNT];
-		int64 rowIndex = 0;
-		int64 rowCount = 0;
-		int64 colCount = 0;
 
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
 		{
 			continue;
 		}
 
-		result = GetRemoteCommandResult(connection, raiseInterrupts);
+		PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 		if (!IsResponseOK(result))
 		{
 			ReportResultError(connection, result, WARNING);
 			continue;
 		}
 
-		rowCount = PQntuples(result);
-		colCount = PQnfields(result);
+		int64 rowCount = PQntuples(result);
+		int64 colCount = PQnfields(result);
 
 		/* Although it is not expected */
 		if (colCount != ACTIVE_TRANSACTION_COLUMN_COUNT)
@@ -300,7 +293,7 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 			continue;
 		}
 
-		for (rowIndex = 0; rowIndex < rowCount; rowIndex++)
+		for (int64 rowIndex = 0; rowIndex < rowCount; rowIndex++)
 		{
 			memset(values, 0, sizeof(values));
 			memset(isNulls, false, sizeof(isNulls));
@@ -334,10 +327,9 @@ Datum
 get_all_active_transactions(PG_FUNCTION_ARGS)
 {
 	TupleDesc tupleDescriptor = NULL;
-	Tuplestorestate *tupleStore = NULL;
 
 	CheckCitusVersion(ERROR);
-	tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
+	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
 
 	StoreAllActiveTransactions(tupleStore, tupleDescriptor);
 
@@ -355,7 +347,6 @@ get_all_active_transactions(PG_FUNCTION_ARGS)
 static void
 StoreAllActiveTransactions(Tuplestorestate *tupleStore, TupleDesc tupleDescriptor)
 {
-	int backendIndex = 0;
 	Datum values[ACTIVE_TRANSACTION_COLUMN_COUNT];
 	bool isNulls[ACTIVE_TRANSACTION_COLUMN_COUNT];
 	bool showAllTransactions = superuser();
@@ -377,18 +368,14 @@ StoreAllActiveTransactions(Tuplestorestate *tupleStore, TupleDesc tupleDescripto
 	/* we're reading all distributed transactions, prevent new backends */
 	LockBackendSharedMemory(LW_SHARED);
 
-	for (backendIndex = 0; backendIndex < MaxBackends; ++backendIndex)
+	for (int backendIndex = 0; backendIndex < MaxBackends; ++backendIndex)
 	{
 		BackendData *currentBackend =
 			&backendManagementShmemData->backends[backendIndex];
-		bool coordinatorOriginatedQuery = false;
 
 		/* to work on data after releasing g spinlock to protect against errors */
-		Oid databaseId = InvalidOid;
-		int backendPid = -1;
 		int initiatorNodeIdentifier = -1;
 		uint64 transactionNumber = 0;
-		TimestampTz transactionIdTimestamp = 0;
 
 		SpinLockAcquire(&currentBackend->mutex);
 
@@ -409,8 +396,8 @@ StoreAllActiveTransactions(Tuplestorestate *tupleStore, TupleDesc tupleDescripto
 			continue;
 		}
 
-		databaseId = currentBackend->databaseId;
-		backendPid = ProcGlobal->allProcs[backendIndex].pid;
+		Oid databaseId = currentBackend->databaseId;
+		int backendPid = ProcGlobal->allProcs[backendIndex].pid;
 		initiatorNodeIdentifier = currentBackend->citusBackend.initiatorNodeIdentifier;
 
 		/*
@@ -421,10 +408,11 @@ StoreAllActiveTransactions(Tuplestorestate *tupleStore, TupleDesc tupleDescripto
 		 * field with the same name. The reason is that it also covers backends that are not
 		 * inside a distributed transaction.
 		 */
-		coordinatorOriginatedQuery = currentBackend->citusBackend.transactionOriginator;
+		bool coordinatorOriginatedQuery =
+			currentBackend->citusBackend.transactionOriginator;
 
 		transactionNumber = currentBackend->transactionId.transactionNumber;
-		transactionIdTimestamp = currentBackend->transactionId.timestamp;
+		TimestampTz transactionIdTimestamp = currentBackend->transactionId.timestamp;
 
 		SpinLockRelease(&currentBackend->mutex);
 
@@ -489,8 +477,6 @@ BackendManagementShmemInit(void)
 
 	if (!alreadyInitialized)
 	{
-		int backendIndex = 0;
-		int totalProcs = 0;
 		char *trancheName = "Backend Management Tranche";
 
 		NamedLWLockTranche *namedLockTranche =
@@ -518,8 +504,8 @@ BackendManagementShmemInit(void)
 		 * We also initiate initiatorNodeIdentifier to -1, which can never be
 		 * used as a node id.
 		 */
-		totalProcs = TotalProcCount();
-		for (backendIndex = 0; backendIndex < totalProcs; ++backendIndex)
+		int totalProcs = TotalProcCount();
+		for (int backendIndex = 0; backendIndex < totalProcs; ++backendIndex)
 		{
 			BackendData *backendData =
 				&backendManagementShmemData->backends[backendIndex];
@@ -809,7 +795,6 @@ CurrentDistributedTransactionNumber(void)
 void
 GetBackendDataForProc(PGPROC *proc, BackendData *result)
 {
-	BackendData *backendData = NULL;
 	int pgprocno = proc->pgprocno;
 
 	if (proc->lockGroupLeader != NULL)
@@ -817,7 +802,7 @@ GetBackendDataForProc(PGPROC *proc, BackendData *result)
 		pgprocno = proc->lockGroupLeader->pgprocno;
 	}
 
-	backendData = &backendManagementShmemData->backends[pgprocno];
+	BackendData *backendData = &backendManagementShmemData->backends[pgprocno];
 
 	SpinLockAcquire(&backendData->mutex);
 
@@ -903,14 +888,12 @@ List *
 ActiveDistributedTransactionNumbers(void)
 {
 	List *activeTransactionNumberList = NIL;
-	int curBackend = 0;
 
 	/* build list of starting procs */
-	for (curBackend = 0; curBackend < MaxBackends; curBackend++)
+	for (int curBackend = 0; curBackend < MaxBackends; curBackend++)
 	{
 		PGPROC *currentProc = &ProcGlobal->allProcs[curBackend];
 		BackendData currentBackendData;
-		uint64 *transactionNumber = NULL;
 
 		if (currentProc->pid == 0)
 		{
@@ -932,7 +915,7 @@ ActiveDistributedTransactionNumbers(void)
 			continue;
 		}
 
-		transactionNumber = (uint64 *) palloc0(sizeof(uint64));
+		uint64 *transactionNumber = (uint64 *) palloc0(sizeof(uint64));
 		*transactionNumber = currentBackendData.transactionId.transactionNumber;
 
 		activeTransactionNumberList = lappend(activeTransactionNumberList,

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -59,10 +59,7 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 {
 	RemoteTransaction *transaction = &connection->remoteTransaction;
 	StringInfo beginAndSetDistributedTransactionId = makeStringInfo();
-	DistributedTransactionId *distributedTransactionId = NULL;
 	ListCell *subIdCell = NULL;
-	List *activeSubXacts = NIL;
-	const char *timestamp = NULL;
 
 	Assert(transaction->transactionState == REMOTE_TRANS_INVALID);
 
@@ -84,8 +81,9 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 	 * and send both in one step. The reason is purely performance, we don't want
 	 * seperate roundtrips for these two statements.
 	 */
-	distributedTransactionId = GetCurrentDistributedTransactionId();
-	timestamp = timestamptz_to_str(distributedTransactionId->timestamp);
+	DistributedTransactionId *distributedTransactionId =
+		GetCurrentDistributedTransactionId();
+	const char *timestamp = timestamptz_to_str(distributedTransactionId->timestamp);
 	appendStringInfo(beginAndSetDistributedTransactionId,
 					 "SELECT assign_distributed_transaction_id(%d, " UINT64_FORMAT
 					 ", '%s');",
@@ -94,7 +92,7 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 					 timestamp);
 
 	/* append context for in-progress SAVEPOINTs for this transaction */
-	activeSubXacts = ActiveSubXactContexts();
+	List *activeSubXacts = ActiveSubXactContexts();
 	transaction->lastSuccessfulSubXact = TopSubTransactionId;
 	transaction->lastQueuedSubXact = TopSubTransactionId;
 	foreach(subIdCell, activeSubXacts)
@@ -139,12 +137,11 @@ void
 FinishRemoteTransactionBegin(struct MultiConnection *connection)
 {
 	RemoteTransaction *transaction = &connection->remoteTransaction;
-	bool clearSuccessful = true;
 	bool raiseErrors = true;
 
 	Assert(transaction->transactionState == REMOTE_TRANS_STARTING);
 
-	clearSuccessful = ClearResults(connection, raiseErrors);
+	bool clearSuccessful = ClearResults(connection, raiseErrors);
 	if (clearSuccessful)
 	{
 		transaction->transactionState = REMOTE_TRANS_STARTED;
@@ -276,7 +273,6 @@ void
 FinishRemoteTransactionCommit(MultiConnection *connection)
 {
 	RemoteTransaction *transaction = &connection->remoteTransaction;
-	PGresult *result = NULL;
 	const bool raiseErrors = false;
 	const bool isCommit = true;
 
@@ -284,7 +280,7 @@ FinishRemoteTransactionCommit(MultiConnection *connection)
 		   transaction->transactionState == REMOTE_TRANS_1PC_COMMITTING ||
 		   transaction->transactionState == REMOTE_TRANS_2PC_COMMITTING);
 
-	result = GetRemoteCommandResult(connection, raiseErrors);
+	PGresult *result = GetRemoteCommandResult(connection, raiseErrors);
 
 	if (!IsResponseOK(result))
 	{
@@ -476,7 +472,6 @@ StartRemoteTransactionPrepare(struct MultiConnection *connection)
 	RemoteTransaction *transaction = &connection->remoteTransaction;
 	StringInfoData command;
 	const bool raiseErrors = true;
-	WorkerNode *workerNode = NULL;
 
 	/* can't prepare a nonexistant transaction */
 	Assert(transaction->transactionState != REMOTE_TRANS_INVALID);
@@ -490,7 +485,7 @@ StartRemoteTransactionPrepare(struct MultiConnection *connection)
 	Assign2PCIdentifier(connection);
 
 	/* log transactions to workers in pg_dist_transaction */
-	workerNode = FindWorkerNode(connection->hostname, connection->port);
+	WorkerNode *workerNode = FindWorkerNode(connection->hostname, connection->port);
 	if (workerNode != NULL)
 	{
 		LogTransactionRecord(workerNode->groupId, transaction->preparedName);
@@ -520,12 +515,11 @@ void
 FinishRemoteTransactionPrepare(struct MultiConnection *connection)
 {
 	RemoteTransaction *transaction = &connection->remoteTransaction;
-	PGresult *result = NULL;
 	const bool raiseErrors = true;
 
 	Assert(transaction->transactionState == REMOTE_TRANS_PREPARING);
 
-	result = GetRemoteCommandResult(connection, raiseErrors);
+	PGresult *result = GetRemoteCommandResult(connection, raiseErrors);
 
 	if (!IsResponseOK(result))
 	{
@@ -596,7 +590,6 @@ void
 RemoteTransactionsBeginIfNecessary(List *connectionList)
 {
 	ListCell *connectionCell = NULL;
-	bool raiseInterrupts = true;
 
 	/*
 	 * Don't do anything if not in a coordinated transaction. That allows the
@@ -630,7 +623,7 @@ RemoteTransactionsBeginIfNecessary(List *connectionList)
 		StartRemoteTransactionBegin(connection);
 	}
 
-	raiseInterrupts = true;
+	bool raiseInterrupts = true;
 	WaitForAllConnections(connectionList, raiseInterrupts);
 
 	/* get result of all the BEGINs */
@@ -798,7 +791,6 @@ void
 CoordinatedRemoteTransactionsPrepare(void)
 {
 	dlist_iter iter;
-	bool raiseInterrupts = false;
 	List *connectionList = NIL;
 
 	/* issue PREPARE TRANSACTION; to all relevant remote nodes */
@@ -822,7 +814,7 @@ CoordinatedRemoteTransactionsPrepare(void)
 		connectionList = lappend(connectionList, connection);
 	}
 
-	raiseInterrupts = true;
+	bool raiseInterrupts = true;
 	WaitForAllConnections(connectionList, raiseInterrupts);
 
 	/* Wait for result */
@@ -857,7 +849,6 @@ CoordinatedRemoteTransactionsCommit(void)
 {
 	dlist_iter iter;
 	List *connectionList = NIL;
-	bool raiseInterrupts = false;
 
 	/*
 	 * Issue appropriate transaction commands to remote nodes. If everything
@@ -885,7 +876,7 @@ CoordinatedRemoteTransactionsCommit(void)
 		connectionList = lappend(connectionList, connection);
 	}
 
-	raiseInterrupts = false;
+	bool raiseInterrupts = false;
 	WaitForAllConnections(connectionList, raiseInterrupts);
 
 	/* wait for the replies to the commands to come in */
@@ -921,7 +912,6 @@ CoordinatedRemoteTransactionsAbort(void)
 {
 	dlist_iter iter;
 	List *connectionList = NIL;
-	bool raiseInterrupts = false;
 
 	/* asynchronously send ROLLBACK [PREPARED] */
 	dlist_foreach(iter, &InProgressTransactions)
@@ -942,7 +932,7 @@ CoordinatedRemoteTransactionsAbort(void)
 		connectionList = lappend(connectionList, connection);
 	}
 
-	raiseInterrupts = false;
+	bool raiseInterrupts = false;
 	WaitForAllConnections(connectionList, raiseInterrupts);
 
 	/* and wait for the results */

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -75,14 +75,15 @@ void
 SendCommandToWorkerAsUser(char *nodeName, int32 nodePort, const char *nodeUser,
 						  const char *command)
 {
-	MultiConnection *transactionConnection = NULL;
 	uint connectionFlags = 0;
 
 	BeginOrContinueCoordinatedTransaction();
 	CoordinatedTransactionUse2PC();
 
-	transactionConnection = GetNodeUserDatabaseConnection(connectionFlags, nodeName,
-														  nodePort, nodeUser, NULL);
+	MultiConnection *transactionConnection = GetNodeUserDatabaseConnection(
+		connectionFlags, nodeName,
+		nodePort,
+		nodeUser, NULL);
 
 	MarkRemoteTransactionCritical(transactionConnection);
 	RemoteTransactionBeginIfNecessary(transactionConnection);
@@ -155,14 +156,15 @@ SendBareCommandListToWorkers(TargetWorkerSet targetWorkerSet, List *commandList)
 	/* run commands serially */
 	foreach(workerNodeCell, workerNodeList)
 	{
-		MultiConnection *workerConnection = NULL;
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
 		char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
 		int connectionFlags = FORCE_NEW_CONNECTION;
 
-		workerConnection = GetNodeUserDatabaseConnection(connectionFlags, nodeName,
-														 nodePort, nodeUser, NULL);
+		MultiConnection *workerConnection = GetNodeUserDatabaseConnection(connectionFlags,
+																		  nodeName,
+																		  nodePort,
+																		  nodeUser, NULL);
 
 		/* iterate over the commands and execute them in the same connection */
 		foreach(commandCell, commandList)
@@ -194,14 +196,15 @@ SendBareOptionalCommandListToWorkersAsUser(TargetWorkerSet targetWorkerSet,
 	/* run commands serially */
 	foreach(workerNodeCell, workerNodeList)
 	{
-		MultiConnection *workerConnection = NULL;
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
 		char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
 		int connectionFlags = FORCE_NEW_CONNECTION;
 
-		workerConnection = GetNodeUserDatabaseConnection(connectionFlags, nodeName,
-														 nodePort, user, NULL);
+		MultiConnection *workerConnection = GetNodeUserDatabaseConnection(connectionFlags,
+																		  nodeName,
+																		  nodePort, user,
+																		  NULL);
 
 		/* iterate over the commands and execute them in the same connection */
 		foreach(commandCell, commandList)
@@ -250,11 +253,11 @@ SendCommandToWorkersParams(TargetWorkerSet targetWorkerSet, const char *command,
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
 		char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
-		MultiConnection *connection = NULL;
 		int32 connectionFlags = 0;
 
-		connection = StartNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
-													 user, NULL);
+		MultiConnection *connection = StartNodeUserDatabaseConnection(connectionFlags,
+																	  nodeName, nodePort,
+																	  user, NULL);
 
 		MarkRemoteTransactionCritical(connection);
 
@@ -323,12 +326,12 @@ void
 SendCommandListToWorkerInSingleTransaction(const char *nodeName, int32 nodePort,
 										   const char *nodeUser, List *commandList)
 {
-	MultiConnection *workerConnection = NULL;
 	ListCell *commandCell = NULL;
 	int connectionFlags = FORCE_NEW_CONNECTION;
 
-	workerConnection = GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
-													 nodeUser, NULL);
+	MultiConnection *workerConnection = GetNodeUserDatabaseConnection(connectionFlags,
+																	  nodeName, nodePort,
+																	  nodeUser, NULL);
 
 	MarkRemoteTransactionCritical(workerConnection);
 	RemoteTransactionBegin(workerConnection);

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -66,7 +66,6 @@ StartLockAcquireHelperBackgroundWorker(int backendToHelp, int32 lock_cooldown)
 	BackgroundWorkerHandle *handle = NULL;
 	LockAcquireHelperArgs args;
 	BackgroundWorker worker;
-	MemoryContextCallback *workerCleanup = NULL;
 	memset(&args, 0, sizeof(args));
 	memset(&worker, 0, sizeof(worker));
 
@@ -104,7 +103,7 @@ StartLockAcquireHelperBackgroundWorker(int backendToHelp, int32 lock_cooldown)
 						errhint("Increasing max_worker_processes might help.")));
 	}
 
-	workerCleanup = palloc0(sizeof(MemoryContextCallback));
+	MemoryContextCallback *workerCleanup = palloc0(sizeof(MemoryContextCallback));
 	workerCleanup->func = EnsureStopLockAcquireHelper;
 	workerCleanup->arg = handle;
 
@@ -156,16 +155,14 @@ lock_acquire_helper_sigterm(SIGNAL_ARGS)
 static bool
 ShouldAcquireLock(long sleepms)
 {
-	int rc;
-
 	/* early escape in case we already got the signal to stop acquiring the lock */
 	if (got_sigterm)
 	{
 		return false;
 	}
 
-	rc = WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-				   sleepms * 1L, PG_WAIT_EXTENSION);
+	int rc = WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   sleepms * 1L, PG_WAIT_EXTENSION);
 	ResetLatch(MyLatch);
 
 	/* emergency bailout if postmaster has died */
@@ -246,7 +243,6 @@ LockAcquireHelperMain(Datum main_arg)
 	while (ShouldAcquireLock(100))
 	{
 		int row = 0;
-		int spiStatus = 0;
 
 		elog(LOG, "canceling competing backends for backend %d", backendPid);
 
@@ -259,24 +255,23 @@ LockAcquireHelperMain(Datum main_arg)
 		PushActiveSnapshot(GetTransactionSnapshot());
 		pgstat_report_activity(STATE_RUNNING, sql.data);
 
-		spiStatus = SPI_execute_with_args(sql.data, paramCount, paramTypes, paramValues,
-										  NULL, false, 0);
+		int spiStatus = SPI_execute_with_args(sql.data, paramCount, paramTypes,
+											  paramValues,
+											  NULL, false, 0);
 
 		if (spiStatus == SPI_OK_SELECT)
 		{
 			for (row = 0; row < SPI_processed; row++)
 			{
-				int terminatedPid = 0;
-				bool isTerminated = false;
 				bool isnull = false;
 
-				terminatedPid = DatumGetInt32(SPI_getbinval(SPI_tuptable->vals[0],
-															SPI_tuptable->tupdesc,
-															1, &isnull));
+				int terminatedPid = DatumGetInt32(SPI_getbinval(SPI_tuptable->vals[0],
+																SPI_tuptable->tupdesc,
+																1, &isnull));
 
-				isTerminated = DatumGetBool(SPI_getbinval(SPI_tuptable->vals[0],
-														  SPI_tuptable->tupdesc,
-														  2, &isnull));
+				bool isTerminated = DatumGetBool(SPI_getbinval(SPI_tuptable->vals[0],
+															   SPI_tuptable->tupdesc,
+															   2, &isnull));
 
 				if (isTerminated)
 				{

--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -154,7 +154,6 @@ citus_evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	EState     *estate;
 	ExprState  *exprstate;
 	ExprContext *econtext;
-	MemoryContext oldcontext;
 	Datum		const_val;
 	bool		const_is_null;
 	int16		resultTypLen;
@@ -166,7 +165,7 @@ citus_evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	estate = CreateExecutorState();
 
 	/* We can use the estate's working context to avoid memory leaks. */
-	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+	MemoryContext oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
 
 	/* Make sure any opfuncids are filled in. */
 	fix_opfuncids((Node *) expr);

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -169,7 +169,6 @@ void
 CopyNodeMapMergeJob(COPYFUNC_ARGS)
 {
 	DECLARE_FROM_AND_NEW_NODE(MapMergeJob);
-	int arrayLength = 0;
 
 	copyJobInfo(&newnode->job, &from->job);
 
@@ -179,7 +178,7 @@ CopyNodeMapMergeJob(COPYFUNC_ARGS)
 	COPY_SCALAR_FIELD(partitionCount);
 	COPY_SCALAR_FIELD(sortedShardIntervalArrayLength);
 
-	arrayLength = from->sortedShardIntervalArrayLength;
+	int arrayLength = from->sortedShardIntervalArrayLength;
 
 	/* now build & read sortedShardIntervalArray */
 	COPY_NODE_ARRAY(sortedShardIntervalArray, ShardInterval, arrayLength);

--- a/src/backend/distributed/utils/citus_nodefuncs.c
+++ b/src/backend/distributed/utils/citus_nodefuncs.c
@@ -74,17 +74,10 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind,
 					 char *fragmentSchemaName, char *fragmentTableName,
 					 List *tableIdList)
 {
-	RangeTblFunction *fauxFunction = NULL;
-	FuncExpr *fauxFuncExpr = NULL;
-	Const *rteKindData = NULL;
-	Const *fragmentSchemaData = NULL;
-	Const *fragmentTableData = NULL;
-	Const *tableIdListData = NULL;
-
 	Assert(rte->eref);
 
 	/* store RTE kind as a plain int4 */
-	rteKindData = makeNode(Const);
+	Const *rteKindData = makeNode(Const);
 	rteKindData->consttype = INT4OID;
 	rteKindData->constlen = 4;
 	rteKindData->constvalue = Int32GetDatum(rteKind);
@@ -93,7 +86,7 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind,
 	rteKindData->location = -1;
 
 	/* store the fragment schema as a cstring */
-	fragmentSchemaData = makeNode(Const);
+	Const *fragmentSchemaData = makeNode(Const);
 	fragmentSchemaData->consttype = CSTRINGOID;
 	fragmentSchemaData->constlen = -2;
 	fragmentSchemaData->constvalue = CStringGetDatum(fragmentSchemaName);
@@ -102,7 +95,7 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind,
 	fragmentSchemaData->location = -1;
 
 	/* store the fragment name as a cstring */
-	fragmentTableData = makeNode(Const);
+	Const *fragmentTableData = makeNode(Const);
 	fragmentTableData->consttype = CSTRINGOID;
 	fragmentTableData->constlen = -2;
 	fragmentTableData->constvalue = CStringGetDatum(fragmentTableName);
@@ -111,7 +104,7 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind,
 	fragmentTableData->location = -1;
 
 	/* store the table id list as an array of integers: FIXME */
-	tableIdListData = makeNode(Const);
+	Const *tableIdListData = makeNode(Const);
 	tableIdListData->consttype = CSTRINGOID;
 	tableIdListData->constbyval = false;
 	tableIdListData->constlen = -2;
@@ -130,14 +123,14 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind,
 	}
 
 	/* create function expression to store our faux arguments in */
-	fauxFuncExpr = makeNode(FuncExpr);
+	FuncExpr *fauxFuncExpr = makeNode(FuncExpr);
 	fauxFuncExpr->funcid = CitusExtraDataContainerFuncId();
 	fauxFuncExpr->funcretset = true;
 	fauxFuncExpr->location = -1;
 	fauxFuncExpr->args = list_make4(rteKindData, fragmentSchemaData,
 									fragmentTableData, tableIdListData);
 
-	fauxFunction = makeNode(RangeTblFunction);
+	RangeTblFunction *fauxFunction = makeNode(RangeTblFunction);
 	fauxFunction->funcexpr = (Node *) fauxFuncExpr;
 
 	/* set the column count to pass ruleutils checks, not used elsewhere */
@@ -159,10 +152,6 @@ ExtractRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind *rteKind,
 						 char **fragmentSchemaName, char **fragmentTableName,
 						 List **tableIdList)
 {
-	RangeTblFunction *fauxFunction = NULL;
-	FuncExpr *fauxFuncExpr = NULL;
-	Const *tmpConst = NULL;
-
 	/* set base rte kind first, so this can be used for 'non-extended' RTEs as well */
 	if (rteKind != NULL)
 	{
@@ -199,13 +188,13 @@ ExtractRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind *rteKind,
 	}
 
 	/* should pretty much always be a FuncExpr, but be liberal in what we expect... */
-	fauxFunction = linitial(rte->functions);
+	RangeTblFunction *fauxFunction = linitial(rte->functions);
 	if (!IsA(fauxFunction->funcexpr, FuncExpr))
 	{
 		return;
 	}
 
-	fauxFuncExpr = (FuncExpr *) fauxFunction->funcexpr;
+	FuncExpr *fauxFuncExpr = (FuncExpr *) fauxFunction->funcexpr;
 
 	/*
 	 * There will never be a range table entry with this function id, but for
@@ -229,7 +218,7 @@ ExtractRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind *rteKind,
 	}
 
 	/* extract rteKind */
-	tmpConst = (Const *) linitial(fauxFuncExpr->args);
+	Const *tmpConst = (Const *) linitial(fauxFuncExpr->args);
 	Assert(IsA(tmpConst, Const));
 	Assert(tmpConst->consttype == INT4OID);
 	if (rteKind != NULL)
@@ -419,12 +408,10 @@ const ExtensibleNodeMethods nodeMethods[] =
 void
 RegisterNodes(void)
 {
-	int off;
-
 	StaticAssertExpr(lengthof(nodeMethods) == lengthof(CitusNodeTagNamesD),
 					 "number of node methods and names do not match");
 
-	for (off = 0; off < lengthof(nodeMethods); off++)
+	for (int off = 0; off < lengthof(nodeMethods); off++)
 	{
 		RegisterExtensibleNodeMethods(&nodeMethods[off]);
 	}

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -279,8 +279,6 @@ ReadShardInterval(READFUNC_ARGS)
 READFUNC_RET
 ReadMapMergeJob(READFUNC_ARGS)
 {
-	int arrayLength;
-	int i;
 
 	READ_LOCALS(MapMergeJob);
 
@@ -292,13 +290,13 @@ ReadMapMergeJob(READFUNC_ARGS)
 	READ_UINT_FIELD(partitionCount);
 	READ_INT_FIELD(sortedShardIntervalArrayLength);
 
-	arrayLength = local_node->sortedShardIntervalArrayLength;
+	int arrayLength = local_node->sortedShardIntervalArrayLength;
 
 	/* now build & read sortedShardIntervalArray */
 	local_node->sortedShardIntervalArray =
 			(ShardInterval**) palloc(arrayLength * sizeof(ShardInterval *));
 
-	for (i = 0; i < arrayLength; ++i)
+	for (int i = 0; i < arrayLength; ++i)
 	{
 		/* can't use READ_NODE_FIELD, no field names */
 		local_node->sortedShardIntervalArray[i] = nodeRead(NULL, 0);

--- a/src/backend/distributed/utils/enable_ssl.c
+++ b/src/backend/distributed/utils/enable_ssl.c
@@ -75,13 +75,11 @@ citus_setup_ssl(PG_FUNCTION_ARGS)
 #else /* USE_SSL */
 	if (!EnableSSL && ShouldUseAutoSSL())
 	{
-		Node *enableSSLParseTree = NULL;
-
 		ereport(LOG, (errmsg("citus extension created on postgres without ssl enabled, "
 							 "turning it on during creation of the extension")));
 
 		/* execute the alter system statement to enable ssl on within postgres */
-		enableSSLParseTree = ParseTreeNode(ENABLE_SSL_QUERY);
+		Node *enableSSLParseTree = ParseTreeNode(ENABLE_SSL_QUERY);
 		AlterSystemSetConfigFile((AlterSystemStmt *) enableSSLParseTree);
 
 		if (strcmp(SSLCipherSuites, POSTGRES_DEFAULT_SSL_CIPHERS) == 0)
@@ -141,14 +139,12 @@ citus_check_defaults_for_sslmode(PG_FUNCTION_ARGS)
 	 */
 	if (strcmp(NodeConninfo, "sslmode=require") == 0)
 	{
-		Node *resetCitusNodeConnInfoParseTree = NULL;
-
 		/* execute the alter system statement to reset node_conninfo to the old default */
 
 		ereport(LOG, (errmsg("reset citus.node_conninfo to old default value as the new "
 							 "value is incompatible with the current ssl setting")));
 
-		resetCitusNodeConnInfoParseTree = ParseTreeNode(RESET_CITUS_NODE_CONNINFO);
+		Node *resetCitusNodeConnInfoParseTree = ParseTreeNode(RESET_CITUS_NODE_CONNINFO);
 		AlterSystemSetConfigFile((AlterSystemStmt *) resetCitusNodeConnInfoParseTree);
 		configChanged = true;
 	}
@@ -289,13 +285,8 @@ CreateCertificatesWhenNeeded()
 static EVP_PKEY *
 GeneratePrivateKey()
 {
-	int success = 0;
-	EVP_PKEY *privateKey = NULL;
-	BIGNUM *exponent = NULL;
-	RSA *rsa = NULL;
-
 	/* Allocate memory for the EVP_PKEY structure. */
-	privateKey = EVP_PKEY_new();
+	EVP_PKEY *privateKey = EVP_PKEY_new();
 	if (!privateKey)
 	{
 		ereport(ERROR, (errmsg("unable to allocate space for private key")));
@@ -303,17 +294,17 @@ GeneratePrivateKey()
 	EnsureReleaseResource((MemoryContextCallbackFunction) (&EVP_PKEY_free),
 						  privateKey);
 
-	exponent = BN_new();
+	BIGNUM *exponent = BN_new();
 	EnsureReleaseResource((MemoryContextCallbackFunction) (&BN_free), exponent);
 
 	/* load the exponent to use for the generation of the key */
-	success = BN_set_word(exponent, RSA_F4);
+	int success = BN_set_word(exponent, RSA_F4);
 	if (success != 1)
 	{
 		ereport(ERROR, (errmsg("unable to prepare exponent for RSA algorithm")));
 	}
 
-	rsa = RSA_new();
+	RSA *rsa = RSA_new();
 	success = RSA_generate_key_ex(rsa, 2048, exponent, NULL);
 	if (success != 1)
 	{
@@ -338,10 +329,7 @@ GeneratePrivateKey()
 static X509 *
 CreateCertificate(EVP_PKEY *privateKey)
 {
-	X509 *certificate = NULL;
-	X509_NAME *subjectName = NULL;
-
-	certificate = X509_new();
+	X509 *certificate = X509_new();
 	if (!certificate)
 	{
 		ereport(ERROR, (errmsg("unable to allocate space for the x509 certificate")));
@@ -374,7 +362,7 @@ CreateCertificate(EVP_PKEY *privateKey)
 	X509_set_pubkey(certificate, privateKey);
 
 	/* Set the common name for the certificate */
-	subjectName = X509_get_subject_name(certificate);
+	X509_NAME *subjectName = X509_get_subject_name(certificate);
 	X509_NAME_add_entry_by_txt(subjectName, X509_SUBJECT_COMMON_NAME, MBSTRING_ASC,
 							   (unsigned char *) CITUS_AUTO_SSL_COMMON_NAME, -1, -1,
 							   0);
@@ -402,19 +390,17 @@ StoreCertificate(EVP_PKEY *privateKey, X509 *certificate)
 	const char *privateKeyFilename = ssl_key_file;
 	const char *certificateFilename = ssl_cert_file;
 
-	FILE *privateKeyFile = NULL;
-	FILE *certificateFile = NULL;
-	int success = 0;
 
 	/* Open the private key file and write the private key in PEM format to it */
-	privateKeyFile = fopen(privateKeyFilename, "wb");
+	FILE *privateKeyFile = fopen(privateKeyFilename, "wb");
 	if (!privateKeyFile)
 	{
 		ereport(ERROR, (errmsg("unable to open private key file '%s' for writing",
 							   privateKeyFilename)));
 	}
 
-	success = PEM_write_PrivateKey(privateKeyFile, privateKey, NULL, NULL, 0, NULL, NULL);
+	int success = PEM_write_PrivateKey(privateKeyFile, privateKey, NULL, NULL, 0, NULL,
+									   NULL);
 	fclose(privateKeyFile);
 	if (!success)
 	{
@@ -422,7 +408,7 @@ StoreCertificate(EVP_PKEY *privateKey, X509 *certificate)
 	}
 
 	/* Open the certificate file and write the certificate in the PEM format to it */
-	certificateFile = fopen(certificateFilename, "wb");
+	FILE *certificateFile = fopen(certificateFilename, "wb");
 	if (!certificateFile)
 	{
 		ereport(ERROR, (errmsg("unable to open certificate file '%s' for writing",

--- a/src/backend/distributed/utils/function_utils.c
+++ b/src/backend/distributed/utils/function_utils.c
@@ -39,18 +39,16 @@ Oid
 FunctionOidExtended(const char *schemaName, const char *functionName, int argumentCount,
 					bool missingOK)
 {
-	FuncCandidateList functionList = NULL;
-	Oid functionOid = InvalidOid;
-
 	char *qualifiedFunctionName = quote_qualified_identifier(schemaName, functionName);
 	List *qualifiedFunctionNameList = stringToQualifiedNameList(qualifiedFunctionName);
 	List *argumentList = NIL;
 	const bool findVariadics = false;
 	const bool findDefaults = false;
 
-	functionList = FuncnameGetCandidates(qualifiedFunctionNameList, argumentCount,
-										 argumentList, findVariadics,
-										 findDefaults, true);
+	FuncCandidateList functionList = FuncnameGetCandidates(qualifiedFunctionNameList,
+														   argumentCount,
+														   argumentList, findVariadics,
+														   findDefaults, true);
 
 	if (functionList == NULL)
 	{
@@ -69,7 +67,7 @@ FunctionOidExtended(const char *schemaName, const char *functionName, int argume
 	}
 
 	/* get function oid from function list's head */
-	functionOid = functionList->oid;
+	Oid functionOid = functionList->oid;
 
 	return functionOid;
 }

--- a/src/backend/distributed/utils/listutils.c
+++ b/src/backend/distributed/utils/listutils.c
@@ -97,14 +97,13 @@ PointerArrayFromList(List *pointerList)
 ArrayType *
 DatumArrayToArrayType(Datum *datumArray, int datumCount, Oid datumTypeId)
 {
-	ArrayType *arrayObject = NULL;
 	int16 typeLength = 0;
 	bool typeByValue = false;
 	char typeAlignment = 0;
 
 	get_typlenbyvalalign(datumTypeId, &typeLength, &typeByValue, &typeAlignment);
-	arrayObject = construct_array(datumArray, datumCount, datumTypeId,
-								  typeLength, typeByValue, typeAlignment);
+	ArrayType *arrayObject = construct_array(datumArray, datumCount, datumTypeId,
+											 typeLength, typeByValue, typeAlignment);
 
 	return arrayObject;
 }
@@ -125,7 +124,6 @@ HTAB *
 ListToHashSet(List *itemList, Size keySize, bool isStringList)
 {
 	HASHCTL info;
-	HTAB *itemSet = NULL;
 	ListCell *itemCell = NULL;
 	int flags = HASH_ELEM | HASH_CONTEXT;
 
@@ -143,7 +141,7 @@ ListToHashSet(List *itemList, Size keySize, bool isStringList)
 		flags |= HASH_BLOBS;
 	}
 
-	itemSet = hash_create("ListToHashSet", capacity, &info, flags);
+	HTAB *itemSet = hash_create("ListToHashSet", capacity, &info, flags);
 
 	foreach(itemCell, itemList)
 	{

--- a/src/backend/distributed/utils/multi_resowner.c
+++ b/src/backend/distributed/utils/multi_resowner.c
@@ -113,10 +113,8 @@ ResourceOwnerEnlargeJobDirectories(ResourceOwner owner)
 void
 ResourceOwnerRememberJobDirectory(ResourceOwner owner, uint64 jobId)
 {
-	JobDirectoryEntry *entry = NULL;
-
 	Assert(NumRegisteredJobDirectories + 1 <= NumAllocatedJobDirectories);
-	entry = &RegisteredJobDirectories[NumRegisteredJobDirectories];
+	JobDirectoryEntry *entry = &RegisteredJobDirectories[NumRegisteredJobDirectories];
 	entry->owner = owner;
 	entry->jobId = jobId;
 	NumRegisteredJobDirectories++;
@@ -128,9 +126,8 @@ void
 ResourceOwnerForgetJobDirectory(ResourceOwner owner, uint64 jobId)
 {
 	int lastJobIndex = NumRegisteredJobDirectories - 1;
-	int jobIndex = 0;
 
-	for (jobIndex = lastJobIndex; jobIndex >= 0; jobIndex--)
+	for (int jobIndex = lastJobIndex; jobIndex >= 0; jobIndex--)
 	{
 		JobDirectoryEntry *entry = &RegisteredJobDirectories[jobIndex];
 

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -98,9 +98,6 @@ lock_shard_metadata(PG_FUNCTION_ARGS)
 {
 	LOCKMODE lockMode = IntToLockMode(PG_GETARG_INT32(0));
 	ArrayType *shardIdArrayObject = PG_GETARG_ARRAYTYPE_P(1);
-	Datum *shardIdArrayDatum = NULL;
-	int shardIdCount = 0;
-	int shardIdIndex = 0;
 
 	CheckCitusVersion(ERROR);
 
@@ -112,10 +109,10 @@ lock_shard_metadata(PG_FUNCTION_ARGS)
 	/* we don't want random users to block writes */
 	EnsureSuperUser();
 
-	shardIdCount = ArrayObjectCount(shardIdArrayObject);
-	shardIdArrayDatum = DeconstructArrayObject(shardIdArrayObject);
+	int shardIdCount = ArrayObjectCount(shardIdArrayObject);
+	Datum *shardIdArrayDatum = DeconstructArrayObject(shardIdArrayObject);
 
-	for (shardIdIndex = 0; shardIdIndex < shardIdCount; shardIdIndex++)
+	for (int shardIdIndex = 0; shardIdIndex < shardIdCount; shardIdIndex++)
 	{
 		int64 shardId = DatumGetInt64(shardIdArrayDatum[shardIdIndex]);
 
@@ -138,9 +135,6 @@ lock_shard_resources(PG_FUNCTION_ARGS)
 {
 	LOCKMODE lockMode = IntToLockMode(PG_GETARG_INT32(0));
 	ArrayType *shardIdArrayObject = PG_GETARG_ARRAYTYPE_P(1);
-	Datum *shardIdArrayDatum = NULL;
-	int shardIdCount = 0;
-	int shardIdIndex = 0;
 
 	CheckCitusVersion(ERROR);
 
@@ -152,10 +146,10 @@ lock_shard_resources(PG_FUNCTION_ARGS)
 	/* we don't want random users to block writes */
 	EnsureSuperUser();
 
-	shardIdCount = ArrayObjectCount(shardIdArrayObject);
-	shardIdArrayDatum = DeconstructArrayObject(shardIdArrayObject);
+	int shardIdCount = ArrayObjectCount(shardIdArrayObject);
+	Datum *shardIdArrayDatum = DeconstructArrayObject(shardIdArrayObject);
 
-	for (shardIdIndex = 0; shardIdIndex < shardIdCount; shardIdIndex++)
+	for (int shardIdIndex = 0; shardIdIndex < shardIdCount; shardIdIndex++)
 	{
 		int64 shardId = DatumGetInt64(shardIdArrayDatum[shardIdIndex]);
 
@@ -183,7 +177,6 @@ LockShardListResourcesOnFirstWorker(LOCKMODE lockmode, List *shardIntervalList)
 	WorkerNode *firstWorkerNode = GetFirstPrimaryWorkerNode();
 	int connectionFlags = 0;
 	const char *superuser = CitusExtensionOwnerName();
-	MultiConnection *firstWorkerConnection = NULL;
 
 	appendStringInfo(lockCommand, "SELECT lock_shard_resources(%d, ARRAY[", lockmode);
 
@@ -210,10 +203,14 @@ LockShardListResourcesOnFirstWorker(LOCKMODE lockmode, List *shardIntervalList)
 	 * Use the superuser connection to make sure we are allowed to lock.
 	 * This also helps ensure we only use one connection.
 	 */
-	firstWorkerConnection = GetNodeUserDatabaseConnection(connectionFlags,
-														  firstWorkerNode->workerName,
-														  firstWorkerNode->workerPort,
-														  superuser, NULL);
+	MultiConnection *firstWorkerConnection = GetNodeUserDatabaseConnection(
+		connectionFlags,
+		firstWorkerNode
+		->workerName,
+		firstWorkerNode
+		->workerPort,
+		superuser,
+		NULL);
 
 	/* the SELECT .. FOR UPDATE breaks if we lose the connection */
 	MarkRemoteTransactionCritical(firstWorkerConnection);
@@ -234,7 +231,6 @@ static bool
 IsFirstWorkerNode()
 {
 	List *workerNodeList = ActivePrimaryWorkerNodeList(NoLock);
-	WorkerNode *firstWorkerNode = NULL;
 
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
@@ -243,7 +239,7 @@ IsFirstWorkerNode()
 		return false;
 	}
 
-	firstWorkerNode = (WorkerNode *) linitial(workerNodeList);
+	WorkerNode *firstWorkerNode = (WorkerNode *) linitial(workerNodeList);
 
 	if (firstWorkerNode->groupId == GetLocalGroupId())
 	{
@@ -433,14 +429,13 @@ GetSortedReferenceShardIntervals(List *relationList)
 	foreach(relationCell, relationList)
 	{
 		Oid relationId = lfirst_oid(relationCell);
-		List *currentShardIntervalList = NIL;
 
 		if (PartitionMethod(relationId) != DISTRIBUTE_BY_NONE)
 		{
 			continue;
 		}
 
-		currentShardIntervalList = LoadShardIntervalList(relationId);
+		List *currentShardIntervalList = LoadShardIntervalList(relationId);
 		shardIntervalList = lappend(shardIntervalList, linitial(
 										currentShardIntervalList));
 	}
@@ -463,11 +458,10 @@ TryLockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode)
 	LOCKTAG tag;
 	const bool sessionLock = false;
 	const bool dontWait = true;
-	bool lockAcquired = false;
 
 	SET_LOCKTAG_SHARD_METADATA_RESOURCE(tag, MyDatabaseId, shardId);
 
-	lockAcquired = LockAcquire(&tag, lockMode, sessionLock, dontWait);
+	bool lockAcquired = LockAcquire(&tag, lockMode, sessionLock, dontWait);
 
 	return lockAcquired;
 }
@@ -704,8 +698,7 @@ LockModeTextToLockMode(const char *lockModeName)
 {
 	LOCKMODE lockMode = -1;
 
-	int lockIndex = 0;
-	for (lockIndex = 0; lockIndex < lock_mode_to_string_map_count; lockIndex++)
+	for (int lockIndex = 0; lockIndex < lock_mode_to_string_map_count; lockIndex++)
 	{
 		const struct LockModeToStringType *lockMap = lockmode_to_string_map + lockIndex;
 		if (pg_strncasecmp(lockMap->name, lockModeName, NAMEDATALEN) == 0)
@@ -738,8 +731,7 @@ LockModeToLockModeText(LOCKMODE lockMode)
 {
 	const char *lockModeText = NULL;
 
-	int lockIndex = 0;
-	for (lockIndex = 0; lockIndex < lock_mode_to_string_map_count; lockIndex++)
+	for (int lockIndex = 0; lockIndex < lock_mode_to_string_map_count; lockIndex++)
 	{
 		const struct LockModeToStringType *lockMap = lockmode_to_string_map + lockIndex;
 		if (lockMode == lockMap->lockMode)
@@ -777,28 +769,23 @@ lock_relation_if_exists(PG_FUNCTION_ARGS)
 {
 	text *relationName = PG_GETARG_TEXT_P(0);
 	text *lockModeText = PG_GETARG_TEXT_P(1);
-	Oid relationId = InvalidOid;
 	char *lockModeCString = text_to_cstring(lockModeText);
-	List *relationNameList = NIL;
-	RangeVar *relation = NULL;
-	LOCKMODE lockMode = NoLock;
-	bool relationExists = false;
 
 	/* ensure that we're in a transaction block */
 	RequireTransactionBlock(true, "lock_relation_if_exists");
 
 	/* get the lock mode */
-	lockMode = LockModeTextToLockMode(lockModeCString);
+	LOCKMODE lockMode = LockModeTextToLockMode(lockModeCString);
 
 	/* resolve relationId from passed in schema and relation name */
-	relationNameList = textToQualifiedNameList(relationName);
-	relation = makeRangeVarFromNameList(relationNameList);
+	List *relationNameList = textToQualifiedNameList(relationName);
+	RangeVar *relation = makeRangeVarFromNameList(relationNameList);
 
 	/* lock the relation with the lock mode */
-	relationId = RangeVarGetRelidExtended(relation, lockMode, RVR_MISSING_OK,
-										  CitusRangeVarCallbackForLockTable,
-										  (void *) &lockMode);
-	relationExists = OidIsValid(relationId);
+	Oid relationId = RangeVarGetRelidExtended(relation, lockMode, RVR_MISSING_OK,
+											  CitusRangeVarCallbackForLockTable,
+											  (void *) &lockMode);
+	bool relationExists = OidIsValid(relationId);
 
 	PG_RETURN_BOOL(relationExists);
 }
@@ -816,7 +803,6 @@ CitusRangeVarCallbackForLockTable(const RangeVar *rangeVar, Oid relationId,
 								  Oid oldRelationId, void *arg)
 {
 	LOCKMODE lockmode = *(LOCKMODE *) arg;
-	AclResult aclResult;
 
 	if (!OidIsValid(relationId))
 	{
@@ -832,7 +818,7 @@ CitusRangeVarCallbackForLockTable(const RangeVar *rangeVar, Oid relationId,
 	}
 
 	/* check permissions */
-	aclResult = CitusLockTableAclCheck(relationId, lockmode, GetUserId());
+	AclResult aclResult = CitusLockTableAclCheck(relationId, lockmode, GetUserId());
 	if (aclResult != ACLCHECK_OK)
 	{
 		aclcheck_error(aclResult, get_relkind_objtype(get_rel_relkind(relationId)),
@@ -851,7 +837,6 @@ CitusRangeVarCallbackForLockTable(const RangeVar *rangeVar, Oid relationId,
 static AclResult
 CitusLockTableAclCheck(Oid relationId, LOCKMODE lockmode, Oid userId)
 {
-	AclResult aclResult;
 	AclMode aclMask;
 
 	/* verify adequate privilege */
@@ -868,7 +853,7 @@ CitusLockTableAclCheck(Oid relationId, LOCKMODE lockmode, Oid userId)
 		aclMask = ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE;
 	}
 
-	aclResult = pg_class_aclcheck(relationId, userId, aclMask);
+	AclResult aclResult = pg_class_aclcheck(relationId, userId, aclMask);
 
 	return aclResult;
 }

--- a/src/backend/distributed/utils/role.c
+++ b/src/backend/distributed/utils/role.c
@@ -32,14 +32,13 @@ alter_role_if_exists(PG_FUNCTION_ARGS)
 	const char *rolename = text_to_cstring(rolenameText);
 	text *utilityQueryText = PG_GETARG_TEXT_P(1);
 	const char *utilityQuery = text_to_cstring(utilityQueryText);
-	Node *parseTree = NULL;
 
 	if (get_role_oid(rolename, true) == InvalidOid)
 	{
 		PG_RETURN_BOOL(false);
 	}
 
-	parseTree = ParseTreeNode(utilityQuery);
+	Node *parseTree = ParseTreeNode(utilityQuery);
 
 	CitusProcessUtility(parseTree, utilityQuery, PROCESS_UTILITY_TOPLEVEL, NULL,
 						None_Receiver, NULL);

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -250,7 +250,6 @@ ShardInterval *
 FindShardInterval(Datum partitionColumnValue, DistTableCacheEntry *cacheEntry)
 {
 	Datum searchedValue = partitionColumnValue;
-	int shardIndex = INVALID_SHARD_INDEX;
 
 	if (cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH)
 	{
@@ -259,7 +258,7 @@ FindShardInterval(Datum partitionColumnValue, DistTableCacheEntry *cacheEntry)
 										  partitionColumnValue);
 	}
 
-	shardIndex = FindShardIntervalIndex(searchedValue, cacheEntry);
+	int shardIndex = FindShardIntervalIndex(searchedValue, cacheEntry);
 
 	if (shardIndex == INVALID_SHARD_INDEX)
 	{
@@ -379,13 +378,12 @@ SearchCachedShardInterval(Datum partitionColumnValue, ShardInterval **shardInter
 	while (lowerBoundIndex < upperBoundIndex)
 	{
 		int middleIndex = (lowerBoundIndex + upperBoundIndex) / 2;
-		int maxValueComparison = 0;
-		int minValueComparison = 0;
 
-		minValueComparison = FunctionCall2Coll(compareFunction,
-											   DEFAULT_COLLATION_OID,
-											   partitionColumnValue,
-											   shardIntervalCache[middleIndex]->minValue);
+		int minValueComparison = FunctionCall2Coll(compareFunction,
+												   DEFAULT_COLLATION_OID,
+												   partitionColumnValue,
+												   shardIntervalCache[middleIndex]->
+												   minValue);
 
 		if (DatumGetInt32(minValueComparison) < 0)
 		{
@@ -393,10 +391,11 @@ SearchCachedShardInterval(Datum partitionColumnValue, ShardInterval **shardInter
 			continue;
 		}
 
-		maxValueComparison = FunctionCall2Coll(compareFunction,
-											   DEFAULT_COLLATION_OID,
-											   partitionColumnValue,
-											   shardIntervalCache[middleIndex]->maxValue);
+		int maxValueComparison = FunctionCall2Coll(compareFunction,
+												   DEFAULT_COLLATION_OID,
+												   partitionColumnValue,
+												   shardIntervalCache[middleIndex]->
+												   maxValue);
 
 		if (DatumGetInt32(maxValueComparison) <= 0)
 		{
@@ -420,7 +419,6 @@ SingleReplicatedTable(Oid relationId)
 {
 	List *shardList = LoadShardList(relationId);
 	List *shardPlacementList = NIL;
-	Oid shardId = INVALID_SHARD_ID;
 
 	/* we could have append/range distributed tables without shards */
 	if (list_length(shardList) <= 1)
@@ -429,7 +427,7 @@ SingleReplicatedTable(Oid relationId)
 	}
 
 	/* checking only for the first shard id should suffice */
-	shardId = (*(uint64 *) linitial(shardList));
+	Oid shardId = (*(uint64 *) linitial(shardList));
 
 	/* for hash distributed tables, it is sufficient to only check one shard */
 	if (PartitionMethod(relationId) == DISTRIBUTE_BY_HASH)

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -122,9 +122,8 @@ CollectBasicUsageStatistics(void)
 	}
 	PG_CATCH();
 	{
-		ErrorData *edata = NULL;
 		MemoryContextSwitchTo(savedContext);
-		edata = CopyErrorData();
+		ErrorData *edata = CopyErrorData();
 		FlushErrorState();
 
 		RollbackAndReleaseCurrentSubTransaction();
@@ -193,7 +192,6 @@ DistributedTablesSize(List *distTableOids)
 	foreach(distTableOidCell, distTableOids)
 	{
 		Oid relationId = lfirst_oid(distTableOidCell);
-		Datum tableSizeDatum = 0;
 
 		/*
 		 * Relations can get dropped after getting the Oid list and before we
@@ -217,8 +215,8 @@ DistributedTablesSize(List *distTableOids)
 			continue;
 		}
 
-		tableSizeDatum = DirectFunctionCall1(citus_table_size,
-											 ObjectIdGetDatum(relationId));
+		Datum tableSizeDatum = DirectFunctionCall1(citus_table_size,
+												   ObjectIdGetDatum(relationId));
 		totalSize += DatumGetInt64(tableSizeDatum);
 		heap_close(relation, AccessShareLock);
 	}
@@ -265,10 +263,9 @@ SendHttpPostJsonRequest(const char *url, const char *jsonObj, long timeoutSecond
 						curl_write_callback responseCallback)
 {
 	bool success = false;
-	CURL *curl = NULL;
 
 	curl_global_init(CURL_GLOBAL_DEFAULT);
-	curl = curl_easy_init();
+	CURL *curl = curl_easy_init();
 	if (curl)
 	{
 		struct curl_slist *headers = NULL;
@@ -348,8 +345,7 @@ citus_server_id(PG_FUNCTION_ARGS)
 	 */
 	if (!pg_strong_random((char *) buf, UUID_LEN))
 	{
-		int bufIdx = 0;
-		for (bufIdx = 0; bufIdx < UUID_LEN; bufIdx++)
+		for (int bufIdx = 0; bufIdx < UUID_LEN; bufIdx++)
 		{
 			buf[bufIdx] = (uint8) (random() & 0xFF);
 		}
@@ -411,11 +407,10 @@ uname(struct utsname *buf)
 
 	{
 		SYSTEM_INFO info;
-		DWORD procarch;
 		char *arch;
 
 		GetSystemInfo(&info);
-		procarch = info.wProcessorArchitecture;
+		DWORD procarch = info.wProcessorArchitecture;
 
 		switch (procarch)
 		{

--- a/src/backend/distributed/worker/task_tracker.c
+++ b/src/backend/distributed/worker/task_tracker.c
@@ -131,7 +131,6 @@ TaskTrackerRegister(void)
 void
 TaskTrackerMain(Datum main_arg)
 {
-	MemoryContext TaskTrackerContext = NULL;
 	sigjmp_buf local_sigjmp_buf;
 	static bool processStartUp = true;
 
@@ -147,10 +146,11 @@ TaskTrackerMain(Datum main_arg)
 	 * that we can reset the context during error recovery and thereby avoid
 	 * possible memory leaks.
 	 */
-	TaskTrackerContext = AllocSetContextCreateExtended(TopMemoryContext, "Task Tracker",
-													   ALLOCSET_DEFAULT_MINSIZE,
-													   ALLOCSET_DEFAULT_INITSIZE,
-													   ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext TaskTrackerContext = AllocSetContextCreateExtended(TopMemoryContext,
+																	 "Task Tracker",
+																	 ALLOCSET_DEFAULT_MINSIZE,
+																	 ALLOCSET_DEFAULT_INITSIZE,
+																	 ALLOCSET_DEFAULT_MAXSIZE);
 	MemoryContextSwitchTo(TaskTrackerContext);
 
 	/*
@@ -282,17 +282,15 @@ TaskTrackerMain(Datum main_arg)
 WorkerTask *
 WorkerTasksHashEnter(uint64 jobId, uint32 taskId)
 {
-	WorkerTask *workerTask = NULL;
-	void *hashKey = NULL;
 	bool handleFound = false;
 
 	WorkerTask searchTask;
 	searchTask.jobId = jobId;
 	searchTask.taskId = taskId;
 
-	hashKey = (void *) &searchTask;
-	workerTask = (WorkerTask *) hash_search(TaskTrackerTaskHash, hashKey,
-											HASH_ENTER_NULL, &handleFound);
+	void *hashKey = (void *) &searchTask;
+	WorkerTask *workerTask = (WorkerTask *) hash_search(TaskTrackerTaskHash, hashKey,
+														HASH_ENTER_NULL, &handleFound);
 	if (workerTask == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY),
@@ -320,16 +318,13 @@ WorkerTasksHashEnter(uint64 jobId, uint32 taskId)
 WorkerTask *
 WorkerTasksHashFind(uint64 jobId, uint32 taskId)
 {
-	WorkerTask *workerTask = NULL;
-	void *hashKey = NULL;
-
 	WorkerTask searchTask;
 	searchTask.jobId = jobId;
 	searchTask.taskId = taskId;
 
-	hashKey = (void *) &searchTask;
-	workerTask = (WorkerTask *) hash_search(TaskTrackerTaskHash, hashKey,
-											HASH_FIND, NULL);
+	void *hashKey = (void *) &searchTask;
+	WorkerTask *workerTask = (WorkerTask *) hash_search(TaskTrackerTaskHash, hashKey,
+														HASH_FIND, NULL);
 
 	return workerTask;
 }
@@ -383,7 +378,6 @@ TrackerCleanupJobSchemas(void)
 	foreach(databaseNameCell, databaseNameList)
 	{
 		char *databaseName = (char *) lfirst(databaseNameCell);
-		WorkerTask *cleanupTask = NULL;
 
 		/* template0 database does not accept connections */
 		int skipDatabaseName = strncmp(databaseName, TEMPLATE0_NAME, NAMEDATALEN);
@@ -397,7 +391,7 @@ TrackerCleanupJobSchemas(void)
 		 * tracker process. We also assign high priorities to these tasks so
 		 * that they get scheduled before everyone else.
 		 */
-		cleanupTask = WorkerTasksHashEnter(jobId, taskIndex);
+		WorkerTask *cleanupTask = WorkerTasksHashEnter(jobId, taskIndex);
 		cleanupTask->assignedAt = HIGH_PRIORITY_TASK_TIME;
 		cleanupTask->taskStatus = TASK_ASSIGNED;
 
@@ -429,11 +423,10 @@ static void
 TrackerCleanupConnections(HTAB *WorkerTasksHash)
 {
 	HASH_SEQ_STATUS status;
-	WorkerTask *currentTask = NULL;
 
 	hash_seq_init(&status, WorkerTasksHash);
 
-	currentTask = (WorkerTask *) hash_seq_search(&status);
+	WorkerTask *currentTask = (WorkerTask *) hash_seq_search(&status);
 	while (currentTask != NULL)
 	{
 		if (currentTask->connectionId != INVALID_CONNECTION_ID)
@@ -457,11 +450,10 @@ TrackerRegisterShutDown(HTAB *WorkerTasksHash)
 {
 	uint64 jobId = RESERVED_JOB_ID;
 	uint32 taskId = SHUTDOWN_MARKER_TASK_ID;
-	WorkerTask *shutdownMarkerTask = NULL;
 
 	LWLockAcquire(&WorkerTasksSharedState->taskHashLock, LW_EXCLUSIVE);
 
-	shutdownMarkerTask = WorkerTasksHashEnter(jobId, taskId);
+	WorkerTask *shutdownMarkerTask = WorkerTasksHashEnter(jobId, taskId);
 	shutdownMarkerTask->taskStatus = TASK_SUCCEEDED;
 	shutdownMarkerTask->connectionId = INVALID_CONNECTION_ID;
 
@@ -539,11 +531,10 @@ static Size
 TaskTrackerShmemSize(void)
 {
 	Size size = 0;
-	Size hashSize = 0;
 
 	size = add_size(size, sizeof(WorkerTasksSharedStateData));
 
-	hashSize = hash_estimate_size(MaxTrackedTasksPerNode, WORKER_TASK_SIZE);
+	Size hashSize = hash_estimate_size(MaxTrackedTasksPerNode, WORKER_TASK_SIZE);
 	size = add_size(size, hashSize);
 
 	return size;
@@ -556,12 +547,9 @@ TaskTrackerShmemInit(void)
 {
 	bool alreadyInitialized = false;
 	HASHCTL info;
-	int hashFlags = 0;
-	long maxTableSize = 0;
-	long initTableSize = 0;
 
-	maxTableSize = (long) MaxTrackedTasksPerNode;
-	initTableSize = maxTableSize / 8;
+	long maxTableSize = (long) MaxTrackedTasksPerNode;
+	long initTableSize = maxTableSize / 8;
 
 	/*
 	 * Allocate the control structure for the hash table that maps unique task
@@ -572,7 +560,7 @@ TaskTrackerShmemInit(void)
 	info.keysize = sizeof(uint64) + sizeof(uint32);
 	info.entrysize = WORKER_TASK_SIZE;
 	info.hash = tag_hash;
-	hashFlags = (HASH_ELEM | HASH_FUNCTION);
+	int hashFlags = (HASH_ELEM | HASH_FUNCTION);
 
 	/*
 	 * Currently the lock isn't required because allocation only happens at
@@ -632,34 +620,30 @@ static List *
 SchedulableTaskList(HTAB *WorkerTasksHash)
 {
 	List *schedulableTaskList = NIL;
-	WorkerTask *schedulableTaskQueue = NULL;
-	uint32 runningTaskCount = 0;
-	uint32 schedulableTaskCount = 0;
-	uint32 tasksToScheduleCount = 0;
-	uint32 queueIndex = 0;
 
-	runningTaskCount = CountTasksMatchingCriteria(WorkerTasksHash, &RunningTask);
+	uint32 runningTaskCount = CountTasksMatchingCriteria(WorkerTasksHash, &RunningTask);
 	if (runningTaskCount >= MaxRunningTasksPerNode)
 	{
 		return NIL;  /* we already have enough tasks running */
 	}
 
-	schedulableTaskCount = CountTasksMatchingCriteria(WorkerTasksHash, &SchedulableTask);
+	uint32 schedulableTaskCount = CountTasksMatchingCriteria(WorkerTasksHash,
+															 &SchedulableTask);
 	if (schedulableTaskCount == 0)
 	{
 		return NIL;  /* we do not have any new tasks to schedule */
 	}
 
-	tasksToScheduleCount = MaxRunningTasksPerNode - runningTaskCount;
+	uint32 tasksToScheduleCount = MaxRunningTasksPerNode - runningTaskCount;
 	if (tasksToScheduleCount > schedulableTaskCount)
 	{
 		tasksToScheduleCount = schedulableTaskCount;
 	}
 
 	/* get all schedulable tasks ordered according to a priority criteria */
-	schedulableTaskQueue = SchedulableTaskPriorityQueue(WorkerTasksHash);
+	WorkerTask *schedulableTaskQueue = SchedulableTaskPriorityQueue(WorkerTasksHash);
 
-	for (queueIndex = 0; queueIndex < tasksToScheduleCount; queueIndex++)
+	for (uint32 queueIndex = 0; queueIndex < tasksToScheduleCount; queueIndex++)
 	{
 		WorkerTask *schedulableTask = (WorkerTask *) palloc0(WORKER_TASK_SIZE);
 		WorkerTask *queuedTask = WORKER_TASK_AT(schedulableTaskQueue, queueIndex);
@@ -685,25 +669,22 @@ static WorkerTask *
 SchedulableTaskPriorityQueue(HTAB *WorkerTasksHash)
 {
 	HASH_SEQ_STATUS status;
-	WorkerTask *currentTask = NULL;
-	WorkerTask *priorityQueue = NULL;
-	uint32 queueSize = 0;
 	uint32 queueIndex = 0;
 
 	/* our priority queue size equals to the number of schedulable tasks */
-	queueSize = CountTasksMatchingCriteria(WorkerTasksHash, &SchedulableTask);
+	uint32 queueSize = CountTasksMatchingCriteria(WorkerTasksHash, &SchedulableTask);
 	if (queueSize == 0)
 	{
 		return NULL;
 	}
 
 	/* allocate an array of tasks for our priority queue */
-	priorityQueue = (WorkerTask *) palloc0(WORKER_TASK_SIZE * queueSize);
+	WorkerTask *priorityQueue = (WorkerTask *) palloc0(WORKER_TASK_SIZE * queueSize);
 
 	/* copy tasks in the shared hash to the priority queue */
 	hash_seq_init(&status, WorkerTasksHash);
 
-	currentTask = (WorkerTask *) hash_seq_search(&status);
+	WorkerTask *currentTask = (WorkerTask *) hash_seq_search(&status);
 	while (currentTask != NULL)
 	{
 		if (SchedulableTask(currentTask))
@@ -734,12 +715,11 @@ CountTasksMatchingCriteria(HTAB *WorkerTasksHash,
 						   bool (*CriteriaFunction)(WorkerTask *))
 {
 	HASH_SEQ_STATUS status;
-	WorkerTask *currentTask = NULL;
 	uint32 taskCount = 0;
 
 	hash_seq_init(&status, WorkerTasksHash);
 
-	currentTask = (WorkerTask *) hash_seq_search(&status);
+	WorkerTask *currentTask = (WorkerTask *) hash_seq_search(&status);
 	while (currentTask != NULL)
 	{
 		bool matchesCriteria = (*CriteriaFunction)(currentTask);
@@ -809,11 +789,10 @@ ScheduleWorkerTasks(HTAB *WorkerTasksHash, List *schedulableTaskList)
 	foreach(schedulableTaskCell, schedulableTaskList)
 	{
 		WorkerTask *schedulableTask = (WorkerTask *) lfirst(schedulableTaskCell);
-		WorkerTask *taskToSchedule = NULL;
 		void *hashKey = (void *) schedulableTask;
 
-		taskToSchedule = (WorkerTask *) hash_search(WorkerTasksHash, hashKey,
-													HASH_FIND, NULL);
+		WorkerTask *taskToSchedule = (WorkerTask *) hash_search(WorkerTasksHash, hashKey,
+																HASH_FIND, NULL);
 
 		/* if task is null, the shared hash is in an incosistent state */
 		if (taskToSchedule == NULL)
@@ -850,12 +829,10 @@ static void
 ManageWorkerTasksHash(HTAB *WorkerTasksHash)
 {
 	HASH_SEQ_STATUS status;
-	List *schedulableTaskList = NIL;
-	WorkerTask *currentTask = NULL;
 
 	/* ask the scheduler if we have new tasks to schedule */
 	LWLockAcquire(&WorkerTasksSharedState->taskHashLock, LW_SHARED);
-	schedulableTaskList = SchedulableTaskList(WorkerTasksHash);
+	List *schedulableTaskList = SchedulableTaskList(WorkerTasksHash);
 	LWLockRelease(&WorkerTasksSharedState->taskHashLock);
 
 	LWLockAcquire(&WorkerTasksSharedState->taskHashLock, LW_EXCLUSIVE);
@@ -875,7 +852,7 @@ ManageWorkerTasksHash(HTAB *WorkerTasksHash)
 	/* now iterate over all tasks, and manage them */
 	hash_seq_init(&status, WorkerTasksHash);
 
-	currentTask = (WorkerTask *) hash_seq_search(&status);
+	WorkerTask *currentTask = (WorkerTask *) hash_seq_search(&status);
 	while (currentTask != NULL)
 	{
 		ManageWorkerTask(currentTask, WorkerTasksHash);

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -68,18 +68,15 @@ task_tracker_assign_task(PG_FUNCTION_ARGS)
 	text *taskCallStringText = PG_GETARG_TEXT_P(2);
 
 	StringInfo jobSchemaName = JobSchemaName(jobId);
-	bool schemaExists = false;
 
-	WorkerTask *workerTask = NULL;
 	char *taskCallString = text_to_cstring(taskCallStringText);
 	uint32 taskCallStringLength = strlen(taskCallString);
 
-	bool taskTrackerRunning = false;
 
 	CheckCitusVersion(ERROR);
 
 	/* check that we have a running task tracker on this host */
-	taskTrackerRunning = TaskTrackerRunning();
+	bool taskTrackerRunning = TaskTrackerRunning();
 	if (!taskTrackerRunning)
 	{
 		ereport(ERROR, (errcode(ERRCODE_CANNOT_CONNECT_NOW),
@@ -102,7 +99,7 @@ task_tracker_assign_task(PG_FUNCTION_ARGS)
 	 * schema is already visible, and we immediately release the resource lock.
 	 */
 	LockJobResource(jobId, AccessExclusiveLock);
-	schemaExists = JobSchemaExists(jobSchemaName);
+	bool schemaExists = JobSchemaExists(jobSchemaName);
 	if (!schemaExists)
 	{
 		/* lock gets automatically released upon return from this function */
@@ -120,7 +117,7 @@ task_tracker_assign_task(PG_FUNCTION_ARGS)
 	LWLockAcquire(&WorkerTasksSharedState->taskHashLock, LW_EXCLUSIVE);
 
 	/* check if we already have the task in our shared hash */
-	workerTask = WorkerTasksHashFind(jobId, taskId);
+	WorkerTask *workerTask = WorkerTasksHashFind(jobId, taskId);
 	if (workerTask == NULL)
 	{
 		CreateTask(jobId, taskId, taskCallString);
@@ -146,11 +143,10 @@ task_tracker_task_status(PG_FUNCTION_ARGS)
 	WorkerTask *workerTask = NULL;
 	uint32 taskStatus = 0;
 	char *userName = CurrentUserName();
-	bool taskTrackerRunning = false;
 
 	CheckCitusVersion(ERROR);
 
-	taskTrackerRunning = TaskTrackerRunning();
+	bool taskTrackerRunning = TaskTrackerRunning();
 
 	if (taskTrackerRunning)
 	{
@@ -188,15 +184,11 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 {
 	uint64 jobId = PG_GETARG_INT64(0);
 
-	bool schemaExists = false;
 	HASH_SEQ_STATUS status;
-	WorkerTask *currentTask = NULL;
-	StringInfo jobDirectoryName = NULL;
-	StringInfo jobSchemaName = NULL;
 
 	CheckCitusVersion(ERROR);
 
-	jobSchemaName = JobSchemaName(jobId);
+	StringInfo jobSchemaName = JobSchemaName(jobId);
 
 	/*
 	 * We'll keep this lock for a while, but that's ok because nothing
@@ -204,7 +196,7 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 	 */
 	LockJobResource(jobId, AccessExclusiveLock);
 
-	schemaExists = JobSchemaExists(jobSchemaName);
+	bool schemaExists = JobSchemaExists(jobSchemaName);
 	if (schemaExists)
 	{
 		Oid schemaId = get_namespace_oid(jobSchemaName->data, false);
@@ -220,7 +212,7 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 
 	hash_seq_init(&status, TaskTrackerTaskHash);
 
-	currentTask = (WorkerTask *) hash_seq_search(&status);
+	WorkerTask *currentTask = (WorkerTask *) hash_seq_search(&status);
 	while (currentTask != NULL)
 	{
 		if (currentTask->jobId == jobId)
@@ -239,7 +231,7 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 	 * schema drop call can block if another process is creating the schema or
 	 * writing to a table within the schema.
 	 */
-	jobDirectoryName = JobDirectoryName(jobId);
+	StringInfo jobDirectoryName = JobDirectoryName(jobId);
 	CitusRemoveDirectory(jobDirectoryName);
 
 	RemoveJobSchema(jobSchemaName);
@@ -281,12 +273,10 @@ task_tracker_conninfo_cache_invalidate(PG_FUNCTION_ARGS)
 static bool
 TaskTrackerRunning(void)
 {
-	WorkerTask *workerTask = NULL;
-	bool postmasterAlive = true;
 	bool taskTrackerRunning = true;
 
 	/* if postmaster shut down, infer task tracker shut down from it */
-	postmasterAlive = PostmasterIsAlive();
+	bool postmasterAlive = PostmasterIsAlive();
 	if (!postmasterAlive)
 	{
 		return false;
@@ -299,7 +289,8 @@ TaskTrackerRunning(void)
 	 */
 	LWLockAcquire(&WorkerTasksSharedState->taskHashLock, LW_SHARED);
 
-	workerTask = WorkerTasksHashFind(RESERVED_JOB_ID, SHUTDOWN_MARKER_TASK_ID);
+	WorkerTask *workerTask = WorkerTasksHashFind(RESERVED_JOB_ID,
+												 SHUTDOWN_MARKER_TASK_ID);
 	if (workerTask != NULL)
 	{
 		taskTrackerRunning = false;
@@ -321,15 +312,13 @@ static void
 CreateJobSchema(StringInfo schemaName)
 {
 	const char *queryString = NULL;
-	bool oldAllowSystemTableMods = false;
 
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
-	CreateSchemaStmt *createSchemaStmt = NULL;
 	RoleSpec currentUserRole = { 0 };
 
 	/* allow schema names that start with pg_ */
-	oldAllowSystemTableMods = allowSystemTableMods;
+	bool oldAllowSystemTableMods = allowSystemTableMods;
 	allowSystemTableMods = true;
 
 	/* ensure we're allowed to create this schema */
@@ -342,7 +331,7 @@ CreateJobSchema(StringInfo schemaName)
 	currentUserRole.rolename = GetUserNameFromId(savedUserId, false);
 	currentUserRole.location = -1;
 
-	createSchemaStmt = makeNode(CreateSchemaStmt);
+	CreateSchemaStmt *createSchemaStmt = makeNode(CreateSchemaStmt);
 	createSchemaStmt->schemaname = schemaName->data;
 	createSchemaStmt->schemaElts = NIL;
 
@@ -366,20 +355,18 @@ CreateJobSchema(StringInfo schemaName)
 static void
 CreateTask(uint64 jobId, uint32 taskId, char *taskCallString)
 {
-	WorkerTask *workerTask = NULL;
-	uint32 assignmentTime = 0;
 	char *databaseName = CurrentDatabaseName();
 	char *userName = CurrentUserName();
 
 	/* increase task priority for cleanup tasks */
-	assignmentTime = (uint32) time(NULL);
+	uint32 assignmentTime = (uint32) time(NULL);
 	if (taskId == JOB_CLEANUP_TASK_ID)
 	{
 		assignmentTime = HIGH_PRIORITY_TASK_TIME;
 	}
 
 	/* enter the worker task into shared hash and initialize the task */
-	workerTask = WorkerTasksHashEnter(jobId, taskId);
+	WorkerTask *workerTask = WorkerTasksHashEnter(jobId, taskId);
 	workerTask->assignedAt = assignmentTime;
 	strlcpy(workerTask->taskCallString, taskCallString, MaxTaskStringSize);
 
@@ -399,9 +386,7 @@ CreateTask(uint64 jobId, uint32 taskId, char *taskCallString)
 static void
 UpdateTask(WorkerTask *workerTask, char *taskCallString)
 {
-	TaskStatus taskStatus = TASK_STATUS_INVALID_FIRST;
-
-	taskStatus = workerTask->taskStatus;
+	TaskStatus taskStatus = workerTask->taskStatus;
 	Assert(taskStatus != TASK_STATUS_INVALID_FIRST);
 
 	/*
@@ -434,7 +419,6 @@ UpdateTask(WorkerTask *workerTask, char *taskCallString)
 static void
 CleanupTask(WorkerTask *workerTask)
 {
-	WorkerTask *taskRemoved = NULL;
 	void *hashKey = (void *) workerTask;
 
 	/*
@@ -461,7 +445,8 @@ CleanupTask(WorkerTask *workerTask)
 	}
 
 	/* remove the task from the shared hash */
-	taskRemoved = hash_search(TaskTrackerTaskHash, hashKey, HASH_REMOVE, NULL);
+	WorkerTask *taskRemoved = hash_search(TaskTrackerTaskHash, hashKey, HASH_REMOVE,
+										  NULL);
 	if (taskRemoved == NULL)
 	{
 		ereport(FATAL, (errmsg("worker task hash corrupted")));

--- a/src/backend/distributed/worker/worker_drop_protocol.c
+++ b/src/backend/distributed/worker/worker_drop_protocol.c
@@ -51,8 +51,6 @@ worker_drop_distributed_table(PG_FUNCTION_ARGS)
 	Oid relationId = ResolveRelationId(relationName, true);
 
 	ObjectAddress distributedTableObject = { InvalidOid, InvalidOid, 0 };
-	Relation distributedRelation = NULL;
-	List *shardList = NULL;
 	ListCell *shardCell = NULL;
 	char relationKind = '\0';
 
@@ -66,10 +64,10 @@ worker_drop_distributed_table(PG_FUNCTION_ARGS)
 		PG_RETURN_VOID();
 	}
 
-	shardList = LoadShardList(relationId);
+	List *shardList = LoadShardList(relationId);
 
 	/* first check the relation type */
-	distributedRelation = relation_open(relationId, AccessShareLock);
+	Relation distributedRelation = relation_open(relationId, AccessShareLock);
 	relationKind = distributedRelation->rd_rel->relkind;
 	EnsureRelationKindSupported(relationId);
 
@@ -112,12 +110,11 @@ worker_drop_distributed_table(PG_FUNCTION_ARGS)
 	/* iterate over shardList to delete the corresponding rows */
 	foreach(shardCell, shardList)
 	{
-		List *shardPlacementList = NIL;
 		ListCell *shardPlacementCell = NULL;
 		uint64 *shardIdPointer = (uint64 *) lfirst(shardCell);
 		uint64 shardId = (*shardIdPointer);
 
-		shardPlacementList = ShardPlacementList(shardId);
+		List *shardPlacementList = ShardPlacementList(shardId);
 		foreach(shardPlacementCell, shardPlacementList)
 		{
 			ShardPlacement *placement = (ShardPlacement *) lfirst(shardPlacementCell);

--- a/src/backend/distributed/worker/worker_merge_protocol.c
+++ b/src/backend/distributed/worker/worker_merge_protocol.c
@@ -77,9 +77,6 @@ worker_merge_files_into_table(PG_FUNCTION_ARGS)
 	StringInfo jobSchemaName = JobSchemaName(jobId);
 	StringInfo taskTableName = TaskTableName(taskId);
 	StringInfo taskDirectoryName = TaskDirectoryName(jobId, taskId);
-	bool schemaExists = false;
-	List *columnNameList = NIL;
-	List *columnTypeList = NIL;
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
 	Oid userId = GetUserId();
@@ -100,7 +97,7 @@ worker_merge_files_into_table(PG_FUNCTION_ARGS)
 	 * If the schema for the job isn't already created by the task tracker
 	 * protocol, we fall to using the default 'public' schema.
 	 */
-	schemaExists = JobSchemaExists(jobSchemaName);
+	bool schemaExists = JobSchemaExists(jobSchemaName);
 	if (!schemaExists)
 	{
 		/*
@@ -125,8 +122,8 @@ worker_merge_files_into_table(PG_FUNCTION_ARGS)
 	}
 
 	/* create the task table and copy files into the table */
-	columnNameList = ArrayObjectToCStringList(columnNameObject);
-	columnTypeList = ArrayObjectToCStringList(columnTypeObject);
+	List *columnNameList = ArrayObjectToCStringList(columnNameObject);
+	List *columnTypeList = ArrayObjectToCStringList(columnTypeObject);
 
 	CreateTaskTable(jobSchemaName, taskTableName, columnNameList, columnTypeList);
 
@@ -172,12 +169,6 @@ worker_merge_files_and_run_query(PG_FUNCTION_ARGS)
 	StringInfo intermediateTableName = TaskTableName(taskId);
 	StringInfo mergeTableName = makeStringInfo();
 	StringInfo setSearchPathString = makeStringInfo();
-	bool schemaExists = false;
-	int connected = 0;
-	int setSearchPathResult = 0;
-	int createMergeTableResult = 0;
-	int createIntermediateTableResult = 0;
-	int finished = 0;
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
 	Oid userId = GetUserId();
@@ -188,7 +179,7 @@ worker_merge_files_and_run_query(PG_FUNCTION_ARGS)
 	 * If the schema for the job isn't already created by the task tracker
 	 * protocol, we fall to using the default 'public' schema.
 	 */
-	schemaExists = JobSchemaExists(jobSchemaName);
+	bool schemaExists = JobSchemaExists(jobSchemaName);
 	if (!schemaExists)
 	{
 		resetStringInfo(jobSchemaName);
@@ -206,20 +197,20 @@ worker_merge_files_and_run_query(PG_FUNCTION_ARGS)
 	/* Add "public" to search path to access UDFs in public schema */
 	appendStringInfo(setSearchPathString, ",public");
 
-	connected = SPI_connect();
+	int connected = SPI_connect();
 	if (connected != SPI_OK_CONNECT)
 	{
 		ereport(ERROR, (errmsg("could not connect to SPI manager")));
 	}
 
-	setSearchPathResult = SPI_exec(setSearchPathString->data, 0);
+	int setSearchPathResult = SPI_exec(setSearchPathString->data, 0);
 	if (setSearchPathResult < 0)
 	{
 		ereport(ERROR, (errmsg("execution was not successful \"%s\"",
 							   setSearchPathString->data)));
 	}
 
-	createMergeTableResult = SPI_exec(createMergeTableQuery, 0);
+	int createMergeTableResult = SPI_exec(createMergeTableQuery, 0);
 	if (createMergeTableResult < 0)
 	{
 		ereport(ERROR, (errmsg("execution was not successful \"%s\"",
@@ -237,14 +228,14 @@ worker_merge_files_and_run_query(PG_FUNCTION_ARGS)
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
-	createIntermediateTableResult = SPI_exec(createIntermediateTableQuery, 0);
+	int createIntermediateTableResult = SPI_exec(createIntermediateTableQuery, 0);
 	if (createIntermediateTableResult < 0)
 	{
 		ereport(ERROR, (errmsg("execution was not successful \"%s\"",
 							   createIntermediateTableQuery)));
 	}
 
-	finished = SPI_finish();
+	int finished = SPI_finish();
 	if (finished != SPI_OK_FINISH)
 	{
 		ereport(ERROR, (errmsg("could not disconnect from SPI manager")));
@@ -341,8 +332,7 @@ ArrayObjectToCStringList(ArrayType *arrayObject)
 	Datum *datumArray = DeconstructArrayObject(arrayObject);
 	int32 arraySize = ArrayObjectCount(arrayObject);
 
-	int32 arrayIndex = 0;
-	for (arrayIndex = 0; arrayIndex < arraySize; arrayIndex++)
+	for (int32 arrayIndex = 0; arrayIndex < arraySize; arrayIndex++)
 	{
 		Datum datum = datumArray[arrayIndex];
 		char *cstring = TextDatumGetCString(datum);
@@ -371,10 +361,9 @@ void
 RemoveJobSchema(StringInfo schemaName)
 {
 	Datum schemaNameDatum = CStringGetDatum(schemaName->data);
-	Oid schemaId = InvalidOid;
 
-	schemaId = GetSysCacheOid1Compat(NAMESPACENAME, Anum_pg_namespace_oid,
-									 schemaNameDatum);
+	Oid schemaId = GetSysCacheOid1Compat(NAMESPACENAME, Anum_pg_namespace_oid,
+										 schemaNameDatum);
 	if (OidIsValid(schemaId))
 	{
 		ObjectAddress schemaObject = { 0, 0, 0 };
@@ -420,11 +409,7 @@ static void
 CreateTaskTable(StringInfo schemaName, StringInfo relationName,
 				List *columnNameList, List *columnTypeList)
 {
-	CreateStmt *createStatement = NULL;
-	RangeVar *relation = NULL;
-	List *columnDefinitionList = NIL;
 	Oid relationId PG_USED_FOR_ASSERTS_ONLY = InvalidOid;
-	ObjectAddress relationObject;
 
 	Assert(schemaName != NULL);
 	Assert(relationName != NULL);
@@ -434,13 +419,14 @@ CreateTaskTable(StringInfo schemaName, StringInfo relationName,
 	 * statements occur in the same transaction. Still, we want to make the
 	 * relation unlogged once we upgrade to PostgreSQL 9.1.
 	 */
-	relation = makeRangeVar(schemaName->data, relationName->data, -1);
-	columnDefinitionList = ColumnDefinitionList(columnNameList, columnTypeList);
+	RangeVar *relation = makeRangeVar(schemaName->data, relationName->data, -1);
+	List *columnDefinitionList = ColumnDefinitionList(columnNameList, columnTypeList);
 
-	createStatement = CreateStatement(relation, columnDefinitionList);
+	CreateStmt *createStatement = CreateStatement(relation, columnDefinitionList);
 
-	relationObject = DefineRelation(createStatement, RELKIND_RELATION, InvalidOid, NULL,
-									NULL);
+	ObjectAddress relationObject = DefineRelation(createStatement, RELKIND_RELATION,
+												  InvalidOid, NULL,
+												  NULL);
 	relationId = relationObject.objectId;
 
 	Assert(relationId != InvalidOid);
@@ -474,14 +460,12 @@ ColumnDefinitionList(List *columnNameList, List *columnTypeList)
 		Oid columnTypeId = InvalidOid;
 		int32 columnTypeMod = -1;
 		bool missingOK = false;
-		TypeName *typeName = NULL;
-		ColumnDef *columnDefinition = NULL;
 
 		parseTypeString(columnType, &columnTypeId, &columnTypeMod, missingOK);
-		typeName = makeTypeNameFromOid(columnTypeId, columnTypeMod);
+		TypeName *typeName = makeTypeNameFromOid(columnTypeId, columnTypeMod);
 
 		/* we then create the column definition */
-		columnDefinition = makeNode(ColumnDef);
+		ColumnDef *columnDefinition = makeNode(ColumnDef);
 		columnDefinition->colname = (char *) columnName;
 		columnDefinition->typeName = typeName;
 		columnDefinition->is_local = true;
@@ -533,7 +517,6 @@ CopyTaskFilesFromDirectory(StringInfo schemaName, StringInfo relationName,
 						   StringInfo sourceDirectoryName, Oid userId)
 {
 	const char *directoryName = sourceDirectoryName->data;
-	struct dirent *directoryEntry = NULL;
 	uint64 copiedRowTotal = 0;
 	StringInfo expectedFileSuffix = makeStringInfo();
 
@@ -546,14 +529,11 @@ CopyTaskFilesFromDirectory(StringInfo schemaName, StringInfo relationName,
 
 	appendStringInfo(expectedFileSuffix, ".%u", userId);
 
-	directoryEntry = ReadDir(directory, directoryName);
+	struct dirent *directoryEntry = ReadDir(directory, directoryName);
 	for (; directoryEntry != NULL; directoryEntry = ReadDir(directory, directoryName))
 	{
 		const char *baseFilename = directoryEntry->d_name;
 		const char *queryString = NULL;
-		StringInfo fullFilename = NULL;
-		RangeVar *relation = NULL;
-		CopyStmt *copyStatement = NULL;
 		uint64 copiedRowCount = 0;
 
 		/* if system file or lingering task file, skip it */
@@ -576,12 +556,12 @@ CopyTaskFilesFromDirectory(StringInfo schemaName, StringInfo relationName,
 			continue;
 		}
 
-		fullFilename = makeStringInfo();
+		StringInfo fullFilename = makeStringInfo();
 		appendStringInfo(fullFilename, "%s/%s", directoryName, baseFilename);
 
 		/* build relation object and copy statement */
-		relation = makeRangeVar(schemaName->data, relationName->data, -1);
-		copyStatement = CopyStatement(relation, fullFilename->data);
+		RangeVar *relation = makeRangeVar(schemaName->data, relationName->data, -1);
+		CopyStmt *copyStatement = CopyStatement(relation, fullFilename->data);
 		if (BinaryWorkerCopyFormat)
 		{
 			DefElem *copyOption = makeDefElem("format", (Node *) makeString("binary"),


### PR DESCRIPTION
One pattern we have in our codebase is a lot of useless 0/NULL declarations at the top of the function scope, so we have this code:
```c
int a = 0;
int b = 2;
Assert(b == 2);
a = b + b;
```
instead of the shorter:
```c
int b = 2;
Assert(b == 2);
int a = b + b;
```
After failing to find a tool that merges declarations. I decided that a regex
should be able to do it as well. The idea is that should find a declaration and if the next occurunce of the variable is an assignment, the declaration will be moved there.

After some trial and error I came up with this bash script:
```bash
#!/bin/bash
shopt -s globstar
while true; do
    perl -i -p0e 's/\n\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t)?(?=\b(?P=variable)\b))(?<=\n\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t$+{type}$+{variable} =/sg' ./**/*.c;
    # The following are simply the same regex, but repeated for different tab sizes
    # (this is needed because variable sized backtracking is not supported in perl)
    perl -i -p0e 's/\n\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t$+{type}$+{variable} =/sg' ./**/*.c;
    perl -i -p0e 's/\n\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t$+{type}$+{variable} =/sg' ./**/*.c;
    perl -i -p0e 's/\n\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t$+{type}$+{variable} =/sg' ./**/*.c;
    perl -i -p0e 's/\n\t\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t\t$+{type}$+{variable} =/sg' ./**/*.c;
    perl -i -p0e 's/\n\t\t\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t\t\t$+{type}$+{variable} =/sg' ./**/*.c;
    git diff --quiet && break;
    git add .;
done
```
For a better view of the first regex try this:
https://www.debuggex.com/r/_6Ajy7jetf4QdUaE

The way it works is roughly like this:
1. find a declaration + initialization
2. if the initializer is not a single variable/constant, don't consider replacing it
2. if it is a simple initializer, take the type and variable from that declaration
3. find the next use of this variable
4. if the next use is not an assignment, don't do anything (the value of the original initialization is used)
5. if the next use is an assignment, remove the old declaration + initialization and prefix it with the type:
    - unless the variable is also used in the same line of the new initialization, e.g:
      ```c
      int a = 1;
      a = a + a;
      ```

Source: https://xkcd.com/1171/

This could be as a check and automatic fixer to `citus_indent`. It does depend on the fact that it's run through citus_indent before though. And it also depends on the fact that variables are actually used (which the compiler guarantees for us with `-Werror` in CI), right now this:
```c
int
main(int argc, char *argv[])
{
	int a = 1;
	if (1)
	{
		int a = 2;
	}
	else
	{
		a = 3;
	}

	return 0;
}
```
becomes this:
```c
int
main(int argc, char *argv[])
{
	int a = 1;
	if (1)
	{
	}
	else
	{
		int a = 3;
	}

	return 0;
}
```
This should be pretty easy to fix though if we care about that, because scope is pretty well defined.

Note: This regex currently has to known false negatives for replacement (i.e. replacement is not done when it would be possible):
1. ~~comments containing the the variable name~~ (fixed now)
```c
int foo = 0;
/* setting foo */
foo = 4;
```
2. code in `#if`/`#ifdef`
```c
int foo = 0;
#ifdef SOMETHING
foo = 1
#else
foo = 2
#endif
```
This failing on `#if`/`#ifdef` one is done by stop trying to replace whenever a # character is found. Outside of strings and comments these are really only for preprocessor statements, so that should be pretty fine.