### PR TITLE
For composite types, add cast to the parameter to ease remote node detect the type

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_11.c
+++ b/src/backend/distributed/deparser/ruleutils_11.c
@@ -4419,9 +4419,20 @@ get_parameter(Param *param, deparse_context *context)
 	}
 
 	/*
-	 * Not PARAM_EXEC, or couldn't find referent: just print $N.
+	 * Not PARAM_EXEC, or couldn't find referent: for base types just print $N.
+	 * For composite types, add cast to the parameter to ease remote node detect
+	 * the type.
 	 */
-	appendStringInfo(context->buf, "$%d", param->paramid);
+	if (param->paramtype >= FirstNormalObjectId)
+	{
+		char *typeName = format_type_with_typemod(param->paramtype, param->paramtypmod);
+
+		appendStringInfo(context->buf, "$%d::%s", param->paramid, typeName);
+	}
+	else
+	{
+		appendStringInfo(context->buf, "$%d", param->paramid);
+	}
 }
 
 /*

--- a/src/backend/distributed/deparser/ruleutils_12.c
+++ b/src/backend/distributed/deparser/ruleutils_12.c
@@ -4433,9 +4433,20 @@ get_parameter(Param *param, deparse_context *context)
 	}
 
 	/*
-	 * Not PARAM_EXEC, or couldn't find referent: just print $N.
+	 * Not PARAM_EXEC, or couldn't find referent: for base types just print $N.
+	 * For composite types, add cast to the parameter to ease remote node detect
+	 * the type.
 	 */
