### PR TITLE
add local copy execution

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1258,12 +1258,15 @@ CopyLocalDataIntoShards(Oid distributedRelationId)
 	ExprContext *econtext = GetPerTupleExprContext(estate);
 	econtext->ecxt_scantuple = slot;
 
+	/* here we already have the data locally */
+	bool hasCopyDataLocally = true;
 	copyDest =
 		(DestReceiver *) CreateCitusCopyDestReceiver(distributedRelationId,
 													 columnNameList,
 													 partitionColumnIndex,
 													 estate, stopOnFailure,
-													 NULL);
+													 NULL,
+													 hasCopyDataLocally);
 
 	/* initialise state for writing to shards, we'll open connections on demand */
 	copyDest->rStartup(copyDest, 0, tupleDescriptor);

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1258,15 +1258,12 @@ CopyLocalDataIntoShards(Oid distributedRelationId)
 	ExprContext *econtext = GetPerTupleExprContext(estate);
 	econtext->ecxt_scantuple = slot;
 
-	/* here we already have the data locally */
-	bool hasCopyDataLocally = true;
 	copyDest =
 		(DestReceiver *) CreateCitusCopyDestReceiver(distributedRelationId,
 													 columnNameList,
 													 partitionColumnIndex,
 													 estate, stopOnFailure,
-													 NULL,
-													 hasCopyDataLocally);
+													 NULL);
 
 	/* initialise state for writing to shards, we'll open connections on demand */
 	copyDest->rStartup(copyDest, 0, tupleDescriptor);

--- a/src/backend/distributed/commands/local_multi_copy.c
+++ b/src/backend/distributed/commands/local_multi_copy.c
@@ -1,0 +1,241 @@
+/*-------------------------------------------------------------------------
+ *
+ * local_multi_copy.c
+ *    Commands for running a copy locally
+ *
+ * For each local placement, we have a buffer. When we receive a slot
+ * from a copy, the slot will be put to the corresponding buffer based
+ * on the shard id. When the buffer size exceeds the threshold a local
+ * copy will be done. Also If we reach to the end of copy, we will send
+ * the current buffer for local copy.
+ *
+ * The existing logic from multi_copy.c and format are used, therefore
+ * even if user did not do a copy with binary format, it is possible that
+ * we are going to be using binary format internally.
+ *
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "commands/copy.h"
+#include "catalog/namespace.h"
+#include "parser/parse_relation.h"
+#include "utils/lsyscache.h"
+#include "nodes/makefuncs.h"
+#include "safe_lib.h"
+#include <netinet/in.h> /* for htons */
+
+#include "distributed/transmit.h"
+#include "distributed/commands/multi_copy.h"
+#include "distributed/multi_partitioning_utils.h"
+#include "distributed/local_executor.h"
+#include "distributed/local_multi_copy.h"
+#include "distributed/shard_utils.h"
+
+/*
+ * LOCAL_COPY_BUFFER_SIZE is buffer size for local copy.
+ * There will be one buffer for each local placement, therefore
+ * the maximum amount of memory that might be alocated is
+ * LOCAL_COPY_BUFFER_SIZE * #local_placement
+ */
+#define LOCAL_COPY_BUFFER_SIZE (1 * 512 * 1024)
+
+
+static int ReadFromLocalBufferCallback(void *outbuf, int minread, int maxread);
+static Relation CreateCopiedShard(RangeVar *distributedRel, Relation shard);
+static void AddSlotToBuffer(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest,
+							bool isBinary);
+
+static bool ShouldSendCopyNow(StringInfo buffer);
+static void DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId,
+						CopyStmt *copyStatement, bool isEndOfCopy);
+static bool ShouldAddBinaryHeaders(StringInfo buffer, bool isBinary);
+
+/*
+ * localCopyBuffer is used in copy callback to return the copied rows.
+ * The reason this is a global variable is that we cannot pass an additional
+ * argument to the copy callback.
+ */
+StringInfo localCopyBuffer;
+
+/*
+ * ProcessLocalCopy adds the given slot and does a local copy if
+ * this is the end of copy, or the buffer size exceeds the threshold.
+ */
+void
+ProcessLocalCopy(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest, int64 shardId,
+				 StringInfo buffer, bool isEndOfCopy)
+{
+	/*
+	 * Here we save the previous buffer, and put the local shard's buffer
+	 * into copyOutState. The motivation is to use the existing logic to
+	 * serialize a row slot into buffer.
+	 */
+	StringInfo previousBuffer = copyDest->copyOutState->fe_msgbuf;
+	copyDest->copyOutState->fe_msgbuf = buffer;
+
+	/* since we are doing a local copy, the following statements should use local execution to see the changes */
+	TransactionAccessedLocalPlacement = true;
+
+	bool isBinaryCopy = copyDest->copyOutState->binary;
+	AddSlotToBuffer(slot, copyDest, isBinaryCopy);
+
+	if (isEndOfCopy || ShouldSendCopyNow(buffer))
+	{
+		if (isBinaryCopy)
+		{
+			AppendCopyBinaryFooters(copyDest->copyOutState);
+		}
+
+		DoLocalCopy(buffer, copyDest->distributedRelationId, shardId,
+					copyDest->copyStatement, isEndOfCopy);
+	}
+	copyDest->copyOutState->fe_msgbuf = previousBuffer;
+}
+
+
+/*
+ * AddSlotToBuffer serializes the given slot and adds it to the buffer in copyDest.
+ * If the copy format is binary, it adds binary headers as well.
+ */
+static void
+AddSlotToBuffer(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest, bool isBinary)
+{
+	if (ShouldAddBinaryHeaders(copyDest->copyOutState->fe_msgbuf, isBinary))
+	{
+		AppendCopyBinaryHeaders(copyDest->copyOutState);
+	}
+
+	if (slot != NULL)
+	{
+		Datum *columnValues = slot->tts_values;
+		bool *columnNulls = slot->tts_isnull;
+		FmgrInfo *columnOutputFunctions = copyDest->columnOutputFunctions;
+		CopyCoercionData *columnCoercionPaths = copyDest->columnCoercionPaths;
+
+		AppendCopyRowData(columnValues, columnNulls, copyDest->tupleDescriptor,
+						  copyDest->copyOutState, columnOutputFunctions,
+						  columnCoercionPaths);
+	}
+}
+
+
+/*
+ * ShouldSendCopyNow returns true if the given buffer size exceeds the
+ * local copy buffer size threshold.
+ */
+static bool
+ShouldSendCopyNow(StringInfo buffer)
+{
+	return buffer->len > LOCAL_COPY_BUFFER_SIZE;
+}
+
+
+/*
+ * DoLocalCopy finds the shard table from the distributed relation id, and copies the given
+ * buffer into the shard.
+ */
+static void
+DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId, CopyStmt *copyStatement,
+			bool isEndOfCopy)
+{
+	localCopyBuffer = buffer;
+
+	Oid shardOid = GetShardLocalTableOid(relationId, shardId);
+	Relation shard = heap_open(shardOid, RowExclusiveLock);
+	Relation copiedShard = CreateCopiedShard(copyStatement->relation, shard);
+	ParseState *pState = make_parsestate(NULL);
+
+	/* p_rtable of pState is set so that we can check constraints. */
+	pState->p_rtable = CreateRangeTable(copiedShard, ACL_INSERT);
+
+	CopyState cstate = BeginCopyFrom(pState, copiedShard, NULL, false,
+									 ReadFromLocalBufferCallback,
+									 copyStatement->attlist, copyStatement->options);
+	CopyFrom(cstate);
+	EndCopyFrom(cstate);
+
+	heap_close(shard, NoLock);
+	free_parsestate(pState);
+	FreeStringInfo(buffer);
+	if (!isEndOfCopy)
+	{
+		buffer = makeStringInfo();
+	}
+}
+
+
+/*
+ * ShouldAddBinaryHeaders returns true if the given buffer
+ * is empty and the format is binary.
+ */
+static bool
+ShouldAddBinaryHeaders(StringInfo buffer, bool isBinary)
+{
+	if (!isBinary)
+	{
+		return false;
+	}
+	return buffer->len == 0;
+}
+
+
+/*
+ * CreateCopiedShard clones deep copies the necessary fields of the given
+ * relation.
+ */
+Relation
+CreateCopiedShard(RangeVar *distributedRel, Relation shard)
+{
+	TupleDesc tupleDescriptor = RelationGetDescr(shard);
+
+	Relation copiedDistributedRelation = (Relation) palloc(sizeof(RelationData));
+	Form_pg_class copiedDistributedRelationTuple = (Form_pg_class) palloc(
+		CLASS_TUPLE_SIZE);
+
+	*copiedDistributedRelation = *shard;
+	*copiedDistributedRelationTuple = *shard->rd_rel;
+
+	copiedDistributedRelation->rd_rel = copiedDistributedRelationTuple;
+	copiedDistributedRelation->rd_att = CreateTupleDescCopyConstr(tupleDescriptor);
+
+	Oid tableId = RangeVarGetRelid(distributedRel, NoLock, false);
+
+	/*
+	 * BeginCopyFrom opens all partitions of given partitioned table with relation_open
+	 * and it expects its caller to close those relations. We do not have direct access
+	 * to opened relations, thus we are changing relkind of partitioned tables so that
+	 * Postgres will treat those tables as regular relations and will not open its
+	 * partitions.
+	 */
+	if (PartitionedTable(tableId))
+	{
+		copiedDistributedRelationTuple->relkind = RELKIND_RELATION;
+	}
+	return copiedDistributedRelation;
+}
+
+
+/*
+ * ReadFromLocalBufferCallback is the copy callback.
+ * It always tries to copy maxread bytes.
+ */
+static int
+ReadFromLocalBufferCallback(void *outbuf, int minread, int maxread)
+{
+	int bytesread = 0;
+	int avail = localCopyBuffer->len - localCopyBuffer->cursor;
+	int bytesToRead = Min(avail, maxread);
+	if (bytesToRead > 0)
+	{
+		memcpy_s(outbuf, bytesToRead + strlen((char *) outbuf),
+				 &localCopyBuffer->data[localCopyBuffer->cursor], bytesToRead);
+	}
+	bytesread += bytesToRead;
+	localCopyBuffer->cursor += bytesToRead;
+
+	return bytesread;
+}

