### PR TITLE
Skip parse/deparse of local fast-path queries

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -132,7 +132,9 @@
 #include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
 #include "distributed/citus_custom_scan.h"
+#include "distributed/citus_ruleutils.h"
 #include "distributed/connection_management.h"
+#include "distributed/deparse_shard_query.h"
 #include "distributed/distributed_execution_locks.h"
 #include "distributed/local_executor.h"
 #include "distributed/multi_client_executor.h"
@@ -541,6 +543,7 @@ typedef struct TaskPlacementExecution
 
 /* local functions */
 static DistributedExecution * CreateDistributedExecution(RowModifyLevel modLevel,
+														 Query *jobQuery,
 														 List *taskList, bool
 														 hasReturning,
 														 ParamListInfo paramListInfo,
@@ -672,6 +675,7 @@ AdaptiveExecutor(CitusScanState *scanState)
 
 	DistributedExecution *execution = CreateDistributedExecution(
 		distributedPlan->modLevel,
+		job->jobQuery,
 		taskList,
 		distributedPlan->hasReturning,
 		paramListInfo,
@@ -888,7 +892,7 @@ ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
 	}
 
 	DistributedExecution *execution =
-		CreateDistributedExecution(modLevel, taskList, hasReturning, paramListInfo,
+		CreateDistributedExecution(modLevel, NULL, taskList, hasReturning, paramListInfo,
 								   tupleDescriptor, tupleStore, targetPoolSize,
 								   xactProperties);
 
@@ -905,7 +909,8 @@ ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
  * a distributed plan.
  */
 static DistributedExecution *
-CreateDistributedExecution(RowModifyLevel modLevel, List *taskList, bool hasReturning,
+CreateDistributedExecution(RowModifyLevel modLevel, Query *jobQuery, List *taskList,
+						   bool hasReturning,
 						   ParamListInfo paramListInfo, TupleDesc tupleDescriptor,
 						   Tuplestorestate *tupleStore, int targetPoolSize,
 						   TransactionProperties *xactProperties)
@@ -959,6 +964,21 @@ CreateDistributedExecution(RowModifyLevel modLevel, List *taskList, bool hasRetu
 
 		ExtractLocalAndRemoteTasks(readOnlyPlan, taskList, &execution->localTaskList,
 								   &execution->remoteTaskList);
+	}
+	else if (jobQuery && list_length(execution->tasksToExecute) == 1)
+	{
+		Task *task = (Task *) linitial(execution->tasksToExecute);
+
+		if (TaskAccessesLocalNode(task))
+		{
+			/*
+			 * For performance reasons, the queryString is not generated for
+			 * local-fast path queries during the planning. However, at this
+			 * point the executor decided that the task cannot be executed locally.
+			 * So, generate the queryString.
+			 */
+			GenerateShardQueryStringIfMissing(jobQuery, task);
+		}
 	}
 
 	return execution;

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -499,6 +499,8 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 	/* mark that we don't want the router planner to generate dummy hosts/queries */
 	bool replacePrunedQueryWithDummy = false;
 
+	bool localFastPathQuery = false;
+
 	/*
 	 * Use router planner to decide on whether we can push down the query or not.
 	 * If we can, we also rely on the side-effects that all RTEs have been updated
@@ -511,7 +513,8 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 														  &relationShardList,
 														  &prunedShardIntervalListList,
 														  replacePrunedQueryWithDummy,
-														  &multiShardModifyQuery, NULL);
+														  &multiShardModifyQuery, NULL,
+														  &localFastPathQuery);
 
 	Assert(!multiShardModifyQuery);
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -66,6 +66,8 @@
 bool ExplainDistributedQueries = true;
 bool ExplainAllTasks = false;
 
+bool ExplainStatementRunning = false;
+
 
 /* Result for a single remote EXPLAIN command */
 typedef struct RemoteExplainPlan

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2102,7 +2102,8 @@ PlanRouterQuery(Query *originalQuery,
 			ShardPlacement *shardPlacement =
 				FindShardPlacementOnGroup(GetLocalGroupId(), shardInterval->shardId);
 			if (shardPlacement != NULL &&
-				!ReferenceTableShardId(shardInterval->shardId) &&
+				(!ReferenceTableShardId(shardInterval->shardId) ||
+				 !IsModifyCommand(originalQuery)) &&
 				!ExplainStatementRunning)
 			{
 				/*

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -31,6 +31,7 @@
 #include "distributed/master_protocol.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_executor.h"
+#include "distributed/multi_explain.h"
 #include "distributed/multi_join_order.h"
 #include "distributed/multi_logical_planner.h"
 #include "distributed/multi_logical_optimizer.h"
@@ -160,11 +161,11 @@ static List * TargetShardIntervalForFastPathQuery(Query *query,
 												  Const *distributionKeyValue);
 static List * SingleShardSelectTaskList(Query *query, uint64 jobId,
 										List *relationShardList, List *placementList,
-										uint64 shardId);
+										uint64 shardId, bool localFastPathQuery);
 static bool RowLocksOnRelations(Node *node, List **rtiLockList);
 static List * SingleShardModifyTaskList(Query *query, uint64 jobId,
 										List *relationShardList, List *placementList,
-										uint64 shardId);
+										uint64 shardId, bool localFastPathQuery);
 static void ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 														TaskAssignmentPolicyType
 														taskAssignmentPolicy,
@@ -1666,6 +1667,7 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 	List *relationShardList = NIL;
 	List *prunedShardIntervalListList = NIL;
 	bool isMultiShardModifyQuery = false;
+	bool localFastPathQuery = false;
 	Const *partitionKeyValue = NULL;
 
 	/* router planner should create task even if it doesn't hit a shard at all */
@@ -1679,7 +1681,8 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 									   &prunedShardIntervalListList,
 									   replacePrunedQueryWithDummy,
 									   &isMultiShardModifyQuery,
-									   &partitionKeyValue);
+									   &partitionKeyValue,
+									   &localFastPathQuery);
 	if (*planningError)
 	{
 		return NULL;
@@ -1707,7 +1710,7 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 	{
 		job->taskList = SingleShardSelectTaskList(originalQuery, job->jobId,
 												  relationShardList, placementList,
-												  shardId);
+												  shardId, localFastPathQuery);
 
 		/*
 		 * Queries to reference tables, or distributed tables with multiple replica's have
@@ -1742,7 +1745,7 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 	{
 		job->taskList = SingleShardModifyTaskList(originalQuery, job->jobId,
 												  relationShardList, placementList,
-												  shardId);
+												  shardId, localFastPathQuery);
 	}
 
 	job->requiresMasterEvaluation = requiresMasterEvaluation;
@@ -1837,17 +1840,29 @@ RemoveCoordinatorPlacement(List *placementList)
  */
 static List *
 SingleShardSelectTaskList(Query *query, uint64 jobId, List *relationShardList,
-						  List *placementList,
-						  uint64 shardId)
+						  List *placementList, uint64 shardId, bool localFastPathQuery)
 {
 	Task *task = CreateTask(SELECT_TASK);
 	StringInfo queryString = makeStringInfo();
 	List *relationRowLockList = NIL;
 
 	RowLocksOnRelations((Node *) query, &relationRowLockList);
-	pg_get_query_def(query, queryString);
 
-	task->queryString = queryString->data;
+	/*
+	 * For performance reasons, we skip generating the queryString for local
+	 * fast path queries. With this, we can avoid deparsing during the execution
+	 * as well.
+	 */
+	if (localFastPathQuery)
+	{
+		queryString = NULL;
+	}
+	else
+	{
+		pg_get_query_def(query, queryString);
+	}
+
+	task->queryString = queryString ? queryString->data : NULL;
 	task->anchorShardId = shardId;
 	task->jobId = jobId;
 	task->taskPlacementList = placementList;
@@ -1905,7 +1920,7 @@ RowLocksOnRelations(Node *node, List **relationRowLockList)
  */
 static List *
 SingleShardModifyTaskList(Query *query, uint64 jobId, List *relationShardList,
-						  List *placementList, uint64 shardId)
+						  List *placementList, uint64 shardId, bool localFastPathQuery)
 {
 	Task *task = CreateTask(MODIFY_TASK);
 	StringInfo queryString = makeStringInfo();
@@ -1926,9 +1941,21 @@ SingleShardModifyTaskList(Query *query, uint64 jobId, List *relationShardList,
 							   "and modify a reference table")));
 	}
 
-	pg_get_query_def(query, queryString);
+	/*
+	 * For performance reasons, we skip generating the queryString for local
+	 * fast path queries. With this, we can avoid deparsing during the execution
+	 * as well.
+	 */
+	if (localFastPathQuery)
+	{
+		queryString = NULL;
+	}
+	else
+	{
+		pg_get_query_def(query, queryString);
+	}
 
-	task->queryString = queryString->data;
+	task->queryString = queryString ? queryString->data : NULL;
 	task->anchorShardId = shardId;
 	task->jobId = jobId;
 	task->taskPlacementList = placementList;
@@ -2021,7 +2048,7 @@ PlanRouterQuery(Query *originalQuery,
 				List **placementList, uint64 *anchorShardId, List **relationShardList,
 				List **prunedShardIntervalListList,
 				bool replacePrunedQueryWithDummy, bool *multiShardModifyQuery,
-				Const **partitionValueConst)
+				Const **partitionValueConst, bool *localFastPathQuery)
 {
 	static uint32 zeroShardQueryRoundRobin = 0;
 
@@ -2051,7 +2078,6 @@ PlanRouterQuery(Query *originalQuery,
 			TargetShardIntervalForFastPathQuery(originalQuery, partitionValueConst,
 												&isMultiShardQuery, distributionKeyValue);
 
-
 		/*
 		 * This could only happen when there is a parameter on the distribution key.
 		 * We defer error here, later the planner is forced to use a generic plan
@@ -2067,10 +2093,31 @@ PlanRouterQuery(Query *originalQuery,
 
 		*prunedShardIntervalListList = list_make1(shardIntervalList);
 
-		if (!isMultiShardQuery)
+		if (!isMultiShardQuery && list_length(shardIntervalList) == 1)
 		{
 			ereport(DEBUG2, (errmsg("Distributed planning for a fast-path router "
 									"query")));
+
+			ShardInterval *shardInterval = (ShardInterval *) linitial(shardIntervalList);
+			ShardPlacement *shardPlacement =
+				FindShardPlacementOnGroup(GetLocalGroupId(), shardInterval->shardId);
+			if (shardPlacement != NULL &&
+				!ReferenceTableShardId(shardInterval->shardId) &&
+				!ExplainStatementRunning)
+			{
+				/*
+				 * The query could be executed locally, but that's not a decision
+				 * we can give at the moment. We're only doing some performance
+				 * optimizations if that's how the executor behaves. Otherwise, the
+				 * optimizations would be lost during the execution.
+				 *
+				 * Modifications on reference tables needs to be executed remotely as
+				 * well, so doesn't worth the optimization.
+				 *
+				 * Citus cannot handle EXPLAIN on local tables, so skip those as well.
+				 */
+				*localFastPathQuery = true;
+			}
 		}
 	}
 	else
