### PR TITLE
Do not prune shards if the distribution key is NULL

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -545,8 +545,8 @@ HandleDeferredShardPruningForFastPathQueries(DistributedPlan *distributedPlan)
 	bool isMultiShardQuery = false;
 	List *shardIntervalList =
 		TargetShardIntervalForFastPathQuery(workerJob->jobQuery,
-											&workerJob->partitionKeyValue,
-											&isMultiShardQuery, NULL);
+											&isMultiShardQuery, NULL,
+											&workerJob->partitionKeyValue);
 
 	/*
 	 * A fast-path router query can only yield multiple shards when the parameter

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -749,11 +749,19 @@ AddPartitionKeyRestrictionToInstance(ClauseWalkerContext *context, OpExpr *opCla
 															constantClause);
 		if (constantClause == NULL)
 		{
-			/* couldn't coerce value, so we note this as a restriction we don't grok */
+			/* couldn't coerce value, so we save it in otherRestrictions */
 			prune->otherRestrictions = lappend(prune->otherRestrictions, opClause);
 
 			return;
 		}
+	}
+
+	if (constantClause->constisnull)
+	{
+		/* we cannot do pruning for NULL values, so we save it in otherRestrictions */
+		prune->otherRestrictions = lappend(prune->otherRestrictions, opClause);
+
+		return;
 	}
 
 	/* at this point, we'd better be able to pass binary Datums to comparison functions */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -77,9 +77,9 @@ extern List * WorkersContainingAllShards(List *prunedShardIntervalsList);
 
 extern uint64 GetAnchorShardId(List *relationShardList);
 extern List * TargetShardIntervalForFastPathQuery(Query *query,
-												  Const **partitionValueConst,
 												  bool *isMultiShardQuery,
-												  Const *distributionKeyValue);
+												  Const *inputDistributionKeyValue,
+												  Const **outGoingPartitionValueConst);
 extern void GenerateSingleShardRouterTaskList(Job *job,
 											  List *relationShardList,
 											  List *placementList, uint64 shardId);

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -1636,6 +1636,68 @@ DEBUG:  Plan is router executable
  41 |         1 | aznavour     |      11814
 (5 rows)
 
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+PREPARE author_articles_update(int) AS
+	UPDATE articles_hash SET title = 'test' WHERE author_id = $1;
+EXECUTE author_articles_update(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE author_articles_update(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE author_articles_update(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE author_articles_update(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE author_articles_update(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE author_articles_update(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE author_articles_update(NULL);
 -- queries inside plpgsql functions could be router plannable
 CREATE OR REPLACE FUNCTION author_articles_max_id() RETURNS int AS $$
 DECLARE

--- a/src/test/regress/expected/null_parameters.out
+++ b/src/test/regress/expected/null_parameters.out
@@ -1,0 +1,1585 @@
+-- this file contain tests with pruning of NULL
+-- values with prepared statements
+CREATE SCHEMA null_parameters;
+SET search_path TO null_parameters;
+SET citus.next_shard_id TO 1680000;
+CREATE TABLE text_dist_column (key text, value text);
+SELECT create_distributed_table('text_dist_column', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEBUG;
+PREPARE null_select_on_text AS SELECT count(*) FROM text_dist_column WHERE key = NULL;
+EXECUTE null_select_on_text;
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1;
+EXECUTE null_select_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(5::text);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(NULL::varchar);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param('test'::varchar);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param(5::text);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_and_false(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 AND false;
+EXECUTE null_select_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_false(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_and_in(text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1);
+EXECUTE null_select_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_and_in_2(text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1, 'test');
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_and_in_3(text, text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1, $2);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_and_in_4(text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1) AND false;
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- not a fast-path, still good to run
+PREPARE null_select_on_text_param_and_in_5(text, text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 OR key = $2;
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(1, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_5(1, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- not a fast-path, still good to have
+PREPARE null_select_on_text_param_and_in_6(text) AS SELECT count(*) FROM text_dist_column WHERE key NOT IN (SELECT value FROM text_dist_column WHERE key = $1);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM null_parameters.text_dist_column WHERE (key OPERATOR(pg_catalog.=) NULL::text)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM null_parameters.text_dist_column WHERE (NOT (key OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value text))))
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_7(text) AS SELECT count(*) FROM text_dist_column WHERE (key = $1) is true;
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_7(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_8(text) AS SELECT count(*) FROM text_dist_column WHERE key = ANY(ARRAY[$1]);
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_8(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_9(text) AS SELECT count(*) FROM text_dist_column WHERE key = ANY(ARRAY[$1, 'test']);
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_9(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_10(text) AS SELECT count(*) FROM text_dist_column WHERE key = ALL(ARRAY[$1]);
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_10(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_11(text) AS SELECT count(*) FROM text_dist_column WHERE (CASE WHEN key > $1 THEN key::int / 100 > 1 ELSE false END);
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_11(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_12(text) AS SELECT count(*) FROM text_dist_column WHERE COALESCE(($1::int/50000)::bool, false);
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_12(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_13(text) AS SELECT count(*) FROM text_dist_column WHERE NULLIF(($1::int/50000)::bool, false);
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_13(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_14(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 AND 0!=0;
+EXECUTE null_select_on_text_param_14(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_14(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_15(text) AS SELECT count(*) FROM text_dist_column WHERE row(key, 100) > row($1, 0);
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_15(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_16(text) AS SELECT count(*) FROM text_dist_column WHERE key IS DISTINCT FROM $1;
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_16(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_17(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 AND 0!=1;
+EXECUTE null_select_on_text_param_17(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_17(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_18(text) AS SELECT count(*) FROM text_dist_column WHERE key = upper($1);
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_18(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_select_on_text_param_19(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1::varchar(4);
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_text_param_19(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE null_update_on_text AS UPDATE text_dist_column SET value = '' WHERE key = NULL;
+EXECUTE null_update_on_text(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+PREPARE null_update_on_text_param(text) AS UPDATE text_dist_column SET value = '' WHERE key = $1;
+EXECUTE null_update_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param(NULL);
+PREPARE null_update_on_text_param_and_false(text) AS UPDATE text_dist_column SET value = '' WHERE key = $1 AND false;
+EXECUTE null_update_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_false(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_false(NULL);
+PREPARE null_update_on_text_param_and_in(text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1);
+EXECUTE null_update_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in(NULL);
+PREPARE null_update_on_text_param_and_in_2(text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1, 'test');
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+PREPARE null_update_on_text_param_and_in_3(text, text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1, $2);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_3(NULL, 'test');
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+DETAIL:  distribution column value: test
+PREPARE null_update_on_text_param_and_in_4(text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1) and false;
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+-- sanity check with JSBONB column
+CREATE TABLE jsonb_dist_column (key jsonb, value text);
+DEBUG:  building index "pg_toast_xxxxx_index" on table "pg_toast_xxxxx" serially
+SELECT create_distributed_table('jsonb_dist_column', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+PREPARE null_select_on_json_param(jsonb) AS SELECT count(*) FROM jsonb_dist_column WHERE key = $1;
+EXECUTE null_select_on_json_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_json_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_json_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_json_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_json_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_json_param(NULL);
+DEBUG:  Deferred pruning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE null_select_on_json_param(NULL);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA null_parameters CASCADE;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -201,7 +201,7 @@ test: multi_transaction_recovery
 # multi_router_planner creates hash partitioned tables.
 # ---------
 test: multi_copy fast_path_router_modify
-test: multi_router_planner multi_router_planner_fast_path
+test: multi_router_planner multi_router_planner_fast_path null_parameters
 
 # ----------
 # multi_large_shardid loads more lineitem data using high shard identifiers

--- a/src/test/regress/sql/multi_router_planner_fast_path.sql
+++ b/src/test/regress/sql/multi_router_planner_fast_path.sql
@@ -666,6 +666,25 @@ EXECUTE author_articles(1);
 EXECUTE author_articles(1);
 EXECUTE author_articles(1);
 
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+
+PREPARE author_articles_update(int) AS
+	UPDATE articles_hash SET title = 'test' WHERE author_id = $1;
+
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+
 -- queries inside plpgsql functions could be router plannable
 CREATE OR REPLACE FUNCTION author_articles_max_id() RETURNS int AS $$
 DECLARE

--- a/src/test/regress/sql/null_parameters.sql
+++ b/src/test/regress/sql/null_parameters.sql
@@ -1,0 +1,315 @@
+-- this file contain tests with pruning of NULL
+-- values with prepared statements
+CREATE SCHEMA null_parameters;
+SET search_path TO null_parameters;
+
+SET citus.next_shard_id TO 1680000;
+CREATE TABLE text_dist_column (key text, value text);
+SELECT create_distributed_table('text_dist_column', 'key');
+
+SET client_min_messages TO DEBUG;
+
+
+PREPARE null_select_on_text AS SELECT count(*) FROM text_dist_column WHERE key = NULL;
+EXECUTE null_select_on_text;
+EXECUTE null_select_on_text;
+EXECUTE null_select_on_text;
+EXECUTE null_select_on_text;
+EXECUTE null_select_on_text;
+EXECUTE null_select_on_text;
+
+PREPARE null_select_on_text_param(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1;
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(5::text);
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(NULL);
+EXECUTE null_select_on_text_param(NULL::varchar);
+EXECUTE null_select_on_text_param('test'::varchar);
+EXECUTE null_select_on_text_param(5::text);
+
+PREPARE null_select_on_text_param_and_false(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 AND false;
+EXECUTE null_select_on_text_param_and_false(NULL);
+EXECUTE null_select_on_text_param_and_false(NULL);
+EXECUTE null_select_on_text_param_and_false(NULL);
+EXECUTE null_select_on_text_param_and_false(NULL);
+EXECUTE null_select_on_text_param_and_false(NULL);
+EXECUTE null_select_on_text_param_and_false(NULL);
+EXECUTE null_select_on_text_param_and_false(NULL);
+
+PREPARE null_select_on_text_param_and_in(text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1);
+EXECUTE null_select_on_text_param_and_in(NULL);
+EXECUTE null_select_on_text_param_and_in(NULL);
+EXECUTE null_select_on_text_param_and_in(NULL);
+EXECUTE null_select_on_text_param_and_in(NULL);
+EXECUTE null_select_on_text_param_and_in(NULL);
+EXECUTE null_select_on_text_param_and_in(NULL);
+
+PREPARE null_select_on_text_param_and_in_2(text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1, 'test');
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+EXECUTE null_select_on_text_param_and_in_2(NULL);
+
+PREPARE null_select_on_text_param_and_in_3(text, text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1, $2);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_3(NULL, NULL);
+
+
+PREPARE null_select_on_text_param_and_in_4(text) AS SELECT count(*) FROM text_dist_column WHERE key IN ($1) AND false;
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+EXECUTE null_select_on_text_param_and_in_4(NULL);
+
+-- not a fast-path, still good to run
+PREPARE null_select_on_text_param_and_in_5(text, text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 OR key = $2;
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(1, NULL);
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(NULL, NULL);
+EXECUTE null_select_on_text_param_and_in_5(1, NULL);
+
+-- not a fast-path, still good to have
+PREPARE null_select_on_text_param_and_in_6(text) AS SELECT count(*) FROM text_dist_column WHERE key NOT IN (SELECT value FROM text_dist_column WHERE key = $1);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+EXECUTE null_select_on_text_param_and_in_6(NULL);
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_7(text) AS SELECT count(*) FROM text_dist_column WHERE (key = $1) is true;
+EXECUTE null_select_on_text_param_7(NULL);
+EXECUTE null_select_on_text_param_7(NULL);
+EXECUTE null_select_on_text_param_7(NULL);
+EXECUTE null_select_on_text_param_7(NULL);
+EXECUTE null_select_on_text_param_7(NULL);
+EXECUTE null_select_on_text_param_7(NULL);
+EXECUTE null_select_on_text_param_7(NULL);
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_8(text) AS SELECT count(*) FROM text_dist_column WHERE key = ANY(ARRAY[$1]);
+EXECUTE null_select_on_text_param_8(NULL);
+EXECUTE null_select_on_text_param_8(NULL);
+EXECUTE null_select_on_text_param_8(NULL);
+EXECUTE null_select_on_text_param_8(NULL);
+EXECUTE null_select_on_text_param_8(NULL);
+EXECUTE null_select_on_text_param_8(NULL);
+EXECUTE null_select_on_text_param_8(NULL);
+
+
+PREPARE null_select_on_text_param_9(text) AS SELECT count(*) FROM text_dist_column WHERE key = ANY(ARRAY[$1, 'test']);
+EXECUTE null_select_on_text_param_9(NULL);
+EXECUTE null_select_on_text_param_9(NULL);
+EXECUTE null_select_on_text_param_9(NULL);
+EXECUTE null_select_on_text_param_9(NULL);
+EXECUTE null_select_on_text_param_9(NULL);
+EXECUTE null_select_on_text_param_9(NULL);
+EXECUTE null_select_on_text_param_9(NULL);
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_10(text) AS SELECT count(*) FROM text_dist_column WHERE key = ALL(ARRAY[$1]);
+EXECUTE null_select_on_text_param_10(NULL);
+EXECUTE null_select_on_text_param_10(NULL);
+EXECUTE null_select_on_text_param_10(NULL);
+EXECUTE null_select_on_text_param_10(NULL);
+EXECUTE null_select_on_text_param_10(NULL);
+EXECUTE null_select_on_text_param_10(NULL);
+EXECUTE null_select_on_text_param_10(NULL);
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_11(text) AS SELECT count(*) FROM text_dist_column WHERE (CASE WHEN key > $1 THEN key::int / 100 > 1 ELSE false END);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+EXECUTE null_select_on_text_param_11(NULL);
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_12(text) AS SELECT count(*) FROM text_dist_column WHERE COALESCE(($1::int/50000)::bool, false);
+
+EXECUTE null_select_on_text_param_12(NULL);
+EXECUTE null_select_on_text_param_12(NULL);
+EXECUTE null_select_on_text_param_12(NULL);
+EXECUTE null_select_on_text_param_12(NULL);
+EXECUTE null_select_on_text_param_12(NULL);
+EXECUTE null_select_on_text_param_12(NULL);
+EXECUTE null_select_on_text_param_12(NULL);
+
+-- different expression types which may not be fast-path queries
+PREPARE null_select_on_text_param_13(text) AS SELECT count(*) FROM text_dist_column WHERE NULLIF(($1::int/50000)::bool, false);
+
+EXECUTE null_select_on_text_param_13(NULL);
+EXECUTE null_select_on_text_param_13(NULL);
+EXECUTE null_select_on_text_param_13(NULL);
+EXECUTE null_select_on_text_param_13(NULL);
+EXECUTE null_select_on_text_param_13(NULL);
+EXECUTE null_select_on_text_param_13(NULL);
+EXECUTE null_select_on_text_param_13(NULL);
+
+PREPARE null_select_on_text_param_14(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 AND 0!=0;
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+EXECUTE null_select_on_text_param_14(NULL);
+
+PREPARE null_select_on_text_param_15(text) AS SELECT count(*) FROM text_dist_column WHERE row(key, 100) > row($1, 0);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+EXECUTE null_select_on_text_param_15(NULL);
+
+
+PREPARE null_select_on_text_param_16(text) AS SELECT count(*) FROM text_dist_column WHERE key IS DISTINCT FROM $1;
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+EXECUTE null_select_on_text_param_16(NULL);
+
+
+
+PREPARE null_select_on_text_param_17(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1 AND 0!=1;
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+EXECUTE null_select_on_text_param_17(NULL);
+
+PREPARE null_select_on_text_param_18(text) AS SELECT count(*) FROM text_dist_column WHERE key = upper($1);
+EXECUTE null_select_on_text_param_18(NULL);
+EXECUTE null_select_on_text_param_18(NULL);
+EXECUTE null_select_on_text_param_18(NULL);
+EXECUTE null_select_on_text_param_18(NULL);
+EXECUTE null_select_on_text_param_18(NULL);
+EXECUTE null_select_on_text_param_18(NULL);
+EXECUTE null_select_on_text_param_18(NULL);
+
+PREPARE null_select_on_text_param_19(text) AS SELECT count(*) FROM text_dist_column WHERE key = $1::varchar(4);
+EXECUTE null_select_on_text_param_19(NULL);
+EXECUTE null_select_on_text_param_19(NULL);
+EXECUTE null_select_on_text_param_19(NULL);
+EXECUTE null_select_on_text_param_19(NULL);
+EXECUTE null_select_on_text_param_19(NULL);
+EXECUTE null_select_on_text_param_19(NULL);
+EXECUTE null_select_on_text_param_19(NULL);
+
+
+PREPARE null_update_on_text AS UPDATE text_dist_column SET value = '' WHERE key = NULL;
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+EXECUTE null_update_on_text(NULL);
+
+
+PREPARE null_update_on_text_param(text) AS UPDATE text_dist_column SET value = '' WHERE key = $1;
+EXECUTE null_update_on_text_param(NULL);
+EXECUTE null_update_on_text_param(NULL);
+EXECUTE null_update_on_text_param(NULL);
+EXECUTE null_update_on_text_param(NULL);
+EXECUTE null_update_on_text_param(NULL);
+EXECUTE null_update_on_text_param(NULL);
+EXECUTE null_update_on_text_param(NULL);
+
+
+PREPARE null_update_on_text_param_and_false(text) AS UPDATE text_dist_column SET value = '' WHERE key = $1 AND false;
+EXECUTE null_update_on_text_param_and_false(NULL);
+EXECUTE null_update_on_text_param_and_false(NULL);
+EXECUTE null_update_on_text_param_and_false(NULL);
+EXECUTE null_update_on_text_param_and_false(NULL);
+EXECUTE null_update_on_text_param_and_false(NULL);
+EXECUTE null_update_on_text_param_and_false(NULL);
+EXECUTE null_update_on_text_param_and_false(NULL);
+
+
+
+PREPARE null_update_on_text_param_and_in(text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1);
+EXECUTE null_update_on_text_param_and_in(NULL);
+EXECUTE null_update_on_text_param_and_in(NULL);
+EXECUTE null_update_on_text_param_and_in(NULL);
+EXECUTE null_update_on_text_param_and_in(NULL);
+EXECUTE null_update_on_text_param_and_in(NULL);
+EXECUTE null_update_on_text_param_and_in(NULL);
+EXECUTE null_update_on_text_param_and_in(NULL);
+
+
+
+PREPARE null_update_on_text_param_and_in_2(text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1, 'test');
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+EXECUTE null_update_on_text_param_and_in_2(NULL);
+
+
+PREPARE null_update_on_text_param_and_in_3(text, text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1, $2);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_update_on_text_param_and_in_3(NULL, NULL);
+EXECUTE null_update_on_text_param_and_in_3(NULL, 'test');
+
+PREPARE null_update_on_text_param_and_in_4(text) AS UPDATE text_dist_column SET value = '' WHERE key IN ($1) and false;
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+EXECUTE null_update_on_text_param_and_in_4(NULL);
+
+-- sanity check with JSBONB column
+CREATE TABLE jsonb_dist_column (key jsonb, value text);
+SELECT create_distributed_table('jsonb_dist_column', 'key');
+PREPARE null_select_on_json_param(jsonb) AS SELECT count(*) FROM jsonb_dist_column WHERE key = $1;
+EXECUTE null_select_on_json_param(NULL);
+EXECUTE null_select_on_json_param(NULL);
+EXECUTE null_select_on_json_param(NULL);
+EXECUTE null_select_on_json_param(NULL);
+EXECUTE null_select_on_json_param(NULL);
+EXECUTE null_select_on_json_param(NULL);
+EXECUTE null_select_on_json_param(NULL);
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA null_parameters CASCADE;


### PR DESCRIPTION
Fixes #3493

The root of the problem is that, standard_planner() converts the following qual

```
   {OPEXPR
   :opno 98
   :opfuncid 67
   :opresulttype 16
   :opretset false
   :opcollid 0
   :inputcollid 100
   :args (
      {VAR
      :varno 1
      :varattno 1
      :vartype 25
      :vartypmod -1
      :varcollid 100
      :varlevelsup 0
      :varnoold 1
      :varoattno 1
      :location 45
      }
      {CONST
      :consttype 25
      :consttypmod -1
      :constcollid 100
      :constlen -1
      :constbyval false
      :constisnull true
      :location 51
      :constvalue <>
      }
   )
   :location 49
   }
```

To

```
(
   {CONST
   :consttype 16
   :consttypmod -1
   :constcollid 0
   :constlen 1
   :constbyval true
   :constisnull true
   :location -1
   :constvalue <>
   }
)
```

So, Citus doesn't deal with NULL values in real-time or non-fast path router queries.

And, in the FastPathRouter planner, we check constisnull in DistKeyInSimpleOpExpression().
However, in deferred pruning case, we do not check for isnull for const.

Thus, the fix consists of two parts:
- Let PruneShards() not crash when NULL parameter is passed (it used to crash `PerformCompare`)
- For deferred shard pruning in fast-path queries, explicitly check that we have CONST which is not NULL

DESCRIPTION: Fixes a bug that could cause crashes if dist. key is NULL
