### PR TITLE
WIP CleanUpSessions: use ShutdownConnection instead of CloseConnection

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -361,10 +361,10 @@ FindAvailableConnection(dlist_head *connections, uint32 flags)
 			}
 		}
 
-		/* don't return claimed connections */
-		if (connection->claimedExclusively)
+		/* don't return claimed connections or unconnected connections */
+		if (connection->claimedExclusively ||
+			connection->pgConn == NULL)
 		{
-			/* connection is in use for an ongoing operation */
 			continue;
 		}
 
@@ -1068,6 +1068,11 @@ AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit)
 	{
 		MultiConnection *connection =
 			dlist_container(MultiConnection, connectionNode, iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
 
 		/*
 		 * To avoid leaking connections we warn if connections are

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1530,6 +1530,7 @@ CleanUpSessions(DistributedExecution *execution)
 			 * Thus, we prefer ShutdownConnection() over CloseConnection().
 			 */
 			ShutdownConnection(connection);
+			CloseShardPlacementAssociation(connection);
 
 			/*
 			 * Reset the transaction state machine since CloseConnection()

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -815,6 +815,12 @@ CoordinatedRemoteTransactionsPrepare(void)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		Assert(transaction->transactionState != REMOTE_TRANS_NOT_STARTED);
@@ -837,6 +843,12 @@ CoordinatedRemoteTransactionsPrepare(void)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		if (transaction->transactionState != REMOTE_TRANS_PREPARING)
@@ -876,6 +888,12 @@ CoordinatedRemoteTransactionsCommit(void)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		if (transaction->transactionState == REMOTE_TRANS_NOT_STARTED ||
@@ -899,6 +917,12 @@ CoordinatedRemoteTransactionsCommit(void)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		/* nothing to do if not committing / aborting */
@@ -933,6 +957,12 @@ CoordinatedRemoteTransactionsAbort(void)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		if (transaction->transactionState == REMOTE_TRANS_NOT_STARTED ||
@@ -955,6 +985,12 @@ CoordinatedRemoteTransactionsAbort(void)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		if (transaction->transactionState != REMOTE_TRANS_1PC_ABORTING &&
@@ -985,6 +1021,12 @@ CoordinatedRemoteTransactionsSavepointBegin(SubTransactionId subId)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 		if (transaction->transactionFailed)
 		{
@@ -1035,6 +1077,12 @@ CoordinatedRemoteTransactionsSavepointRelease(SubTransactionId subId)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 		if (transaction->transactionFailed)
 		{
@@ -1080,6 +1128,12 @@ CoordinatedRemoteTransactionsSavepointRollback(SubTransactionId subId)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
 		/* cancel any ongoing queries before issuing rollback */
@@ -1117,6 +1171,12 @@ CoordinatedRemoteTransactionsSavepointRollback(SubTransactionId subId)
 	{
 		MultiConnection *connection = dlist_container(MultiConnection, transactionNode,
 													  iter.cur);
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 		if (transaction->transactionFailed && !transaction->transactionRecovering)
 		{

--- a/src/test/regress/expected/failure_single_mod.out
+++ b/src/test/regress/expected/failure_single_mod.out
@@ -107,10 +107,11 @@ DETAIL:  server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 COMMIT;
+ERROR:  failure on connection marked as essential: localhost:xxxxx
 SELECT COUNT(*) FROM mod_test WHERE key=2;
  count
 ---------------------------------------------------------------------
-     1
+     0
 (1 row)
 
 -- some clean up
@@ -120,8 +121,7 @@ WHERE shardid IN (
 ) AND shardstate = 3 RETURNING placementid;
  placementid
 ---------------------------------------------------------------------
-         125
-(1 row)
+(0 rows)
 
 TRUNCATE mod_test;
 -- ==== Clean up, we're done here ====

--- a/src/test/regress/expected/failure_single_select.out
+++ b/src/test/regress/expected/failure_single_select.out
@@ -68,11 +68,8 @@ DETAIL:  server closed the connection unexpectedly
 (2 rows)
 
 INSERT INTO select_test VALUES (3, 'even more data');
+WARNING:  could not establish any connections to the node localhost:xxxxx after 5000 ms
 SELECT * FROM select_test WHERE key = 3;
-WARNING:  connection error: localhost:xxxxx
-DETAIL:  server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
  key |     value
 ---------------------------------------------------------------------
    3 | test data
@@ -81,6 +78,7 @@ DETAIL:  server closed the connection unexpectedly
 (3 rows)
 
 COMMIT;
+ERROR:  failure on connection marked as essential: localhost:xxxxx
 -- some clean up
 UPDATE pg_dist_shard_placement SET shardstate = 1
 WHERE shardid IN (
@@ -171,6 +169,7 @@ DETAIL:  server closed the connection unexpectedly
 (2 rows)
 
 COMMIT;
+ERROR:  failure on connection marked as essential: localhost:xxxxx
 SELECT citus.mitmproxy('conn.onQuery(query="^SELECT").after(2).kill()');
  mitmproxy
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/failure_single_select.out
+++ b/src/test/regress/expected/failure_single_select.out
@@ -68,8 +68,11 @@ DETAIL:  server closed the connection unexpectedly
 (2 rows)
 
 INSERT INTO select_test VALUES (3, 'even more data');
-WARNING:  could not establish any connections to the node localhost:xxxxx after 5000 ms
 SELECT * FROM select_test WHERE key = 3;
+WARNING:  connection error: localhost:xxxxx
+DETAIL:  server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
  key |     value
 ---------------------------------------------------------------------
    3 | test data


### PR DESCRIPTION
Marco's test case runs into #3360 with this PR. But that's addressed in #3382 

TODO: write a test case

The "connection pointer is NULL" warning is the result of `FinishRemoteTransactionCommit` calling `HandleResultTransactionResultError`. Maybe `connectionSetChanged = true` isn't enough to prevent the connection from being reused *(spoiler: we need to check pgConn nullness elsewhere in code)*

Fixes #2179 