### PR TITLE
Fix flaky test introduced by #3374

### DIFF
--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -191,7 +191,10 @@ test: multi_modifications
 test: multi_distribution_metadata
 test: multi_generate_ddl_commands multi_create_shards multi_prune_shard_list multi_repair_shards
 test: multi_upsert multi_simple_queries multi_data_types
-test: multi_utilities foreign_key_to_reference_table validate_constraint
+# multi_utilities cannot be run in parallel with other tests because it checks
+# global locks
+test: multi_utilities
+test: foreign_key_to_reference_table validate_constraint
 test: multi_modifying_xacts
 test: multi_repartition_udt multi_repartitioned_subquery_udf multi_subtransactions
 test: multi_transaction_recovery


### PR DESCRIPTION
Since #3374 multi_utilities is not safe to run in parallel anymore. This
is because it now also shows locks on shards created outside it's own
test. This is not really possible to fix.

Example of flaky test:
- https://circleci.com/gh/citusdata/citus/89995
- https://circleci.com/gh/citusdata/citus/90017