### PR TITLE
Change DistributedResultFragment::nodeId to uint32.

### DIFF
--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -37,8 +37,8 @@
  */
 typedef struct NodePair
 {
-	int sourceNodeId;
-	int targetNodeId;
+	uint32 sourceNodeId;
+	uint32 targetNodeId;
 } NodePair;
 
 
@@ -214,7 +214,7 @@ WrapTasksForPartitioning(char *resultIdPrefix, List *selectTaskList,
 			ShardPlacement *shardPlacement = lfirst(placementCell);
 			StringInfo wrappedQuery = makeStringInfo();
 			appendStringInfo(wrappedQuery,
-							 "SELECT %d, partition_index"
+							 "SELECT %u, partition_index"
 							 ", %s || '_' || partition_index::text "
 							 ", rows_written "
 							 "FROM worker_partition_query_result"
@@ -370,8 +370,8 @@ TupleToDistributedResultFragment(TupleTableSlot *tupleSlot,
 								 DistTableCacheEntry *targetRelation)
 {
 	bool isNull = false;
-	int sourceNodeId = DatumGetInt32(slot_getattr(tupleSlot, 1, &isNull));
-	int targetShardIndex = DatumGetInt32(slot_getattr(tupleSlot, 2, &isNull));
+	uint32 sourceNodeId = DatumGetUInt32(slot_getattr(tupleSlot, 1, &isNull));
+	uint32 targetShardIndex = DatumGetUInt32(slot_getattr(tupleSlot, 2, &isNull));
 	text *resultId = DatumGetTextP(slot_getattr(tupleSlot, 3, &isNull));
 	int64 rowCount = DatumGetInt64(slot_getattr(tupleSlot, 4, &isNull));
 
@@ -533,7 +533,7 @@ FragmentTransferTaskList(List *fragmentListTransfers)
 	{
 		NodeToNodeFragmentsTransfer *fragmentsTransfer = lfirst(transferCell);
 
-		int targetNodeId = fragmentsTransfer->nodes.targetNodeId;
+		uint32 targetNodeId = fragmentsTransfer->nodes.targetNodeId;
 
 		/* these should have already been pruned away in ColocationTransfers */
 		Assert(targetNodeId != fragmentsTransfer->nodes.sourceNodeId);

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -88,9 +88,9 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 		bool columnNulls[5] = { 0 };
 		Datum columnValues[5] = {
 			CStringGetTextDatum(fragment->resultId),
-			Int32GetDatum(fragment->nodeId),
+			UInt32GetDatum(fragment->nodeId),
 			Int64GetDatum(fragment->rowCount),
-			Int64GetDatum(fragment->targetShardId),
+			UInt64GetDatum(fragment->targetShardId),
 			Int32GetDatum(fragment->targetShardIndex)
 		};
 

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -31,7 +31,7 @@ typedef struct DistributedResultFragment
 	char *resultId;
 
 	/* location of the result */
-	int nodeId;
+	uint32 nodeId;
 
 	/* number of rows in the result file */
 	int rowCount;


### PR DESCRIPTION
This is to match the type of WorkerNode::nodeId.

See https://github.com/citusdata/citus/pull/3413 for more discussion.
