### PR TITLE
Actually check that test output normalization is applied in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: ci/normalize_expected.sh
       - run:
           name: 'Check if changed'
-          command: git diff --cached --exit-code
+          command: git diff --exit-code
   check-sql-snapshots:
     docker:
       - image: 'citus/extbuilder:latest'

--- a/src/test/regress/expected/worker_remove_files.out
+++ b/src/test/regress/expected/worker_remove_files.out
@@ -1,8 +1,8 @@
 -- Clear job directory used by previous tests
 \set JobId 201010
 SELECT task_tracker_cleanup_job(:JobId);
- task_tracker_cleanup_job 
---------------------------
- 
+ task_tracker_cleanup_job
+---------------------------------------------------------------------
+
 (1 row)
 


### PR DESCRIPTION
Fixup of an issue with #3336 that caused CI not to check correctly that
normalized test output was committed.