--- a/src/backend/distributed/commands/local_multi_copy.c
+++ b/src/backend/distributed/commands/local_multi_copy.c
@@ -88,6 +88,7 @@ WriteTupleToLocalShard(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest, in
 		DoLocalCopy(localCopyOutState->fe_msgbuf, copyDest->distributedRelationId,
 					shardId,
 					copyDest->copyStatement, isEndOfCopy);
+		resetStringInfo(localCopyOutState->fe_msgbuf);
 	}
 }
 
@@ -173,7 +174,6 @@ DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId, CopyStmt *copyStat
 
 	heap_close(shard, NoLock);
 	free_parsestate(pState);
-	resetStringInfo(buffer);
 }
 
 

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -553,6 +553,10 @@ CacheLocalPlanForShardQuery(Task *task, DistributedPlan *originalDistributedPlan
 PlannedStmt *
 GetCachedLocalPlan(Task *task, DistributedPlan *distributedPlan)
 {
+	if (distributedPlan->workerJob == NULL)
+	{
+		return NULL;
+	}
 	List *cachedPlanList = distributedPlan->workerJob->localPlannedStatements;
 	LocalPlannedStatement *localPlannedStatement = NULL;
 

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -581,13 +581,16 @@ ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
 	int partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
 																  columnNameList);
 
+	bool hasCopyDataLocally = true;
+
 	/* set up a DestReceiver that copies into the intermediate table */
 	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
 																  columnNameList,
 																  partitionColumnIndex,
 																  executorState,
 																  stopOnFailure,
-																  intermediateResultIdPrefix);
+																  intermediateResultIdPrefix,
+																  hasCopyDataLocally);
 
 	ExecutePlanIntoDestReceiver(selectPlan, paramListInfo, (DestReceiver *) copyDest);
 
@@ -623,12 +626,15 @@ ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 	int partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
 																  columnNameList);
 
+	bool hasCopyDataLocally = true;
+
 	/* set up a DestReceiver that copies into the distributed table */
 	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
 																  columnNameList,
 																  partitionColumnIndex,
 																  executorState,
-																  stopOnFailure, NULL);
+																  stopOnFailure, NULL,
+																  hasCopyDataLocally);
 
 	ExecutePlanIntoDestReceiver(selectPlan, paramListInfo, (DestReceiver *) copyDest);
 

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -581,16 +581,13 @@ ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
 	int partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
 																  columnNameList);
 
-	bool hasCopyDataLocally = true;
-
 	/* set up a DestReceiver that copies into the intermediate table */
 	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
 																  columnNameList,
 																  partitionColumnIndex,
 																  executorState,
 																  stopOnFailure,
-																  intermediateResultIdPrefix,
-																  hasCopyDataLocally);
+																  intermediateResultIdPrefix);
 
 	ExecutePlanIntoDestReceiver(selectPlan, paramListInfo, (DestReceiver *) copyDest);
 
@@ -626,15 +623,12 @@ ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 	int partitionColumnIndex = PartitionColumnIndexFromColumnList(targetRelationId,
 																  columnNameList);
 
-	bool hasCopyDataLocally = true;
-
 	/* set up a DestReceiver that copies into the distributed table */
 	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
 																  columnNameList,
 																  partitionColumnIndex,
 																  executorState,
-																  stopOnFailure, NULL,
-																  hasCopyDataLocally);
+																  stopOnFailure, NULL);
 
 	ExecutePlanIntoDestReceiver(selectPlan, paramListInfo, (DestReceiver *) copyDest);
 

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -232,6 +232,48 @@ ExecuteLocalTaskList(CitusScanState *scanState, List *taskList)
 
 
 /*
+ * ExtractAndExecuteLocalAndRemoteTasks extracts local and remote tasks
+ * if local execution can be used and executes them.
+ */
+uint64
+ExtractAndExecuteLocalAndRemoteTasks(CitusScanState *scanState,
+									 List *taskList, RowModifyLevel rowModifyLevel, bool
+									 hasReturning)
+{
+	uint64 processedRows = 0;
+	List *localTaskList = NIL;
+	List *remoteTaskList = NIL;
+	TupleDesc tupleDescriptor = ScanStateGetTupleDescriptor(scanState);
+
+	if (ShouldExecuteTasksLocally(taskList))
+	{
+		bool readOnlyPlan = false;
+
+		/* set local (if any) & remote tasks */
+		ExtractLocalAndRemoteTasks(readOnlyPlan, taskList, &localTaskList,
+								   &remoteTaskList);
+		processedRows += ExecuteLocalTaskList(scanState, localTaskList);
+	}
+	else
+	{
+		/* all tasks should be executed via remote connections */
+		remoteTaskList = taskList;
+	}
+
+	/* execute remote tasks if any */
+	if (list_length(remoteTaskList) > 0)
+	{
+		processedRows += ExecuteTaskListIntoTupleStore(rowModifyLevel, remoteTaskList,
+													   tupleDescriptor,
+													   scanState->tuplestorestate,
+													   hasReturning);
+	}
+
+	return processedRows;
+}
+
+
+/*
  * ExtractParametersForLocalExecution extracts parameter types and values
  * from the given ParamListInfo structure, and fills parameter type and
  * value arrays. It does not change the oid of custom types, because the

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -335,12 +335,8 @@ UpdateRelationsToLocalShardTables(Node *node, List *relationShardList)
 		return true;
 	}
 
-<<<<<<< HEAD
-	Oid shardOid = GetShardLocalTableOid(relationShard->relationId, relationShard->shardId);
-=======
 	Oid shardOid = GetShardLocalTableOid(relationShard->relationId,
 										 relationShard->shardId);
->>>>>>> add the support to execute copy locally
 
 	newRte->relid = shardOid;
 

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -335,7 +335,12 @@ UpdateRelationsToLocalShardTables(Node *node, List *relationShardList)
 		return true;
 	}
 
-	Oid shardOid = GetShardOid(relationShard->relationId, relationShard->shardId);
+<<<<<<< HEAD
+	Oid shardOid = GetShardLocalTableOid(relationShard->relationId, relationShard->shardId);
+=======
+	Oid shardOid = GetShardLocalTableOid(relationShard->relationId,
+										 relationShard->shardId);
+>>>>>>> add the support to execute copy locally
 
 	newRte->relid = shardOid;
 

--- a/src/backend/distributed/utils/shard_utils.c
+++ b/src/backend/distributed/utils/shard_utils.c
@@ -16,11 +16,11 @@
 #include "distributed/shard_utils.h"
 
 /*
- * GetShardOid returns the oid of the shard from the given distributed relation
+ * GetShardLocalTableOid returns the oid of the shard from the given distributed relation
  * with the shardid.
  */
 Oid
-GetShardOid(Oid distRelId, uint64 shardId)
+GetShardLocalTableOid(Oid distRelId, uint64 shardId)
 {
 	char *relationName = get_rel_name(distRelId);
 	AppendShardIdToName(&relationName, shardId);

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -130,6 +130,9 @@ typedef struct CitusCopyDestReceiver
 	/* useful for tracking multi shard accesses */
 	bool multiShardCopy;
 
+	/* if true, should copy to local placements in the current session */
+	bool shouldUseLocalCopy;
+
 	/* copy into intermediate result */
 	char *intermediateResultIdPrefix;
 } CitusCopyDestReceiver;
