### PR TITLE
Address a couple issues with maintenace daemon management

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -37,7 +37,6 @@ static List * ExtensionNameListToObjectAddressList(List *extensionObjectList);
 static void MarkExistingObjectDependenciesDistributedIfSupported(void);
 static void EnsureSequentialModeForExtensionDDL(void);
 static bool ShouldPropagateExtensionCommand(Node *parseTree);
-static bool IsDropCitusStmt(Node *parseTree);
 static bool IsAlterExtensionSetSchemaCitus(Node *parseTree);
 static Node * RecreateExtensionStmt(Oid extensionOid);
 
@@ -727,7 +726,7 @@ IsCreateAlterExtensionUpdateCitusStmt(Node *parseTree)
  * IsDropCitusStmt iterates the objects to be dropped in a drop statement
  * and try to find citus there.
  */
-static bool
+bool
 IsDropCitusStmt(Node *parseTree)
 {
 	ListCell *objectCell = NULL;

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -452,6 +452,11 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		}
 	}
 
+	if (IsDropCitusStmt(parsetree))
+	{
+		StopMaintenanceDaemon(MyDatabaseId);
+	}
+
 	pstmt->utilityStmt = parsetree;
 
 	PG_TRY();
@@ -633,11 +638,14 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		PostprocessVacuumStmt(vacuumStmt, queryString);
 	}
 
