### PR TITLE
PlacementExecutionDone: We may mark placements as failed multiple times

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -3491,6 +3491,15 @@ PlacementExecutionDone(TaskPlacementExecution *placementExecution, bool succeede
 	TaskExecutionState executionState = shardCommandExecution->executionState;
 	bool failedPlacementExecutionIsOnPendingQueue = false;
 
+	if (placementExecution->executionState == PLACEMENT_EXECUTION_FAILED)
+	{
+		/*
+		 * We may mark placements as failed multiple times, but should only act
+		 * the first time. Nor should we accept success after failure.
+		 */
+		return;
+	}
+
 	/* mark the placement execution as finished */
 	if (succeeded)
 	{


### PR DESCRIPTION
I was unable to come up with a test case for check-failure. First `conn.kill()` kills the first connection the insert is executed on, rather than the second. Changing the mitmproxy port to be greater than worker_1_port succeeded in having the second connection killed, but didn't hit error case for some reason

Fixes #3360 