### PR TITLE
aggregate_support test: test DISTINCT, ORDER BY, FILTER, & no intermediate results

### DIFF
--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -58,8 +58,7 @@ select create_distributed_table('aggdata', 'id');
 (1 row)
 
 insert into aggdata (id, key, val, valf) values (1, 1, 2, 11.2), (2, 1, NULL, 2.1), (3, 2, 2, 3.22), (4, 2, 3, 4.23), (5, 2, 5, 5.25), (6, 3, 4, 63.4), (7, 5, NULL, 75), (8, 6, NULL, NULL), (9, 6, NULL, 96), (10, 7, 8, 1078), (11, 9, 0, 1.19);
-select key, sum2(val), sum2_strict(val), stddev(valf)
-from aggdata group by key order by key;
+select key, sum2(val), sum2_strict(val), stddev(valf) from aggdata group by key order by key;
  key | sum2 | sum2_strict |      stddev      
 -----+------+-------------+------------------
    1 |      |           4 | 6.43467170879758
@@ -70,6 +69,49 @@ from aggdata group by key order by key;
    7 |   16 |          16 |                 
    9 |    0 |           0 |                 
 (7 rows)
+
+-- FILTER supported
+select key, sum2(val) filter (where valf < 5), sum2_strict(val) filter (where valf < 5) from aggdata group by key order by key;
+ key | sum2 | sum2_strict 
+-----+------+-------------
+   1 |      |            
+   2 |      |          10
+   3 |      |            
+   5 |      |            
+   6 |      |            
+   7 |      |            
+   9 |    0 |           0
+(7 rows)
+
+-- DISTINCT unsupported, unless grouped by partition key
+select key, sum2(distinct val), sum2_strict(distinct val) from aggdata group by key order by key;
+ERROR:  cannot compute aggregate (distinct)
+DETAIL:  table partitioning is unsuitable for aggregate (distinct)
+select id, sum2(distinct val), sum2_strict(distinct val) from aggdata group by id order by id;
+ id | sum2 | sum2_strict 
+----+------+-------------
+  1 |    4 |           4
+  2 |      |            
+  3 |    4 |           4
+  4 |    6 |           6
+  5 |   10 |          10
+  6 |    8 |           8
+  7 |      |            
+  8 |      |            
+  9 |      |            
+ 10 |   16 |          16
+ 11 |    0 |           0
+(11 rows)
+
+-- ORDER BY unsupported
+select key, sum2(val order by valf), sum2_strict(val order by valf) from aggdata group by key order by key;
+ERROR:  unsupported aggregate function sum2
+-- Without intermediate results we return NULL, even though the correct result is 0
+select sum2(val) from aggdata where valf = 0;
+ sum2 
+------
+     
+(1 row)
 
 -- test polymorphic aggregates from https://github.com/citusdata/citus/issues/2397
 -- we do not currently support pseudotypes for transition types, so this errors for now
@@ -121,8 +163,7 @@ create aggregate sumstring(text) (
 	combinefunc = sumstring_sfunc,
 	initcond = '0'
 );
-select sumstring(valf::text order by id)
-from aggdata where valf is not null;
+select sumstring(valf::text) from aggdata where valf is not null;
 ERROR:  function "aggregate_support.sumstring(text)" does not exist
 CONTEXT:  while executing command on localhost:57637
 select create_distributed_function('sumstring(text)');
@@ -131,8 +172,7 @@ select create_distributed_function('sumstring(text)');
  
 (1 row)
 
-select sumstring(valf::text order by id)
-from aggdata where valf is not null;
+select sumstring(valf::text) from aggdata where valf is not null;
  sumstring 
 -----------
  1339.59

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -52,8 +52,18 @@ select create_distributed_function('sum2_strict(int)');
 create table aggdata (id int, key int, val int, valf float8);
 select create_distributed_table('aggdata', 'id');
 insert into aggdata (id, key, val, valf) values (1, 1, 2, 11.2), (2, 1, NULL, 2.1), (3, 2, 2, 3.22), (4, 2, 3, 4.23), (5, 2, 5, 5.25), (6, 3, 4, 63.4), (7, 5, NULL, 75), (8, 6, NULL, NULL), (9, 6, NULL, 96), (10, 7, 8, 1078), (11, 9, 0, 1.19);
-select key, sum2(val), sum2_strict(val), stddev(valf)
-from aggdata group by key order by key;
+
+select key, sum2(val), sum2_strict(val), stddev(valf) from aggdata group by key order by key;
+-- FILTER supported
+select key, sum2(val) filter (where valf < 5), sum2_strict(val) filter (where valf < 5) from aggdata group by key order by key;
+-- DISTINCT unsupported, unless grouped by partition key
+select key, sum2(distinct val), sum2_strict(distinct val) from aggdata group by key order by key;
+select id, sum2(distinct val), sum2_strict(distinct val) from aggdata group by id order by id;
+-- ORDER BY unsupported
+select key, sum2(val order by valf), sum2_strict(val order by valf) from aggdata group by key order by key;
+-- Without intermediate results we return NULL, even though the correct result is 0
+select sum2(val) from aggdata where valf = 0;
+
 
 -- test polymorphic aggregates from https://github.com/citusdata/citus/issues/2397
 -- we do not currently support pseudotypes for transition types, so this errors for now
@@ -102,11 +112,9 @@ create aggregate sumstring(text) (
 	initcond = '0'
 );
 
-select sumstring(valf::text order by id)
-from aggdata where valf is not null;
+select sumstring(valf::text) from aggdata where valf is not null;
 select create_distributed_function('sumstring(text)');
-select sumstring(valf::text order by id)
-from aggdata where valf is not null;
+select sumstring(valf::text) from aggdata where valf is not null;
 
 -- test aggregate with stype that has an expanded read-write form
 CREATE FUNCTION array_sort (int[])


### PR DESCRIPTION
Previously,
- we'd push down ORDER BY, but this doesn't order intermediate results between workers
- we'd keep FILTER on master aggregate, which would raise an error about unexpected cstrings
