### PR TITLE
Implement read_intermediate_results

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -136,6 +136,7 @@ typedef struct MetadataCacheData
 	Oid citusCatalogNamespaceId;
 	Oid copyFormatTypeId;
 	Oid readIntermediateResultFuncId;
+	Oid readIntermediateResultArrayFuncId;
 	Oid extraDataContainerFuncId;
 	Oid workerHashFunctionId;
 	Oid anyValueFunctionId;
@@ -2062,6 +2063,26 @@ CitusReadIntermediateResultFuncId(void)
 	}
 
 	return MetadataCache.readIntermediateResultFuncId;
+}
+
+
+/* return oid of the read_intermediate_results(text[],citus_copy_format) function */
+Oid
+CitusReadIntermediateResultArrayFuncId(void)
+{
+	if (MetadataCache.readIntermediateResultArrayFuncId == InvalidOid)
+	{
+		List *functionNameList = list_make2(makeString("pg_catalog"),
+											makeString("read_intermediate_results"));
+		Oid copyFormatTypeOid = CitusCopyFormatTypeId();
+		Oid paramOids[2] = { TEXTARRAYOID, copyFormatTypeOid };
+		bool missingOK = false;
+
+		MetadataCache.readIntermediateResultArrayFuncId =
+			LookupFuncName(functionNameList, 2, paramOids, missingOK);
+	}
+
+	return MetadataCache.readIntermediateResultArrayFuncId;
 }
 
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -78,6 +78,8 @@ static bool ErrorHintRequired(const char *errorHint, Query *queryTree);
 static bool HasTablesample(Query *queryTree);
 static bool HasComplexRangeTableType(Query *queryTree);
 static bool IsReadIntermediateResultFunction(Node *node);
+static bool IsReadIntermediateResultArrayFunction(Node *node);
+static bool IsFunctionWithOid(Node *node, Oid funcOid);
 static bool ExtractFromExpressionWalker(Node *node,
 										QualifierWalkerContext *walkerContext);
 static List * MultiTableNodeList(List *tableEntryList, List *rangeTableList);
