### PR TITLE
Do not go through standard_planner() for INSERTs

### DIFF
--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -35,6 +35,7 @@
 #include "postgres.h"
 
 #include "distributed/distributed_planner.h"
+#include "distributed/insert_select_planner.h"
 #include "distributed/multi_physical_planner.h" /* only to use some utility functions */
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_router_planner.h"
@@ -171,9 +172,9 @@ FastPathRouterQuery(Query *query)
 		return false;
 	}
 
-	if (!(query->commandType == CMD_SELECT || query->commandType == CMD_UPDATE ||
-		  query->commandType == CMD_DELETE))
+	if (query->commandType == CMD_INSERT && CheckInsertSelectQuery(query))
 	{
+		/* we don't support INSERT..SELECT in the fast-path */
 		return false;
 	}
 

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -70,7 +70,6 @@ static DeferredErrorMessage * InsertPartitionColumnMatchesSelect(Query *query,
 																 selectPartitionColumnTableId);
 static DistributedPlan * CreateCoordinatorInsertSelectPlan(uint64 planId, Query *parse);
 static DeferredErrorMessage * CoordinatorInsertSelectSupported(Query *insertSelectQuery);
-static bool CheckInsertSelectQuery(Query *query);
 
 
 /*
@@ -129,7 +128,7 @@ InsertSelectIntoLocalTable(Query *query)
  * This function is inspired from getInsertSelectQuery() on
  * rewrite/rewriteManip.c.
  */
-static bool
+bool
 CheckInsertSelectQuery(Query *query)
 {
 	CmdType commandType = query->commandType;

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -223,6 +223,9 @@ CreateModifyPlan(Query *originalQuery, Query *query,
 	}
 	else
 	{
+		/* all INSERTs are fast path queries */
+		Assert(FastPathRouterQuery(originalQuery));
+
 		job = RouterInsertJob(originalQuery, query, &distributedPlan->planningError);
 	}
 

--- a/src/include/distributed/insert_select_planner.h
+++ b/src/include/distributed/insert_select_planner.h
@@ -24,6 +24,7 @@
 
 
 extern bool InsertSelectIntoDistributedTable(Query *query);
+extern bool CheckInsertSelectQuery(Query *query);
 extern bool InsertSelectIntoLocalTable(Query *query);
 extern Query * ReorderInsertSelectTargetLists(Query *originalQuery,
 											  RangeTblEntry *insertRte,


### PR DESCRIPTION
Do not go through standard_planner() for INSERTs
    
That seems unnecessary. We already have the notion of FastPath queries,
simply add it there.

It is probably more logical to merge this PR before #3332, #3337 and #3338 so that
we make sure to build all the logic for INSERTs as well (@JelteF let me know what you think) 
    
Especially re-consider #3337 for INSERTs where there is  a parameter on the dist. key like
```SQL
PREPARE p1(int) AS INSERT INTO dist_table (dist_key) VALUES ($1)
```
the above can still skip parse/deparse for local queries.
