### PR TITLE
Support any inner join on a reference table

### DIFF
--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -227,6 +227,10 @@ JoinOnColumns(Var *currentColumn, Var *candidateColumn, List *joinClauseList)
 		OpExpr *joinClause = castNode(OpExpr, lfirst(joinClauseCell));
 		Var *leftColumn = LeftColumnOrNULL(joinClause);
 		Var *rightColumn = RightColumnOrNULL(joinClause);
+		if (!OperatorImplementsEquality(joinClause->opno))
+		{
+			continue;
+		}
 
 		/*
 		 * Check if both join columns and both partition key columns match, since the
@@ -1015,6 +1019,10 @@ SinglePartitionJoinClause(Var *partitionColumn, List *applicableJoinClauses)
 	foreach(applicableJoinClauseCell, applicableJoinClauses)
 	{
 		OpExpr *applicableJoinClause = castNode(OpExpr, lfirst(applicableJoinClauseCell));
+		if (!OperatorImplementsEquality(applicableJoinClause->opno))
+		{
+			continue;
+		}
 		Var *leftColumn = LeftColumnOrNULL(applicableJoinClause);
 		Var *rightColumn = RightColumnOrNULL(applicableJoinClause);
 		if (leftColumn == NULL || rightColumn == NULL)
@@ -1086,6 +1094,10 @@ DualPartitionJoinClause(List *applicableJoinClauses)
 	foreach(applicableJoinClauseCell, applicableJoinClauses)
 	{
 		OpExpr *applicableJoinClause = (OpExpr *) lfirst(applicableJoinClauseCell);
+		if (!OperatorImplementsEquality(applicableJoinClause->opno))
+		{
+			continue;
+		}
 		Var *leftColumn = LeftColumnOrNULL(applicableJoinClause);
 		Var *rightColumn = RightColumnOrNULL(applicableJoinClause);
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1429,11 +1429,6 @@ IsJoinClause(Node *clause)
 {
 	Var *var = NULL;
 
-	if (!IsA(clause, OpExpr))
-	{
-		return false;
-	}
-
 	/*
 	 * take all column references from the clause, if we find 2 column references from a
 	 * different relation we assume this is a join clause
@@ -1689,7 +1684,7 @@ MultiSelectNode(List *whereClauseList)
 	foreach(whereClauseCell, whereClauseList)
 	{
 		Node *whereClause = (Node *) lfirst(whereClauseCell);
-		if (IsSelectClause(whereClause) || or_clause(whereClause))
+		if (IsSelectClause(whereClause))
 		{
 			selectClauseList = lappend(selectClauseList, whereClause);
 		}

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1434,22 +1434,6 @@ IsJoinClause(Node *clause)
 		return false;
 	}
 
-	OpExpr *operatorExpression = castNode(OpExpr, clause);
-	bool equalsOperator = OperatorImplementsEquality(operatorExpression->opno);
-
-	if (!equalsOperator)
-	{
-		/*
-		 * The single and dual repartition join and local join planners expect the clauses
-		 * to be equi-join to calculate a hash on which to distribute.
-		 *
-		 * In the future we should move this clause to those planners and allow
-		 * non-equi-join's in the reference join and cartesian product. This is tracked in
-		 * https://github.com/citusdata/citus/issues/3198
-		 */
-		return false;
-	}
-
 	/*
 	 * take all column references from the clause, if we find 2 column references from a
 	 * different relation we assume this is a join clause

--- a/src/include/distributed/multi_join_order.h
+++ b/src/include/distributed/multi_join_order.h
@@ -15,6 +15,8 @@
 #ifndef MULTI_JOIN_ORDER_H
 #define MULTI_JOIN_ORDER_H
 
+#include "postgres.h"
+
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
 
@@ -83,9 +85,10 @@ extern bool EnableSingleHashRepartitioning;
 extern List * JoinExprList(FromExpr *fromExpr);
 extern List * JoinOrderList(List *rangeTableEntryList, List *joinClauseList);
 extern bool IsApplicableJoinClause(List *leftTableIdList, uint32 rightTableId,
-								   OpExpr *joinClause);
+								   Node *joinClause);
 extern List * ApplicableJoinClauses(List *leftTableIdList, uint32 rightTableId,
 									List *joinClauseList);
+extern bool NodeIsEqualsOpExpr(Node *node);
 extern OpExpr * SinglePartitionJoinClause(Var *partitionColumn,
 										  List *applicableJoinClauses);
 extern OpExpr * DualPartitionJoinClause(List *applicableJoinClauses);

--- a/src/include/distributed/multi_join_order.h
+++ b/src/include/distributed/multi_join_order.h
@@ -35,7 +35,8 @@ typedef enum JoinRuleType
 	SINGLE_HASH_PARTITION_JOIN = 3,
 	SINGLE_RANGE_PARTITION_JOIN = 4,
 	DUAL_PARTITION_JOIN = 5,
-	CARTESIAN_PRODUCT = 6,
+	CARTESIAN_PRODUCT_REFERENCE_JOIN = 6,
+	CARTESIAN_PRODUCT = 7,
 
 	/*
 	 * Add new join rule types above this comment. After adding, you must also
@@ -89,6 +90,8 @@ extern bool IsApplicableJoinClause(List *leftTableIdList, uint32 rightTableId,
 extern List * ApplicableJoinClauses(List *leftTableIdList, uint32 rightTableId,
 									List *joinClauseList);
 extern bool NodeIsEqualsOpExpr(Node *node);
+extern bool IsSupportedReferenceJoin(JoinType joinType, bool leftIsReferenceTable,
+									 bool rightIsReferenceTable);
 extern OpExpr * SinglePartitionJoinClause(Var *partitionColumn,
 										  List *applicableJoinClauses);
 extern OpExpr * DualPartitionJoinClause(List *applicableJoinClauses);

--- a/src/test/regress/expected/dml_recursive.out
+++ b/src/test/regress/expected/dml_recursive.out
@@ -185,7 +185,51 @@ DEBUG:  Plan 12 query after replacing subqueries and CTEs: UPDATE recursive_dml_
 (1 row)
 
 -- there is a lateral join (e.g., corrolated subquery) thus the subqueries cannot be
--- recursively planned
+-- recursively planned, however it can be planned using the repartition planner
+SET citus.enable_repartition_joins to on;
+SELECT DISTINCT foo_inner_1.tenant_id FROM
+(
+    SELECT
+        second_distributed_table.dept, second_distributed_table.tenant_id
+    FROM
+        second_distributed_table, distributed_table
+    WHERE
+        distributed_table.tenant_id = second_distributed_table.tenant_id
+    AND
+        second_distributed_table.dept IN (3,4)
+)
+foo_inner_1 JOIN LATERAL
+(
+    SELECT
+        second_distributed_table.tenant_id
+    FROM
+        second_distributed_table, distributed_table
+    WHERE
+        distributed_table.tenant_id = second_distributed_table.tenant_id
+        AND foo_inner_1.dept = second_distributed_table.dept
+    AND
+        second_distributed_table.dept IN (4,5)
+) foo_inner_2
+ON (foo_inner_2.tenant_id != foo_inner_1.tenant_id)
+ORDER BY foo_inner_1.tenant_id;
+ tenant_id 
+-----------
+ 14
+ 24
+ 34
+ 4
+ 44
+ 54
+ 64
+ 74
+ 84
+ 94
+(10 rows)
+
+RESET citus.enable_repartition_joins;
+-- there is a lateral join (e.g., corrolated subquery) thus the subqueries cannot be
+-- recursively planned, this one can not be planned by the repartion planner
+-- because of the IN query on a non unique column
 UPDATE
 	second_distributed_table
 SET
@@ -201,8 +245,7 @@ FROM
 		WHERE
 			distributed_table.tenant_id = second_distributed_table.tenant_id
 		AND
-			second_distributed_table.dept IN (3,4)
-	)
+			second_distributed_table.dept IN (select dept from second_distributed_table))
 	foo_inner_1 JOIN LATERAL
 	(
 		SELECT
@@ -218,6 +261,7 @@ FROM
 	ON (foo_inner_2.tenant_id != foo_inner_1.tenant_id)
 	) as foo
 RETURNING *;
+DEBUG:  generating subplan 15_1 for subquery SELECT dept FROM recursive_dml_queries.second_distributed_table
 ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 -- again a corrolated subquery
 -- this time distribution key eq. exists
@@ -253,8 +297,8 @@ ERROR:  complex joins are only supported when all distributed tables are joined 
 INSERT INTO
 	second_distributed_table (tenant_id, dept)
 VALUES ('3', (WITH  vals AS (SELECT 3) select * from vals));
-DEBUG:  generating subplan 18_1 for CTE vals: SELECT 3
-DEBUG:  Plan 18 query after replacing subqueries and CTEs: INSERT INTO recursive_dml_queries.second_distributed_table (tenant_id, dept) VALUES ('3'::text, (SELECT vals."?column?" FROM (SELECT intermediate_result."?column?" FROM read_intermediate_result('18_1'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer)) vals))
+DEBUG:  generating subplan 20_1 for CTE vals: SELECT 3
+DEBUG:  Plan 20 query after replacing subqueries and CTEs: INSERT INTO recursive_dml_queries.second_distributed_table (tenant_id, dept) VALUES ('3'::text, (SELECT vals."?column?" FROM (SELECT intermediate_result."?column?" FROM read_intermediate_result('20_1'::text, 'binary'::citus_copy_format) intermediate_result("?column?" integer)) vals))
 ERROR:  subqueries are not supported within INSERT queries
 HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
 INSERT INTO
@@ -277,8 +321,8 @@ UPDATE distributed_table
 SET dept = 5
 FROM cte_1
 WHERE distributed_table.tenant_id < cte_1.tenant_id;
-DEBUG:  generating subplan 20_1 for CTE cte_1: WITH cte_2 AS (SELECT second_distributed_table.tenant_id AS cte2_id FROM recursive_dml_queries.second_distributed_table WHERE (second_distributed_table.dept OPERATOR(pg_catalog.>=) 2)) UPDATE recursive_dml_queries.distributed_table SET dept = 10 RETURNING tenant_id, dept, info
-DEBUG:  Plan 20 query after replacing subqueries and CTEs: UPDATE recursive_dml_queries.distributed_table SET dept = 5 FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept, intermediate_result.info FROM read_intermediate_result('20_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer, info jsonb)) cte_1 WHERE (distributed_table.tenant_id OPERATOR(pg_catalog.<) cte_1.tenant_id)
+DEBUG:  generating subplan 22_1 for CTE cte_1: WITH cte_2 AS (SELECT second_distributed_table.tenant_id AS cte2_id FROM recursive_dml_queries.second_distributed_table WHERE (second_distributed_table.dept OPERATOR(pg_catalog.>=) 2)) UPDATE recursive_dml_queries.distributed_table SET dept = 10 RETURNING tenant_id, dept, info
+DEBUG:  Plan 22 query after replacing subqueries and CTEs: UPDATE recursive_dml_queries.distributed_table SET dept = 5 FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept, intermediate_result.info FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer, info jsonb)) cte_1 WHERE (distributed_table.tenant_id OPERATOR(pg_catalog.<) cte_1.tenant_id)
 WITH cte_1 AS (
     WITH cte_2 AS (
         SELECT tenant_id as cte2_id
@@ -293,8 +337,8 @@ UPDATE distributed_table
 SET dept = 5
 FROM cte_1
 WHERE distributed_table.tenant_id < cte_1.tenant_id;
-DEBUG:  generating subplan 22_1 for CTE cte_1: WITH cte_2 AS (SELECT second_distributed_table.tenant_id AS cte2_id FROM recursive_dml_queries.second_distributed_table WHERE (second_distributed_table.dept OPERATOR(pg_catalog.>=) 2)) UPDATE recursive_dml_queries.distributed_table SET dept = 10 RETURNING tenant_id, dept, info
-DEBUG:  Plan 22 query after replacing subqueries and CTEs: UPDATE recursive_dml_queries.distributed_table SET dept = 5 FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept, intermediate_result.info FROM read_intermediate_result('22_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer, info jsonb)) cte_1 WHERE (distributed_table.tenant_id OPERATOR(pg_catalog.<) cte_1.tenant_id)
+DEBUG:  generating subplan 24_1 for CTE cte_1: WITH cte_2 AS (SELECT second_distributed_table.tenant_id AS cte2_id FROM recursive_dml_queries.second_distributed_table WHERE (second_distributed_table.dept OPERATOR(pg_catalog.>=) 2)) UPDATE recursive_dml_queries.distributed_table SET dept = 10 RETURNING tenant_id, dept, info
+DEBUG:  Plan 24 query after replacing subqueries and CTEs: UPDATE recursive_dml_queries.distributed_table SET dept = 5 FROM (SELECT intermediate_result.tenant_id, intermediate_result.dept, intermediate_result.info FROM read_intermediate_result('24_1'::text, 'binary'::citus_copy_format) intermediate_result(tenant_id text, dept integer, info jsonb)) cte_1 WHERE (distributed_table.tenant_id OPERATOR(pg_catalog.<) cte_1.tenant_id)
 -- we don't support updating local table with a join with
 -- distributed tables
 UPDATE

--- a/src/test/regress/expected/expression_reference_join.out
+++ b/src/test/regress/expected/expression_reference_join.out
@@ -41,8 +41,11 @@ ORDER BY 1,2,3;
  2 | 2 | 2 | 4 | 4
 (4 rows)
 
--- The join clause is wider than it used to be, causing this query to be recognized by the LogicalPlanner as a repartition join.
--- Unplannable query due to a three-way join which causes no valid path (besides the cartesian product) to be found
+-- The join clause is wider than it used to be, causing this query to be
+-- recognized by the LogicalPlanner as a repartition join.
+-- Due to a three-way join this causes no valid path, besides the cartesian
+-- product on reference tables. This is allowed, so it should be able to be
+-- planned.
 SELECT *
 FROM
     test t1 JOIN test t2 USING (y), -- causes repartition, which makes this not routable or pushdownable
@@ -50,7 +53,19 @@ FROM
     ref b
 WHERE t2.y - a.a - b.b = 0
 ORDER BY 1,2,3;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Cartesian products are currently unsupported
+ y | x | x | a | b | a | b 
+---+---+---+---+---+---+---
+(0 rows)
+
+-- The join clause is wider than it used to be, causing this query to be recognized by the LogicalPlanner as a repartition join.
+-- Unplannable query due to a three-way join which causes no valid path to be found
+SELECT *
+FROM
+    test t1 JOIN test t2 USING (y), -- causes repartition, which makes this not routable or pushdownable
+    test a,
+    test b
+WHERE t2.y - a.x - b.x = 0
+ORDER BY 1,2,3;
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 SET client_min_messages TO WARNING;
 DROP SCHEMA expression_reference_join CASCADE;

--- a/src/test/regress/expected/multi_join_order_additional.out
+++ b/src/test/regress/expected/multi_join_order_additional.out
@@ -99,9 +99,7 @@ LOG:  join order: [ "lineitem" ][ local partition join "orders" ]
 
 EXPLAIN SELECT l_quantity FROM lineitem, orders
 	WHERE (l_orderkey = o_orderkey OR l_quantity > 5);
-LOG:  join order: [ "lineitem" ][ cartesian product "orders" ]
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Cartesian products are currently unsupported
+ERROR:  complex joins are only supported when all distributed tables are joined on their distribution columns with equal operator
 EXPLAIN SELECT count(*) FROM orders, lineitem_hash
 	WHERE o_orderkey = l_orderkey;
 LOG:  join order: [ "orders" ][ single range partition join "lineitem_hash" ]

--- a/src/test/regress/expected/multi_mx_reference_table.out
+++ b/src/test/regress/expected/multi_mx_reference_table.out
@@ -804,11 +804,11 @@ INSERT INTO colocated_table_test_2 VALUES (2, 2.0, '2', '2016-12-02');
 \c - - - :worker_1_port
 SET client_min_messages TO DEBUG1;
 SET citus.log_multi_join_order TO TRUE;
-SELECT 
+SELECT
 	reference_table_test.value_1
-FROM 
+FROM
 	reference_table_test, colocated_table_test
-WHERE 
+WHERE
 	colocated_table_test.value_1 = reference_table_test.value_1
 ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
@@ -818,11 +818,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
+SELECT
 	colocated_table_test.value_2
-FROM 
-	reference_table_test, colocated_table_test 
-WHERE 
+FROM
+	reference_table_test, colocated_table_test
+WHERE
 	colocated_table_test.value_2 = reference_table_test.value_2
 ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
@@ -832,11 +832,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
+SELECT
 	colocated_table_test.value_2
-FROM 
+FROM
 	colocated_table_test, reference_table_test
-WHERE 
+WHERE
 	reference_table_test.value_1 = colocated_table_test.value_1
 ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
@@ -846,21 +846,29 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
-	colocated_table_test.value_2 
-FROM 
+SET citus.enable_repartition_joins = on;
+SELECT
+	colocated_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_2 = reference_table_test.value_2
-ORDER BY 1;
-LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ cartesian product "colocated_table_test_2" ]
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Cartesian products are currently unsupported
-SELECT 
-	colocated_table_test.value_2 
-FROM 
+ORDER BY colocated_table_test.value_2;
+LOG:  join order: [ "colocated_table_test_2" ][ cartesian product reference join "reference_table_test" ][ dual partition join "colocated_table_test" ]
+ value_2 
+---------
+       1
+       1
+       2
+       2
+(4 rows)
+
+RESET citus.enable_repartition_joins;
+SELECT
+	colocated_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_1 = colocated_table_test_2.value_1 AND colocated_table_test.value_2 = reference_table_test.value_2
 ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ local partition join "colocated_table_test_2" ]
@@ -871,11 +879,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
 (2 rows)
 
 SET citus.task_executor_type to "task-tracker";
-SELECT 
-	colocated_table_test.value_2 
-FROM 
+SELECT
+	colocated_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_2 = colocated_table_test_2.value_2 AND colocated_table_test.value_2 = reference_table_test.value_2
 ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ dual partition join "colocated_table_test_2" ]
@@ -885,11 +893,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
-	reference_table_test.value_2 
-FROM 
+SELECT
+	reference_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_1 = reference_table_test.value_1 AND colocated_table_test_2.value_1 = reference_table_test.value_1
 ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ dual partition join "colocated_table_test_2" ]

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1004,11 +1004,11 @@ INSERT INTO colocated_table_test_2 VALUES (1, 1.0, '1', '2016-12-01');
 INSERT INTO colocated_table_test_2 VALUES (2, 2.0, '2', '2016-12-02');
 SET client_min_messages TO DEBUG1;
 SET citus.log_multi_join_order TO TRUE;
-SELECT 
+SELECT
 	reference_table_test.value_1
-FROM 
+FROM
 	reference_table_test, colocated_table_test
-WHERE 
+WHERE
 	colocated_table_test.value_1 = reference_table_test.value_1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_1 
@@ -1017,11 +1017,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
+SELECT
 	colocated_table_test.value_2
-FROM 
-	reference_table_test, colocated_table_test 
-WHERE 
+FROM
+	reference_table_test, colocated_table_test
+WHERE
 	colocated_table_test.value_2 = reference_table_test.value_2;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2 
@@ -1030,11 +1030,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
+SELECT
 	colocated_table_test.value_2
-FROM 
+FROM
 	colocated_table_test, reference_table_test
-WHERE 
+WHERE
 	reference_table_test.value_1 = colocated_table_test.value_1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2 
@@ -1043,20 +1043,29 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
-	colocated_table_test.value_2 
-FROM 
+SET citus.enable_repartition_joins = on;
+SELECT
+	colocated_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
-	colocated_table_test.value_2 = reference_table_test.value_2;
-LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ cartesian product "colocated_table_test_2" ]
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Cartesian products are currently unsupported
-SELECT 
-	colocated_table_test.value_2 
-FROM 
+WHERE
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY colocated_table_test.value_2;
+LOG:  join order: [ "colocated_table_test_2" ][ cartesian product reference join "reference_table_test" ][ dual partition join "colocated_table_test" ]
+ value_2 
+---------
+       1
+       1
+       2
+       2
+(4 rows)
+
+RESET citus.enable_repartition_joins;
+SELECT
+	colocated_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_1 = colocated_table_test_2.value_1 AND colocated_table_test.value_2 = reference_table_test.value_2;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ local partition join "colocated_table_test_2" ]
  value_2 
@@ -1066,11 +1075,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
 (2 rows)
 
 SET citus.task_executor_type to "task-tracker";
-SELECT 
-	colocated_table_test.value_2 
-FROM 
+SELECT
+	colocated_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_2 = colocated_table_test_2.value_2 AND colocated_table_test.value_2 = reference_table_test.value_2;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ dual partition join "colocated_table_test_2" ]
  value_2 
@@ -1079,11 +1088,11 @@ LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_te
        2
 (2 rows)
 
-SELECT 
-	reference_table_test.value_2 
-FROM 
+SELECT
+	reference_table_test.value_2
+FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
-WHERE 
+WHERE
 	colocated_table_test.value_1 = reference_table_test.value_1 AND colocated_table_test_2.value_1 = reference_table_test.value_1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ][ dual partition join "colocated_table_test_2" ]
  value_2 
@@ -1096,7 +1105,7 @@ SET citus.log_multi_join_order TO FALSE;
 SET citus.shard_count TO DEFAULT;
 SET citus.task_executor_type to "adaptive";
 -- some INSERT .. SELECT queries that involve both hash distributed and reference tables
--- should go via coordinator since we're inserting into reference table where 
+-- should go via coordinator since we're inserting into reference table where
 -- not all the participants are reference tables
 INSERT INTO
 	reference_table_test (value_1)
@@ -1122,7 +1131,7 @@ DEBUG:  Collecting INSERT ... SELECT results on coordinator
 -- safe to push down even lack of equality between partition column and column of reference table
 INSERT INTO
 	colocated_table_test (value_1, value_2)
-SELECT 
+SELECT
 	colocated_table_test_2.value_1, reference_table_test.value_2
 FROM
 	colocated_table_test_2, reference_table_test
@@ -1135,10 +1144,10 @@ RETURNING value_1, value_2;
        2 |       2
 (2 rows)
 
--- similar query with the above, this time partition key but without equality 
+-- similar query with the above, this time partition key but without equality
 INSERT INTO
 	colocated_table_test (value_1, value_2)
-SELECT 
+SELECT
 	colocated_table_test_2.value_1, reference_table_test.value_2
 FROM
 	colocated_table_test_2, reference_table_test
@@ -1251,7 +1260,7 @@ WHERE
        2 |       2
 (2 rows)
 
--- let's now test TRUNCATE and DROP TABLE 
+-- let's now test TRUNCATE and DROP TABLE
 -- delete all rows and ingest some data
 DELETE FROM reference_table_test;
 INSERT INTO reference_table_test VALUES (1, 1.0, '1', '2016-12-01');
@@ -1442,7 +1451,7 @@ CREATE OR REPLACE FUNCTION select_count_all() RETURNS bigint AS '
         FROM
                 reference_table_test;
 ' LANGUAGE SQL;
-CREATE OR REPLACE FUNCTION insert_into_ref_table(value_1 int, value_2 float, value_3 text, value_4 timestamp) 
+CREATE OR REPLACE FUNCTION insert_into_ref_table(value_1 int, value_2 float, value_3 text, value_4 timestamp)
 RETURNS void AS '
        INSERT INTO reference_table_test VALUES ($1, $2, $3, $4);
 ' LANGUAGE SQL;
@@ -1497,7 +1506,7 @@ SELECT select_count_all();
 
 TRUNCATE reference_table_test;
 -- some prepared queries and pl/pgsql functions
-PREPARE insert_into_ref_table_pr (int, float, text, timestamp) 
+PREPARE insert_into_ref_table_pr (int, float, text, timestamp)
 	AS INSERT INTO reference_table_test VALUES ($1, $2, $3, $4);
 -- reference tables do not have up-to-five execution limit as other tables
 EXECUTE insert_into_ref_table_pr(1, 1.0, '1', '2016-12-01');
@@ -1587,7 +1596,7 @@ ROLLBACK;
 -- clean up tables, ...
 SET client_min_messages TO ERROR;
 DROP SEQUENCE example_ref_value_seq;
-DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, 
+DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third,
 		   reference_table_test_fourth, reference_schema.reference_table_ddl, reference_table_composite,
 		   colocated_table_test, colocated_table_test_2, append_reference_tmp_table;
 DROP TYPE reference_comp_key;

--- a/src/test/regress/expected/multi_repartition_join_ref.out
+++ b/src/test/regress/expected/multi_repartition_join_ref.out
@@ -1,0 +1,226 @@
+SET citus.log_multi_join_order to TRUE;
+SET client_min_messages to DEBUG1;
+SET citus.enable_repartition_joins to on;
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND l_suppkey < s_suppkey
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ reference join "supplier" ][ single range partition join "part_append" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+       195 |       196 |   804
+       245 |       246 |   754
+       278 |       279 |   721
+       308 |       309 |   691
+       309 |       310 |  1380
+       350 |       351 |   649
+       358 |       359 |   641
+       574 |       575 |   425
+       641 |       642 |   358
+       654 |       655 |   345
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND int4eq(l_suppkey, s_suppkey)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ reference join "supplier" ][ single range partition join "part_append" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+       195 |       196 |     1
+       245 |       246 |     1
+       278 |       279 |     1
+       308 |       309 |     1
+       309 |       310 |     2
+       350 |       351 |     1
+       358 |       359 |     1
+       574 |       575 |     1
+       641 |       642 |     1
+       654 |       655 |     1
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND NOT int4ne(l_suppkey, s_suppkey)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ reference join "supplier" ][ single range partition join "part_append" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+       195 |       196 |     1
+       245 |       246 |     1
+       278 |       279 |     1
+       308 |       309 |     1
+       309 |       310 |     2
+       350 |       351 |     1
+       358 |       359 |     1
+       574 |       575 |     1
+       641 |       642 |     1
+       654 |       655 |     1
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ single range partition join "part_append" ][ cartesian product reference join "supplier" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+        18 |      7519 |  1000
+        79 |      7580 |  1000
+        91 |      2592 |  1000
+       149 |      5150 |  1000
+       149 |      7650 |  1000
+       175 |      5176 |  1000
+       179 |      2680 |  1000
+       182 |      7683 |  1000
+       195 |       196 |  1000
+       204 |      7705 |  1000
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND (int4eq(l_suppkey, s_suppkey) OR l_suppkey = s_suppkey)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ reference join "supplier" ][ single range partition join "part_append" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+       195 |       196 |     1
+       245 |       246 |     1
+       278 |       279 |     1
+       308 |       309 |     1
+       309 |       310 |     2
+       350 |       351 |     1
+       358 |       359 |     1
+       574 |       575 |     1
+       641 |       642 |     1
+       654 |       655 |     1
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND (int4eq(l_suppkey, s_suppkey) OR random() > 2)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ reference join "supplier" ][ single range partition join "part_append" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+       195 |       196 |     1
+       245 |       246 |     1
+       278 |       279 |     1
+       308 |       309 |     1
+       309 |       310 |     2
+       350 |       351 |     1
+       358 |       359 |     1
+       574 |       575 |     1
+       641 |       642 |     1
+       654 |       655 |     1
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND (l_suppkey = 1 OR s_suppkey = 1)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ reference join "supplier" ][ single range partition join "part_append" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+        18 |      7519 |     1
+        79 |      7580 |     1
+        91 |      2592 |     1
+       149 |      5150 |     1
+       149 |      7650 |     1
+       175 |      5176 |     1
+       179 |      2680 |     1
+       182 |      7683 |     1
+       195 |       196 |     1
+       204 |      7705 |     1
+(10 rows)
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND l_partkey + p_partkey = s_suppkey
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+LOG:  join order: [ "lineitem" ][ single range partition join "part_append" ][ reference join "supplier" ]
+DEBUG:  push down of limit count: 10
+ l_partkey | l_suppkey | count 
+-----------+-----------+-------
+        18 |      7519 |     1
+        79 |      7580 |     1
+        91 |      2592 |     1
+       149 |      5150 |     1
+       149 |      7650 |     1
+       175 |      5176 |     1
+       179 |      2680 |     1
+       182 |      7683 |     1
+       195 |       196 |     1
+       204 |      7705 |     1
+(10 rows)
+

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -112,7 +112,7 @@ test: multi_join_order_tpch_repartition
 # new shards before these tests, as they expect specific shard identifiers in
 # the output.
 # ----------
-test: multi_repartition_join_planning multi_repartition_join_pruning multi_repartition_join_task_assignment
+test: multi_repartition_join_planning multi_repartition_join_pruning multi_repartition_join_task_assignment multi_repartition_join_ref
 test: adaptive_executor_repartition
 
 # ---------

--- a/src/test/regress/sql/expression_reference_join.sql
+++ b/src/test/regress/sql/expression_reference_join.sql
@@ -27,8 +27,11 @@ FROM
 WHERE t2.y * 2 = a.a
 ORDER BY 1,2,3;
 
--- The join clause is wider than it used to be, causing this query to be recognized by the LogicalPlanner as a repartition join.
--- Unplannable query due to a three-way join which causes no valid path (besides the cartesian product) to be found
+-- The join clause is wider than it used to be, causing this query to be
+-- recognized by the LogicalPlanner as a repartition join.
+-- Due to a three-way join this causes no valid path, besides the cartesian
+-- product on reference tables. This is allowed, so it should be able to be
+-- planned.
 SELECT *
 FROM
     test t1 JOIN test t2 USING (y), -- causes repartition, which makes this not routable or pushdownable
@@ -36,6 +39,18 @@ FROM
     ref b
 WHERE t2.y - a.a - b.b = 0
 ORDER BY 1,2,3;
+
+
+-- The join clause is wider than it used to be, causing this query to be recognized by the LogicalPlanner as a repartition join.
+-- Unplannable query due to a three-way join which causes no valid path to be found
+SELECT *
+FROM
+    test t1 JOIN test t2 USING (y), -- causes repartition, which makes this not routable or pushdownable
+    test a,
+    test b
+WHERE t2.y - a.x - b.x = 0
+ORDER BY 1,2,3;
+
 
 SET client_min_messages TO WARNING;
 DROP SCHEMA expression_reference_join CASCADE;

--- a/src/test/regress/sql/multi_mx_reference_table.sql
+++ b/src/test/regress/sql/multi_mx_reference_table.sql
@@ -518,13 +518,15 @@ WHERE
 ORDER BY 1;
 
 
+SET citus.enable_repartition_joins = on;
 SELECT
 	colocated_table_test.value_2
 FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE
 	colocated_table_test.value_2 = reference_table_test.value_2
-ORDER BY 1;
+ORDER BY colocated_table_test.value_2;
+RESET citus.enable_repartition_joins;
 
 SELECT
 	colocated_table_test.value_2

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -656,12 +656,15 @@ FROM
 WHERE
 	reference_table_test.value_1 = colocated_table_test.value_1;
 
+SET citus.enable_repartition_joins = on;
 SELECT
 	colocated_table_test.value_2
 FROM
 	reference_table_test, colocated_table_test, colocated_table_test_2
 WHERE
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY colocated_table_test.value_2;
+RESET citus.enable_repartition_joins;
 
 SELECT
 	colocated_table_test.value_2

--- a/src/test/regress/sql/multi_repartition_join_ref.sql
+++ b/src/test/regress/sql/multi_repartition_join_ref.sql
@@ -1,0 +1,105 @@
+SET citus.log_multi_join_order to TRUE;
+SET client_min_messages to DEBUG1;
+SET citus.enable_repartition_joins to on;
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND l_suppkey < s_suppkey
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND int4eq(l_suppkey, s_suppkey)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND NOT int4ne(l_suppkey, s_suppkey)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND (int4eq(l_suppkey, s_suppkey) OR l_suppkey = s_suppkey)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND (int4eq(l_suppkey, s_suppkey) OR random() > 2)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND (l_suppkey = 1 OR s_suppkey = 1)
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;
+
+SELECT
+    l_partkey, l_suppkey, count(*)
+FROM
+    lineitem, part_append, supplier
+WHERE
+    l_partkey = p_partkey
+    AND l_partkey + p_partkey = s_suppkey
+GROUP BY
+    l_partkey, l_suppkey
+ORDER BY
+    l_partkey, l_suppkey
+LIMIT 10;


### PR DESCRIPTION
DESCRIPTION: Support any inner join on a reference table

This PR works by doing two things:
1. Expand the notion of a join condition to any expression that contains
   columns from two or more tables.
2. Support cartesian products on reference tables.

Cartesian products on reference tables are considered in the join order planner
as the least desirable join (except for normal cartesian products). That way
they will be done at the end of the join. This is preferable since the
cartesian product multiplies the rows. By doing it at the end at least these
multiplications of rows will not be sent over the network when doing
repartitioning, only when sending to the master.

Fixes #3079
Fixes #3198