### PR TITLE
Fix reindent version inconsistencies.

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -183,8 +183,8 @@ CitusModifyBeginScan(CustomScanState *node, EState *estate, int eflags)
 	 * executions of a prepared statement. Instead we create a deep copy that we only
 	 * use for the current execution.
 	 */
-	DistributedPlan *distributedPlan = scanState->distributedPlan = copyObject(
-		scanState->distributedPlan);
+	DistributedPlan *distributedPlan = copyObject(scanState->distributedPlan);
+	scanState->distributedPlan = distributedPlan;
 
 	Job *workerJob = distributedPlan->workerJob;
 	Query *jobQuery = workerJob->jobQuery;

--- a/src/backend/distributed/test/fake_fdw.c
+++ b/src/backend/distributed/test/fake_fdw.c
@@ -118,7 +118,10 @@ FakeGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid,
  * FakeBeginForeignScan begins the fake plan (i.e. does nothing).
  */
 static void
-FakeBeginForeignScan(ForeignScanState *node, int eflags) { }
+FakeBeginForeignScan(ForeignScanState *node, int eflags)
+{
+	/* this comment is for indentation consistency */
+}
 
 
 /*
@@ -138,11 +141,17 @@ FakeIterateForeignScan(ForeignScanState *node)
  * FakeReScanForeignScan restarts the fake plan (i.e. does nothing).
  */
 static void
-FakeReScanForeignScan(ForeignScanState *node) { }
+FakeReScanForeignScan(ForeignScanState *node)
+{
+	/* this comment is for indentation consistency */
+}
 
 
 /*
  * FakeEndForeignScan ends the fake plan (i.e. does nothing).
  */
 static void
-FakeEndForeignScan(ForeignScanState *node) { }
+FakeEndForeignScan(ForeignScanState *node)
+{
+	/* this comment is for indentation consistency */
+}

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -33,8 +33,8 @@ CitusSetTag(Node *node, int tag)
 
 
 #define DECLARE_FROM_AND_NEW_NODE(nodeTypeName) \
-	nodeTypeName *newnode = (nodeTypeName *) \
-							CitusSetTag((Node *) target_node, T_ ## nodeTypeName); \
+	nodeTypeName *newnode = \
+		(nodeTypeName *) CitusSetTag((Node *) target_node, T_ ## nodeTypeName); \
 	nodeTypeName *from = (nodeTypeName *) source_node
 
 /* Copy a simple scalar field (int, float, bool, enum, etc) */


### PR DESCRIPTION
Different versions of reindent tool reformatted citus_custom_scan.c
and citus_copyfuncs.c differently. So some developers spent some
extra attention not to commit these two files after reindent.

This PR tries to address this by slight modification which seem to be reformatted consistently across all versions.

