### PR TITLE
switch back to old memory context in cache local plan for task

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -433,6 +433,7 @@ CacheLocalPlanForTask(Task *task, DistributedPlan *originalDistributedPlan)
 	if (rangeTableEntry->relid == InvalidOid)
 	{
 		pfree(shardQuery);
+		MemoryContextSwitchTo(oldContext);
 		return;
 	}
 


### PR DESCRIPTION
In case of not seeing the relation id because of a shard creation, we return immediately without switching back to the old memory context. I am guessing this was not the intended behavior. 