### PR TITLE
remove copyright years

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -5,7 +5,7 @@
  *
  *    Procedures can be distributed with create_distributed_function.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -4,7 +4,7 @@
  * This file contains functions to create, alter and drop policies on
  * distributed tables.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -3,7 +3,7 @@
  * dependencies.c
  *    Commands to create dependencies of an object on all workers.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -10,7 +10,7 @@
  *
  *    ALTER or DROP operations are not yet propagated.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -36,7 +36,7 @@
  *       types will be created during the activation of a new node to allow
  *       reference tables to use this type.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/commands/variableset.c
+++ b/src/backend/distributed/commands/variableset.c
@@ -3,7 +3,7 @@
  * variableset.c
  *    Support for propagation of SET (commands to set variables)
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -3,7 +3,7 @@
  * placement_connection.c
  *   Per placement connection handling.
  *
- * Copyright (c) 2016-2017, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -8,7 +8,7 @@
  *    can be used to reapply them on remote postgres nodes like the citus
  *    workers.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/deparse_type_stmts.c
+++ b/src/backend/distributed/deparser/deparse_type_stmts.c
@@ -9,7 +9,7 @@
  *	  should be reused across multiple statements and should live in their own deparse
  *	  file.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/format_collate.c
+++ b/src/backend/distributed/deparser/format_collate.c
@@ -5,7 +5,7 @@
  *
  *    This file is modeled after postgres' utils/adt/format_*.c files
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/objectaddress.c
+++ b/src/backend/distributed/deparser/objectaddress.c
@@ -5,7 +5,7 @@
  *    an ObjectAddress. Here we have a walker for parsetrees to find the
  *    address of the object targeted.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/qualify.c
+++ b/src/backend/distributed/deparser/qualify.c
@@ -14,7 +14,7 @@
  *	  all functions related to fully qualifying parsetrees that interact
  *	  with types.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/deparser/qualify_type_stmt.c
+++ b/src/backend/distributed/deparser/qualify_type_stmt.c
@@ -11,7 +11,7 @@
  *	  Goal would be that the deparser functions for these statements can
  *	  serialize the statement without any external lookups.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -10,7 +10,7 @@
  * for each task, and (b) distributed execution plans can include map/reduce
  * execution primitives, which involve writing intermediate results to files.
  *
- * Copyright (c) 2013-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -5,7 +5,7 @@
  * This file contains functions to distribute a table by creating shards for it
  * across a set of worker nodes.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -6,7 +6,7 @@
  * in a delete command and deletes a shard if and only if all rows in the shard
  * satisfy the conditions in the delete command.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -3,7 +3,7 @@
  * master_metadata_utility.c
  *    Routines for reading and modifying master node's metadata.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -5,7 +5,7 @@
  * This file contains functions to repair unhealthy shard placements using data
  * from healthy ones.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/master/master_split_shards.c
+++ b/src/backend/distributed/master/master_split_shards.c
@@ -5,7 +5,7 @@
  * This file contains functions to split a shard according to a given
  * distribution column value.
  *
- * Copyright (c) 2014-2017, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -7,7 +7,7 @@
  * command, but also differ from them in that users stage data from tables and
  * not files, and that they can also append to existing shards.
  *
- * Copyright (c) 2013-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/master/master_truncate.c
+++ b/src/backend/distributed/master/master_truncate.c
@@ -4,7 +4,7 @@
  *
  * Routine for truncating local data after a table has been distributed.
  *
- * Copyright (c) 2014-2017, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/master/shard_rebalancer.c
+++ b/src/backend/distributed/master/shard_rebalancer.c
@@ -4,7 +4,7 @@
  *
  * Function definitions for the shard rebalancer tool.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -3,7 +3,7 @@
  * dependency.c
  *	  Functions to reason about distributed objects and their dependencies
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -3,7 +3,7 @@
  * distobject.c
  *	  Functions to interact with distributed objects by their ObjectAddress
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -4,7 +4,7 @@
  *
  * This file contains functions for deparsing shard queries.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -29,7 +29,7 @@
  * could use to decide the shard that a distributed query touches reside on
  * a worker node.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -5,7 +5,7 @@
  * This file contains functions to plan multiple shard queries without any
  * aggregation step including distributed table modifications.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -41,7 +41,7 @@
  * Finally, the union of the shards found by each pruning instance is
  * returned.
  *
- * Copyright (c) 2014-2017, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/blackhole_am.c
+++ b/src/backend/distributed/test/blackhole_am.c
@@ -3,7 +3,7 @@
  * blackhole_am.c
  *	  blackhole table access method code
  *
- * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1996-PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  *

--- a/src/backend/distributed/test/colocation_utils.c
+++ b/src/backend/distributed/test/colocation_utils.c
@@ -5,7 +5,7 @@
  * This file contains functions to test co-location functionality
  * within Citus.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/create_shards.c
+++ b/src/backend/distributed/test/create_shards.c
@@ -5,7 +5,7 @@
  * This file contains functions to exercise shard creation functionality
  * within Citus.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/deparse_shard_query.c
+++ b/src/backend/distributed/test/deparse_shard_query.c
@@ -5,7 +5,7 @@
  * This file contains functions to exercise deparsing of INSERT .. SELECT queries
  * for distributed tables.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/distributed_deadlock_detection.c
