### PR TITLE
Improve prepared statement handling with stable/volatile functions and parameters

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -312,8 +312,8 @@ CitusBeginScanWithCoordinatorProcessing(CustomScanState *node, EState *estate, i
 	else if (jobQuery->commandType == CMD_SELECT && !workerJob->deferredPruning)
 	{
 		/* we'll use generated strings, no need to have the parameters anymore */
-		EState *executorState = planState->state;
-		//ResetExecutionParameters(executorState);
+		/*EState *executorState = planState->state; */
+		/*ResetExecutionParameters(executorState); */
 
 		/* we're done, we don't want to evaluate functions for SELECT queries */
 		return;

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -311,10 +311,6 @@ CitusBeginScanWithCoordinatorProcessing(CustomScanState *node, EState *estate, i
 	}
 	else if (jobQuery->commandType == CMD_SELECT && !workerJob->deferredPruning)
 	{
-		/* we'll use generated strings, no need to have the parameters anymore */
-		/*EState *executorState = planState->state; */
-		/*ResetExecutionParameters(executorState); */
-
 		/* we're done, we don't want to evaluate functions for SELECT queries */
 		return;
 	}

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -313,7 +313,7 @@ CitusBeginScanWithCoordinatorProcessing(CustomScanState *node, EState *estate, i
 	{
 		/* we'll use generated strings, no need to have the parameters anymore */
 		EState *executorState = planState->state;
-		ResetExecutionParameters(executorState);
+		//ResetExecutionParameters(executorState);
 
 		/* we're done, we don't want to evaluate functions for SELECT queries */
 		return;

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -820,6 +820,8 @@ SELECT DISTINCT trim(value) FROM (
         limit 2
     ) t;
 PREPARE local_prepare_param (int) AS SELECT count(*) FROM distributed_table WHERE key = $1;
+PREPARE local_prepare_param_master_evaluation_fast_path AS SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) FROM distributed_table a WHERE key = $1 GROUP BY key, value;
+PREPARE local_prepare_param_master_evaluation_router AS SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) FROM distributed_table a JOIN distributed_table b USING(key) WHERE a.key = $1 GROUP BY a.key, a.value;
 PREPARE remote_prepare_param (int) AS SELECT count(*) FROM distributed_table WHERE key != $1;
 BEGIN;
 	-- 6 local execution without params
@@ -961,6 +963,100 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
  count
 ---------------------------------------------------------------------
      0
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(1);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470001 a WHERE (key OPERATOR(pg_catalog.=) 1) GROUP BY key, value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 1, "value" : "12"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(5);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470001 a WHERE (key OPERATOR(pg_catalog.=) 5) GROUP BY key, value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 5, "value" : "56"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(6);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470003 a WHERE (key OPERATOR(pg_catalog.=) 6) GROUP BY key, value
+ json_agg
+---------------------------------------------------------------------
+(0 rows)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(1);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470001 a WHERE (key OPERATOR(pg_catalog.=) 1) GROUP BY key, value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 1, "value" : "12"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(5);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470001 a WHERE (key OPERATOR(pg_catalog.=) 5) GROUP BY key, value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 5, "value" : "56"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(6);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470003 a WHERE (key OPERATOR(pg_catalog.=) 6) GROUP BY key, value
+ json_agg
+---------------------------------------------------------------------
+(0 rows)
+
+	EXECUTE local_prepare_param_master_evaluation_fast_path(1);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', key, 'value', value)) AS json_agg FROM local_shard_execution.distributed_table_1470001 a WHERE (key OPERATOR(pg_catalog.=) 1) GROUP BY key, value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 1, "value" : "12"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_router(1);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470001 a(key, value, age) JOIN local_shard_execution.distributed_table_1470001 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 1, "value" : "12"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_router(5);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470001 a(key, value, age) JOIN local_shard_execution.distributed_table_1470001 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 5, "value" : "56"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_router(6);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470003 a(key, value, age) JOIN local_shard_execution.distributed_table_1470003 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+ json_agg
+---------------------------------------------------------------------
+(0 rows)
+
+	EXECUTE local_prepare_param_master_evaluation_router(1);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470001 a(key, value, age) JOIN local_shard_execution.distributed_table_1470001 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 1, "value" : "12"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_router(5);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470001 a(key, value, age) JOIN local_shard_execution.distributed_table_1470001 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 5, "value" : "56"}]
+(1 row)
+
+	EXECUTE local_prepare_param_master_evaluation_router(6);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470003 a(key, value, age) JOIN local_shard_execution.distributed_table_1470003 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+ json_agg
+---------------------------------------------------------------------
+(0 rows)
+
+	EXECUTE local_prepare_param_master_evaluation_router(1);
+NOTICE:  executing the command locally: SELECT json_agg(json_build_object('key', a.key, 'value', a.value)) AS json_agg FROM (local_shard_execution.distributed_table_1470001 a(key, value, age) JOIN local_shard_execution.distributed_table_1470001 b(key, value, age) USING (key)) WHERE (a.key OPERATOR(pg_catalog.=) $1) GROUP BY a.key, a.value
+           json_agg
+---------------------------------------------------------------------
+ [{"key" : 1, "value" : "12"}]
 (1 row)
 
 	-- followed by a non-local execution

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -2248,6 +2248,100 @@ DETAIL:  distribution column value: 4
 (1 row)
 
 SET client_min_messages to 'NOTICE';
