### PR TITLE
add gitref to the output of citus_version

### DIFF
--- a/Makefile.global.in
+++ b/Makefile.global.in
@@ -17,6 +17,16 @@ postgres_abs_builddir:=@POSTGRES_BUILDDIR@
 PG_CONFIG:=@PG_CONFIG@
 PGXS:=$(shell $(PG_CONFIG) --pgxs)
 
+# if both, git is installed and there is a .git directory in the working dir we set the
+# GIT_VERSION to a human readable gitref that resembles the version from which citus is
+# built. During releases it will show the tagname which by convention is the verion of the
+# release
+ifneq (@GIT_BIN@,)
+ifneq (@HAS_DOTGIT@,)
+	GIT_VERSION := "$(shell @GIT_BIN@ describe --dirty --always --tags)"
+endif
+endif
+
 # Support for VPATH builds (i.e. builds from outside the source tree)
 vpath_build=@vpath_build@
 ifeq ($(vpath_build),yes)
@@ -69,6 +79,9 @@ endif
 
 # Add options passed to configure or computed therein, to CFLAGS/CPPFLAGS/...
 override CFLAGS += @CFLAGS@ @CITUS_CFLAGS@
+ifneq ($(GIT_VERSION),)
+    override CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 override CPPFLAGS := @CPPFLAGS@ @CITUS_CPPFLAGS@ -I '${citus_abs_top_srcdir}/src/include' -I'${citus_top_builddir}/src/include' $(CPPFLAGS)
 override LDFLAGS += @LDFLAGS@ @CITUS_LDFLAGS@
 

--- a/configure
+++ b/configure
@@ -622,11 +622,13 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+HAS_DOTGIT
 POSTGRES_BUILDDIR
 POSTGRES_SRCDIR
 CITUS_LDFLAGS
 CITUS_CPPFLAGS
 CITUS_CFLAGS
+GIT_BIN
 EGREP
 GREP
 CPP
@@ -4478,6 +4480,69 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+# Check if git is installed, when installed the gitref of the checkout will be baked in the application
+# Extract the first word of "git", so it can be a program name with args.
+set dummy git; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_GIT_BIN+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $GIT_BIN in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_GIT_BIN="$GIT_BIN" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_GIT_BIN="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+GIT_BIN=$ac_cv_path_GIT_BIN
+if test -n "$GIT_BIN"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $GIT_BIN" >&5
+$as_echo "$GIT_BIN" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for .git" >&5
+$as_echo_n "checking for .git... " >&6; }
+if ${ac_cv_file__git+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r ".git"; then
+  ac_cv_file__git=yes
+else
+  ac_cv_file__git=no
+fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__git" >&5
+$as_echo "$ac_cv_file__git" >&6; }
+if test "x$ac_cv_file__git" = xyes; then :
+  HAS_DOTGIT=yes
+else
+  HAS_DOTGIT=
+fi
+
+
 CITUS_CFLAGS="$CITUS_CFLAGS"
 
 CITUS_CPPFLAGS="$CITUS_CPPFLAGS"
@@ -4487,6 +4552,8 @@ CITUS_LDFLAGS="$LIBS $CITUS_LDFLAGS"
 POSTGRES_SRCDIR="$POSTGRES_SRCDIR"
 
 POSTGRES_BUILDDIR="$POSTGRES_BUILDDIR"
+
+HAS_DOTGIT="$HAS_DOTGIT"
 
 
 ac_config_files="$ac_config_files Makefile.global"

