### PR TITLE
Don't call UpdateRelationToShardNames for local fast path queries

### DIFF
--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -498,6 +498,7 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 
 	/* mark that we don't want the router planner to generate dummy hosts/queries */
 	bool replacePrunedQueryWithDummy = false;
+	bool localFastPathQuery = false;
 
 	/*
 	 * Use router planner to decide on whether we can push down the query or not.
@@ -511,9 +512,12 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 														  &relationShardList,
 														  &prunedShardIntervalListList,
 														  replacePrunedQueryWithDummy,
-														  &multiShardModifyQuery, NULL);
+														  &multiShardModifyQuery,
+														  NULL,
+														  &localFastPathQuery);
 
 	Assert(!multiShardModifyQuery);
+	Assert(!localFastPathQuery);
 
 	if (planningError)
 	{
@@ -571,6 +575,7 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 
 	Task *modifyTask = CreateBasicTask(jobId, taskIdIndex, MODIFY_TASK,
 									   queryString->data);
+	modifyTask->localFastPathQuery = localFastPathQuery;
 	modifyTask->dependentTaskList = NULL;
 	modifyTask->anchorShardId = shardId;
 	modifyTask->taskPlacementList = insertShardPlacementList;

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -262,6 +262,7 @@ CopyNodeTask(COPYFUNC_ARGS)
 	COPY_NODE_FIELD(rowValuesLists);
 	COPY_SCALAR_FIELD(partiallyLocalOrRemote);
 	COPY_NODE_FIELD(query);
+	COPY_SCALAR_FIELD(localFastPathQuery);
 }
 
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -479,6 +479,7 @@ OutTask(OUTFUNC_ARGS)
 	WRITE_NODE_FIELD(rowValuesLists);
 	WRITE_BOOL_FIELD(partiallyLocalOrRemote);
 	WRITE_NODE_FIELD(query);
+	WRITE_BOOL_FIELD(localFastPathQuery);
 }
 
 

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -393,6 +393,7 @@ ReadTask(READFUNC_ARGS)
 	READ_NODE_FIELD(rowValuesLists);
 	READ_BOOL_FIELD(partiallyLocalOrRemote);
 	READ_NODE_FIELD(query);
+	READ_BOOL_FIELD(localFastPathQuery);
 
 	READ_DONE();
 }

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -223,6 +223,15 @@ typedef struct Task
 	 */
 	bool partiallyLocalOrRemote;
 	Query *query;
+
+	/*
+	 * This is true when this task is a fast path query that can be locally
+	 * executed.  Some steps are skipped in the planner that are only needed
+	 * for deparsing the query. This is normally not needed, but in case of
+	 * logging or EXPLAINing the query we use this field to run these steps
+	 * anyway when deparsing the query for those purposes.
+	 */
+	bool localFastPathQuery;
 } Task;
 
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -42,7 +42,8 @@ extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
 											  List **prunedShardIntervalListList,
 											  bool replacePrunedQueryWithDummy,
 											  bool *multiShardModifyQuery,
-											  Const **partitionValueConst);
+											  Const **partitionValueConst,
+											  bool *localFastPathQuery);
 extern List * RouterInsertTaskList(Query *query, DeferredErrorMessage **planningError);
 extern Const * ExtractInsertPartitionKeyValue(Query *query);
 extern List * TargetShardIntervalsForRestrictInfo(RelationRestrictionContext *


### PR DESCRIPTION
This was an optimization from #3337 that was left out of #3368. It makes sure
that the query tree is not traversed to replace tables with
`citus_extradata_container` calls for local fast path queries.