### PR TITLE
Disable Postgres parallelism by default in tests

### DIFF
--- a/src/test/regress/expected/multi_distributed_transaction_id.out
+++ b/src/test/regress/expected/multi_distributed_transaction_id.out
@@ -142,6 +142,7 @@ INSERT INTO parallel_id_test VALUES (1234567), (1234567), (1234568), (1234568);
 ANALYSE parallel_id_test;
 SET LOCAL max_parallel_workers_per_gather TO 2;
 SET LOCAL parallel_tuple_cost TO 0;
+SET LOCAL parallel_setup_cost TO 0;
 EXPLAIN (COSTS OFF)
 SELECT a FROM parallel_id_test WHERE a = parallel_worker_transaction_id_test();
                          QUERY PLAN

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -1106,21 +1106,11 @@ EXPLAIN (COSTS FALSE, FORMAT YAML)
             Dependent Jobs:
               - Map Task Count: 2
                 Merge Task Count: 1
--- test parallel aggregates
-SET parallel_setup_cost=0;
-SET parallel_tuple_cost=0;
-SET min_parallel_relation_size=0;
-ERROR:  unrecognized configuration parameter "min_parallel_relation_size"
-SET min_parallel_table_scan_size=0;
-SET max_parallel_workers_per_gather=4;
 -- ensure local plans display correctly
 CREATE TABLE lineitem_clone (LIKE lineitem);
 EXPLAIN (COSTS FALSE) SELECT avg(l_linenumber) FROM lineitem_clone;
-Finalize Aggregate
-  ->  Gather
-        Workers Planned: 3
-        ->  Partial Aggregate
-              ->  Parallel Seq Scan on lineitem_clone
+Aggregate
+  ->  Seq Scan on lineitem_clone
 -- ensure distributed plans don't break
 EXPLAIN (COSTS FALSE) SELECT avg(l_linenumber) FROM lineitem;
 Aggregate

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1605,13 +1605,6 @@ SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id,
 (16 rows)
 
 -- set partition-wise join on and parallel to off
-SELECT success FROM run_command_on_workers('alter system set max_parallel_workers_per_gather = 0');
- success
----------------------------------------------------------------------
- t
- t
-(2 rows)
-
 SELECT success FROM run_command_on_workers('alter system set enable_partitionwise_join to on');
  success
 ---------------------------------------------------------------------
@@ -1710,13 +1703,6 @@ SELECT success FROM run_command_on_workers('alter system reset enable_indexscan'
 (2 rows)
 
 SELECT success FROM run_command_on_workers('alter system reset enable_indexonlyscan');
- success
----------------------------------------------------------------------
- t
- t
-(2 rows)
-
-SELECT success FROM run_command_on_workers('alter system reset max_parallel_workers_per_gather');
  success
 ---------------------------------------------------------------------
  t

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -412,7 +412,7 @@ SELECT * FROM partitioning_test WHERE id = 9 OR id = 10 ORDER BY 1;
 -- create default partition
 CREATE TABLE partitioning_test_default PARTITION OF partitioning_test DEFAULT;
 \d+ partitioning_test
-                       Table "public.partitioning_test"
+                             Table "public.partitioning_test"
  Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description
 ---------------------------------------------------------------------
  id     | integer |           |          |         | plain   |              |
@@ -1584,27 +1584,25 @@ SELECT success FROM run_command_on_workers('select pg_reload_conf()');
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id, subid);
-                                                                                QUERY PLAN
+                                                                           QUERY PLAN
 ---------------------------------------------------------------------
  Custom Scan (Citus Adaptive)
    Task Count: 4
    Tasks Shown: One of 4
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
-         ->  Gather
-               Workers Planned: 2
-               ->  Parallel Hash Join
-                     Hash Cond: ((partitioning_hash_join_test.id = partitioning_hash_test_1.id) AND (partitioning_hash_join_test.subid = partitioning_hash_test_1.subid))
-                     ->  Parallel Append
-                           ->  Parallel Seq Scan on partitioning_hash_join_test_0_1660133 partitioning_hash_join_test
-                           ->  Parallel Seq Scan on partitioning_hash_join_test_1_1660137 partitioning_hash_join_test_1
-                           ->  Parallel Seq Scan on partitioning_hash_join_test_2_1660141 partitioning_hash_join_test_2
-                     ->  Parallel Hash
-                           ->  Parallel Append
-                                 ->  Parallel Seq Scan on partitioning_hash_test_1_1660020 partitioning_hash_test_1
-                                 ->  Parallel Seq Scan on partitioning_hash_test_0_1660016 partitioning_hash_test
-                                 ->  Parallel Seq Scan on partitioning_hash_test_2_1660032 partitioning_hash_test_2
-(18 rows)
+         ->  Hash Join
+               Hash Cond: ((partitioning_hash_join_test.id = partitioning_hash_test.id) AND (partitioning_hash_join_test.subid = partitioning_hash_test.subid))
+               ->  Append
+                     ->  Seq Scan on partitioning_hash_join_test_0_1660133 partitioning_hash_join_test
+                     ->  Seq Scan on partitioning_hash_join_test_1_1660137 partitioning_hash_join_test_1
+                     ->  Seq Scan on partitioning_hash_join_test_2_1660141 partitioning_hash_join_test_2
+               ->  Hash
+                     ->  Append
+                           ->  Seq Scan on partitioning_hash_test_0_1660016 partitioning_hash_test
+                           ->  Seq Scan on partitioning_hash_test_1_1660020 partitioning_hash_test_1
+                           ->  Seq Scan on partitioning_hash_test_2_1660032 partitioning_hash_test_2
+(16 rows)
 
 -- set partition-wise join on and parallel to off
 SELECT success FROM run_command_on_workers('alter system set max_parallel_workers_per_gather = 0');

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -320,6 +320,10 @@ if (-e $hll_control)
 }
 push(@pgOptions, '-c', "shared_preload_libraries=${sharedPreloadLibraries}");
 
