### PR TITLE
(WIP) Don't use COPY format for intermediate results.

### DIFF
--- a/src/backend/distributed/executor/intermediate_result_encoder.c
+++ b/src/backend/distributed/executor/intermediate_result_encoder.c
@@ -1,0 +1,233 @@
+/*-------------------------------------------------------------------------
+ *
+ * intermediate_result_encoder.c
+ *   Functions for encoding and decoding intermediate results.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+
+#include "catalog/pg_enum.h"
+#include "commands/copy.h"
+#include "distributed/commands/multi_copy.h"
+#include "distributed/connection_management.h"
+#include "distributed/intermediate_results.h"
+#include "distributed/master_metadata_utility.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/multi_client_executor.h"
+#include "distributed/multi_executor.h"
+#include "distributed/remote_commands.h"
+#include "distributed/transmit.h"
+#include "distributed/transaction_identifier.h"
+#include "distributed/tuplestore.h"
+#include "distributed/version_compat.h"
+#include "distributed/worker_protocol.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "nodes/primnodes.h"
+#include "storage/fd.h"
+#include "tcop/tcopprot.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/syscache.h"
+
+
+static void SerializeSingleDatum(StringInfo datumBuffer, Datum datum,
+								 bool datumTypeByValue, int datumTypeLength,
+								 char datumTypeAlign);
+
+IntermediateResultEncoder *
+IntermediateResultEncoderCreate(TupleDesc tupleDesc, IntermediateResultFormat format)
+{
+	IntermediateResultEncoder *encoder = palloc0(sizeof(IntermediateResultEncoder));
+	encoder->format = format;
+	encoder->tupleDescriptor = tupleDesc;
+	encoder->outputBuffer = makeStringInfo();
+
+	return encoder;
+}
+
+
+void
+IntermediateResultEncoderReceive(IntermediateResultEncoder *encoder,
+								 Datum *values, bool *nulls)
+{
+	StringInfo buffer = encoder->outputBuffer;
+	TupleDesc tupleDescriptor = encoder->tupleDescriptor;
+
+	/* place holder for tuple size so we fill it later */
+	int sizePos = buffer->len;
+	int size = 0;
+	appendBinaryStringInfo(buffer, (char *) &size, sizeof(size));
+
+	for (int columnIndex = 0; columnIndex < tupleDescriptor->natts;)
+	{
+		unsigned char bitarray = 0;
+		for (int bitIndex = 0; bitIndex < 8 && columnIndex < tupleDescriptor->natts;
+			 bitIndex++, columnIndex++)
+		{
+			if (nulls[columnIndex])
+			{
+				bitarray |= (1 << bitIndex);
+			}
+		}
+
+		appendBinaryStringInfo(buffer, (char *) &bitarray, 1);
+	}
+
+	/* serialize tuple ... */
+	for (int columnIndex = 0; columnIndex < tupleDescriptor->natts; columnIndex++)
+	{
+		if (nulls[columnIndex])
+		{
+			continue;
+		}
+
+		Form_pg_attribute attributeForm = TupleDescAttr(tupleDescriptor, columnIndex);
+		SerializeSingleDatum(buffer, values[columnIndex],
+							 attributeForm->attbyval, attributeForm->attlen,
+							 attributeForm->attalign);
+	}
+
+	/* fill in the correct size */
+	size = buffer->len - sizePos - sizeof(size);
+	memcpy(buffer->data + sizePos, &size, sizeof(size));
+}
+
+
+void
+IntermediateResultEncoderDone(IntermediateResultEncoder *encoder)
+{
+	/* todo */
+}
+
+
+/*
+ * SerializeSingleDatum serializes the given datum value and appends it to the
+ * provided string info buffer.
+ *
+ * (taken from cstore_fdw)
+ */
+static void
+SerializeSingleDatum(StringInfo datumBuffer, Datum datum, bool datumTypeByValue,
+					 int datumTypeLength, char datumTypeAlign)
+{
+	uint32 datumLength = att_addlength_datum(0, datumTypeLength, datum);
+	uint32 datumLengthAligned = att_align_nominal(datumLength, datumTypeAlign);
+
+	enlargeStringInfo(datumBuffer, datumBuffer->len + datumLengthAligned + 1);
+
+	char *currentDatumDataPointer = datumBuffer->data + datumBuffer->len;
+
+	if (datumTypeLength > 0)
+	{
+		if (datumTypeByValue)
+		{
+			store_att_byval(currentDatumDataPointer, datum, datumTypeLength);
+		}
+		else
+		{
+			memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumTypeLength);
+		}
+	}
+	else
+	{
+		Assert(!datumTypeByValue);
+		memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumLength);
+	}
+
+	datumBuffer->len += datumLengthAligned;
+}
+
+
+/*
+ * ReadFileIntoTupleStore parses the records in a COPY-formatted file according
+ * according to the given tuple descriptor and stores the records in a tuple
+ * store.
+ */
+void
+ReadFileIntoTupleStore(char *fileName, IntermediateResultFormat format,
+					   TupleDesc tupleDescriptor, Tuplestorestate *tupstore)
+{
+	EState *executorState = CreateExecutorState();
+	MemoryContext executorTupleContext = GetPerTupleMemoryContext(executorState);
+
+	int columnCount = tupleDescriptor->natts;
+	Datum *columnValues = palloc0(columnCount * sizeof(Datum));
+	bool *columnNulls = palloc0(columnCount * sizeof(bool));
+
+	const int fileFlags = (O_RDONLY | PG_BINARY);
+	const int fileMode = 0;
+	StringInfo buffer = makeStringInfo();
+
+	/* we currently do not check if the caller has permissions for this file */
+	File fileDesc = FileOpenForTransmit(fileName, fileFlags, fileMode);
+	FileCompat fileCompat = FileCompatFromFileStart(fileDesc);
+
+	int tupleSize = 0;
+
+	while (FileReadCompat(&fileCompat, (char *) &tupleSize, sizeof(tupleSize),
+						  PG_WAIT_IO) == sizeof(tupleSize))
+	{
+		ResetPerTupleExprContext(executorState);
+		MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
+
+		enlargeStringInfo(buffer, tupleSize);
+		FileReadCompat(&fileCompat, buffer->data, tupleSize, PG_WAIT_IO);
+		uint32 currentDatumDataOffset = 0;
+
+		for (int columnIndex = 0; columnIndex < tupleDescriptor->natts;)
+		{
+			unsigned char bitarray = buffer->data[currentDatumDataOffset++];
+			for (int bitIndex = 0; bitIndex < 8 && columnIndex < tupleDescriptor->natts;
+				 bitIndex++, columnIndex++)
+			{
+				if (bitarray & (1 << bitIndex))
+				{
+					columnNulls[columnIndex] = true;
+				}
+				else
+				{
+					columnNulls[columnIndex] = false;
+				}
+			}
+		}
+
+		for (int columnIndex = 0; columnIndex < tupleDescriptor->natts; columnIndex++)
+		{
+			if (columnNulls[columnIndex])
+			{
+				continue;
+			}
+
+			Form_pg_attribute attributeForm = TupleDescAttr(tupleDescriptor, columnIndex);
+			char *currentDatumDataPointer = buffer->data + currentDatumDataOffset;
+
+			columnValues[columnIndex] = fetch_att(currentDatumDataPointer,
+												  attributeForm->attbyval,
+												  attributeForm->attlen);
+
+			currentDatumDataOffset = att_addlength_datum(currentDatumDataOffset,
+														 attributeForm->attlen,
+														 currentDatumDataPointer);
+			currentDatumDataOffset = att_align_nominal(currentDatumDataOffset,
+													   attributeForm->attalign);
+		}
+
+		tuplestore_putvalues(tupstore, tupleDescriptor, columnValues, columnNulls);
+		MemoryContextSwitchTo(oldContext);
+	}
+
+	pfree(columnValues);
+	pfree(columnNulls);
+}

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -395,7 +395,7 @@ RemoteFileDestReceiverReceive(TupleTableSlot *slot, DestReceiver *dest)
 	size = buffer->len - sizePos - sizeof(size);
 	memcpy(buffer->data + sizePos, &size, sizeof(size));
 
