### PR TITLE
multi_extension: always clear activity snapshot before polling pg_stat_activity

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -305,7 +305,7 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		if (dbDataWorkerPid != MyProcPid)
 		{
 			/* if multiple daemons are alive, only keep the one in the hash table */
-			proc_exit(1);
+			proc_exit(0);
 		}
 
 		CHECK_FOR_INTERRUPTS();

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -298,6 +298,16 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		double timeout = 10000.0; /* use this if the deadlock detection is disabled */
 		bool foundDeadlock = false;
 
+		LWLockAcquire(&MaintenanceDaemonControl->lock, LW_EXCLUSIVE);
+		pid_t dbDataWorkerPid = myDbData->workerPid;
+		LWLockRelease(&MaintenanceDaemonControl->lock);
+
+		if (dbDataWorkerPid != MyProcPid)
+		{
+			/* if multiple daemons are alive, only keep the one in the hash table */
+			proc_exit(1);
+		}
+
 		CHECK_FOR_INTERRUPTS();
 
 		/*

--- a/src/test/regress/expected/distributed_procedure.out
+++ b/src/test/regress/expected/distributed_procedure.out
@@ -29,10 +29,6 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-CREATE OR REPLACE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
-    RETURNS void
-    LANGUAGE C STRICT
-    AS 'citus';
 -- procedures are distributed by text arguments, when run in isolation it is not guaranteed a table actually exists.
 CREATE TABLE colocation_table(id text);
 SET citus.replication_model TO 'streaming';
@@ -49,7 +45,7 @@ SELECT create_distributed_function('raise_info(text)', '$1', colocate_with := 'c
 
 (1 row)
 
-SELECT wait_until_metadata_sync();
+SELECT public.wait_until_metadata_sync();
  wait_until_metadata_sync
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -15,14 +15,14 @@ DECLARE
    activity record;
 BEGIN
     LOOP
+        PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-	WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE
             PERFORM pg_sleep(0.1);
-            PERFORM pg_stat_clear_snapshot();
-        END IF ;
+        END IF;
     END LOOP;
 END;
 $$;
@@ -253,14 +253,14 @@ DECLARE
    activity record;
 BEGIN
     LOOP
+        PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-	WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE
             PERFORM pg_sleep(0.1);
-            PERFORM pg_stat_clear_snapshot();
-        END IF ;
+        END IF;
     END LOOP;
 END;
 $$;

--- a/src/test/regress/sql/distributed_procedure.sql
+++ b/src/test/regress/sql/distributed_procedure.sql
@@ -22,11 +22,6 @@ ALTER SYSTEM SET citus.metadata_sync_interval TO 3000;
 ALTER SYSTEM SET citus.metadata_sync_retry_interval TO 500;
 SELECT pg_reload_conf();
 
-CREATE OR REPLACE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
-    RETURNS void
-    LANGUAGE C STRICT
-    AS 'citus';
-
 -- procedures are distributed by text arguments, when run in isolation it is not guaranteed a table actually exists.
 CREATE TABLE colocation_table(id text);
 SET citus.replication_model TO 'streaming';
@@ -34,7 +29,7 @@ SET citus.shard_replication_factor TO 1;
 SELECT create_distributed_table('colocation_table','id');
 
 SELECT create_distributed_function('raise_info(text)', '$1', colocate_with := 'colocation_table');
-SELECT wait_until_metadata_sync();
+SELECT public.wait_until_metadata_sync();
 
 SELECT * FROM run_command_on_workers($$CALL procedure_tests.raise_info('hello');$$) ORDER BY 1,2;
 SELECT public.verify_function_is_same_on_workers('procedure_tests.raise_info(text)');

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -19,14 +19,14 @@ DECLARE
    activity record;
 BEGIN
     LOOP
+        PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-	WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE
             PERFORM pg_sleep(0.1);
-            PERFORM pg_stat_clear_snapshot();
-        END IF ;
+        END IF;
     END LOOP;
 END;
 $$;
@@ -237,14 +237,14 @@ DECLARE
    activity record;
 BEGIN
     LOOP
+        PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-	WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE
             PERFORM pg_sleep(0.1);
-            PERFORM pg_stat_clear_snapshot();
-        END IF ;
+        END IF;
     END LOOP;
 END;
 $$;


### PR DESCRIPTION
Example of what I'm trying to fix: https://app.circleci.com/jobs/github/citusdata/citus/84955

Unfortunately this test isn't a high offender for flakiness. Hard to tell if we need to wait on maintenance worker or if this is a matter of stale data from postgres. This PR attempts to address the latter theory

If issues persist, I'd look into integrating `wait_until_metadata_sync` into the test

Fixes #3409 though it doesn't include a test