### PR TITLE
Prototype: improve local execution by increasing parallelism

### DIFF
--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -251,6 +251,11 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 			XactModificationLevel = XACT_MODIFICATION_NONE;
 			TransactionAccessedLocalPlacement = false;
+			if (LocalExecutionStateHash != NULL)
+			{
+				hash_destroy(LocalExecutionStateHash);
+			}
+			LocalExecutionStateHash = NULL;
 			TransactionConnectedToLocalGroup = false;
 			dlist_init(&InProgressTransactions);
 			activeSetStmts = NULL;
@@ -307,6 +312,11 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			XactModificationLevel = XACT_MODIFICATION_NONE;
 			TransactionAccessedLocalPlacement = false;
 			TransactionConnectedToLocalGroup = false;
+			if (LocalExecutionStateHash != NULL)
+			{
+				hash_destroy(LocalExecutionStateHash);
+			}
+			LocalExecutionStateHash = NULL;
 			dlist_init(&InProgressTransactions);
 			activeSetStmts = NULL;
 			CoordinatedTransactionUses2PC = false;

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -20,8 +20,11 @@ extern bool LogLocalCommands;
 extern bool TransactionAccessedLocalPlacement;
 extern bool TransactionConnectedToLocalGroup;
 
+extern HTAB *LocalExecutionStateHash;
+
 /* extern function declarations */
-extern uint64 ExecuteLocalTaskList(CitusScanState *scanState, List *taskList);
+extern uint64 ExecuteLocalTaskList(CitusScanState *scanState, List *taskList,
+								   HTAB *localExecutionStateHash);
 extern void ExtractLocalAndRemoteTasks(bool readOnlyPlan, List *taskList,
 									   List **localTaskList, List **remoteTaskList);
 extern bool ShouldExecuteTasksLocally(List *taskList);
@@ -29,5 +32,5 @@ extern bool AnyTaskAccessesLocalNode(List *taskList);
 extern bool TaskAccessesLocalNode(Task *task);
 extern void ErrorIfTransactionAccessedPlacementsLocally(void);
 extern void DisableLocalExecution(void);
-
+extern HTAB * CreateLocalExecutionStateHash(void);
 #endif /* LOCAL_EXECUTION_H */


### PR DESCRIPTION
If we have a single task and the placement it accesses is in our local node, we choose to run it locally. Then for all the subsequent accesses of local placements, we force using the current session, which means that they will be executed sequentially, and we might lose a lot of parallelism. 

For example:

```
BEGIN;
-- this will be run locally
SELECT count(*) FROM reference_table;
-- this will be forced to run locally
SELECT count(*) FROM distributed_table;
-- all the following calls will be forced to run locally
COMMIT;
```

However we could have run `SELECT count(*) FROM distributed_table` in parallel, and if it had many local placements, we could benefit from parallelism a lot.

So, I thought that for a multiple statement transaction, we can keep track of which placements are accessed locally, and for the subsequent placement accesses, we can run local execution only for the placements that were previously run locally.

So in that case with this PR:

```
BEGIN;
-- this will be run locally
SELECT count(*) FROM reference_table;
-- this will not be run locally because it is not a single task and none of its placements was run locally
SELECT count(*) FROM distributed_table;
COMMIT;
```

```
BEGIN;
-- this will be run locally as it hits a local placement and a single task
INSERT INTO distributed_table values ( <a value that hits a local placement>);
--only one of the tasks that access the previously locally accessed placement will be run locally
SELECT count(*) FROM distributed_table;
COMMIT;
```

This PR is currently opened to get a feedback for the idea, does this approach make sense in general? 