+# Avoid parallelism to stabilize explain plans
+push(@pgOptions, '-c', "max_parallel_workers_per_gather=0");
+
+# Allow CREATE SUBSCRIPTION to work
 push(@pgOptions, '-c', "wal_level=logical");
 
 # Citus options set for the tests

--- a/src/test/regress/sql/multi_distributed_transaction_id.sql
+++ b/src/test/regress/sql/multi_distributed_transaction_id.sql
@@ -98,6 +98,7 @@ ANALYSE parallel_id_test;
 
 SET LOCAL max_parallel_workers_per_gather TO 2;
 SET LOCAL parallel_tuple_cost TO 0;
+SET LOCAL parallel_setup_cost TO 0;
 
 EXPLAIN (COSTS OFF)
 SELECT a FROM parallel_id_test WHERE a = parallel_worker_transaction_id_test();

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -485,13 +485,6 @@ EXPLAIN (COSTS FALSE, FORMAT YAML)
 	AND o_custkey = c_custkey
 	AND l_suppkey = s_suppkey;
 
--- test parallel aggregates
-SET parallel_setup_cost=0;
-SET parallel_tuple_cost=0;
-SET min_parallel_relation_size=0;
-SET min_parallel_table_scan_size=0;
-SET max_parallel_workers_per_gather=4;
-
 -- ensure local plans display correctly
 CREATE TABLE lineitem_clone (LIKE lineitem);
 EXPLAIN (COSTS FALSE) SELECT avg(l_linenumber) FROM lineitem_clone;

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -987,7 +987,6 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM partitioning_hash_test JOIN partitioning_hash_join_test USING (id, subid);
 
 -- set partition-wise join on and parallel to off
-SELECT success FROM run_command_on_workers('alter system set max_parallel_workers_per_gather = 0');
 SELECT success FROM run_command_on_workers('alter system set enable_partitionwise_join to on');
 SELECT success FROM run_command_on_workers('select pg_reload_conf()');
 
@@ -1009,7 +1008,6 @@ SELECT success FROM run_command_on_workers('alter system reset enable_mergejoin'
 SELECT success FROM run_command_on_workers('alter system reset enable_nestloop');
 SELECT success FROM run_command_on_workers('alter system reset enable_indexscan');
 SELECT success FROM run_command_on_workers('alter system reset enable_indexonlyscan');
-SELECT success FROM run_command_on_workers('alter system reset max_parallel_workers_per_gather');
 SELECT success FROM run_command_on_workers('select pg_reload_conf()');
 
 RESET enable_partitionwise_join;


### PR DESCRIPTION
Avoid flappy test resulting from parallel operations in explain output.