### PR TITLE
Fix adaptive repartition join leak

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -189,7 +189,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		ExecuteTaskListExtended(ROW_MODIFY_NONE, list_make1(task),
 								tupleDesc, tupleStore, hasReturning,
 								MaxAdaptiveExecutorPoolSize,
-								&xactProperties);
+								&xactProperties, NIL);
 
 		while (tuplestore_gettupleslot(tupleStore, true, false, slot))
 		{

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -353,7 +353,7 @@ FindAvailableConnection(dlist_head *connections, uint32 flags)
 
 		if (flags & OUTSIDE_TRANSACTION)
 		{
-			/* dont return connections that are used in transactions */
+			/* don't return connections that are used in transactions */
 			if (connection->remoteTransaction.transactionState !=
 				REMOTE_TRANS_NOT_STARTED)
 			{

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -646,7 +646,7 @@ AdaptiveExecutor(CitusScanState *scanState)
 	/*
 	 * PostgreSQL takes locks on all partitions in the executor. It's not entirely
 	 * clear why this is necessary (instead of locking the parent during DDL), but
-	 * We do the same for consistency.
+	 * we do the same for consistency.
 	 */
 	LockPartitionsForDistributedPlan(distributedPlan);
 

--- a/src/backend/distributed/executor/directed_acyclic_graph_execution.c
+++ b/src/backend/distributed/executor/directed_acyclic_graph_execution.c
@@ -51,7 +51,7 @@ static bool IsTaskAlreadyCompleted(Task *task, HTAB *completedTasks);
  * execute all of them in parallel. The parallelism is bound by MaxAdaptiveExecutorPoolSize.
  */
 void
-ExecuteTasksInDependencyOrder(List *allTasks, List *excludedTasks)
+ExecuteTasksInDependencyOrder(List *allTasks, List *excludedTasks, List *jobIds)
 {
 	HTAB *completedTasks = CreateTaskHashTable();
 
@@ -66,7 +66,7 @@ ExecuteTasksInDependencyOrder(List *allTasks, List *excludedTasks)
 			break;
 		}
 		ExecuteTaskListOutsideTransaction(ROW_MODIFY_NONE, curTasks,
-										  MaxAdaptiveExecutorPoolSize);
+										  MaxAdaptiveExecutorPoolSize, jobIds);
 
 		AddCompletedTasks(curTasks, completedTasks);
 		curTasks = NIL;

--- a/src/backend/distributed/executor/directed_acyclic_graph_execution.c
+++ b/src/backend/distributed/executor/directed_acyclic_graph_execution.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * directed_acylic_graph_execution_logic.c
+ * directed_acyclic_graph_execution_logic.c
  *
  * Logic to run tasks in their dependency order.
  *
@@ -11,7 +11,7 @@
 #include "access/hash.h"
 #include "distributed/hash_helpers.h"
 
-#include "distributed/directed_acylic_graph_execution.h"
+#include "distributed/directed_acyclic_graph_execution.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/adaptive_executor.h"
 #include "distributed/worker_manager.h"

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -413,7 +413,8 @@ ExecuteSelectTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor,
 														 work_mem);
 
 	ExecuteTaskListExtended(ROW_MODIFY_READONLY, taskList, resultDescriptor,
-							resultStore, hasReturning, targetPoolSize, &xactProperties);
+							resultStore, hasReturning, targetPoolSize, &xactProperties,
+							NIL);
 
 	return resultStore;
 }

--- a/src/backend/distributed/executor/repartition_join_execution.c
+++ b/src/backend/distributed/executor/repartition_join_execution.c
@@ -16,8 +16,8 @@
  *
  *
  * Repartition queries do not begin a transaction even if we are in
- * a transaction block. As we dont begin a transaction, they wont see the
- * DDLs that happened earlier in the transaction because we dont have that
+ * a transaction block. As we don't begin a transaction, they won't see the
+ * DDLs that happened earlier in the transaction because we don't have that
  * transaction id with repartition queries. Therefore we error in this case.
  *
  * Copyright (c) Citus Data, Inc.
@@ -29,7 +29,7 @@
 #include "utils/builtins.h"
 #include "distributed/hash_helpers.h"
 
-#include "distributed/directed_acylic_graph_execution.h"
+#include "distributed/directed_acyclic_graph_execution.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/adaptive_executor.h"
 #include "distributed/worker_manager.h"

--- a/src/backend/distributed/executor/repartition_join_execution.c
+++ b/src/backend/distributed/executor/repartition_join_execution.c
@@ -68,7 +68,7 @@ ExecuteDependentTasks(List *topLevelTasks, Job *topLevelJob)
 
 	List *jobIds = CreateTemporarySchemasForMergeTasks(topLevelJob);
 
