### PR TITLE
Make sure to update shard states of partitions on failures

### DIFF
--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -18,6 +18,7 @@
 #include "distributed/master_protocol.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/distributed_planner.h"
+#include "distributed/multi_partitioning_utils.h"
 #include "distributed/placement_connection.h"
 #include "distributed/relation_access_tracking.h"
 #include "utils/hsearch.h"
@@ -1065,8 +1066,7 @@ CheckShardPlacements(ConnectionShardHashEntry *shardEntry)
 		{
 			uint64 shardId = shardEntry->key.shardId;
 			uint64 placementId = placementEntry->key.placementId;
-			GroupShardPlacement *shardPlacement =
-				LoadGroupShardPlacement(shardId, placementId);
+			ShardPlacement *shardPlacement = LoadShardPlacement(shardId, placementId);
 
 			/*
 			 * We only set shard state if its current state is FILE_FINALIZED, which
@@ -1074,7 +1074,7 @@ CheckShardPlacements(ConnectionShardHashEntry *shardEntry)
 			 */
 			if (shardPlacement->shardState == FILE_FINALIZED)
 			{
-				UpdateShardPlacementState(placementEntry->key.placementId, FILE_INACTIVE);
+				MarkShardPlacementInactive(shardPlacement);
 			}
 		}
 	}

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -137,6 +137,7 @@
 #include "distributed/local_executor.h"
 #include "distributed/multi_client_executor.h"
 #include "distributed/multi_executor.h"
+#include "distributed/multi_partitioning_utils.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/multi_resowner.h"
 #include "distributed/multi_server_executor.h"
@@ -3495,7 +3496,7 @@ PlacementExecutionDone(TaskPlacementExecution *placementExecution, bool succeede
 			 */
 			if (shardPlacement->shardState == FILE_FINALIZED)
 			{
-				UpdateShardPlacementState(shardPlacement->placementId, FILE_INACTIVE);
+				MarkShardPlacementInactive(shardPlacement);
 			}
 		}
 

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -127,6 +127,9 @@ extern void InsertIntoPgDistPartition(Oid relationId, char distributionMethod,
 									  char replicationModel);
 extern void DeletePartitionRow(Oid distributedRelationId);
 extern void DeleteShardRow(uint64 shardId);
+extern void UpdatePartitionShardPlacementStates(ShardPlacement *parentShardPlacement,
+												char shardState);
+extern void MarkShardPlacementInactive(ShardPlacement *shardPlacement);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern void DeleteShardPlacementRow(uint64 placementId);
 extern void CreateDistributedTable(Oid relationId, Var *distributionColumn,

--- a/src/test/regress/expected/failure_replicated_partitions.out
+++ b/src/test/regress/expected/failure_replicated_partitions.out
@@ -1,0 +1,70 @@
+SET citus.next_shard_id TO 1490000;
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.shard_replication_factor TO 2;
+SET "citus.replication_model" to "statement";
+SET citus.shard_count TO 4;
+CREATE TABLE partitioned_table (
+	dist_key bigint,
+	partition_id integer
+) PARTITION BY LIST (partition_id );
+SELECT create_distributed_table('partitioned_table', 'dist_key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE partitioned_table_0
+	PARTITION OF partitioned_table (dist_key, partition_id)
+	FOR VALUES IN ( 0 );
+INSERT INTO partitioned_table VALUES (0, 0);
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").kill()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO partitioned_table VALUES (0, 0);
+WARNING:  connection error: localhost:xxxxx
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- use both placements
+SET citus.task_assignment_policy TO "round-robin";
+-- the results should be the same
+SELECT count(*) FROM partitioned_table_0;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT count(*) FROM partitioned_table_0;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT count(*) FROM partitioned_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT count(*) FROM partitioned_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+-- ==== Clean up, we're done here ====
+SELECT citus.mitmproxy('conn.allow()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP TABLE partitioned_table;

--- a/src/test/regress/failure_schedule
+++ b/src/test/regress/failure_schedule
@@ -4,6 +4,7 @@ test: failure_test_helpers
 # this should only be run by pg_regress_multi, you don't need it
 test: failure_setup
 test: multi_test_helpers
+test: failure_replicated_partitions
 test: multi_test_catalog_views
 test: failure_ddl
 test: failure_truncate

--- a/src/test/regress/sql/failure_replicated_partitions.sql
+++ b/src/test/regress/sql/failure_replicated_partitions.sql
@@ -1,0 +1,42 @@
+SET citus.next_shard_id TO 1490000;
+
+SELECT citus.mitmproxy('conn.allow()');
+
+
+SET citus.shard_replication_factor TO 2;
+SET "citus.replication_model" to "statement";
+SET citus.shard_count TO 4;
+
+CREATE TABLE partitioned_table (
+	dist_key bigint,
+	partition_id integer
+) PARTITION BY LIST (partition_id );
+
+SELECT create_distributed_table('partitioned_table', 'dist_key');
+CREATE TABLE partitioned_table_0
+	PARTITION OF partitioned_table (dist_key, partition_id)
+	FOR VALUES IN ( 0 );
+
+
+INSERT INTO partitioned_table VALUES (0, 0);
+
+SELECT citus.mitmproxy('conn.onQuery(query="^INSERT").kill()');
+
+INSERT INTO partitioned_table VALUES (0, 0);
+
+-- use both placements
+SET citus.task_assignment_policy TO "round-robin";
+
+-- the results should be the same
+SELECT count(*) FROM partitioned_table_0;
+SELECT count(*) FROM partitioned_table_0;
+
+SELECT count(*) FROM partitioned_table;
+SELECT count(*) FROM partitioned_table;
+
+
+-- ==== Clean up, we're done here ====
+
+SELECT citus.mitmproxy('conn.allow()');
+DROP TABLE partitioned_table;
+


### PR DESCRIPTION
Fixes #3331

In #2389, we've implemented support for partitioned tables with rep > 1.
The implementation is limiting the use of modification queries on the
partitions. In fact, we error out when any partition is modified via
EnsurePartitionTableNotReplicated().

However, we seem to forgot an important case, where the parent table's
partition is marked as INVALID. In that case, at least one of the partition
becomes INVALID. However, we do not mark partitions as INVALID ever.

If the user queries the partition table directly, Citus could happily send
the query to INVALID placements -- which are not marked as INVALID.

This PR fixes it by marking the placements of the partitions as INVALID
as well.

The shard placement repair logic already re-creates all the partitions,
so should be fine in that front.

DESCRIPTION:Prevent wrong results for replicated partitioned tables after failure 

- [x] Add a test
- [ ] Discuss how to backport the change.