### PR TITLE
Prefer instr_time to TimestampTz when we want CLOCK_MONOTONIC

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -212,9 +212,7 @@ ExplainSubPlans(DistributedPlan *distributedPlan, ExplainState *es)
 			es->indent += 3;
 		}
 
-		/* set the planning time to 0 */
-		INSTR_TIME_SET_CURRENT(planduration);
-		INSTR_TIME_SUBTRACT(planduration, planduration);
+		INSTR_TIME_SET_ZERO(planduration);
 
 		ExplainOnePlan(plan, into, es, queryString, params, NULL, &planduration);
 

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -14,6 +14,7 @@
 #include "distributed/transaction_management.h"
 #include "distributed/remote_transaction.h"
 #include "lib/ilist.h"
+#include "portability/instr_time.h"
 #include "utils/guc.h"
 #include "utils/hsearch.h"
 #include "utils/timestamp.h"
@@ -227,12 +228,14 @@ extern void FinishConnectionListEstablishment(List *multiConnectionList);
 extern void FinishConnectionEstablishment(MultiConnection *connection);
 extern void ClaimConnectionExclusively(MultiConnection *connection);
 extern void UnclaimConnection(MultiConnection *connection);
-extern long DeadlineTimestampTzToTimeout(TimestampTz deadline);
 
 /* dealing with notice handler */
 extern void SetCitusNoticeProcessor(MultiConnection *connection);
 extern char * TrimLogLevel(const char *message);
 extern void UnsetCitusNoticeLevel(void);
 
+/* time utilities */
+extern double MillisecondsPassedSince(instr_time moment);
+extern long MillisecondsToTimeout(instr_time start, long msAfterStart);
 
 #endif /* CONNECTION_MANAGMENT_H */


### PR DESCRIPTION
DESCRIPTION: Avoid timing issues which could be caused by changing system clock

I didn't update the duration code for uploading statistics since that code should probably be removed anyways

`GetCurrentTimestamp` uses `gettimeofday`, whereas `instr_time` is postgres's time type which will use `CLOCK_MONOTONIC` when possible