### PR TITLE
Fix underflow initialization of default values

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -2078,11 +2078,11 @@ WorkerExtendedOpNode(MultiExtendedOp *originalOpNode,
 	bool queryHasAggregates = TargetListHasAggragates(originalTargetEntryList);
 
 	/* initialize to default values */
-	memset(&queryTargetList, 0, sizeof(queryGroupClause));
+	memset(&queryTargetList, 0, sizeof(queryTargetList));
 	memset(&queryGroupClause, 0, sizeof(queryGroupClause));
-	memset(&queryDistinctClause, 0, sizeof(queryGroupClause));
-	memset(&queryWindowClause, 0, sizeof(queryGroupClause));
-	memset(&queryOrderByLimit, 0, sizeof(queryGroupClause));
+	memset(&queryDistinctClause, 0, sizeof(queryDistinctClause));
+	memset(&queryWindowClause, 0, sizeof(queryWindowClause));
+	memset(&queryOrderByLimit, 0, sizeof(queryOrderByLimit));
 
 	/* calculate the next sort group index based on the original target list */
 	Index nextSortGroupRefIndex = GetNextSortGroupRef(originalTargetEntryList);


### PR DESCRIPTION
Initialization of queryWindowClause and queryOrderByLimit "memset" underflow these variables.
It's possible due to invalid usage of sizeof this part of the program cause buffer overflow and function return data corruption in future changes.