### PR TITLE
Refactor: VacuumTaskList function and local_executor.c line lengths

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -790,7 +790,16 @@ DistributedTableCacheEntry(Oid distributedRelationId)
 	else
 	{
 		char *relationName = get_rel_name(distributedRelationId);
-		ereport(ERROR, (errmsg("relation %s is not distributed", relationName)));
+
+		if (relationName == NULL)
+		{
+			ereport(ERROR, (errmsg("relation with OID %u does not exist",
+								   distributedRelationId)));
+		}
+		else
+		{
+			ereport(ERROR, (errmsg("relation %s is not distributed", relationName)));
+		}
 	}
 }
 


### PR DESCRIPTION
Some refactor around `vacuum.c` & `local_executor.c` and some changes to prevent possible invalid memory access issues. (see commit description in cc05ffc)