### PR TITLE
Fix handling of empty intermediate results when distributing custom aggregates

### DIFF
--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -75,11 +75,11 @@ select key, sum2(val) filter (where valf < 5), sum2_strict(val) filter (where va
  key | sum2 | sum2_strict 
 -----+------+-------------
    1 |      |            
-   2 |      |          10
-   3 |      |            
-   5 |      |            
-   6 |      |            
-   7 |      |            
+   2 |   10 |          10
+   3 |    0 |            
+   5 |    0 |            
+   6 |    0 |            
+   7 |    0 |            
    9 |    0 |           0
 (7 rows)
 
@@ -106,11 +106,11 @@ select id, sum2(distinct val), sum2_strict(distinct val) from aggdata group by i
 -- ORDER BY unsupported
 select key, sum2(val order by valf), sum2_strict(val order by valf) from aggdata group by key order by key;
 ERROR:  unsupported aggregate function sum2
--- Without intermediate results we return NULL, even though the correct result is 0
-select sum2(val) from aggdata where valf = 0;
- sum2 
-------
-     
+-- Test handling a lack of intermediate results
+select sum2(val), sum2_strict(val) from aggdata where valf = 0;
+ sum2 | sum2_strict 
+------+-------------
+    0 |            
 (1 row)
 
 -- test polymorphic aggregates from https://github.com/citusdata/citus/issues/2397
@@ -165,7 +165,7 @@ create aggregate sumstring(text) (
 );
 select sumstring(valf::text) from aggdata where valf is not null;
 ERROR:  function "aggregate_support.sumstring(text)" does not exist
-CONTEXT:  while executing command on localhost:57637
+CONTEXT:  while executing command on localhost:57638
 select create_distributed_function('sumstring(text)');
  create_distributed_function 
 -----------------------------

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -61,8 +61,8 @@ select key, sum2(distinct val), sum2_strict(distinct val) from aggdata group by 
 select id, sum2(distinct val), sum2_strict(distinct val) from aggdata group by id order by id;
 -- ORDER BY unsupported
 select key, sum2(val order by valf), sum2_strict(val order by valf) from aggdata group by key order by key;
--- Without intermediate results we return NULL, even though the correct result is 0
-select sum2(val) from aggdata where valf = 0;
+-- Test handling a lack of intermediate results
+select sum2(val), sum2_strict(val) from aggdata where valf = 0;
 
 
 -- test polymorphic aggregates from https://github.com/citusdata/citus/issues/2397


### PR DESCRIPTION
DESCRIPTION: Fix empty intermediate results returning `NULL` when distributing custom aggregates

This leverages `AggGetAggref` to pull the first argument's value. If a user is directly using these aggregates they may not be passing a constant, in that case we continue to return `NULL`

The issue went deeper than I'd initially assessed. `NULL`s were being returned from shards without intermediate results, which could taint the whole result set. This is what causes the change to the `FILTER` test results

Fixes #3219 