+++ b/src/backend/distributed/test/distributed_deadlock_detection.c
@@ -5,7 +5,7 @@
  * This file contains functions to exercise distributed deadlock detection
  * related lower level functionality.
  *
- * Copyright (c) 20167, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/distribution_metadata.c
+++ b/src/backend/distributed/test/distribution_metadata.c
@@ -5,7 +5,7 @@
  * This file contains functions to exercise distributed table metadata
  * functionality within Citus.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/fake_fdw.c
+++ b/src/backend/distributed/test/fake_fdw.c
@@ -5,7 +5,7 @@
  * This file contains a barebones FDW implementation, suitable for use in
  * test code. Inspired by Andrew Dunstan's blackhole_fdw.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/metadata_sync.c
+++ b/src/backend/distributed/test/metadata_sync.c
@@ -5,7 +5,7 @@
  * This file contains functions to exercise the metadata snapshoy
  * generation functionality within Citus.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/prune_shard_list.c
+++ b/src/backend/distributed/test/prune_shard_list.c
@@ -5,7 +5,7 @@
  * This file contains functions to exercise shard creation functionality
  * within Citus.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/test/relation_access_tracking.c
+++ b/src/backend/distributed/test/relation_access_tracking.c
@@ -4,7 +4,7 @@
  *
  * Some test UDF for tracking relation accesses within transaction blocks.
  *
- * Copyright (c) 2014-2018, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/acquire_lock.c
+++ b/src/backend/distributed/utils/acquire_lock.c
@@ -12,7 +12,7 @@
  * can then perform work like deadlock detection, prepared transaction
  * recovery, and cleanup.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -4,7 +4,7 @@
  *
  * This file contains functions to perform useful operations on co-located tables.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/listutils.c
+++ b/src/backend/distributed/utils/listutils.c
@@ -4,7 +4,7 @@
  *
  * This file contains functions to perform useful operations on lists.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -4,7 +4,7 @@
  *
  * Declarations for public utility functions related to reference tables.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -4,7 +4,7 @@
  *
  * This file contains functions to perform useful operations on shard intervals.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/distributed/worker/worker_create_or_replace.c
+++ b/src/backend/distributed/worker/worker_create_or_replace.c
@@ -2,7 +2,7 @@
  *
  * worker_create_or_replace.c
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/citus_acquire_lock.h
+++ b/src/include/distributed/citus_acquire_lock.h
@@ -3,7 +3,7 @@
  * citus_acquire_lock.h
  *	  Background worker to help with acquiering locks by canceling competing backends.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -4,7 +4,7 @@
  *
  * Declarations for public utility functions related to co-located tables.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/deparse_shard_query.h
+++ b/src/include/distributed/deparse_shard_query.h
@@ -5,7 +5,7 @@
  * Declarations for public functions and types related to deparsing shard
  * queries.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -3,7 +3,7 @@
  * deparser.h
  *	  Used when deparsing any ddl parsetree into its sql from.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/enterprise.h
+++ b/src/include/distributed/enterprise.h
@@ -4,7 +4,7 @@
  *
  * Utilities related to enterprise code in the community version.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/listutils.h
+++ b/src/include/distributed/listutils.h
@@ -4,7 +4,7 @@
  *
  * Declarations for public utility functions related to lists.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -3,7 +3,7 @@
  * local_executor.h
  *	Functions and global variables to control local query execution.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -4,7 +4,7 @@
  *	  Type and function declarations used for reading and modifying master
  *    node's metadata.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  * $Id$
  *

--- a/src/include/distributed/metadata/dependency.h
+++ b/src/include/distributed/metadata/dependency.h
@@ -4,7 +4,7 @@
  *    Functions to follow and record dependencies for objects to be
  *    created in the right order.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -3,7 +3,7 @@
  * distobject.h
  *	  Declarations for functions to work with pg_dist_object
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/metadata/namespace.h
+++ b/src/include/distributed/metadata/namespace.h
@@ -3,7 +3,7 @@
  * namespace.h
  *    Helper functions for citus to work with postgres namespaces/schemas
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/metadata/pg_dist_object.h
+++ b/src/include/distributed/metadata/pg_dist_object.h
@@ -9,7 +9,7 @@
  * This also means that all nodes joining the network are assumed to
  * recreate all these objects.
  *
- * Copyright (c) 2019, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -4,7 +4,7 @@
  *
  * Declarations for public functions and types related to router planning.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -4,7 +4,7 @@
  *
  * Declarations for public utility functions related to reference tables.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/shard_pruning.h
+++ b/src/include/distributed/shard_pruning.h
@@ -3,7 +3,7 @@
  * shard_pruning.h
  *   Shard pruning infrastructure.
  *
- * Copyright (c) 2014-2017, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/distributed/shardinterval_utils.h
+++ b/src/include/distributed/shardinterval_utils.h
@@ -4,7 +4,7 @@
  *
  * Declarations for public utility functions related to shard intervals.
  *
- * Copyright (c) 2014-2016, Citus Data, Inc.
+ * Copyright (c) Citus Data, Inc.
  *
  *-------------------------------------------------------------------------
  */


### PR DESCRIPTION
It seems that there were some leftovers in copyrights, this PR removes them. This will probably need to be done in enterprise as well since there could be some files that has copyright with years which do not exist in community.

