### PR TITLE
Make multi_utilities test take 2 seconds instead of 20

### DIFF
--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -231,6 +231,11 @@ begin
     -- reset stats snapshot so we can test again
     perform pg_stat_clear_snapshot();
 
+    -- fail if we reach the end of this loop
+    if i = 100 then
+        raise 'Waited too long for analyze/vacuum';
+    end if;
+
   end loop;
 
   -- report time waited in postmaster log (where it won't change test output)
@@ -241,7 +246,7 @@ $$ language plpgsql;
 \c - - - :worker_2_port
 CREATE MATERIALIZED VIEW prevcounts AS
 SELECT analyze_count, vacuum_count FROM pg_stat_user_tables
-WHERE relname='dustbunnies_990001';
+WHERE relname='dustbunnies_990002';
 -- create function that sleeps until those counters increment
 create function wait_for_stats() returns void as $$
 declare
@@ -255,12 +260,12 @@ begin
     -- check to see if analyze has been updated
     SELECT (st.analyze_count >= pc.analyze_count + 1) INTO analyze_updated
       FROM pg_stat_user_tables AS st, pg_class AS cl, prevcounts AS pc
-     WHERE st.relname='dustbunnies_990001' AND cl.relname='dustbunnies_990001';
+     WHERE st.relname='dustbunnies_990002' AND cl.relname='dustbunnies_990002';
 
      -- check to see if vacuum has been updated
     SELECT (st.vacuum_count >= pc.vacuum_count + 1) INTO vacuum_updated
       FROM pg_stat_user_tables AS st, pg_class AS cl, prevcounts AS pc
-     WHERE st.relname='dustbunnies_990001' AND cl.relname='dustbunnies_990001';
+     WHERE st.relname='dustbunnies_990002' AND cl.relname='dustbunnies_990002';
 
     exit when analyze_updated or vacuum_updated;
 
@@ -269,6 +274,11 @@ begin
 
     -- reset stats snapshot so we can test again
     perform pg_stat_clear_snapshot();
+
+    -- fail if we reach the end of this loop
+    if i = 100 then
+        raise 'Waited too long for analyze/vacuum';
+    end if;
 
   end loop;
 
@@ -379,6 +389,9 @@ WHERE tablename = 'dustbunnies_990002' ORDER BY attname;
  name    |  0.166667
 (3 rows)
 
+REFRESH MATERIALIZED VIEW prevcounts;
+\c - - - :worker_2_port
+REFRESH MATERIALIZED VIEW prevcounts;
 \c - - - :master_port
 -- verify warning for unqualified VACUUM
 VACUUM;


### PR DESCRIPTION
On worker 2 it was waiting for dustbunnies_990001 to be
vacuumed/analyzed. This table doesn't actually exist, so that never
happend. Now it waits for the correct table and throws an error if it
waits more than 10 seconds.