### PR TITLE
Remove useless checks

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -859,25 +859,10 @@ DeferErrorIfQueryNotSupported(Query *queryTree)
 					"clause containing the distribution column";
 	}
 
-	if (queryTree->setOperations)
-	{
-		preconditionsSatisfied = false;
-		errorMessage = "could not run distributed query with UNION, INTERSECT, or "
-					   "EXCEPT";
-		errorHint = filterHint;
-	}
-
 	if (queryTree->hasRecursive)
 	{
 		preconditionsSatisfied = false;
 		errorMessage = "could not run distributed query with RECURSIVE";
-		errorHint = filterHint;
-	}
-
-	if (queryTree->cteList)
-	{
-		preconditionsSatisfied = false;
-		errorMessage = "could not run distributed query with common table expressions";
 		errorHint = filterHint;
 	}
 


### PR DESCRIPTION
We already support CTEs and Set Operations via recursive planning. Whenever we call `DeferErrorIfQueryNotSupported ()`, we error out anyway, so no callers rely on the checks. And, it is a little confusing because we support those.

And, this can be useful in #3161 