@@ -141,7 +144,8 @@ extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   int partitionColumnIndex,
 														   EState *executorState,
 														   bool stopOnFailure,
-														   char *intermediateResultPrefix);
+														   char *intermediateResultPrefix,
+														   bool hasCopyDataLocally);
 extern FmgrInfo * ColumnOutputFunctions(TupleDesc rowDescriptor, bool binaryFormat);
 extern bool CanUseBinaryCopyFormat(TupleDesc tupleDescription);
 extern bool CanUseBinaryCopyFormatForTargetList(List *targetEntryList);
@@ -154,6 +158,7 @@ extern void AppendCopyRowData(Datum *valueArray, bool *isNullArray,
 extern void AppendCopyBinaryHeaders(CopyOutState headerOutputState);
 extern void AppendCopyBinaryFooters(CopyOutState footerOutputState);
 extern void EndRemoteCopy(int64 shardId, List *connectionList);
+extern List * CreateRangeTable(Relation rel, AclMode requiredAccess);
 extern Node * ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag,
 							  const char *queryString);
 extern void CheckCopyPermissions(CopyStmt *copyStatement);

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -144,8 +144,7 @@ extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   int partitionColumnIndex,
 														   EState *executorState,
 														   bool stopOnFailure,
-														   char *intermediateResultPrefix,
-														   bool hasCopyDataLocally);
+														   char *intermediateResultPrefix);
 extern FmgrInfo * ColumnOutputFunctions(TupleDesc rowDescriptor, bool binaryFormat);
 extern bool CanUseBinaryCopyFormat(TupleDesc tupleDescription);
 extern bool CanUseBinaryCopyFormatForTargetList(List *targetEntryList);

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -21,6 +21,9 @@ extern bool TransactionAccessedLocalPlacement;
 extern bool TransactionConnectedToLocalGroup;
 
 /* extern function declarations */
