### PR TITLE
Implement foreign key support between coordinator local tables and reference tables

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -448,9 +448,10 @@ ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oid referencin
 											  FKCONSTR_ACTION_CASCADE ||
 											  constraint->fk_del_action ==
 											  FKCONSTR_ACTION_CASCADE);
-			
-			bool fromReferenceTableToLocalTable = referencingIsReferenceTable && !referencedIsDistributed;
-			
+
+			bool fromReferenceTableToLocalTable = referencingIsReferenceTable &&
+												  !referencedIsDistributed;
+
 			if (fromReferenceTableToLocalTable && onDeleteOrOnUpdateCascade)
 			{
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -400,7 +400,7 @@ ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
 
 
 /*
- * ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable runs check related to foreign
+ * ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable runs checks related to foreign
  * constraints between local tables and reference tables
  */
 void
@@ -431,6 +431,18 @@ ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid, O
 	if ((referencingIsReferenceTable && !referencedIsDistributed) ||
 		(!referencingIsDistributed && referencedIsReferenceTable))
 	{
+		/*
+		 * TODO: I should add a comment for rationale behind it
+		 */
+		if (IsMultiStatementTransaction())
+		{
+			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				/* TODO: is this error applicable ? */
+				errmsg(
+					"cannot define foreign key constraint between local tables "
+					"and reference tables in a transaction block, udf block, or "
+					"distributed CTE subquery")));
+		}
 		/*
 		 * Check if we are in the coordinator and coordinator can have reference
 		 * table replicas

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -501,18 +501,18 @@ ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oid referencin
 
 
 /*
- * ErrorIfCoordinatorHasLocalTableReferencingReferenceTable errors out if we
+ * ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable errors out if we
  * if coordinator has reference table replica for given referance table and if
  * it is involved in a foreign key constraint with a coordinator local table.
  */
 void
-ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(Oid referenceTableOid)
+ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable(Oid referenceTableOid)
 {
 	Oid localTableOid = GetCoordinatorLocalTableHavingFKeyWithReferenceTable(
 		referenceTableOid);
 
 	/*
-	 * There is a local table involved in a foreign key constraint
+	 * There is a coordinator local table involved in a foreign key constraint
 	 * with reference table with referenceTableOid
 	 */
 	if (OidIsValid(localTableOid))
@@ -522,10 +522,10 @@ ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(Oid referenceTableOid)
 
 		ereport(ERROR, (errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
 						errmsg(
-							"cannot remove reference table placements from coordinator"),
+							"cannot remove reference table placement from coordinator"),
 						errdetail(
 							"Local table \"%s\" is involved in a foreign key constraint with "
-							"refence table \"%s\", which has replica(s) in coordinator",
+							"refence table \"%s\", which has replica in coordinator",
 							localTableName, referenceTableName),
 						errhint(
 							"DROP foreign key constraint between them or drop referenced "

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -571,6 +571,7 @@ ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid relationId)
 	/* clean up scan and close system catalog */
 	systable_endscan(scanDescriptor);
 	heap_close(pgConstraint, AccessShareLock);
+
 	return foreignKeyToReferenceTableIncludesGivenColumn;
 }
 
@@ -717,6 +718,7 @@ TableReferenced(Oid relationId)
 													scanKeyCount, scanKey);
 
 	HeapTuple heapTuple = systable_getnext(scanDescriptor);
+
 	while (HeapTupleIsValid(heapTuple))
 	{
 		Form_pg_constraint constraintForm = (Form_pg_constraint) GETSTRUCT(heapTuple);
@@ -731,6 +733,8 @@ TableReferenced(Oid relationId)
 
 		heapTuple = systable_getnext(scanDescriptor);
 	}
+
+	/* clean up scan and close system catalog */
 
 	systable_endscan(scanDescriptor);
 	heap_close(pgConstraint, NoLock);

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -564,6 +564,8 @@ HasForeignKeyToReferenceTable(Oid relationId)
 
 		if (!IsDistributedTable(referencedTableId))
 		{
+			/* TODO: This line should be already there ??*/ // why we hit here ??
+			heapTuple = systable_getnext(scanDescriptor);
 			continue;
 		}
 

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -40,6 +40,7 @@ static void ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
 										  Var *referencedDistColumn,
 										  int *referencingAttrIndex,
 										  int *referencedAttrIndex);
+static Oid GetCoordinatorLocalTableHavingFKeyWithReferenceTable(Oid referenceTableOid);
 
 /*
  * ConstraintIsAForeignKeyToReferenceTable checks if the given constraint is a
@@ -496,6 +497,108 @@ ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oid referencin
 								"to pg_dist_node as well.")));
 		}
 	}
+}
+
+
+/*
+ * ErrorIfCoordinatorHasLocalTableReferencingReferenceTable errors out if we
+ * if coordinator has reference table replica for given referance table and if
+ * it is involved in a foreign key constraint with a coordinator local table.
+ */
+void
+ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(Oid referenceTableOid)
+{
+	Oid localTableOid = GetCoordinatorLocalTableHavingFKeyWithReferenceTable(
+		referenceTableOid);
+
+	/*
+	 * There is a local table involved in a foreign key constraint
+	 * with reference table with referenceTableOid
+	 */
+	if (OidIsValid(localTableOid))
+	{
+		const char *localTableName = get_rel_name(localTableOid);
+		const char *referenceTableName = get_rel_name(referenceTableOid);
+
+		ereport(ERROR, (errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+						errmsg(
+							"cannot remove reference table placements from coordinator"),
+						errdetail(
+							"Local table \"%s\" is involved in a foreign key constraint with "
+							"refence table \"%s\", which has replica(s) in coordinator",
+							localTableName, referenceTableName),
+						errhint(
+							"DROP foreign key constraint between them or drop referenced "
+							"table with DROP ... CASCADE.")));
+	}
+}
+
+
+/*
+ * GetCoordinatorLocalTableHavingFKeyWithReferenceTable returns OID of the
+ * local table that is involved in a foreign key constraint with the reference
+ * table with referenceTableOid.
+ * It does that by scanning pg_constraint for foreign key constraints.
+ *
+ * If there does not exist such a foreign key constraint, returns InvalidOid.
+ * If there exists more than one such a foreign key constraint, we return the
+ * first local table we ecounter while scanning pg_constraint
+ */
+static Oid
+GetCoordinatorLocalTableHavingFKeyWithReferenceTable(Oid referenceTableOid)
+{
+	Oid referenceTableShardOid = GetOnlyShardOidOfReferenceTable(referenceTableOid);
+
+	ScanKeyData scanKey[1];
+	int scanKeyCount = 1;
+
+	Relation pgConstraint = heap_open(ConstraintRelationId, AccessShareLock);
+	ScanKeyInit(&scanKey[0], Anum_pg_constraint_contype, BTEqualStrategyNumber, F_CHAREQ,
+				CharGetDatum(CONSTRAINT_FOREIGN));
+	SysScanDesc scanDescriptor = systable_beginscan(pgConstraint,
+													InvalidOid,
+													false, NULL,
+													scanKeyCount, scanKey);
+
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
+
+	while (HeapTupleIsValid(heapTuple))
+	{
+		Form_pg_constraint constraintForm = (Form_pg_constraint) GETSTRUCT(heapTuple);
+
+		if (constraintForm->confrelid == referenceTableShardOid)
+		{
+			Oid referencingTableId = constraintForm->conrelid;
+
+			if (!IsDistributedTable(referencingTableId))
+			{
+				return referencingTableId;
+			}
+		}
+		else if (constraintForm->conrelid == referenceTableShardOid)
+		{
+			Oid referencedTableId = constraintForm->confrelid;
+
+			if (!IsDistributedTable(referencedTableId))
+			{
+				return referencedTableId;
+			}
+		}
+
+		/*
+		 * If this is not such a relation from/to the given relation, we should
+		 * simply skip.
+		 */
+		heapTuple = systable_getnext(scanDescriptor);
+		continue;
+	}
+
+	/* clean up scan and close system catalog */
+
+	systable_endscan(scanDescriptor);
+	heap_close(pgConstraint, AccessShareLock);
+
+	return InvalidOid;
 }
 
 

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -232,7 +232,7 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char distributionMe
 								errhint(
 									"To define foreign key constraint from a reference table to a "
 									"local table, use ALTER TABLE ADD CONSTRAINT ... command after "
-									"creating the reference table without a foreing key")));
+									"creating the reference table without a foreign key")));
 			}
 
 			/* distributed table to local table */
@@ -394,7 +394,7 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char distributionMe
 								  errhint(
 									  "To define foreign key constraint from a local table to a "
 									  "reference table properly, use ALTER TABLE ADD CONSTRAINT ... "
-									  "command after creating the reference table without a foreing key")));
+									  "command after creating the reference table without a foreign key")));
 			}
 		}
 

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -113,7 +113,7 @@ ConstraintIsAForeignKeyToReferenceTable(char *constraintName, Oid relationId)
  * - If referencing table is a reference table, error out if the referenced table is not a
  *   a reference table.
  *