@@ -2202,12 +2249,20 @@ PlanRouterQuery(Query *originalQuery,
 		return planningError;
 	}
 
-	/*
-	 * If this is an UPDATE or DELETE query which requires master evaluation,
-	 * don't try update shard names, and postpone that to execution phase.
-	 */
-	if (!(UpdateOrDeleteQuery(originalQuery) && RequiresMasterEvaluation(originalQuery)))
+	if (*localFastPathQuery)
 	{
+		/*
+		 * When this is a local-fast path query, skip this relatively
+		 * expensive traversal because we may not need at all and
+		 * performance is important in this path.*/
+	}
+	else if (!(UpdateOrDeleteQuery(originalQuery) &&
+			   RequiresMasterEvaluation(originalQuery)))
+	{
+		/*
+		 * If this is an UPDATE or DELETE query which requires master evaluation,
+		 * don't try update shard names, and postpone that to execution phase.
+		 */
 		UpdateRelationToShardNames((Node *) originalQuery, *relationShardList);
 	}
 

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -24,7 +24,9 @@ extern void ExtractLocalAndRemoteTasks(bool readOnlyPlan, List *taskList,
 									   List **localTaskList, List **remoteTaskList);
 extern bool ShouldExecuteTasksLocally(List *taskList);
 extern void ErrorIfLocalExecutionHappened(void);
