### PR TITLE
check if fast path routing is possible in forced distributed plan too

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -136,7 +136,6 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	bool setPartitionedTablesInherited = false;
 	List *rangeTableList = ExtractRangeTableEntryList(parse);
 	int rteIdCounter = 1;
-	bool fastPathRouterQuery = false;
 	Node *distributionKeyValue = NULL;
 	DistributedPlanningContext planContext = {
 		.query = parse,
@@ -167,11 +166,13 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		else
 		{
 			needsDistributedPlanning = ListContainsDistributedTableRTE(rangeTableList);
-			if (needsDistributedPlanning)
-			{
-				fastPathRouterQuery = FastPathRouterQuery(parse, &distributionKeyValue);
-			}
 		}
+	}
+
+	bool fastPathRouterQuery = false;
+	if (needsDistributedPlanning)
+	{
+		fastPathRouterQuery = FastPathRouterQuery(parse, &distributionKeyValue);
 	}
 
 	if (fastPathRouterQuery)


### PR DESCRIPTION
If the plan is a distributed plan we check if it is a fast path router query as well. However it seems that we miss one case where the plan is forced to be distributed. With a quick look, it seems that this miss was introduced with https://github.com/citusdata/citus/commit/ca293116fa6521e383147abd07d035fdc49f110e