### PR TITLE
Rely on original query for intermediate result pruning

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -76,6 +76,7 @@ static DistributedPlan * CreateDistributedPlan(uint64 planId, Query *originalQue
 											   PlannerRestrictionContext *
 											   plannerRestrictionContext);
 static void FinalizeDistributedPlan(DistributedPlan *plan, Query *originalQuery);
+static void RecordSubPlansUsedInPlan(DistributedPlan *plan, Query *originalQuery);
 static DeferredErrorMessage * DeferErrorIfPartitionTableNotSingleReplicated(Oid
 																			relationId);
 
@@ -824,7 +825,18 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 
 
 /*
- * FinalizeDistributedPlan gets a distributed plan a queryTree, and
+ * FinalizeDistributedPlan is the final step of distributed planning. The function
+ * currently only implements some optimizations for intermediate result(s) pruning.
+ */
+static void
+FinalizeDistributedPlan(DistributedPlan *plan, Query *originalQuery)
+{
+	RecordSubPlansUsedInPlan(plan, originalQuery);
+}
+
+
+/*
+ * RecordSubPlansUsedInPlan gets a distributed plan a queryTree, and
  * updates the usedSubPlanNodeList of the distributed plan.
  *
  * The function simply pulls all the subPlans that are used in the queryTree
@@ -832,7 +844,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
  * in the function.
  */
 static void
-FinalizeDistributedPlan(DistributedPlan *plan, Query *originalQuery)
+RecordSubPlansUsedInPlan(DistributedPlan *plan, Query *originalQuery)
 {
 	/* first, get all the subplans in the query */
 	plan->usedSubPlanNodeList = FindSubPlansUsedInNode((Node *) originalQuery);

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -75,7 +75,7 @@ static DistributedPlan * CreateDistributedPlan(uint64 planId, Query *originalQue
 											   bool hasUnresolvedParams,
 											   PlannerRestrictionContext *
 											   plannerRestrictionContext);
-static void RecordSubPlansUsedInPlan(DistributedPlan *plan, Query *originalQuery);
+static void FinalizeDistributedPlan(DistributedPlan *plan, Query *originalQuery);
 static DeferredErrorMessage * DeferErrorIfPartitionTableNotSingleReplicated(Oid
 																			relationId);
 
@@ -656,7 +656,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 
 		if (distributedPlan->planningError == NULL)
 		{
-			RecordSubPlansUsedInPlan(distributedPlan, originalQuery);
+			FinalizeDistributedPlan(distributedPlan, originalQuery);
 
 			return distributedPlan;
 		}
@@ -678,7 +678,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 										   plannerRestrictionContext);
 		if (distributedPlan->planningError == NULL)
 		{
-			RecordSubPlansUsedInPlan(distributedPlan, originalQuery);
+			FinalizeDistributedPlan(distributedPlan, originalQuery);
 
 			return distributedPlan;
 		}
@@ -772,7 +772,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 												plannerRestrictionContext);
 		distributedPlan->subPlanList = subPlanList;
 
-		RecordSubPlansUsedInPlan(distributedPlan, originalQuery);
+		FinalizeDistributedPlan(distributedPlan, originalQuery);
 
 		return distributedPlan;
 	}
@@ -784,7 +784,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 	 */
 	if (IsModifyCommand(originalQuery))
 	{
-		RecordSubPlansUsedInPlan(distributedPlan, originalQuery);
+		FinalizeDistributedPlan(distributedPlan, originalQuery);
 
 		return distributedPlan;
 	}
@@ -817,14 +817,14 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 	/* distributed plan currently should always succeed or error out */
 	Assert(distributedPlan && distributedPlan->planningError == NULL);
 
-	RecordSubPlansUsedInPlan(distributedPlan, originalQuery);
+	FinalizeDistributedPlan(distributedPlan, originalQuery);
 
 	return distributedPlan;
 }
 
 
 /*
- * RecordSubPlansUsedInPlan gets a distributed plan a queryTree, and
+ * FinalizeDistributedPlan gets a distributed plan a queryTree, and
  * updates the usedSubPlanNodeList of the distributed plan.
  *
  * The function simply pulls all the subPlans that are used in the queryTree
@@ -832,7 +832,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
  * in the function.
  */
 static void
-RecordSubPlansUsedInPlan(DistributedPlan *plan, Query *originalQuery)
+FinalizeDistributedPlan(DistributedPlan *plan, Query *originalQuery)
 {
 	/* first, get all the subplans in the query */
 	plan->usedSubPlanNodeList = FindSubPlansUsedInNode((Node *) originalQuery);

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -69,7 +69,6 @@ bool SubqueryPushdown = false; /* is subquery pushdown enabled */
 /* Local functions forward declarations */
 static bool JoinTreeContainsSubqueryWalker(Node *joinTreeNode, void *context);
 static bool IsFunctionRTE(Node *node);
-static bool IsNodeSubquery(Node *node);
 static bool IsOuterJoinExpr(Node *node);
 static bool WindowPartitionOnDistributionColumn(Query *query);
 static DeferredErrorMessage * DeferErrorIfFromClauseRecurs(Query *queryTree);
@@ -344,7 +343,7 @@ IsFunctionRTE(Node *node)
  * (select 1) are converted to init plans in the rewritten query. In this case
  * the only thing left in the query tree is a Param node with type PARAM_EXEC.
  */
-static bool
+bool
 IsNodeSubquery(Node *node)
 {
 	if (node == NULL)

--- a/src/include/distributed/intermediate_result_pruning.h
+++ b/src/include/distributed/intermediate_result_pruning.h
@@ -15,7 +15,7 @@
 
 extern bool LogIntermediateResults;
 
-extern List * FindSubPlansUsedInPlan(DistributedPlan *plan);
+extern List * FindSubPlansUsedInNode(Node *node);
 extern List * FindAllWorkerNodesUsingSubplan(HTAB *intermediateResultsHash,
 											 char *resultId);
 extern HTAB * MakeIntermediateResultHTAB(void);

--- a/src/include/distributed/query_pushdown_planning.h
+++ b/src/include/distributed/query_pushdown_planning.h
@@ -26,6 +26,7 @@ extern bool SubqueryPushdown;
 extern bool ShouldUseSubqueryPushDown(Query *originalQuery, Query *rewrittenQuery,
 									  PlannerRestrictionContext *plannerRestrictionContext);
 extern bool JoinTreeContainsSubquery(Query *query);
+extern bool IsNodeSubquery(Node *node);
 extern bool HasEmptyJoinTree(Query *query);
 extern bool WhereOrHavingClauseContainsSubquery(Query *query);
 extern bool TargetListContainsSubquery(Query *query);


### PR DESCRIPTION
Basically, on every successful distributed plan creation, make sure
to record the subPlans used in the plan, by checking the originalQuery.

