### PR TITLE
Code cleanup of adaptive_executor, connection_management, placement_connection

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -845,9 +845,9 @@ long
 DeadlineTimestampTzToTimeout(TimestampTz deadline)
 {
 	long secs = 0;
-	int msecs = 0;
-	TimestampDifference(GetCurrentTimestamp(), deadline, &secs, &msecs);
-	return secs * 1000 + msecs / 1000;
+	int microsecs = 0;
+	TimestampDifference(GetCurrentTimestamp(), deadline, &secs, &microsecs);
+	return secs * 1000 + microsecs / 1000;
 }
 
 

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -71,7 +71,7 @@ struct ColocatedPlacementsHashEntry;
  * Hash table mapping placements to a list of connections.
  *
  * This stores a list of connections for each placement, because multiple
- * connections to the same placement may exist at the same time. E.g. a
+ * connections to the same placement may exist at the same time. E.g. an
  * adaptive executor query may reference the same placement in several
  * sub-tasks.
  *
@@ -118,7 +118,7 @@ static HTAB *ConnectionPlacementHash;
  * placements (i.e. the corresponding placements for different colocated
  * distributed tables) need to share connections.  Otherwise things like
  * foreign keys can very easily lead to unprincipled deadlocks.  This means
- * that there can only one DML/DDL connection for a set of colocated
+ * that there can only be one DML/DDL connection for a set of colocated
  * placements.
  *
  * A set of colocated placements is identified, besides node identifying


### PR DESCRIPTION
adaptive_executor: sort includes, use foreach_ptr, remove lies from FinishDistributedExecution docs
connection_management: rename msecs, which isn't milliseconds
placement_connection: small typos

Extracted from #3386