### PR TITLE
Refactor the deparsing of a CREATE EXTENSION to prevent NULL POINTER dereferences

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -171,6 +171,9 @@ PostprocessCreateExtensionStmt(Node *node, const char *queryString)
 	 */
 	AddSchemaFieldIfMissing(stmt);
 
+	/* always send commands with IF NOT EXISTS */
+	stmt->if_not_exists = true;
+
 	const char *createExtensionStmtSql = DeparseTreeNode(node);
 
 	/*

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -12,6 +12,7 @@
 
 #include "citus_version.h"
 #include "catalog/pg_extension_d.h"
+#include "commands/defrem.h"
 #include "commands/extension.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/commands.h"
@@ -101,13 +102,12 @@ ExtractNewExtensionVersion(Node *parseTree)
 		Assert(false);
 	}
 
-	Value *newVersionValue = GetExtensionOption(optionsList, "new_version");
+	DefElem *newVersionValue = GetExtensionOption(optionsList, "new_version");
 
 	/* return target string safely */
 	if (newVersionValue)
 	{
-		const char *newVersion = strVal(newVersionValue);
-
+		const char *newVersion = defGetString(newVersionValue);
 		return pstrdup(newVersion);
 	}
 	else
@@ -204,7 +204,7 @@ AddSchemaFieldIfMissing(CreateExtensionStmt *createExtensionStmt)
 {
 	List *optionsList = createExtensionStmt->options;
 
-	Value *schemaNameValue = GetExtensionOption(optionsList, "schema");
+	DefElem *schemaNameValue = GetExtensionOption(optionsList, "schema");
 
 	if (!schemaNameValue)
 	{

--- a/src/backend/distributed/deparser/deparse_extension_stmts.c
+++ b/src/backend/distributed/deparser/deparse_extension_stmts.c
@@ -33,36 +33,22 @@ static void AppendAlterExtensionStmt(StringInfo buf,
 
 
 /*
- * GetExtensionOption returns Value* of DefElem node with "defname" from "options" list
+ * GetExtensionOption returns DefElem * node with "defname" from "options" list
  */
-Value *
+DefElem *
 GetExtensionOption(List *extensionOptions, const char *defname)
 {
-	Value *targetValue = NULL;
-
-	ListCell *defElemCell = NULL;
-
-	foreach(defElemCell, extensionOptions)
+	DefElem *defElement = NULL;
+	foreach_ptr(defElement, extensionOptions)
 	{
-		DefElem *defElement = (DefElem *) lfirst(defElemCell);
-
-		if (IsA(defElement, DefElem) && strncmp(defElement->defname, defname,
-												NAMEDATALEN) == 0)
+		if (IsA(defElement, DefElem) &&
+			strncmp(defElement->defname, defname, NAMEDATALEN) == 0)
 		{
-			targetValue = (Value *) defElement->arg;
-			break;
+			return defElement;
 		}
 	}
 
-	/* return target string safely */
-	if (targetValue)
-	{
-		return targetValue;
-	}
-	else
-	{
-		return NULL;
-	}
+	return NULL;
 }
 
 

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -97,8 +97,8 @@ extern void QualifyAlterFunctionDependsStmt(Node *stmt);
 extern char * DeparseAlterRoleStmt(Node *stmt);
 
 /* forward declarations for deparse_extension_stmts.c */
-extern Value * GetExtensionOption(List *extensionOptions,
-								  const char *defname);
+extern DefElem * GetExtensionOption(List *extensionOptions,
+									const char *defname);
 extern char * DeparseCreateExtensionStmt(Node *stmt);
 extern char * DeparseDropExtensionStmt(Node *stmt);
 extern char * DeparseAlterExtensionSchemaStmt(Node *stmt);

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -182,6 +182,69 @@ SELECT create_reference_table('ref_table_2');
 
 (1 row)
 
+-- we also add an old style extension from before extensions which we upgrade to an extension
+-- by exercising it before the add node we verify it will create the extension (without upgrading)
+-- it on the new worker as well. For this we use the dict_int extension which is in contrib,
+-- supports FROM unpackaged, and is relatively small
+-- create objects for dict_int manually so we can upgrade from unpacked
+CREATE FUNCTION dintdict_init(internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+CREATE FUNCTION dintdict_lexize(internal, internal, internal, internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
+CREATE TEXT SEARCH DICTIONARY intdict (TEMPLATE = intdict_template);
+COMMENT ON TEXT SEARCH DICTIONARY intdict IS 'dictionary for integers';
+SELECT run_command_on_workers($$
+CREATE FUNCTION dintdict_init(internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+$$);
+        run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE FUNCTION")
+(1 row)
+
+SELECT run_command_on_workers($$
+CREATE FUNCTION dintdict_lexize(internal, internal, internal, internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+$$);
+        run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE FUNCTION")
+(1 row)
+
+SELECT run_command_on_workers($$
+CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
+$$);
+              run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE TEXT SEARCH TEMPLATE")
+(1 row)
+
+SELECT run_command_on_workers($$
+CREATE TEXT SEARCH DICTIONARY intdict (TEMPLATE = intdict_template);
+$$);
+               run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE TEXT SEARCH DICTIONARY")
+(1 row)
+
+SELECT run_command_on_workers($$
+COMMENT ON TEXT SEARCH DICTIONARY intdict IS 'dictionary for integers';
+$$);
+   run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,COMMENT)
+(1 row)
+
+CREATE EXTENSION dict_int FROM unpackaged;
+SELECT run_command_on_workers($$SELECT count(extnamespace) FROM pg_extension WHERE extname = 'dict_int'$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+(1 row)
+
+SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extname = 'dict_int'$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1.0)
+(1 row)
+
 -- and add the other node
 SELECT 1 from master_add_node('localhost', :worker_2_port);
 NOTICE:  Replicating reference table "ref_table_2" to the node localhost:xxxxx
@@ -203,6 +266,21 @@ SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extnam
 ---------------------------------------------------------------------
  (localhost,57637,t,1.3)
  (localhost,57638,t,1.3)
+(2 rows)
+
+-- check for the unpackaged extension to be created correctly
+SELECT run_command_on_workers($$SELECT count(extnamespace) FROM pg_extension WHERE extname = 'dict_int'$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extname = 'dict_int'$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1.0)
+ (localhost,57638,t,1.0)
 (2 rows)
 
 -- and similarly check for the reference table


### PR DESCRIPTION
DESCRIPTION: satisfy static analysis tool for a nullptr dereference

During the static analysis project on the codebase this code has been flagged as having the potential for a null pointer dereference. Funily enough the author had already made a commment of it in the code this was not possible due to us setting the schema name before we pass in the statement. If we want to reuse this code in a later setting this comment might not always apply and we could actually run into null pointer dereference.

This patch changes a bit of the code arround to first of all make sure there is no NULL pointer dereference in this code anymore.
Secondly we allow for better deparsing by setting and adhering to the `if_not_exists` flag on the statement.
And finally add support for all syntax described in the documentation of postgres (FROM was missing).