- * Note that checks performed in this functions are only done via PostProcessAlterTableStmt
+ * Note that checks performed in this functions are only done via PostprocessAlterTableStmt
  * function. Another allowed case is creating foreign key constraint between a reference
  * table and a local table in coordinator. We do not check that case here as we do not have
  * post process steps for it. See ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable and its

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -474,8 +474,9 @@ ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
  */
 void
 ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid,
-																  Oid
-																  referencedTableOid,
+																  Oid referencedTableOid,
+																  AlterTableType
+																  alterTableType,
 																  Constraint *constraint)
 {
 	bool referencingIsDistributed = IsDistributedTable(referencingTableOid);

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -116,7 +116,7 @@ ConstraintIsAForeignKeyToReferenceTable(char *constraintName, Oid relationId)
  * Note that checks performed in this functions are only done via PostprocessAlterTableStmt
  * function. Another allowed case is creating foreign key constraint between a reference
  * table and a local table in coordinator. We do not check that case here as we do not have
- * post process steps for it. See ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable and its
+ * post process steps for it. See ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable and its
  * usage
  */
 void
@@ -183,7 +183,8 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 									  " or a reference table.")));
 		}
 
-		/* set referenced table related variables here in an optimized way */
+		/* set referenced table related variables here if table is referencing itself */
+
 		if (!selfReferencingTable)
 		{
 			referencedDistMethod = PartitionMethod(referencedTableId);
@@ -211,11 +212,12 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 			heapTuple = systable_getnext(scanDescriptor);
 			continue;
 		}
+
 		/*
 		 * Foreign keys from reference tables to distributed tables are not
 		 * supported.
 		 */
-		else if (referencingIsReferenceTable && !referencedIsReferenceTable)
+		if (referencingIsReferenceTable && !referencedIsReferenceTable)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot create foreign key constraint "
@@ -400,12 +402,16 @@ ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
 
 
 /*
- * ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable runs checks related to foreign
- * constraints between local tables and reference tables
+ * ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable runs checks related to ALTER
+ * ADD / DROP foreign key constraints between local tables and reference tables.
+ *
+ * If constraint is not NULL, then we perform checks for ADD command, otherwise we check for DROP.
  */
 void
-ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid, Oid
-													  referencedTableOid)
+ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid,
+																  Oid
+																  referencedTableOid,
+																  Constraint *constraint)
 {
 	bool referencingIsDistributed = IsDistributedTable(referencingTableOid);
 	char referencingDistMethod = 0;
@@ -431,18 +437,44 @@ ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid, O
 	if ((referencingIsReferenceTable && !referencedIsDistributed) ||
 		(!referencingIsDistributed && referencedIsReferenceTable))
 	{
+		/* constraint is not NULL when the command is ALTER TABLE ADD constraint */
+		if (constraint != NULL)
+		{
+			/*
+			 * "ALTER TABLE reference_table ADD CONSTRAINT fkey FOREIGN KEY REFERENCES
+			 * local_table ON DELETE (UPDATE) CASCADE" commands are not supported
+			 */
+			bool onDeleteOrOnUpdateCascade = (constraint->fk_upd_action ==
+											  FKCONSTR_ACTION_CASCADE ||
+											  constraint->fk_del_action ==
+											  FKCONSTR_ACTION_CASCADE);
+			
+			bool fromReferenceTableToLocalTable = referencingIsReferenceTable && !referencedIsDistributed;
+			
+			if (fromReferenceTableToLocalTable && onDeleteOrOnUpdateCascade)
+			{
+				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								errmsg(
+									"cannot create foreign key constraint"),
+								errdetail(
+									"Foreign key constraints from reference tables to coordinator "
+									"local tables cannot enforce ON DELETE / UPDATE CASCADE behaviour")));
+			}
+		}
+
+		/* ALTER TABLE ADD / DROP fkey constraint */
+
 		/*
-		 * TODO: I should add a comment for rationale behind it
+		 * For now, we do not allow ALTER TABLE ADD/DROP fkey commands in multi
+		 * statement transactions
 		 */
 		if (IsMultiStatementTransaction())
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-
-			                /* TODO: is this error applicable ? */
 							errmsg(
-								"cannot define foreign key constraint between local tables "
-								"and reference tables in a transaction block, udf block, or "
-								"distributed CTE subquery")));
+								"cannot ADD/DROP foreign key constraint between coordinator "
+								"local tables and reference tables in a transaction block, "
+								"udf block, or distributed CTE subquery")));
 		}
 
 		/*
@@ -453,13 +485,13 @@ ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid, O
 		{
 			ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 							errmsg(
-								"cannot create foreign key constraint"),
+								"cannot ADD/DROP foreign key constraint"),
 							errdetail(
 								"Referenced table must be a distributed table"
 								" or a reference table or a local table in coordinator."),
 							errhint(
-								"To define foreign constraint between reference tables "
-								"and local tables, consider adding coordinator "
+								"To ADD/DROP foreign constraint between reference tables "
+								"and coordinator local tables, consider adding coordinator "
 								"to pg_dist_node as well.")));
 		}
 	}

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -437,12 +437,14 @@ ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid, O
 		if (IsMultiStatementTransaction())
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				/* TODO: is this error applicable ? */
-				errmsg(
-					"cannot define foreign key constraint between local tables "
-					"and reference tables in a transaction block, udf block, or "
-					"distributed CTE subquery")));
+
+			                /* TODO: is this error applicable ? */
+							errmsg(
+								"cannot define foreign key constraint between local tables "
+								"and reference tables in a transaction block, udf block, or "
+								"distributed CTE subquery")));
 		}
+
 		/*
 		 * Check if we are in the coordinator and coordinator can have reference
 		 * table replicas

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -674,7 +674,7 @@ AlterTableUpdateRefTableAddDropFKeyConstraints(AlterTableStmt *alterTableStateme
 			{
 				/*
 				 * Find referenced table OID by traversing the constraints defined for
-				 * local table. If referenced table is the only shard of a reference 
+				 * local table. If referenced table is the only shard of a reference
 				 * table, find the reference table ownning that shard and perform checks
 				 * via
 				 * ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable
@@ -688,9 +688,13 @@ AlterTableUpdateRefTableAddDropFKeyConstraints(AlterTableStmt *alterTableStateme
 				/* search owner relation only in current search path */
 				bool onlySearchPath = true;
 
-				Oid candidateReferenceTableOid = GetRelationOidOwningShardOid(referencedRelationOid, onlySearchPath);
+				Oid candidateReferenceTableOid = GetRelationOidOwningShardOid(
+					referencedRelationOid, onlySearchPath);
 
