### PR TITLE
Add missing ORDER BY in a CTE

### DIFF
--- a/src/test/regress/expected/with_nested.out
+++ b/src/test/regress/expected/with_nested.out
@@ -393,7 +393,7 @@ cte2 AS (
     )
     SELECT user_id, time, value_1, min(count) FROM cte2_1_1 GROUP BY 1, 2, 3 ORDER BY 1,2,3
   )
-  SELECT * FROM cte2_1 LIMIT 3 OFFSET 2
+  SELECT * FROM cte2_1 ORDER BY 1,2,3,4 LIMIT 3 OFFSET 2
 )
 SELECT * FROM cte2;
  user_id |              time               | value_1 | min 

--- a/src/test/regress/sql/with_nested.sql
+++ b/src/test/regress/sql/with_nested.sql
@@ -321,7 +321,7 @@ cte2 AS (
     )
     SELECT user_id, time, value_1, min(count) FROM cte2_1_1 GROUP BY 1, 2, 3 ORDER BY 1,2,3
   )
-  SELECT * FROM cte2_1 LIMIT 3 OFFSET 2
+  SELECT * FROM cte2_1 ORDER BY 1,2,3,4 LIMIT 3 OFFSET 2
 )
 SELECT * FROM cte2;
 


### PR DESCRIPTION
Otherwise, the query output might not be consistent.
