### PR TITLE
Introduce objects to dist. infrastructure when updating Citus

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -1627,7 +1627,7 @@ CheckAvailableVersion(int elevel)
 
 /*
  * CheckInstalledVersion compares CITUS_EXTENSIONVERSION and the
- * extension's current version from the pg_extemsion catalog table. If they
+ * extension's current version from the pg_extension catalog table. If they
  * are not compatible, this function logs an error with the specified elevel,
  * otherwise it returns true.
  */
@@ -1651,6 +1651,26 @@ CheckInstalledVersion(int elevel)
 	}
 
 	return true;
+}
+
+
+/*
+ * InstalledAndAvailableVersionsSame compares extension's available version and
+ * its current version from the pg_extension catalog table. If they are not same
+ * returns false, otherwise returns true.
+ */
+bool
+InstalledAndAvailableVersionsSame()
+{
+	char *installedVersion = InstalledExtensionVersion();
+	char *availableVersion = AvailableExtensionVersion();
+
+	if (strncmp(installedVersion, availableVersion, NAMEDATALEN) == 0)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 
@@ -1904,7 +1924,7 @@ CitusCatalogNamespaceId(void)
 }
 
 
-/* return oid of pg_dist_shard relation */
+/* return oid of pg_dist_object relation */
 Oid
 DistObjectRelationId(void)
 {

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -81,6 +81,7 @@ extern List * PostprocessAlterExtensionSchemaStmt(Node *stmt,
 												  const char *queryString);
 extern List * PreprocessAlterExtensionUpdateStmt(Node *stmt,
 												 const char *queryString);
+extern void PostprocessAlterExtensionCitusUpdateStmt(Node *node);
 extern List * PreprocessAlterExtensionContentsStmt(Node *node,
 												   const char *queryString);
 extern List * CreateExtensionDDLCommand(const ObjectAddress *extensionAddress);

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -138,6 +138,7 @@ extern void CreateDistributedTable(Oid relationId, Var *distributionColumn,
 extern void CreateTruncateTrigger(Oid relationId);
 
 extern void EnsureDependenciesExistOnAllNodes(const ObjectAddress *target);
+extern List * GetDistributableDependenciesForObject(const ObjectAddress *target);
 extern bool ShouldPropagate(void);
 extern bool ShouldPropagateObject(const ObjectAddress *address);
 extern void ReplicateAllDependenciesToNode(const char *nodeName, int nodePort);

--- a/src/include/distributed/metadata/dependency.h
+++ b/src/include/distributed/metadata/dependency.h
@@ -17,6 +17,7 @@
 #include "catalog/objectaddress.h"
 #include "nodes/pg_list.h"
 
+extern List * GetUniqueDependenciesList(List *objectAddressesList);
 extern List * GetDependenciesForObject(const ObjectAddress *target);
 extern List * OrderObjectAddressListInDependencyOrder(List *objectAddressList);
 extern bool SupportedDependencyByCitus(const ObjectAddress *address);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -150,6 +150,7 @@ extern bool HasOverlappingShardInterval(ShardInterval **shardIntervalArray,
 extern bool CitusHasBeenLoaded(void);
 extern bool CheckCitusVersion(int elevel);
 extern bool CheckAvailableVersion(int elevel);
+extern bool InstalledAndAvailableVersionsSame(void);
 extern bool MajorVersionsCompatible(char *leftVersion, char *rightVersion);
 extern void ErrorIfInconsistentShardIntervals(DistTableCacheEntry *cacheEntry);
 extern void EnsureModificationsCanRun(void);

--- a/src/test/regress/after_citus_upgrade_coord_schedule
+++ b/src/test/regress/after_citus_upgrade_coord_schedule
@@ -1,3 +1,4 @@
 # this schedule is to be run only on coordinators
 
 test: upgrade_basic_after
+test: upgrade_pg_dist_object_test_after

--- a/src/test/regress/before_citus_upgrade_coord_schedule
+++ b/src/test/regress/before_citus_upgrade_coord_schedule
@@ -1,3 +1,4 @@
 # this schedule is to be run on only coordinators
 
 test: upgrade_basic_before
+test: upgrade_pg_dist_object_test_before

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
@@ -1,0 +1,33 @@
+-- drop objects from previous test (uprade_basic_after.sql) for a clean test
+-- drop upgrade_basic schema and switch back to public schema
+SET search_path to public;
+DROP SCHEMA upgrade_basic CASCADE;
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table upgrade_basic.t
+drop cascades to table upgrade_basic.tp
+drop cascades to table upgrade_basic.t_ab
+drop cascades to table upgrade_basic.t2
+drop cascades to table upgrade_basic.r
+drop cascades to table upgrade_basic.tr
+drop cascades to table upgrade_basic.t_append
+-- as we updated citus to available version,
+--   "isn" extension
+--   "new_schema" schema
+--   "public" schema
+--   "fooschema" schema
+--   "footype" type (under schema 'fooschema')
+ -- will now be marked as distributed
+ -- but,
+ --   "seg" extension
+ -- will not be marked as distributed
+-- see underlying objects
+SELECT i.* FROM citus.pg_dist_object, pg_identify_object_as_address(classid, objid, objsubid) i ORDER BY 1, 2, 3;
+      type      | object_names | object_args
+---------------------------------------------------------------------
+  extension      | {isn}               | {}
+  schema         | {fooschema}         | {}
+  schema         | {new_schema}        | {}
+  schema         | {public}            | {}
+  type           | {fooschema.footype} | {}
+ (5 rows)
+

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
@@ -1,0 +1,74 @@
+-- create some objects that we just included into distributed object
+-- infrastructure in 9.1 versions but not included in 9.0.2
+-- extension propagation --
+-- create an extension on all nodes and a table that depends on it
+CREATE EXTENSION isn;
+SELECT run_command_on_workers($$CREATE EXTENSION isn;$$);
+         run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57636,t,"CREATE EXTENSION")
+ (localhost,57637,t,"CREATE EXTENSION")
+(2 rows)
+
+CREATE TABLE isn_dist_table (key int, value issn);
+SELECT create_reference_table('isn_dist_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- create an extension on all nodes, but do not create a table depending on it
+CREATE EXTENSION seg;
+SELECT run_command_on_workers($$CREATE EXTENSION seg;$$);
+         run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57636,t,"CREATE EXTENSION")
+ (localhost,57637,t,"CREATE EXTENSION")
+(2 rows)
+
+-- schema propagation --
+-- public schema
+CREATE TABLE dist_table (a int);
+SELECT create_reference_table('dist_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- custom schema
+CREATE SCHEMA new_schema;
+SET search_path to new_schema;
+CREATE TABLE another_dist_table (a int);
+SELECT create_reference_table('another_dist_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- another custom schema and a type
+-- create table that depends both on a type & schema here (actually type depends on the schema)
+-- here we test if schema is marked as distributed successfully.
+-- This is because tracking the dependencies will hit to the schema for two times
+CREATE SCHEMA fooschema;
+CREATE TYPE fooschema.footype AS (x int, y int);
+SELECT run_command_on_workers($$CREATE SCHEMA fooschema;$$);
+       run_command_on_workers
+---------------------------------------------------------------------
+  (localhost,57636,t,"CREATE SCHEMA")
+  (localhost,57637,t,"CREATE SCHEMA")
+ (2 rows)
+
+ SELECT run_command_on_workers($$CREATE TYPE fooschema.footype AS (x int, y int);$$);
+      run_command_on_workers
+---------------------------------------------------------------------
+  (localhost,57636,t,"CREATE TYPE")
+  (localhost,57637,t,"CREATE TYPE")
+ (2 rows)
+
+ CREATE TABLE fooschema.footable (f fooschema.footype);
+ SELECT create_reference_table('fooschema.footable');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_after.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_after.sql
@@ -1,0 +1,18 @@
+-- drop objects from previous test (uprade_basic_after.sql) for a clean test
+-- drop upgrade_basic schema and switch back to public schema
+SET search_path to public;
+DROP SCHEMA upgrade_basic CASCADE;
+
+-- as we updated citus to available version,
+--   "isn" extension
+--   "new_schema" schema
+--   "public" schema
+--   "fooschema" schema
+--   "footype" type (under schema 'fooschema')
+-- will now be marked as distributed
+-- but,
+--   "seg" extension
+-- will not be marked as distributed
+
+-- see underlying objects
+SELECT i.* FROM citus.pg_dist_object, pg_identify_object_as_address(classid, objid, objsubid) i ORDER BY 1, 2, 3;

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
@@ -1,0 +1,44 @@
+-- create some objects that we just included into distributed object
+-- infrastructure in 9.1 versions but not included in 9.0.2
+
+-- extension propagation --
+
+-- create an extension on all nodes and a table that depends on it
+CREATE EXTENSION isn;
+SELECT run_command_on_workers($$CREATE EXTENSION isn;$$);
+
+CREATE TABLE isn_dist_table (key int, value issn);
+SELECT create_reference_table('isn_dist_table');
+
+-- create an extension on all nodes, but do not create a table depending on it
+CREATE EXTENSION seg;
+SELECT run_command_on_workers($$CREATE EXTENSION seg;$$);
+
+-- schema propagation --
+
+-- public schema
+CREATE TABLE dist_table (a int);
+SELECT create_reference_table('dist_table');
+
+-- custom schema
+CREATE SCHEMA new_schema;
+
+SET search_path to new_schema;
+
+CREATE TABLE another_dist_table (a int);
+SELECT create_reference_table('another_dist_table');
+
+-- another custom schema and a type
+
+-- create table that depends both on a type & schema here (actually type depends on the schema)
+-- here we test if schema is marked as distributed successfully.
+-- This is because tracking the dependencies will hit to the schema for two times
+
+CREATE SCHEMA fooschema;
+CREATE TYPE fooschema.footype AS (x int, y int);
+
+SELECT run_command_on_workers($$CREATE SCHEMA fooschema;$$);
+SELECT run_command_on_workers($$CREATE TYPE fooschema.footype AS (x int, y int);$$);
+
+CREATE TABLE fooschema.footable (f fooschema.footype);
+SELECT create_reference_table('fooschema.footable');


### PR DESCRIPTION
DESCRIPTION: Introduce objects to dist. infrastructure updating Citus

This pr aims to mark existing objects that are not included in distributed object infrastructure in older versions of Citus (but now should be) as distributed, after updating Citus successfully to available version.