+extern uint64 ExtractAndExecuteLocalAndRemoteTasks(CitusScanState *scanState,
+												   List *taskList, RowModifyLevel
+												   rowModifyLevel, bool hasReturning);
 extern uint64 ExecuteLocalTaskList(CitusScanState *scanState, List *taskList);
 extern void ExecuteLocalUtilityTaskList(List *localTaskList);
 extern void ExtractLocalAndRemoteTasks(bool readOnlyPlan, List *taskList,

--- a/src/include/distributed/local_multi_copy.h
+++ b/src/include/distributed/local_multi_copy.h
@@ -1,0 +1,9 @@
+
+#ifndef LOCAL_MULTI_COPY
+#define LOCAL_MULTI_COPY
+
+extern void ProcessLocalCopy(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest, int64
+							 shardId,
+							 StringInfo buffer, bool isEndOfCopy);
+
+#endif /* LOCAL_MULTI_COPY */

--- a/src/include/distributed/local_multi_copy.h
+++ b/src/include/distributed/local_multi_copy.h
@@ -2,8 +2,18 @@
 #ifndef LOCAL_MULTI_COPY
 #define LOCAL_MULTI_COPY
 
-extern void ProcessLocalCopy(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest, int64
-							 shardId,
-							 StringInfo buffer, bool isEndOfCopy);
+/*
+ * LOCAL_COPY_FLUSH_THRESHOLD is the threshold for local copy to be flushed.
+ * There will be one buffer for each local placement, when the buffer size
+ * exceeds this threshold, it will be flushed.
+ */
+#define LOCAL_COPY_FLUSH_THRESHOLD (1 * 512 * 1024)
+
+extern void WriteTupleToLocalShard(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest,
+								   int64
+								   shardId,
+								   CopyOutState localCopyOutState);
+extern void FinishLocalCopyToShard(CitusCopyDestReceiver *copyDest, int64 shardId,
+								   CopyOutState localCopyOutState);
 
 #endif /* LOCAL_MULTI_COPY */

--- a/src/include/distributed/shard_utils.h
+++ b/src/include/distributed/shard_utils.h
@@ -13,6 +13,6 @@
 
 #include "postgres.h"
 
-extern Oid GetShardOid(Oid distRelId, uint64 shardId);
+extern Oid GetShardLocalTableOid(Oid distRelId, uint64 shardId);
 
 #endif /* SHARD_UTILS_H */

--- a/src/test/regress/data/orders.2.data
+++ b/src/test/regress/data/orders.2.data
@@ -1484,4 +1484,4 @@
 14944|535|O|119586.69|1997-10-14|2-HIGH|Clerk#000000962|0|lly. even instructions against
 14945|68|O|210519.05|1996-03-30|1-URGENT|Clerk#000000467|0|nts? fluffily bold grouches after
 14946|580|O|100402.47|1996-11-12|1-URGENT|Clerk#000000116|0|ffily bold dependencies wake. furiously regular instructions aro
-14947|580|O|100402.47|1996-11-12|1-URGENT|Clerk#000000116|0|ffily bold dependencies wake. furiously regular instructions aro
+14947|580|O|100402.47|1996-11-12|1-URGENT|Clerk#000000116|0|ffily bold dependencies wake. furiously regular instructions aro 

--- a/src/test/regress/expected/coordinator_shouldhaveshards.out
+++ b/src/test/regress/expected/coordinator_shouldhaveshards.out
@@ -37,6 +37,8 @@ SET client_min_messages TO LOG;
 SET citus.log_local_commands TO ON;
 -- INSERT..SELECT with COPY under the covers
 INSERT INTO test SELECT s,s FROM generate_series(2,100) s;
+NOTICE:  executing the copy locally for shard xxxxx
+NOTICE:  executing the copy locally for shard xxxxx
 -- router queries execute locally
 INSERT INTO test VALUES (1, 1);
 NOTICE:  executing the command locally: INSERT INTO coordinator_shouldhaveshards.test_1503000 (x, y) VALUES (1, 1)

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -54,6 +54,24 @@ CREATE TABLE local_table (key int PRIMARY KEY);
 DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_pkey" for table "local_table"
 DEBUG:  building index "local_table_pkey" on table "local_table" serially
 INSERT INTO local_table SELECT * from generate_series(1, 10);
+-- partitioned table
+CREATE TABLE collections_list (
+	key bigserial,
+	collection_id integer
+) PARTITION BY LIST (collection_id );
+DEBUG:  CREATE TABLE will create implicit sequence "collections_list_key_seq" for serial column "collections_list.key"
+SELECT create_distributed_table('collections_list', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE collections_list_0
+	PARTITION OF collections_list (key, collection_id)
+	FOR VALUES IN ( 0 );
+CREATE TABLE collections_list_1
+	PARTITION OF collections_list (key, collection_id)
+	FOR VALUES IN ( 1 );
 -- connection worker and get ready for the tests
 \c - - - :worker_1_port
 SET search_path TO local_shard_copy;
@@ -238,6 +256,36 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
  count
 ---------------------------------------------------------------------
     26
+(1 row)
+
+ROLLBACK;
+BEGIN;
+    -- run select with local execution
+    SELECT age FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ age
+---------------------------------------------------------------------
+(0 rows)
+
+    SELECT count(*) FROM collections_list;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330005 collections_list WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330007 collections_list WHERE true
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+    -- the local placements should be executed locally
+    COPY collections_list FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY collections_list, line 1: "1, 0"
+    -- verify that the copy is successful.
+    SELECT count(*) FROM collections_list;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330005 collections_list WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330007 collections_list WHERE true
+ count
+---------------------------------------------------------------------
+     5
 (1 row)
 
 ROLLBACK;

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -1,0 +1,418 @@
+CREATE SCHEMA local_shard_copy;
+SET search_path TO local_shard_copy;
+SET client_min_messages TO DEBUG;
+SELECT * FROM master_add_node('localhost', :master_port, groupid := 0);
+DEBUG:  schema "public" already exists, skipping
+DETAIL:  NOTICE from localhost:xxxxx
+DEBUG:  extension "plpgsql" already exists, skipping
+DETAIL:  NOTICE from localhost:xxxxx
+DEBUG:  schema "citus_mx_test_schema" already exists, skipping
+DETAIL:  NOTICE from localhost:xxxxx
+DEBUG:  schema "citus_mx_test_schema_join_1" already exists, skipping
+DETAIL:  NOTICE from localhost:xxxxx
+DEBUG:  schema "citus_mx_test_schema_join_2" already exists, skipping
+DETAIL:  NOTICE from localhost:xxxxx
+DEBUG:  schema "citus_mx_schema_for_xacts" already exists, skipping
+DETAIL:  NOTICE from localhost:xxxxx
+NOTICE:  Replicating reference table "customer_mx" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "nation_mx" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "part_mx" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "supplier_mx" to the node localhost:xxxxx
+ master_add_node
+---------------------------------------------------------------------
+              32
+(1 row)
+
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO 'streaming';
+CREATE TABLE reference_table (key int PRIMARY KEY);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "reference_table_pkey" for table "reference_table"
+DEBUG:  building index "reference_table_pkey" on table "reference_table" serially
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE distributed_table (key int PRIMARY KEY, age bigint CHECK (age >= 10));
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "distributed_table_pkey" for table "distributed_table"
+DEBUG:  building index "distributed_table_pkey" on table "distributed_table" serially
+SELECT create_distributed_table('distributed_table','key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO distributed_table SELECT *,* FROM generate_series(20, 40);
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO reference_table SELECT * FROM generate_series(1, 10);
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+CREATE TABLE local_table (key int PRIMARY KEY);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_pkey" for table "local_table"
+DEBUG:  building index "local_table_pkey" on table "local_table" serially
+INSERT INTO local_table SELECT * from generate_series(1, 10);
+-- connection worker and get ready for the tests
+\c - - - :worker_1_port
+SET search_path TO local_shard_copy;
+SET citus.log_local_commands TO ON;
+-- returns true of the distribution key filter
+-- on the distributed tables (e.g., WHERE key = 1), we'll hit a shard
+-- placement which is local to this not
+CREATE OR REPLACE FUNCTION shard_of_distribution_column_is_local(dist_key int) RETURNS bool AS $$
+
+		DECLARE shard_is_local BOOLEAN := FALSE;
+
+		BEGIN
+
+		  	WITH  local_shard_ids 			  AS (SELECT get_shard_id_for_distribution_column('local_shard_copy.distributed_table', dist_key)),
+				  all_local_shard_ids_on_node AS (SELECT shardid FROM pg_dist_placement WHERE groupid IN (SELECT groupid FROM pg_dist_local_group))
+		SELECT
+			true INTO shard_is_local
+		FROM
+			local_shard_ids
+		WHERE
+			get_shard_id_for_distribution_column IN (SELECT * FROM all_local_shard_ids_on_node);
+
+		IF shard_is_local IS NULL THEN
+			shard_is_local = FALSE;
+		END IF;
+
+		RETURN shard_is_local;
+        END;
+$$ LANGUAGE plpgsql;
+-- pick some example values that reside on the shards locally and remote
+-- distribution key values of 1,6, 500 and 701 are LOCAL to shards,
+-- we'll use these values in the tests
+SELECT shard_of_distribution_column_is_local(1);
+ shard_of_distribution_column_is_local
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT shard_of_distribution_column_is_local(6);
+ shard_of_distribution_column_is_local
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT shard_of_distribution_column_is_local(500);
+ shard_of_distribution_column_is_local
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT shard_of_distribution_column_is_local(701);
+ shard_of_distribution_column_is_local
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- distribution key values of 11 and 12 are REMOTE to shards
+SELECT shard_of_distribution_column_is_local(11);
+ shard_of_distribution_column_is_local
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT shard_of_distribution_column_is_local(12);
+ shard_of_distribution_column_is_local
+---------------------------------------------------------------------
+ f
+(1 row)
+
+BEGIN;
+    -- run select with local execution
+    SELECT count(*) FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    21
+(1 row)
+
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
+    -- verify that the copy is successful.
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    26
+(1 row)
+
+ROLLBACK;
+BEGIN;
+    -- run select with local execution
+    SELECT count(*) FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    21
+(1 row)
+
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
+    -- verify the put ages.
+    SELECT * FROM distributed_table;
+NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ key | age
+---------------------------------------------------------------------
+  20 |  20
+  24 |  24
+  25 |  25
+  26 |  26
+  31 |  31
+  33 |  33
+  35 |  35
+   1 | 100
+   5 | 500
+  21 |  21
+  28 |  28
+  34 |  34
+  38 |  38
+  39 |  39
+  36 |  36
+  37 |  37
+  40 |  40
+   3 | 300
+   4 | 400
+  22 |  22
+  23 |  23
+  27 |  27
+  29 |  29
+  30 |  30
+  32 |  32
+   2 | 200
+(26 rows)
+
+ROLLBACK;
+BEGIN;
+    -- run select with local execution
+    SELECT count(*) FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    21
+(1 row)
+
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
+    -- verify that the copy is successful.
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    26
+(1 row)
+
+ROLLBACK;
+BEGIN;
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
+    -- run select with local execution
+    SELECT age FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ age
+---------------------------------------------------------------------
+ 100
+(1 row)
+
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    26
+(1 row)
+
+    -- verify that the copy is successful.
+    SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+    26
+(1 row)
+
+ROLLBACK;
+BEGIN;
+-- Since we are in a transaction, the copy should be locally executed.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
+ROLLBACK;
+-- Since we are not in a transaction, the copy should not be locally executed.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+BEGIN;
+-- Since we are in a transaction, the copy should be locally executed. But
+-- we are putting duplicate key, so it should error.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
+ERROR:  duplicate key value violates unique constraint "distributed_table_pkey_1330001"
+DETAIL:  Key (key)=(1) already exists.
+CONTEXT:  COPY distributed_table_1330001, line 1
+ROLLBACK;
+TRUNCATE distributed_table;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+ERROR:  new row for relation "distributed_table_1330001" violates check constraint "distributed_table_age_check"
+DETAIL:  Failing row contains (1, 9).
+BEGIN;
+-- Since we are in a transaction, the execution will be local, however we are putting invalid age.
+-- The constaints should give an error
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1,9"
+ERROR:  new row for relation "distributed_table_1330001" violates check constraint "distributed_table_age_check"
+DETAIL:  Failing row contains (1, 9).
+CONTEXT:  COPY distributed_table_1330001, line 1
+ROLLBACK;
+TRUNCATE distributed_table;
+-- different delimiters
+BEGIN;
+-- initial size
+SELECT count(*) FROM distributed_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+COPY distributed_table FROM STDIN WITH delimiter '|';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1|10"
+-- new size
+SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+ROLLBACK;
+BEGIN;
+-- initial size
+SELECT count(*) FROM distributed_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+COPY distributed_table FROM STDIN WITH delimiter '[';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1[10"
+-- new size
+SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+ROLLBACK;
+-- multiple local copies
+BEGIN;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1,15"
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "10,15"
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "100,15"
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 2: "200,20"
+ROLLBACK;
+-- local copy followed by local copy should see the changes
+-- and error since it is a duplicate primary key.
+BEGIN;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1,15"
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1,16"
+ERROR:  duplicate key value violates unique constraint "distributed_table_pkey_1330001"
+DETAIL:  Key (key)=(1) already exists.
+CONTEXT:  COPY distributed_table_1330001, line 1
+ROLLBACK;
+-- local copy followed by local copy should see the changes
+BEGIN;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1,15"
+-- select should see the change
+SELECT key FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT key FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ key
+---------------------------------------------------------------------
+   1
+(1 row)
+
+ROLLBACK;
+\c - - - :master_port
+SET search_path TO local_shard_copy;
+SET citus.log_local_commands TO ON;
+TRUNCATE TABLE reference_table;
+TRUNCATE TABLE local_table;
+SELECT count(*) FROM reference_table, local_table WHERE reference_table.key = local_table.key;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SET citus.enable_local_execution = 'on';
+BEGIN;
+-- copy should be executed locally
+COPY reference_table FROM STDIN;
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY reference_table, line 1: "1"
+ROLLBACK;
+SET citus.enable_local_execution = 'off';
+BEGIN;
+-- copy should not be executed locally as citus.enable_local_execution = off
+COPY reference_table FROM STDIN;
+ROLLBACK;
+SET citus.enable_local_execution = 'on';
+SET client_min_messages TO ERROR;
+SET search_path TO public;
+DROP SCHEMA local_shard_copy CASCADE;

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -339,6 +339,13 @@ DETAIL:  Key (key)=(1) already exists.
 CONTEXT:  COPY distributed_table_1570001, line 1
 ROLLBACK;
 TRUNCATE distributed_table;
+BEGIN;
+-- insert a lot of data ( around 8MB),
+-- this should use local copy and it will exceed the LOCAL_COPY_FLUSH_THRESHOLD (512KB)
+INSERT INTO distributed_table SELECT * , * FROM generate_series(20, 1000000);
+NOTICE:  executing the copy locally for shard xxxxx
+NOTICE:  executing the copy locally for shard xxxxx
+ROLLBACK;
 COPY distributed_table FROM STDIN WITH delimiter ',';
 ERROR:  new row for relation "distributed_table_1570001" violates check constraint "distributed_table_age_check"
 DETAIL:  Failing row contains (1, 9).
@@ -461,6 +468,7 @@ ROLLBACK;
 SET search_path TO local_shard_copy;
 SET citus.log_local_commands TO ON;
 TRUNCATE TABLE reference_table;
+NOTICE:  executing the command locally: TRUNCATE TABLE local_shard_copy.reference_table_xxxxx CASCADE
 TRUNCATE TABLE local_table;
 SELECT count(*) FROM reference_table, local_table WHERE reference_table.key = local_table.key;
  count

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -242,26 +242,25 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
 ROLLBACK;
 BEGIN;
-    -- the local placements should be executed locally
-    COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
-CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- run select with local execution
     SELECT age FROM distributed_table WHERE key = 1;
 NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  age
 ---------------------------------------------------------------------
- 100
-(1 row)
+(0 rows)
 
     SELECT count(*) FROM distributed_table;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
-    26
+    21
 (1 row)
 
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+NOTICE:  executing the copy locally for shard
+CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- verify that the copy is successful.
     SELECT count(*) FROM distributed_table;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
@@ -307,8 +306,18 @@ ROLLBACK;
 TRUNCATE distributed_table;
 -- different delimiters
 BEGIN;
+-- run select with local execution
+SELECT count(*) FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
 -- initial size
 SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
      0
@@ -328,8 +337,18 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
 ROLLBACK;
 BEGIN;
+-- run select with local execution
+SELECT count(*) FROM distributed_table WHERE key = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
 -- initial size
 SELECT count(*) FROM distributed_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
      0

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -1,6 +1,7 @@
 CREATE SCHEMA local_shard_copy;
 SET search_path TO local_shard_copy;
 SET client_min_messages TO DEBUG;
+SET citus.next_shard_id TO 1570000;
 SELECT * FROM master_add_node('localhost', :master_port, groupid := 0);
 DEBUG:  schema "public" already exists, skipping
 DETAIL:  NOTICE from localhost:xxxxx
@@ -144,15 +145,15 @@ SELECT shard_of_distribution_column_is_local(12);
 BEGIN;
     -- run select with local execution
     SELECT count(*) FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     21
@@ -160,12 +161,12 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
     -- the local placements should be executed locally
     COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- verify that the copy is successful.
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     26
@@ -175,15 +176,15 @@ ROLLBACK;
 BEGIN;
     -- run select with local execution
     SELECT count(*) FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     21
@@ -191,12 +192,12 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
     -- the local placements should be executed locally
     COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- verify the put ages.
     SELECT * FROM distributed_table;
-NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  key | age
 ---------------------------------------------------------------------
   20 |  20
@@ -231,15 +232,15 @@ ROLLBACK;
 BEGIN;
     -- run select with local execution
     SELECT count(*) FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     21
@@ -247,12 +248,12 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
     -- the local placements should be executed locally
     COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- verify that the copy is successful.
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     26
@@ -262,14 +263,14 @@ ROLLBACK;
 BEGIN;
     -- run select with local execution
     SELECT age FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  age
 ---------------------------------------------------------------------
 (0 rows)
 
     SELECT count(*) FROM collections_list;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330005 collections_list WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330007 collections_list WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1570005 collections_list WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1570007 collections_list WHERE true
  count
 ---------------------------------------------------------------------
      0
@@ -277,12 +278,12 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
     -- the local placements should be executed locally
     COPY collections_list FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY collections_list, line 1: "1, 0"
     -- verify that the copy is successful.
     SELECT count(*) FROM collections_list;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330005 collections_list WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1330007 collections_list WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1570005 collections_list WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.collections_list_1570007 collections_list WHERE true
  count
 ---------------------------------------------------------------------
      5
@@ -292,14 +293,14 @@ ROLLBACK;
 BEGIN;
     -- run select with local execution
     SELECT age FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT age FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  age
 ---------------------------------------------------------------------
 (0 rows)
 
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     21
@@ -307,12 +308,12 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
     -- the local placements should be executed locally
     COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- verify that the copy is successful.
     SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
     26
@@ -322,7 +323,7 @@ ROLLBACK;
 BEGIN;
 -- Since we are in a transaction, the copy should be locally executed.
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
 ROLLBACK;
 -- Since we are not in a transaction, the copy should not be locally executed.
@@ -331,32 +332,32 @@ BEGIN;
 -- Since we are in a transaction, the copy should be locally executed. But
 -- we are putting duplicate key, so it should error.
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
-ERROR:  duplicate key value violates unique constraint "distributed_table_pkey_1330001"
+ERROR:  duplicate key value violates unique constraint "distributed_table_pkey_1570001"
 DETAIL:  Key (key)=(1) already exists.
-CONTEXT:  COPY distributed_table_1330001, line 1
+CONTEXT:  COPY distributed_table_1570001, line 1
 ROLLBACK;
 TRUNCATE distributed_table;
 COPY distributed_table FROM STDIN WITH delimiter ',';
-ERROR:  new row for relation "distributed_table_1330001" violates check constraint "distributed_table_age_check"
+ERROR:  new row for relation "distributed_table_1570001" violates check constraint "distributed_table_age_check"
 DETAIL:  Failing row contains (1, 9).
 BEGIN;
 -- Since we are in a transaction, the execution will be local, however we are putting invalid age.
 -- The constaints should give an error
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1,9"
-ERROR:  new row for relation "distributed_table_1330001" violates check constraint "distributed_table_age_check"
+ERROR:  new row for relation "distributed_table_1570001" violates check constraint "distributed_table_age_check"
 DETAIL:  Failing row contains (1, 9).
-CONTEXT:  COPY distributed_table_1330001, line 1
+CONTEXT:  COPY distributed_table_1570001, line 1
 ROLLBACK;
 TRUNCATE distributed_table;
 -- different delimiters
 BEGIN;
 -- run select with local execution
 SELECT count(*) FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  count
 ---------------------------------------------------------------------
      0
@@ -364,20 +365,20 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
 -- initial size
 SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
 COPY distributed_table FROM STDIN WITH delimiter '|';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1|10"
 -- new size
 SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
      3
@@ -387,7 +388,7 @@ ROLLBACK;
 BEGIN;
 -- run select with local execution
 SELECT count(*) FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  count
 ---------------------------------------------------------------------
      0
@@ -395,20 +396,20 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
 -- initial size
 SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
 COPY distributed_table FROM STDIN WITH delimiter '[';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1[10"
 -- new size
 SELECT count(*) FROM distributed_table;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1330003 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  count
 ---------------------------------------------------------------------
      3
@@ -418,38 +419,38 @@ ROLLBACK;
 -- multiple local copies
 BEGIN;
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1,15"
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "10,15"
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "100,15"
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 2: "200,20"
 ROLLBACK;
 -- local copy followed by local copy should see the changes
 -- and error since it is a duplicate primary key.
 BEGIN;
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1,15"
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1,16"
-ERROR:  duplicate key value violates unique constraint "distributed_table_pkey_1330001"
+ERROR:  duplicate key value violates unique constraint "distributed_table_pkey_1570001"
 DETAIL:  Key (key)=(1) already exists.
-CONTEXT:  COPY distributed_table_1330001, line 1
+CONTEXT:  COPY distributed_table_1570001, line 1
 ROLLBACK;
 -- local copy followed by local copy should see the changes
 BEGIN;
 COPY distributed_table FROM STDIN WITH delimiter ',';
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1,15"
 -- select should see the change
 SELECT key FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT key FROM local_shard_copy.distributed_table_1330001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
+NOTICE:  executing the command locally: SELECT key FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
  key
 ---------------------------------------------------------------------
    1
@@ -471,7 +472,7 @@ SET citus.enable_local_execution = 'on';
 BEGIN;
 -- copy should be executed locally
 COPY reference_table FROM STDIN;
-NOTICE:  executing the copy locally for shard
+NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY reference_table, line 1: "1"
 ROLLBACK;
 SET citus.enable_local_execution = 'off';

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -276,6 +276,8 @@ RETURNING *;
 -- that's why it is disallowed to use local execution even if the SELECT
 -- can be executed locally
 INSERT INTO distributed_table SELECT * FROM distributed_table WHERE key = 1 OFFSET 0 ON CONFLICT DO NOTHING;
+NOTICE:  executing the command locally: SELECT key, value, age FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1) OFFSET 0
+NOTICE:  executing the command locally: INSERT INTO local_shard_execution.distributed_table_1470001 AS citus_table_alias (key, value, age) SELECT key, value, age FROM read_intermediate_result('insert_select_XXX_1470001'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text, age bigint) ON CONFLICT DO NOTHING
 INSERT INTO distributed_table SELECT 1, '1',15 FROM distributed_table WHERE key = 2 LIMIT 1 ON CONFLICT DO NOTHING;
 -- sanity check: multi-shard INSERT..SELECT pushdown goes through distributed execution
 INSERT INTO distributed_table SELECT * FROM distributed_table ON CONFLICT DO NOTHING;
@@ -507,28 +509,7 @@ NOTICE:  truncate cascades to table "second_distributed_table"
 ROLLBACK;
 -- load some data so that foreign keys won't complain with the next tests
 INSERT INTO reference_table SELECT i FROM generate_series(500, 600) i;
--- a very similar set of operation, but this time use
--- COPY as the first command
-BEGIN;
-	INSERT INTO distributed_table SELECT i, i::text, i % 10 + 25 FROM generate_series(500, 600) i;
-	-- this could go through local execution, but doesn't because we've already
-	-- done distributed execution
-	SELECT * FROM distributed_table WHERE key = 500 ORDER BY 1,2,3;
- key | value | age
----------------------------------------------------------------------
- 500 | 500   |  25
-(1 row)
-
-	-- utility commands could still use distributed execution
-	TRUNCATE distributed_table CASCADE;
-NOTICE:  truncate cascades to table "second_distributed_table"
-	-- ensure that TRUNCATE made it
-	SELECT * FROM distributed_table WHERE key = 500 ORDER BY 1,2,3;
- key | value | age
----------------------------------------------------------------------
-(0 rows)
-
-ROLLBACK;
+NOTICE:  executing the copy locally for shard xxxxx
 -- show that cascading foreign keys just works fine with local execution
 BEGIN;
 	INSERT INTO reference_table VALUES (701);
@@ -619,6 +600,7 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 (1 row)
 
 	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,1) i;
+NOTICE:  executing the copy locally for shard xxxxx
 ROLLBACK;
 -- a local query is followed by a command that cannot be executed locally
 BEGIN;
@@ -1331,7 +1313,10 @@ NOTICE:  truncate cascades to table "second_distributed_table_xxxxx"
 NOTICE:  executing the command locally: TRUNCATE TABLE local_shard_execution.second_distributed_table_xxxxx CASCADE
 NOTICE:  executing the command locally: TRUNCATE TABLE local_shard_execution.second_distributed_table_xxxxx CASCADE
 INSERT INTO reference_table SELECT i FROM generate_series(500, 600) i;
+NOTICE:  executing the copy locally for shard xxxxx
 INSERT INTO distributed_table SELECT i, i::text, i % 10 + 25 FROM generate_series(500, 600) i;
+NOTICE:  executing the copy locally for shard xxxxx
+NOTICE:  executing the copy locally for shard xxxxx
 -- show that both local, and mixed local-distributed executions
 -- calculate rows processed correctly
 BEGIN;

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -618,25 +618,7 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
      0
 (1 row)
 
-	-- even no need to supply any data
-	COPY distributed_table FROM STDIN WITH CSV;
-ERROR:  cannot execute command because a local execution has accessed a placement in the transaction
-DETAIL:  Some parallel commands cannot be executed if a previous command has already been executed locally
-HINT:  Try re-running the transaction with "SET LOCAL citus.enable_local_execution TO OFF;"
-ROLLBACK;
--- a local query is followed by a command that cannot be executed locally
-BEGIN;
-	SELECT count(*) FROM distributed_table WHERE key = 1;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE (key OPERATOR(pg_catalog.=) 1)
- count
----------------------------------------------------------------------
-     0
-(1 row)
-
-	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,10)i;
-ERROR:  cannot execute command because a local execution has accessed a placement in the transaction
-DETAIL:  Some parallel commands cannot be executed if a previous command has already been executed locally
-HINT:  Try re-running the transaction with "SET LOCAL citus.enable_local_execution TO OFF;"
+	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,1)i;
 ROLLBACK;
 -- a local query is followed by a command that cannot be executed locally
 BEGIN;

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -618,7 +618,7 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
      0
 (1 row)
 
-	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,1)i;
+	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,1) i;
 ROLLBACK;
 -- a local query is followed by a command that cannot be executed locally
 BEGIN;