+CREATE TABLE test_1 (id int, name text);
+SELECT create_distributed_table('test_1', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO test_1 VALUES (1,'1'), (2,'2');
+PREPARE fast_path_router_select_require_master_evaluation(int) AS SELECT json_agg(json_build_object('id', a.id, 'name', a.name)) FROM test_1 a WHERE id = $1 GROUP BY id, name ;
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+PREPARE router_select_require_master_evaluation(int) AS SELECT json_agg(json_build_object('id', a.id, 'name', a.name)) FROM test_1 a JOIN test_1 b USING (id) WHERE id = $1 GROUP BY a.id, a.name ;
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
+EXECUTE router_select_require_master_evaluation(1);
+          json_agg
+---------------------------------------------------------------------
+ [{"id" : 1, "name" : "1"}]
+(1 row)
+
 DROP FUNCTION author_articles_max_id();
 DROP FUNCTION author_articles_id_word_count();
 DROP MATERIALIZED VIEW mv_articles_hash_empty;
@@ -2266,9 +2360,10 @@ DROP TABLE articles_append;
 DROP TABLE collections_list;
 RESET search_path;
 DROP SCHEMA fast_path_router_select CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table fast_path_router_select.articles_hash
 drop cascades to function fast_path_router_select.raise_failed_execution_f_router(text)
 drop cascades to function fast_path_router_select.author_articles_max_id(integer)
 drop cascades to function fast_path_router_select.author_articles_id_word_count(integer)
 drop cascades to view fast_path_router_select.test_view
+drop cascades to table fast_path_router_select.test_1

--- a/src/test/regress/sql/multi_router_planner_fast_path.sql
+++ b/src/test/regress/sql/multi_router_planner_fast_path.sql
@@ -856,6 +856,32 @@ SELECT count(*) FILTER (where value = 15) FROM collections_list_2 WHERE key = 4;
 
 SET client_min_messages to 'NOTICE';
 
+CREATE TABLE test_1 (id int, name text);
+SELECT create_distributed_table('test_1', 'id');
+
+INSERT INTO test_1 VALUES (1,'1'), (2,'2');
+
+PREPARE fast_path_router_select_require_master_evaluation(int) AS SELECT json_agg(json_build_object('id', a.id, 'name', a.name)) FROM test_1 a WHERE id = $1 GROUP BY id, name ;
+
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+EXECUTE fast_path_router_select_require_master_evaluation(1);
+
+
+PREPARE router_select_require_master_evaluation(int) AS SELECT json_agg(json_build_object('id', a.id, 'name', a.name)) FROM test_1 a JOIN test_1 b USING (id) WHERE id = $1 GROUP BY a.id, a.name ;
+
+EXECUTE router_select_require_master_evaluation(1);
+EXECUTE router_select_require_master_evaluation(1);
+EXECUTE router_select_require_master_evaluation(1);
+EXECUTE router_select_require_master_evaluation(1);
+EXECUTE router_select_require_master_evaluation(1);
+EXECUTE router_select_require_master_evaluation(1);
+EXECUTE router_select_require_master_evaluation(1);
+
 DROP FUNCTION author_articles_max_id();
 DROP FUNCTION author_articles_id_word_count();
 


### PR DESCRIPTION
May fix #3548 

This is the 4th bug (#3498, #3454 and #3440) in the same code-path, so I expect full attention from @marcocitus on the patch. I'm not very sure about the fix yet, but opened to show one of fix.

In general, we should improve `CitusBeginScanWithCoordinatorProcessing` as it is very complicated now. The source of the problem is that we have plenty of different ways of doing prepared statements, and it hurts again (#1848)
