### PR TITLE
Fix diff-filter returning wrong diff if lines above were removed

### DIFF
--- a/ci/normalize_expected.sh
+++ b/ci/normalize_expected.sh
@@ -2,6 +2,8 @@
 
 set -eu
 for f in $(git ls-tree -r HEAD --name-only src/test/regress/expected/*.out); do
+	sed -Ef src/test/regress/bin/normalize_remove_lines.sed < "$f" > "$f.modified"
+	mv "$f.modified" "$f"
 	sed -Ef src/test/regress/bin/normalize.sed < "$f" > "$f.modified"
 	mv "$f.modified" "$f"
 done

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -26,3 +26,4 @@
 # output from diff normalization that shouldn't be commited
 *.unmodified
 *.modified
+*.modified-deleted-lines-only

--- a/src/test/regress/bin/diff
+++ b/src/test/regress/bin/diff
@@ -33,8 +33,12 @@ fi
 if test -z "${VANILLATEST:-}"
 then
 	touch "$file1"  # when adding a new test the expected file does not exist
-	sed -Ef $BASEDIR/normalize.sed < "$file1" > "$file1.modified"
-	sed -Ef $BASEDIR/normalize.sed < "$file2" > "$file2.modified"
+
+	sed -Ef "$BASEDIR/normalize_remove_lines.sed" < "$file1" > "$file1.modified-deleted-lines-only"
+	sed -Ef "$BASEDIR/normalize_remove_lines.sed" < "$file2" > "$file2.modified-deleted-lines-only"
+
+	sed -Ef "$BASEDIR/normalize.sed" < "$file1.modified-deleted-lines-only" > "$file1.modified"
+	sed -Ef "$BASEDIR/normalize.sed" < "$file2.modified-deleted-lines-only" > "$file2.modified"
 	"$DIFF" -w $args "$file1.modified" "$file2.modified" | diff-filter
 	exit ${PIPESTATUS[0]}
 else

--- a/src/test/regress/bin/diff-filter
+++ b/src/test/regress/bin/diff-filter
@@ -12,7 +12,7 @@ def main():
 		if line.startswith('+++ '):
 			tab = line.rindex('\t')
 			fname = line[4:tab]
-			file2 = iter(open(fname.replace('.modified', '')))
+			file2 = iter(open(fname.replace('.modified', '.modified-deleted-lines-only')))
 			file2line = 1
 			stdout.write(line)
 		elif line.startswith('@@ '):

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -43,23 +43,12 @@ s/name_len_12345678901234567890123456789012345678_fcd8ab6f_[0-9]+/name_len_12345
 
 # normalize pkey constraints in multi_insert_select.sql
 s/"(raw_events_second_user_id_value_1_key_|agg_events_user_id_value_1_agg_key_)[0-9]+"/"\1xxxxxxx"/g
-
-# ignore could not consume warnings
-/WARNING:  could not consume data from worker node/d
-
-# ignore WAL warnings
-/DEBUG: .+creating and filling new WAL file/d
-
 # normalize file names for partitioned files
 s/(task_[0-9]+\.)[0-9]+/\1xxxx/g
 s/(job_[0-9]+\/task_[0-9]+\/p_[0-9]+\.)[0-9]+/\1xxxx/g
 
 # isolation_ref2ref_foreign_keys
 s/"(ref_table_[0-9]_|ref_table_[0-9]_value_fkey_)[0-9]+"/"\1xxxxxxx"/g
-
-# Line info varies between versions
-/^LINE [0-9]+:.*$/d
-/^ *\^$/d
 
 # Remove trailing whitespace
 s/ *$//g

--- a/src/test/regress/bin/normalize_remove_lines.sed
+++ b/src/test/regress/bin/normalize_remove_lines.sed
@@ -1,0 +1,14 @@
+# Rules to normalize test outputs.
+#
+# This file contains all the rules that completely remove lines. These lines
+# are removed because they don't appear consistently.
+
+# ignore could not consume warnings
+/WARNING:  could not consume data from worker node/d
+
+# ignore WAL warnings
+/DEBUG: .+creating and filling new WAL file/d
+
+# Line info varies between versions
+/^LINE [0-9]+:.*$/d
+/^ *\^$/d


### PR DESCRIPTION
The new diff-filter helper introduced in #3419 showed incorrect lines when
lines above were completely removed from the file. This fixes that by reading
the original lines from a file that does not have the normalization
replacements, but does have the normalization removes.