### PR TITLE
Output filenames in ensure_no_intermediate_data_leak

### DIFF
--- a/src/test/regress/expected/ensure_no_intermediate_data_leak.out
+++ b/src/test/regress/expected/ensure_no_intermediate_data_leak.out
@@ -5,12 +5,25 @@
 -- AND ON THE WORKERS. HOWEVER, WE HAVE SOME ISSUES AROUND
 -- WINDOWS SUPPORT SO WE DISABLE THIS TEST ON WINDOWS
 ---------------------------------------------------------------------
-SELECT pg_ls_dir('base/pgsql_job_cache') WHERE citus_version() NOT ILIKE '%windows%';
- pg_ls_dir
+WITH xact_dirs AS (
+  SELECT pg_ls_dir('base/pgsql_job_cache') dir WHERE citus_version() NOT ILIKE '%windows%'
+), result_files AS (
+  SELECT dir, pg_ls_dir('base/pgsql_job_cache/' || dir) result_file FROM xact_dirs
+)
+SELECT array_agg((xact_dirs.dir, result_files.result_file)) FROM xact_dirs LEFT OUTER JOIN result_files ON xact_dirs.dir = result_files.dir;
+ array_agg
 ---------------------------------------------------------------------
-(0 rows)
 
-SELECT * FROM run_command_on_workers($$SELECT pg_ls_dir('base/pgsql_job_cache') r WHERE citus_version() NOT ILIKE '%windows%'$$) WHERE result <> '';
+(1 row)
+
+SELECT * FROM run_command_on_workers($$
+  WITH xact_dirs AS (
+    SELECT pg_ls_dir('base/pgsql_job_cache') dir WHERE citus_version() NOT ILIKE '%windows%'
+  ), result_files AS (
+    SELECT dir, pg_ls_dir('base/pgsql_job_cache/' || dir) result_file FROM xact_dirs
+  )
+  SELECT array_agg((xact_dirs.dir, result_files.result_file)) FROM xact_dirs LEFT OUTER JOIN result_files ON xact_dirs.dir = result_files.dir;
+$$) WHERE result <> '';
  nodename | nodeport | success | result
 ---------------------------------------------------------------------
 (0 rows)


### PR DESCRIPTION
This can helpful in guiding us where to look when this test fails. For example, if the result file has repartitioned_results_ prefix, then we need to look into repartitioned insert/select. Otherwise it is probably a CTE or a subquery.

