### PR TITLE
not continue in sequential execution if a cancellation is received

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1808,6 +1808,13 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
 		execution->totalTaskCount = 1;
 		execution->unfinishedTaskCount = 1;
 
+		CHECK_FOR_INTERRUPTS();
+
+		if (InterruptHoldoffCount > 0 && (QueryCancelPending || ProcDiePending))
+		{
+			break;
+		}
+
 		/* simply call the regular execution function */
 		RunDistributedExecution(execution);
 	}

--- a/src/test/regress/expected/failure_multi_row_insert.out
+++ b/src/test/regress/expected/failure_multi_row_insert.out
@@ -134,6 +134,23 @@ SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").cancel(' || :pid || ')');
 
 INSERT INTO reference_table VALUES (1), (2), (3), (4);
 ERROR:  canceling statement due to user request
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+INSERT INTO distributed_table VALUES (1,1), (2,2), (3,3), (4,2), (5,2), (6,2), (7,2);
+ERROR:  canceling statement due to user request
+-- cancel the second insert over the same connection
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").after(1).cancel(' || :pid || ')');
+ mitmproxy 
+-----------
+ 
+(1 row)
+
+INSERT INTO distributed_table VALUES (1,1), (2,2), (3,3), (4,2), (5,2), (6,2), (7,2);
+ERROR:  canceling statement due to user request
 -- we've either failed or cancelled all queries, so should be empty
 SELECT * FROM distributed_table;
  key | value 

--- a/src/test/regress/sql/failure_multi_row_insert.sql
+++ b/src/test/regress/sql/failure_multi_row_insert.sql
@@ -70,6 +70,13 @@ INSERT INTO distributed_table VALUES (2,21), (1,22);
 SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").cancel(' || :pid || ')');
 INSERT INTO reference_table VALUES (1), (2), (3), (4);
 
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").cancel(' || :pid || ')');
+INSERT INTO distributed_table VALUES (1,1), (2,2), (3,3), (4,2), (5,2), (6,2), (7,2);
+
+-- cancel the second insert over the same connection
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").after(1).cancel(' || :pid || ')');
+INSERT INTO distributed_table VALUES (1,1), (2,2), (3,3), (4,2), (5,2), (6,2), (7,2);
+
 -- we've either failed or cancelled all queries, so should be empty
 SELECT * FROM distributed_table;
 SELECT * FROM reference_table;


### PR DESCRIPTION
If there is a cancellation in sequential execution, we should not continue execution and return. This PR adds that.


Fixes #3023.