### PR TITLE
Implement fetch_intermediate_results

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2735,7 +2735,14 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 	{
 		const char *resultId = copyStatement->relation->relname;
 
-		ReceiveQueryResultViaCopy(resultId);
+		if (copyStatement->is_from)
+		{
+			ReceiveQueryResultViaCopy(resultId);
+		}
+		else
+		{
+			SendQueryResultViaCopy(resultId);
+		}
 
 		return NULL;
 	}

--- a/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
+++ b/src/backend/distributed/sql/citus--9.1-1--9.2-1.sql
@@ -1,4 +1,5 @@
 #include "udfs/read_intermediate_results/9.2-1.sql"
+#include "udfs/fetch_intermediate_results/9.2-1.sql"
 
 ALTER TABLE pg_catalog.pg_dist_colocation ADD distributioncolumncollation oid;
 UPDATE pg_catalog.pg_dist_colocation dc SET distributioncolumncollation = t.typcollation

--- a/src/backend/distributed/sql/udfs/fetch_intermediate_results/9.2-1.sql
+++ b/src/backend/distributed/sql/udfs/fetch_intermediate_results/9.2-1.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION pg_catalog.fetch_intermediate_results(
+    result_ids text[],
+    node_name text,
+    node_port int)
+RETURNS bigint
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$fetch_intermediate_results$$;
+COMMENT ON FUNCTION pg_catalog.fetch_intermediate_results(text[],text,int)
+IS 'fetch array of intermediate results from a remote node. returns number of bytes read.';

--- a/src/backend/distributed/sql/udfs/fetch_intermediate_results/latest.sql
+++ b/src/backend/distributed/sql/udfs/fetch_intermediate_results/latest.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION pg_catalog.fetch_intermediate_results(
+    result_ids text[],
+    node_name text,
+    node_port int)
+RETURNS bigint
+LANGUAGE C STRICT VOLATILE
+AS 'MODULE_PATHNAME', $$fetch_intermediate_results$$;
+COMMENT ON FUNCTION pg_catalog.fetch_intermediate_results(text[],text,int)
+IS 'fetch array of intermediate results from a remote node. returns number of bytes read.';

--- a/src/backend/distributed/test/intermediate_results.c
+++ b/src/backend/distributed/test/intermediate_results.c
@@ -1,0 +1,70 @@
+/*-------------------------------------------------------------------------
+ *
+ * test/src/intermediate_results.c
+ *
+ * This file contains functions to test functions related to
+ * src/backend/distributed/executor/intermediate_results.c.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+
+#include "distributed/commands/multi_copy.h"
+#include "distributed/connection_management.h"
+#include "distributed/intermediate_results.h"
+#include "distributed/multi_executor.h"
+#include "distributed/remote_commands.h"
+
+PG_FUNCTION_INFO_V1(store_intermediate_result_on_node);
+
+
+/*
+ * store_intermediate_result_on_node executes a query and streams the results
+ * into a file on the given node.
+ */
+Datum
+store_intermediate_result_on_node(PG_FUNCTION_ARGS)
+{
+	text *nodeNameText = PG_GETARG_TEXT_P(0);
+	char *nodeNameString = text_to_cstring(nodeNameText);
+	int nodePort = PG_GETARG_INT32(1);
+	text *resultIdText = PG_GETARG_TEXT_P(2);
+	char *resultIdString = text_to_cstring(resultIdText);
+	text *queryText = PG_GETARG_TEXT_P(3);
+	char *queryString = text_to_cstring(queryText);
+	bool writeLocalFile = false;
+	ParamListInfo paramListInfo = NULL;
+
+	CheckCitusVersion(ERROR);
+
+	WorkerNode *workerNode = FindWorkerNode(nodeNameString, nodePort);
+
+	/*
+	 * Make sure that this transaction has a distributed transaction ID.
+	 *
+	 * Intermediate results will be stored in a directory that is derived
+	 * from the distributed transaction ID.
+	 */
+	UseCoordinatedTransaction();
+
+	EState *estate = CreateExecutorState();
+	DestReceiver *resultDest = CreateRemoteFileDestReceiver(resultIdString, estate,
+															list_make1(workerNode),
+															writeLocalFile);
+
+	ExecuteQueryStringIntoDestReceiver(queryString, paramListInfo,
+									   (DestReceiver *) resultDest);
+
+	FreeExecutorState(estate);
+
+	PG_RETURN_VOID();
+}

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -25,6 +25,7 @@
 extern DestReceiver * CreateRemoteFileDestReceiver(char *resultId, EState *executorState,
 												   List *initialNodeList, bool
 												   writeLocalFile);
