### PR TITLE
Use any available non-data connection for intermediate results

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -50,6 +50,7 @@ static bool ShouldShutdownConnection(MultiConnection *connection, const int
 static void ResetConnection(MultiConnection *connection);
 static void DefaultCitusNoticeProcessor(void *arg, const char *message);
 static MultiConnection * FindAvailableConnection(dlist_head *connections, uint32 flags);
+static void GivePurposeToConnection(MultiConnection *connection, int flags);
 static bool RemoteTransactionIdle(MultiConnection *connection);
 static int EventSetSizeForConnectionList(List *connections);
 
@@ -174,48 +175,6 @@ MultiConnection *
 GetNodeConnection(uint32 flags, const char *hostname, int32 port)
 {
 	return GetNodeUserDatabaseConnection(flags, hostname, port, NULL, NULL);
-}
-
-
-/*
- * GetNonDataAccessConnection() establishes a connection to remote node, using
- * default user and database. The returned connection is guaranteed to not have
- * been used for any data access over any placements.
- *
- * See StartNonDataAccessConnection for details.
- */
-MultiConnection *
-GetNonDataAccessConnection(const char *hostname, int32 port)
-{
-	MultiConnection *connection = StartNonDataAccessConnection(hostname, port);
-
-	FinishConnectionEstablishment(connection);
-
-	return connection;
-}
-
-
-/*
- * StartNonDataAccessConnection() initiates a connection that is
- * guaranteed to not have been used for any data access over any
- * placements.
- *
- * The returned connection is started with the default user and database.
- */
-MultiConnection *
-StartNonDataAccessConnection(const char *hostname, int32 port)
-{
-	uint32 flags = 0;
-	MultiConnection *connection = StartNodeConnection(flags, hostname, port);
-
-	if (ConnectionUsedForAnyPlacements(connection))
-	{
-		flags = FORCE_NEW_CONNECTION;
-
-		connection = StartNodeConnection(flags, hostname, port);
-	}
-
-	return connection;
 }
 
 
@@ -351,6 +310,8 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port, 
 		connection = FindAvailableConnection(entry->connections, flags);
 		if (connection)
 		{
+			GivePurposeToConnection(connection, flags);
+
 			return connection;
 		}
 	}
@@ -359,17 +320,27 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port, 
 	 * Either no caching desired, or no pre-established, non-claimed,
 	 * connection present. Initiate connection establishment.
 	 */
+
 	connection = StartConnectionEstablishment(&key);
 
 	dlist_push_tail(entry->connections, &connection->connectionNode);
 
 	ResetShardPlacementAssociation(connection);
+	GivePurposeToConnection(connection, flags);
 
 	return connection;
 }
 
 
-/* StartNodeUserDatabaseConnection() helper */
+/*
+ * FindAvailableConnection searches the given list of connections for one that
+ * is not claimed exclusively or marked as a side channel. If the caller passed
+ * the REQUIRE_SIDECHANNEL flag, it will only return a connection that has not
+ * been used to access shard placements and that connectoin will only be returned
+ * in subsequent calls if the REQUIRE_SIDECHANNEL flag is passed.
+ *
+ * If no connection is available, FindAvailableConnection returns NULL.
+ */
 static MultiConnection *
 FindAvailableConnection(dlist_head *connections, uint32 flags)
 {
@@ -380,16 +351,59 @@ FindAvailableConnection(dlist_head *connections, uint32 flags)
 		MultiConnection *connection =
 			dlist_container(MultiConnection, connectionNode, iter.cur);
 
-		/* don't return claimed connections */
 		if (connection->claimedExclusively)
 		{
+			/* connection is in use for an ongoing operation */
 			continue;
 		}
 
-		return connection;
+		if ((flags & REQUIRE_SIDECHANNEL) != 0)
+		{
+			if (connection->purpose == CONNECTION_PURPOSE_SIDECHANNEL ||
+				connection->purpose == CONNECTION_PURPOSE_ANY)
+			{
+				/* side channel must not have been used to access data */
+				Assert(!ConnectionUsedForAnyPlacements(connection));
+
+				return connection;
+			}
+		}
+		else if (connection->purpose == CONNECTION_PURPOSE_DATA_ACCESS ||
+				 connection->purpose == CONNECTION_PURPOSE_ANY)
+		{
+			/* can use this connection to access data */
+			return connection;
+		}
 	}
 
 	return NULL;
+}
+
+
+/*
+ * GivePurposeToConnection gives purpose to a connection if it does not already
+ * have a purpose. More specifically, it marks the connection as a sidechannel
+ * if the REQUIRE_SIDECHANNEL flag is set.
+ */
+static void
+GivePurposeToConnection(MultiConnection *connection, int flags)
+{
+	if (connection->purpose != CONNECTION_PURPOSE_ANY)
+	{
+		/* connection already has a purpose */
+		return;
+	}
+
+	if ((flags & REQUIRE_SIDECHANNEL) != 0)
+	{
+		/* connection should not be used for data access */
+		connection->purpose = CONNECTION_PURPOSE_SIDECHANNEL;
+	}
+	else
+	{
+		/* connection should be used for data access */
+		connection->purpose = CONNECTION_PURPOSE_DATA_ACCESS;
+	}
 }
 
 
