### PR TITLE
Fix potential segfault from standard_planner inlining functions

### DIFF
--- a/src/test/regress/expected/multi_subquery_union.out
+++ b/src/test/regress/expected/multi_subquery_union.out
@@ -1237,5 +1237,14 @@ ORDER BY types;
      3 |              1
 (4 rows)
 
+-- Previously this produced a segfault from standard_planner introducing a subquery after we'd called AssignRTEIdentities
+CREATE OR REPLACE FUNCTION users_udf()
+RETURNS TABLE(user_id int)
+AS $$SELECT user_id FROM users_reference_table;$$
+LANGUAGE sql stable;
+SELECT user_id FROM users_table
+UNION SELECT u.user_id FROM users_table, users_udf() u;
+ERROR:  cannot perform distributed planning on this query because parameterized queries for SQL functions referencing distributed tables are not supported
+HINT:  Consider using PL/pgSQL functions instead.
 DROP TABLE events_reference_table;
 DROP TABLE users_reference_table;

--- a/src/test/regress/sql/multi_subquery_union.sql
+++ b/src/test/regress/sql/multi_subquery_union.sql
@@ -890,5 +890,14 @@ FROM
 GROUP BY types
 ORDER BY types;
 
+-- Previously this produced a segfault from standard_planner introducing a subquery after we'd called AssignRTEIdentities
+CREATE OR REPLACE FUNCTION users_udf()
+RETURNS TABLE(user_id int)
+AS $$SELECT user_id FROM users_reference_table;$$
+LANGUAGE sql stable;
+
+SELECT user_id FROM users_table
+UNION SELECT u.user_id FROM users_table, users_udf() u;
+
 DROP TABLE events_reference_table;
 DROP TABLE users_reference_table;


### PR DESCRIPTION
Calling `GetRTEIdentity` on a `RangeTblEntry` which was added midway through `distributed_planner` segfaults, as we collect a list of `RangeTblEntry`s at the very beginning of `distributed_planner`

This could happen if `standard_planner` inlined a function call to something like `SELECT * FROM table`, since we function definitions aren't part of the initial query tree