+extern void SendQueryResultViaCopy(const char *resultId);
 extern void ReceiveQueryResultViaCopy(const char *resultId);
 extern void RemoveIntermediateResultsDirectory(void);
 extern int64 IntermediateResultSize(char *resultId);

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -73,3 +73,6 @@ s/_id_ref_id_fkey/_id_fkey/g
 s/_ref_id_id_fkey_/_ref_id_fkey_/g
 s/fk_test_2_col1_col2_fkey/fk_test_2_col1_fkey/g
 s/_id_other_column_ref_fkey/_id_fkey/g
+
+# intermediate_results
+s/(ERROR.*)pgsql_job_cache\/([0-9]+_[0-9]+_[0-9]+)\/(.*).data/\1pgsql_job_cache\/xx_x_xxx\/\3.data/g

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -1,6 +1,11 @@
 -- Test functions for copying intermediate results
 CREATE SCHEMA intermediate_results;
 SET search_path TO 'intermediate_results';
+-- helper udfs
+CREATE OR REPLACE FUNCTION pg_catalog.store_intermediate_result_on_node(nodename text, nodeport int, result_id text, query text)
+    RETURNS void
+    LANGUAGE C STRICT VOLATILE
+    AS 'citus', $$store_intermediate_result_on_node$$;
 -- in the same transaction we can read a result
 BEGIN;
 SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,5) s');
