### PR TITLE
Fix random output ordering in CTE inlining test

### DIFF
--- a/src/test/regress/expected/cte_inline.out
+++ b/src/test/regress/expected/cte_inline.out
@@ -1035,7 +1035,7 @@ PREPARE non_inlined_cte_without_params AS
     SELECT
         *, (SELECT 1)
     FROM
-        cte_1 ORDER BY 1 DESC LIMIT 3;
+        cte_1 ORDER BY 1 DESC, 2 DESC, 3 DESC LIMIT 3;
 PREPARE inlined_cte_has_parameter_on_non_dist_key(text) AS
 	WITH cte_1 AS (SELECT count(*) FROM test_table WHERE value = $1 GROUP BY key)
 	SELECT * FROM cte_1 ORDER BY 1 DESC LIMIT 3;
@@ -1108,54 +1108,54 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  generating subplan XXX_1 for CTE cte_1: SELECT key, value, other_value FROM cte_inline.test_table
 DEBUG:  Router planner cannot handle multi-shard select queries
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT key, value, other_value, (SELECT 1) FROM (SELECT intermediate_result.key, intermediate_result.value, intermediate_result.other_value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text, other_value jsonb)) cte_1 ORDER BY key DESC LIMIT 3
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT key, value, other_value, (SELECT 1) FROM (SELECT intermediate_result.key, intermediate_result.value, intermediate_result.other_value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text, other_value jsonb)) cte_1 ORDER BY key DESC, value DESC, other_value DESC LIMIT 3
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   8 | test8  | {"f1": 8, "f2": 144, "f3": "test8"}   |        1
-   8 | test18 | {"f1": 18, "f2": 324, "f3": "test18"} |        1
-   8 | test28 | {"f1": 28, "f2": 504, "f3": "test28"} |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   8 | test8  | {"f1": 8, "f2": 144, "f3": "test8"}   |        1
-   8 | test18 | {"f1": 18, "f2": 324, "f3": "test18"} |        1
-   8 | test28 | {"f1": 28, "f2": 504, "f3": "test28"} |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   8 | test8  | {"f1": 8, "f2": 144, "f3": "test8"}   |        1
-   8 | test18 | {"f1": 18, "f2": 324, "f3": "test18"} |        1
-   8 | test28 | {"f1": 28, "f2": 504, "f3": "test28"} |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   8 | test8  | {"f1": 8, "f2": 144, "f3": "test8"}   |        1
-   8 | test18 | {"f1": 18, "f2": 324, "f3": "test18"} |        1
-   8 | test28 | {"f1": 28, "f2": 504, "f3": "test28"} |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   8 | test8  | {"f1": 8, "f2": 144, "f3": "test8"}   |        1
-   8 | test18 | {"f1": 18, "f2": 324, "f3": "test18"} |        1
-   8 | test28 | {"f1": 28, "f2": 504, "f3": "test28"} |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   8 | test8  | {"f1": 8, "f2": 144, "f3": "test8"}   |        1
-   8 | test18 | {"f1": 18, "f2": 324, "f3": "test18"} |        1
-   8 | test28 | {"f1": 28, "f2": 504, "f3": "test28"} |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
+   8 | test98 |             |        1
 (3 rows)
 
 EXECUTE inlined_cte_has_parameter_on_non_dist_key('test1');

--- a/src/test/regress/expected/cte_inline_0.out
+++ b/src/test/regress/expected/cte_inline_0.out
@@ -903,7 +903,7 @@ PREPARE non_inlined_cte_without_params AS
     SELECT
         *, (SELECT 1)
     FROM
-        cte_1 ORDER BY 1 DESC LIMIT 3;
+        cte_1 ORDER BY 1 DESC, 2 DESC, 3 DESC LIMIT 3;
 PREPARE inlined_cte_has_parameter_on_non_dist_key(text) AS
 	WITH cte_1 AS (SELECT count(*) FROM test_table WHERE value = $1 GROUP BY key)
 	SELECT * FROM cte_1 ORDER BY 1 DESC LIMIT 3;
@@ -976,54 +976,54 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  generating subplan XXX_1 for CTE cte_1: SELECT key, value, other_value FROM cte_inline.test_table
 DEBUG:  Router planner cannot handle multi-shard select queries
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT key, value, other_value, (SELECT 1) FROM (SELECT intermediate_result.key, intermediate_result.value, intermediate_result.other_value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text, other_value jsonb)) cte_1 ORDER BY key DESC LIMIT 3
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT key, value, other_value, (SELECT 1) FROM (SELECT intermediate_result.key, intermediate_result.value, intermediate_result.other_value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text, other_value jsonb)) cte_1 ORDER BY key DESC, value DESC, other_value DESC LIMIT 3
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   9 | test9  | {"f1": 9, "f2": 162, "f3": "test9"}   |        1
-   9 | test19 | {"f1": 19, "f2": 342, "f3": "test19"} |        1
-   9 | test29 | {"f1": 29, "f2": 522, "f3": "test29"} |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   9 | test9  | {"f1": 9, "f2": 162, "f3": "test9"}   |        1
-   9 | test19 | {"f1": 19, "f2": 342, "f3": "test19"} |        1
-   9 | test29 | {"f1": 29, "f2": 522, "f3": "test29"} |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   9 | test9  | {"f1": 9, "f2": 162, "f3": "test9"}   |        1
-   9 | test19 | {"f1": 19, "f2": 342, "f3": "test19"} |        1
-   9 | test29 | {"f1": 29, "f2": 522, "f3": "test29"} |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   9 | test9  | {"f1": 9, "f2": 162, "f3": "test9"}   |        1
-   9 | test19 | {"f1": 19, "f2": 342, "f3": "test19"} |        1
-   9 | test29 | {"f1": 29, "f2": 522, "f3": "test29"} |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   9 | test9  | {"f1": 9, "f2": 162, "f3": "test9"}   |        1
-   9 | test19 | {"f1": 19, "f2": 342, "f3": "test19"} |        1
-   9 | test29 | {"f1": 29, "f2": 522, "f3": "test29"} |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
 (3 rows)
 
 EXECUTE non_inlined_cte_without_params;
- key | value  |              other_value              | ?column?
+ key | value  | other_value | ?column?
 ---------------------------------------------------------------------
-   9 | test9  | {"f1": 9, "f2": 162, "f3": "test9"}   |        1
-   9 | test19 | {"f1": 19, "f2": 342, "f3": "test19"} |        1
-   9 | test29 | {"f1": 29, "f2": 522, "f3": "test29"} |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
+   9 | test99 |             |        1
 (3 rows)
 
 EXECUTE inlined_cte_has_parameter_on_non_dist_key('test1');

--- a/src/test/regress/sql/cte_inline.sql
+++ b/src/test/regress/sql/cte_inline.sql
@@ -495,7 +495,7 @@ PREPARE non_inlined_cte_without_params AS
     SELECT
         *, (SELECT 1)
     FROM
-        cte_1 ORDER BY 1 DESC LIMIT 3;
+        cte_1 ORDER BY 1 DESC, 2 DESC, 3 DESC LIMIT 3;
 PREPARE inlined_cte_has_parameter_on_non_dist_key(text) AS
 	WITH cte_1 AS (SELECT count(*) FROM test_table WHERE value = $1 GROUP BY key)
 	SELECT * FROM cte_1 ORDER BY 1 DESC LIMIT 3;


### PR DESCRIPTION
Proof of flakyness: https://circleci.com/gh/citusdata/citus/84588?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link