-	appendStringInfo(context->buf, "$%d", param->paramid);
+	if (param->paramtype >= FirstNormalObjectId)
+	{
+		char *typeName = format_type_with_typemod(param->paramtype, param->paramtypmod);
+
+		appendStringInfo(context->buf, "$%d::%s", param->paramid, typeName);
+	}
+	else
+	{
+		appendStringInfo(context->buf, "$%d", param->paramid);
+	}
 }
 
 /*

--- a/src/test/regress/expected/multi_data_types.out
+++ b/src/test/regress/expected/multi_data_types.out
@@ -85,6 +85,50 @@ INSERT INTO composite_type_partitioned_table VALUES  (2, '(3, 4)'::test_composit
 INSERT INTO composite_type_partitioned_table VALUES  (3, '(5, 6)'::test_composite_type);
 INSERT INTO composite_type_partitioned_table VALUES  (4, '(7, 8)'::test_composite_type);
 INSERT INTO composite_type_partitioned_table VALUES  (5, '(9, 10)'::test_composite_type);
+PREPARE do_insert(int,test_composite_type) AS INSERT INTO composite_type_partitioned_table VALUES ($1,$2);
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+PREPARE get_id(test_composite_type) AS SELECT min(id) FROM composite_type_partitioned_table WHERE col = $1;
+EXECUTE get_id('(9,10)');
+ min
+---------------------------------------------------------------------
+   5
+(1 row)
+
+EXECUTE get_id('(9,10)');
+ min
+---------------------------------------------------------------------
+   5
+(1 row)
+
+EXECUTE get_id('(9,10)');
+ min
+---------------------------------------------------------------------
+   5
+(1 row)
+
+EXECUTE get_id('(9,10)');
+ min
+---------------------------------------------------------------------
+   5
+(1 row)
+
+EXECUTE get_id('(9,10)');
+ min
+---------------------------------------------------------------------
+   5
+(1 row)
+
+EXECUTE get_id('(9,10)');
+ min
+---------------------------------------------------------------------
+   5
+(1 row)
+
 SELECT * FROM composite_type_partitioned_table WHERE col =  '(7, 8)'::test_composite_type;
  id |  col
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -275,6 +275,109 @@ EXECUTE prepared_insert('comment-3', '(3, 30)');
 EXECUTE prepared_insert('comment-4', '(4, 40)');
 EXECUTE prepared_insert('comment-5', '(5, 50)');
 EXECUTE prepared_insert('comment-6', '(6, 60)');
+-- to make this work, Citus adds the type casting for composite keys
+-- during the deparsing
+PREPARE prepared_custom_type_select(test_composite_type) AS
+	SELECT count(*) FROM router_executor_table WHERE id = 1 AND stats = $1;
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+CREATE SCHEMA internal_test_schema;
+SET search_path TO internal_test_schema;
+-- to make this work, Citus adds the type casting for composite keys
+-- during the deparsing
+PREPARE prepared_custom_type_select_with_search_path(public.test_composite_type) AS
+	SELECT count(*) FROM public.router_executor_table WHERE id = 1 AND stats = $1;
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- also show that it works even if we explicitly cast the type
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)'::public.test_composite_type);
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+DROP SCHEMA internal_test_schema CASCADE;
+SET search_path TO public;
 SELECT * FROM router_executor_table ORDER BY comment;
  id |  comment  | stats
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/multi_data_types.sql
+++ b/src/test/regress/sql/multi_data_types.sql
@@ -80,6 +80,23 @@ INSERT INTO composite_type_partitioned_table VALUES  (3, '(5, 6)'::test_composit
 INSERT INTO composite_type_partitioned_table VALUES  (4, '(7, 8)'::test_composite_type);
 INSERT INTO composite_type_partitioned_table VALUES  (5, '(9, 10)'::test_composite_type);
 
+PREPARE do_insert(int,test_composite_type) AS INSERT INTO composite_type_partitioned_table VALUES ($1,$2);
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+EXECUTE do_insert(5, '(9,10)');
+
+PREPARE get_id(test_composite_type) AS SELECT min(id) FROM composite_type_partitioned_table WHERE col = $1;
+EXECUTE get_id('(9,10)');
+EXECUTE get_id('(9,10)');
+EXECUTE get_id('(9,10)');
+EXECUTE get_id('(9,10)');
+EXECUTE get_id('(9,10)');
+EXECUTE get_id('(9,10)');
+
+
 SELECT * FROM composite_type_partitioned_table WHERE col =  '(7, 8)'::test_composite_type;
 
 UPDATE composite_type_partitioned_table SET id = 6 WHERE col =  '(7, 8)'::test_composite_type;

--- a/src/test/regress/sql/multi_prepare_sql.sql
+++ b/src/test/regress/sql/multi_prepare_sql.sql
@@ -179,6 +179,41 @@ EXECUTE prepared_insert('comment-4', '(4, 40)');
 EXECUTE prepared_insert('comment-5', '(5, 50)');
 EXECUTE prepared_insert('comment-6', '(6, 60)');
 
+-- to make this work, Citus adds the type casting for composite keys
+-- during the deparsing
+PREPARE prepared_custom_type_select(test_composite_type) AS
+	SELECT count(*) FROM router_executor_table WHERE id = 1 AND stats = $1;
+
+EXECUTE prepared_custom_type_select('(1,1)');
+EXECUTE prepared_custom_type_select('(1,1)');
+EXECUTE prepared_custom_type_select('(1,1)');
+EXECUTE prepared_custom_type_select('(1,1)');
+EXECUTE prepared_custom_type_select('(1,1)');
+EXECUTE prepared_custom_type_select('(1,1)');
+EXECUTE prepared_custom_type_select('(1,1)');
+
+CREATE SCHEMA internal_test_schema;
+SET search_path TO internal_test_schema;
+
+-- to make this work, Citus adds the type casting for composite keys
+-- during the deparsing
+PREPARE prepared_custom_type_select_with_search_path(public.test_composite_type) AS
+	SELECT count(*) FROM public.router_executor_table WHERE id = 1 AND stats = $1;
+
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)');
+
+-- also show that it works even if we explicitly cast the type
+EXECUTE prepared_custom_type_select_with_search_path('(1,1)'::public.test_composite_type);
+
+DROP SCHEMA internal_test_schema CASCADE;
+SET search_path TO public;
+
 SELECT * FROM router_executor_table ORDER BY comment;
 
 -- test parameterized selects


### PR DESCRIPTION
Fixes #661  and required for #3553

We're adding bunch of tests in #3553 so not adding here seems OK. Opened PR separately for future reference.


Marked as backport as needed for #3553 