-	ExecuteTasksInDependencyOrder(allTasks, topLevelTasks);
+	ExecuteTasksInDependencyOrder(allTasks, topLevelTasks, jobIds);
 
 	return jobIds;
 }

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -238,7 +238,7 @@ JoinOnColumns(Var *currentColumn, Var *candidateColumn, List *joinClauseList)
 
 		/*
 		 * Check if both join columns and both partition key columns match, since the
-		 * current and candidate column's can't be NULL we know they wont match if either
+		 * current and candidate column's can't be NULL we know they won't match if either
 		 * of the columns resolved to NULL above.
 		 */
 		if (equal(leftColumn, currentColumn) &&

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -10,11 +10,10 @@ extern int MaxAdaptiveExecutorPoolSize;
 /* GUC, number of ms to wait between opening connections to the same worker */
 extern int ExecutorSlowStartInterval;
 
-extern uint64 ExecuteTaskList(RowModifyLevel modLevel, List *taskList, int
-							  targetPoolSize);
+extern uint64 ExecuteTaskList(RowModifyLevel modLevel, List *taskList,
+							  int targetPoolSize);
 extern uint64 ExecuteTaskListOutsideTransaction(RowModifyLevel modLevel, List *taskList,
-												int
-												targetPoolSize);
+												int targetPoolSize, List *jobIdList);
 
 
 #endif /* ADAPTIVE_EXECUTOR_H */

--- a/src/include/distributed/directed_acyclic_graph_execution.h
+++ b/src/include/distributed/directed_acyclic_graph_execution.h
@@ -14,7 +14,8 @@
 
 #include "nodes/pg_list.h"
 
-extern void ExecuteTasksInDependencyOrder(List *allTasks, List *excludedTasks);
+extern void ExecuteTasksInDependencyOrder(List *allTasks, List *excludedTasks,
+										  List *jobIds);
 
 
 #endif /* DIRECTED_ACYCLIC_GRAPH_EXECUTION_H */

--- a/src/include/distributed/directed_acyclic_graph_execution.h
+++ b/src/include/distributed/directed_acyclic_graph_execution.h
@@ -1,14 +1,14 @@
 /*-------------------------------------------------------------------------
  *
- * directed_acylic_graph_execution.h
- *	  Execution logic for directed acylic graph tasks.
+ * directed_acyclic_graph_execution.h
+ *	  Execution logic for directed acyclic graph tasks.
  *
  * Copyright (c) Citus Data, Inc.
  *-------------------------------------------------------------------------
  */
 
-#ifndef DIRECTED_ACYLIC_GRAPH_EXECUTION_H
-#define DIRECTED_ACYLIC_GRAPH_EXECUTION_H
+#ifndef DIRECTED_ACYCLIC_GRAPH_EXECUTION_H
+#define DIRECTED_ACYCLIC_GRAPH_EXECUTION_H
 
 #include "postgres.h"
 
@@ -17,4 +17,4 @@
 extern void ExecuteTasksInDependencyOrder(List *allTasks, List *excludedTasks);
 
 
-#endif /* DIRECTED_ACYLIC_GRAPH_EXECUTION_H */
+#endif /* DIRECTED_ACYCLIC_GRAPH_EXECUTION_H */

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -77,7 +77,8 @@ extern uint64 ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
 									  TupleDesc tupleDescriptor,
 									  Tuplestorestate *tupleStore,
 									  bool hasReturning, int targetPoolSize,
-									  TransactionProperties *xactProperties);
+									  TransactionProperties *xactProperties,
+									  List *jobIdList);
 extern uint64 ExecuteTaskListIntoTupleStore(RowModifyLevel modLevel, List *taskList,
 											TupleDesc tupleDescriptor,
 											Tuplestorestate *tupleStore,

--- a/src/test/regress/upgrade/README.md
+++ b/src/test/regress/upgrade/README.md
@@ -89,7 +89,7 @@ How the citus upgrade test work:
 
 Note that when the version of citus changes, we should update `MASTER_VERSION` with the new version of citus otherwise that will be outdated and it will fail.
 
-There is a target for citus upgrade test. We run citus upgrade tests both in normal mode and in mixed mode. In mixed mode, we dont upgrade one of the workers. `'citus.enable_version_checks' : 'false'` is used to prevent citus from giving an error for mixed mode.
+There is a target for citus upgrade test. We run citus upgrade tests both in normal mode and in mixed mode. In mixed mode, we don't upgrade one of the workers. `'citus.enable_version_checks' : 'false'` is used to prevent citus from giving an error for mixed mode.
 
 To see full command list:
 


### PR DESCRIPTION
Fixes #3459

First commit: typo noticed while reviewing #3169 
Second commit: connectionId in MultiConnection added by #3169 seems to be only used for one pre-existing log message. Debug code? Removed
Third commit: fix jobIdList never being set for DistributedExecution