### PR TITLE
Don't error for ENOENT in CitusRemoveDirectory.

### DIFF
--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -783,7 +783,7 @@ CitusRemoveDirectory(StringInfo filename)
 		removed = unlink(filename->data);
 	}
 
-	if (removed != 0)
+	if (removed != 0 && errno != ENOENT)
 	{
 		ereport(ERROR, (errcode_for_file_access(),
 						errmsg("could not remove file \"%s\": %m", filename->data)));


### PR DESCRIPTION
For concurrency reasons, this can happen even if initial stat succeeded.

This might help with reducing frequency of `ensure_no_intermediate_data_leak` failures.