### PR TITLE
add code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Slack Status](http://slack.citusdata.com/badge.svg)](https://slack.citusdata.com)
 [![Latest Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.citusdata.com/)
 [![Circleci Status](https://circleci.com/gh/citusdata/citus.svg?style=svg)](https://circleci.com/gh/citusdata/citus.svg?style=svg)
+[![Code Coverage](https://codecov.io/gh/citusdata/citus/branch/master/graph/badge.svg)](https://codecov.io/gh/citusdata/citus/branch/master/graph/badge.svg)
 
 ### What is Citus?
 


### PR DESCRIPTION
This PR adds code coverage badge so that the master code coverage will be displayed in README.

You can see how that looks like here: 
https://github.com/citusdata/citus/blob/58ed931d7a04b2a98e1adcba9911497814b33e4a/README.md