### PR TITLE
Update diff-filter to handle lines removed by normalization

### DIFF
--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -9,6 +9,7 @@
 /build/
 /results/
 /log/
+/bin/test/results/
 
 # Regression test output
 /regression.diffs

--- a/src/test/regress/bin/diff
+++ b/src/test/regress/bin/diff
@@ -4,9 +4,6 @@
 # doing the actual diff. Rules for normalization are in normalize.sed. See
 # the comments there for more information.
 #
-# We only normalize tests listed in normalized_tests.lst. We use the bare
-# diff for other tests.
-#
 # Note that src/test/regress/Makefile adds this directory to $PATH so
 # pg_regress uses this diff tool instead of the system diff tool.
 set -eu -o pipefail
@@ -33,9 +30,9 @@ fi
 if test -z "${VANILLATEST:-}"
 then
 	touch "$file1"  # when adding a new test the expected file does not exist
-	sed -Ef $BASEDIR/normalize.sed < "$file1" > "$file1.modified"
-	sed -Ef $BASEDIR/normalize.sed < "$file2" > "$file2.modified"
-	"$DIFF" -w $args "$file1.modified" "$file2.modified" | diff-filter
+	sed -Ef "$BASEDIR/normalize.sed" < "$file1" > "$file1.modified"
+	sed -Ef "$BASEDIR/normalize.sed" < "$file2" > "$file2.modified"
+	"$DIFF" -w $args "$file1.modified" "$file2.modified" | diff-filter "$BASEDIR/normalize.sed"
 	exit ${PIPESTATUS[0]}
 else
 	exec "$DIFF" -w $args "$file1" "$file2"

