### PR TITLE
Refactor some pieces of code before implementing local drop & truncate execution

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -37,9 +37,9 @@
  * same connection since it may hold relevant locks or have uncommitted
  * writes. In that case we "assign" the task to a connection by adding
  * it to the task queue of specific connection (in
- * AssignTasksToConnectionsOrWorkerPool ). Otherwise we consider the task unassigned
- * and add it to the task queue of a worker pool, which means that it
- * can be executed over any connection in the pool.
+ * AssignTasksToConnectionsOrWorkerPool ). Otherwise we consider the task
+ * unassigned and add it to the task queue of a worker pool, which means
+ * that it can be executed over any connection in the pool.
  *
  * A task may be executed on multiple placements in case of a reference
  * table or a replicated distributed table. Depending on the type of
@@ -772,7 +772,7 @@ RunLocalExecution(CitusScanState *scanState, DistributedExecution *execution)
 	uint64 rowsProcessed = ExecuteLocalTaskList(scanState, execution->localTaskList);
 
 	/*
-	 * We're deliberately not setting execution->rowsProceessed here. The main reason
+	 * We're deliberately not setting execution->rowsProcessed here. The main reason
 	 * is that modifications to reference tables would end-up setting it both here
 	 * and in AdaptiveExecutor. Instead, we set executorState here and skip updating it
 	 * for reference table modifications in AdaptiveExecutor.
@@ -884,7 +884,7 @@ ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
 	ParamListInfo paramListInfo = NULL;
 
 	/*
-	 * The code-paths that rely on this function do not know how execute
+	 * The code-paths that rely on this function do not know how to execute
 	 * commands locally.
 	 */
 	ErrorIfTransactionAccessedPlacementsLocally();

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -20,16 +20,14 @@ extern bool LogLocalCommands;
 extern bool TransactionAccessedLocalPlacement;
 extern bool TransactionConnectedToLocalGroup;
 
+/* extern function declarations */
 extern uint64 ExecuteLocalTaskList(CitusScanState *scanState, List *taskList);
 extern void ExtractLocalAndRemoteTasks(bool readOnlyPlan, List *taskList,
 									   List **localTaskList, List **remoteTaskList);
 extern bool ShouldExecuteTasksLocally(List *taskList);
+extern bool AnyTaskAccessesLocalNode(List *taskList);
+extern bool TaskAccessesLocalNode(Task *task);
 extern void ErrorIfTransactionAccessedPlacementsLocally(void);
-extern void SetTaskQueryAndPlacementList(Task *task, Query *query, List *placementList);
-extern char * TaskQueryString(Task *task);
-extern bool TaskAccessesLocalNode(Task *task);
 extern void DisableLocalExecution(void);
-extern bool AnyTaskAccessesRemoteNode(List *taskList);
-extern bool TaskAccessesLocalNode(Task *task);
 
 #endif /* LOCAL_EXECUTION_H */


### PR DESCRIPTION
This pr aims to:
* Fix some typos around the local execution
* Some cleanup in `local_executor.h`
* Refactor `DropShards` function before introducing local execution of `DROP` commands