-				bool candidateIsReferenceTable = OidIsValid(candidateReferenceTableOid) && (PartitionMethod(candidateReferenceTableOid) == DISTRIBUTE_BY_NONE);
+				bool candidateIsReferenceTable = OidIsValid(candidateReferenceTableOid) &&
+												 (PartitionMethod(
+													  candidateReferenceTableOid) ==
+												  DISTRIBUTE_BY_NONE);
 
 				if (!candidateIsReferenceTable)
 				{
@@ -707,7 +711,7 @@ AlterTableUpdateRefTableAddDropFKeyConstraints(AlterTableStmt *alterTableStateme
 				/*
 				 * Now we have a foreign key constraint to be droped via and ALTER TABLE DROP
 				 * CONSTRAINT command, which is previously defined from a coordinator local
-				 * table to a reference reference table, whose relation id is 
+				 * table to a reference reference table, whose relation id is
 				 * candidateReferenceTableOid
 				 */
 

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -36,7 +36,6 @@
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
-
 /* Local functions forward declarations for unsupported command checks */
 static void ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement);
 static List * InterShardDDLTaskList(Oid leftRelationId, Oid rightRelationId,

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -583,13 +583,15 @@ AlterTableUpdateAddFKeyConstraints(AlterTableStmt *alterTableStatement)
 										  (PartitionMethod(referencedRelationOid) ==
 										   DISTRIBUTE_BY_NONE);
 
+		ErrorIfUnsupportedAlterAddFKeyBetweenReferecenceAndLocalTable(
+			referencingRelationOid,
+			referencedRelationOid,
+			constraint);
+
 		/*
 		 * Replace reference table's name if we are to define foreign key constraint
 		 * between a local table and a reference table
 		 */
-
-		ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(referencingRelationOid,
-															  referencedRelationOid);
 
 		/* reference table references to a local table */
 		if (referencingIsReferenceTable && referencedIsLocalTable)

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -93,22 +93,6 @@ PreprocessDropTableStmt(Node *node, const char *queryString)
 			continue;
 		}
 
-		bool relationIsReferenceTable = (PartitionMethod(relationId) ==
-										 DISTRIBUTE_BY_NONE);
-
-		if (relationIsReferenceTable && dropTableStatement->behavior != DROP_CASCADE)
-		{
-			/*
-			 * Error out if there is a coordinator local table having a foreign
-			 * key to reference table having referenceTableOid and if drop behaviour
-			 * is not CASCADE.
-			 * Note that below function is actually designed to error out for the
-			 * opposite case, where the reference table having a foreign key to local
-			 * table, but that case will already be handled PostgreSQL
-			 */
-			ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable(relationId);
-		}
-
 		/* invalidate foreign key cache if the table involved in any foreign key */
 		if ((TableReferenced(relationId) || TableReferencing(relationId)))
 		{

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -84,10 +84,29 @@ PreprocessDropTableStmt(Node *node, const char *queryString)
 
 		Oid relationId = RangeVarGetRelid(tableRangeVar, AccessShareLock, missingOK);
 
+		bool relationIsDistributed = (relationId != InvalidOid && IsDistributedTable(
+										  relationId));
+
 		/* we're not interested in non-valid, non-distributed relations */
-		if (relationId == InvalidOid || !IsDistributedTable(relationId))
+		if (!relationIsDistributed)
 		{
 			continue;
+		}
+
+		bool relationIsReferenceTable = (PartitionMethod(relationId) ==
+										 DISTRIBUTE_BY_NONE);
+
+		if (relationIsReferenceTable && dropTableStatement->behavior != DROP_CASCADE)
+		{
+			/*
+			 * Error out if there is a coordinator local table having a foreign
+			 * key to reference table having referenceTableOid and if drop behaviour
+			 * is not CASCADE.
+			 * Note that below function is actually designed to error out for the
+			 * opposite case, where the reference table having a foreign key to local
+			 * table, but that case will already be handled PostgreSQL
+			 */
+			ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable(relationId);
 		}
 
 		/* invalidate foreign key cache if the table involved in any foreign key */

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -42,8 +42,7 @@
 /* Local functions forward declarations for unsupported command checks */
 static Oid GetReferencedTableOidByFKeyConstraintName(Oid referencingRelationOid, const
 													 char *constraintName);
-static void AlterTableUpdateRefTableAddDropFKeyConstraints(
-	AlterTableStmt *alterTableStatement);
+static void PreprocessAlterTableAddDropFKey(AlterTableStmt *alterTableStatement);
 static void ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement);
 static List * InterShardDDLTaskList(Oid leftRelationId, Oid rightRelationId,
 									const char *commandString);
@@ -287,7 +286,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
 	 * In the mean time, set skip_validation fields to true if needed.
 	 * See function's leading comment.
 	 */
-	AlterTableUpdateRefTableAddDropFKeyConstraints(alterTableStatement);
+	PreprocessAlterTableAddDropFKey(alterTableStatement);
 
 	LOCKMODE lockmode = AlterTableGetLockLevel(alterTableStatement->cmds);
 	Oid leftRelationId = AlterTableLookupRelation(alterTableStatement, lockmode);
@@ -321,7 +320,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
 	 *  - is a distributed table, then we already error'ed out in CreateDistributedPlan
 	 *  - is a reference table, then PostgreSQL will just handle the rest as we already
 	 * replaced reference table with its only shard while traversing the constraints in
-	 * AlterTableUpdateRefTableAddDropFKeyConstraints function
+	 * PreprocessAlterTableAddDropFKey function
 	 */
 	if (referencingIsLocalTable)
 	{
@@ -382,7 +381,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
 
 				/*
 				 * We already inspected this case and performed other needed changes in
-				 * AlterTableUpdateRefTableAddDropFKeyConstraints function
+				 * PreprocessAlterTableAddDropFKey function
 				 */
 			}
 		}
@@ -483,7 +482,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
 		 * Here we return NIL if referenced table is a local table and referencing
 		 * table is a local table for PostgreSQL to handle the rest as we already
 		 * replaced reference table with its only shard while traversing the
-		 * constraints in AlterTableUpdateRefTableAddDropFKeyConstraints
+		 * constraints in PreprocessAlterTableAddDropFKey
 		 */
 		if (referencedIsLocalTable)
 		{
@@ -516,7 +515,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
 
 
 /*
- * AlterTableUpdateRefTableAddDropFKeyConstraints function replaces reference table name on
+ * PreprocessAlterTableAddDropFKey function replaces reference table name on
  * table(s) if we are to define foreign key constraint between a local table and
  * a reference table. It can be the the referencing relation or the referenced
  * relation indicated in a "constraint" field within the subcommands.
@@ -526,7 +525,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
  * constraint subcommands if the referencing table not a local table
  */
 static void
-AlterTableUpdateRefTableAddDropFKeyConstraints(AlterTableStmt *alterTableStatement)
+PreprocessAlterTableAddDropFKey(AlterTableStmt *alterTableStatement)
 {
 	/* TODO: should I take lock here */
 	Oid referencingRelationOid = AlterTableLookupRelation(alterTableStatement, NoLock);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -579,6 +579,7 @@ PreprocessAlterTableAddDropFKey(AlterTableStmt *alterTableStatement)
 			ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(
 				referencingRelationOid,
 				referencedRelationOid,
+				AT_AddConstraint,
 				constraint);
 
 			/*
@@ -666,6 +667,7 @@ PreprocessAlterTableAddDropFKey(AlterTableStmt *alterTableStatement)
 				ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(
 					referencingRelationOid,
 					referencedRelationOid,
+					AT_DropConstraint,
 					constraint);
 
 				/* rewrite referenced table name */
@@ -725,6 +727,7 @@ PreprocessAlterTableAddDropFKey(AlterTableStmt *alterTableStatement)
 				ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(
 					referencingRelationOid,
 					candidateReferenceTableOid,
+					AT_DropConstraint,
 					constraint);
 			}
 		}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1139,7 +1139,7 @@ ErrorIfUnsupportedConstraint(Relation relation, char distributionMethod,
 	 * We first perform check for foreign constraints. It is important to do this check
 	 * before next check, because other types of constraints are allowed on reference
 	 * tables and we return early for those constraints thanks to next check. Therefore,
-	 * for reference tables, we first check for foreing constraints and if they are OK,
+	 * for reference tables, we first check for foreign constraints and if they are OK,
 	 * we do not error out for other types of constraints.
 	 */
 	ErrorIfUnsupportedForeignConstraintExists(relation, distributionMethod,

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -651,7 +651,10 @@ IsValidLocalReferenceTableJoinPlan(PlannedStmt *plan)
 			return false;
 		}
 
-		if (RelationIsAKnownShard(rangeTableEntry->relid, onlySearchPath))
+		/* check if the relation in range table entry is a know shard relation */
+		Oid ownerRelationOid = GetRelationOidOwningShardOid(rangeTableEntry->relid, onlySearchPath);
+		
+		if (OidIsValid(ownerRelationOid))
 		{
 			/*
 			 * We don't allow joining non-reference distributed tables, so we

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -68,7 +68,7 @@ int ExecutorLevel = 0;
 /* local function forward declarations */
 static Relation StubRelation(TupleDesc tupleDescriptor);
 static bool AlterTableConstraintCheck(QueryDesc *queryDesc);
-static bool IsLocalReferenceTableJoinPlan(PlannedStmt *plan);
+static bool IsValidLocalReferenceTableJoinPlan(PlannedStmt *plan);
 
 /*
  * CitusExecutorStart is the ExecutorStart_hook that gets called when
@@ -121,6 +121,11 @@ void
 CitusExecutorRun(QueryDesc *queryDesc,
 				 ScanDirection direction, uint64 count, bool execute_once)
 {
+	/*
+	 * Check if we are in the coordinator and coordinator can have reference
+	 * table replicas
+	 */
+
 	DestReceiver *dest = queryDesc->dest;
 
 	PG_TRY();
@@ -129,19 +134,19 @@ CitusExecutorRun(QueryDesc *queryDesc,
 
 		if (CitusHasBeenLoaded())
 		{
-			if (IsLocalReferenceTableJoinPlan(queryDesc->plannedstmt) &&
-				IsMultiStatementTransaction())
+			if (IsValidLocalReferenceTableJoinPlan(queryDesc->plannedstmt) && IsMultiStatementTransaction())
 			{
 				/*
-				 * Currently we don't support this to avoid problems with tuple
-				 * visibility, locking, etc. For example, change to the reference
-				 * table can go through a MultiConnection, which won't be visible
-				 * to the locally planned queries.
-				 */
+				* Currently we don't support this to avoid problems with tuple
+				* visibility, locking, etc. For example, change to the reference
+				* table can go through a MultiConnection, which won't be visible
+				* to the locally planned queries.
+				*/
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("cannot join local tables and reference tables in "
-									   "a transaction block, udf block, or distributed "
-									   "CTE subquery")));
+								errmsg(
+									"cannot join local tables and reference tables in "
+									"a transaction block, udf block, or distributed "
+									"CTE subquery")));
 			}
 		}
 