--- a/configure.in
+++ b/configure.in
@@ -212,11 +212,16 @@ PGAC_ARG_REQ(with, reports-hostname, [HOSTNAME],
 AC_DEFINE_UNQUOTED(REPORTS_BASE_URL, "$REPORTS_BASE_URL",
                    [Base URL for statistics collection and update checks])
 
+# Check if git is installed, when installed the gitref of the checkout will be baked in the application
+AC_PATH_PROG(GIT_BIN, git)
+AC_CHECK_FILE(.git,[HAS_DOTGIT=yes], [HAS_DOTGIT=])
+
 AC_SUBST(CITUS_CFLAGS, "$CITUS_CFLAGS")
 AC_SUBST(CITUS_CPPFLAGS, "$CITUS_CPPFLAGS")
 AC_SUBST(CITUS_LDFLAGS, "$LIBS $CITUS_LDFLAGS")
 AC_SUBST(POSTGRES_SRCDIR, "$POSTGRES_SRCDIR")
 AC_SUBST(POSTGRES_BUILDDIR, "$POSTGRES_BUILDDIR")
+AC_SUBST(HAS_DOTGIT, "$HAS_DOTGIT")
 
 AC_CONFIG_FILES([Makefile.global])
 AC_CONFIG_HEADERS([src/include/citus_config.h] [src/include/citus_version.h])

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -19,6 +19,12 @@ SUBDIRS = . commands connection ddl deparser executor master metadata planner pr
 OBJS += \
 	$(patsubst $(citus_abs_srcdir)/%.c,%.o,$(foreach dir,$(SUBDIRS), $(sort $(wildcard $(citus_abs_srcdir)/$(dir)/*.c))))
 
+# make sure citus_version.o is always recompiled to reflect the correct gitref for every build
+# idea came from https://stackoverflow.com/a/3304967
+utils/citus_version.o: FORCE
+FORCE:
+.PHONY: FORCE
+
 # be explicit about the default target
 all:
 

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -19,12 +19,6 @@ SUBDIRS = . commands connection ddl deparser executor master metadata planner pr
 OBJS += \
 	$(patsubst $(citus_abs_srcdir)/%.c,%.o,$(foreach dir,$(SUBDIRS), $(sort $(wildcard $(citus_abs_srcdir)/$(dir)/*.c))))
 
-# make sure citus_version.o is always recompiled to reflect the correct gitref for every build
-# idea came from https://stackoverflow.com/a/3304967
-utils/citus_version.o: FORCE
-FORCE:
-.PHONY: FORCE
-
 # be explicit about the default target
 all:
 
@@ -33,6 +27,15 @@ NO_PGXS = 1
 SHLIB_LINK = $(libpq)
 
 include $(citus_top_builddir)/Makefile.global
+
+# make sure citus_version.o is recompiled whenever any change is made to the binary or any
+# other artifact being installed to reflect the correct gitref for every build
+CITUS_VERSION_INVALIDATE := $(filter-out utils/citus_version.o,$(OBJS))
+CITUS_VERSION_INVALIDATE += $(generated_sql_files)
+ifneq ($(wildcard $(citus_top_builddir)/.git/.*),)
+        CITUS_VERSION_INVALIDATE += $(citus_top_builddir)/.git/index
+endif
+utils/citus_version.o: $(CITUS_VERSION_INVALIDATE)
 
 SHLIB_LINK += $(filter -lssl -lcrypto -lssleay32 -leay32, $(LIBS))
 

--- a/src/backend/distributed/utils/citus_version.c
+++ b/src/backend/distributed/utils/citus_version.c
@@ -18,9 +18,15 @@
 /* exports for SQL callable functions */
 PG_FUNCTION_INFO_V1(citus_version);
 
+/* GIT_VERSION is passed in as a compiler flag during builds that have git installed */
+#ifdef GIT_VERSION
+#define GIT_REF " gitref: " GIT_VERSION
+#else
+#define GIT_REF
+#endif
 
 Datum
 citus_version(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_TEXT_P(cstring_to_text(CITUS_VERSION_STR));
+	PG_RETURN_TEXT_P(cstring_to_text(CITUS_VERSION_STR GIT_REF));
 }


### PR DESCRIPTION
DESCRIPTION: add gitref to the output of citus_version

During debugging of custom builds it is hard to know the exact version of the citus build you are using. This patch will add a human readable/understandable git reference to the build of citus which can be retrieved by calling `citus_version();`.

```sql
# SELECT citus_version();
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                    citus_version                                                                    │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Citus 9.1devel on x86_64-apple-darwin19.0.0, compiled by Apple clang version 11.0.0 (clang-1100.0.33.12), 64-bit gitref: v6.1.0-rc2-2107-g229115582 │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(1 row)

Time: 36.899 ms
```

For the first commit in this PR (at time of writing the gitref is: `v6.1.0-rc2-2107-g229115582`.
This tells the developer the following things
 - closest tag on the tree `v6.1.0-rc2`
 - commits on top of the tag `2107`
 - short git sha of commit: `229115582`

If a build is from an exact tag only the tag name will be shown. Since we build our release versions from tags named eg. `v9.1.0` that will be in the build as the gitref.

During development it looks a bit strange at the moment that it seems to be a `v6.1.0-rc2` build. We can solve this to merge the last released version into the `master` branch after releasing. This normally is a simple merge without any conflicts as the release branch and `master` are pretty up-to-date.

An example of the output after merging `v9.1.0` into this branch:
```sql
# SELECT citus_version();
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                               citus_version                                                                │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Citus 9.1.0 on x86_64-apple-darwin19.0.0, compiled by Apple clang version 11.0.0 (clang-1100.0.33.12), 64-bit gitref: v9.1.0-19-g8ac40740c │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(1 row)

Time: 312.196 ms
```

This would make it more intuitive to the reader of the gitref we compiled a newer version than `v9.1.0` which makes sense during development of `9.2.0`, however this would require a small change to our release runbook with the addition of merging the tagged release into master.

As a safe guard the gitref is _only_ added if the build environment has git installed and has the `.git` directory available next to the source. Meaning we don't break any build pipeline that doesn't have it, but we won't see the git ref in the final build.

Lastly a nice feature of `git describe`; it will add `...-dirty` to the gitref if there are uncommitted changes in the working directory during compilation. Giving even more information about the actual build you are looking at.