### PR TITLE
CurrentDatabaseName: return const char* as we're borrowing from cache

### DIFF
--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -846,7 +846,7 @@ TrackerConnectPoll(TaskTracker *taskTracker)
 		{
 			char *nodeName = taskTracker->workerName;
 			uint32 nodePort = taskTracker->workerPort;
-			char *nodeDatabase = CurrentDatabaseName();
+			const char *nodeDatabase = CurrentDatabaseName();
 			char *nodeUser = taskTracker->userName;
 
 			int32 connectionId = MultiClientConnectStart(nodeName, nodePort,

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -2281,7 +2281,7 @@ CitusTableVisibleFuncId(void)
  * one session connected to it, we do not need to implement any invalidation
  * mechanism.
  */
-char *
+const char *
 CurrentDatabaseName(void)
 {
 	if (!MetadataCache.databaseNameValid)

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -517,7 +517,7 @@ ExplainTaskPlacement(ShardPlacement *taskPlacement, List *explainOutputList,
 	StringInfo nodeAddress = makeStringInfo();
 	char *nodeName = taskPlacement->nodeName;
 	uint32 nodePort = taskPlacement->nodePort;
-	char *nodeDatabase = CurrentDatabaseName();
+	const char *nodeDatabase = CurrentDatabaseName();
 	ListCell *explainOutputCell = NULL;
 	int rowIndex = 0;
 

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -354,7 +354,7 @@ CreateJobSchema(StringInfo schemaName)
 static void
 CreateTask(uint64 jobId, uint32 taskId, char *taskCallString)
 {
-	char *databaseName = CurrentDatabaseName();
+	const char *databaseName = CurrentDatabaseName();
 	char *userName = CurrentUserName();
 
 	/* increase task priority for cleanup tasks */

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -238,7 +238,7 @@ ReceiveRegularFile(const char *nodeName, uint32 nodePort, const char *nodeUser,
 	}
 
 	/* we use the same database name on the master and worker nodes */
-	char *nodeDatabase = CurrentDatabaseName();
+	const char *nodeDatabase = CurrentDatabaseName();
 
 	/* connect to remote node */
 	int32 connectionId = MultiClientConnect(nodeName, nodePort, nodeDatabase, nodeUser);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -216,7 +216,7 @@ extern Oid BinaryCopyFormatId(void);
 extern Oid CitusExtensionOwner(void);
 extern char * CitusExtensionOwnerName(void);
 extern char * CurrentUserName(void);
-extern char * CurrentDatabaseName(void);
+extern const char * CurrentDatabaseName(void);
 
 
 #endif /* METADATA_CACHE_H */


### PR DESCRIPTION
We should return const pointers when we're not passing on ownership, nor wanting to allow mutability