@@ -413,6 +418,127 @@ EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['stored_squares
 (1 row)
 
 END;
+--
+-- fetch_intermediate_results
+--
+-- straightforward, single-result case
+BEGIN;
+SELECT broadcast_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1, 5) s');
+ broadcast_intermediate_result 
+-------------------------------
+                             5
+(1 row)
+
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1']::text[], 'localhost', :worker_2_port);
+ fetch_intermediate_results 
+----------------------------
+                        111
+(1 row)
+
+SELECT * FROM read_intermediate_result('squares_1', 'binary') AS res (x int, x2 int);
+ x | x2 
+---+----
+ 1 |  1
+ 2 |  4
+ 3 |  9
+ 4 | 16
+ 5 | 25
+(5 rows)
+
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1']::text[], 'localhost', :worker_1_port);
+ fetch_intermediate_results 
+----------------------------
+                        111
+(1 row)
+
+SELECT * FROM read_intermediate_result('squares_1', 'binary') AS res (x int, x2 int);
+ x | x2 
+---+----
+ 1 |  1
+ 2 |  4
+ 3 |  9
+ 4 | 16
+ 5 | 25
+(5 rows)
+
+END;
+-- multiple results, and some error cases
+BEGIN;
+SELECT store_intermediate_result_on_node('localhost', :worker_1_port,
+                                         'squares_1', 'SELECT s, s*s FROM generate_series(1, 2) s');
+ store_intermediate_result_on_node 
+-----------------------------------
+ 
+(1 row)
+
+SELECT store_intermediate_result_on_node('localhost', :worker_1_port,
+                                         'squares_2', 'SELECT s, s*s FROM generate_series(3, 4) s');
+ store_intermediate_result_on_node 
+-----------------------------------
+ 
+(1 row)
+
+SAVEPOINT s1;
+-- results aren't available on coordinator yet
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ERROR:  result "squares_1" does not exist
+ROLLBACK TO SAVEPOINT s1;
+-- fetch from worker 2 should fail
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_2_port);
+ERROR:  could not open file "base/pgsql_job_cache/10_0_200/squares_1.data": No such file or directory
+CONTEXT:  while executing command on localhost:57638
+ROLLBACK TO SAVEPOINT s1;
+-- still, results aren't available on coordinator yet
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ERROR:  result "squares_1" does not exist
+ROLLBACK TO SAVEPOINT s1;
+-- fetch from worker 1 should succeed
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
+ fetch_intermediate_results 
+----------------------------
+                        114
+(1 row)
+
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ x | x2 
+---+----
+ 1 |  1
+ 2 |  4
+ 3 |  9
+ 4 | 16
+(4 rows)
+
+-- fetching again should succeed
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
+ fetch_intermediate_results 
+----------------------------
+                        114
+(1 row)
+
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ x | x2 
+---+----
+ 1 |  1
+ 2 |  4
+ 3 |  9
+ 4 | 16
+(4 rows)
+
+ROLLBACK TO SAVEPOINT s1;
+-- empty result id list should succeed
+SELECT * FROM fetch_intermediate_results(ARRAY[]::text[], 'localhost', :worker_1_port);
+ fetch_intermediate_results 
+----------------------------
+                          0
+(1 row)
+
+-- null in result id list should error gracefully
+SELECT * FROM fetch_intermediate_results(ARRAY[NULL, 'squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
+ERROR:  worker array object cannot contain null values
+END;
+-- results should have been deleted after transaction commit
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ERROR:  result "squares_1" does not exist
 DROP SCHEMA intermediate_results CASCADE;
 NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to table interesting_squares

--- a/src/test/regress/sql/intermediate_results.sql
+++ b/src/test/regress/sql/intermediate_results.sql
@@ -2,6 +2,12 @@
 CREATE SCHEMA intermediate_results;
 SET search_path TO 'intermediate_results';
 
+-- helper udfs
+CREATE OR REPLACE FUNCTION pg_catalog.store_intermediate_result_on_node(nodename text, nodeport int, result_id text, query text)
+    RETURNS void
+    LANGUAGE C STRICT VOLATILE
+    AS 'citus', $$store_intermediate_result_on_node$$;
+
 -- in the same transaction we can read a result
 BEGIN;
 SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,5) s');
@@ -217,5 +223,50 @@ EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['hellos_1', 'he
 SELECT create_intermediate_result('stored_squares', 'SELECT square FROM stored_squares');
 EXPLAIN (COSTS ON) SELECT * FROM read_intermediate_results(ARRAY['stored_squares'], 'text') AS res (s intermediate_results.square_type);
 END;
+
+--
+-- fetch_intermediate_results
+--
+
+-- straightforward, single-result case
+BEGIN;
+SELECT broadcast_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1, 5) s');
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1']::text[], 'localhost', :worker_2_port);
+SELECT * FROM read_intermediate_result('squares_1', 'binary') AS res (x int, x2 int);
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1']::text[], 'localhost', :worker_1_port);
+SELECT * FROM read_intermediate_result('squares_1', 'binary') AS res (x int, x2 int);
+END;
+
+-- multiple results, and some error cases
+BEGIN;
+SELECT store_intermediate_result_on_node('localhost', :worker_1_port,
+                                         'squares_1', 'SELECT s, s*s FROM generate_series(1, 2) s');
+SELECT store_intermediate_result_on_node('localhost', :worker_1_port,
+                                         'squares_2', 'SELECT s, s*s FROM generate_series(3, 4) s');
+SAVEPOINT s1;
+-- results aren't available on coordinator yet
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ROLLBACK TO SAVEPOINT s1;
+-- fetch from worker 2 should fail
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_2_port);
+ROLLBACK TO SAVEPOINT s1;
+-- still, results aren't available on coordinator yet
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ROLLBACK TO SAVEPOINT s1;
+-- fetch from worker 1 should succeed
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+-- fetching again should succeed
+SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
+ROLLBACK TO SAVEPOINT s1;
+-- empty result id list should succeed
+SELECT * FROM fetch_intermediate_results(ARRAY[]::text[], 'localhost', :worker_1_port);
+-- null in result id list should error gracefully
+SELECT * FROM fetch_intermediate_results(ARRAY[NULL, 'squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
+END;
+
+-- results should have been deleted after transaction commit
+SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
 
 DROP SCHEMA intermediate_results CASCADE;


### PR DESCRIPTION
Implements a UDF to fetch multiple result files from a node over a single connection:

```sql
SELECT fetch_intermediate_results(ARRAY['result_id_1', 'result_id_2', ...]::text[], nodehost, nodeport);
```

Also implements the `COPY result_id TO ... WITH (format result);` syntax to aid the above UDF.

This is a step towards implementing `INSERT INTO ... SELECT` with repartitiong.