### PR TITLE
Semmle: Actively check one possible NULL deref case

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -865,7 +865,11 @@ ErrorIfUnsupportedConstraint(Relation relation, char distributionMethod,
 		return;
 	}
 
-	Assert(distributionColumn != NULL);
+	if (distributionColumn == NULL)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("distribution column of distributed table is NULL")));
+	}
 
 	char *relationName = RelationGetRelationName(relation);
 	List *indexOidList = RelationGetIndexList(relation);


### PR DESCRIPTION
Calling `ErrorIfUnsupportedConstraint` was still giving errors on Semmle. This
makes sure that we check for NULL at runtime. This way we can safely ignore all
errors created by this function.