### PR TITLE
Fix error in DML with NULL expression in where clause

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -5122,6 +5122,11 @@ ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(Task *, List 
 	ListCell *placementListCell = NULL;
 	uint32 unAssignedTaskCount = 0;
 
+	if (taskList == NIL)
+	{
+		return NIL;
+	}
+
 	/*
 	 * We first sort tasks by their anchor shard id. We then sort placements for
 	 * each anchor shard by the placement's insertion time. Note that we sort

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1715,6 +1715,11 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 												 MODIFY_TASK,
 												 requiresMasterEvaluation);
 	}
+	else if (shardId == INVALID_SHARD_ID)
+	{
+		/* modification that prunes to 0 shards */
+		job->taskList = NIL;
+	}
 	else
 	{
 		job->taskList = SingleShardModifyTaskList(originalQuery, job->jobId,
@@ -2068,7 +2073,6 @@ PlanRouterQuery(Query *originalQuery,
 		}
 
 		Assert(UpdateOrDeleteQuery(originalQuery));
-
 		planningError = ModifyQuerySupported(originalQuery, originalQuery,
 											 isMultiShardQuery,
 											 plannerRestrictionContext);

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -875,6 +875,13 @@ INSERT INTO raw_table VALUES (2, 400);
 INSERT INTO raw_table VALUES (2, 500);
 INSERT INTO summary_table VALUES (1);
 INSERT INTO summary_table VALUES (2);
+-- test noop deletes and updates
+DELETE FROM summary_table WHERE false;
+DELETE FROM summary_table WHERE null;
+DELETE FROM summary_table WHERE null > jsonb_build_array();
+UPDATE summary_table SET uniques = 0 WHERE false;
+UPDATE summary_table SET uniques = 0 WHERE null;
+UPDATE summary_table SET uniques = 0 WHERE null > jsonb_build_array();
 SELECT * FROM summary_table ORDER BY id;
  id | min_value | average_value | count | uniques 
 ----+-----------+---------------+-------+---------

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -547,6 +547,15 @@ INSERT INTO raw_table VALUES (2, 500);
 INSERT INTO summary_table VALUES (1);
 INSERT INTO summary_table VALUES (2);
 
+-- test noop deletes and updates
+DELETE FROM summary_table WHERE false;
+DELETE FROM summary_table WHERE null;
+DELETE FROM summary_table WHERE null > jsonb_build_array();
+
+UPDATE summary_table SET uniques = 0 WHERE false;
+UPDATE summary_table SET uniques = 0 WHERE null;
+UPDATE summary_table SET uniques = 0 WHERE null > jsonb_build_array();
+
 SELECT * FROM summary_table ORDER BY id;
 
 UPDATE summary_table SET average_value = average_query.average FROM (


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that caused some noop DML statements to fail

We generated a task without an anchor shard ID for the query in #3236, which later causes a failure in the executor when looking up placements. We should always have an empty task list for DML that prunes to 0 shards, since it cannot return a result.

Fixes #3236