@@ -577,13 +582,13 @@ AlterTableConstraintCheck(QueryDesc *queryDesc)
 
 
 /*
- * IsLocalReferenceTableJoinPlan returns true if the given plan joins local tables
- * with reference table shards.
+ * IsValidLocalReferenceTableJoinPlan returns true if the given plan
+ * is a valid join between reference tables and local tables
  *
- * This should be consistent with IsLocalReferenceTableJoin() in distributed_planner.c.
+ * This should be consistent with IsValidLocalReferenceTableJoin() in distributed_planner.c.
  */
 static bool
-IsLocalReferenceTableJoinPlan(PlannedStmt *plan)
+IsValidLocalReferenceTableJoinPlan(PlannedStmt *plan)
 {
 	bool hasReferenceTable = false;
 	bool hasLocalTable = false;

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -589,9 +589,9 @@ IsLocalReferenceTableJoinPlan(PlannedStmt *plan)
 	bool hasLocalTable = false;
 	ListCell *rangeTableCell = NULL;
 
-	/* 
+	/*
 	 * Check if we are in the coordinator and coordinator can have reference
-	 * table replicas 
+	 * table replicas
 	 */
 	if (!CanUseCoordinatorLocalTablesWithReferenceTables())
 	{

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -652,8 +652,9 @@ IsValidLocalReferenceTableJoinPlan(PlannedStmt *plan)
 		}
 
 		/* check if the relation in range table entry is a know shard relation */
-		Oid ownerRelationOid = GetRelationOidOwningShardOid(rangeTableEntry->relid, onlySearchPath);
-		
+		Oid ownerRelationOid = GetRelationOidOwningShardOid(rangeTableEntry->relid,
+															onlySearchPath);
+
 		if (OidIsValid(ownerRelationOid))
 		{
 			/*

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -588,28 +588,12 @@ IsLocalReferenceTableJoinPlan(PlannedStmt *plan)
 	bool hasReferenceTable = false;
 	bool hasLocalTable = false;
 	ListCell *rangeTableCell = NULL;
-	bool hasReferenceTableReplica = false;
 
-	/*
-	 * We only allow join between reference tables and local tables in the
-	 * coordinator.
+	/* 
+	 * Check if we are in the coordinator and coordinator can have reference
+	 * table replicas 
 	 */
-	if (!IsCoordinator())
-	{
-		return false;
-	}
-
-	/*
-	 * All groups that have pg_dist_node entries, also have reference
-	 * table replicas.
-	 */
-	PrimaryNodeForGroup(GetLocalGroupId(), &hasReferenceTableReplica);
-
-	/*
-	 * If reference table doesn't have replicas on the coordinator, we don't
-	 * allow joins with local tables.
-	 */
-	if (!hasReferenceTableReplica)
+	if (!CanUseCoordinatorLocalTablesWithReferenceTables())
 	{
 		return false;
 	}

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -134,14 +134,15 @@ CitusExecutorRun(QueryDesc *queryDesc,
 
 		if (CitusHasBeenLoaded())
 		{
-			if (IsValidLocalReferenceTableJoinPlan(queryDesc->plannedstmt) && IsMultiStatementTransaction())
+			if (IsValidLocalReferenceTableJoinPlan(queryDesc->plannedstmt) &&
+				IsMultiStatementTransaction())
 			{
 				/*
-				* Currently we don't support this to avoid problems with tuple
-				* visibility, locking, etc. For example, change to the reference
-				* table can go through a MultiConnection, which won't be visible
-				* to the locally planned queries.
-				*/
+				 * Currently we don't support this to avoid problems with tuple
+				 * visibility, locking, etc. For example, change to the reference
+				 * table can go through a MultiConnection, which won't be visible
+				 * to the locally planned queries.
+				 */
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								errmsg(
 									"cannot join local tables and reference tables in "

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -507,6 +507,30 @@ LoadShardIntervalList(Oid relationId)
 
 
 /*
+ * GetOnlyShardOidOfReferenceTable returns oid of the one and only shard of the
+ * given reference table. Caller of this function must ensure that referenceTableOid
+ * is owned by a reference table.
+ */
+Oid
+GetOnlyShardOidOfReferenceTable(Oid referenceTableOid)
+{
+	/* TODO: should we use LoadShardIntervalList here ? */
+	ShardInterval *referenceTableShardInterval = cacheEntry->sortedShardIntervalArray[0];
+	uint64 referenceTableShardId = shardInterval->shardId;
+
+	/* construct reference table's one & only shard's name */
+	char *referenceTableShardName = get_rel_name(referenceTableOid);
+	AppendShardIdToName(&referenceTableShardName, referenceTableShardId);
+
+	Oid referenceTableSchemaOid = get_rel_namespace(referenceTableOid);
+
+	Oid referenceTableShardOid = get_relname_relid(referenceTableShardName, referenceTableSchemaOid);
+
+	return referenceTableShardOid;
+}
+
+
+/*
  * ShardIntervalCount returns number of shard intervals for a given distributed table.
  * The function returns 0 if table is not distributed, or no shards can be found for
  * the given relation id.

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -514,9 +514,11 @@ LoadShardIntervalList(Oid relationId)
 Oid
 GetOnlyShardOidOfReferenceTable(Oid referenceTableOid)
 {
+	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(referenceTableOid);
+
 	/* TODO: should we use LoadShardIntervalList here ? */
 	ShardInterval *referenceTableShardInterval = cacheEntry->sortedShardIntervalArray[0];
-	uint64 referenceTableShardId = shardInterval->shardId;
+	uint64 referenceTableShardId = referenceTableShardInterval->shardId;
 
 	/* construct reference table's one & only shard's name */
 	char *referenceTableShardName = get_rel_name(referenceTableOid);
@@ -524,7 +526,8 @@ GetOnlyShardOidOfReferenceTable(Oid referenceTableOid)
 
 	Oid referenceTableSchemaOid = get_rel_namespace(referenceTableOid);
 
-	Oid referenceTableShardOid = get_relname_relid(referenceTableShardName, referenceTableSchemaOid);
+	Oid referenceTableShardOid = get_relname_relid(referenceTableShardName,
+												   referenceTableSchemaOid);
 
 	return referenceTableShardOid;
 }

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -772,7 +772,7 @@ ShardStorageType(Oid relationId)
 bool
 IsCoordinator(void)
 {
-	return (GetLocalGroupId() == 0);
+	return (GetLocalGroupId() == COORDINATOR_GROUP_ID);
 }
 
 

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -16,6 +16,7 @@
 
 #include "commands/dbcommands.h"
 #include "distributed/hash_helpers.h"
+#include "distributed/master_protocol.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_client_executor.h"
 #include "distributed/worker_manager.h"
@@ -45,7 +46,7 @@ static WorkerNode * FindRandomNodeFromList(List *candidateWorkerNodeList);
 static bool OddNumber(uint32 number);
 static bool ListMember(List *currentList, WorkerNode *workerNode);
 static bool NodeIsPrimaryWorker(WorkerNode *node);
-static bool CanHaveReferenceTableReplicas(void);
+static bool NodeHasReferenceTableReplicas(void);
 static bool NodeIsReadableWorker(WorkerNode *node);
 
 
@@ -400,20 +401,21 @@ NodeIsPrimaryWorker(WorkerNode *node)
 	return !NodeIsCoordinator(node) && NodeIsPrimary(node);
 }
 
+
 /*
- * CanUseCoordinatorLocalTablesWithReferenceTables returns true if we 
- * are allowed to use coordinator local tables with reference tables 
+ * CanUseCoordinatorLocalTablesWithReferenceTables returns true if we
+ * are allowed to use coordinator local tables with reference tables
  * for joining or defining foreign keys between them.
  */
 bool
 CanUseCoordinatorLocalTablesWithReferenceTables()
 {
 	/*
-	 * Using local tables of coordinator with reference tables is only allowed 
+	 * Using local tables of coordinator with reference tables is only allowed
 	 * if we are in the coordinator.
-	 * 
+	 *
 	 * Also, to check if coordinator can have reference table replicas in below
-	 * check, we should be in the coordinator. 
+	 * check, we should be in the coordinator.
 	 */
 	if (!IsCoordinator())
 	{
@@ -424,7 +426,7 @@ CanUseCoordinatorLocalTablesWithReferenceTables()
 	 * If reference table doesn't have replicas on the coordinator, we don't
 	 * use local tables in coordinator with reference tables.
 	 */
-	if (!CanHaveReferenceTableReplicas())
+	if (!NodeHasReferenceTableReplicas())
 	{
 		return false;
 	}
@@ -434,13 +436,13 @@ CanUseCoordinatorLocalTablesWithReferenceTables()
 
 
 /*
- * CanHaveReferenceTableReplicas returns true if current node can have
+ * NodeHasReferenceTableReplicas returns true if current node can have
  * reference table replicas. This is only possible if we called below
  * command formerly
  * "SELECT master_add_node(coordinator_hostname, coordinator_port, groupId => 0)"
  */
 static bool
-CanHaveReferenceTableReplicas()
+NodeHasReferenceTableReplicas()
 {
 	bool hasReferenceTableReplica = false;
 

--- a/src/backend/distributed/master/worker_node_manager.c
+++ b/src/backend/distributed/master/worker_node_manager.c
@@ -408,7 +408,7 @@ NodeIsPrimaryWorker(WorkerNode *node)
  * for joining or defining foreign keys between them.
  */
 bool
-CanUseCoordinatorLocalTablesWithReferenceTables()
+CanUseCoordinatorLocalTablesWithReferenceTables(void)
 {
 	/*
 	 * Using local tables of coordinator with reference tables is only allowed
@@ -442,7 +442,7 @@ CanUseCoordinatorLocalTablesWithReferenceTables()
  * "SELECT master_add_node(coordinator_hostname, coordinator_port, groupId => 0)"
  */
 static bool
-NodeHasReferenceTableReplicas()
+NodeHasReferenceTableReplicas(void)
 {
 	bool hasReferenceTableReplica = false;
 

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -2221,14 +2221,7 @@ UpdateReferenceTablesWithShard(Node *node, void *context)
 		return false;
 	}
 
-	ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[0];
-	uint64 shardId = shardInterval->shardId;
-
-	char *relationName = get_rel_name(relationId);
-	AppendShardIdToName(&relationName, shardId);
-
-	Oid schemaId = get_rel_namespace(relationId);
-	newRte->relid = get_relname_relid(relationName, schemaId);
+	newRte->relid = GetOnlyShardOidOfReferenceTable(relationId);
 
 	/*
 	 * Parser locks relations in addRangeTableEntry(). So we should lock the

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -15,6 +15,7 @@
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/genam.h"
+#include "catalog/pg_constraint.h"
 #include "distributed/colocation_utils.h"
 #include "distributed/commands.h"
 #include "distributed/listutils.h"
@@ -400,16 +401,18 @@ CreateReferenceTableColocationId()
 
 
 /*
- * DeleteAllReferenceTablePlacementsFromNodeGroup function iterates over list of reference
- * tables and deletes all reference table placements from pg_dist_placement table
- * for given group.
+ * DeleteAllReferenceTablePlacementsFromNodeGroup function iterates over list of
+ * reference tables and deletes all reference table placements from pg_dist_placement
+ * table for given group.
+ *
+ * Error out if we are to remove coordinator if it has reference table replicas and
+ * if any of those replicas is involved in a foreign constraint with a coordinator
+ * local table.
  */
 void
 DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId)
 {
 	List *referenceTableList = ReferenceTableOidList();
-	List *referenceShardIntervalList = NIL;
-	ListCell *referenceTableCell = NULL;
 
 	/* if there are no reference tables, we do not need to do anything */
 	if (list_length(referenceTableList) == 0)
@@ -424,11 +427,13 @@ DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId)
 	referenceTableList = SortList(referenceTableList, CompareOids);
 	if (ClusterHasKnownMetadataWorkers())
 	{
-		referenceShardIntervalList = GetSortedReferenceShardIntervals(referenceTableList);
+		List *referenceShardIntervalList = GetSortedReferenceShardIntervals(
+			referenceTableList);
 
 		BlockWritesToShardList(referenceShardIntervalList);
 	}
 
+	ListCell *referenceTableCell = NULL;
 	foreach(referenceTableCell, referenceTableList)
 	{
 		StringInfo deletePlacementCommand = makeStringInfo();
@@ -443,10 +448,21 @@ DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId)
 		}
 
 		GroupShardPlacement *placement = (GroupShardPlacement *) linitial(placements);
+		uint64 referenceTableShardId = placement->shardId;
 
-		LockShardDistributionMetadata(placement->shardId, ExclusiveLock);
+		LockShardDistributionMetadata(referenceTableShardId, ExclusiveLock);
 
 		DeleteShardPlacementRow(placement->placementId);
+
+		/*
+		 * Error out if we are to remove coordinator and if reference table with
+		 * referenceTableId is involved in a foreign constraint with a coordinator
+		 * local table.
+		 */
+		if (groupId == COORDINATOR_GROUP_ID)
+		{
+			ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(referenceTableId);
+		}
 
 		appendStringInfo(deletePlacementCommand,
 						 "DELETE FROM pg_dist_placement WHERE placementid = "

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -461,7 +461,7 @@ DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId)
 		 */
 		if (groupId == COORDINATOR_GROUP_ID)
 		{
-			ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(referenceTableId);
+			ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable(referenceTableId);
 		}
 
 		appendStringInfo(deletePlacementCommand,

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -13,6 +13,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_class.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/master_protocol.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/worker_shard_visibility.h"
 #include "nodes/nodeFuncs.h"
@@ -124,8 +125,7 @@ GetRelationOidOwningShardOid(Oid shardRelationId, bool onlySearchPath)
 		return InvalidOid;
 	}
 
-	int localGroupId = GetLocalGroupId();
-	if (localGroupId == 0)
+	if (IsCoordinator())
 	{
 		bool coordinatorIsKnown = false;
 		PrimaryNodeForGroup(0, &coordinatorIsKnown);

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -31,7 +31,7 @@ PG_FUNCTION_INFO_V1(relation_is_a_known_shard);
 
 /*
  * relation_is_a_known_shard a wrapper around GetRelationOidOwningShardOid(),
- * so see the details there. The function also treats the indexes on shards as 
+ * so see the details there. The function also treats the indexes on shards as
  * if they were shards.
  */
 Datum
@@ -44,7 +44,7 @@ relation_is_a_known_shard(PG_FUNCTION_ARGS)
 
 	/* return if the relation in range table entry is a know shard relation */
 	Oid ownerRelationOid = GetRelationOidOwningShardOid(relationId, onlySearchPath);
-	
+
 	PG_RETURN_BOOL(OidIsValid(ownerRelationOid));
 }
 
@@ -71,10 +71,10 @@ citus_table_is_visible(PG_FUNCTION_ARGS)
 	{
 		PG_RETURN_NULL();
 	}
-	
+
 	/* check if the relation in range table entry is a know shard relation */
 	Oid ownerRelationOid = GetRelationOidOwningShardOid(relationId, onlySearchPath);
-	
+
 	if (OidIsValid(ownerRelationOid))
 	{
 		/*
@@ -103,7 +103,7 @@ citus_table_is_visible(PG_FUNCTION_ARGS)
 
 
 /*
- * RelationOwningShardRelationOid gets a relationId, returns OID 
+ * RelationOwningShardRelationOid gets a relationId, returns OID
  * of the relation owning the shard if it's a valid shard of it.
  * In case of failure, It returns InvalidOid if missingOk is true,
  * otherwise may error out in subsequent function calls.

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -97,12 +97,12 @@ extern void ErrorIfUnsupportedForeignConstraintExists(Relation relation,
 													  char distributionMethod,
 													  Var *distributionColumn,
 													  uint32 colocationId);
-extern void ErrorIfUnsupportedAlterAddFKeyBetweenReferecenceAndLocalTable(Oid
-																		  referencingTableOid,
-																		  Oid
-																		  referencedTableOid,
-																		  Constraint *
-																		  constraint);
+extern void ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oid
+																			  referencingTableOid,
+																			  Oid
+																			  referencedTableOid,
+																			  Constraint *
+																			  constraint);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -103,8 +103,8 @@ extern void ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oi
 																			  referencedTableOid,
 																			  Constraint *
 																			  constraint);
-extern void ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(Oid
-																	 referenceTableOid);
+extern void ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable(Oid
+																		referenceTableOid);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -97,9 +97,12 @@ extern void ErrorIfUnsupportedForeignConstraintExists(Relation relation,
 													  char distributionMethod,
 													  Var *distributionColumn,
 													  uint32 colocationId);
-extern void ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid,
-																  Oid
-																  referencedTableOid);
+extern void ErrorIfUnsupportedAlterAddFKeyBetweenReferecenceAndLocalTable(Oid
+																		  referencingTableOid,
+																		  Oid
+																		  referencedTableOid,
+																		  Constraint *
+																		  constraint);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -101,6 +101,8 @@ extern void ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oi
 																			  referencingTableOid,
 																			  Oid
 																			  referencedTableOid,
+																			  AlterTableType
+																			  alterTableType,
 																			  Constraint *
 																			  constraint);
 extern void ErrorIfCoordinatorHasLocalTableHavingFKeyWithReferenceTable(Oid

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -103,6 +103,8 @@ extern void ErrorIfUnsupportedAlterAddDropFKeyBetweenReferecenceAndLocalTable(Oi
 																			  referencedTableOid,
 																			  Constraint *
 																			  constraint);
+extern void ErrorIfCoordinatorHasLocalTableReferencingReferenceTable(Oid
+																	 referenceTableOid);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -97,6 +97,9 @@ extern void ErrorIfUnsupportedForeignConstraintExists(Relation relation,
 													  char distributionMethod,
 													  Var *distributionColumn,
 													  uint32 colocationId);
+extern void ErrorIfUnsupportedFKeyBetweenReferecenceAndLocalTable(Oid referencingTableOid,
+																  Oid
+																  referencedTableOid);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -99,6 +99,7 @@ extern Datum citus_relation_size(PG_FUNCTION_ARGS);
 /* Function declarations to read shard and shard placement data */
 extern uint32 TableShardReplicationFactor(Oid relationId);
 extern List * LoadShardIntervalList(Oid relationId);
+extern Oid GetOnlyShardOidOfReferenceTable(Oid referenceTableOid);
 extern int ShardIntervalCount(Oid relationId);
 extern List * LoadShardList(Oid relationId);
 extern void CopyShardInterval(ShardInterval *srcInterval, ShardInterval *destInterval);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -72,6 +72,7 @@ extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern uint32 ActivePrimaryWorkerNodeCount(void);
 extern List * ActivePrimaryWorkerNodeList(LOCKMODE lockMode);
 extern List * ActivePrimaryNodeList(LOCKMODE lockMode);
+extern bool CanUseCoordinatorLocalTablesWithReferenceTables(void);
 extern List * ReferenceTablePlacementNodeList(LOCKMODE lockMode);
 extern List * DistributedTablePlacementNodeList(LOCKMODE lockMode);
 extern bool NodeCanHaveDistTablePlacements(WorkerNode *node);

--- a/src/include/distributed/worker_shard_visibility.h
+++ b/src/include/distributed/worker_shard_visibility.h
@@ -17,7 +17,7 @@ extern bool OverrideTableVisibility;
 
 
 extern void ReplaceTableVisibleFunction(Node *inputNode);
-extern bool RelationIsAKnownShard(Oid shardRelationId, bool onlySearchPath);
+extern Oid GetRelationOidOwningShardOid(Oid shardRelationId, bool onlySearchPath);
 
 
 #endif /* WORKER_SHARD_VISIBILITY_H */

--- a/src/test/regress/expected/failure_multi_shard_update_delete.out
+++ b/src/test/regress/expected/failure_multi_shard_update_delete.out
@@ -24,6 +24,9 @@ SELECT create_distributed_table('t1', 'a');
 (1 row)
 
 SELECT create_reference_table('r1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/foreign_key_between_refrence_table_local_table.out
+++ b/src/test/regress/expected/foreign_key_between_refrence_table_local_table.out
@@ -1,0 +1,215 @@
+CREATE SCHEMA fkey_reference_local_table;
+SET search_path TO 'fkey_reference_local_table';
+-- create test tables
+CREATE TABLE local_table(l1 int);
+CREATE TABLE reference_table(r1 int primary key);
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- foreign key from local table to reference table --
+-- this should fail
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+ERROR:  cannot ADD/DROP foreign key constraint
+DETAIL:  Referenced table must be a distributed table or a reference table or a local table in coordinator.
+HINT:  To ADD/DROP foreign constraint between reference tables and coordinator local tables, consider adding coordinator to pg_dist_node as well.
+-- we do not support ALTER TABLE ADD CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+ERROR:  cannot ADD/DROP foreign key constraint between coordinator local tables and reference tables in a transaction block, udf block, or distributed CTE subquery
+COMMIT;
+-- replicate reference table to coordinator
+SELECT master_add_node('localhost', :master_port, groupId => 0);
+NOTICE:  Replicating reference table "orders_reference" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "customer" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "nation" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "part" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "supplier" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "multi_outer_join_right_reference" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "multi_outer_join_third_reference" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "reference_table" to the node localhost:xxxxx
+ master_add_node
+---------------------------------------------------------------------
+               4
+(1 row)
+
+-- we support ON DELETE CASCADE behaviour in "ALTER TABLE ADD fkey local_table (to reference_table) commands
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE CASCADE;
+-- show that on delete cascade works
+INSERT INTO reference_table VALUES (11);
+INSERT INTO local_table VALUES (11);
+DELETE FROM reference_table WHERE r1=11;
+SELECT * FROM local_table ORDER BY l1;
+ l1
+---------------------------------------------------------------------
+(0 rows)
+
+-- show that we support drop constraint
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+-- we support ON UPDATE CASCADE behaviour in "ALTER TABLE ADD fkey local_table (to reference table)" commands
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1) ON UPDATE CASCADE;
+-- show that on delete cascade works
+INSERT INTO reference_table VALUES (12);
+INSERT INTO local_table VALUES (12);
+UPDATE reference_table SET r1=13 WHERE r1=12;
+SELECT * FROM local_table ORDER BY l1;
+ l1
+---------------------------------------------------------------------
+ 13
+(1 row)
+
+-- drop constraint for next commands
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+-- show that we are checking for foreign key constraint while defining
+INSERT INTO local_table VALUES (2);
+-- this should fail
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+ERROR:  insert or update on table "local_table" violates foreign key constraint "fkey_local_to_ref"
+DETAIL:  Key (l1)=(2) is not present in table "reference_table_1190015".
+INSERT INTO reference_table VALUES (2);
+-- this should work
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+-- show that we are checking for foreign key constraint after defining
+-- this should fail
+INSERT INTO local_table VALUES (1);
+ERROR:  insert or update on table "local_table" violates foreign key constraint "fkey_local_to_ref"
+DETAIL:  Key (l1)=(1) is not present in table "reference_table_1190015".
+INSERT INTO reference_table VALUES (1);
+-- this should work
+INSERT INTO local_table VALUES (1);
+-- we do not support ALTER TABLE DROP CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+ERROR:  cannot ADD/DROP foreign key constraint between coordinator local tables and reference tables in a transaction block, udf block, or distributed CTE subquery
+COMMIT;
+-- show that we do not allow removing coordinator when we have a fkey constraint
+-- between a coordinator local table and a reference table
+SELECT master_remove_node('localhost', :master_port);
+ERROR:  cannot remove reference table placement from coordinator
+DETAIL:  Local table "local_table" is involved in a foreign key constraint with refence table "reference_table", which has replica in coordinator
+HINT:  DROP foreign key constraint between them or drop referenced table with DROP ... CASCADE.
+-- drop and add constraint for next commands
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+-- show that drop table without CASCADE does not error as we already append CASCADE
+DROP TABLE reference_table;
+-- drop local_table finally
+DROP TABLE local_table;
+-- TODO: drop them together after fixing the bug
+-- create test tables
+CREATE TABLE local_table(l1 int primary key);
+CREATE TABLE reference_table(r1 int);
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- remove master node from pg_dist_node
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+-- foreign key from reference table to local table --
+-- this should fail
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+ERROR:  cannot ADD/DROP foreign key constraint
+DETAIL:  Referenced table must be a distributed table or a reference table or a local table in coordinator.
+HINT:  To ADD/DROP foreign constraint between reference tables and coordinator local tables, consider adding coordinator to pg_dist_node as well.
+-- we do not support ALTER TABLE ADD CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+ERROR:  cannot ADD/DROP foreign key constraint between coordinator local tables and reference tables in a transaction block, udf block, or distributed CTE subquery
+COMMIT;
+-- replicate reference table to coordinator
+SELECT master_add_node('localhost', :master_port, groupId => 0);
+NOTICE:  Replicating reference table "orders_reference" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "customer" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "nation" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "part" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "supplier" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "multi_outer_join_right_reference" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "multi_outer_join_third_reference" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "reference_table" to the node localhost:xxxxx
+ master_add_node
+---------------------------------------------------------------------
+               5
+(1 row)
+
+-- show that we are checking for foreign key constraint while defining
+INSERT INTO reference_table VALUES (3);
+-- this should fail
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+ERROR:  insert or update on table "reference_table_1190016" violates foreign key constraint "fkey_ref_to_local"
+DETAIL:  Key (r1)=(3) is not present in table "local_table".
+INSERT INTO local_table VALUES (3);
+-- this should work
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+-- show that we are checking for foreign key constraint after defining
+-- this should fail
+INSERT INTO reference_table VALUES (4);
+ERROR:  insert or update on table "reference_table_1190016" violates foreign key constraint "fkey_ref_to_local"
+DETAIL:  Key (r1)=(4) is not present in table "local_table".
+INSERT INTO local_table VALUES (4);
+-- we do not support ON DELETE/UPDATE CASCADE behaviour in "ALTER TABLE ADD fkey reference_table (to local_table)" commands
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1) ON DELETE CASCADE;
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints from reference tables to coordinator local tables can only enforce RESTRICT or NO ACTION behaviour ON DELETE / UPDATE
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1) ON UPDATE CASCADE;
+ERROR:  cannot create foreign key constraint
+DETAIL:  Foreign key constraints from reference tables to coordinator local tables can only enforce RESTRICT or NO ACTION behaviour ON DELETE / UPDATE
+-- this should work
+INSERT INTO reference_table VALUES (4);
+-- we do not support ALTER TABLE DROP CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE reference_table DROP CONSTRAINT fkey_ref_to_local;
+ERROR:  cannot ADD/DROP foreign key constraint between coordinator local tables and reference tables in a transaction block, udf block, or distributed CTE subquery
+COMMIt;
+-- show that we do not allow removing coordinator when we have a fkey constraint
+-- between a coordinator local table and a reference table
+SELECT master_remove_node('localhost', :master_port);
+ERROR:  cannot remove reference table placement from coordinator
+DETAIL:  Local table "local_table" is involved in a foreign key constraint with refence table "reference_table", which has replica in coordinator
+HINT:  DROP foreign key constraint between them or drop referenced table with DROP ... CASCADE.
+-- show that we support drop constraint
+ALTER TABLE reference_table DROP CONSTRAINT fkey_ref_to_local;
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+-- show that drop table errors as expected
+DROP TABLE local_table;
+ERROR:  cannot drop table local_table because other objects depend on it
+DETAIL:  constraint fkey_ref_to_local on table reference_table_1190016 depends on table local_table
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+-- this should work
+DROP TABLE local_table CASCADE;
+NOTICE:  drop cascades to constraint fkey_ref_to_local on table reference_table_1190016
+-- drop reference_table finally
+DROP TABLE reference_table;
+-- TODO: drop them together after fixing the bug
+-- TODO: test schema / table name escape
+-- TODO: test create table behaviour, also implement error out conditions
+-- TODO: partitioned tables
+-- TEARDOWN -- -- -- --
+-- print table reference table content to make sure we successfully inserted/deleted values
+SELECT * FROM reference_table ORDER BY r1;
+ERROR:  relation "reference_table" does not exist
+-- remove master node from pg_dist_node
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+-- print table contents to make sure we successfully inserted/deleted values
+SELECT * FROM local_table ORDER BY l1;
+ERROR:  relation "local_table" does not exist
+SELECT * FROM reference_table ORDER BY r1;
+ERROR:  relation "reference_table" does not exist
+DROP SCHEMA fkey_reference_local_table;

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -1242,6 +1242,9 @@ BEGIN;
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 	INSERT INTO test_table_2 SELECT i, i FROM generate_series(0,100) i;
 	SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
 NOTICE:  Copying data from local table...
  create_reference_table
 ---------------------------------------------------------------------
@@ -1266,6 +1269,9 @@ BEGIN;
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 	INSERT INTO test_table_2 SELECT i, i FROM generate_series(0,100) i;
 	SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
 NOTICE:  Copying data from local table...
  create_reference_table
 ---------------------------------------------------------------------
@@ -1287,6 +1293,9 @@ BEGIN;
 	CREATE TABLE test_table_1(id int PRIMARY KEY);
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 	SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table.out
@@ -745,6 +745,9 @@ CREATE TABLE referencing_table(id int, ref_id int DEFAULT -1, FOREIGN KEY (ref_i
 INSERT INTO referenced_table VALUES (1,1), (2,2), (3,3);
 INSERT INTO referencing_table VALUES (1,1), (2,2), (3,3);
 SELECT create_reference_table('referenced_table');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
 NOTICE:  Copying data from local table...
  create_reference_table
 ---------------------------------------------------------------------
@@ -859,12 +862,18 @@ CREATE TABLE referenced_table(test_column int, test_column2 int, PRIMARY KEY(tes
 CREATE TABLE referenced_table2(test_column int, test_column2 int, PRIMARY KEY(test_column2));
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY (id) REFERENCES referenced_table(test_column) ON DELETE CASCADE, FOREIGN KEY (id) REFERENCES referenced_table2(test_column2) ON DELETE CASCADE);
 SELECT create_reference_table('referenced_table');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
 (1 row)
 
 SELECT create_reference_table('referenced_table2');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -985,6 +994,7 @@ CREATE TABLE referenced_table2(test_column int, test_column2 int, PRIMARY KEY(te
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY (id) REFERENCES referenced_table(test_column) ON DELETE CASCADE);
 BEGIN;
   SELECT create_reference_table('referenced_table');
+WARNING:  should not create foreign key constraint in this way
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1125,6 +1135,12 @@ CREATE TABLE referenced_table(test_column int, test_column2 int UNIQUE, PRIMARY 
 CREATE TABLE referencing_table(id int PRIMARY KEY, ref_id int, FOREIGN KEY (id) REFERENCES referenced_table(test_column) ON DELETE CASCADE);
 CREATE TABLE referencing_table2(id int, ref_id int, FOREIGN KEY (ref_id) REFERENCES referenced_table(test_column2) ON DELETE CASCADE, FOREIGN KEY (id) REFERENCES referencing_table(id) ON DELETE CASCADE);
 SELECT create_reference_table('referenced_table');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1304,6 +1320,9 @@ BEGIN;
   CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
   INSERT INTO test_table_2 SELECT i, i FROM generate_series(0,100) i;
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
 NOTICE:  Copying data from local table...
  create_reference_table
 ---------------------------------------------------------------------
@@ -1321,6 +1340,9 @@ BEGIN;
   CREATE TABLE test_table_1(id int PRIMARY KEY);
   CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1341,6 +1363,9 @@ COMMIT;
 CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1401,6 +1426,9 @@ ERROR:  table "test_table_1" does not exist
 CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1426,6 +1454,9 @@ BEGIN;
   CREATE TABLE test_table_1(id int PRIMARY KEY);
   CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1451,6 +1482,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1475,6 +1509,9 @@ CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 BEGIN;
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1499,6 +1536,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1524,6 +1564,9 @@ CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 BEGIN;
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1549,6 +1592,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY, id2 int);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1585,6 +1631,9 @@ CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 BEGIN;
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1611,6 +1660,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1636,6 +1688,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1664,6 +1719,9 @@ CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 BEGIN;
   SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1690,6 +1748,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1722,6 +1783,9 @@ DROP TABLE test_table_1, test_table_2;
 CREATE TABLE test_table_1(id int PRIMARY KEY);
 CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int, FOREIGN KEY(value_1) REFERENCES test_table_1(id));
 SELECT create_reference_table('test_table_1');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -836,7 +836,7 @@ SELECT create_distributed_table('referenced_by_reference_table', 'id');
 CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_by_reference_table(id));
 SELECT create_reference_table('reference_table');
 ERROR:  cannot create foreign key constraint since foreign keys from reference tables to distributed tables are not supported
-DETAIL:  A reference table can only have reference keys to other reference tables
+DETAIL:  A reference table can only have reference keys to other reference tables or a local table in coordinator
 -- test foreign key creation on CREATE TABLE from + to reference table
 DROP TABLE reference_table;
 CREATE TABLE reference_table(id int PRIMARY KEY, referencing_column int);
@@ -886,7 +886,7 @@ SELECT create_reference_table('reference_table');
 
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_by_reference_table(id);
 ERROR:  cannot create foreign key constraint since foreign keys from reference tables to distributed tables are not supported
-DETAIL:  A reference table can only have reference keys to other reference tables
+DETAIL:  A reference table can only have reference keys to other reference tables or a local table in coordinator
 -- test foreign key creation on ALTER TABLE to reference table
 CREATE TABLE references_to_reference_table(id int, referencing_column int);
 SELECT create_distributed_table('references_to_reference_table', 'referencing_column');
@@ -920,7 +920,8 @@ SELECT create_reference_table('reference_table');
 
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_local_table(id);
 ERROR:  cannot create foreign key constraint
-DETAIL:  Referenced table must be a distributed table or a reference table.
+DETAIL:  Referenced table must be a distributed table or a reference table or a local table in coordinator.
+HINT:  To define foreign constraint between reference tables and local tables, consider adding coordinator to pg_dist_node as well.
 -- test foreign key creation on ALTER TABLE on self referencing reference table
 DROP TABLE self_referencing_reference_table;
 CREATE TABLE self_referencing_reference_table(

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -919,9 +919,9 @@ SELECT create_reference_table('reference_table');
 (1 row)
 
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_local_table(id);
-ERROR:  cannot create foreign key constraint
+ERROR:  cannot ADD/DROP foreign key constraint
 DETAIL:  Referenced table must be a distributed table or a reference table or a local table in coordinator.
-HINT:  To define foreign constraint between reference tables and local tables, consider adding coordinator to pg_dist_node as well.
+HINT:  To ADD/DROP foreign constraint between reference tables and coordinator local tables, consider adding coordinator to pg_dist_node as well.
 -- test foreign key creation on ALTER TABLE on self referencing reference table
 DROP TABLE self_referencing_reference_table;
 CREATE TABLE self_referencing_reference_table(

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -860,7 +860,8 @@ NOTICE:  drop cascades to constraint reference_table_second_referencing_column_f
 CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_local_table(id));
 SELECT create_reference_table('reference_table');
 ERROR:  cannot create foreign key constraint
-DETAIL:  Referenced table must be a distributed table or a reference table.
+DETAIL:  Local table having a foreign key constraint to another local table cannot be upgraded to a reference table
+HINT:  To define foreign key constraint from a reference table to a local table, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
 -- test foreign key creation on CREATE TABLE on self referencing reference table
 CREATE TABLE self_referencing_reference_table(
     id int,

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -661,6 +661,12 @@ CREATE TABLE ref_table_3(id int primary key, v int references ref_table_2(id));
 SELECT create_reference_table('ref_table_1'),
        create_reference_table('ref_table_2'),
        create_reference_table('ref_table_3');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table | create_reference_table | create_reference_table
 ---------------------------------------------------------------------
                         |                        |

--- a/src/test/regress/expected/mx_foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/mx_foreign_key_to_reference_table.out
@@ -30,12 +30,18 @@ CREATE TABLE referencing_table(id int, ref_id int);
 ALTER TABLE referencing_table ADD CONSTRAINT fkey_ref FOREIGN KEY (id) REFERENCES referenced_table(test_column) ON DELETE CASCADE;
 ALTER TABLE referencing_table ADD CONSTRAINT foreign_key_2 FOREIGN KEY (id) REFERENCES referenced_table2(test_column2) ON DELETE CASCADE;
 SELECT create_reference_table('referenced_table');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 
 (1 row)
 
 SELECT create_reference_table('referenced_table2');
+WARNING:  should not create foreign key constraint in this way
+DETAIL:  Local table referenced by another local table should not be upgraded to a reference table
+HINT:  To define foreign key constraint from a local table to a reference table properly, use ALTER TABLE ADD CONSTRAINT ... command after creating the reference table without a foreign key
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -191,6 +191,7 @@ test: multi_utilities foreign_key_to_reference_table validate_constraint
 test: multi_modifying_xacts
 test: multi_repartition_udt multi_repartitioned_subquery_udf multi_subtransactions
 test: multi_transaction_recovery
+test: foreign_key_between_refrence_table_local_table
 
 # ---------
 # multi_copy creates hash and range-partitioned tables and performs COPY

--- a/src/test/regress/sql/foreign_key_between_refrence_table_local_table.sql
+++ b/src/test/regress/sql/foreign_key_between_refrence_table_local_table.sql
@@ -1,0 +1,185 @@
+CREATE SCHEMA fkey_reference_local_table;
+SET search_path TO 'fkey_reference_local_table';
+
+-- create test tables
+
+CREATE TABLE local_table(l1 int);
+CREATE TABLE reference_table(r1 int primary key);
+SELECT create_reference_table('reference_table');
+
+-- foreign key from local table to reference table --
+
+-- this should fail
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+
+-- we do not support ALTER TABLE ADD CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+COMMIT;
+
+-- replicate reference table to coordinator
+SELECT master_add_node('localhost', :master_port, groupId => 0);
+
+-- we support ON DELETE CASCADE behaviour in "ALTER TABLE ADD fkey local_table (to reference_table) commands
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE CASCADE;
+
+-- show that on delete cascade works
+INSERT INTO reference_table VALUES (11);
+INSERT INTO local_table VALUES (11);
+DELETE FROM reference_table WHERE r1=11;
+SELECT * FROM local_table ORDER BY l1;
+
+-- show that we support drop constraint
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+
+-- we support ON UPDATE CASCADE behaviour in "ALTER TABLE ADD fkey local_table (to reference table)" commands
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1) ON UPDATE CASCADE;
+
+-- show that on delete cascade works
+INSERT INTO reference_table VALUES (12);
+INSERT INTO local_table VALUES (12);
+UPDATE reference_table SET r1=13 WHERE r1=12;
+SELECT * FROM local_table ORDER BY l1;
+
+-- drop constraint for next commands
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+
+-- show that we are checking for foreign key constraint while defining
+
+INSERT INTO local_table VALUES (2);
+
+-- this should fail
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+
+INSERT INTO reference_table VALUES (2);
+
+-- this should work
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+
+-- show that we are checking for foreign key constraint after defining
+
+-- this should fail
+INSERT INTO local_table VALUES (1);
+
+INSERT INTO reference_table VALUES (1);
+
+-- this should work
+INSERT INTO local_table VALUES (1);
+
+-- we do not support ALTER TABLE DROP CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+COMMIT;
+
+-- show that we do not allow removing coordinator when we have a fkey constraint
+-- between a coordinator local table and a reference table
+SELECT master_remove_node('localhost', :master_port);
+
+-- drop and add constraint for next commands
+ALTER TABLE local_table DROP CONSTRAINT fkey_local_to_ref;
+
+ALTER TABLE local_table ADD CONSTRAINT fkey_local_to_ref FOREIGN KEY(l1) REFERENCES reference_table(r1);
+
+-- show that drop table without CASCADE does not error as we already append CASCADE
+DROP TABLE reference_table;
+
+-- drop local_table finally
+DROP TABLE local_table;
+
+-- TODO: drop them together after fixing the bug
+
+-- create test tables
+
+CREATE TABLE local_table(l1 int primary key);
+CREATE TABLE reference_table(r1 int);
+SELECT create_reference_table('reference_table');
+
+-- remove master node from pg_dist_node
+SELECT master_remove_node('localhost', :master_port);
+
+-- foreign key from reference table to local table --
+
+-- this should fail
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+
+-- we do not support ALTER TABLE ADD CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+COMMIT;
+
+-- replicate reference table to coordinator
+
+SELECT master_add_node('localhost', :master_port, groupId => 0);
+
+-- show that we are checking for foreign key constraint while defining
+
+INSERT INTO reference_table VALUES (3);
+
+-- this should fail
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+
+INSERT INTO local_table VALUES (3);
+
+-- this should work
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+
+-- show that we are checking for foreign key constraint after defining
+
+-- this should fail
+INSERT INTO reference_table VALUES (4);
+
+INSERT INTO local_table VALUES (4);
+
+-- we do not support ON DELETE/UPDATE CASCADE behaviour in "ALTER TABLE ADD fkey reference_table (to local_table)" commands
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1) ON DELETE CASCADE;
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1) ON UPDATE CASCADE;
+
+-- this should work
+INSERT INTO reference_table VALUES (4);
+
+-- we do not support ALTER TABLE DROP CONSTRAINT fkey between local & reference table
+-- within a transaction block, below block should fail
+BEGIN;
+ALTER TABLE reference_table DROP CONSTRAINT fkey_ref_to_local;
+COMMIt;
+
+-- show that we do not allow removing coordinator when we have a fkey constraint
+-- between a coordinator local table and a reference table
+SELECT master_remove_node('localhost', :master_port);
+
+-- show that we support drop constraint
+ALTER TABLE reference_table DROP CONSTRAINT fkey_ref_to_local;
+
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES local_table(l1);
+
+-- show that drop table errors as expected
+DROP TABLE local_table;
+
+-- this should work
+DROP TABLE local_table CASCADE;
+
+-- drop reference_table finally
+DROP TABLE reference_table;
+
+-- TODO: drop them together after fixing the bug
+
+-- TODO: test schema / table name escape
+-- TODO: test create table behaviour, also implement error out conditions
+-- TODO: partitioned tables
+
+-- TEARDOWN -- -- -- --
+
+-- print table reference table content to make sure we successfully inserted/deleted values
+SELECT * FROM reference_table ORDER BY r1;
+
+-- remove master node from pg_dist_node
+SELECT master_remove_node('localhost', :master_port);
+
+-- print table contents to make sure we successfully inserted/deleted values
+SELECT * FROM local_table ORDER BY l1;
+SELECT * FROM reference_table ORDER BY r1;
+
+DROP SCHEMA fkey_reference_local_table;


### PR DESCRIPTION
DESCRIPTION: Implement foreign key support between coordinator local tables and reference tables

After this change, users will be able to define foreign keys between local tables and reference tables in coordinator if reference tables have replicas on coordinator

TO-DO list:

- [x] Implement ALTER TABLE ADD CONSTRAINT fkey ref_table references local_table
- [x] Implement ALTER TABLE ADD CONSTRAINT fkey local_table references  ref_table
- [x] Implement ALTER TABLE ref_table DROP CONSTRAINT fkey (to local_table)
- [x] error out / give warning for commands like "CREATE TABLE local_table REFERENCES ref_table"
- [ ] Write regression tests 
- [ ] Distributed deadlock issue (in another pr)
