### PR TITLE
Intermediate row pull up should be false whenever we can fully push down grouping

### DIFF
--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -76,7 +76,8 @@ BuildExtendedOpNodeProperties(MultiExtendedOp *extendedOpNode, bool
 		hasNonPartitionColumnDistinctAgg;
 	extendedOpNodeProperties.pullDistinctColumns = pullDistinctColumns;
 	extendedOpNodeProperties.pushDownWindowFunctions = pushDownWindowFunctions;
-	extendedOpNodeProperties.pullUpIntermediateRows = pullUpIntermediateRows;
+	extendedOpNodeProperties.pullUpIntermediateRows =
+		!groupedByDisjointPartitionColumn && pullUpIntermediateRows;
 
 	return extendedOpNodeProperties;
 }

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -127,6 +127,25 @@ select key, stddev(valf) from aggdata group by key having stddev(val::float8) > 
    2 | 1.01500410508201
 (1 row)
 
+-- Test https://github.com/citusdata/citus/issues/3446
+set citus.coordinator_aggregation_strategy to 'row-gather';
+select id, stddev(val) from aggdata group by id order by 1;
+ id | stddev
+---------------------------------------------------------------------
+  1 |
+  2 |
+  3 |
+  4 |
+  5 |
+  6 |
+  7 |
+  8 |
+  9 |
+ 10 |
+ 11 |
+(11 rows)
+
+set citus.coordinator_aggregation_strategy to 'disabled';
 -- test polymorphic aggregates from https://github.com/citusdata/citus/issues/2397
 -- we do not currently support pseudotypes for transition types, so this errors for now
 CREATE OR REPLACE FUNCTION first_agg(anyelement, anyelement)

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -68,6 +68,10 @@ select sum2(val), sum2_strict(val) from aggdata where valf = 0;
 select key, stddev(valf) from aggdata group by key having stddev(valf) > 2 order by key;
 select key, stddev(valf) from aggdata group by key having stddev(val::float8) > 1 order by key;
 
+-- Test https://github.com/citusdata/citus/issues/3446
+set citus.coordinator_aggregation_strategy to 'row-gather';
+select id, stddev(val) from aggdata group by id order by 1;
+set citus.coordinator_aggregation_strategy to 'disabled';
 
 -- test polymorphic aggregates from https://github.com/citusdata/citus/issues/2397
 -- we do not currently support pseudotypes for transition types, so this errors for now


### PR DESCRIPTION
SELECT id, stdev(y_int) FROM tbl GROUP BY id; was ending up with pullUpIntermediateRows & groupedByDisjointPartitionColumn both set to true,
this would then have the GROUP BY not pushed down while pushing down the aggregate

DESCRIPTION: Fix pushing down aggregates we do not support partial aggregation for while row-gather is enabled in queries which are grouped by a partition column

Fixes #3446