-	if (buffer->len > 4096)
+	if (buffer->len > 8192)
 	{
 		/* send row to nodes */
 		BroadcastCopyData(buffer, connectionList);
@@ -1026,7 +1026,6 @@ SerializeSingleDatum(StringInfo datumBuffer, Datum datum, bool datumTypeByValue,
 	enlargeStringInfo(datumBuffer, datumBuffer->len + datumLengthAligned + 1);
 
 	char *currentDatumDataPointer = datumBuffer->data + datumBuffer->len;
-	memset(currentDatumDataPointer, 0, datumLengthAligned);
 
 	if (datumTypeLength > 0)
 	{

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -237,8 +237,9 @@ RemoteFileDestReceiverStartup(DestReceiver *dest, int operation,
 	List *connectionList = NIL;
 	ListCell *connectionCell = NULL;
 
+	IntermediateResultFormat format = ResultFileFormatForTupleDesc(inputTupleDescriptor);
 	resultDest->encoder = IntermediateResultEncoderCreate(inputTupleDescriptor,
-														  TUPLE_DUMP_FORMAT);
+														  format);
 
 	if (resultDest->writeLocalFile)
 	{

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -236,10 +236,11 @@ RemoteFileDestReceiverStartup(DestReceiver *dest, int operation,
 	ListCell *initialNodeCell = NULL;
 	List *connectionList = NIL;
 	ListCell *connectionCell = NULL;
-
+	MemoryContext tupleContext = GetPerTupleMemoryContext(resultDest->executorState);
 	IntermediateResultFormat format = ResultFileFormatForTupleDesc(inputTupleDescriptor);
+
 	resultDest->encoder = IntermediateResultEncoderCreate(inputTupleDescriptor,
-														  format);
+														  format, tupleContext);
 
 	if (resultDest->writeLocalFile)
 	{
@@ -469,6 +470,8 @@ static void
 RemoteFileDestReceiverDestroy(DestReceiver *destReceiver)
 {
 	RemoteFileDestReceiver *resultDest = (RemoteFileDestReceiver *) destReceiver;
+
+	IntermediateResultEncoderDestroy(resultDest->encoder);
 
 	pfree(resultDest);
 }

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -307,7 +307,7 @@ ReadFileIntoTupleStore(char *fileName, char *copyFormat, TupleDesc tupleDescript
 			for (int bitIndex = 0; bitIndex < 8 && columnIndex < tupleDescriptor->natts;
 				 bitIndex++, columnIndex++)
 			{
-				if (bitarray && (1 << bitIndex))
+				if (bitarray & (1 << bitIndex))
 				{
 					columnNulls[columnIndex] = true;
 				}

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -459,8 +459,11 @@ PartitionedResultDestReceiverReceive(TupleTableSlot *slot, DestReceiver *copyDes
 						 partitionIndex);
 		char *filePath = QueryResultFileName(resultId->data);
 
+		IntermediateResultFormat format =
+			partitionedDest->binaryCopy ? BINARY_COPY_FORMAT : TEXT_COPY_FORMAT;
+
 		partitionDest = CreateFileDestReceiver(filePath, partitionedDest->perTupleContext,
-											   partitionedDest->binaryCopy);
+											   format);
 		partitionedDest->partitionDestReceivers[partitionIndex] = partitionDest;
 		partitionDest->rStartup(partitionDest, 0, partitionedDest->tupleDescriptor);
 	}

--- a/src/backend/distributed/sql/citus--9.2-1--9.2-2.sql
+++ b/src/backend/distributed/sql/citus--9.2-1--9.2-2.sql
@@ -2,3 +2,5 @@
 
 -- reserve UINT32_MAX (4294967295) for a special node
 ALTER SEQUENCE pg_catalog.pg_dist_node_nodeid_seq MAXVALUE 4294967294;
+
+ALTER TYPE pg_catalog.citus_copy_format ADD VALUE 'datum';

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -48,6 +48,23 @@ typedef struct DistributedResultFragment
 } DistributedResultFragment;
 
 
+typedef enum IntermediateResultFormat
+{
+	TEXT_COPY_FORMAT,
+	BINARY_COPY_FORMAT,
+	TUPLE_DUMP_FORMAT
+} IntermediateResultFormat;
+
+typedef struct IntermediateResultEncoder
+{
+	IntermediateResultFormat format;
+	TupleDesc tupleDescriptor;
+	StringInfo outputBuffer;
+
+	void *private;
+} IntermediateResultEncoder;
+
+
 /* intermediate_results.c */
 extern DestReceiver * CreateRemoteFileDestReceiver(char *resultId, EState *executorState,
 												   List *initialNodeList, bool
@@ -58,6 +75,17 @@ extern void RemoveIntermediateResultsDirectory(void);
 extern int64 IntermediateResultSize(char *resultId);
 extern char * QueryResultFileName(const char *resultId);
 extern char * CreateIntermediateResultsDirectory(void);
+
+/* encoding intermediate result files */
+extern IntermediateResultEncoder * IntermediateResultEncoderCreate(TupleDesc tupleDesc,
+																   IntermediateResultFormat
+																   format);
+extern void IntermediateResultEncoderReceive(IntermediateResultEncoder *encoder,
+											 Datum *values, bool *nulls);
+extern void IntermediateResultEncoderDone(IntermediateResultEncoder *encoder);
+extern void ReadFileIntoTupleStore(char *fileName, IntermediateResultFormat format,
+								   TupleDesc tupleDescriptor, Tuplestorestate *tupstore);
+
 
 /* distributed_intermediate_results.c */
 extern List ** RedistributeTaskListResults(char *resultIdPrefix,

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -81,10 +81,12 @@ extern char * CreateIntermediateResultsDirectory(void);
 /* encoding intermediate result files */
 extern IntermediateResultEncoder * IntermediateResultEncoderCreate(TupleDesc tupleDesc,
 																   IntermediateResultFormat
-																   format);
+																   format, MemoryContext
+																   tupleContext);
 extern void IntermediateResultEncoderReceive(IntermediateResultEncoder *encoder,
 											 Datum *values, bool *nulls);
 extern void IntermediateResultEncoderDone(IntermediateResultEncoder *encoder);
+extern void IntermediateResultEncoderDestroy(IntermediateResultEncoder *encoder);
 extern void ReadFileIntoTupleStore(char *fileName, IntermediateResultFormat format,
 								   TupleDesc tupleDescriptor, Tuplestorestate *tupstore);
 extern IntermediateResultFormat ResultFileFormatForTupleDesc(TupleDesc tupleDesc);

--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -61,7 +61,9 @@ typedef struct IntermediateResultEncoder
 	TupleDesc tupleDescriptor;
 	StringInfo outputBuffer;
 
-	void *private;
+	/* used when format is *_COPY_FORMAT */
+	CopyOutState copyOutState;
+	FmgrInfo *columnOutputFunctions;
 } IntermediateResultEncoder;
 
 
@@ -85,7 +87,7 @@ extern void IntermediateResultEncoderReceive(IntermediateResultEncoder *encoder,
 extern void IntermediateResultEncoderDone(IntermediateResultEncoder *encoder);
 extern void ReadFileIntoTupleStore(char *fileName, IntermediateResultFormat format,
 								   TupleDesc tupleDescriptor, Tuplestorestate *tupstore);
-
+extern IntermediateResultFormat ResultFileFormatForTupleDesc(TupleDesc tupleDesc);
 
 /* distributed_intermediate_results.c */
 extern List ** RedistributeTaskListResults(char *resultIdPrefix,

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -89,8 +89,6 @@ extern uint64 ExecuteTaskList(RowModifyLevel modLevel, List *taskList, int
 extern TupleTableSlot * CitusExecScan(CustomScanState *node);
 extern TupleTableSlot * ReturnTupleFromTuplestore(CitusScanState *scanState);
 extern void LoadTuplesIntoTupleStore(CitusScanState *citusScanState, Job *workerJob);
-extern void ReadFileIntoTupleStore(char *fileName, char *copyFormat, TupleDesc
-								   tupleDescriptor, Tuplestorestate *tupstore);
 extern Query * ParseQueryString(const char *queryString, Oid *paramOids, int numParams);
 extern void ExecuteQueryStringIntoDestReceiver(const char *queryString, ParamListInfo
 											   params,

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -17,6 +17,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "distributed/intermediate_results.h"
 #include "distributed/shardinterval_utils.h"
 #include "lib/stringinfo.h"
 #include "nodes/parsenodes.h"
@@ -138,7 +139,7 @@ extern CreateStmt * CreateStatement(RangeVar *relation, List *columnDefinitionLi
 extern CopyStmt * CopyStatement(RangeVar *relation, char *sourceFilename);
 extern DestReceiver * CreateFileDestReceiver(char *filePath,
 											 MemoryContext tupleContext,
-											 bool binaryCopyFormat);
+											 IntermediateResultFormat format);
 extern void FileDestReceiverStats(DestReceiver *dest,
 								  uint64 *rowsSent,
 								  uint64 *bytesSent);


### PR DESCRIPTION
We don't need to use COPY formats for intermediate result files. We can just dump the datums into the result file.

This prototype is far from being reviewable or mergeable, just did a quick hack to see how much performance gain we can get.

For the following case:

```sql
CREATE TABLE t(a int, b int, c int);
SELECT create_distributed_table('t', 'a');

INSERT INTO t SELECT i, 2 * i, 3 * i FROM generate_series(1, 10000000) i;

WITH r AS (
    SELECT random(), a, b, c FROM t
) SELECT count(a) FROM r;
```

The CTE takes 34s with master and 27.6s with current branch, so about 19% improvement.

The plan is:
- [ ] Phase 1: Use this only for recursive planner, but make repartition join and insert/select with repartitioning tests pass by not using this. Alternatively refactor all of them to use same functions for writing to result files.
- [ ] try to optimize this further. I think shaving another 10-20% shouldn't be difficult.
- [ ] Phase 2: after we have tested this with CTEs, also use it in repartition joins and insert/select with repartitioning.