### PR TITLE
Split propagate extension test and add alternative output

### DIFF
--- a/src/test/regress/expected/escape_extension_name.out
+++ b/src/test/regress/expected/escape_extension_name.out
@@ -1,0 +1,71 @@
+CREATE SCHEMA "extension'test";
+-- use  a schema name with escape character
+SET search_path TO "extension'test";
+-- test if citus can escape the extension name
+-- this output will help us to understand why we have alternative outputs for this test
+-- print true if uuid-ossp is available false otherwise
+SELECT CASE WHEN COUNT(*) > 0
+  THEN 'CREATE EXTENSION "uuid-ossp"'
+  ELSE 'SELECT false AS uuid_ossp_present'
+  END AS uuid_present_command
+FROM pg_available_extensions()
+WHERE name = 'uuid-ossp'
+\gset
+:uuid_present_command;
+-- show that the extension is created on both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+SET client_min_messages TO WARNING;
+DROP EXTENSION "uuid-ossp";
+RESET client_min_messages;
+-- show that the extension is dropped from both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- show that extension recreation on new nodes works also fine with extension names that require escaping
+SELECT 1 from master_remove_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+-- this output will help us to understand why we have alternative outputs for this test
+-- print true if uuid-ossp is available false otherwise
+SELECT CASE WHEN COUNT(*) > 0
+  THEN 'CREATE EXTENSION "uuid-ossp"'
+  ELSE 'SELECT false AS uuid_ossp_present'
+  END AS uuid_present_command
+FROM pg_available_extensions()
+WHERE name = 'uuid-ossp'
+\gset
+:uuid_present_command;
+-- and add the other node
+SELECT 1 from master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+-- show that the extension exists on both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+SET client_min_messages TO WARNING;
+DROP EXTENSION "uuid-ossp";
+RESET client_min_messages;
+-- drop the schema and all the objects
+SET client_min_messages TO WARNING;
+DROP SCHEMA "extension'test" CASCADE;

--- a/src/test/regress/expected/escape_extension_name_0.out
+++ b/src/test/regress/expected/escape_extension_name_0.out
@@ -1,0 +1,83 @@
+CREATE SCHEMA "extension'test";
+-- use  a schema name with escape character
+SET search_path TO "extension'test";
+-- test if citus can escape the extension name
+-- this output will help us to understand why we have alternative outputs for this test
+-- print true if uuid-ossp is available false otherwise
+SELECT CASE WHEN COUNT(*) > 0
+  THEN 'CREATE EXTENSION "uuid-ossp"'
+  ELSE 'SELECT false AS uuid_ossp_present'
+  END AS uuid_present_command
+FROM pg_available_extensions()
+WHERE name = 'uuid-ossp'
+\gset
+:uuid_present_command;
+ uuid_ossp_present 
+-------------------
+ f
+(1 row)
+
+-- show that the extension is created on both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+SET client_min_messages TO WARNING;
+DROP EXTENSION "uuid-ossp";
+ERROR:  extension "uuid-ossp" does not exist
+RESET client_min_messages;
+-- show that the extension is dropped from both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- show that extension recreation on new nodes works also fine with extension names that require escaping
+SELECT 1 from master_remove_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+-- this output will help us to understand why we have alternative outputs for this test
+-- print true if uuid-ossp is available false otherwise
+SELECT CASE WHEN COUNT(*) > 0
+  THEN 'CREATE EXTENSION "uuid-ossp"'
+  ELSE 'SELECT false AS uuid_ossp_present'
+  END AS uuid_present_command
+FROM pg_available_extensions()
+WHERE name = 'uuid-ossp'
+\gset
+:uuid_present_command;
+ uuid_ossp_present 
+-------------------
+ f
+(1 row)
+
+-- and add the other node
+SELECT 1 from master_add_node('localhost', :worker_2_port);
+ ?column? 
+----------
+        1
+(1 row)
+
+-- show that the extension exists on both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+ run_command_on_workers 
+------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+SET client_min_messages TO WARNING;
+DROP EXTENSION "uuid-ossp";
+ERROR:  extension "uuid-ossp" does not exist
+RESET client_min_messages;
+-- drop the schema and all the objects
+SET client_min_messages TO WARNING;
+DROP SCHEMA "extension'test" CASCADE;

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -385,54 +385,6 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname 
  (localhost,57638,t,2)
 (2 rows)
 