--- a/src/test/regress/bin/diff-filter
+++ b/src/test/regress/bin/diff-filter
@@ -5,15 +5,51 @@ diff-filter denormalizes diff output by having lines beginning with ' ' or '+'
 come from file2's unmodified version.
 """
 
+from sys import argv, stdin, stdout
+import re
+
+
+class FileScanner:
+	"""
+	FileScanner is an iterator over the lines of a file.
+	It can apply a rewrite rule which can be used to skip lines.
+	"""
+	def __init__(self, file, rewrite = lambda x:x):
+		self.file = file
+		self.line = 1
+		self.rewrite = rewrite
+
+	def __next__(self):
+		while True:
+			nextline = self.rewrite(next(self.file))
+			if nextline is not None:
+				self.line += 1
+				return nextline
+
+
 def main():
-	from sys import stdin, stdout
+	# we only test //d rules, as we need to ignore those lines
+	regexregex = re.compile(r"^/(?P<rule>.*)/d$")
+	regexpipeline = []
+	for line in open(argv[1]):
+		line = line.strip()
+		if not line or line.startswith('#') or not line.endswith('d'):
+			continue
+		rule = regexregex.match(line)
+		if not rule:
+			raise 'Failed to parse regex rule: %s' % line
+		regexpipeline.append(re.compile(rule.group('rule')))
+
+	def sed(line):
+		if any(regex.match(line) for regex in regexpipeline):
+			return None
+		return line
 
 	for line in stdin:
 		if line.startswith('+++ '):
 			tab = line.rindex('\t')
 			fname = line[4:tab]
-			file2 = iter(open(fname.replace('.modified', '')))
-			file2line = 1
+			file2 = FileScanner(open(fname.replace('.modified', '')), sed)
 			stdout.write(line)
 		elif line.startswith('@@ '):
 			idx_start = line.index('+') + 1
@@ -21,19 +57,17 @@ def main():
 			while line[idx_end].isdigit():
 				idx_end += 1
 			linenum = int(line[idx_start:idx_end])
-			while file2line < linenum:
+			while file2.line < linenum:
 				next(file2)
-				file2line += 1
 			stdout.write(line)
 		elif line.startswith(' '):
 			stdout.write(' ')
 			stdout.write(next(file2))
-			file2line += 1
 		elif line.startswith('+'):
 			stdout.write('+')
 			stdout.write(next(file2))
-			file2line += 1
 		else:
 			stdout.write(line)
+
 
 main()

--- a/src/test/regress/bin/test/expected/different.out
+++ b/src/test/regress/bin/test/expected/different.out
@@ -1,0 +1,17 @@
+--- file.out.modified
++++ file_different.out.modified
+@@ -1,3 +1,2 @@
+-This line is missing in file_different
+ Ports are replaced with xxxxx: localhost:2187
+ This line is the same
+@@ -7,6 +6,8 @@
+ Filler 2, localhost:1111
+ Filler 3, localhost:111
+-This line is missing in file_different
++This line has been inserted
++This line has also been inserted, localhost:10812
+ Line below will be removed, localhost:2781
+-This line will be changed ✓
++This line has been changed ✇
+ End of file
++New line at end

--- a/src/test/regress/bin/test/file.out
+++ b/src/test/regress/bin/test/file.out
@@ -1,0 +1,14 @@
+This line is missing in file_different
+Ports are replaced with xxxxx: localhost:1728
+This line is the same
+This line is also the same
+DEBUG: we remove this line creating and filling new WAL file
+Line above was deleted é
+Filler 1, localhost:21870
+Filler 2, localhost:2187
+Filler 3, localhost:218
+This line is missing in file_different
+Line below will be removed, localhost:2187
+DEBUG: we remove this line creating and filling new WAL file
+This line will be changed ✓
+End of file

--- a/src/test/regress/bin/test/file_different.out
+++ b/src/test/regress/bin/test/file_different.out
@@ -1,0 +1,15 @@
+Ports are replaced with xxxxx: localhost:2187
+This line is the same
+This line is also the same
+DEBUG: we remove this line creating and filling new WAL file
+Line above was deleted é
+Filler 1, localhost:11111
+Filler 2, localhost:1111
+Filler 3, localhost:111
+This line has been inserted
+This line has also been inserted, localhost:10812
+DEBUG: we remove this line creating and filling new WAL file
+Line below will be removed, localhost:2781
+This line has been changed ✇
+End of file
+New line at end

--- a/src/test/regress/bin/test/file_same.out
+++ b/src/test/regress/bin/test/file_same.out
@@ -1,0 +1,14 @@
+This line is missing in file_different
+Ports are replaced with xxxxx: localhost:1728
+This line is the same
+This line is also the same
+DEBUG: we remove this line creating and filling new WAL file
+Line above was deleted é
+Filler 1, localhost:21870
+Filler 2, localhost:2187
+Filler 3, localhost:218
+This line is missing in file_different
+Line below will be removed, localhost:2187
+DEBUG: we remove this line creating and filling new WAL file
+This line will be changed ✓
+End of file

--- a/src/test/regress/bin/test_diff
+++ b/src/test/regress/bin/test_diff
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT=`realpath -s "$0"`
+SCRIPTPATH=`dirname "$SCRIPT"`
+PATH="$SCRIPTPATH:$PATH"
+
+cp "$SCRIPTPATH/test/file.out" "$SCRIPTPATH/test/file_same.out"
+mkdir -p "$SCRIPTPATH/test/results"
+
+# diff file.out against file_$1.out, also strip out timestamps & file paths
+function create_result()
+{
+	diff -dU2 -w "$SCRIPTPATH/test/file.out" "$SCRIPTPATH/test/file_$1.out" \
+		| sed -E 's/^(\+\+\+|---).+\/([^/]+)\t.+$/\1 \2/' \
+		> "$SCRIPTPATH/test/results/$1.out"
+}
+
+# compare whether result is same as expected
+function check_result()
+{
+	cmp -s "$SCRIPTPATH/test/expected/$1.out" "$SCRIPTPATH/test/results/$1.out"
+	if test $? -ne 0
+	then
+		diff -u "$SCRIPTPATH/test/expected/$1.out" "$SCRIPTPATH/test/results/$1.out"
+		exit 1
+	fi
+}
+
+function test_case()
+{
+	# call twice as tests invoke diff multiple times
+	create_result "$1"
+	create_result "$1"
+	check_result "$1"
+}
+
+test_case "same"
+test_case "different"

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -817,7 +817,7 @@ else
     $exitcode = system("$plainRegress", @arguments);
 }
 
-system (catfile("bin", "copy_modified"));
+system ("copy_modified");
 my $endTime = time();
 
 if ($exitcode == 0) {


### PR DESCRIPTION
Add a script to test our diff logic

pg_regress_multi updated to rely on $PATH having copy_modified to fix testing with VPATH

Ideally we'd have `make check-diff` to invoke `test_diff`

Closes #3427 
