### PR TITLE
Update shardPlacement->nodeId from `int` to `uint`

### DIFF
--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -134,7 +134,7 @@ static HTAB *ConnectionPlacementHash;
 typedef struct ColocatedPlacementsHashKey
 {
 	/* to identify host - database can't differ */
-	int nodeId;
+	uint32 nodeId;
 
 	/* colocation group, or invalid */
 	uint32 colocationGroupId;

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -411,7 +411,7 @@ OutShardPlacement(OUTFUNC_ARGS)
 	WRITE_INT_FIELD(groupId);
 	WRITE_STRING_FIELD(nodeName);
 	WRITE_UINT_FIELD(nodePort);
-	WRITE_INT_FIELD(nodeId);
+	WRITE_UINT_FIELD(nodeId);
 	/* so we can deal with 0 */
 	WRITE_INT_FIELD(partitionMethod);
 	WRITE_UINT_FIELD(colocationGroupId);

--- a/src/backend/distributed/utils/citus_readfuncs.c
+++ b/src/backend/distributed/utils/citus_readfuncs.c
@@ -321,7 +321,7 @@ ReadShardPlacement(READFUNC_ARGS)
 	READ_INT_FIELD(groupId);
 	READ_STRING_FIELD(nodeName);
 	READ_UINT_FIELD(nodePort);
-	READ_INT_FIELD(nodeId);
+	READ_UINT_FIELD(nodeId);
 	/* so we can deal with 0 */
 	READ_INT_FIELD(partitionMethod);
 	READ_UINT_FIELD(colocationGroupId);

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -81,7 +81,7 @@ typedef struct ShardPlacement
 	/* the rest of the fields aren't from pg_dist_placement */
 	char *nodeName;
 	uint32 nodePort;
-	int nodeId;
+	uint32 nodeId;
 	char partitionMethod;
 	uint32 colocationGroupId;
 	uint32 representativeValue;


### PR DESCRIPTION
Fixes #3412 and useful for #3410 

As the source of the shardPlacement->nodeId is always workerNode->nodeId,
and that is uint32.

We had this hack because of: https://github.com/citusdata/citus/pull/2633/commits/0ea4e52df512acd678ed7ad0cb128638221a3a5a#r266421409

And, that is gone with: https://github.com/citusdata/citus/commit/90056f7d3cd9f2035dd90d38c658a7211151f3c9#diff-c532177d74c72d3f0e7cd10e448ab3c6L1123

So, we're safe to do it now.