+extern void GenerateShardQueryStringIfMissing(Query *workerJobQuery, Task *task);
 extern void DisableLocalExecution(void);
+extern bool TaskAccessesLocalNode(Task *task);
 extern bool AnyTaskAccessesRemoteNode(List *taskList);
 
 #endif /* LOCAL_EXECUTION_H */

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -16,4 +16,7 @@
 extern bool ExplainDistributedQueries;
 extern bool ExplainAllTasks;
 
+/* internal state, not a GUC */
+extern bool ExplainStatementRunning;
+
 #endif /* MULTI_EXPLAIN_H */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -42,7 +42,8 @@ extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
 											  List **prunedShardIntervalListList,
 											  bool replacePrunedQueryWithDummy,
 											  bool *multiShardModifyQuery,
-											  Const **partitionValueConst);
+											  Const **partitionValueConst,
+											  bool *localFastPathQuery);
 extern List * RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError);
 extern Const * ExtractInsertPartitionKeyValue(Query *query);
 extern List * TargetShardIntervalsForRestrictInfo(RelationRestrictionContext *

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -1415,6 +1415,33 @@ LOG:  executing the command locally: DELETE FROM local_shard_execution.reference
 (2 rows)
 
 COMMIT;
+-- however complex the query, local execution can handle
+SET client_min_messages TO LOG;
+SET citus.log_local_commands TO ON;
+WITH cte_1 AS
+  (SELECT *
+   FROM
+     (WITH cte_1 AS
+        (SELECT *
+         FROM distributed_table
+         WHERE key = 1) SELECT *
+      FROM cte_1) AS foo)
+SELECT count(*)
+FROM cte_1
+JOIN distributed_table USING (key)
+WHERE distributed_table.key = 1
+  AND distributed_table.key IN
+    (SELECT key
+     FROM distributed_table
+     WHERE key = 1);
+LOG:  executing the command locally: WITH cte_1 AS (SELECT foo.key, foo.value, foo.age FROM (WITH cte_1 AS (SELECT distributed_table_1.key, distributed_table_1.value, distributed_table_1.age FROM local_shard_execution.distributed_table_1470001 distributed_table_1 WHERE (distributed_table_1.key OPERATOR(pg_catalog.=) 1)) SELECT cte_1_1.key, cte_1_1.value, cte_1_1.age FROM cte_1 cte_1_1) foo) SELECT count(*) AS count FROM (cte_1 JOIN local_shard_execution.distributed_table_1470001 distributed_table(key, value, age) USING (key)) WHERE ((distributed_table.key OPERATOR(pg_catalog.=) 1) AND (distributed_table.key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table_1.key FROM local_shard_execution.distributed_table_1470001 distributed_table_1 WHERE (distributed_table_1.key OPERATOR(pg_catalog.=) 1))))
+ count 
+-------
+     0
+(1 row)
+
+RESET client_min_messages;
+RESET citus.log_local_commands;
 \c - - - :master_port
 -- local execution with custom type
 SET citus.replication_model TO "streaming";

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -806,6 +806,15 @@ INSERT INTO distributed_table VALUES (1, '11',21), (2,'22',22), (3,'33',33), (4,
 (5 rows)
 
 PREPARE local_prepare_no_param AS SELECT count(*) FROM distributed_table WHERE key = 1;
+PREPARE local_prepare_no_param_subquery AS
+SELECT DISTINCT trim(value) FROM (
+    SELECT value FROM distributed_table
+    WHERE
+        key IN (1, 6, 500, 701)
+        AND (select 2) > random()
+        order by 1
+        limit 2
+    ) t;
 PREPARE local_prepare_param (int) AS SELECT count(*) FROM distributed_table WHERE key = $1;
 PREPARE remote_prepare_param (int) AS SELECT count(*) FROM distributed_table WHERE key != $1;
 BEGIN;
@@ -850,6 +859,55 @@ LOG:  executing the command locally: SELECT count(*) AS count FROM local_shard_e
  count
 ---------------------------------------------------------------------
      1
+(1 row)
+
+	-- 6 local execution without params and some subqueries
+	EXECUTE local_prepare_no_param_subquery;
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+ btrim
+---------------------------------------------------------------------
+ 12
+(1 row)
+
+	EXECUTE local_prepare_no_param_subquery;
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+ btrim
+---------------------------------------------------------------------
+ 12
+(1 row)
+
+	EXECUTE local_prepare_no_param_subquery;
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+ btrim
+---------------------------------------------------------------------
+ 12
+(1 row)
+
+	EXECUTE local_prepare_no_param_subquery;
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+ btrim
+---------------------------------------------------------------------
+ 12
+(1 row)
+
+	EXECUTE local_prepare_no_param_subquery;
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+ btrim
+---------------------------------------------------------------------
+ 12
+(1 row)
+
+	EXECUTE local_prepare_no_param_subquery;
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+LOG:  executing the command locally: SELECT worker_column_1 AS value FROM (SELECT distributed_table.value AS worker_column_1 FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE ((distributed_table.key OPERATOR(pg_catalog.=) ANY (ARRAY[1, 6, 500, 701])) AND (((SELECT 2))::double precision OPERATOR(pg_catalog.>) random()))) worker_subquery ORDER BY worker_column_1 LIMIT '2'::bigint
+ btrim
+---------------------------------------------------------------------
+ 12
 (1 row)
 
 	-- 6 local executions with params
@@ -1368,6 +1426,7 @@ EXECUTE serial_prepared_local;
 -- Citus currently doesn't allow using task_assignment_policy for intermediate results
 WITH distributed_local_mixed AS (INSERT INTO reference_table VALUES (1000) RETURNING *) SELECT * FROM distributed_local_mixed;
 LOG:  executing the command locally: INSERT INTO local_shard_execution.reference_table_1470000 (key) VALUES (1000) RETURNING key
+LOG:  executing the command locally: SELECT key FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_local_mixed
  key
 ---------------------------------------------------------------------
  1000
@@ -1435,8 +1494,8 @@ WHERE distributed_table.key = 1
      FROM distributed_table
      WHERE key = 1);
 LOG:  executing the command locally: WITH cte_1 AS (SELECT foo.key, foo.value, foo.age FROM (WITH cte_1 AS (SELECT distributed_table_1.key, distributed_table_1.value, distributed_table_1.age FROM local_shard_execution.distributed_table_1470001 distributed_table_1 WHERE (distributed_table_1.key OPERATOR(pg_catalog.=) 1)) SELECT cte_1_1.key, cte_1_1.value, cte_1_1.age FROM cte_1 cte_1_1) foo) SELECT count(*) AS count FROM (cte_1 JOIN local_shard_execution.distributed_table_1470001 distributed_table(key, value, age) USING (key)) WHERE ((distributed_table.key OPERATOR(pg_catalog.=) 1) AND (distributed_table.key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table_1.key FROM local_shard_execution.distributed_table_1470001 distributed_table_1 WHERE (distributed_table_1.key OPERATOR(pg_catalog.=) 1))))
