### PR TITLE
rename REMOTE_TRANS_INVALID to REMOTE_TRANS_IDLE

### DIFF
--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -781,7 +781,7 @@ ConnectionModifiedPlacement(MultiConnection *connection)
 {
 	dlist_iter placementIter;
 
-	if (connection->remoteTransaction.transactionState == REMOTE_TRANS_INVALID)
+	if (connection->remoteTransaction.transactionState == REMOTE_TRANS_NOT_STARTED)
 	{
 		/*
 		 * When StartPlacementListConnection() is called, we set the

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1365,7 +1365,7 @@ CleanUpSessions(DistributedExecution *execution)
 
 				ClearResults(connection, false);
 			}
-			else if (!(transactionState == REMOTE_TRANS_INVALID ||
+			else if (!(transactionState == REMOTE_TRANS_NOT_STARTED ||
 					   transactionState == REMOTE_TRANS_STARTED))
 			{
 				/*
@@ -2467,7 +2467,7 @@ ConnectionStateMachine(WorkerSession *session)
 				if (!connection->remoteTransaction.beginSent)
 				{
 					connection->remoteTransaction.transactionState =
-						REMOTE_TRANS_INVALID;
+						REMOTE_TRANS_NOT_STARTED;
 				}
 
 				break;
@@ -2581,7 +2581,7 @@ TransactionStateMachine(WorkerSession *session)
 
 		switch (currentState)
 		{
-			case REMOTE_TRANS_INVALID:
+			case REMOTE_TRANS_NOT_STARTED:
 			{
 				if (execution->isTransaction)
 				{
@@ -2677,7 +2677,7 @@ TransactionStateMachine(WorkerSession *session)
 				}
 				else
 				{
-					transaction->transactionState = REMOTE_TRANS_INVALID;
+					transaction->transactionState = REMOTE_TRANS_NOT_STARTED;
 				}
 				break;
 			}
@@ -3433,7 +3433,7 @@ PlacementExecutionReady(TaskPlacementExecution *placementExecution)
 							&placementExecution->sessionReadyQueueNode);
 		}
 
-		if (transactionState == REMOTE_TRANS_INVALID ||
+		if (transactionState == REMOTE_TRANS_NOT_STARTED ||
 			transactionState == REMOTE_TRANS_STARTED)
 		{
 			/*
@@ -3467,7 +3467,7 @@ PlacementExecutionReady(TaskPlacementExecution *placementExecution)
 			RemoteTransaction *transaction = &(connection->remoteTransaction);
 			RemoteTransactionState transactionState = transaction->transactionState;
 
-			if (transactionState == REMOTE_TRANS_INVALID ||
+			if (transactionState == REMOTE_TRANS_NOT_STARTED ||
 				transactionState == REMOTE_TRANS_STARTED)
 			{
 				UpdateConnectionWaitFlags(session,

--- a/src/include/distributed/remote_transaction.h
+++ b/src/include/distributed/remote_transaction.h
@@ -26,7 +26,7 @@ struct MultiConnection;
 typedef enum
 {
 	/* no transaction active */
-	REMOTE_TRANS_INVALID = 0,
+	REMOTE_TRANS_NOT_STARTED = 0,
 
 	/* transaction start */
 	REMOTE_TRANS_STARTING,


### PR DESCRIPTION
REMOTE_TRANS_INVALID seems like a state where we should not be. Because it is an `invalid` state, however from the usage it seems that it is like the state where there is no transaction, so it is `idle`. I feel like the wording REMOTE_TRANS_IDLE better describes what this state is.