@@ -769,17 +771,51 @@ ContainsReadIntermediateResultFunction(Node *node)
 
 
 /*
+ * ContainsReadIntermediateResultArrayFunction determines whether an expresion
+ * tree contains a call to the read_intermediate_results(result_ids, format)
+ * function.
+ */
+bool
+ContainsReadIntermediateResultArrayFunction(Node *node)
+{
+	return FindNodeCheck(node, IsReadIntermediateResultArrayFunction);
+}
+
+
+/*
  * IsReadIntermediateResultFunction determines whether a given node is a function call
  * to the read_intermediate_result function.
  */
 static bool
 IsReadIntermediateResultFunction(Node *node)
 {
+	return IsFunctionWithOid(node, CitusReadIntermediateResultFuncId());
+}
+
+
+/*
+ * IsReadIntermediateResultArrayFunction determines whether a given node is a
+ * function call to the read_intermediate_results(result_ids, format) function.
+ */
+static bool
+IsReadIntermediateResultArrayFunction(Node *node)
+{
+	return IsFunctionWithOid(node, CitusReadIntermediateResultArrayFuncId());
+}
+
+
+/*
+ * IsFunctionWithOid determines whether a given node is a function call
+ * to the read_intermediate_result function.
+ */
+static bool
+IsFunctionWithOid(Node *node, Oid funcOid)
+{
 	if (IsA(node, FuncExpr))
 	{
 		FuncExpr *funcExpr = (FuncExpr *) node;
 
-		if (funcExpr->funcid == CitusReadIntermediateResultFuncId())
+		if (funcExpr->funcid == funcOid)
 		{
 			return true;
 		}

--- a/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
+++ b/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
@@ -1,3 +1,5 @@
+#include "udfs/read_intermediate_results/9.2-1.sql"
+
 ALTER TABLE pg_catalog.pg_dist_colocation ADD distributioncolumncollation oid;
 UPDATE pg_catalog.pg_dist_colocation dc SET distributioncolumncollation = t.typcollation
 	FROM pg_catalog.pg_type t WHERE t.oid = dc.distributioncolumntype;

--- a/src/backend/distributed/sql/udfs/read_intermediate_results/9.2-1.sql
+++ b/src/backend/distributed/sql/udfs/read_intermediate_results/9.2-1.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION pg_catalog.read_intermediate_results(
+    result_ids text[],
+    format pg_catalog.citus_copy_format default 'csv')
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE
+AS 'MODULE_PATHNAME', $$read_intermediate_result_array$$;
+COMMENT ON FUNCTION pg_catalog.read_intermediate_results(text[],pg_catalog.citus_copy_format)
+IS 'read a set files and return them as a set of records';

--- a/src/backend/distributed/sql/udfs/read_intermediate_results/latest.sql
+++ b/src/backend/distributed/sql/udfs/read_intermediate_results/latest.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION pg_catalog.read_intermediate_results(
+    result_ids text[],
+    format pg_catalog.citus_copy_format default 'csv')
+RETURNS SETOF record
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE
+AS 'MODULE_PATHNAME', $$read_intermediate_result_array$$;
+COMMENT ON FUNCTION pg_catalog.read_intermediate_results(text[],pg_catalog.citus_copy_format)
+IS 'read a set files and return them as a set of records';

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -188,6 +188,7 @@ extern Oid CitusCopyFormatTypeId(void);
 
 /* function oids */
 extern Oid CitusReadIntermediateResultFuncId(void);
+Oid CitusReadIntermediateResultArrayFuncId(void);
 extern Oid CitusExtraDataContainerFuncId(void);
 extern Oid CitusWorkerHashFunctionId(void);
 extern Oid CitusAnyValueFunctionId(void);

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -193,6 +193,7 @@ extern bool FindNodeCheckInRangeTableList(List *rtable, bool (*check)(Node *));
 extern bool IsDistributedTableRTE(Node *node);
 extern bool QueryContainsDistributedTableRTE(Query *query);
 extern bool ContainsReadIntermediateResultFunction(Node *node);
+extern bool ContainsReadIntermediateResultArrayFunction(Node *node);
 extern char * FindIntermediateResultIdIfExists(RangeTblEntry *rte);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -201,10 +201,10 @@ SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series
                         632
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
-                  QUERY PLAN                   
------------------------------------------------
- Function Scan on read_intermediate_result res
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_result res  (cost=0.00..4.55 rows=632 width=8)
 (1 row)
 
 -- less accurate results for variable types
@@ -214,10 +214,10 @@ SELECT create_intermediate_result('hellos', $$SELECT s, 'hello-'||s FROM generat
                          63
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT * FROM read_intermediate_result('hellos', 'binary') AS res (x int, y text);
-                  QUERY PLAN                   
------------------------------------------------
- Function Scan on read_intermediate_result res
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_result('hellos', 'binary') AS res (x int, y text);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_result res  (cost=0.00..0.32 rows=30 width=36)
 (1 row)
 
 -- not very accurate results for text encoding
@@ -227,10 +227,10 @@ SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_s
                           4
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT * FROM read_intermediate_result('stored_squares', 'text') AS res (s intermediate_results.square_type);
-                  QUERY PLAN                   
------------------------------------------------
- Function Scan on read_intermediate_result res
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_result('stored_squares', 'text') AS res (s intermediate_results.square_type);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_result res  (cost=0.00..0.01 rows=1 width=32)
 (1 row)
 
 END;
@@ -367,6 +367,50 @@ ON (squares.x::text = interested_in) WHERE user_id = 'jon' ORDER BY 1,2;
  jon     | 2             | 2 |  4 | (1,2)
  jon     | 5             | 5 | 25 | (2,3)
 (2 rows)
+
+END;
+-- Cost estimation for read_intermediate_results
+BEGIN;
+-- almost accurate row count estimates for primitive types
+SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1,632) s'),
+       create_intermediate_result('squares_2', 'SELECT s, s*s FROM generate_series(633,1024) s');
+ create_intermediate_result | create_intermediate_result 
+----------------------------+----------------------------
+                        632 |                        392
+(1 row)
+
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2'], 'binary') AS res (x int, x2 int);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Function Scan on read_intermediate_results res  (cost=0.00..7.37 rows=1024 width=8)
+(1 row)
+
+-- less accurate results for variable types
+SELECT create_intermediate_result('hellos_1', $$SELECT s, 'hello-'||s FROM generate_series(1,63) s$$),
+       create_intermediate_result('hellos_2', $$SELECT s, 'hello-'||s FROM generate_series(64,129) s$$);
+ create_intermediate_result | create_intermediate_result 
+----------------------------+----------------------------
+                         63 |                         66
+(1 row)
+
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['hellos_1', 'hellos_2'], 'binary') AS res (x int, y text);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Function Scan on read_intermediate_results res  (cost=0.00..0.66 rows=62 width=36)
+(1 row)
+
+-- not very accurate results for text encoding
+SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_squares');
+ create_intermediate_result 
+----------------------------
+                          4
+(1 row)
+
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['stored_squares'], 'text') AS res (s intermediate_results.square_type);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Function Scan on read_intermediate_results res  (cost=0.00..0.01 rows=1 width=32)
+(1 row)
 
 END;
 DROP SCHEMA intermediate_results CASCADE;

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -122,7 +122,7 @@ SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series
 (1 row)
 
 SELECT * FROM read_intermediate_result('squares', 'csv') AS res (x int, x2 int);
