### PR TITLE
Fix a crash when calling a distributed function from PL/pgSQL

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -63,6 +63,9 @@ static List *plannerRestrictionContextList = NIL;
 int MultiTaskQueryLogLevel = MULTI_TASK_QUERY_INFO_OFF; /* multi-task query log level */
 static uint64 NextPlanId = 1;
 
+/* keep track of planner call stack levels */
+int PlannerLevel = 0;
+
 
 static bool ListContainsDistributedTableRTE(List *rangeTableList);
 static bool IsUpdateOrDelete(Query *query);
@@ -189,6 +192,14 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	PG_TRY();
 	{
 		/*
+		 * We keep track of how many times we've recursed into the planner, primarily
+		 * to detect whether we are in a function call. We need to make sure that the
+		 * PlannerLevel is decremented exactly once at the end of this PG_TRY block,
+		 * both in the happy case and when an error occurs.
+		 */
+		PlannerLevel++;
+
+		/*
 		 * For trivial queries, we're skipping the standard_planner() in
 		 * order to eliminate its overhead.
 		 *
@@ -242,13 +253,19 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 				result->planTree->total_cost = FLT_MAX / 100000000;
 			}
 		}
+
+		PlannerLevel--;
 	}
 	PG_CATCH();
 	{
 		PopPlannerRestrictionContext();
+
+		PlannerLevel--;
+
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
 
 	/* remove the context from the context list */
 	PopPlannerRestrictionContext();

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -32,6 +32,11 @@
 
 #define CURSOR_OPT_FORCE_DISTRIBUTED 0x080000
 
+
+/* level of planner calls */
+extern int PlannerLevel;
+
+
 typedef struct RelationRestrictionContext
 {
 	bool hasDistributedRelation;

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -519,7 +519,7 @@ SELECT create_distributed_function('add_with_param_names(int, int)', '$3');
 ERROR:  cannot distribute the function "add_with_param_names" since the distribution argument is not valid
 HINT:  Either provide a valid function argument name or a valid "$paramIndex" to create_distributed_function()
 SELECT create_distributed_function('add_with_param_names(int, int)', '$1a');
-ERROR:  invalid input syntax for type integer: "1a"
+ERROR:  invalid input syntax for integer: "1a"
 -- non existing column name
 SELECT create_distributed_function('add_with_param_names(int, int)', 'aaa');
 ERROR:  cannot distribute the function "add_with_param_names" since the distribution argument is not valid 
@@ -745,6 +745,61 @@ SELECT public.wait_until_metadata_sync();
  
 (1 row)
 
+SET citus.shard_replication_factor TO 1;
+SET citus.shard_count TO 4;
+CREATE TABLE test (id int, name text);
+SELECT create_distributed_table('test','id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO test VALUES (3,'three');
+CREATE OR REPLACE FUNCTION increment(int)
+RETURNS NUMERIC AS $$
+DECLARE ret_val NUMERIC;
+BEGIN
+        SELECT max(id)::numeric+1 INTO ret_val  FROM test WHERE id = $1;
+        RETURN ret_val;
+END;
+$$  LANGUAGE plpgsql;
+SELECT create_distributed_function('increment(int)', '$1', colocate_with := 'test');
+ create_distributed_function 
+-----------------------------
+ 
+(1 row)
+
+-- call a distributed function inside a pl/pgsql function
+CREATE OR REPLACE FUNCTION test_func_calls_dist_func()
+RETURNS NUMERIC AS $$
+DECLARE incremented_val NUMERIC;
+BEGIN
+        SELECT INTO incremented_val increment(1);
+        RETURN incremented_val;
+END;
+$$  LANGUAGE plpgsql;
+SELECT test_func_calls_dist_func();
+ test_func_calls_dist_func 
+---------------------------
+                          
+(1 row)
+
+SELECT test_func_calls_dist_func();
+ test_func_calls_dist_func 
+---------------------------
+                          
+(1 row)
+
+-- test an INSERT..SELECT via the coordinator just because it is kind of funky
+INSERT INTO test SELECT increment(3);
+SELECT * FROM test ORDER BY id;
+ id | name  
+----+-------
+  3 | three
+  4 | 
+(2 rows)
+
+DROP TABLE test;
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
 DROP SCHEMA function_tests2 CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fix a crash when calling a distributed function from PL/pgSQL

We currently do not always correctly detect being in PL/pgSQL, which causes issues when calling a distributed function from PL/pgSQL since we might incorrectly delegate it.

Fixes #3291