### PR TITLE
Improve single hash-repartitioning with numeric (or non-int) types

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4278,12 +4278,16 @@ CreateMapQueryString(MapMergeJob *mapMergeJob, Task *filterTask,
 	ShardInterval **intervalArray = mapMergeJob->sortedShardIntervalArray;
 	uint32 intervalCount = mapMergeJob->partitionCount;
 
-	if (partitionType != SINGLE_HASH_PARTITION_TYPE && partitionType !=
-		RANGE_PARTITION_TYPE)
+	if (partitionType == DUAL_HASH_PARTITION_TYPE)
 	{
 		partitionColumnType = INT4OID;
 		partitionColumnTypeMod = get_typmodin(INT4OID);
 		intervalArray = GenerateSyntheticShardIntervalArray(intervalCount);
+	}
+	else if (partitionType == SINGLE_HASH_PARTITION_TYPE)
+	{
+		partitionColumnType = INT4OID;
+		partitionColumnTypeMod = get_typmodin(INT4OID);
 	}
 
 	ArrayType *splitPointObject = SplitPointObject(intervalArray, intervalCount);

--- a/src/test/regress/expected/single_hash_repartition_join.out
+++ b/src/test/regress/expected/single_hash_repartition_join.out
@@ -493,10 +493,24 @@ DETAIL:  Creating dependency on merge taskId 20
 ERROR:  the query contains a join that requires repartitioning
 HINT:  Set citus.enable_repartition_joins to on to enable repartitioning
 RESET client_min_messages;
+CREATE TABLE test_numeric  (a numeric, b numeric);
+SET citus.shard_count TO 7;
+SELECT create_distributed_table('test_numeric', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO test_numeric SELECT i,i FROM generate_series(0,1000) i;
+SET citus.enable_single_hash_repartition_joins TO ON;
+SET citus.enable_repartition_joins TO on;
+SELECT count(*) FROM test_numeric t1 JOIN test_numeric as t2 ON (t1.a = t2.b);
+ count
+---------------------------------------------------------------------
+  1001
+(1 row)
+
+SET client_min_messages TO ERROR;
 RESET search_path;
 DROP SCHEMA single_hash_repartition CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to table single_hash_repartition.single_hash_repartition_first
-drop cascades to table single_hash_repartition.single_hash_repartition_second
-drop cascades to table single_hash_repartition.ref_table
 SET citus.enable_single_hash_repartition_joins TO OFF;

--- a/src/test/regress/sql/single_hash_repartition_join.sql
+++ b/src/test/regress/sql/single_hash_repartition_join.sql
@@ -137,6 +137,16 @@ WHERE
 
 RESET client_min_messages;
 
+CREATE TABLE test_numeric  (a numeric, b numeric);
+SET citus.shard_count TO 7;
+SELECT create_distributed_table('test_numeric', 'a');
+
+INSERT INTO test_numeric SELECT i,i FROM generate_series(0,1000) i;
+SET citus.enable_single_hash_repartition_joins TO ON;
+SET citus.enable_repartition_joins TO on;
+SELECT count(*) FROM test_numeric t1 JOIN test_numeric as t2 ON (t1.a = t2.b);
+
+SET client_min_messages TO ERROR;
 RESET search_path;
 DROP SCHEMA single_hash_repartition CASCADE;
 SET citus.enable_single_hash_repartition_joins TO OFF;


### PR DESCRIPTION
We used to treat the shard interval array that we passed as numeric[].
However, it should be int[], as the shard ranges are int[].

So, the worker hash step changes from:

```SQL
NOTICE:  issuing SELECT worker_hash_partition_table  (415168987137, 1, 'SELECT b FROM chbenchmark_all_queries.test_numeric_102334 t2 WHERE true', 'b', 'numeric'::regtype, '{-2147483648,-1533916892,-920350136,-306783380,306783376,920350132,1533916888}'::numeric[])

```
To:
```SQL
NOTICE:  issuing SELECT worker_hash_partition_table  (415168987137, 1, 'SELECT b FROM chbenchmark_all_queries.test_numeric_102334 t2 WHERE true', 'b', 'numeric'::regtype, '{-2147483648,-1533916892,-920350136,-306783380,306783376,920350132,1533916888}'::integer[])
```


DESCRIPTION:  Fixes a bug that might crash on various datatypes with single hash repartition