### PR TITLE
Fix inconsistent shard metadata issue

### DIFF
--- a/src/test/regress/expected/multi_cache_invalidation.out
+++ b/src/test/regress/expected/multi_cache_invalidation.out
@@ -1,24 +1,48 @@
+-- test that we are tolerant to the relation ID of a shard being changed
+-- and do not cache invalid metadata
+CREATE SCHEMA mci_1;
+CREATE SCHEMA mci_2;
 SET citus.next_shard_id TO 1601000;
-SET citus.shard_count TO 1;
-SET citus.shard_replication_factor TO 1;
-CREATE TABLE tab9 (test_id integer NOT NULL, data int);
-CREATE TABLE tab10 (test_id integer NOT NULL, data int);
-SELECT create_distributed_table('tab9', 'test_id', 'hash');
+CREATE TABLE mci_1.test (test_id integer NOT NULL, data int);
+CREATE TABLE mci_2.test (test_id integer NOT NULL, data int);
+SELECT create_distributed_table('mci_1.test', 'test_id');
  create_distributed_table 
 --------------------------
  
 (1 row)
 
-SELECT master_create_distributed_table('tab10', 'test_id', 'hash');
- master_create_distributed_table 
----------------------------------
+SELECT create_distributed_table('mci_2.test', 'test_id', 'append');
+ create_distributed_table 
+--------------------------
  
 (1 row)
 
-TRUNCATE tab9;
-UPDATE pg_dist_shard SET logicalrelid = 'tab10'::regclass WHERE logicalrelid = 'tab9'::regclass;
-TRUNCATE tab10;
-ERROR:  cached metadata for shard 1601000 is inconsistent
-HINT:  Reconnect and try again.
-DROP TABLE tab9;
-DROP TABLE tab10;
+INSERT INTO mci_1.test VALUES (1,2), (3,4);
+-- move shards into other append-distributed table
+SELECT run_command_on_placements('mci_1.test', 'ALTER TABLE %s SET SCHEMA mci_2');
+         run_command_on_placements         
+-------------------------------------------
+ (localhost,57637,1601000,t,"ALTER TABLE")
+ (localhost,57638,1601000,t,"ALTER TABLE")
+ (localhost,57637,1601001,t,"ALTER TABLE")
+ (localhost,57638,1601001,t,"ALTER TABLE")
+ (localhost,57637,1601002,t,"ALTER TABLE")
+ (localhost,57638,1601002,t,"ALTER TABLE")
+ (localhost,57637,1601003,t,"ALTER TABLE")
+ (localhost,57638,1601003,t,"ALTER TABLE")
+(8 rows)
+
+UPDATE pg_dist_shard
+SET logicalrelid = 'mci_2.test'::regclass, shardminvalue = NULL, shardmaxvalue = NULL
+WHERE logicalrelid = 'mci_1.test'::regclass;
+SELECT * FROM mci_2.test ORDER BY test_id;
+ test_id | data 
+---------+------
+       1 |    2
+       3 |    4
+(2 rows)
+
+DROP SCHEMA mci_1 CASCADE;
+NOTICE:  drop cascades to table mci_1.test
+DROP SCHEMA mci_2 CASCADE;
+NOTICE:  drop cascades to table mci_2.test

--- a/src/test/regress/sql/multi_cache_invalidation.sql
+++ b/src/test/regress/sql/multi_cache_invalidation.sql
@@ -1,13 +1,23 @@
-SET citus.next_shard_id TO 1601000;
-SET citus.shard_count TO 1;
-SET citus.shard_replication_factor TO 1;
-CREATE TABLE tab9 (test_id integer NOT NULL, data int);
-CREATE TABLE tab10 (test_id integer NOT NULL, data int);
-SELECT create_distributed_table('tab9', 'test_id', 'hash');
-SELECT master_create_distributed_table('tab10', 'test_id', 'hash');
-TRUNCATE tab9;
-UPDATE pg_dist_shard SET logicalrelid = 'tab10'::regclass WHERE logicalrelid = 'tab9'::regclass;
-TRUNCATE tab10;
+-- test that we are tolerant to the relation ID of a shard being changed
+-- and do not cache invalid metadata
+CREATE SCHEMA mci_1;
+CREATE SCHEMA mci_2;
 
-DROP TABLE tab9;
-DROP TABLE tab10;
+SET citus.next_shard_id TO 1601000;
+CREATE TABLE mci_1.test (test_id integer NOT NULL, data int);
+CREATE TABLE mci_2.test (test_id integer NOT NULL, data int);
+SELECT create_distributed_table('mci_1.test', 'test_id');
+SELECT create_distributed_table('mci_2.test', 'test_id', 'append');
+
+INSERT INTO mci_1.test VALUES (1,2), (3,4);
+
+-- move shards into other append-distributed table
+SELECT run_command_on_placements('mci_1.test', 'ALTER TABLE %s SET SCHEMA mci_2');
+UPDATE pg_dist_shard
+SET logicalrelid = 'mci_2.test'::regclass, shardminvalue = NULL, shardmaxvalue = NULL
+WHERE logicalrelid = 'mci_1.test'::regclass;
+
+SELECT * FROM mci_2.test ORDER BY test_id;
+
+DROP SCHEMA mci_1 CASCADE;
+DROP SCHEMA mci_2 CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes cached metadata for shard is inconsistent issue

Metadata syncing routinely changes the relation IDs of a shard, which caused an error for open sessions. The main problem is that we do not clear the table cache entry of the old relation, because we will never do a cache lookup for this entry again. 

This PR clears the DistTableCacheEntry of the old relation when first looking up the new relation. More details in the comments.

Fixes #3038
Fixes #2853