### PR TITLE
fix uninitialized variable warning

### DIFF
--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -47,7 +47,7 @@ static List * UnionRelationRestrictionLists(List *firstRelationList,
 ColocatedJoinChecker
 CreateColocatedJoinChecker(Query *subquery, PlannerRestrictionContext *restrictionContext)
 {
-	ColocatedJoinChecker colocatedJoinChecker;
+	ColocatedJoinChecker colocatedJoinChecker = { 0 };
 
 	Query *anchorSubquery = NULL;
 


### PR DESCRIPTION
fix uninitialized variable warning we have while packaging Citus