### PR TITLE
Fix strange errors in DML with unreachable sublinks

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -640,7 +640,7 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 	}
 
 	/* extract range table entries */
-	ExtractRangeTableEntryWalker((Node *) queryTree, &rangeTableList);
+	ExtractRangeTableEntryWalker((Node *) originalQuery, &rangeTableList);
 
 	foreach(rangeTableCell, rangeTableList)
 	{

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1285,6 +1285,18 @@ HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
 INSERT INTO summary_table (id) VALUES ((SELECT id FROM reference_summary_table));
 ERROR:  subqueries are not supported within INSERT queries
 HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+-- subqueries that would be eliminated by = null clauses
+DELETE FROM summary_table WHERE (
+    SELECT 1 FROM pg_catalog.pg_statio_sys_sequences
+) = null;
+DELETE FROM summary_table WHERE (
+    SELECT (select action_statement from information_schema.triggers)
+    FROM pg_catalog.pg_statio_sys_sequences
+) = null;
+ERROR:  relation pg_namespace is not distributed
+DELETE FROM summary_table WHERE id < (
+    SELECT 0 FROM pg_dist_node
+);
 DROP TABLE raw_table;
 DROP TABLE summary_table;
 DROP TABLE reference_raw_table;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -858,6 +858,19 @@ INSERT INTO summary_table (id) VALUES (5), ((SELECT id FROM summary_table));
 INSERT INTO reference_summary_table (id) VALUES ((SELECT id FROM summary_table));
 INSERT INTO summary_table (id) VALUES ((SELECT id FROM reference_summary_table));
 
+-- subqueries that would be eliminated by = null clauses
+DELETE FROM summary_table WHERE (
+    SELECT 1 FROM pg_catalog.pg_statio_sys_sequences
+) = null;
+DELETE FROM summary_table WHERE (
+    SELECT (select action_statement from information_schema.triggers)
+    FROM pg_catalog.pg_statio_sys_sequences
+) = null;
+
+DELETE FROM summary_table WHERE id < (
+    SELECT 0 FROM pg_dist_node
+);
+
 DROP TABLE raw_table;
 DROP TABLE summary_table;
 DROP TABLE reference_raw_table;


### PR DESCRIPTION
DESCRIPTION: Fix strange errors in DML with unreachable sublinks

We were checking the relations in ModifyQuerySupported using the rewritten query, but the rewritten query omits unreachable sublinks. Since we eventually use the original query, this causes strange errors when the unreachable sublinks are not supported by other parts of the code.

Fixes #3235 