### PR TITLE
diff-filter: use utf8 encoding, not ascii

### DIFF
--- a/src/test/regress/bin/diff
+++ b/src/test/regress/bin/diff
@@ -32,7 +32,7 @@ then
 	touch "$file1"  # when adding a new test the expected file does not exist
 	sed -Ef "$BASEDIR/normalize.sed" < "$file1" > "$file1.modified"
 	sed -Ef "$BASEDIR/normalize.sed" < "$file2" > "$file2.modified"
-	"$DIFF" -w $args "$file1.modified" "$file2.modified" | diff-filter "$BASEDIR/normalize.sed"
+	"$DIFF" -w $args "$file1.modified" "$file2.modified" | LC_CTYPE=C.UTF-8 diff-filter "$BASEDIR/normalize.sed"
 	exit ${PIPESTATUS[0]}
 else
 	exec "$DIFF" -w $args "$file1" "$file2"

--- a/src/test/regress/bin/diff-filter
+++ b/src/test/regress/bin/diff-filter
@@ -49,7 +49,7 @@ def main():
 		if line.startswith('+++ '):
 			tab = line.rindex('\t')
 			fname = line[4:tab]
-			file2 = FileScanner(open(fname.replace('.modified', '')), sed)
+			file2 = FileScanner(open(fname.replace('.modified', ''), encoding='utf8'), sed)
 			stdout.write(line)
 		elif line.startswith('@@ '):
 			idx_start = line.index('+') + 1


### PR DESCRIPTION
Relevant PEPs if you're curious: https://www.python.org/dev/peps/pep-0540 https://www.python.org/dev/peps/pep-0538

Unfortunately those are for Python 3.7 & CircleCI is using Python 3.5 with LC_CTYPE not set to a UTF8 locale. So work around that

Example ci failure: https://app.circleci.com/jobs/github/citusdata/citus/85796