- count 
--------
+ count
+---------------------------------------------------------------------
      0
 (1 row)
 

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -1173,7 +1173,6 @@ DEBUG:  Plan is router executable
 SELECT *
 	FROM articles_hash
 	WHERE author_id = 1 and false;
-DEBUG:  Distributed planning for a fast-path router query
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count
@@ -1195,7 +1194,6 @@ DETAIL:  distribution column value: 1
 SELECT *
 	FROM articles_hash
 	WHERE null and author_id = 1;
-DEBUG:  Distributed planning for a fast-path router query
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
  id | author_id | title | word_count

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -462,6 +462,15 @@ INSERT INTO distributed_table VALUES (1, '11',21), (2,'22',22), (3,'33',33), (4,
 
 
 PREPARE local_prepare_no_param AS SELECT count(*) FROM distributed_table WHERE key = 1;
+PREPARE local_prepare_no_param_subquery AS
+SELECT DISTINCT trim(value) FROM (
+    SELECT value FROM distributed_table
+    WHERE
+        key IN (1, 6, 500, 701)
+        AND (select 2) > random()
+        order by 1
+        limit 2
+    ) t;
 PREPARE local_prepare_param (int) AS SELECT count(*) FROM distributed_table WHERE key = $1;
 PREPARE remote_prepare_param (int) AS SELECT count(*) FROM distributed_table WHERE key != $1;
 BEGIN;
@@ -472,6 +481,14 @@ BEGIN;
 	EXECUTE local_prepare_no_param;
 	EXECUTE local_prepare_no_param;
 	EXECUTE local_prepare_no_param;
+
+	-- 6 local execution without params and some subqueries
+	EXECUTE local_prepare_no_param_subquery;
+	EXECUTE local_prepare_no_param_subquery;
+	EXECUTE local_prepare_no_param_subquery;
+	EXECUTE local_prepare_no_param_subquery;
+	EXECUTE local_prepare_no_param_subquery;
+	EXECUTE local_prepare_no_param_subquery;
 
 	-- 6 local executions with params
 	EXECUTE local_prepare_param(1);

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -733,6 +733,28 @@ BEGIN;
     DELETE FROM reference_table RETURNING key;
 COMMIT;
 
+-- however complex the query, local execution can handle
+SET client_min_messages TO LOG;
+SET citus.log_local_commands TO ON;
+WITH cte_1 AS
+  (SELECT *
+   FROM
+     (WITH cte_1 AS
+        (SELECT *
+         FROM distributed_table
+         WHERE key = 1) SELECT *
+      FROM cte_1) AS foo)
+SELECT count(*)
+FROM cte_1
+JOIN distributed_table USING (key)
+WHERE distributed_table.key = 1
+  AND distributed_table.key IN
+    (SELECT key
+     FROM distributed_table
+     WHERE key = 1);
+
+RESET client_min_messages;
+RESET citus.log_local_commands;
 
 \c - - - :master_port
 


### PR DESCRIPTION
If we're dealing with local fast-path queries, we can skip the expensive
operations of parse/deparse of the queries.

Given that the planner cannot know in advance whether the query is going
to be executed locally, it tries its best, skips expensive operations.

However, the executor could end-up with doing the expensive operations
if needed.

**This increase the performance around %13 on top of #3332  when the workers CPU bottlenecked**

The changes are inspired from #2830 and in-person discussions with @marcocitus   