-ERROR:  invalid input syntax for integer: "PGCOPY"
+ERROR:  invalid input syntax for type integer: "PGCOPY"
 END;
 -- try a composite type
 CREATE TYPE intermediate_results.square_type AS (x text, x2 int);
@@ -259,6 +259,116 @@ select broadcast_intermediate_result('a', 'prepare foo as select 1');
 ERROR:  cannot execute utility commands
 select create_intermediate_result('a', 'create table foo(int serial)');
 ERROR:  cannot execute utility commands
+--
+-- read_intermediate_results
+--
+BEGIN;
+SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1,3) s'),
+       create_intermediate_result('squares_2', 'SELECT s, s*s FROM generate_series(4,6) s'),
+       create_intermediate_result('squares_3', 'SELECT s, s*s FROM generate_series(7,10) s');
+ create_intermediate_result | create_intermediate_result | create_intermediate_result 
+----------------------------+----------------------------+----------------------------
+                          3 |                          3 |                          4
+(1 row)
+
+SELECT count(*) FROM read_intermediate_results(ARRAY[]::text[], 'binary') AS res (x int, x2 int);
+ count 
+-------
+     0
+(1 row)
+
+SELECT * FROM read_intermediate_results(ARRAY['squares_1']::text[], 'binary') AS res (x int, x2 int);
+ x | x2 
+---+----
+ 1 |  1
+ 2 |  4
+ 3 |  9
+(3 rows)
+
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2', 'squares_3']::text[], 'binary') AS res (x int, x2 int);
+ x  | x2  
+----+-----
+  1 |   1
+  2 |   4
+  3 |   9
+  4 |  16
+  5 |  25
+  6 |  36
+  7 |  49
+  8 |  64
+  9 |  81
+ 10 | 100
+(10 rows)
+
+COMMIT;
+-- in separate transactions, the result is no longer available
+SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1,5) s');
+ create_intermediate_result 
+----------------------------
+                          5
+(1 row)
+
+SELECT * FROM read_intermediate_results(ARRAY['squares_1']::text[], 'binary') AS res (x int, x2 int);
+ERROR:  result "squares_1" does not exist
+-- error behaviour, and also check that results are deleted on rollback
+BEGIN;
+SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1,3) s');
+ create_intermediate_result 
+----------------------------
+                          3
+(1 row)
+
+SAVEPOINT s1;
+SELECT * FROM read_intermediate_results(ARRAY['notexistingfile', 'squares_1'], 'binary') AS res (x int, x2 int);
+ERROR:  result "notexistingfile" does not exist
+ROLLBACK TO SAVEPOINT s1;
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'notexistingfile'], 'binary') AS res (x int, x2 int);
+ERROR:  result "notexistingfile" does not exist
+ROLLBACK TO SAVEPOINT s1;
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', NULL], 'binary') AS res (x int, x2 int);
+ERROR:  null array element not allowed in this context
+ROLLBACK TO SAVEPOINT s1;
+-- after rollbacks we should be able to run vail read_intermediate_results still.
+SELECT count(*) FROM read_intermediate_results(ARRAY['squares_1']::text[], 'binary') AS res (x int, x2 int);
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM read_intermediate_results(ARRAY[]::text[], 'binary') AS res (x int, x2 int);
+ count 
+-------
+     0
+(1 row)
+
+END;
+SELECT * FROM read_intermediate_results(ARRAY['squares_1']::text[], 'binary') AS res (x int, x2 int);
+ERROR:  result "squares_1" does not exist
+-- Test non-binary format: read_intermediate_results(..., 'text')
+BEGIN;
+-- ROW(...) types switch the output format to text
+SELECT broadcast_intermediate_result('stored_squares_1',
+                                     'SELECT s, s*s, ROW(1::text, 2) FROM generate_series(1,3) s'),
+       broadcast_intermediate_result('stored_squares_2',
+                                     'SELECT s, s*s, ROW(2::text, 3) FROM generate_series(4,6) s');
+ broadcast_intermediate_result | broadcast_intermediate_result 
+-------------------------------+-------------------------------
+                             3 |                             3
+(1 row)
+
+-- query the intermediate result in a router query using text format
+SELECT * FROM interesting_squares JOIN (
+  SELECT * FROM
+    read_intermediate_results(ARRAY['stored_squares_1', 'stored_squares_2'], 'binary') AS res (x int, x2 int, z intermediate_results.square_type)
+) squares
+ON (squares.x::text = interested_in) WHERE user_id = 'jon' ORDER BY 1,2;
+ user_id | interested_in | x | x2 |   z   
+---------+---------------+---+----+-------
+ jon     | 2             | 2 |  4 | (1,2)
+ jon     | 5             | 5 | 25 | (2,3)
+(2 rows)
+
+END;
 DROP SCHEMA intermediate_results CASCADE;
 NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to table interesting_squares