--- test if citus can escape the extension name
-CREATE EXTENSION "uuid-ossp";
--- show that the extension is created on both nodes
-SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
- run_command_on_workers 
-------------------------
- (localhost,57637,t,1)
- (localhost,57638,t,1)
-(2 rows)
-
-SET client_min_messages TO WARNING;
-DROP EXTENSION "uuid-ossp";
-RESET client_min_messages;
--- show that the extension is dropped from both nodes
-SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
- run_command_on_workers 
-------------------------
- (localhost,57637,t,0)
- (localhost,57638,t,0)
-(2 rows)
-
--- show that extension recreation on new nodes works also fine with extension names that require escaping
-SELECT 1 from master_remove_node('localhost', :worker_2_port);
- ?column? 
-----------
-        1
-(1 row)
-
-CREATE EXTENSION "uuid-ossp";
--- and add the other node
-SELECT 1 from master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "t3" to the node localhost:57638
- ?column? 
-----------
-        1
-(1 row)
-
--- show that the extension exists on both nodes
-SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
- run_command_on_workers 
-------------------------
- (localhost,57637,t,1)
- (localhost,57638,t,1)
-(2 rows)
-
-SET client_min_messages TO WARNING;
-DROP EXTENSION "uuid-ossp";
-RESET client_min_messages;
 -- drop the schema and all the objects
 SET client_min_messages TO WARNING;
 DROP SCHEMA "extension'test" CASCADE;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -24,6 +24,7 @@ test: multi_703_upgrade
 test: multi_cluster_management
 test: alter_role_propagation
 test: propagate_extension_commands
+test: escape_extension_name
 test: multi_test_helpers
 test: multi_test_catalog_views
 test: multi_table_ddl

--- a/src/test/regress/sql/escape_extension_name.sql
+++ b/src/test/regress/sql/escape_extension_name.sql
@@ -1,0 +1,56 @@
+CREATE SCHEMA "extension'test";
+
+-- use  a schema name with escape character
+SET search_path TO "extension'test";
+
+-- test if citus can escape the extension name
+
+-- this output will help us to understand why we have alternative outputs for this test
+-- print true if uuid-ossp is available false otherwise
+SELECT CASE WHEN COUNT(*) > 0
+  THEN 'CREATE EXTENSION "uuid-ossp"'
+  ELSE 'SELECT false AS uuid_ossp_present'
+  END AS uuid_present_command
+FROM pg_available_extensions()
+WHERE name = 'uuid-ossp'
+\gset
+:uuid_present_command;
+
+-- show that the extension is created on both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+
+SET client_min_messages TO WARNING;
+DROP EXTENSION "uuid-ossp";
+RESET client_min_messages;
+
+-- show that the extension is dropped from both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+
+-- show that extension recreation on new nodes works also fine with extension names that require escaping
+SELECT 1 from master_remove_node('localhost', :worker_2_port);
+
+-- this output will help us to understand why we have alternative outputs for this test
+-- print true if uuid-ossp is available false otherwise
+SELECT CASE WHEN COUNT(*) > 0
+  THEN 'CREATE EXTENSION "uuid-ossp"'
+  ELSE 'SELECT false AS uuid_ossp_present'
+  END AS uuid_present_command
+FROM pg_available_extensions()
+WHERE name = 'uuid-ossp'
+\gset
+:uuid_present_command;
+
+-- and add the other node
+SELECT 1 from master_add_node('localhost', :worker_2_port);
+
+-- show that the extension exists on both nodes
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
+
+SET client_min_messages TO WARNING;
+DROP EXTENSION "uuid-ossp";
+RESET client_min_messages;
+
+-- drop the schema and all the objects
+SET client_min_messages TO WARNING;
+DROP SCHEMA "extension'test" CASCADE;
+

--- a/src/test/regress/sql/propagate_extension_commands.sql
+++ b/src/test/regress/sql/propagate_extension_commands.sql
@@ -229,34 +229,6 @@ SELECT 1 from master_add_node('localhost', :worker_2_port);
 SELECT count(*) FROM citus.pg_dist_object WHERE objid IN (SELECT oid FROM pg_extension WHERE extname IN ('seg', 'isn'));
 SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname IN ('seg', 'isn')$$);
 
--- test if citus can escape the extension name
-CREATE EXTENSION "uuid-ossp";
-
--- show that the extension is created on both nodes
-SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
-
-SET client_min_messages TO WARNING;
-DROP EXTENSION "uuid-ossp";
-RESET client_min_messages;
-
--- show that the extension is dropped from both nodes
-SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
-
--- show that extension recreation on new nodes works also fine with extension names that require escaping
-SELECT 1 from master_remove_node('localhost', :worker_2_port);
-
-CREATE EXTENSION "uuid-ossp";
-
--- and add the other node
-SELECT 1 from master_add_node('localhost', :worker_2_port);
-
--- show that the extension exists on both nodes
-SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'uuid-ossp'$$);
-
-SET client_min_messages TO WARNING;
-DROP EXTENSION "uuid-ossp";
-RESET client_min_messages;
-
 -- drop the schema and all the objects
 SET client_min_messages TO WARNING;
 DROP SCHEMA "extension'test" CASCADE;


### PR DESCRIPTION
* This pr aims to add an alternative output file for "escape extension name" tests.  
* Before doing this, we first picked those tests from existing regression test file (`propagate_extension_commands.sql`) and moved them to a new regression test file.

This is because, we need `uuid` library installed to perform "escape extension name tests" but it is not maintained well according to [PostgreSQL Documentation](https://www.postgresql.org/docs/12/uuid-ossp.html)