--- a/src/test/regress/expected/locally_execute_intermediate_results.out
+++ b/src/test/regress/expected/locally_execute_intermediate_results.out
@@ -35,6 +35,7 @@ SELECT create_reference_table('ref_table');
 INSERT INTO table_1    VALUES (1, '1'), (2, '2'), (3, '3'), (4, '4');
 INSERT INTO table_2    VALUES                     (3, '3'), (4, '4'), (5, '5'), (6, '6');
 INSERT INTO ref_table  VALUES (1, '1'), (2, '2'), (3, '3'), (4, '4'), (5, '5'), (6, '6');
+NOTICE:  executing the command locally: INSERT INTO locally_execute_intermediate_results.ref_table_1580008 AS citus_table_alias (key, value) VALUES (1,'1'::text), (2,'2'::text), (3,'3'::text), (4,'4'::text), (5,'5'::text), (6,'6'::text)
 -- prevent PG 11 - PG 12 outputs to diverge
 -- and have a lot more CTEs recursively planned for the
 -- sake of increasing the test coverage
@@ -270,6 +271,7 @@ key
 FROM a JOIN ref_table USING (key)
 GROUP BY key
 HAVING (max(ref_table.value) <= (SELECT value FROM a));
+NOTICE:  executing the command locally: WITH a AS (SELECT max(ref_table_1.key) AS key, max(ref_table_1.value) AS value FROM locally_execute_intermediate_results.ref_table_1580008 ref_table_1) SELECT count(*) AS count, a.key FROM (a JOIN locally_execute_intermediate_results.ref_table_1580008 ref_table(key, value) USING (key)) GROUP BY a.key HAVING (max(ref_table.value) OPERATOR(pg_catalog.<=) (SELECT a_1.value FROM a a_1))
  count | key
 ---------------------------------------------------------------------
      1 |   6
