### PR TITLE
Fix null relation name due to DROP on distributed table in a transaction block

### DIFF
--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -134,11 +134,11 @@ ExecuteTruncateStmtSequentialIfNecessary(TruncateStmt *command)
 
 			ereport(DEBUG1, (errmsg("switching to sequential query execution mode"),
 							 errdetail(
-								 "Reference relation \"%s\" is modified, which might lead "
+								 "Reference table \"%s\" is modified, which might lead "
 								 "to data inconsistencies or distributed deadlocks via "
-								 "parallel accesses to hash distributed relations due to "
+								 "parallel accesses to hash distributed tables due to "
 								 "foreign keys. Any parallel modification to "
-								 "those hash distributed relations in the same "
+								 "those hash distributed tables in the same "
 								 "transaction can only be executed in sequential query "
 								 "execution mode", relationName)));
 

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -722,8 +722,8 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 		 */
 		if (relationName == NULL)
 		{
-			ereport(ERROR, (errmsg("cannot execute %s on reference relation because "
-								   "there was a parallel %s access to distributed relation "
+			ereport(ERROR, (errmsg("cannot execute %s on reference table because "
+								   "there was a parallel %s access to distributed table "
 								   "\"%s\" in the same transaction",
 								   accessTypeText, conflictingAccessTypeText,
 								   conflictingRelationName),
@@ -734,8 +734,8 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 		else
 		{
 			ereport(ERROR, (errmsg(
-								"cannot execute %s on reference relation \"%s\" because "
-								"there was a parallel %s access to distributed relation "
+								"cannot execute %s on reference table \"%s\" because "
+								"there was a parallel %s access to distributed table "
 								"\"%s\" in the same transaction",
 								accessTypeText, relationName,
 								conflictingAccessTypeText,
@@ -776,11 +776,11 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 			 */
 			ereport(DEBUG1, (errmsg("switching to sequential query execution mode"),
 							 errdetail(
-								 "Reference relation \"%s\" is modified, which might lead "
+								 "Reference table \"%s\" is modified, which might lead "
 								 "to data inconsistencies or distributed deadlocks via "
-								 "parallel accesses to hash distributed relations due to "
+								 "parallel accesses to hash distributed tables due to "
 								 "foreign keys. Any parallel modification to "
-								 "those hash distributed relations in the same "
+								 "those hash distributed tables in the same "
 								 "transaction can only be executed in sequential query "
 								 "execution mode", relationName)));
 
@@ -841,8 +841,8 @@ CheckConflictingParallelRelationAccesses(Oid relationId, ShardPlacementAccessTyp
 			 * would still use the already opened parallel connections to the workers,
 			 * thus contradicting our purpose of using sequential mode.
 			 */
-			ereport(ERROR, (errmsg("cannot execute parallel %s on relation \"%s\" "
-								   "after %s command on reference relation "
+			ereport(ERROR, (errmsg("cannot execute parallel %s on table \"%s\" "
+								   "after %s command on reference table "
 								   "\"%s\" because there is a foreign key between "
 								   "them and \"%s\" has been accessed in this transaction",
 								   accessTypeText, relationName,
@@ -859,8 +859,8 @@ CheckConflictingParallelRelationAccesses(Oid relationId, ShardPlacementAccessTyp
 		else
 		{
 			ereport(DEBUG1, (errmsg("switching to sequential query execution mode"),
-							 errdetail("cannot execute parallel %s on relation \"%s\" "
-									   "after %s command on reference relation "
+							 errdetail("cannot execute parallel %s on table \"%s\" "
+									   "after %s command on reference table "
 									   "\"%s\" because there is a foreign key between "
 									   "them and \"%s\" has been accessed in this transaction",
 									   accessTypeText, relationName,

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -217,7 +217,7 @@ BEGIN;
 
 	ALTER TABLE on_update_fkey_table ADD COLUMN X INT;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  cannot execute parallel DDL on relation "on_update_fkey_table" after SELECT command on reference relation "reference_table" because there is a foreign key between them and "reference_table" has been accessed in this transaction
+DETAIL:  cannot execute parallel DDL on table "on_update_fkey_table" after SELECT command on reference table "reference_table" because there is a foreign key between them and "reference_table" has been accessed in this transaction
 ROLLBACK;
 BEGIN;
 	SELECT count(*) FROM transitive_reference_table;
@@ -228,7 +228,7 @@ BEGIN;
 
 	ALTER TABLE on_update_fkey_table ADD COLUMN X INT;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  cannot execute parallel DDL on relation "on_update_fkey_table" after SELECT command on reference relation "transitive_reference_table" because there is a foreign key between them and "transitive_reference_table" has been accessed in this transaction
+DETAIL:  cannot execute parallel DDL on table "on_update_fkey_table" after SELECT command on reference table "transitive_reference_table" because there is a foreign key between them and "transitive_reference_table" has been accessed in this transaction
 ROLLBACK;
 -- case 1.7.1: SELECT to a reference table is followed by a DDL that is on
 -- the foreign key column
@@ -308,7 +308,7 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE on_update_fkey_table ADD COLUMN X INT;
-ERROR:  cannot execute parallel DDL on relation "on_update_fkey_table" after SELECT command on reference relation "reference_table" because there is a foreign key between them and "reference_table" has been accessed in this transaction
+ERROR:  cannot execute parallel DDL on table "on_update_fkey_table" after SELECT command on reference table "reference_table" because there is a foreign key between them and "reference_table" has been accessed in this transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
@@ -326,7 +326,7 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE on_update_fkey_table ADD COLUMN X INT;
-ERROR:  cannot execute parallel DDL on relation "on_update_fkey_table" after SELECT command on reference relation "transitive_reference_table" because there is a foreign key between them and "transitive_reference_table" has been accessed in this transaction
+ERROR:  cannot execute parallel DDL on table "on_update_fkey_table" after SELECT command on reference table "transitive_reference_table" because there is a foreign key between them and "transitive_reference_table" has been accessed in this transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
@@ -353,7 +353,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	SELECT count(*) FROM on_update_fkey_table WHERE value_1 = 99;
  count
 ---------------------------------------------------------------------
@@ -370,7 +370,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	SELECT count(*) FROM on_update_fkey_table WHERE value_1 = 99;
  count
 ---------------------------------------------------------------------
@@ -388,7 +388,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	SELECT count(*) FROM on_update_fkey_table WHERE value_1 = 101 AND id = 99;
  count
 ---------------------------------------------------------------------
@@ -417,7 +417,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	SELECT count(*) FROM on_update_fkey_table WHERE value_1 = 101 AND id = 99;
  count
 ---------------------------------------------------------------------
@@ -447,20 +447,20 @@ ROLLBACK;
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 15;
 ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 15;
 ROLLBACK;
 -- case 2.4: UPDATE to a reference table is followed by multiple router UPDATEs
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 101 WHERE id = 1;
 	UPDATE on_update_fkey_table SET value_1 = 101 WHERE id = 2;
 	UPDATE on_update_fkey_table SET value_1 = 101 WHERE id = 3;
@@ -469,7 +469,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 101 WHERE id = 1;
 ERROR:  insert or update on table "on_update_fkey_table_xxxxxxx" violates foreign key constraint "fkey_xxxxxxx"
 DETAIL:  Key (value_1)=(101) is not present in table "reference_table_2380001".
@@ -485,7 +485,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE bigint;
 DEBUG:  rewriting table "on_update_fkey_table"
 DEBUG:  building index "on_update_fkey_table_pkey" on table "on_update_fkey_table" serially
@@ -494,7 +494,7 @@ ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE bigint;
 DEBUG:  rewriting table "on_update_fkey_table"
 DEBUG:  building index "on_update_fkey_table_pkey" on table "on_update_fkey_table" serially
@@ -504,26 +504,26 @@ ROLLBACK;
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	ALTER TABLE on_update_fkey_table ADD COLUMN value_1_X INT;
 ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	ALTER TABLE on_update_fkey_table ADD COLUMN value_1_X INT;
 ROLLBACK;
 -- case 2.7: UPDATE to a reference table is followed by COPY
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	COPY on_update_fkey_table FROM STDIN WITH CSV;
 ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	COPY on_update_fkey_table FROM STDIN WITH CSV;
 ERROR:  insert or update on table "on_update_fkey_table_xxxxxxx" violates foreign key constraint "fkey_xxxxxxx"
 DETAIL:  Key (value_1)=(101) is not present in table "reference_table_2380001".
@@ -532,14 +532,14 @@ ROLLBACK;
 BEGIN;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	TRUNCATE on_update_fkey_table;
 DEBUG:  building index "on_update_fkey_table_pkey" on table "on_update_fkey_table" serially
 ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	TRUNCATE on_update_fkey_table;
 DEBUG:  building index "on_update_fkey_table_pkey" on table "on_update_fkey_table" serially
 ROLLBACK;
@@ -547,7 +547,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE reference_table ALTER COLUMN id SET DEFAULT 1001;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	SELECT count(*) FROM on_update_fkey_table;
  count
 ---------------------------------------------------------------------
@@ -558,7 +558,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DEFAULT 1001;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	SELECT count(*) FROM on_update_fkey_table;
  count
 ---------------------------------------------------------------------
@@ -589,20 +589,20 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE reference_table ALTER COLUMN id SET DEFAULT 1001;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 5 WHERE id != 11;
 ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DEFAULT 1001;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 5 WHERE id != 11;
 ROLLBACK;
 -- case 3.4: DDL to a reference table followed by multiple router UPDATEs
 BEGIN;
 	ALTER TABLE reference_table ALTER COLUMN id SET DEFAULT 1001;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 98 WHERE id = 1;
 	UPDATE on_update_fkey_table SET value_1 = 98 WHERE id = 2;
 	UPDATE on_update_fkey_table SET value_1 = 98 WHERE id = 3;
@@ -611,7 +611,7 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DEFAULT 1001;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	UPDATE on_update_fkey_table SET value_1 = 98 WHERE id = 1;
 	UPDATE on_update_fkey_table SET value_1 = 98 WHERE id = 2;
 	UPDATE on_update_fkey_table SET value_1 = 98 WHERE id = 3;
@@ -659,27 +659,27 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE reference_table  ADD COLUMN X int;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	COPY on_update_fkey_table FROM STDIN WITH CSV;
 ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table  ADD COLUMN X int;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	COPY on_update_fkey_table FROM STDIN WITH CSV;
 ROLLBACK;
 -- case 3.8: DDL to a reference table is followed by TRUNCATE
 BEGIN;
 	ALTER TABLE reference_table  ADD COLUMN X int;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	TRUNCATE on_update_fkey_table;
 DEBUG:  building index "on_update_fkey_table_pkey" on table "on_update_fkey_table" serially
 ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table  ADD COLUMN X int;
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	TRUNCATE on_update_fkey_table;
 DEBUG:  building index "on_update_fkey_table_pkey" on table "on_update_fkey_table" serially
 ROLLBACK;
@@ -766,7 +766,7 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE reference_table ADD COLUMN X INT;
-ERROR:  cannot execute DDL on reference relation "reference_table" because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
@@ -777,7 +777,7 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE transitive_reference_table ADD COLUMN X INT;
-ERROR:  cannot execute DDL on reference relation "transitive_reference_table" because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "transitive_reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 4.4: SELECT to a dist table is follwed by a DDL to a reference table
@@ -792,7 +792,7 @@ BEGIN;
 DEBUG:  rewriting table "reference_table"
 DEBUG:  building index "reference_table_pkey" on table "reference_table" serially
 DEBUG:  validating foreign key constraint "fkey"
-ERROR:  cannot execute DDL on reference relation "reference_table" because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
@@ -806,7 +806,7 @@ BEGIN;
 DEBUG:  rewriting table "transitive_reference_table"
 DEBUG:  building index "transitive_reference_table_pkey" on table "transitive_reference_table" serially
 DEBUG:  validating foreign key constraint "fkey"
-ERROR:  cannot execute DDL on reference relation "transitive_reference_table" because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "transitive_reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 4.5: SELECT to a dist table is follwed by a TRUNCATE
@@ -821,7 +821,7 @@ BEGIN;
 
 	TRUNCATE reference_table CASCADE;
 NOTICE:  truncate cascades to table "on_update_fkey_table"
-ERROR:  cannot execute DDL on reference relation "reference_table" because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 ROLLBACK;
 BEGIN;
 	SELECT count(*) FROM on_update_fkey_table WHERE value_1 = 99;
@@ -833,7 +833,7 @@ BEGIN;
 	TRUNCATE transitive_reference_table CASCADE;
 NOTICE:  truncate cascades to table "reference_table"
 NOTICE:  truncate cascades to table "on_update_fkey_table"
-ERROR:  cannot execute DDL on reference relation "transitive_reference_table" because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "transitive_reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 ROLLBACK;
 -- case 4.6: Router SELECT to a dist table is followed by a TRUNCATE
 BEGIN;
@@ -871,7 +871,7 @@ BEGIN;
 
 	DROP TABLE reference_table CASCADE;
 NOTICE:  drop cascades to constraint fkey on table on_update_fkey_table
-ERROR:  cannot execute DDL on reference relation because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 ROLLBACK;
 -- case 4.8: Router SELECT to a dist table is followed by a TRUNCATE
 -- No errors expected from below block as SELECT there is a router
@@ -911,52 +911,52 @@ ROLLBACK;
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	UPDATE reference_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute DML on reference relation "reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	UPDATE transitive_reference_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute DML on reference relation "transitive_reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "transitive_reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 5.3: Parallel UPDATE on distributed table follow by an unrelated DDL on reference table
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE reference_table ADD COLUMN X INT;
-ERROR:  cannot execute DDL on reference relation "reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE transitive_reference_table ADD COLUMN X INT;
-ERROR:  cannot execute DDL on reference relation "transitive_reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "transitive_reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 5.4: Parallel UPDATE on distributed table follow by a related DDL on reference table
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE reference_table ALTER COLUMN id SET DATA TYPE smallint;
-ERROR:  cannot execute DDL on reference relation "reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 16 WHERE value_1 = 15;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DATA TYPE smallint;
-ERROR:  cannot execute DDL on reference relation "transitive_reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "transitive_reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:1: Unrelated parallel DDL on distributed table followed by SELECT on ref. table
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	SELECT count(*) FROM reference_table;
-ERROR:  cannot execute SELECT on reference relation "reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute SELECT on reference table "reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	SELECT count(*) FROM transitive_reference_table;
-ERROR:  cannot execute SELECT on reference relation "transitive_reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute SELECT on reference table "transitive_reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:2: Related parallel DDL on distributed table followed by SELECT on ref. table
@@ -972,39 +972,39 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	SELECT count(*) FROM reference_table;
-ERROR:  cannot execute SELECT on reference relation "reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute SELECT on reference table "reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	SELECT count(*) FROM transitive_reference_table;
-ERROR:  cannot execute SELECT on reference relation "transitive_reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute SELECT on reference table "transitive_reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:4: Related parallel DDL on distributed table followed by SELECT on ref. table
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	UPDATE reference_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute DML on reference relation "reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	UPDATE transitive_reference_table SET id = 160 WHERE id = 15;
-ERROR:  cannot execute DML on reference relation "transitive_reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "transitive_reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:5: Unrelated parallel DDL on distributed table followed by unrelated DDL on ref. table
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	ALTER TABLE reference_table ADD COLUMN X int;
-ERROR:  cannot execute DDL on reference relation "reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	ALTER TABLE on_update_fkey_table ADD COLUMN X int;
 	ALTER TABLE transitive_reference_table ADD COLUMN X int;
-ERROR:  cannot execute DDL on reference relation "transitive_reference_table" because there was a parallel DDL access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DDL on reference table "transitive_reference_table" because there was a parallel DDL access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- case 6:6: Unrelated parallel DDL on distributed table followed by related DDL on ref. table
@@ -1020,13 +1020,13 @@ ROLLBACK;
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 5 WHERE id != 11;
 	DELETE FROM reference_table  WHERE id = 99;
-ERROR:  cannot execute DML on reference relation "reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	UPDATE on_update_fkey_table SET value_1 = 5 WHERE id != 11;
 	DELETE FROM transitive_reference_table  WHERE id = 99;
-ERROR:  cannot execute DML on reference relation "transitive_reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "transitive_reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- an unrelated update followed by update on dist table and update
@@ -1035,14 +1035,14 @@ BEGIN;
 	UPDATE unrelated_dist_table SET value_1 = 15;
 	UPDATE on_update_fkey_table SET value_1 = 5 WHERE id != 11;
 	UPDATE reference_table SET id = 101 WHERE id = 99;
-ERROR:  cannot execute DML on reference relation "reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 BEGIN;
 	UPDATE unrelated_dist_table SET value_1 = 15;
 	UPDATE on_update_fkey_table SET value_1 = 5 WHERE id != 11;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
-ERROR:  cannot execute DML on reference relation "transitive_reference_table" because there was a parallel DML access to distributed relation "on_update_fkey_table" in the same transaction
+ERROR:  cannot execute DML on reference table "transitive_reference_table" because there was a parallel DML access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
 -- an unrelated update followed by update on the reference table and update
@@ -1380,7 +1380,7 @@ INSERT INTO reference_table SELECT i FROM generate_series(0, 10) i;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 INSERT INTO distributed_table SELECT i, i % 10  FROM generate_series(0, 100) i;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
@@ -1391,7 +1391,7 @@ WITH t1 AS (DELETE FROM reference_table RETURNING id)
 DEBUG:  generating subplan XXX_1 for CTE t1: DELETE FROM test_fkey_to_ref_in_tx.reference_table RETURNING id
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: DELETE FROM test_fkey_to_ref_in_tx.distributed_table USING (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer)) t1 WHERE (distributed_table.value_1 OPERATOR(pg_catalog.=) t1.id) RETURNING distributed_table.id, distributed_table.value_1, t1.id
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
  id | value_1 | id
 ---------------------------------------------------------------------
 (0 rows)
@@ -1401,7 +1401,7 @@ INSERT INTO reference_table SELECT i FROM generate_series(0, 10) i;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 INSERT INTO distributed_table SELECT i, i % 10  FROM generate_series(0, 100) i;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 DEBUG:  Collecting INSERT ... SELECT results on coordinator
@@ -1412,7 +1412,7 @@ WITH t1 AS (DELETE FROM reference_table RETURNING id)
 DEBUG:  generating subplan XXX_1 for CTE t1: DELETE FROM test_fkey_to_ref_in_tx.reference_table RETURNING id
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM test_fkey_to_ref_in_tx.distributed_table, (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer)) t1 WHERE (distributed_table.value_1 OPERATOR(pg_catalog.=) t1.id)
 DEBUG:  switching to sequential query execution mode
-DETAIL:  Reference relation "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed relations due to foreign keys. Any parallel modification to those hash distributed relations in the same transaction can only be executed in sequential query execution mode
+DETAIL:  Reference table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
  count
 ---------------------------------------------------------------------
      0
@@ -1426,7 +1426,7 @@ WITH t1 AS (DELETE FROM distributed_table RETURNING id),
 DEBUG:  generating subplan XXX_1 for CTE t1: DELETE FROM test_fkey_to_ref_in_tx.distributed_table RETURNING id
 DEBUG:  generating subplan XXX_2 for CTE t2: DELETE FROM test_fkey_to_ref_in_tx.reference_table RETURNING id
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM test_fkey_to_ref_in_tx.distributed_table, (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer)) t1, (SELECT intermediate_result.id FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(id integer)) t2 WHERE ((distributed_table.value_1 OPERATOR(pg_catalog.=) t1.id) AND (distributed_table.value_1 OPERATOR(pg_catalog.=) t2.id))
-ERROR:  cannot execute DML on reference relation "reference_table" because there was a parallel DML access to distributed relation "distributed_table" in the same transaction
+ERROR:  cannot execute DML on reference table "reference_table" because there was a parallel DML access to distributed table "distributed_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 -- similarly this should fail since we first access to a distributed
 -- table via t1, and then access to the reference table in the main query
@@ -1434,7 +1434,7 @@ WITH t1 AS (DELETE FROM distributed_table RETURNING id)
 	DELETE FROM reference_table RETURNING id;
 DEBUG:  generating subplan XXX_1 for CTE t1: DELETE FROM test_fkey_to_ref_in_tx.distributed_table RETURNING id
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: DELETE FROM test_fkey_to_ref_in_tx.reference_table RETURNING id
-ERROR:  cannot execute DML on reference relation "reference_table" because there was a parallel DML access to distributed relation "distributed_table" in the same transaction
+ERROR:  cannot execute DML on reference table "reference_table" because there was a parallel DML access to distributed table "distributed_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 -- finally, make sure that we can execute the same queries
 -- in the sequential mode

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -857,6 +857,35 @@ BEGIN;
 NOTICE:  truncate cascades to table "reference_table"
 NOTICE:  truncate cascades to table "on_update_fkey_table"
 ROLLBACK;
+-- case 4.7: SELECT to a dist table is followed by a DROP
+-- DROP following SELECT is important as we error out after
+-- the standart process utility hook drops the table.
+-- That could cause SIGSEGV before the patch.
+-- Below block should "successfully" error out
+BEGIN;
+	SELECT count(*) FROM on_update_fkey_table;
+ count
+---------------------------------------------------------------------
+  1001
+(1 row)
+
+	DROP TABLE reference_table CASCADE;
+NOTICE:  drop cascades to constraint fkey on table on_update_fkey_table
+ERROR:  cannot execute DDL on reference relation because there was a parallel SELECT access to distributed relation "on_update_fkey_table" in the same transaction
+ROLLBACK;
+-- case 4.8: Router SELECT to a dist table is followed by a TRUNCATE
+-- No errors expected from below block as SELECT there is a router
+-- query
+BEGIN;
+	SELECT count(*) FROM on_update_fkey_table WHERE id = 9;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+	DROP TABLE reference_table CASCADE;
+NOTICE:  drop cascades to constraint fkey on table on_update_fkey_table
+ROLLBACK;
 RESET client_min_messages;
 \set VERBOSITY default
 -- case 5.1: Parallel UPDATE on distributed table follow by a SELECT

--- a/src/test/regress/sql/foreign_key_restriction_enforcement.sql
+++ b/src/test/regress/sql/foreign_key_restriction_enforcement.sql
@@ -489,6 +489,24 @@ BEGIN;
 	TRUNCATE transitive_reference_table CASCADE;
 ROLLBACK;
 
+-- case 4.7: SELECT to a dist table is followed by a DROP
+-- DROP following SELECT is important as we error out after
+-- the standart process utility hook drops the table.
+-- That could cause SIGSEGV before the patch.
+-- Below block should "successfully" error out
+BEGIN;
+	SELECT count(*) FROM on_update_fkey_table;
+	DROP TABLE reference_table CASCADE;
+ROLLBACK;
+
+-- case 4.8: Router SELECT to a dist table is followed by a TRUNCATE
+-- No errors expected from below block as SELECT there is a router
+-- query
+BEGIN;
+	SELECT count(*) FROM on_update_fkey_table WHERE id = 9;
+	DROP TABLE reference_table CASCADE;
+ROLLBACK;
+
 RESET client_min_messages;
 \set VERBOSITY default
 


### PR DESCRIPTION
DESCRIPTION:  Fix null relation name due to DROP on distributed table in a transaction block

Fixes #3520 