### PR TITLE
Simplify INSERT logic in router planner

### DIFF
--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -2362,6 +2362,7 @@ DETAIL:  distribution column value: 1
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 -- verify insert is successfull (not router plannable and executable)
 SELECT id
 	FROM articles_hash

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -2139,6 +2139,7 @@ DETAIL:  distribution column value: 1
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 DEBUG:  Creating router plan
 DEBUG:  Plan is router executable
+DETAIL:  distribution column value: 1
 -- verify insert is successfull (not router plannable and executable)
 SELECT id
 	FROM articles_hash


### PR DESCRIPTION
Some further refactoring to simplify the implementation of INSERTs. 

The basic idea is to always defer shard pruning, which gets rid of a bunch of logic in the router planner. We only call RouterInsertTaskList from the executor now.

In theory, this could hurt prepared statement performance, but only in cases where the distribution column is a constant. It seems unlikely that any application is able to meaningfully benefit from prepared statements if it needs to re-define one for every distribution column value.