### PR TITLE
add IsCancellationReceived utility function

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -25,6 +25,7 @@
 #include "distributed/hash_helpers.h"
 #include "distributed/placement_connection.h"
 #include "distributed/run_from_same_connection.h"
+#include "distributed/cancel_utils.h"
 #include "distributed/remote_commands.h"
 #include "distributed/version_compat.h"
 #include "mb/pg_wchar.h"
@@ -738,7 +739,7 @@ FinishConnectionListEstablishment(List *multiConnectionList)
 
 				CHECK_FOR_INTERRUPTS();
 
-				if (InterruptHoldoffCount > 0 && (QueryCancelPending || ProcDiePending))
+				if (IsHoldOffCancellationReceived())
 				{
 					/*
 					 * because we can't break from 2 loops easily we need to not forget to

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -143,6 +143,7 @@
 #include "distributed/placement_access.h"
 #include "distributed/placement_connection.h"
 #include "distributed/relation_access_tracking.h"
+#include "distributed/cancel_utils.h"
 #include "distributed/remote_commands.h"
 #include "distributed/resource_lock.h"
 #include "distributed/subplan_execution.h"
@@ -1810,7 +1811,7 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
 
 		CHECK_FOR_INTERRUPTS();
 
-		if (InterruptHoldoffCount > 0 && (QueryCancelPending || ProcDiePending))
+		if (IsHoldOffCancellationReceived())
 		{
 			break;
 		}
@@ -1918,8 +1919,7 @@ RunDistributedExecution(DistributedExecution *execution)
 						CHECK_FOR_INTERRUPTS();
 					}
 
-					if (InterruptHoldoffCount > 0 && (QueryCancelPending ||
-													  ProcDiePending))
+					if (IsHoldOffCancellationReceived())
 					{
 						/*
 						 * Break out of event loop immediately in case of cancellation.

--- a/src/backend/distributed/utils/cancel_utils.c
+++ b/src/backend/distributed/utils/cancel_utils.c
@@ -1,0 +1,25 @@
+/*
+ * cancel_utils.c
+ *
+ * Utilities related to query cancellation
+ *
+ * Copyright (c) Citus Data, Inc.
+ */
+
+
+#include "postgres.h"
+#include "miscadmin.h"
+#include "distributed/cancel_utils.h"
+
+
+/*
+ * IsHoldOffCancellationReceived returns true if a cancel signal
+ * was sent and HOLD_INTERRUPTS was called prior to this. The motivation
+ * here is that since our queries can take a long time, in some places
+ * we do not want to wait even if HOLD_INTERRUPTS was called.
+ */
+bool
+IsHoldOffCancellationReceived()
+{
+	return InterruptHoldoffCount > 0 && (QueryCancelPending || ProcDiePending);
+}

--- a/src/include/distributed/cancel_utils.h
+++ b/src/include/distributed/cancel_utils.h
@@ -1,0 +1,17 @@
+/*-------------------------------------------------------------------------
+ *
+ * cencel_utils.h
+ *	  Utilities related to query cancellation
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CANCEL_UTILS_H
+#define CANCEL_UTILS_H
+
+
+extern bool IsHoldOffCancellationReceived(void);
+
+#endif /* CANCEL_UTILS_H */


### PR DESCRIPTION
This PR adds `IsHoldOffCancellationReceived` utility function to remove duplicate code in different parts of the codebase to understand cancellation when HOLD_INTERRUPTS is called.

The motivation behind this method is that we want to take immediate action in parts of execution that could take a long time. So even if HOLD_INTERRUPTS is set, we do the cancellation.
