### PR TITLE
replace `Begin` words in coordinated transactions with `Use`

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -298,7 +298,7 @@ PG_FUNCTION_INFO_V1(citus_text_send_as_jsonb);
 static void
 CitusCopyFrom(CopyStmt *copyStatement, char *completionTag)
 {
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	/* disallow COPY to/from file or program except for superusers */
 	if (copyStatement->filename != NULL && !superuser())
@@ -2251,7 +2251,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	/* keep the table metadata to avoid looking it up for every tuple */
 	copyDest->tableMetadata = cacheEntry;
 
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	if (cacheEntry->replicationModel == REPLICATION_MODEL_2PC ||
 		MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC)

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -237,7 +237,7 @@ AcquireDistributedLockOnRelations(List *relationIdList, LOCKMODE lockMode)
 	relationIdList = SortList(relationIdList, CompareOids);
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	foreach_oid(relationId, relationIdList)
 	{

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -897,7 +897,7 @@ StartDistributedExecution(DistributedExecution *execution)
 		 */
 		if (DistributedExecutionRequiresRollback(execution) || LocalExecutionHappened)
 		{
-			BeginOrContinueCoordinatedTransaction();
+			UseCoordinatedTransaction();
 
 			if (TaskListRequires2PC(taskList) || LocalExecutionHappened)
 			{

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -122,7 +122,7 @@ broadcast_intermediate_result(PG_FUNCTION_ARGS)
 	 * Intermediate results will be stored in a directory that is derived
 	 * from the distributed transaction ID.
 	 */
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	List *nodeList = ActivePrimaryWorkerNodeList(NoLock);
 	EState *estate = CreateExecutorState();
@@ -164,7 +164,7 @@ create_intermediate_result(PG_FUNCTION_ARGS)
 	 * Intermediate results will be stored in a directory that is derived
 	 * from the distributed transaction ID.
 	 */
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	EState *estate = CreateExecutorState();
 	RemoteFileDestReceiver *resultDest =

--- a/src/backend/distributed/executor/subplan_execution.c
+++ b/src/backend/distributed/executor/subplan_execution.c
@@ -53,7 +53,7 @@ ExecuteSubPlans(DistributedPlan *distributedPlan)
 	 * Intermediate results of subplans will be stored in a directory that is
 	 * derived from the distributed transaction ID.
 	 */
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	foreach(subPlanCell, subPlanList)
 	{

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -361,7 +361,7 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 {
 	ListCell *shardIntervalCell = NULL;
 
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	/* At this point we intentionally decided to not use 2PC for reference tables */
 	if (MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC)

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -284,7 +284,7 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 						errhint("Try running master_create_empty_shard() first")));
 	}
 
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	/* issue command to append table to each shard placement */
 	foreach(shardPlacementCell, shardPlacementList)

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -386,7 +386,7 @@ RemoteExplain(Task *task, ExplainState *es)
 	 * Use a coordinated transaction to ensure that we open a transaction block
 	 * such that we can set a savepoint.
 	 */
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	for (int placementIndex = 0; placementIndex < placementCount; placementIndex++)
 	{

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -720,7 +720,7 @@ GetCurrentDistributedTransactionId(void)
  * sets it for the current backend. It also sets the databaseId and
  * processId fields.
  *
- * This function should only be called on BeginCoordinatedTransaction(). Any other
+ * This function should only be called on UseCoordinatedTransaction(). Any other
  * callers is very likely to break the distributed transaction management.
  */
 void

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -89,7 +89,7 @@ SendCommandToWorkerAsUser(char *nodeName, int32 nodePort, const char *nodeUser,
 {
 	uint connectionFlags = 0;
 
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 	CoordinatedTransactionUse2PC();
 
 	MultiConnection *transactionConnection = GetNodeUserDatabaseConnection(
@@ -279,7 +279,7 @@ SendCommandToWorkersParamsInternal(TargetWorkerSet targetWorkerSet, const char *
 	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, ShareLock);
 	ListCell *workerNodeCell = NULL;
 
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 	CoordinatedTransactionUse2PC();
 
 	/* open connections in parallel */

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -197,7 +197,7 @@ LockShardListResourcesOnFirstWorker(LOCKMODE lockmode, List *shardIntervalList)
 	appendStringInfo(lockCommand, "])");
 
 	/* need to hold the lock until commit */
-	BeginOrContinueCoordinatedTransaction();
+	UseCoordinatedTransaction();
 
 	/*
 	 * Use the superuser connection to make sure we are allowed to lock.

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -106,7 +106,7 @@ extern StringInfo activeSetStmts;
 /*
  * Coordinated transaction management.
  */
-extern void BeginOrContinueCoordinatedTransaction(void);
+extern void UseCoordinatedTransaction(void);
 extern bool InCoordinatedTransaction(void);
 extern void CoordinatedTransactionUse2PC(void);
 extern bool IsMultiStatementTransaction(void);


### PR DESCRIPTION
This PR replaces the action words in coordinated transactions. When I read the method `BeginOrContinueCoordinatedTransaction` for a very long time I assumed that It actually begins a coordinated transaction. Like it sends the `BEGIN` command. If it was sending a `BEGIN` command, I would name it just like this, so I find it confusing. Instead we do set up some state for later use. I have replaced `Begin` with `Use`.  Let me know if you have any other suggestion.