### PR TITLE
(WIP) INSERT...SELECT with repartitioning (not ready for review)

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2735,7 +2735,14 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 	{
 		const char *resultId = copyStatement->relation->relname;
 
-		ReceiveQueryResultViaCopy(resultId);
+		if (copyStatement->is_from)
+		{
+			ReceiveQueryResultViaCopy(resultId);
+		}
+		else
+		{
+			SendQueryResultViaCopy(resultId);
+		}
 
 		return NULL;
 	}

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -183,8 +183,8 @@ CitusModifyBeginScan(CustomScanState *node, EState *estate, int eflags)
 	 * executions of a prepared statement. Instead we create a deep copy that we only
 	 * use for the current execution.
 	 */
-	DistributedPlan *distributedPlan = scanState->distributedPlan = copyObject(
-		scanState->distributedPlan);
+	DistributedPlan *distributedPlan = copyObject(scanState->distributedPlan);
+	scanState->distributedPlan = distributedPlan;
 
 	Job *workerJob = distributedPlan->workerJob;
 	Query *jobQuery = workerJob->jobQuery;

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -1,0 +1,818 @@
+/*-------------------------------------------------------------------------
+ *
+ * distributed_intermediate_results.c
+ *   Functions for reading and writing distributed intermediate results.
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "port.h"
+
+#include "access/hash.h"
+#include "access/nbtree.h"
+#include "access/tupdesc.h"
+#include "catalog/pg_am.h"
+#include "catalog/pg_enum.h"
+#include "catalog/pg_type.h"
+#include "commands/copy.h"
+#include "distributed/citus_ruleutils.h"
+#include "distributed/colocation_utils.h"
+#include "distributed/commands/multi_copy.h"
+#include "distributed/connection_management.h"
+#include "distributed/intermediate_results.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_executor.h"
+#include "distributed/recursive_planning.h"
+#include "distributed/redistribution.h"
+#include "distributed/remote_commands.h"
+#include "distributed/sharding.h"
+#include "distributed/transmit.h"
+#include "distributed/transaction_identifier.h"
+#include "distributed/tuplestore.h"
+#include "distributed/worker_protocol.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "storage/fd.h"
+#include "tcop/pquery.h"
+#include "tcop/tcopprot.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/portal.h"
+#include "utils/syscache.h"
+
+
+/*
+ * NodePair contains the source and destination node in a NodeToNodeFragmentsTransfer.
+ * It is a separate struct to use it as a key in a hash table.
+ */
+typedef struct NodePair
+{
+	int sourceNodeId;
+	int targetNodeId;
+} NodePair;
+
+
+/*
+ * NodeToNodeFragmentsTransfer contains all fragments that need to be fetched from
+ * the source node to the destination node in the NodePair.
+ */
+typedef struct NodeToNodeFragmentsTransfer
+{
+	NodePair nodes;
+	List *fragmentsToFetch;
+} NodeToNodeFragmentsTransfer;
+
+
+/*
+ * TargetShardFragment
+ */
+typedef struct TargetShardFragments
+{
+	/* index of the target shard, when shards are sorted by minvalue */
+	int targetShardIndex;
+
+	/* list of TargetShardFragmentStats, one for each fragment in the target shard */
+	List *fragments;
+} TargetShardFragments;
+
+
+/*
+ * PredistributionStats contains the statistics on individual fragments when task
+ * results are partitioned into fragments using
+ * worker_predistribute_query_result.
+ */
+typedef struct PredistributionStats
+{
+	int targetShardCount;
+	TargetShardFragments *targetShardFragments;
+} PredistributionStats;
+
+
+static RedistributedQueryResult * RedistributeDistributedQueryResult(char *distResultId,
+																	 Query *query,
+																	 int
+																	 distributionColumnIndex,
+																	 DistributionScheme *
+																	 targetDistribution,
+																	 bool isForWrites);
+static RedistributedQueryResult * RedistributeTaskListResult(char *distResultId,
+															 List *taskList,
+															 int distributionColumnIndex,
+															 DistributionScheme *
+															 targetDistribution,
+															 bool isForWrites);
+static void WrapTasksForPredistribution(List *taskList, char *resultPrefix,
+										int distributionColumnIndex,
+										DistributionScheme *targetDistribution);
+static ArrayType * ShardMinValueArrayForDistribution(PartitioningScheme *partitioning);
+static char * SourceShardPrefix(char *resultPrefix, uint64 shardId);
+static RedistributedQueryResult * CreateRedistributedQueryResult(char *resultPrefix,
+																 PredistributionStats *
+																 predistributionStats,
+																 DistributionScheme *
+																 targetDistribution,
+																 bool isForWrites,
+																 List **
+																 fragmentsTransferList);
+static PredistributionStats * ExecutePredistributionTasks(List *taskList,
+														  DistributionScheme *
+														  targetDistribution);
+static PredistributionStats * CreatePredistributionStats(int targetShardCount);
+static PredistributionStats * TupleStoreToPredistributionStats(
+	Tuplestorestate *tupleStore, TupleDesc resultDescriptor,
+	DistributionScheme *
+	targetDistribution);
+static List * BuildFetchTaskListForFragmentTransfers(char *resultPrefix,
+													 List *fragmentsTransferList);
+static char * BuildQueryStringForFragmentsTransfer(char *resultPrefix,
+												   NodeToNodeFragmentsTransfer *
+												   fragmentsTransfer);
+static char * TargetShardFragmentName(char *resultPrefix,
+									  TargetShardFragmentStats *fragmentStats);
+static void ExecuteFetchTasks(List *fetchTaskList);
+static Tuplestorestate * ExecuteTasksIntoTupleStore(List *taskList, TupleDesc
+													resultDescriptor);
+
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(partition_distributed_query_result);
+
+
+/*
+ * partition_distributed_query_result executes a query and writes the results
+ * into a set of local files according to the partition scheme and the partition
+ * column.
+ */
+Datum
+partition_distributed_query_result(PG_FUNCTION_ARGS)
+{
+	text *distResultIdText = PG_GETARG_TEXT_P(0);
+	char *distResultIdString = text_to_cstring(distResultIdText);
+	text *queryText = PG_GETARG_TEXT_P(1);
+	char *queryString = text_to_cstring(queryText);
+	int distributionColumnIndex = PG_GETARG_INT32(2);
+	int colocationId = PG_GETARG_INT32(3);
+
+	TupleDesc tupleDescriptor = NULL;
+	int shardIndex = 0;
+
+	CheckCitusVersion(ERROR);
+	SetupTuplestore(fcinfo, &tupleDescriptor);
+
+	DistributionScheme *targetDistribution = GetDistributionSchemeForColocationId(
+		colocationId);
+
+	/* parse the query */
+	Query *query = ParseQueryString(queryString, NULL, 0);
+
+	RedistributedQueryResult *result = RedistributeDistributedQueryResult(
+		distResultIdString, query,
+		distributionColumnIndex,
+		targetDistribution,
+		true);
+
+	int shardCount = targetDistribution->partitioning.partitionCount;
+
+	for (shardIndex = 0; shardIndex < shardCount; shardIndex++)
+	{
+		ReassembledFragmentSet *fragmentSet =
+			&(result->reassembledFragmentSets[shardIndex]);
+		StringInfo deparsedQuery = makeStringInfo();
+
+		Query *fragmentSetQuery = ReadReassembledFragmentSetQuery(distResultIdString,
+																  query->targetList,
+																  fragmentSet);
+
+		pg_get_query_def(fragmentSetQuery, deparsedQuery);
+
+		elog(NOTICE, "on node %d: %s", fragmentSet->nodeId, deparsedQuery->data);
+	}
+
+	PG_RETURN_VOID();
+}
+
+
+/*
+ * RedistributeDistributedQueryResult executes the given query, which must
+ * be a distributed query without a merge step, and redistributes the result
+ * according to the target distribution.
+ */
+static RedistributedQueryResult *
+RedistributeDistributedQueryResult(char *distResultId, Query *query,
+								   int distributionColumnIndex,
+								   DistributionScheme *targetDistribution,
+								   bool isForWrites)
+{
+	int cursorOptions = 0;
+	ParamListInfo paramListInfo = NULL;
+
+	/* plan the query */
+	PlannedStmt *queryPlan = pg_plan_query(query, cursorOptions, paramListInfo);
+	if (!IsA(queryPlan->planTree, CustomScan))
+	{
+		/* TODO: fall back to partitioned pull-push */
+		ereport(ERROR, (errmsg("query is not a simple distributed query")));
+	}
+
+	DistributedPlan *distributedPlan = GetDistributedPlan(
+		(CustomScan *) queryPlan->planTree);
+
+	RedistributedQueryResult *result = RedistributeDistributedPlanResult(distResultId,
+																		 distributedPlan,
+																		 distributionColumnIndex,
+																		 targetDistribution,
+																		 isForWrites);
+
+	return result;
+}
+
+
+RedistributedQueryResult *
+RedistributeDistributedPlanResult(char *distResultId, DistributedPlan *distributedPlan,
+								  int distributionColumnIndex,
+								  DistributionScheme *targetDistribution,
+								  bool isForWrites)
+{
+	/* TODO: check for weird plans (insert select) */
+
+	List *taskList = distributedPlan->workerJob->taskList;
+
+	RedistributedQueryResult *result = RedistributeTaskListResult(distResultId, taskList,
+																  distributionColumnIndex,
+																  targetDistribution,
+																  isForWrites);
+
+	return result;
+}
+
+
+static RedistributedQueryResult *
+RedistributeTaskListResult(char *distResultId, List *taskList,
+						   int distributionColumnIndex,
+						   DistributionScheme *targetDistribution, bool isForWrites)
+{
+	List *fragmentsTransferList = NIL;
+
+	/* make sure we have a distributed transaction ID and send BEGIN */
+	BeginOrContinueCoordinatedTransaction();
+
+	/*
+	 * Wrap tasks in worker_predistribute_query_result calls
+	 * to generate a fragment for each shard in the target distribution.
+	 */
+	WrapTasksForPredistribution(taskList, distResultId, distributionColumnIndex,
+								targetDistribution);
+
+	/*
+	 * Execute the worker_predistribute_query_result tasks and
+	 * collect statistics to prune out empty fragments.
+	 */
+	PredistributionStats *predistributionStats = ExecutePredistributionTasks(taskList,
+																			 targetDistribution);
+
+	/*
+	 * Create an object that represents redistributed query results. We
+	 * derive the fetch tasks from the result.
+	 */
+	RedistributedQueryResult *result = CreateRedistributedQueryResult(distResultId,
+																	  predistributionStats,
+																	  targetDistribution,
+																	  isForWrites,
+																	  &
+																	  fragmentsTransferList);
+
+	List *fetchTaskList = BuildFetchTaskListForFragmentTransfers(distResultId,
+																 fragmentsTransferList);
+
+	/*
+	 * Execute the fetch tasks, after this the result is ready to be used
+	 * in distributed queries.
+	 */
+	ExecuteFetchTasks(fetchTaskList);
+
+	return result;
+}
+
+
+/*
+ * WrapTasksForPredistribution wraps the query strings in a given list of tasks
+ * in calls to worker_predistribute_query_result, in order to generate
+ * a fragment (intermediate result) for each shard in the target distribution.
+ * Rows are written to a fragment based on the value in the distribution column
+ * of the query result.
+ */
+static void
+WrapTasksForPredistribution(List *taskList, char *resultPrefix, int
+							distributionColumnIndex,
+							DistributionScheme *targetDistribution)
+{
+	ListCell *taskCell = NULL;
+	PartitioningScheme *partitioning = &(targetDistribution->partitioning);
+	ArrayType *splitPointObject = ShardMinValueArrayForDistribution(partitioning);
+	StringInfo splitPointString = SplitPointArrayString(splitPointObject,
+														partitioning->valueTypeId,
+														partitioning->valueTypeMod);
+
+	foreach(taskCell, taskList)
+	{
+		Task *task = (Task *) lfirst(taskCell);
+		StringInfo wrappedQuery = makeStringInfo();
+		List *shardPlacementList = task->taskPlacementList;
+
+		if (list_length(shardPlacementList) > 1)
+		{
+			ereport(ERROR, (errmsg("repartitioning is currently only available for "
+								   "queries on distributed tables without replication")));
+		}
+
+		ShardPlacement *shardPlacement = linitial(shardPlacementList);
+		char *taskPrefix = SourceShardPrefix(resultPrefix, task->anchorShardId);
+
+		appendStringInfo(wrappedQuery,
+						 "SELECT %d, " UINT64_FORMAT
+						 ", partition_index, bytes_written, rows_written "
+						 "FROM worker_predistribute_query_result"
+						 "(%s,%s,%d,%s)",
+						 shardPlacement->nodeId,
+						 task->anchorShardId,
+						 quote_literal_cstr(taskPrefix),
+						 quote_literal_cstr(task->queryString),
+						 distributionColumnIndex,
+						 splitPointString->data);
+
+		task->queryString = wrappedQuery->data;
+	}
+}
+
+
+/*
+ * ShardMinValueArrayForDistribution constructs a SQL array for the min values
+ * of the partitions.
+ */
+static ArrayType *
+ShardMinValueArrayForDistribution(PartitioningScheme *partitioning)
+{
+	uint32 partitionIndex = 0;
+	Oid typeId = partitioning->valueTypeId;
+
+	bool typeByValue = false;
+	char typeAlignment = 0;
+	int16 typeLength = 0;
+
+	uint32 minDatumCount = partitioning->partitionCount;
+	Datum *minDatumArray = palloc0(partitioning->partitionCount * sizeof(Datum));
+
+	for (partitionIndex = 0; partitionIndex < minDatumCount; partitionIndex++)
+	{
+		DatumRange *hashRange = &(partitioning->ranges[partitionIndex]);
+
+		minDatumArray[partitionIndex] = hashRange->minValue;
+	}
+
+	get_typlenbyvalalign(typeId, &typeLength, &typeByValue, &typeAlignment);
+
+	ArrayType *splitPointObject = construct_array(minDatumArray, minDatumCount, typeId,
+												  typeLength, typeByValue, typeAlignment);
+
+	return splitPointObject;
+}
+
+
+static char *
+SourceShardPrefix(char *resultPrefix, uint64 shardId)
+{
+	StringInfo taskPrefix = makeStringInfo();
+
+	appendStringInfo(taskPrefix, "%s.from." UINT64_FORMAT ".to", resultPrefix, shardId);
+
+	return taskPrefix->data;
+}
+
+
+/*
+ * ExecutePredistributionTasks executes a list of tasks that were generated using
+ * WrapTasksForPredistribution.
+ */
+static PredistributionStats *
+ExecutePredistributionTasks(List *taskList, DistributionScheme *targetDistribution)
+{
+	TupleDesc resultDescriptor = NULL;
+	Tuplestorestate *resultStore = NULL;
+	int resultColumnCount = 5;
+	PredistributionStats *predistributionStats = NULL;
+
+
+#if PG_VERSION_NUM >= 120000
+	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount);
+#else
+	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount, false);
+#endif
+
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 1, "node_id",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 2, "shard_id",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 3, "partition_index",
+					   INT4OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 4, "bytes_written",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 5, "rows_written",
+					   INT8OID, -1, 0);
+
+	resultStore = ExecuteTasksIntoTupleStore(taskList, resultDescriptor);
+	predistributionStats = TupleStoreToPredistributionStats(resultStore, resultDescriptor,
+															targetDistribution);
+
+	return predistributionStats;
+}
+
+
+static PredistributionStats *
+TupleStoreToPredistributionStats(Tuplestorestate *tupleStore, TupleDesc resultDescriptor,
+								 DistributionScheme *targetDistribution)
+{
+	TupleTableSlot *slot = MakeSingleTupleTableSlotCompat(resultDescriptor,
+														  &TTSOpsMinimalTuple);
+	PartitioningScheme *partitioning = &targetDistribution->partitioning;
+	int shardCount = partitioning->partitionCount;
+
+	PredistributionStats *predistributionStats = CreatePredistributionStats(shardCount);
+
+	while (tuplestore_gettupleslot(tupleStore, true, false, slot))
+	{
+		TargetShardFragmentStats *shardFragmentStats = palloc0(
+			sizeof(TargetShardFragmentStats));
+		bool isNull = false;
+
+		int sourceNodeId = DatumGetInt32(slot_getattr(slot, 1, &isNull));
+		int64 sourceShardId = DatumGetInt64(slot_getattr(slot, 2, &isNull));
+		int targetShardIndex = DatumGetInt32(slot_getattr(slot, 3, &isNull));
+		int64 byteCount = DatumGetInt64(slot_getattr(slot, 4, &isNull));
+		int64 rowCount = DatumGetInt64(slot_getattr(slot, 5, &isNull));
+
+		/* protect against garbage results */
+		if (targetShardIndex < 0 || targetShardIndex >= shardCount)
+		{
+			ereport(ERROR, (errmsg("target shard index %d out of range",
+								   targetShardIndex)));
+		}
+
+		shardFragmentStats = palloc0(sizeof(TargetShardFragmentStats));
+		shardFragmentStats->sourceNodeId = sourceNodeId;
+		shardFragmentStats->sourceShardId = sourceShardId;
+		shardFragmentStats->targetShardIndex = targetShardIndex;
+		shardFragmentStats->byteCount = byteCount;
+		shardFragmentStats->rowCount = rowCount;
+
+		TargetShardFragments *fragmentSet =
+			&(predistributionStats->targetShardFragments[targetShardIndex]);
+		fragmentSet->fragments = lappend(fragmentSet->fragments, shardFragmentStats);
+
+		ExecClearTuple(slot);
+	}
+
+	ExecDropSingleTupleTableSlot(slot);
+
+	return predistributionStats;
+}
+
+
+/*
+ * CreatePredistributionStats creates a data structure for holding the statistics
+ * returned by executing SQL tasks wrapped in worker_predistribute_query_result
+ * calls.
+ */
+static PredistributionStats *
+CreatePredistributionStats(int targetShardCount)
+{
+	PredistributionStats *predistributionStats = palloc0(sizeof(PredistributionStats));
+	int targetShardIndex = 0;
+
+	predistributionStats->targetShardCount = targetShardCount;
+	predistributionStats->targetShardFragments =
+		palloc0(targetShardCount * sizeof(TargetShardFragments));
+
+	for (targetShardIndex = 0; targetShardIndex < targetShardCount; targetShardIndex++)
+	{
+		TargetShardFragments *fragmentSet =
+			&(predistributionStats->targetShardFragments[targetShardIndex]);
+
+		fragmentSet->targetShardIndex = targetShardIndex;
+		fragmentSet->fragments = NIL;
+	}
+
+	return predistributionStats;
+}
+
+
+/*
+ * CreateRedistributedQueryResult creates a RedistributedQueryResult that contains
+ * the reassembled fragment sets which are effectively shards in the temporary
+ * distributed table that consist of smaller fragments. Empty fragments are filtered
+ * out using the pre-distribution statistics.
+ *
+ * As part of the process, we also build the list of transfers that need to happen
+ * to get the fragments to the right place, grouped by a pair of source and target
+ * nodes such that we only open one connection per node pair.
+ *
+ * TODO: maybe generate the transfer list separately
+ */
+static RedistributedQueryResult *
+CreateRedistributedQueryResult(char *resultPrefix,
+							   PredistributionStats *predistributionStats,
+							   DistributionScheme *targetDistribution,
+							   bool isForWrites,
+							   List **fragmentsTransferList)
+{
+	PartitioningScheme *partitioning = &targetDistribution->partitioning;
+	NodeToNodeFragmentsTransfer *fragmentsTransfer = NULL;
+	int targetShardIndex = 0;
+	int targetShardCount = partitioning->partitionCount;
+	HASHCTL info;
+	HASH_SEQ_STATUS status;
+
+	ReassembledFragmentSet *reassembledFragmentSets = palloc0(
+		sizeof(ReassembledFragmentSet) * targetShardCount);
+
+	RedistributedQueryResult *result = palloc0(sizeof(RedistributedQueryResult));
+	result->resultPrefix = pstrdup(resultPrefix);
+	result->partitioning = partitioning;
+	result->reassembledFragmentSets = reassembledFragmentSets;
+
+	memset(&info, 0, sizeof(info));
+	info.keysize = sizeof(NodePair);
+	info.entrysize = sizeof(NodeToNodeFragmentsTransfer);
+	info.hcxt = CurrentMemoryContext;
+	uint32 hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
+
+	HTAB *nodeToNodeTransfers = hash_create("Fragment transfers", 32, &info, hashFlags);
+
+	/*
+	 * For each target shard, there is a TargetShardFragments that contains
+	 * statistics on all fragments that make up the shard from the time they
+	 * were generated on their respective source nodes.
+	 *
+	 * In this loop we transform TargetShardFragments into ReassembledFragmentSet,
+	 * which is tied to a particular (target) node and does not contain empty
+	 * fragments. This allows us to construct the appropriate fetch and read tasks.
+	 *
+	 * Effectively, TargetShardFragments represents the fragments in a target
+	 * shard before redistribution and ReassembledFragmentSet represents the
+	 * fragments in a target shard after redistribution.
+	 */
+	for (targetShardIndex = 0; targetShardIndex < targetShardCount; targetShardIndex++)
+	{
+		TargetShardFragments *targetShardFragments =
+			&(predistributionStats->targetShardFragments[targetShardIndex]);
+		ReassembledFragmentSet *reassembledFragments =
+			&(reassembledFragmentSets[targetShardIndex]);
+
+		ListCell *fragmentCell = NULL;
+		int *nodeGroupIds = targetDistribution->groupIds[targetShardIndex];
+
+		/* TODO: consider replication */
+		int targetGroupId = nodeGroupIds[0];
+
+		/* TODO: consider follower clusters (isForWrites) */
+		WorkerNode *targetNode = PrimaryNodeForGroup(targetGroupId, NULL);
+
+		List *targetShardFragmentStatsList = NIL;
+
+		foreach(fragmentCell, targetShardFragments->fragments)
+		{
+			TargetShardFragmentStats *fragmentStats = lfirst(fragmentCell);
+			NodePair nodePair = {
+				fragmentStats->sourceNodeId,
+				targetNode->nodeId
+			};
+			bool foundPair = false;
+
+			if (fragmentStats->rowCount == 0)
+			{
+				/* no data in fragment */
+				continue;
+			}
+
+			targetShardFragmentStatsList = lappend(targetShardFragmentStatsList,
+												   fragmentStats);
+
+			if (nodePair.sourceNodeId == nodePair.targetNodeId)
+			{
+				/* fragment is already on the right node, not transfer needed */
+				continue;
+			}
+
+			fragmentsTransfer = hash_search(nodeToNodeTransfers, &nodePair, HASH_ENTER,
+											&foundPair);
+			if (!foundPair)
+			{
+				fragmentsTransfer->fragmentsToFetch = NIL;
+			}
+
+			fragmentsTransfer->fragmentsToFetch = lappend(
+				fragmentsTransfer->fragmentsToFetch,
+				fragmentStats);
+		}
+
+		reassembledFragments->nodeId = targetNode->nodeId;
+		reassembledFragments->fragments = targetShardFragmentStatsList;
+	}
+
+	if (fragmentsTransferList != NULL)
+	{
+		hash_seq_init(&status, nodeToNodeTransfers);
+
+		while ((fragmentsTransfer = hash_seq_search(&status)) != NULL)
+		{
+			if (list_length(fragmentsTransfer->fragmentsToFetch) == 0)
+			{
+				/* all fragments from source to target were empty */
+				continue;
+			}
+
+			*fragmentsTransferList = lappend(*fragmentsTransferList, fragmentsTransfer);
+		}
+	}
+
+	return result;
+}
+
+
+/*
+ * BuildFetchTaskListForFragmentTransfers expects a list of NodeToNodeFragmentsTransfers
+ * and for each transfer it builds an appropriate fetch_intermediate_result task to
+ * perform the transfer.
+ */
+static List *
+BuildFetchTaskListForFragmentTransfers(char *resultPrefix, List *fragmentsTransferList)
+{
+	List *fetchTaskList = NIL;
+	ListCell *fragmentsTransferCell = NULL;
+
+	foreach(fragmentsTransferCell, fragmentsTransferList)
+	{
+		NodeToNodeFragmentsTransfer *fragmentsTransfer = lfirst(fragmentsTransferCell);
+		int targetNodeId = fragmentsTransfer->nodes.targetNodeId;
+		WorkerNode *workerNode = LookupNodeByNodeId(targetNodeId);
+
+		if (list_length(fragmentsTransfer->fragmentsToFetch) == 0)
+		{
+			continue;
+		}
+
+		ShardPlacement *targetPlacement = CitusMakeNode(ShardPlacement);
+		targetPlacement->nodeName = workerNode->workerName;
+		targetPlacement->nodePort = workerNode->workerPort;
+		targetPlacement->groupId = workerNode->groupId;
+
+		Task *task = CitusMakeNode(Task);
+		task->taskType = MODIFY_TASK;
+		task->queryString = BuildQueryStringForFragmentsTransfer(resultPrefix,
+																 fragmentsTransfer);
+		task->taskPlacementList = list_make1(targetPlacement);
+
+		fetchTaskList = lappend(fetchTaskList, task);
+	}
+
+	return fetchTaskList;
+}
+
+
+/*
+ * BuildQueryStringForFragmentsTransfer builds a fetch_intermediate_result query to
+ * perform the given node-to-node transfer by executing the query on the target
+ * node.
+ */
+static char *
+BuildQueryStringForFragmentsTransfer(char *resultPrefix,
+									 NodeToNodeFragmentsTransfer *fragmentsTransfer)
+{
+	ListCell *fragmentCell = NULL;
+	StringInfo queryString = makeStringInfo();
+	StringInfo fragmentNamesArrayString = makeStringInfo();
+	int fragmentCount = 0;
+	NodePair *nodePair = &fragmentsTransfer->nodes;
+	WorkerNode *sourceNode = LookupNodeByNodeId(nodePair->sourceNodeId);
+
+	appendStringInfoString(fragmentNamesArrayString, "ARRAY[");
+
+	foreach(fragmentCell, fragmentsTransfer->fragmentsToFetch)
+	{
+		TargetShardFragmentStats *fragmentStats = lfirst(fragmentCell);
+		char *fragmentName = TargetShardFragmentName(resultPrefix, fragmentStats);
+
+		if (fragmentCount > 0)
+		{
+			appendStringInfoString(fragmentNamesArrayString, ",");
+		}
+
+		appendStringInfoString(fragmentNamesArrayString,
+							   quote_literal_cstr(fragmentName));
+
+		fragmentCount++;
+	}
+
+	appendStringInfoString(fragmentNamesArrayString, "]::text[]");
+
+	appendStringInfo(queryString,
+					 "SELECT %d, bytes FROM fetch_intermediate_results(%s,%s,%d) bytes",
+					 nodePair->targetNodeId,
+					 fragmentNamesArrayString->data,
+					 quote_literal_cstr(sourceNode->workerName),
+					 sourceNode->workerPort);
+
+	return queryString->data;
+}
+
+
+static char *
+TargetShardFragmentName(char *resultPrefix, TargetShardFragmentStats *fragmentStats)
+{
+	StringInfo fragmentName = makeStringInfo();
+	int targetShardIndex = fragmentStats->targetShardIndex;
+
+	char *sourceShardPrefix = SourceShardPrefix(resultPrefix,
+												fragmentStats->sourceShardId);
+
+	appendStringInfo(fragmentName, "%s.%d", sourceShardPrefix, targetShardIndex);
+
+	return fragmentName->data;
+}
+
+
+/*
+ * ExecuteFetchTasks executes a list of fetch tasks and discards the results.
+ * The fetch task returns the number of bytes written, but this is currently
+ * unused.
+ */
+static void
+ExecuteFetchTasks(List *fetchTaskList)
+{
+	TupleDesc resultDescriptor = NULL;
+	int resultColumnCount = 2;
+
+#if PG_VERSION_NUM >= 120000
+	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount);
+#else
+	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount, false);
+#endif
+
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 1, "node_id",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 2, "bytes_written",
+					   INT8OID, -1, 0);
+
+	ExecuteTasksIntoTupleStore(fetchTaskList, resultDescriptor);
+}
+
+
+static Tuplestorestate *
+ExecuteTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor)
+{
+	bool hasReturning = true;
+	int targetPoolSize = MaxAdaptiveExecutorPoolSize;
+	bool randomAccess = true;
+	bool interTransactions = false;
+
+	Tuplestorestate *resultStore = tuplestore_begin_heap(randomAccess, interTransactions,
+														 work_mem);
+
+	ExecuteTaskListExtended(ROW_MODIFY_READONLY, taskList, resultDescriptor,
+							resultStore, hasReturning, targetPoolSize);
+
+	return resultStore;
+}
+
+
+Query *
+ReadReassembledFragmentSetQuery(char *resultPrefix, List *targetList,
+								ReassembledFragmentSet *fragmentSet)
+{
+	ListCell *fragmentCell = NULL;
+	List *fragmentNames = NIL;
+
+	foreach(fragmentCell, fragmentSet->fragments)
+	{
+		TargetShardFragmentStats *fragmentStats = lfirst(fragmentCell);
+
+		char *fragmentName = TargetShardFragmentName(resultPrefix, fragmentStats);
+
+		fragmentNames = lappend(fragmentNames, fragmentName);
+	}
+
+	Query *query = BuildReadIntermediateResultsArrayQuery(targetList, NIL, fragmentNames);
+
+	return query;
+}

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -242,7 +242,7 @@ WrapTasksForPredistribution(List *taskList, char *resultPrefix, int
 
 		appendStringInfo(wrappedQuery,
 						 "SELECT %d, " UINT64_FORMAT
-						 ", partition_index, bytes_written, rows_written "
+						 ", partition_index, rows_written "
 						 "FROM worker_predistribute_query_result"
 						 "(%s,%s,%d,%s)",
 						 shardPlacement->nodeId,
@@ -326,9 +326,7 @@ ExecutePredistributionTasks(List *taskList, DistributionScheme *targetDistributi
 					   INT8OID, -1, 0);
 	TupleDescInitEntry(resultDescriptor, (AttrNumber) 3, "partition_index",
 					   INT4OID, -1, 0);
-	TupleDescInitEntry(resultDescriptor, (AttrNumber) 4, "bytes_written",
-					   INT8OID, -1, 0);
-	TupleDescInitEntry(resultDescriptor, (AttrNumber) 5, "rows_written",
+	TupleDescInitEntry(resultDescriptor, (AttrNumber) 4, "rows_written",
 					   INT8OID, -1, 0);
 
 	resultStore = ExecuteTasksIntoTupleStore(taskList, resultDescriptor);
@@ -359,7 +357,6 @@ TupleStoreToPredistributionStats(Tuplestorestate *tupleStore, TupleDesc resultDe
 		int sourceNodeId = DatumGetInt32(slot_getattr(slot, 1, &isNull));
 		int64 sourceShardId = DatumGetInt64(slot_getattr(slot, 2, &isNull));
 		int targetShardIndex = DatumGetInt32(slot_getattr(slot, 3, &isNull));
-		int64 byteCount = DatumGetInt64(slot_getattr(slot, 4, &isNull));
 		int64 rowCount = DatumGetInt64(slot_getattr(slot, 5, &isNull));
 
 		/* protect against garbage results */
@@ -373,7 +370,6 @@ TupleStoreToPredistributionStats(Tuplestorestate *tupleStore, TupleDesc resultDe
 		shardFragmentStats->sourceNodeId = sourceNodeId;
 		shardFragmentStats->sourceShardId = sourceShardId;
 		shardFragmentStats->targetShardIndex = targetShardIndex;
-		shardFragmentStats->byteCount = byteCount;
 		shardFragmentStats->rowCount = rowCount;
 
 		TargetShardFragments *fragmentSet =

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -88,16 +88,15 @@ static void SendCopyDataOverConnection(StringInfo dataBuffer,
 									   MultiConnection *connection);
 static void RemoteFileDestReceiverShutdown(DestReceiver *destReceiver);
 static void RemoteFileDestReceiverDestroy(DestReceiver *destReceiver);
-
-static char * CreateIntermediateResultsDirectory(void);
-static char * IntermediateResultsDirectory(void);
-static char * QueryResultFileName(const char *resultId);
+static int64 FetchRemoteIntermediateResult(MultiConnection *connection, char *resultId);
 
 
 /* exports for SQL callable functions */
 PG_FUNCTION_INFO_V1(read_intermediate_result);
+PG_FUNCTION_INFO_V1(read_intermediate_result_array);
 PG_FUNCTION_INFO_V1(broadcast_intermediate_result);
 PG_FUNCTION_INFO_V1(create_intermediate_result);
+PG_FUNCTION_INFO_V1(fetch_intermediate_results);
 
 
 /*
@@ -506,6 +505,20 @@ RemoteFileDestReceiverDestroy(DestReceiver *destReceiver)
 
 
 /*
+ * SendQueryResultViaCopy is called when a COPY "resultid" TO STDOUT
+ * WITH (format result) command is received from the client. The
+ * contents of the file are sent directly to the client.
+ */
+void
+SendQueryResultViaCopy(const char *resultId)
+{
+	const char *resultFileName = QueryResultFileName(resultId);
+
+	SendRegularFile(resultFileName);
+}
+
+
+/*
  * ReceiveQueryResultViaCopy is called when a COPY "resultid" FROM
  * STDIN WITH (format result) command is received from the client.
  * The command is followed by the raw copy data stream, which is
@@ -530,7 +543,7 @@ ReceiveQueryResultViaCopy(const char *resultId)
  * directory for the current transaction if it does not exist and ensures
  * that the directory is removed at the end of the transaction.
  */
-static char *
+char *
 CreateIntermediateResultsDirectory(void)
 {
 	char *resultDirectory = IntermediateResultsDirectory();
@@ -565,7 +578,7 @@ CreateIntermediateResultsDirectory(void)
  * an intermediate result with the given key in the per transaction
  * result directory.
  */
-static char *
+char *
 QueryResultFileName(const char *resultId)
 {
 	StringInfo resultFileName = makeStringInfo();
@@ -577,6 +590,7 @@ QueryResultFileName(const char *resultId)
 		if (!((*checkChar >= 'a' && *checkChar <= 'z') ||
 			  (*checkChar >= 'A' && *checkChar <= 'Z') ||
 			  (*checkChar >= '0' && *checkChar <= '9') ||
+			  (*checkChar == '.') ||
 			  (*checkChar == '_') || (*checkChar == '-')))
 		{
 			ereport(ERROR, (errcode(ERRCODE_INVALID_NAME),
@@ -610,7 +624,7 @@ QueryResultFileName(const char *resultId)
  *
  * The pgsql_job_cache directory is emptied on restart in case of failure.
  */
-static char *
+char *
 IntermediateResultsDirectory(void)
 {
 	StringInfo resultFileName = makeStringInfo();
@@ -683,6 +697,8 @@ IntermediateResultSize(char *resultId)
  * The file is read from the directory returned by IntermediateResultsDirectory,
  * which includes the user ID.
  *
+ * If the file is a directory, all the files in the directory are concatenated.
+ *
  * read_intermediate_result is a volatile function because it cannot be
  * evaluated until execution time, but for distributed planning purposes we can
  * treat it in the same way as immutable functions and reference tables, since
@@ -713,9 +729,215 @@ read_intermediate_result(PG_FUNCTION_ARGS)
 
 	Tuplestorestate *tupstore = SetupTuplestore(fcinfo, &tupleDescriptor);
 
-	ReadFileIntoTupleStore(resultFileName, copyFormatLabel, tupleDescriptor, tupstore);
+	ReadFileIntoTupleStore(resultFileName, copyFormatLabel, tupleDescriptor,
+						   tupstore);
 
 	tuplestore_donestoring(tupstore);
 
 	return (Datum) 0;
+}
+
+
+Datum
+read_intermediate_result_array(PG_FUNCTION_ARGS)
+{
+	ArrayType *resultIdObject = PG_GETARG_ARRAYTYPE_P(0);
+	Datum copyFormatOidDatum = PG_GETARG_DATUM(1);
+
+	int resultIndex = 0;
+
+	Datum copyFormatLabelDatum = DirectFunctionCall1(enum_out, copyFormatOidDatum);
+	char *copyFormatLabel = DatumGetCString(copyFormatLabelDatum);
+
+	TupleDesc tupleDescriptor = NULL;
+
+	CheckCitusVersion(ERROR);
+
+	Tuplestorestate *tupstore = SetupTuplestore(fcinfo, &tupleDescriptor);
+
+	int32 resultCount = ArrayGetNItems(ARR_NDIM(resultIdObject), ARR_DIMS(
+										   resultIdObject));
+	if (resultCount == 0)
+	{
+		tuplestore_donestoring(tupstore);
+		PG_RETURN_VOID();
+	}
+
+	Datum *resultIdArray = DeconstructArrayObject(resultIdObject);
+
+	for (resultIndex = 0; resultIndex < resultCount; resultIndex++)
+	{
+		char *resultId = TextDatumGetCString(resultIdArray[resultIndex]);
+		char *resultFileName = QueryResultFileName(resultId);
+		struct stat fileStat;
+
+		int statOK = stat(resultFileName, &fileStat);
+		if (statOK != 0)
+		{
+			ereport(ERROR, (errcode_for_file_access(),
+							errmsg("result \"%s\" does not exist", resultId)));
+		}
+
+		ReadFileIntoTupleStore(resultFileName, copyFormatLabel, tupleDescriptor,
+							   tupstore);
+	}
+
+	tuplestore_donestoring(tupstore);
+
+	return (Datum) 0;
+}
+
+
+/*
+ * fetch_intermediate_results fetches a set of intermediate results defined in an
+ * array of result IDs from a remote node and writes them to a local intermediate
+ * result with the same ID.
+ */
+Datum
+fetch_intermediate_results(PG_FUNCTION_ARGS)
+{
+	ArrayType *resultIdObject = PG_GETARG_ARRAYTYPE_P(0);
+	Datum *resultIdArray = DeconstructArrayObject(resultIdObject);
+	int32 resultCount = ArrayObjectCount(resultIdObject);
+	text *remoteHostText = PG_GETARG_TEXT_P(1);
+	char *remoteHost = text_to_cstring(remoteHostText);
+	int remotePort = PG_GETARG_INT32(2);
+
+	int connectionFlags = 0;
+	int resultIndex = 0;
+	int64 totalBytesWritten = 0L;
+
+	CheckCitusVersion(ERROR);
+
+	if (resultCount == 0)
+	{
+		PG_RETURN_INT64(0);
+	}
+
+	if (!IsMultiStatementTransaction())
+	{
+		ereport(ERROR, (errmsg("fetch_intermediate_results can only be used in a "
+							   "distributed transaction")));
+	}
+
+	MultiConnection *connection = GetNodeConnection(connectionFlags, remoteHost,
+													remotePort);
+
+	if (PQstatus(connection->pgConn) != CONNECTION_OK)
+	{
+		ereport(ERROR, (errmsg("cannot connect to %s:%d to fetch intermediate "
+							   "results",
+							   remoteHost, remotePort)));
+	}
+
+	RemoteTransactionBegin(connection);
+
+	for (resultIndex = 0; resultIndex < resultCount; resultIndex++)
+	{
+		char *resultId = TextDatumGetCString(resultIdArray[resultIndex]);
+
+		totalBytesWritten += FetchRemoteIntermediateResult(connection, resultId);
+	}
+
+	RemoteTransactionCommit(connection);
+	CloseConnection(connection);
+
+	PG_RETURN_INT64(totalBytesWritten);
+}
+
+
+/*
+ * FetchRemoteIntermediateResult fetches a remote intermediate result over
+ * the given connection.
+ */
+static int64
+FetchRemoteIntermediateResult(MultiConnection *connection, char *resultId)
+{
+	int64 totalBytesWritten = 0;
+
+	StringInfo copyCommand = makeStringInfo();
+	const int fileFlags = (O_APPEND | O_CREAT | O_RDWR | O_TRUNC | PG_BINARY);
+	const int fileMode = (S_IRUSR | S_IWUSR);
+
+	PGconn *pgConn = connection->pgConn;
+	int socket = PQsocket(pgConn);
+	bool raiseErrors = true;
+
+	CreateIntermediateResultsDirectory();
+
+	char *localPath = QueryResultFileName(resultId);
+	File fileDesc = FileOpenForTransmit(localPath, fileFlags, fileMode);
+	FileCompat fileCompat = FileCompatFromFileStart(fileDesc);
+
+	appendStringInfo(copyCommand, "COPY \"%s\" TO STDOUT WITH (format result)",
+					 resultId);
+
+	if (!SendRemoteCommand(connection, copyCommand->data))
+	{
+		ReportConnectionError(connection, ERROR);
+	}
+
+	PGresult *result = GetRemoteCommandResult(connection, raiseErrors);
+	if (PQresultStatus(result) != PGRES_COPY_OUT)
+	{
+		ReportResultError(connection, result, ERROR);
+	}
+
+	PQclear(result);
+
+	while (true)
+	{
+		char *receiveBuffer = NULL;
+		bool asynchronous = true;
+		int waitFlags = WL_SOCKET_READABLE;
+
+		if (PQconsumeInput(pgConn) == 0)
+		{
+			ereport(ERROR, (errmsg("failed to read result \"%s\" from node %s:%d",
+								   resultId, connection->hostname, connection->port)));
+		}
+
+		int bytesReceived = PQgetCopyData(pgConn, &receiveBuffer, asynchronous);
+
+		while (bytesReceived > 0)
+		{
+			int bytesWritten = FileWriteCompat(&fileCompat, receiveBuffer,
+											   bytesReceived, PG_WAIT_IO);
+			if (bytesWritten < bytesReceived)
+			{
+				ereport(ERROR, (errcode_for_file_access(),
+								errmsg("could not append to file: %m")));
+			}
+
+			totalBytesWritten += bytesWritten;
+
+			PQfreemem(receiveBuffer);
+
+			bytesReceived = PQgetCopyData(pgConn, &receiveBuffer, asynchronous);
+		}
+
+		if (bytesReceived < 0)
+		{
+			/* end of copy stream reached */
+			break;
+		}
+
+		int rc = WaitLatchOrSocket(MyLatch, waitFlags, socket, 0, PG_WAIT_EXTENSION);
+		if (rc & WL_POSTMASTER_DEATH)
+		{
+			ereport(ERROR, (errmsg("postmaster was shut down, exiting")));
+		}
+
+		if (rc & WL_LATCH_SET)
+		{
+			ResetLatch(MyLatch);
+			CHECK_FOR_INTERRUPTS();
+		}
+	}
+
+	FileClose(fileDesc);
+
+	ClearResults(connection, raiseErrors);
+
+	return totalBytesWritten;
 }

--- a/src/backend/distributed/executor/partition_intermediate_results.c
+++ b/src/backend/distributed/executor/partition_intermediate_results.c
@@ -221,17 +221,15 @@ worker_predistribute_query_result(PG_FUNCTION_ARGS)
 	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
 	{
 		FileOutputStream *partitionFile = &resultDest->partitionFiles[partitionIndex];
-		int64 bytesWritten = partitionFile->bytesWritten;
 		int64 recordsWritten = partitionFile->recordsWritten;
-		Datum values[3];
-		bool nulls[3];
+		Datum values[2];
+		bool nulls[2];
 
 		memset(values, 0, sizeof(values));
 		memset(nulls, 0, sizeof(nulls));
 
 		values[0] = Int32GetDatum(partitionIndex);
 		values[1] = UInt64GetDatum(recordsWritten);
-		values[2] = UInt64GetDatum(bytesWritten);
 
 		tuplestore_putvalues(tupleStore, returnTupleDesc, values, nulls);
 	}

--- a/src/backend/distributed/executor/partition_intermediate_results.c
+++ b/src/backend/distributed/executor/partition_intermediate_results.c
@@ -1,0 +1,621 @@
+/*-------------------------------------------------------------------------
+ *
+ * partition_intermediate_results.c
+ *   Functions for writing partitioned intermediate results.
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "port.h"
+
+#include "access/hash.h"
+#include "access/nbtree.h"
+#include "catalog/pg_am.h"
+#include "catalog/pg_enum.h"
+#include "commands/copy.h"
+#include "distributed/commands/multi_copy.h"
+#include "distributed/connection_management.h"
+#include "distributed/intermediate_results.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_executor.h"
+#include "distributed/remote_commands.h"
+#include "distributed/transmit.h"
+#include "distributed/transaction_identifier.h"
+#include "distributed/tuplestore.h"
+#include "distributed/worker_protocol.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "storage/fd.h"
+#include "tcop/pquery.h"
+#include "tcop/tcopprot.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/portal.h"
+#include "utils/syscache.h"
+
+
+struct PartitionedResultDestReceiver;
+typedef uint32 (*PartitionIdFunc)(Datum, void *);
+
+
+/* CopyDestReceiver can be used to stream results into a distributed table */
+typedef struct PartitionedResultDestReceiver
+{
+	/* public DestReceiver interface */
+	DestReceiver pub;
+
+	char *resultIdPrefix;
+
+	/* descriptor of the tuples that are sent to the worker */
+	TupleDesc tupleDescriptor;
+
+	/* EState for per-tuple memory allocation */
+	EState *executorState;
+
+	/* MemoryContext for DestReceiver session */
+	MemoryContext memoryContext;
+
+	/* partitioning logic */
+	int partitionColumnIndex;
+	PartitionIdFunc determinePartitionId;
+	void *partitionContext;
+
+	/* output files */
+	int partitionCount;
+	FileOutputStream *partitionFiles;
+
+	/* state on how to copy out data types */
+	CopyOutState copyOutState;
+	FmgrInfo *columnOutputFunctions;
+
+	/* number of tuples sent */
+	uint64 tuplesSent;
+} PartitionedResultDestReceiver;
+
+
+static DestReceiver * CreatePartitionedResultDestReceiver(char *resultId,
+														  EState *executorState,
+														  int partitionColumnIndex,
+														  int partitionCount,
+														  PartitionIdFunc partitionIdFunc,
+														  void *partitionContext);
+static HashPartitionContext * CreateHashPartitionContext(Datum *hashRangeArray,
+														 int partitionCount,
+														 Oid partitionColumnType,
+														 Oid partitionColumnCollation);
+static uint32 HashPartitionId(Datum partitionValue, void *context);
+static void PartitionedResultDestReceiverStartup(DestReceiver *dest, int operation,
+												 TupleDesc inputTupleDescriptor);
+static bool PartitionedResultDestReceiverReceive(TupleTableSlot *slot,
+												 DestReceiver *dest);
+static void FileOutputStreamOpen(FileOutputStream *file);
+static void FileOutputStreamWrite(FileOutputStream *file, StringInfo dataToWrite);
+static void FileOutputStreamFlush(FileOutputStream *file);
+static void PartitionedResultDestReceiverShutdown(DestReceiver *destReceiver);
+static void PartitionedResultDestReceiverDestroy(DestReceiver *destReceiver);
+
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(worker_predistribute_query_result);
+
+
+/*
+ * worker_predistribute_query_result executes a query and writes the results
+ * into a set of local files according to the partition scheme and the partition
+ * column.
+ */
+Datum
+worker_predistribute_query_result(PG_FUNCTION_ARGS)
+{
+	ReturnSetInfo *resultInfo = (ReturnSetInfo *) fcinfo->resultinfo;
+
+	text *resultIdPrefixText = PG_GETARG_TEXT_P(0);
+	char *resultIdPrefixString = text_to_cstring(resultIdPrefixText);
+	text *queryText = PG_GETARG_TEXT_P(1);
+	char *queryString = text_to_cstring(queryText);
+
+	int partitionColumnIndex = PG_GETARG_INT32(2);
+	ArrayType *hashRangeObject = PG_GETARG_ARRAYTYPE_P(3);
+
+
+	Datum *hashRangeArray = DeconstructArrayObject(hashRangeObject);
+	int32 partitionCount = ArrayObjectCount(hashRangeObject);
+
+	ParamListInfo paramListInfo = NULL;
+
+	TupleDesc returnTupleDesc = NULL;
+	MemoryContext perQueryContext = resultInfo->econtext->ecxt_per_query_memory;
+	int partitionIndex = 0;
+
+	int eflags = 0;
+	long count = FETCH_ALL;
+
+	CheckCitusVersion(ERROR);
+
+	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &returnTupleDesc);
+
+	if (partitionCount == 0)
+	{
+		ereport(ERROR, (errmsg("number of partitions cannot be 0")));
+	}
+
+	if (partitionColumnIndex < 0)
+	{
+		ereport(ERROR, (errmsg("partition column index cannot be negative")));
+	}
+
+	/* parse the query */
+	Query *query = ParseQueryString(queryString, NULL, 0);
+
+	/* plan the query */
+	int cursorOptions = CURSOR_OPT_PARALLEL_OK;
+	PlannedStmt *queryPlan = pg_plan_query(query, cursorOptions, paramListInfo);
+
+	/* create a new portal for executing the query */
+	Portal portal = CreateNewPortal();
+
+	/* don't display the portal in pg_cursors, it is for internal use only */
+	portal->visible = false;
+
+	/* start execution early in order to extract the tuple descriptor  */
+	PortalDefineQuery(portal, NULL, queryString, "SELECT", list_make1(queryPlan), NULL);
+	PortalStart(portal, paramListInfo, eflags, GetActiveSnapshot());
+
+	/* extract the partition column */
+	TupleDesc tupleDescriptor = portal->tupDesc;
+
+	if (tupleDescriptor == NULL)
+	{
+		elog(ERROR, "no tuple descriptor");
+	}
+
+	if (partitionColumnIndex >= tupleDescriptor->natts)
+	{
+		ereport(ERROR, (errmsg("partition column index cannot be greater than %d",
+							   tupleDescriptor->natts - 1)));
+	}
+
+	/* determine the partition column type */
+	FormData_pg_attribute *attr = TupleDescAttr(tupleDescriptor, partitionColumnIndex);
+	Oid partitionColumnType = attr->atttypid;
+	Oid partitionColumnCollation = attr->attcollation;
+
+	/* build the partition context */
+	HashPartitionContext *partitionContext = CreateHashPartitionContext(hashRangeArray,
+																		partitionCount,
+																		partitionColumnType,
+																		partitionColumnCollation);
+
+	/* prepare the output destination */
+	EState *estate = CreateExecutorState();
+	DestReceiver *dest = CreatePartitionedResultDestReceiver(resultIdPrefixString, estate,
+															 partitionColumnIndex,
+															 partitionCount,
+															 HashPartitionId,
+															 partitionContext);
+
+	PartitionedResultDestReceiver *resultDest = (PartitionedResultDestReceiver *) dest;
+
+	/* execute the query */
+	PortalRun(portal, count, false, true, dest, dest, NULL);
+
+	MemoryContext oldContext = MemoryContextSwitchTo(perQueryContext);
+
+	tupleStore = tuplestore_begin_heap(true, false, work_mem);
+	resultInfo->returnMode = SFRM_Materialize;
+	resultInfo->setResult = tupleStore;
+	resultInfo->setDesc = returnTupleDesc;
+
+	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
+	{
+		FileOutputStream *partitionFile = &resultDest->partitionFiles[partitionIndex];
+		int64 bytesWritten = partitionFile->bytesWritten;
+		int64 recordsWritten = partitionFile->recordsWritten;
+		Datum values[3];
+		bool nulls[3];
+
+		memset(values, 0, sizeof(values));
+		memset(nulls, 0, sizeof(nulls));
+
+		values[0] = Int32GetDatum(partitionIndex);
+		values[1] = UInt64GetDatum(recordsWritten);
+		values[2] = UInt64GetDatum(bytesWritten);
+
+		tuplestore_putvalues(tupleStore, returnTupleDesc, values, nulls);
+	}
+
+	tuplestore_donestoring(tupleStore);
+
+	MemoryContextSwitchTo(oldContext);
+
+	PortalDrop(portal, false);
+	FreeExecutorState(estate);
+
+	PG_RETURN_INT64(resultDest->tuplesSent);
+}
+
+
+/*
+ * CreateHashPartitionContext creates a new partition context for dividing
+ * values of type partitionColumnType into hash buckets according to the
+ * ranges whose minimum hash value is in hashRangeArray.
+ */
+static HashPartitionContext *
+CreateHashPartitionContext(Datum *hashRangeArray, int partitionCount,
+						   Oid partitionColumnType, Oid partitionColumnCollation)
+{
+	HashPartitionContext *partitionContext = palloc0(sizeof(HashPartitionContext));
+	partitionContext->syntheticShardIntervalArray =
+		SyntheticShardIntervalArrayForShardMinValues(hashRangeArray, partitionCount);
+	partitionContext->hasUniformHashDistribution =
+		HasUniformHashDistribution(partitionContext->syntheticShardIntervalArray,
+								   partitionCount);
+
+	/* use column's type information to get the hashing function */
+	FmgrInfo *hashFunction = GetFunctionInfo(partitionColumnType, HASH_AM_OID,
+											 HASHSTANDARD_PROC);
+
+	partitionContext->hashFunction = hashFunction;
+	partitionContext->partitionCount = partitionCount;
+	partitionContext->collation = partitionColumnCollation;
+
+	/* we'll use binary search, we need the comparison function */
+	if (!partitionContext->hasUniformHashDistribution)
+	{
+		partitionContext->comparisonFunction =
+			GetFunctionInfo(partitionColumnType, BTREE_AM_OID, BTORDER_PROC);
+	}
+
+	return partitionContext;
+}
+
+
+/*
+ * HashPartitionId determines the partition number for the given data value
+ * using hash partitioning. More specifically, the function returns zero if the
+ * given data value is null. If not, the function follows the exact same approach
+ * as Citus distributed planner uses.
+ */
+static uint32
+HashPartitionId(Datum partitionValue, void *context)
+{
+	HashPartitionContext *hashPartitionContext = (HashPartitionContext *) context;
+	FmgrInfo *hashFunction = hashPartitionContext->hashFunction;
+	uint32 partitionCount = hashPartitionContext->partitionCount;
+	ShardInterval **syntheticShardIntervalArray =
+		hashPartitionContext->syntheticShardIntervalArray;
+	FmgrInfo *comparisonFunction = hashPartitionContext->comparisonFunction;
+	Oid collation = hashPartitionContext->collation;
+	Datum hashDatum = FunctionCall1Coll(hashFunction, partitionValue, collation);
+	int32 hashResult = 0;
+	uint32 hashPartitionId = 0;
+
+	if (hashDatum == 0)
+	{
+		return hashPartitionId;
+	}
+
+	if (hashPartitionContext->hasUniformHashDistribution)
+	{
+		uint64 hashTokenIncrement = HASH_TOKEN_COUNT / partitionCount;
+
+		hashResult = DatumGetInt32(hashDatum);
+		hashPartitionId = (uint32) (hashResult - INT32_MIN) / hashTokenIncrement;
+	}
+	else
+	{
+		hashPartitionId =
+			SearchCachedShardInterval(hashDatum, syntheticShardIntervalArray,
+									  partitionCount, collation, comparisonFunction);
+	}
+
+	return hashPartitionId;
+}
+
+
+/*
+ * CreatePartitionedResultDestReceiver creates a DestReceiver that streams results
+ * to a set of worker nodes. If the scope of the intermediate result is a
+ * distributed transaction, then it's up to the caller to ensure that a
+ * coordinated transaction is started prior to using the DestReceiver.
+ */
+static DestReceiver *
+CreatePartitionedResultDestReceiver(char *resultIdPrefix, EState *executorState,
+									int partitionColumnIndex,
+									int partitionCount, PartitionIdFunc partitionIdFunc,
+									void *partitionContext)
+{
+	PartitionedResultDestReceiver *resultDest = (PartitionedResultDestReceiver *) palloc0(
+		sizeof(PartitionedResultDestReceiver));
+
+	/* set up the DestReceiver function pointers */
+	resultDest->pub.receiveSlot = PartitionedResultDestReceiverReceive;
+	resultDest->pub.rStartup = PartitionedResultDestReceiverStartup;
+	resultDest->pub.rShutdown = PartitionedResultDestReceiverShutdown;
+	resultDest->pub.rDestroy = PartitionedResultDestReceiverDestroy;
+	resultDest->pub.mydest = DestCopyOut;
+
+	/* set up output parameters */
+	resultDest->resultIdPrefix = resultIdPrefix;
+	resultDest->executorState = executorState;
+	resultDest->memoryContext = CurrentMemoryContext;
+	resultDest->partitionColumnIndex = partitionColumnIndex;
+	resultDest->partitionCount = partitionCount;
+	resultDest->determinePartitionId = partitionIdFunc;
+	resultDest->partitionContext = partitionContext;
+	resultDest->partitionFiles =
+		(FileOutputStream *) palloc0(partitionCount * sizeof(FileOutputStream));
+
+	return (DestReceiver *) resultDest;
+}
+
+
+/*
+ * PartitionedResultDestReceiverStartup implements the rStartup interface of
+ * PartitionedResultDestReceiver. It opens the relation
+ */
+static void
+PartitionedResultDestReceiverStartup(DestReceiver *dest, int operation,
+									 TupleDesc inputTupleDescriptor)
+{
+	PartitionedResultDestReceiver *resultDest = (PartitionedResultDestReceiver *) dest;
+
+	const char *resultIdPrefix = resultDest->resultIdPrefix;
+
+	const char *delimiterCharacter = "\t";
+	const char *nullPrintCharacter = "\\N";
+
+	int partitionCount = resultDest->partitionCount;
+	int partitionIndex = 0;
+	FileOutputStream *partitionFileArray = resultDest->partitionFiles;
+
+	resultDest->tupleDescriptor = inputTupleDescriptor;
+
+	/* define how tuples will be serialised */
+	CopyOutState copyOutState = (CopyOutState) palloc0(sizeof(CopyOutStateData));
+	copyOutState->delim = (char *) delimiterCharacter;
+	copyOutState->null_print = (char *) nullPrintCharacter;
+	copyOutState->null_print_client = (char *) nullPrintCharacter;
+	copyOutState->binary = CanUseBinaryCopyFormat(inputTupleDescriptor);
+	copyOutState->fe_msgbuf = makeStringInfo();
+	copyOutState->rowcontext = GetPerTupleMemoryContext(resultDest->executorState);
+	resultDest->copyOutState = copyOutState;
+
+	resultDest->columnOutputFunctions = ColumnOutputFunctions(inputTupleDescriptor,
+															  copyOutState->binary);
+
+	/* make sure the directory exists */
+	CreateIntermediateResultsDirectory();
+
+	uint32 fileBufferSize = (uint32) Max(16384 * 1024 / partitionCount, 1024);
+
+	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
+	{
+		StringInfo resultId = makeStringInfo();
+		StringInfo filePathStringInfo = makeStringInfo();
+
+		appendStringInfo(resultId, "%s.%d", resultIdPrefix, partitionIndex);
+
+		char *filePath = QueryResultFileName(resultId->data);
+		appendStringInfoString(filePathStringInfo, filePath);
+
+		/* initialize the entry but do not create the file yet */
+		partitionFileArray[partitionIndex].fileDescriptor = 0;
+		partitionFileArray[partitionIndex].fileBuffer = makeStringInfo();
+		partitionFileArray[partitionIndex].filePath = filePathStringInfo;
+		partitionFileArray[partitionIndex].bufferSize = fileBufferSize;
+		partitionFileArray[partitionIndex].bytesWritten = 0L;
+		partitionFileArray[partitionIndex].recordsWritten = 0L;
+	}
+}
+
+
+/*
+ * PartitionedResultDestReceiverReceive implements the receiveSlot function of
+ * PartitionedResultDestReceiver. It takes a TupleTableSlot and sends the contents to
+ * all worker nodes.
+ */
+static bool
+PartitionedResultDestReceiverReceive(TupleTableSlot *slot, DestReceiver *dest)
+{
+	PartitionedResultDestReceiver *resultDest = (PartitionedResultDestReceiver *) dest;
+
+	TupleDesc tupleDescriptor = resultDest->tupleDescriptor;
+
+	CopyOutState copyOutState = resultDest->copyOutState;
+	FmgrInfo *columnOutputFunctions = resultDest->columnOutputFunctions;
+	int partitionColumnIndex = resultDest->partitionColumnIndex;
+
+	StringInfo copyData = copyOutState->fe_msgbuf;
+
+	void *partitionContext = resultDest->partitionContext;
+
+	EState *executorState = resultDest->executorState;
+	MemoryContext executorTupleContext = GetPerTupleMemoryContext(executorState);
+	MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
+
+	/* deform the tuple */
+	slot_getallattrs(slot);
+
+	Datum *columnValues = slot->tts_values;
+	bool *columnNulls = slot->tts_isnull;
+
+	/* find the partition column value */
+	Datum partitionColumnValue = columnValues[partitionColumnIndex];
+
+	/* determine the right partition */
+	int partitionId = resultDest->determinePartitionId(partitionColumnValue,
+													   partitionContext);
+
+	/* find the right partition file */
+	FileOutputStream *partitionFile = &resultDest->partitionFiles[partitionId];
+	if (partitionFile->fileDescriptor == 0)
+	{
+		/* create the file */
+		FileOutputStreamOpen(partitionFile);
+
+		if (copyOutState->binary)
+		{
+			/* send headers when using binary encoding */
+			resetStringInfo(copyOutState->fe_msgbuf);
+			AppendCopyBinaryHeaders(copyOutState);
+
+			FileOutputStreamWrite(partitionFile, copyOutState->fe_msgbuf);
+		}
+	}
+
+	/* construct row in COPY format */
+	resetStringInfo(copyData);
+	AppendCopyRowData(columnValues, columnNulls, tupleDescriptor,
+					  copyOutState, columnOutputFunctions, NULL);
+
+	/* append row to the file */
+	FileOutputStreamWrite(partitionFile, copyOutState->fe_msgbuf);
+
+	partitionFile->recordsWritten++;
+	resultDest->tuplesSent++;
+
+	MemoryContextSwitchTo(oldContext);
+	ResetPerTupleExprContext(executorState);
+
+	return true;
+}
+
+
+/*
+ * FileOutputStreamOpen opens the file and adds headers if necessary.
+ */
+static void
+FileOutputStreamOpen(FileOutputStream *file)
+{
+	const int fileFlags = (O_APPEND | O_CREAT | O_RDWR | O_TRUNC | PG_BINARY);
+	const int fileMode = (S_IRUSR | S_IWUSR);
+	char *filePath = file->filePath->data;
+
+	File fileDescriptor = PathNameOpenFilePerm(filePath, fileFlags, fileMode);
+	if (fileDescriptor < 0)
+	{
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not open file \"%s\": %m", filePath)));
+	}
+
+	file->fileDescriptor = fileDescriptor;
+}
+
+
+/*
+ * FileOutputStreamWrite appends given data to file stream's internal buffers.
+ * The function then checks if buffered data exceeds preconfigured buffer size;
+ * if so, the function flushes the buffer to the underlying file.
+ */
+static void
+FileOutputStreamWrite(FileOutputStream *file, StringInfo dataToWrite)
+{
+	StringInfo fileBuffer = file->fileBuffer;
+	uint32 newBufferSize = fileBuffer->len + dataToWrite->len;
+
+	appendBinaryStringInfo(fileBuffer, dataToWrite->data, dataToWrite->len);
+
+	file->bytesWritten += dataToWrite->len;
+
+	if (newBufferSize > file->bufferSize)
+	{
+		FileOutputStreamFlush(file);
+
+		resetStringInfo(fileBuffer);
+	}
+}
+
+
+/* Flushes data buffered in the file stream object to the underlying file. */
+static void
+FileOutputStreamFlush(FileOutputStream *file)
+{
+	StringInfo fileBuffer = file->fileBuffer;
+
+	errno = 0;
+	int written = FileWriteCompat(&file->fileCompat, fileBuffer->data,
+								  fileBuffer->len, PG_WAIT_IO);
+	if (written != fileBuffer->len)
+	{
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not write %d bytes to partition file \"%s\"",
+							   fileBuffer->len, file->filePath->data)));
+	}
+}
+
+
+/*
+ * PartitionedResultDestReceiverShutdown implements the rShutdown interface of
+ * PartitionedResultDestReceiver. It ends the COPY on all the open connections and closes
+ * the relation.
+ */
+static void
+PartitionedResultDestReceiverShutdown(DestReceiver *destReceiver)
+{
+	PartitionedResultDestReceiver *resultDest =
+		(PartitionedResultDestReceiver *) destReceiver;
+	int partitionCount = resultDest->partitionCount;
+	int partitionIndex = 0;
+
+	CopyOutState copyOutState = resultDest->copyOutState;
+
+	for (partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
+	{
+		FileOutputStream *partitionFile = &resultDest->partitionFiles[partitionIndex];
+
+		if (partitionFile->fileDescriptor != 0)
+		{
+			if (copyOutState->binary)
+			{
+				/* send footers when using binary encoding */
+				resetStringInfo(copyOutState->fe_msgbuf);
+				AppendCopyBinaryFooters(copyOutState);
+
+				FileOutputStreamWrite(partitionFile, copyOutState->fe_msgbuf);
+			}
+
+			FileOutputStreamFlush(partitionFile);
+			FileClose(partitionFile->fileDescriptor);
+		}
+
+		FreeStringInfo(partitionFile->fileBuffer);
+		FreeStringInfo(partitionFile->filePath);
+	}
+}
+
+
+/*
+ * PartitionedResultDestReceiverDestroy frees memory allocated as part of the
+ * PartitionedResultDestReceiver and closes file descriptors.
+ */
+static void
+PartitionedResultDestReceiverDestroy(DestReceiver *destReceiver)
+{
+	PartitionedResultDestReceiver *resultDest =
+		(PartitionedResultDestReceiver *) destReceiver;
+
+	if (resultDest->copyOutState)
+	{
+		pfree(resultDest->copyOutState);
+	}
+
+	if (resultDest->columnOutputFunctions)
+	{
+		pfree(resultDest->columnOutputFunctions);
+	}
+
+	pfree(resultDest);
+}

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -136,6 +136,7 @@ typedef struct MetadataCacheData
 	Oid citusCatalogNamespaceId;
 	Oid copyFormatTypeId;
 	Oid readIntermediateResultFuncId;
+	Oid readIntermediateResultArrayFuncId;
 	Oid extraDataContainerFuncId;
 	Oid workerHashFunctionId;
 	Oid anyValueFunctionId;
@@ -2062,6 +2063,38 @@ CitusReadIntermediateResultFuncId(void)
 	}
 
 	return MetadataCache.readIntermediateResultFuncId;
+}
+
+
+/* return oid of the read_intermediate_result(text[],citus_copy_format) function */
+Oid
+CitusReadIntermediateResultArrayFuncId(void)
+{
+	if (MetadataCache.readIntermediateResultArrayFuncId == InvalidOid)
+	{
+		List *functionNameList = list_make2(makeString("pg_catalog"),
+											makeString("read_intermediate_result"));
+		Oid copyFormatTypeOid = CitusCopyFormatTypeId();
+		Oid paramOids[2] = { TEXTARRAYOID, copyFormatTypeOid };
+		bool missingOK = false;
+
+		MetadataCache.readIntermediateResultArrayFuncId =
+			LookupFuncName(functionNameList, 2, paramOids, missingOK);
+	}
+
+	return MetadataCache.readIntermediateResultArrayFuncId;
+}
+
+
+/*
+ * IsReadIntermediateResultFunctionId returns whether the given OID is
+ * of a read_intermediate_result function.
+ */
+bool
+IsReadIntermediateResultFunctionId(Oid functionId)
+{
+	return functionId == CitusReadIntermediateResultFuncId() ||
+		   functionId == CitusReadIntermediateResultArrayFuncId();
 }
 
 

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1612,6 +1612,12 @@ AdjustReadIntermediateResultCost(RangeTblEntry *rangeTableEntry, RelOptInfo *rel
 		return;
 	}
 
+	if (resultIdConst->consttype != TEXTOID)
+	{
+		/* currently only handles a single result */
+		return;
+	}
+
 	resultIdDatum = resultIdConst->constvalue;
 	resultId = TextDatumGetCString(resultIdDatum);
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -779,7 +779,7 @@ IsReadIntermediateResultFunction(Node *node)
 	{
 		FuncExpr *funcExpr = (FuncExpr *) node;
 
-		if (funcExpr->funcid == CitusReadIntermediateResultFuncId())
+		if (IsReadIntermediateResultFunctionId(funcExpr->funcid))
 		{
 			return true;
 		}

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -130,8 +130,6 @@ static MapMergeJob * BuildMapMergeJob(Query *jobQuery, List *dependentJobList,
 									  Oid baseRelationId,
 									  BoundaryNodeJobType boundaryNodeJobType);
 static uint32 HashPartitionCount(void);
-static ArrayType * SplitPointObject(ShardInterval **shardIntervalArray,
-									uint32 shardIntervalCount);
 
 /* Local functions forward declarations for task list creation and helper functions */
 static bool DistributedPlanRouterExecutable(DistributedPlan *distributedPlan);
@@ -197,8 +195,6 @@ static List * MapTaskList(MapMergeJob *mapMergeJob, List *filterTaskList);
 static StringInfo CreateMapQueryString(MapMergeJob *mapMergeJob, Task *filterTask,
 									   char *partitionColumnName);
 static char * ColumnName(Var *column, List *rangeTableList);
-static StringInfo SplitPointArrayString(ArrayType *splitPointObject,
-										Oid columnType, int32 columnTypeMod);
 static List * MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList,
 							uint32 taskIdIndex);
 static StringInfo ColumnNameArrayString(uint32 columnCount, uint64 generatingJobId);
@@ -1957,7 +1953,7 @@ HashPartitionCount(void)
  * shard interval's minimum value, sorts and inserts these minimum values into a
  * new array. This sorted array is then used by the MapMerge job.
  */
-static ArrayType *
+ArrayType *
 SplitPointObject(ShardInterval **shardIntervalArray, uint32 shardIntervalCount)
 {
 	Oid typeId = InvalidOid;
@@ -4375,7 +4371,7 @@ ColumnName(Var *column, List *rangeTableList)
  * object, and converts this array (and array's typed elements) to their string
  * representations.
  */
-static StringInfo
+StringInfo
 SplitPointArrayString(ArrayType *splitPointObject, Oid columnType, int32 columnTypeMod)
 {
 	Datum splitPointDatum = PointerGetDatum(splitPointObject);

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -59,6 +59,7 @@
 #include "distributed/commands/multi_copy.h"
 #include "distributed/distributed_planner.h"
 #include "distributed/errormessage.h"
+#include "distributed/intermediate_results.h"
 #include "distributed/log_utils.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_logical_planner.h"
@@ -1542,6 +1543,75 @@ ShouldTransformRTE(RangeTblEntry *rangeTableEntry)
 Query *
 BuildSubPlanResultQuery(List *targetEntryList, List *columnAliasList, char *resultId)
 {
+	Const *resultIdConst = makeNode(Const);
+	resultIdConst->consttype = TEXTOID;
+	resultIdConst->consttypmod = -1;
+	resultIdConst->constlen = -1;
+	resultIdConst->constvalue = CStringGetTextDatum(resultId);
+	resultIdConst->constbyval = false;
+	resultIdConst->constisnull = false;
+	resultIdConst->location = -1;
+
+	return BuildReadIntermediateResultsQuery(targetEntryList, columnAliasList,
+											 resultIdConst);
+}
+
+
+/*
+ * BuildSubPlanResultQuery returns a query of the form:
+ *
+ * SELECT
+ *   <target list>
+ * FROM
+ *   read_intermediate_result(ARRAY[<resultNames>], '<copy format'>)
+ *   AS res (<column definition list>);
+ *
+ * The caller can optionally supply a columnAliasList, which is useful for
+ * CTEs that have column aliases.
+ *
+ * If any of the types in the target list cannot be used in the binary copy format,
+ * then the copy format 'text' is used, otherwise 'binary' is used.
+ */
+Query *
+BuildReadIntermediateResultsArrayQuery(List *targetEntryList, List *columnAliasList,
+									   List *resultNames)
+{
+	Const *resultIdConst = makeNode(Const);
+	resultIdConst->consttype = TEXTARRAYOID;
+	resultIdConst->consttypmod = -1;
+	resultIdConst->constlen = -1;
+	resultIdConst->constvalue = PointerGetDatum(strlist_to_textarray(resultNames));
+	resultIdConst->constbyval = false;
+	resultIdConst->constisnull = false;
+	resultIdConst->location = -1;
+
+	return BuildReadIntermediateResultsQuery(targetEntryList, columnAliasList,
+											 resultIdConst);
+}
+
+
+/*
+ * BuildReadIntermediateResultsQuery returns a query of the form:
+ *
+ * SELECT
+ *   <target list>
+ * FROM
+ *   read_intermediate_result(<resultIdConst>, '<copy format'>)
+ *   AS res (<column definition list>);
+ *
+ * The caller can optionally supply a columnAliasList, which is useful for
+ * replacing CTEs that have column aliases.
+ *
+ * If any of the types in the target list cannot be used in the binary copy format,
+ * then the copy format 'text' is used, otherwise 'binary' is used.
+ *
+ * The resultIdConst can be supplied by the caller to allow both single files
+ * and arrays of files.
+ */
+Query *
+BuildReadIntermediateResultsQuery(List *targetEntryList, List *columnAliasList,
+								  Const *resultIdConst)
+{
 	List *funcColNames = NIL;
 	List *funcColTypes = NIL;
 	List *funcColTypMods = NIL;
@@ -1615,15 +1685,6 @@ BuildSubPlanResultQuery(List *targetEntryList, List *columnAliasList, char *resu
 
 		columnNumber++;
 	}
-
-	Const *resultIdConst = makeNode(Const);
-	resultIdConst->consttype = TEXTOID;
-	resultIdConst->consttypmod = -1;
-	resultIdConst->constlen = -1;
-	resultIdConst->constvalue = CStringGetTextDatum(resultId);
-	resultIdConst->constbyval = false;
-	resultIdConst->constisnull = false;
-	resultIdConst->location = -1;
 
 	/* build the citus_copy_format parameter for the call to read_intermediate_result */
 	if (!useBinaryCopyFormat)

--- a/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
+++ b/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
@@ -9,3 +9,50 @@ DROP INDEX pg_dist_colocation_configuration_index;
 CREATE INDEX pg_dist_colocation_configuration_index
 ON pg_dist_colocation USING btree(distributioncolumntype, shardcount, replicationfactor, distributioncolumncollation);
 
+CREATE OR REPLACE FUNCTION pg_catalog.worker_predistribute_query_result(
+    result_prefix text,
+    query text,
+    partition_column_index int,
+    hash_ranges int[],
+    OUT partition_index int,
+    OUT rows_written bigint,
+    OUT bytes_written bigint)
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$worker_predistribute_query_result$$;
+COMMENT ON FUNCTION pg_catalog.worker_predistribute_query_result(result_prefix text, query text, partition_column_index int, hash_ranges int[])
+IS 'execute a query and partitions its results in set of local result files';
+
+CREATE OR REPLACE FUNCTION pg_catalog.fetch_intermediate_results(
+    result_prefixes text[],
+    node_name text,
+    node_port int)
+RETURNS bigint
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$fetch_intermediate_results$$;
+COMMENT ON FUNCTION pg_catalog.fetch_intermediate_results(text[],text,int)
+IS 'fetch an intermediate result from a remote node';
+
+CREATE OR REPLACE FUNCTION pg_catalog.read_intermediate_result(
+    result_ids text[],
+    format pg_catalog.citus_copy_format default 'csv')
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE
+AS 'MODULE_PATHNAME', $$read_intermediate_result_array$$;
+COMMENT ON FUNCTION pg_catalog.read_intermediate_result(text[],pg_catalog.citus_copy_format)
+IS 'read a set files and return them as a set of records';
+
+CREATE OR REPLACE FUNCTION pg_catalog.partition_distributed_query_result(
+    dist_result_id text,
+    query text,
+    partition_column_index int,
+    colocation_id int,
+    OUT shard_id bigint,
+    OUT partition_index int,
+    OUT bytes_written bigint,
+    OUT rows_written bigint)
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$partition_distributed_query_result$$;
+COMMENT ON FUNCTION pg_catalog.partition_distributed_query_result(text, text, int, int)
+IS 'execute a query and partitions its results in set of local result files';

--- a/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
+++ b/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
@@ -15,8 +15,7 @@ CREATE OR REPLACE FUNCTION pg_catalog.worker_predistribute_query_result(
     partition_column_index int,
     hash_ranges int[],
     OUT partition_index int,
-    OUT rows_written bigint,
-    OUT bytes_written bigint)
+    OUT rows_written bigint)
 RETURNS SETOF record
 LANGUAGE C STRICT VOLATILE
 AS 'MODULE_PATHNAME', $$worker_predistribute_query_result$$;

--- a/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
+++ b/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
@@ -41,18 +41,3 @@ LANGUAGE C STRICT VOLATILE PARALLEL SAFE
 AS 'MODULE_PATHNAME', $$read_intermediate_result_array$$;
 COMMENT ON FUNCTION pg_catalog.read_intermediate_result(text[],pg_catalog.citus_copy_format)
 IS 'read a set files and return them as a set of records';
-
-CREATE OR REPLACE FUNCTION pg_catalog.partition_distributed_query_result(
-    dist_result_id text,
-    query text,
-    partition_column_index int,
-    colocation_id int,
-    OUT shard_id bigint,
-    OUT partition_index int,
-    OUT bytes_written bigint,
-    OUT rows_written bigint)
-RETURNS SETOF record
-LANGUAGE C STRICT VOLATILE
-AS 'MODULE_PATHNAME', $$partition_distributed_query_result$$;
-COMMENT ON FUNCTION pg_catalog.partition_distributed_query_result(text, text, int, int)
-IS 'execute a query and partitions its results in set of local result files';

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -410,7 +410,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 		case XACT_EVENT_PARALLEL_PRE_COMMIT:
 		case XACT_EVENT_PRE_PREPARE:
 		{
-			if (CurrentCoordinatedTransactionState > COORD_TRANS_NONE)
+			if (InCoordinatedTransaction())
 			{
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								errmsg("cannot use 2PC in transactions involving "

--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -234,7 +234,7 @@ citus_evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 static bool
 CitusIsVolatileFunctionIdChecker(Oid func_id, void *context)
 {
-	if (func_id == CitusReadIntermediateResultFuncId())
+	if (IsReadIntermediateResultFunctionId(func_id))
 	{
 		return false;
 	}
@@ -273,7 +273,7 @@ CitusIsVolatileFunction(Node *node)
 static bool
 CitusIsMutableFunctionIdChecker(Oid func_id, void *context)
 {
-	if (func_id == CitusReadIntermediateResultFuncId())
+	if (IsReadIntermediateResultFunctionId(func_id))
 	{
 		return false;
 	}

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -50,6 +50,8 @@ static int CompareShardPlacementsByNode(const void *leftElement,
 static void UpdateRelationColocationGroup(Oid distributedRelationId, uint32 colocationId);
 static List * ColocationGroupTableList(Oid colocationId);
 static void DeleteColocationGroup(uint32 colocationId);
+static void LoadPartitioningSchemeForRelationId(PartitioningScheme *partitioningScheme,
+												Oid relationId);
 
 
 /* exports for SQL callable functions */
@@ -1035,4 +1037,112 @@ DeleteColocationGroup(uint32 colocationId)
 
 	systable_endscan(scanDescriptor);
 	heap_close(pgDistColocation, RowExclusiveLock);
+}
+
+
+/*
+ * GetPartitioningSchemeForColocationId returns the sharding scheme for a given
+ * co-location ID or NULL if there is no table for the co-location ID.
+ */
+PartitioningScheme *
+GetPartitioningSchemeForColocationId(int colocationId)
+{
+	Oid relationId = ColocatedTableId(colocationId);
+	if (relationId == InvalidOid)
+	{
+		/* no distributed table exists for this co-location ID */
+		return NULL;
+	}
+
+	PartitioningScheme *partitioningScheme = (PartitioningScheme *) palloc0(
+		sizeof(PartitioningScheme));
+
+	LoadPartitioningSchemeForRelationId(partitioningScheme, relationId);
+
+	return partitioningScheme;
+}
+
+
+static void
+LoadPartitioningSchemeForRelationId(PartitioningScheme *partitioningScheme, Oid
+									relationId)
+{
+	int shardIndex = 0;
+
+	DistTableCacheEntry *distTableCacheEntry = DistributedTableCacheEntry(relationId);
+	int shardCount = distTableCacheEntry->shardIntervalArrayLength;
+
+	if (shardCount == 0)
+	{
+		/* table does not have shards */
+		return;
+	}
+
+	partitioningScheme->partitionCount = shardCount;
+	partitioningScheme->ranges = (DatumRange *) palloc(shardCount * sizeof(DatumRange));
+
+	for (shardIndex = 0; shardIndex < shardCount; shardIndex++)
+	{
+		ShardInterval *shardInterval =
+			distTableCacheEntry->sortedShardIntervalArray[shardIndex];
+
+		partitioningScheme->ranges[shardIndex].minValue = shardInterval->minValue;
+		partitioningScheme->ranges[shardIndex].maxValue = shardInterval->maxValue;
+
+		partitioningScheme->valueTypeId = shardInterval->valueTypeId;
+		partitioningScheme->valueTypeLen = shardInterval->valueTypeLen;
+		partitioningScheme->valueByVal = shardInterval->valueByVal;
+	}
+}
+
+
+DistributionScheme *
+GetDistributionSchemeForColocationId(int colocationId)
+{
+	Oid relationId = ColocatedTableId(colocationId);
+	if (relationId == InvalidOid)
+	{
+		/* no distributed table exists for this co-location ID */
+		return NULL;
+	}
+
+	return GetDistributionSchemeForRelationId(relationId);
+}
+
+
+DistributionScheme *
+GetDistributionSchemeForRelationId(Oid relationId)
+{
+	int shardIndex = 0;
+
+	DistTableCacheEntry *distTableCacheEntry = DistributedTableCacheEntry(relationId);
+	int shardCount = distTableCacheEntry->shardIntervalArrayLength;
+
+	DistributionScheme *distributionScheme = (DistributionScheme *) palloc0(
+		sizeof(DistributionScheme));
+	distributionScheme->colocationId = distTableCacheEntry->colocationId;
+	distributionScheme->groupIds = (int **) palloc0(sizeof(int *) * shardCount);
+
+	LoadPartitioningSchemeForRelationId(&distributionScheme->partitioning, relationId);
+
+	for (shardIndex = 0; shardIndex < shardCount; shardIndex++)
+	{
+		GroupShardPlacement *placementArray =
+			distTableCacheEntry->arrayOfPlacementArrays[shardIndex];
+		int placementCount =
+			distTableCacheEntry->arrayOfPlacementArrayLengths[shardIndex];
+		int placementIndex = 0;
+
+		distributionScheme->groupIds[shardIndex] =
+			(int *) palloc0(sizeof(int) * (placementCount + 1));
+
+		for (placementIndex = 0; placementIndex < placementCount; placementIndex++)
+		{
+			GroupShardPlacement *placement = &placementArray[placementIndex];
+
+			distributionScheme->groupIds[shardIndex][placementIndex] = placement->groupId;
+		}
+	}
+
+	return distributionScheme;
 }

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -57,9 +57,6 @@ static uint32 FileBufferSizeInBytes = 0; /* file buffer size to init later */
 
 
 /* Local functions forward declarations */
-static ShardInterval ** SyntheticShardIntervalArrayForShardMinValues(
-	Datum *shardMinValues,
-	int shardCount);
 static StringInfo InitTaskAttemptDirectory(uint64 jobId, uint32 taskId);
 static uint32 FileBufferSize(int partitionBufferSizeInKB, uint32 fileCount);
 static FileOutputStream * OpenPartitionFiles(StringInfo directoryName, uint32 fileCount);
@@ -246,7 +243,7 @@ worker_hash_partition_table(PG_FUNCTION_ARGS)
  * The function only fills the min/max values of shard the intervals. Thus, should
  * not be used for general purpose operations.
  */
-static ShardInterval **
+ShardInterval **
 SyntheticShardIntervalArrayForShardMinValues(Datum *shardMinValues, int shardCount)
 {
 	Datum nextShardMaxValue = Int32GetDatum(INT32_MAX);

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -12,6 +12,7 @@
 #ifndef COLOCATION_UTILS_H_
 #define COLOCATION_UTILS_H_
 
+#include "distributed/sharding.h"
 #include "distributed/shardinterval_utils.h"
 #include "nodes/pg_list.h"
 
@@ -35,5 +36,8 @@ extern void CheckReplicationModel(Oid sourceRelationId, Oid targetRelationId);
 extern void CheckDistributionColumnType(Oid sourceRelationId, Oid targetRelationId);
 
 extern void DeleteColocationGroupIfNoTablesBelong(uint32 colocationId);
+extern PartitioningScheme * GetPartitioningSchemeForColocationId(int colocationId);
+extern DistributionScheme * GetDistributionSchemeForColocationId(int colocationId);
+extern DistributionScheme * GetDistributionSchemeForRelationId(Oid relationId);
 
 #endif /* COLOCATION_UTILS_H_ */

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -15,6 +15,7 @@
 #include "fmgr.h"
 
 #include "distributed/commands/multi_copy.h"
+#include "distributed/sharding.h"
 #include "nodes/execnodes.h"
 #include "nodes/pg_list.h"
 #include "tcop/dest.h"
@@ -22,12 +23,21 @@
 #include "utils/palloc.h"
 
 
+extern char * CreateIntermediateResultsDirectory(void);
+extern char * IntermediateResultsDirectory(void);
+extern char * QueryResultFileName(const char *resultId);
 extern DestReceiver * CreateRemoteFileDestReceiver(char *resultId, EState *executorState,
 												   List *initialNodeList, bool
 												   writeLocalFile);
+extern void SendQueryResultViaCopy(const char *resultId);
 extern void ReceiveQueryResultViaCopy(const char *resultId);
 extern void RemoveIntermediateResultsDirectory(void);
 extern int64 IntermediateResultSize(char *resultId);
-
+extern Query * BuildReadIntermediateResultsQuery(List *targetEntryList,
+												 List *columnAliasList,
+												 Const *resultIdConst);
+extern Query * BuildReadIntermediateResultsArrayQuery(List *targetEntryList,
+													  List *columnAliasList,
+													  List *resultNames);
 
 #endif /* INTERMEDIATE_RESULTS_H */

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -188,6 +188,8 @@ extern Oid CitusCopyFormatTypeId(void);
 
 /* function oids */
 extern Oid CitusReadIntermediateResultFuncId(void);
+extern Oid CitusReadIntermediateResultArrayFuncId(void);
+extern bool IsReadIntermediateResultFunctionId(Oid functionId);
 extern Oid CitusExtraDataContainerFuncId(void);
 extern Oid CitusWorkerHashFunctionId(void);
 extern Oid CitusAnyValueFunctionId(void);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -379,6 +379,10 @@ extern bool ShardIntervalsOverlap(ShardInterval *firstInterval,
 extern bool CoPartitionedTables(Oid firstRelationId, Oid secondRelationId);
 extern ShardInterval ** GenerateSyntheticShardIntervalArray(int partitionCount);
 extern RowModifyLevel RowModifyLevelForQuery(Query *query);
+extern ArrayType * SplitPointObject(ShardInterval **shardIntervalArray,
+									uint32 shardIntervalCount);
+extern StringInfo SplitPointArrayString(ArrayType *splitPointObject,
+										Oid columnType, int32 columnTypeMod);
 
 
 /* function declarations for Task and Task list operations */

--- a/src/include/distributed/redistribution.h
+++ b/src/include/distributed/redistribution.h
@@ -25,7 +25,6 @@ typedef struct TargetShardFragmentStats
 	int sourceNodeId;
 	uint64 sourceShardId;
 	int targetShardIndex;
-	long byteCount;
 	long rowCount;
 } TargetShardFragmentStats;
 

--- a/src/include/distributed/redistribution.h
+++ b/src/include/distributed/redistribution.h
@@ -1,0 +1,79 @@
+/*-------------------------------------------------------------------------
+ *
+ * redistribution.h
+ *
+ * Functions for re-distributing query results.
+ *
+ * Copyright (c) 2019, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef REDISTRIBUTION_H
+#define REDISTRIBUTION_H
+
+
+#include "distributed/sharding.h"
+
+
+/*
+ * TargetShardFragmentStats contains statistics on the fragments that came
+ * out of predistribution using worker_predistribute_query_result.
+ */
+typedef struct TargetShardFragmentStats
+{
+	int sourceNodeId;
+	uint64 sourceShardId;
+	int targetShardIndex;
+	long byteCount;
+	long rowCount;
+} TargetShardFragmentStats;
+
+/*
+ * ReassembledFragmentSet represents a set of fragments that have been fetched
+ * to a particular node and when concatenated form one shard of a
+ * RedistributedQueryResult.
+ */
+typedef struct ReassembledFragmentSet
+{
+	/* node where the fragments are located */
+	int nodeId;
+
+	/* list of TargetShardFragmentStats for each fragment in a target partition */
+	List *fragments;
+} ReassembledFragmentSet;
+
+
+/*
+ * A RedistributedQueryResult represents a temporary distributed table that
+ * originated from a redistribuion operation and is therefore stored as a
+ * set of fragments per shard, which need to be concatenated at run-time.
+ */
+typedef struct RedistributedQueryResult
+{
+	/* prefix of all fragment names */
+	char *resultPrefix;
+
+	/* the partitioning between the fragment sets */
+	PartitioningScheme *partitioning;
+
+	/*
+	 * Array of reassembled fragment sets, keyed by partition index.
+	 *
+	 * The number of elements in the array is partitioning->partitionCount.
+	 */
+	ReassembledFragmentSet *reassembledFragmentSets;
+} RedistributedQueryResult;
+
+
+RedistributedQueryResult * RedistributeDistributedPlanResult(char *distResultId,
+															 DistributedPlan *
+															 distributedPlan,
+															 int distributionColumnIndex,
+															 DistributionScheme *
+															 targetDistribution,
+															 bool isForWrites);
+Query * ReadReassembledFragmentSetQuery(char *resultPrefix, List *targetList,
+										ReassembledFragmentSet *fragmentSet);
+
+#endif

--- a/src/include/distributed/sharding.h
+++ b/src/include/distributed/sharding.h
@@ -1,0 +1,70 @@
+/*-------------------------------------------------------------------------
+ *
+ * sharding.h
+ *
+ * Copyright (c) 2017, Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef SHARDING_H
+#define SHARDING_H
+
+
+#include "fmgr.h"
+
+
+/*
+ * DatumRange represents a range of values.
+ */
+typedef struct DatumRange
+{
+	Datum minValue;
+	Datum maxValue;
+} DatumRange;
+
+/*
+ * PartitionScheme represents a full partitioning scheme for a
+ * distributed table.
+ */
+typedef struct PartitioningScheme
+{
+	/* number of partitions */
+	int partitionCount;
+
+	/* ordered range of values for each partition */
+	DatumRange *ranges;
+
+	/* min/max value datum's typeId */
+	Oid valueTypeId;
+
+	/* min/max value datum's typeMod */
+	int32 valueTypeMod;
+
+	/* min/max value datum's typelen */
+	int valueTypeLen;
+
+	/* min/max value datum's byval */
+	bool valueByVal;
+} PartitioningScheme;
+
+/*
+ * DistributionScheme is a partitioning scheme that assigns
+ * partitions to nodes.
+ */
+typedef struct DistributionScheme
+{
+	PartitioningScheme partitioning;
+
+	/*
+	 * groupIds is an array group ID arrays, indicating where the partition
+	 * at a given index is placed.
+	 */
+	int **groupIds;
+
+	/* co-location ID for this sharding scheme (-1 if not co-located) */
+	int colocationId;
+} DistributionScheme;
+
+
+#endif /* SHARDING_H */

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -83,6 +83,7 @@ typedef struct HashPartitionContext
 	ShardInterval **syntheticShardIntervalArray;
 	uint32 partitionCount;
 	bool hasUniformHashDistribution;
+	Oid collation;
 } HashPartitionContext;
 
 
@@ -94,9 +95,13 @@ typedef struct HashPartitionContext
  */
 typedef struct FileOutputStream
 {
+	File fileDescriptor;
 	FileCompat fileCompat;
 	StringInfo fileBuffer;
 	StringInfo filePath;
+	uint32 bufferSize;
+	int64 bytesWritten;
+	int64 recordsWritten;
 } FileOutputStream;
 
 
@@ -128,7 +133,9 @@ extern List * TableDDLCommandList(const char *nodeName, uint32 nodePort,
 								  const char *tableName);
 extern int64 WorkerExecuteSqlTask(Query *query, char *taskFilename,
 								  bool binaryCopyFormat);
-
+extern ShardInterval ** SyntheticShardIntervalArrayForShardMinValues(
+	Datum *shardMinValues,
+	int shardCount);
 
 /* Function declarations shared with the master planner */
 extern StringInfo TaskFilename(StringInfo directoryName, uint32 taskId);

--- a/src/test/regress/sql/insert_select_repartition.sql
+++ b/src/test/regress/sql/insert_select_repartition.sql
@@ -1,0 +1,15 @@
+
+CREATE SCHEMA insert_select_repartition;
+SET search_path TO 'insert_select_repartition';
+
+SET citus.shard_count TO 8;
+CREATE TABLE src_table (a int);
+SELECT create_distributed_table('src_table', 'a');
+INSERT INTO src_table SELECT i FROM generate_series(1, 100) i;
+
+SET citus.shard_count TO 3;
+CREATE TABLE trg_table (a int);
+SELECT create_distributed_table('trg_table', 'a');
+INSERT INTO trg_table SELECT * FROM src_table;
+
+DROP SCHEMA insert_select_repartition;


### PR DESCRIPTION
DESCRIPTION: INSERT...SELECT with repartitioning

Copy of #3078, rebased + compile with pg12. Keeping  #3078 in case I miss anything.

We currently have two methods of executing an INSERT...SELECT: 
- in parallel between co-located shards, used when the distribution column value is preserved between source and target table
- via the coordinator using COPY, used in all other cases

The first method scales horizontally, but the second method can get bottlenecked on single core performance on the coordinator, and may cause the coordinator to run out of disk space.

This PR adds a third method:
- distributed repartitioning of the select result, used in cases where the SELECT is a distributed query that does not require a merge on the coordinator

The INSERT..SELECT runs in 3 phases:
1. Run SELECT tasks wrapped in worker_predistribute_query_result to partition query results into fragments which correspond to the hash ranges of the shards in the destination table
2. Fetch fragments to the corresponding destination shard using fetch_intermediate_result using one call per node pair
3. Run INSERT INTO .. SELECT .. FROM read_intermediate_result(..) into the shards of the destination table, where read_intermediate_result reads the concatenation of fragments that correspond to the hash range of the shard

In each phase, the tasks are executed by the adaptive executor. Empty tasks are pruned away during execution.