--- a/src/test/regress/sql/intermediate_results.sql
+++ b/src/test/regress/sql/intermediate_results.sql
@@ -121,15 +121,15 @@ END;
 BEGIN;
 -- accurate row count estimates for primitive types
 SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,632) s');
-EXPLAIN (COSTS OFF) SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
 
 -- less accurate results for variable types
 SELECT create_intermediate_result('hellos', $$SELECT s, 'hello-'||s FROM generate_series(1,63) s$$);
-EXPLAIN (COSTS OFF) SELECT * FROM read_intermediate_result('hellos', 'binary') AS res (x int, y text);
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_result('hellos', 'binary') AS res (x int, y text);
 
 -- not very accurate results for text encoding
 SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_squares');
-EXPLAIN (COSTS OFF) SELECT * FROM read_intermediate_result('stored_squares', 'text') AS res (s intermediate_results.square_type);
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_result('stored_squares', 'text') AS res (s intermediate_results.square_type);
 END;
 
 -- pipe query output into a result file and create a table to check the result
@@ -201,5 +201,21 @@ ON (squares.x::text = interested_in) WHERE user_id = 'jon' ORDER BY 1,2;
 
 END;
 
+-- Cost estimation for read_intermediate_results
+BEGIN;
+-- almost accurate row count estimates for primitive types
+SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1,632) s'),
+       create_intermediate_result('squares_2', 'SELECT s, s*s FROM generate_series(633,1024) s');
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2'], 'binary') AS res (x int, x2 int);
+
+-- less accurate results for variable types
+SELECT create_intermediate_result('hellos_1', $$SELECT s, 'hello-'||s FROM generate_series(1,63) s$$),
+       create_intermediate_result('hellos_2', $$SELECT s, 'hello-'||s FROM generate_series(64,129) s$$);
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['hellos_1', 'hellos_2'], 'binary') AS res (x int, y text);
+
+-- not very accurate results for text encoding
+SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_squares');
+EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['stored_squares'], 'text') AS res (s intermediate_results.square_type);
+END;
 
 DROP SCHEMA intermediate_results CASCADE;


### PR DESCRIPTION
Implements a UDF for reading multiple result files in the same call, like:

```sql
SELECT * FROM 
  read_intermediate_results(ARRAY['squares_1', 'squares_2', 'squares_3']::text[], 'binary') 
    AS res (x int, x2 int);
```

This is a step towards implementing `INSERT INTO ... SELECT`