@@ -961,11 +975,11 @@ StartConnectionEstablishment(ConnectionHashKey *key)
 	strlcpy(connection->database, key->database, NAMEDATALEN);
 	strlcpy(connection->user, key->user, NAMEDATALEN);
 
-
 	connection->pgConn = PQconnectStartParams((const char **) entry->keywords,
 											  (const char **) entry->values,
 											  false);
 	connection->connectionStart = GetCurrentTimestamp();
+	connection->purpose = CONNECTION_PURPOSE_ANY;
 
 	/*
 	 * To avoid issues with interrupts not getting caught all our connections
@@ -1122,6 +1136,7 @@ ResetConnection(MultiConnection *connection)
 
 	/* reset copy state */
 	connection->copyBytesWrittenSinceLastFlush = 0;
+	connection->purpose = CONNECTION_PURPOSE_ANY;
 
 	UnclaimConnection(connection);
 }

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -276,7 +276,9 @@ RemoteFileDestReceiverStartup(DestReceiver *dest, int operation,
 		 * exclusively and that would prevent the consecutive DML/DDL
 		 * use the same connection.
 		 */
-		MultiConnection *connection = StartNonDataAccessConnection(nodeName, nodePort);
+		int flags = REQUIRE_SIDECHANNEL;
+
+		MultiConnection *connection = StartNodeConnection(flags, nodeName, nodePort);
 		ClaimConnectionExclusively(connection);
 		MarkRemoteTransactionCritical(connection);
 

--- a/src/test/regress/expected/with_transactions.out
+++ b/src/test/regress/expected/with_transactions.out
@@ -17,15 +17,15 @@ SELECT create_distributed_table('second_raw_table', 'tenant_id');
  
 (1 row)
 
-INSERT INTO 
-	raw_table (tenant_id, income, created_at) 
-SELECT 
-	i % 10, i * 10.0, timestamp '2014-01-10 20:00:00' + i * interval '1 day' 
-FROM 
+INSERT INTO
+	raw_table (tenant_id, income, created_at)
+SELECT
+	i % 10, i * 10.0, timestamp '2014-01-10 20:00:00' + i * interval '1 day'
+FROM
 	generate_series (0, 100) i;
 INSERT INTO second_raw_table SELECT * FROM raw_table;
 SET client_min_messages TO DEBUG1;
--- run a transaction which DELETE 
+-- run a transaction which DELETE
 BEGIN;
 	WITH ids_to_delete AS
 		(
@@ -78,7 +78,7 @@ COMMIT;
 -- sequential insert followed by parallel update works just fine
 WITH ids_inserted AS
 (
-  INSERT INTO raw_table VALUES (11, 1000, now()), (12, 1000, now()), (13, 1000, now()) RETURNING tenant_id 
+  INSERT INTO raw_table VALUES (11, 1000, now()), (12, 1000, now()), (13, 1000, now()) RETURNING tenant_id
 )
 UPDATE raw_table SET created_at = '2001-02-10 20:00:00' WHERE tenant_id IN (SELECT tenant_id FROM ids_inserted);
 DEBUG:  generating subplan 12_1 for CTE ids_inserted: INSERT INTO with_transactions.raw_table (tenant_id, income, created_at) VALUES (11,1000,now()), (12,1000,now()), (13,1000,now()) RETURNING raw_table.tenant_id
@@ -119,8 +119,29 @@ DEBUG:  push down of limit count: 3
 
 ROLLBACK;
 RESET client_min_messages;
-RESET citus.shard_count;
+CREATE OR REPLACE FUNCTION run_ctes(id int)
+RETURNS text
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+	value text;
+BEGIN
+
+	WITH
+	dist AS (SELECT tenant_id FROM raw_table WHERE tenant_id < 10 OFFSET 0)
+	SELECT count(*) INTO value FROM dist WHERE id = tenant_id;
+
+	RETURN value ;
+END;
+$BODY$;
+SELECT count(*) FROM (SELECT run_ctes(s) FROM generate_series(1,current_setting('max_connections')::int+2) s) a;
+ count 
+-------
+   102
+(1 row)
+
 DROP SCHEMA with_transactions CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table raw_table
 drop cascades to table second_raw_table
+drop cascades to function run_ctes(integer)


### PR DESCRIPTION
DESCRIPTION: Fix an issue that caused CTEs to sometimes leak connections

When we send intermediate results to workers we pick a connection that did not access any placements. The reason is that the connection might otherwise occupy a connection that is needed during the query. However, the logic in StartNonDataAccessConnection picked an arbitrary connection and decided to open a new one if it accessed data, rather than using any of the available connections that did not access data. Under some circumstances, this would cause repeated CTEs in the same transaction to keep opening new connections because a connection that is inspected in StartNonDataAccessConnection is always one that accessed a placement.

This PR fixes the issue by inspecting all available connections when asking for a non-data access connection, and marking it as non-data-access to avoid using it for placement access, such that there will always be a connection available for sending intermediate results.

Fixes #3300