-	/*
-	 * Ensure value is valid, we can't do some checks during CREATE
-	 * EXTENSION. This is important to register some invalidation callbacks.
-	 */
-	CitusHasBeenLoaded();
+	if (!IsDropCitusStmt(parsetree) && !IsA(parsetree, DropdbStmt))
+	{
+		/*
+		 * Ensure value is valid, we can't do some checks during CREATE
+		 * EXTENSION. This is important to register some invalidation callbacks.
+		 */
+		CitusHasBeenLoaded();
+	}
 }
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -71,6 +71,7 @@ extern ObjectAddress DefineCollationStmtObjectAddress(Node *stmt, bool missing_o
 extern List * PostprocessDefineCollationStmt(Node *stmt, const char *queryString);
 
 /* extension.c - forward declarations */
+extern bool IsDropCitusStmt(Node *parsetree);
 extern bool IsCreateAlterExtensionUpdateCitusStmt(Node *parsetree);
 extern void ErrorIfUnstableCreateOrAlterExtensionStmt(Node *parsetree);
 extern List * PostprocessCreateExtensionStmt(Node *stmt, const char *queryString);

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -6,7 +6,7 @@
 -- It'd be nice to script generation of this file, but alas, that's
 -- not done yet.
 SET citus.next_shard_id TO 580000;
-CREATE SCHEMA test;
+SELECT $definition$
 CREATE OR REPLACE FUNCTION test.maintenance_worker(p_dbname text DEFAULT current_database())
     RETURNS pg_stat_activity
     LANGUAGE plpgsql
@@ -14,18 +14,23 @@ AS $$
 DECLARE
    activity record;
 BEGIN
+    DO 'BEGIN END'; -- Force maintenance daemon to start
     LOOP
+        PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-	WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE
             PERFORM pg_sleep(0.1);
-            PERFORM pg_stat_clear_snapshot();
         END IF ;
     END LOOP;
 END;
 $$;
+$definition$ create_function_test_maintenance_worker
+\gset
+CREATE SCHEMA test;
+:create_function_test_maintenance_worker
 -- check maintenance daemon is started
 SELECT datname, current_database(),
     usename, (SELECT extowner::regrole::text FROM pg_extension WHERE extname = 'citus')
@@ -221,6 +226,45 @@ ALTER EXTENSION citus UPDATE;
 (0 rows)
 
 \c - - - :master_port
+-- test https://github.com/citusdata/citus/issues/3409
+CREATE USER testuser2 SUPERUSER;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SET ROLE testuser2;
+DROP EXTENSION Citus;
+-- Loop until we see there's no maintenance daemon running
+DO $$begin
+    for i in 0 .. 100 loop
+        if i = 100 then raise 'Waited too long'; end if;
+        PERFORM pg_stat_clear_snapshot();
+        perform * from pg_stat_activity where application_name = 'Citus Maintenance Daemon';
+        if not found then exit; end if;
+        perform pg_sleep(0.1);
+    end loop;
+end$$;
+SELECT datid, datname, usename FROM pg_stat_activity WHERE application_name = 'Citus Maintenance Daemon';
+ datid | datname | usename
+---------------------------------------------------------------------
+(0 rows)
+
+CREATE EXTENSION Citus;
+-- Loop until we there's a maintenance daemon running
+DO $$begin
+    for i in 0 .. 100 loop
+        if i = 100 then raise 'Waited too long'; end if;
+        PERFORM pg_stat_clear_snapshot();
+        perform * from pg_stat_activity where application_name = 'Citus Maintenance Daemon';
+        if found then exit; end if;
+        perform pg_sleep(0.1);
+    end loop;
+end$$;
+SELECT datid, datname, usename FROM pg_stat_activity WHERE application_name = 'Citus Maintenance Daemon';
+ datid |  datname   |  usename
+---------------------------------------------------------------------
+ 16384 | regression | testuser2
+(1 row)
+
+RESET ROLE;
 -- check that maintenance daemon gets (re-)started for the right user
 DROP EXTENSION citus;
 CREATE USER testuser SUPERUSER;
@@ -246,26 +290,8 @@ HINT:  You can manually create a database and its extensions on workers.
 \c another
 CREATE EXTENSION citus;
 CREATE SCHEMA test;
-CREATE OR REPLACE FUNCTION test.maintenance_worker(p_dbname text DEFAULT current_database())
-    RETURNS pg_stat_activity
-    LANGUAGE plpgsql
-AS $$
-DECLARE
-   activity record;
-BEGIN
-    LOOP
-        SELECT * INTO activity FROM pg_stat_activity
-	WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
-        IF activity.pid IS NOT NULL THEN
-            RETURN activity;
-        ELSE
-            PERFORM pg_sleep(0.1);
-            PERFORM pg_stat_clear_snapshot();
-        END IF ;
-    END LOOP;
-END;
-$$;
--- see that the deamon started
+:create_function_test_maintenance_worker
+-- see that the daemon started
 SELECT datname, current_database(),
     usename, (SELECT extowner::regrole::text FROM pg_extension WHERE extname = 'citus')
 FROM test.maintenance_worker();
@@ -276,12 +302,12 @@ FROM test.maintenance_worker();
 
 -- Test that database with active worker can be dropped.
 \c regression
-CREATE SCHEMA test_deamon;
+CREATE SCHEMA test_daemon;
 -- we create a similar function on the regression database
 -- note that this function checks for the existence of the daemon
 -- when not found, returns true else tries for 5 times and
 -- returns false
-CREATE OR REPLACE FUNCTION test_deamon.maintenance_deamon_died(p_dbname text)
+CREATE OR REPLACE FUNCTION test_daemon.maintenance_daemon_died(p_dbname text)
     RETURNS boolean
     LANGUAGE plpgsql
 AS $$
@@ -289,31 +315,29 @@ DECLARE
    activity record;
 BEGIN
     PERFORM pg_stat_clear_snapshot();
-    LOOP
-        SELECT * INTO activity FROM pg_stat_activity
-        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
-        IF activity.pid IS NULL THEN
-            RETURN true;
-        ELSE
-            RETURN false;
-        END IF;
-    END LOOP;
+    SELECT * INTO activity FROM pg_stat_activity
+    WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+    IF activity.pid IS NULL THEN
+        RETURN true;
+    ELSE
+        RETURN false;
+    END IF;
 END;
 $$;
--- drop the database and see that the deamon is dead
+-- drop the database and see that the daemon is dead
 DROP DATABASE another;
 SELECT
     *
 FROM
-    test_deamon.maintenance_deamon_died('another');
- maintenance_deamon_died
+    test_daemon.maintenance_daemon_died('another');
+ maintenance_daemon_died
 ---------------------------------------------------------------------
  t
 (1 row)
 
 -- we don't need the schema and the function anymore
-DROP SCHEMA test_deamon CASCADE;
-NOTICE:  drop cascades to function test_deamon.maintenance_deamon_died(text)
+DROP SCHEMA test_daemon CASCADE;
+NOTICE:  drop cascades to function test_daemon.maintenance_daemon_died(text)
 -- verify citus does not crash while creating a table when run against an older worker
 -- create_distributed_table piggybacks multiple commands into single one, if one worker
 -- did not have the required UDF it should fail instead of crash.


### PR DESCRIPTION
- Stop the daemon when citus extension is dropped
- Bail on maintenance daemon startup if myDbData is started with a non-zero pid
- Stop maintenance daemon from spawning itself
- Don't use postgres die, just wrap proc_exit(0)
- Assert(myDbData->workerPid == MyProcPid)

Only implementing the first item was insufficient to deal with the issue of multiple daemons existing when current user changes before drop.

DESCRIPTION: avoid having multiple maintenance daemons active for a single database

Closes #3438
Closes #3409