### PR TITLE
Expand the set of aggregates which cannot have LIMIT approximated

### DIFF
--- a/src/test/regress/expected/multi_limit_clause_approximate.out
+++ b/src/test/regress/expected/multi_limit_clause_approximate.out
@@ -90,10 +90,45 @@ DEBUG:  push down of limit count: 150
 -- We now test scenarios where applying the limit optimization wouldn't produce
 -- meaningful results. First, we check that we don't push down the limit clause
 -- for non-commutative aggregates.
-SELECT l_partkey, avg(l_suppkey) AS average FROM lineitem
+SELECT l_partkey, avg(l_suppkey) FROM lineitem
 	GROUP BY l_partkey
-	ORDER BY average DESC, l_partkey LIMIT 10;
- l_partkey |        average
+	ORDER BY 2 DESC, l_partkey LIMIT 10;
+ l_partkey |          avg
+---------------------------------------------------------------------
+      9998 | 9999.0000000000000000
+    102466 | 9997.0000000000000000
+    184959 | 9996.0000000000000000
+     17492 | 9994.0000000000000000
+    124966 | 9991.0000000000000000
+     89989 | 9990.0000000000000000
+     32479 | 9989.0000000000000000
+    144960 | 9989.0000000000000000
+    147473 | 9988.0000000000000000
+     37481 | 9985.0000000000000000
+(10 rows)
+
+SELECT l_partkey, stddev(l_suppkey::float8) FROM lineitem
+	GROUP BY l_partkey
+	ORDER BY 2 DESC NULLS LAST, l_partkey LIMIT 10;
+ l_partkey |      stddev
+---------------------------------------------------------------------
+    192434 | 5343.60594542674
+    160226 | 5337.24198439606
+    151174 |  5335.1206640525
+     60844 | 5316.02878096046
+     62405 | 5316.02878096046
+     50168 |  5313.9074606169
+     52148 |  5313.9074606169
+     52398 |  5313.9074606169
+     10259 | 5305.42217924267
+      3496 | 5303.30085889911
+(10 rows)
+
+-- also test that we handle execution on coordinator properly
+SELECT l_partkey, avg(distinct l_suppkey) FROM lineitem
+	GROUP BY l_partkey
+	ORDER BY 2 DESC, l_partkey LIMIT 10;
+ l_partkey |          avg
 ---------------------------------------------------------------------
       9998 | 9999.0000000000000000
     102466 | 9997.0000000000000000

--- a/src/test/regress/sql/multi_limit_clause_approximate.sql
+++ b/src/test/regress/sql/multi_limit_clause_approximate.sql
@@ -48,9 +48,17 @@ SELECT c_custkey, c_name, count(*) as lineitem_count
 -- meaningful results. First, we check that we don't push down the limit clause
 -- for non-commutative aggregates.
 
-SELECT l_partkey, avg(l_suppkey) AS average FROM lineitem
+SELECT l_partkey, avg(l_suppkey) FROM lineitem
 	GROUP BY l_partkey
-	ORDER BY average DESC, l_partkey LIMIT 10;
+	ORDER BY 2 DESC, l_partkey LIMIT 10;
+SELECT l_partkey, stddev(l_suppkey::float8) FROM lineitem
+	GROUP BY l_partkey
+	ORDER BY 2 DESC NULLS LAST, l_partkey LIMIT 10;
+
+-- also test that we handle execution on coordinator properly
+SELECT l_partkey, avg(distinct l_suppkey) FROM lineitem
+	GROUP BY l_partkey
+	ORDER BY 2 DESC, l_partkey LIMIT 10;
 
 -- Next, check that we don't apply the limit optimization for expressions that
 -- have aggregates within them


### PR DESCRIPTION
DESCRIPTION: restrict LIMIT approximation for non commutative aggregates

Previously we only prevented AVG from being pushed down, but this may be incorrect:
- array_agg, while somewhat non sensical to order by, will potentially be missing values
- combinefunc aggregation will raise errors about cstrings not being comparable (while we also can't know if the aggregate is commutative)

This commit limits approximating LIMIT pushdown when ordering by aggregates to:
min, max, sum, count, bit_and, bit_or, every, any
Which means of those we previously supported, we now exclude:
avg, array_agg, jsonb_agg, jsonb_object_agg, json_agg, json_object_agg, hll_add, hll_union, topn_add, topn_union

'Commutative' may not be the best word, but it's what previous comments were using in differentiating `avg`. It's also arguable that the `array_agg` case is fine since it's an approximation. So it may be best to only prevent LIMIT approximation for COMBINEFUNC aggregation

hll/topn are moot since we currently raise an error if ordering by an hll type:
https://github.com/citusdata/citus/blob/77589b2b086350de99ef6824cc770a562f8983b6/src/backend/distributed/planner/multi_logical_optimizer.c#L440-L453