@@ -328,7 +330,9 @@ DEBUG:  Subplan XXX_2 will be written to local file
 NOTICE:  executing the command locally: SELECT key, value FROM (SELECT intermediate_result.key, intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text)) cte_1
 DEBUG:  Subplan XXX_3 will be sent to localhost:xxxxx
 DEBUG:  Subplan XXX_3 will be sent to localhost:xxxxx
+DEBUG:  Subplan XXX_3 will be sent to localhost:xxxxx
 NOTICE:  executing the command locally: SELECT max(key) AS key FROM (SELECT intermediate_result.key, intermediate_result.value FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text)) cte_2
+NOTICE:  executing the command locally: SELECT cte_3.key, ref_table.value FROM ((SELECT intermediate_result.key FROM read_intermediate_result('XXX_3'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) cte_3 JOIN locally_execute_intermediate_results.ref_table_1580008 ref_table(key, value) USING (key))
  key | value
 ---------------------------------------------------------------------
    4 | 4
@@ -766,6 +770,7 @@ DEBUG:  generating subplan XXX_3 for CTE cte_3: SELECT max(key) AS key FROM (SEL
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT cte_3.key, ref_table.value FROM ((SELECT intermediate_result.key FROM read_intermediate_result('XXX_3'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) cte_3 JOIN locally_execute_intermediate_results.ref_table USING (key))
 DEBUG:  Subplan XXX_1 will be written to local file
 DEBUG:  Subplan XXX_2 will be written to local file
+DEBUG:  Subplan XXX_3 will be sent to localhost:xxxxx
 DEBUG:  Subplan XXX_3 will be sent to localhost:xxxxx
 DEBUG:  Subplan XXX_3 will be sent to localhost:xxxxx
  key | value

--- a/src/test/regress/expected/master_evaluation_modify.out
+++ b/src/test/regress/expected/master_evaluation_modify.out
@@ -951,6 +951,7 @@ NOTICE:  executing the command locally: DELETE FROM master_evaluation_combinatio
 (1 row)
 
 INSERT INTO user_info_data SELECT 3, ('test', get_local_node_id_stable() > 0)::user_data, i FROM generate_series(0,7)i;
+NOTICE:  executing the copy locally for shard xxxxx
 PREPARE fast_path_router_with_param_and_func_on_non_dist_key(int) AS
 	DELETE FROM user_info_data WHERE user_id = 3 AND user_index = $1 AND u_data = ('test', (get_local_node_id_stable() > 0)::int)::user_data RETURNING user_id, user_index;
 EXECUTE fast_path_router_with_param_and_func_on_non_dist_key(0);
@@ -1438,6 +1439,7 @@ NOTICE:  executing the command locally: DELETE FROM master_evaluation_combinatio
 (1 row)
 
 INSERT INTO user_info_data SELECT 3, ('test', get_local_node_id_stable() > 0)::user_data, i FROM generate_series(0,7)i;
+NOTICE:  executing the copy locally for shard xxxxx
 PREPARE router_with_param_and_func_on_non_dist_key(int) AS
 	DELETE FROM user_info_data WHERE user_id = 3 AND user_id = 3 AND user_index = $1 AND u_data = ('test', (get_local_node_id_stable() > 0)::int)::user_data RETURNING user_id, user_index;
 EXECUTE router_with_param_and_func_on_non_dist_key(0);

--- a/src/test/regress/expected/multi_mx_insert_select_repartition.out
+++ b/src/test/regress/expected/multi_mx_insert_select_repartition.out
@@ -102,9 +102,9 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM multi_mx_i
 (1 row)
 
     insert into target_table SELECT a FROM source_table LIMIT 10;
-ERROR:  cannot execute command because a local execution has accessed a placement in the transaction
-DETAIL:  Some parallel commands cannot be executed if a previous command has already been executed locally
-HINT:  Try re-running the transaction with "SET LOCAL citus.enable_local_execution TO OFF;"
+NOTICE:  executing the command locally: SELECT a FROM multi_mx_insert_select_repartition.source_table_4213581 source_table WHERE true LIMIT '10'::bigint
+NOTICE:  executing the command locally: SELECT a FROM multi_mx_insert_select_repartition.source_table_4213583 source_table WHERE true LIMIT '10'::bigint
+NOTICE:  executing the copy locally for shard xxxxx
 ROLLBACK;
 \c - - - :master_port
 SET search_path TO multi_mx_insert_select_repartition;

--- a/src/test/regress/expected/multi_mx_transaction_recovery.out
+++ b/src/test/regress/expected/multi_mx_transaction_recovery.out
@@ -142,7 +142,7 @@ INSERT INTO test_recovery (x) SELECT 'hello-'||s FROM generate_series(1,100) s;
 SELECT count(*) FROM pg_dist_transaction;
  count
 ---------------------------------------------------------------------
-     4
+     2
 (1 row)
 
 SELECT recover_prepared_transactions();

--- a/src/test/regress/expected/multi_mx_truncate_from_worker.out
+++ b/src/test/regress/expected/multi_mx_truncate_from_worker.out
@@ -118,6 +118,8 @@ INSERT INTO "refer'ence_table" SELECT i FROM generate_series(0, 100) i;
 SET search_path TO 'truncate_from_workers';
 -- make sure that DMLs-SELECTs works along with TRUNCATE worker fine
 BEGIN;
+	-- we can enable local execution when truncate can be executed locally.
+	SET citus.enable_local_execution = 'off';
 	INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 	SELECT count(*) FROM on_update_fkey_table;
  count

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -499,11 +499,13 @@ SELECT create_reference_table('replicate_reference_table_copy');
 
 (1 row)
 
+SET citus.enable_local_execution = 'off';
 BEGIN;
 COPY replicate_reference_table_copy FROM STDIN;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ERROR:  cannot open new connections after the first modification command within a transaction
 ROLLBACK;
+RESET citus.enable_local_execution;
 DROP TABLE replicate_reference_table_copy;
 -- test executing DDL command then adding a new node in a transaction
 CREATE TABLE replicate_reference_table_ddl(column1 int);

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -17,6 +17,7 @@ SELECT create_reference_table('squares');
 (1 row)
 
 INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
+NOTICE:  executing the copy locally for shard xxxxx
 -- should be executed locally
 SELECT count(*) FROM squares;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM replicate_ref_to_coordinator.squares_8000000 squares

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -39,7 +39,7 @@ test: multi_mx_metadata
 test: master_evaluation master_evaluation_modify master_evaluation_select
 test: multi_mx_call
 test: multi_mx_function_call_delegation
-test: multi_mx_modifications local_shard_execution
+test: multi_mx_modifications local_shard_execution local_shard_copy
 test: multi_mx_transaction_recovery
 test: multi_mx_modifying_xacts
 test: multi_mx_explain

--- a/src/test/regress/sql/local_shard_copy.sql
+++ b/src/test/regress/sql/local_shard_copy.sql
@@ -212,6 +212,14 @@ ROLLBACK;
 
 TRUNCATE distributed_table;
 
+BEGIN;
+
+-- insert a lot of data ( around 8MB),
+-- this should use local copy and it will exceed the LOCAL_COPY_FLUSH_THRESHOLD (512KB)
+INSERT INTO distributed_table SELECT * , * FROM generate_series(20, 1000000);
+
+ROLLBACK;
+
 COPY distributed_table FROM STDIN WITH delimiter ',';
 1, 9
 \.

--- a/src/test/regress/sql/local_shard_copy.sql
+++ b/src/test/regress/sql/local_shard_copy.sql
@@ -1,0 +1,298 @@
+CREATE SCHEMA local_shard_copy;
+SET search_path TO local_shard_copy;
+
+SET client_min_messages TO DEBUG;
+
+SELECT * FROM master_add_node('localhost', :master_port, groupid := 0);
+
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.replication_model TO 'streaming';
+
+
+CREATE TABLE reference_table (key int PRIMARY KEY);
+SELECT create_reference_table('reference_table');
+
+CREATE TABLE distributed_table (key int PRIMARY KEY, age bigint CHECK (age >= 10));
+SELECT create_distributed_table('distributed_table','key');
+
+INSERT INTO distributed_table SELECT *,* FROM generate_series(20, 40);
+INSERT INTO reference_table SELECT * FROM generate_series(1, 10);
+
+CREATE TABLE local_table (key int PRIMARY KEY);
+INSERT INTO local_table SELECT * from generate_series(1, 10);
+
+
+-- connection worker and get ready for the tests
+\c - - - :worker_1_port
+
+SET search_path TO local_shard_copy;
+SET citus.log_local_commands TO ON;
+
+-- returns true of the distribution key filter
+-- on the distributed tables (e.g., WHERE key = 1), we'll hit a shard
+-- placement which is local to this not
+CREATE OR REPLACE FUNCTION shard_of_distribution_column_is_local(dist_key int) RETURNS bool AS $$
+
+		DECLARE shard_is_local BOOLEAN := FALSE;
+
+		BEGIN
+
+		  	WITH  local_shard_ids 			  AS (SELECT get_shard_id_for_distribution_column('local_shard_copy.distributed_table', dist_key)),
+				  all_local_shard_ids_on_node AS (SELECT shardid FROM pg_dist_placement WHERE groupid IN (SELECT groupid FROM pg_dist_local_group))
+		SELECT
+			true INTO shard_is_local
+		FROM
+			local_shard_ids
+		WHERE
+			get_shard_id_for_distribution_column IN (SELECT * FROM all_local_shard_ids_on_node);
+
+		IF shard_is_local IS NULL THEN
+			shard_is_local = FALSE;
+		END IF;
+
+		RETURN shard_is_local;
+        END;
+$$ LANGUAGE plpgsql;
+
+-- pick some example values that reside on the shards locally and remote
+
+-- distribution key values of 1,6, 500 and 701 are LOCAL to shards,
+-- we'll use these values in the tests
+SELECT shard_of_distribution_column_is_local(1);
+SELECT shard_of_distribution_column_is_local(6);
+SELECT shard_of_distribution_column_is_local(500);
+SELECT shard_of_distribution_column_is_local(701);
+
+-- distribution key values of 11 and 12 are REMOTE to shards
+SELECT shard_of_distribution_column_is_local(11);
+SELECT shard_of_distribution_column_is_local(12);
+
+BEGIN;
+    -- run select with local execution
+    SELECT count(*) FROM distributed_table WHERE key = 1;
+
+    SELECT count(*) FROM distributed_table;
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+    -- verify that the copy is successful.
+    SELECT count(*) FROM distributed_table;
+
+ROLLBACK;
+
+BEGIN;
+    -- run select with local execution
+    SELECT count(*) FROM distributed_table WHERE key = 1;
+
+    SELECT count(*) FROM distributed_table;
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+    -- verify the put ages.
+    SELECT * FROM distributed_table;
+
+ROLLBACK;
+
+
+BEGIN;
+    -- run select with local execution
+    SELECT count(*) FROM distributed_table WHERE key = 1;
+
+    SELECT count(*) FROM distributed_table;
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+    -- verify that the copy is successful.
+    SELECT count(*) FROM distributed_table;
+
+ROLLBACK;
+
+BEGIN;
+    -- the local placements should be executed locally
+    COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+    -- run select with local execution
+    SELECT age FROM distributed_table WHERE key = 1;
+
+    SELECT count(*) FROM distributed_table;
+
+    -- verify that the copy is successful.
+    SELECT count(*) FROM distributed_table;
+
+ROLLBACK;
+
+BEGIN;
+-- Since we are in a transaction, the copy should be locally executed.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+ROLLBACK;
+
+-- Since we are not in a transaction, the copy should not be locally executed.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+
+BEGIN;
+-- Since we are in a transaction, the copy should be locally executed. But
+-- we are putting duplicate key, so it should error.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 100
+2, 200
+3, 300
+4, 400
+5, 500
+\.
+ROLLBACK;
+
+TRUNCATE distributed_table;
+
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1, 9
+\.
+
+BEGIN;
+-- Since we are in a transaction, the execution will be local, however we are putting invalid age.
+-- The constaints should give an error
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1,9
+\.
+ROLLBACK;
+
+TRUNCATE distributed_table;
+
+
+-- different delimiters
+BEGIN;
+-- initial size
+SELECT count(*) FROM distributed_table;
+COPY distributed_table FROM STDIN WITH delimiter '|';
+1|10
+2|30
+3|40
+\.
+-- new size
+SELECT count(*) FROM distributed_table;
+ROLLBACK;
+
+BEGIN;
+-- initial size
+SELECT count(*) FROM distributed_table;
+COPY distributed_table FROM STDIN WITH delimiter '[';
+1[10
+2[30
+3[40
+\.
+-- new size
+SELECT count(*) FROM distributed_table;
+ROLLBACK;
+
+
+-- multiple local copies
+BEGIN;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1,15
+2,20
+3,30
+\.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+10,15
+20,20
+30,30
+\.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+100,15
+200,20
+300,30
+\.
+ROLLBACK;
+
+-- local copy followed by local copy should see the changes
+-- and error since it is a duplicate primary key.
+BEGIN;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1,15
+\.
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1,16
+\.
+ROLLBACK;
+
+
+-- local copy followed by local copy should see the changes
+BEGIN;
+COPY distributed_table FROM STDIN WITH delimiter ',';
+1,15
+\.
+-- select should see the change
+SELECT key FROM distributed_table WHERE key = 1;
+ROLLBACK;
+
+\c - - - :master_port
+
+SET search_path TO local_shard_copy;
+SET citus.log_local_commands TO ON;
+
+TRUNCATE TABLE reference_table;
+TRUNCATE TABLE local_table;
+
+SELECT count(*) FROM reference_table, local_table WHERE reference_table.key = local_table.key;
+
+SET citus.enable_local_execution = 'on';
+
+BEGIN;
+-- copy should be executed locally
+COPY reference_table FROM STDIN;
+1
+2
+3
+4
+\.
+ROLLBACK;
+
+SET citus.enable_local_execution = 'off';
+
+BEGIN;
+-- copy should not be executed locally as citus.enable_local_execution = off
+COPY reference_table FROM STDIN;
+1
+2
+3
+4
+\.
+ROLLBACK;
+
+SET citus.enable_local_execution = 'on';
+
+SET client_min_messages TO ERROR;
+SET search_path TO public;
+DROP SCHEMA local_shard_copy CASCADE;

--- a/src/test/regress/sql/local_shard_copy.sql
+++ b/src/test/regress/sql/local_shard_copy.sql
@@ -2,6 +2,7 @@ CREATE SCHEMA local_shard_copy;
 SET search_path TO local_shard_copy;
 
 SET client_min_messages TO DEBUG;
+SET citus.next_shard_id TO 1570000;
 
 SELECT * FROM master_add_node('localhost', :master_port, groupid := 0);
 

--- a/src/test/regress/sql/local_shard_copy.sql
+++ b/src/test/regress/sql/local_shard_copy.sql
@@ -124,6 +124,10 @@ BEGIN;
 ROLLBACK;
 
 BEGIN;
+    -- run select with local execution
+    SELECT age FROM distributed_table WHERE key = 1;
+
+    SELECT count(*) FROM distributed_table;
     -- the local placements should be executed locally
     COPY distributed_table FROM STDIN WITH delimiter ',';
 1, 100
@@ -132,10 +136,7 @@ BEGIN;
 4, 400
 5, 500
 \.
-    -- run select with local execution
-    SELECT age FROM distributed_table WHERE key = 1;
 
-    SELECT count(*) FROM distributed_table;
 
     -- verify that the copy is successful.
     SELECT count(*) FROM distributed_table;
@@ -193,6 +194,8 @@ TRUNCATE distributed_table;
 
 -- different delimiters
 BEGIN;
+-- run select with local execution
+SELECT count(*) FROM distributed_table WHERE key = 1;
 -- initial size
 SELECT count(*) FROM distributed_table;
 COPY distributed_table FROM STDIN WITH delimiter '|';
@@ -205,6 +208,8 @@ SELECT count(*) FROM distributed_table;
 ROLLBACK;
 
 BEGIN;
+-- run select with local execution
+SELECT count(*) FROM distributed_table WHERE key = 1;
 -- initial size
 SELECT count(*) FROM distributed_table;
 COPY distributed_table FROM STDIN WITH delimiter '[';

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -356,15 +356,7 @@ ROLLBACK;
 BEGIN;
 	SELECT count(*) FROM distributed_table WHERE key = 1;
 
-	-- even no need to supply any data
-	COPY distributed_table FROM STDIN WITH CSV;
-ROLLBACK;
-
--- a local query is followed by a command that cannot be executed locally
-BEGIN;
-	SELECT count(*) FROM distributed_table WHERE key = 1;
-
-	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,10)i;
+	INSERT INTO distributed_table (key) SELECT i FROM generate_series(1,1) i;
 ROLLBACK;
 
 -- a local query is followed by a command that cannot be executed locally

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -305,22 +305,6 @@ ROLLBACK;
 -- load some data so that foreign keys won't complain with the next tests
 INSERT INTO reference_table SELECT i FROM generate_series(500, 600) i;
 
--- a very similar set of operation, but this time use
--- COPY as the first command
-BEGIN;
-	INSERT INTO distributed_table SELECT i, i::text, i % 10 + 25 FROM generate_series(500, 600) i;
-
-	-- this could go through local execution, but doesn't because we've already
-	-- done distributed execution
-	SELECT * FROM distributed_table WHERE key = 500 ORDER BY 1,2,3;
-
-	-- utility commands could still use distributed execution
-	TRUNCATE distributed_table CASCADE;
-
-	-- ensure that TRUNCATE made it
-	SELECT * FROM distributed_table WHERE key = 500 ORDER BY 1,2,3;
-ROLLBACK;
-
 -- show that cascading foreign keys just works fine with local execution
 BEGIN;
 	INSERT INTO reference_table VALUES (701);

--- a/src/test/regress/sql/multi_mx_truncate_from_worker.sql
+++ b/src/test/regress/sql/multi_mx_truncate_from_worker.sql
@@ -85,6 +85,8 @@ SET search_path TO 'truncate_from_workers';
 
 -- make sure that DMLs-SELECTs works along with TRUNCATE worker fine
 BEGIN;
+	-- we can enable local execution when truncate can be executed locally.
+	SET citus.enable_local_execution = 'off';
 	INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 	SELECT count(*) FROM on_update_fkey_table;
 	TRUNCATE on_update_fkey_table;

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -323,6 +323,7 @@ DROP TABLE replicate_reference_table_insert;
 CREATE TABLE replicate_reference_table_copy(column1 int);
 SELECT create_reference_table('replicate_reference_table_copy');
 
+SET citus.enable_local_execution = 'off';
 BEGIN;
 COPY replicate_reference_table_copy FROM STDIN;
 1
@@ -333,6 +334,8 @@ COPY replicate_reference_table_copy FROM STDIN;
 \.
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 ROLLBACK;
+
+RESET citus.enable_local_execution;
 
 DROP TABLE replicate_reference_table_copy;
 


### PR DESCRIPTION
DESCRIPTION: add local copy execution

This PR adds the support to execute copy locally. A copy will be executed locally if
- Local execution is enabled and current transaction accessed a local placement
- Local execution is enabled and we are inside a transaction block.

So even if local execution is enabled but we are not in a transaction block, the copy will not be run locally. 

This will not run locally:
```
COPY distributed_table FROM STDIN;
....
```

This will run locally:
```
SET citus.enable_local_execution to 'on';
BEGIN;
COPY distributed_table FROM STDIN;
COMMIT;
....
```
.
There are 3 ways to do a copy in postgres programmatically: 
- from a file
- from a program
- from a callback function

I have chosen to implement it with a callback function, which means that we write the rows of copy from a callback function to the output buffer, which is used to insert tuples into the actual table.

For each shard id, we have a buffer that keeps the current rows to be written, we perform the actual copy operation either when:
- copy buffer for the given shard id reaches to a threshold, which is currently 512KB
- we reach to the end of the copy

The buffer size is debatable(512KB). At a given time, we might allocate (local placement * buffer size) memory at most.

The local copy uses the same copy format as remote copy, which means that we serialize the data in the same format as remote copy and send it locally. 

There was also the option to use ExecSimpleRelationInsert to insert 
slots one by one, which would avoid the extra
serialization/deserialization but doing some benchmarks it seems that
using buffers are significantly better in terms of the performance.

You can see this comment for more details: https://github.com/citusdata/citus/pull/3557#discussion_r389499054
