### PR TITLE
Implement support for RECORD[] where we support RECORD

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -1402,7 +1402,7 @@ MasterExtendedOpNode(MultiExtendedOp *originalOpNode,
 			column->varoattno = walkerContext->columnId;
 			walkerContext->columnId++;
 
-			if (column->vartype == RECORDOID)
+			if (column->vartype == RECORDOID || column->vartype == RECORDARRAYOID)
 			{
 				column->vartypmod = BlessRecordExpression(originalTargetEntry->expr);
 			}

--- a/src/backend/distributed/planner/multi_master_planner.c
+++ b/src/backend/distributed/planner/multi_master_planner.c
@@ -110,7 +110,7 @@ MasterTargetList(List *workerTargetList)
 		masterColumn->varoattno = columnId;
 		columnId++;
 
-		if (masterColumn->vartype == RECORDOID)
+		if (masterColumn->vartype == RECORDOID || masterColumn->vartype == RECORDARRAYOID)
 		{
 			masterColumn->vartypmod = BlessRecordExpression(workerTargetEntry->expr);
 		}

--- a/src/test/regress/expected/row_types.out
+++ b/src/test/regress/expected/row_types.out
@@ -11,7 +11,7 @@ SELECT create_distributed_table('test','x');
 CREATE OR REPLACE FUNCTION table_returner(INT) RETURNS TABLE(name text, id INT)
 AS $$
 BEGIN
-   RETURN QUERY SELECT $1::text, $1;
+    RETURN QUERY SELECT $1::text, $1;
 END;
 $$ language plpgsql;
 SELECT create_distributed_function('table_returner(int)');
@@ -24,8 +24,8 @@ CREATE OR REPLACE FUNCTION record_returner(INOUT id int, OUT name text)
 RETURNS record
 AS $$
 BEGIN
-   id := id + 1;
-   name := 'returned';
+    id := id + 1;
+    name := 'returned';
 END;
 $$ language plpgsql;
 SELECT create_distributed_function('record_returner(int)');
@@ -52,6 +52,24 @@ SELECT (x,y) FROM test GROUP BY x, y ORDER BY x, y;
  (1,3)
  (2,2)
  (2,3)
+(4 rows)
+
+SELECT ARRAY[(x,(y,x)),(y,(x,y))] FROM test ORDER BY x, y;
+               array               
+-----------------------------------
+ {"(1,\"(2,1)\")","(2,\"(1,2)\")"}
+ {"(1,\"(3,1)\")","(3,\"(1,3)\")"}
+ {"(2,\"(2,2)\")","(2,\"(2,2)\")"}
+ {"(2,\"(3,2)\")","(3,\"(2,3)\")"}
+(4 rows)
+
+SELECT ARRAY[[(x,(y,x))],[(x,(x,y))]] FROM test ORDER BY x, y;
+                 array                 
+---------------------------------------
+ {{"(1,\"(2,1)\")"},{"(1,\"(1,2)\")"}}
+ {{"(1,\"(3,1)\")"},{"(1,\"(1,3)\")"}}
+ {{"(2,\"(2,2)\")"},{"(2,\"(2,2)\")"}}
+ {{"(2,\"(3,2)\")"},{"(2,\"(2,3)\")"}}
 (4 rows)
 
 select distinct (x,y) AS foo, x, y FROM test ORDER BY x, y;
@@ -81,6 +99,11 @@ SELECT record_returner(x) FROM test ORDER BY x, y;
  (3,returned)
 (4 rows)
 
+-- RECORD[] with varying shape unsupported
+SELECT ARRAY[(x,(y,x),y),(y,(x,y))] FROM test ORDER BY x, y;
+ERROR:  input of anonymous composite types is not implemented
+SELECT ARRAY[[(x,(y,x))],[((x,x),y)]] FROM test ORDER BY x, y;
+ERROR:  input of anonymous composite types is not implemented
 -- router queries support row types
 SELECT (x,y) FROM test WHERE x = 1 ORDER BY x, y;
   row  
@@ -94,6 +117,20 @@ SELECT (x,y) AS foo FROM test WHERE x = 1 ORDER BY x, y;
 -------
  (1,2)
  (1,3)
+(2 rows)
+
+SELECT ARRAY[(x,(y,x)),(y,(x,y))] FROM test WHERE x = 1 ORDER BY x, y;
+               array               
+-----------------------------------
+ {"(1,\"(2,1)\")","(2,\"(1,2)\")"}
+ {"(1,\"(3,1)\")","(3,\"(1,3)\")"}
+(2 rows)
+
+SELECT ARRAY[[(x,(y,x))],[(x,(x,y))]] FROM test WHERE x = 1 ORDER BY x, y;
+                 array                 
+---------------------------------------
+ {{"(1,\"(2,1)\")"},{"(1,\"(1,2)\")"}}
+ {{"(1,\"(3,1)\")"},{"(1,\"(1,3)\")"}}
 (2 rows)
 
 select distinct (x,y) AS foo, x, y FROM test WHERE x = 1 ORDER BY x, y;
@@ -117,6 +154,11 @@ SELECT record_returner(x) FROM test WHERE x = 1 ORDER BY x, y;
  (2,returned)
 (2 rows)
 
+-- RECORD[] with varying shape unsupported
+SELECT ARRAY[(x,(y,x),y),(y,(x,y))] FROM test WHERE x = 1 ORDER BY x, y;
+ERROR:  input of anonymous composite types is not implemented
+SELECT ARRAY[[(x,(y,x))],[((x,x),y)]] FROM test WHERE x = 1 ORDER BY x, y;
+ERROR:  input of anonymous composite types is not implemented
 -- nested row expressions
 SELECT (x,(x,y)) AS foo FROM test WHERE x = 1 ORDER BY x, y;
      foo     

--- a/src/test/regress/sql/row_types.sql
+++ b/src/test/regress/sql/row_types.sql
@@ -8,7 +8,7 @@ SELECT create_distributed_table('test','x');
 CREATE OR REPLACE FUNCTION table_returner(INT) RETURNS TABLE(name text, id INT)
 AS $$
 BEGIN
-   RETURN QUERY SELECT $1::text, $1;
+    RETURN QUERY SELECT $1::text, $1;
 END;
 $$ language plpgsql;
 SELECT create_distributed_function('table_returner(int)');
@@ -17,8 +17,8 @@ CREATE OR REPLACE FUNCTION record_returner(INOUT id int, OUT name text)
 RETURNS record
 AS $$
 BEGIN
-   id := id + 1;
-   name := 'returned';
+    id := id + 1;
+    name := 'returned';
 END;
 $$ language plpgsql;
 SELECT create_distributed_function('record_returner(int)');
@@ -29,16 +29,26 @@ INSERT INTO test VALUES (1,2), (1,3), (2,2), (2,3);
 -- multi-shard queries support row types
 SELECT (x,y) FROM test ORDER BY x, y;
 SELECT (x,y) FROM test GROUP BY x, y ORDER BY x, y;
+SELECT ARRAY[(x,(y,x)),(y,(x,y))] FROM test ORDER BY x, y;
+SELECT ARRAY[[(x,(y,x))],[(x,(x,y))]] FROM test ORDER BY x, y;
 select distinct (x,y) AS foo, x, y FROM test ORDER BY x, y;
 SELECT table_returner(x) FROM test ORDER BY x, y;
 SELECT record_returner(x) FROM test ORDER BY x, y;
+-- RECORD[] with varying shape unsupported
+SELECT ARRAY[(x,(y,x),y),(y,(x,y))] FROM test ORDER BY x, y;
+SELECT ARRAY[[(x,(y,x))],[((x,x),y)]] FROM test ORDER BY x, y;
 
 -- router queries support row types
 SELECT (x,y) FROM test WHERE x = 1 ORDER BY x, y;
 SELECT (x,y) AS foo FROM test WHERE x = 1 ORDER BY x, y;
+SELECT ARRAY[(x,(y,x)),(y,(x,y))] FROM test WHERE x = 1 ORDER BY x, y;
+SELECT ARRAY[[(x,(y,x))],[(x,(x,y))]] FROM test WHERE x = 1 ORDER BY x, y;
 select distinct (x,y) AS foo, x, y FROM test WHERE x = 1 ORDER BY x, y;
 SELECT table_returner(x) FROM test WHERE x = 1 ORDER BY x, y;
 SELECT record_returner(x) FROM test WHERE x = 1 ORDER BY x, y;
+-- RECORD[] with varying shape unsupported
+SELECT ARRAY[(x,(y,x),y),(y,(x,y))] FROM test WHERE x = 1 ORDER BY x, y;
+SELECT ARRAY[[(x,(y,x))],[((x,x),y)]] FROM test WHERE x = 1 ORDER BY x, y;
 
 -- nested row expressions
 SELECT (x,(x,y)) AS foo FROM test WHERE x = 1 ORDER BY x, y;


### PR DESCRIPTION
DESCRIPTION: Support `RECORD[]` columns in queries where we support `RECORD`

TODO:
- [x] test `RECORD[]` being returned by function *(sql & plpgsql functions cannot return `RECORD[]`)*
- [x] test multidimensional/nested array

Future PR can address: *(started a branch, `support-more-record-expressions`)*
- support other expression types are not covered by `FuncExpr`/`RowExpr`/`ArrayExpr`
  - `OpExpr` & `NullIfExpr` *(the latter for `NULLIF((1,2),(3,4))`)*
  - `FuncExpr` or `OpExpr` with function whose return type is `ANYELEMENT`
  - `CoalesceExpr`, `MinMaxExpr`, `CaseExpr`