### PR TITLE
repartition_join_execution: Don't store 64 bit integers as pointers

### DIFF
--- a/src/backend/distributed/executor/repartition_join_execution.c
+++ b/src/backend/distributed/executor/repartition_join_execution.c
@@ -106,7 +106,10 @@ ExtractJobsInJobTree(Job *job)
 static void
 TraverseJobTree(Job *curJob, List **jobIds)
 {
-	*jobIds = lappend(*jobIds, (void *) curJob->jobId);
+	uint64 *jobIdPointer = palloc(sizeof(uint64));
+	*jobIdPointer = curJob->jobId;
+
+	*jobIds = lappend(*jobIds, jobIdPointer);
 
 	Job *childJob = NULL;
 	foreach_ptr(childJob, curJob->dependentJobList)
@@ -124,10 +127,10 @@ GenerateCreateSchemasCommand(List *jobIds, char *ownerName)
 {
 	StringInfo createSchemaCommand = makeStringInfo();
 
-	void *jobIdPointer = NULL;
+	uint64 *jobIdPointer = NULL;
 	foreach_ptr(jobIdPointer, jobIds)
 	{
-		uint64 jobId = (uint64) jobIdPointer;
+		uint64 jobId = *jobIdPointer;
 		appendStringInfo(createSchemaCommand, WORKER_CREATE_SCHEMA_QUERY,
 						 jobId, quote_literal_cstr(ownerName));
 	}
@@ -147,10 +150,10 @@ GenerateJobCommands(List *jobIds, char *templateCommand)
 {
 	StringInfo createSchemaCommand = makeStringInfo();
 
-	void *jobIdPointer = NULL;
+	uint64 *jobIdPointer = NULL;
 	foreach_ptr(jobIdPointer, jobIds)
 	{
-		uint64 jobId = (uint64) jobIdPointer;
+		uint64 jobId = *jobIdPointer;
 		appendStringInfo(createSchemaCommand, templateCommand, jobId);
 	}
 	return createSchemaCommand->data;


### PR DESCRIPTION
If we'd like to keep this, it'd be better to implement a `List64` interface that can allocate on 32 bit systems. Then update `master_metadata_utility`, `multi_task_tracker_executor`, & `backend_data` to use this