### PR TITLE
send repartition cleanup jobs in parallel to all workers

### DIFF
--- a/src/backend/distributed/executor/repartition_join_execution.c
+++ b/src/backend/distributed/executor/repartition_join_execution.c
@@ -167,9 +167,8 @@ GenerateJobCommands(List *jobIds, char *templateCommand)
 void
 DoRepartitionCleanup(List *jobIds)
 {
-	SendOptionalCommandListToAllWorkers(list_make1(GenerateDeleteJobsCommand(
-													   jobIds)),
-										CitusExtensionOwnerName());
+	SendCommandToWorkersOptionalInParallel(ALL_WORKERS, GenerateDeleteJobsCommand(jobIds),
+										   CitusExtensionOwnerName());
 }
 
 

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -48,6 +48,9 @@ extern void SendCommandListToWorkerInSingleTransaction(const char *nodeName,
 													   int32 nodePort,
 													   const char *nodeUser,
 													   List *commandList);
+extern void SendCommandToWorkersOptionalInParallel(TargetWorkerSet targetWorkerSet, const
+												   char *command,
+												   const char *user);
 extern void RemoveWorkerTransaction(char *nodeName, int32 nodePort);
 
 /* helper functions for worker transactions */


### PR DESCRIPTION
Repartition cleanup jobs are not sent in parallel to all workers in a way that:
- if sending a cleanup query fails, an error is returned
- if executing a cleanup query fails, an error is NOT returned

Fixes #3464.