### PR TITLE
Try to create clear distinction between DistributedTable vs CitusTable

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -97,7 +97,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		return false;
 	}
 
-	DistTableCacheEntry *distTable = DistributedTableCacheEntry(colocatedRelationId);
+	DistTableCacheEntry *distTable = CitusTableCacheEntry(colocatedRelationId);
 	Var *partitionColumn = distTable->partitionColumn;
 	if (partitionColumn == NULL)
 	{

--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -36,7 +36,7 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand)
 
 		if (OidIsValid(relationId))
 		{
-			showPropagationWarning = IsDistributedTable(relationId);
+			showPropagationWarning = IsCitusTable(relationId);
 		}
 	}
 

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -723,7 +723,7 @@ EnsureRelationCanBeDistributed(Oid relationId, Var *distributionColumn,
 	}
 
 	/* partitions cannot be distributed if their parent is not distributed */
-	if (PartitionTable(relationId) && !IsDistributedTable(parentRelationId))
+	if (PartitionTable(relationId) && !IsCitusTable(parentRelationId))
 	{
 		char *parentRelationName = get_rel_name(parentRelationId);
 
@@ -793,7 +793,7 @@ static void
 EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 							  Oid distributionColumnType, Oid sourceRelationId)
 {
-	DistTableCacheEntry *sourceTableEntry = DistributedTableCacheEntry(sourceRelationId);
+	DistTableCacheEntry *sourceTableEntry = CitusTableCacheEntry(sourceRelationId);
 	char sourceDistributionMethod = sourceTableEntry->partitionMethod;
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 	Var *sourceDistributionColumn = ForceDistPartitionKey(sourceRelationId);
@@ -890,9 +890,9 @@ EnsureTableNotDistributed(Oid relationId)
 {
 	char *relationName = get_rel_name(relationId);
 
-	bool isDistributedTable = IsDistributedTable(relationId);
+	bool isCitusTable = IsCitusTable(relationId);
 
-	if (isDistributedTable)
+	if (isCitusTable)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 						errmsg("table \"%s\" is already distributed",
@@ -1030,7 +1030,7 @@ LocalTableEmpty(Oid tableId)
 	int rowId = 0;
 	int attributeId = 1;
 
-	AssertArg(!IsDistributedTable(tableId));
+	AssertArg(!IsCitusTable(tableId));
 
 	int spiConnectionResult = SPI_connect();
 	if (spiConnectionResult != SPI_OK_CONNECT)

--- a/src/backend/distributed/commands/drop_distributed_table.c
+++ b/src/backend/distributed/commands/drop_distributed_table.c
@@ -72,7 +72,7 @@ master_remove_partition_metadata(PG_FUNCTION_ARGS)
 	 * user-friendly, but this function is really only meant to be called
 	 * from the trigger.
 	 */
-	if (!IsDistributedTable(relationId) || !EnableDDLPropagation)
+	if (!IsCitusTable(relationId) || !EnableDDLPropagation)
 	{
 		PG_RETURN_VOID();
 	}
@@ -132,7 +132,7 @@ MasterRemoveDistributedTableMetadataFromWorkers(Oid relationId, char *schemaName
 	 * user-friendly, but this function is really only meant to be called
 	 * from the trigger.
 	 */
-	if (!IsDistributedTable(relationId) || !EnableDDLPropagation)
+	if (!IsCitusTable(relationId) || !EnableDDLPropagation)
 	{
 		return;
 	}

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -76,7 +76,7 @@ ConstraintIsAForeignKeyToReferenceTable(char *constraintName, Oid relationId)
 
 		Oid referencedTableId = constraintForm->confrelid;
 
-		Assert(IsDistributedTable(referencedTableId));
+		Assert(IsCitusTable(referencedTableId));
 
 		if (PartitionMethod(referencedTableId) == DISTRIBUTE_BY_NONE)
 		{
@@ -125,9 +125,9 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 
 	Oid referencingTableId = relation->rd_id;
 	bool referencingNotReplicated = true;
-	bool referencingIsDistributed = IsDistributedTable(referencingTableId);
+	bool referencingIsCitus = IsCitusTable(referencingTableId);
 
-	if (referencingIsDistributed)
+	if (referencingIsCitus)
 	{
 		/* ALTER TABLE command is applied over single replicated table */
 		referencingNotReplicated = SingleReplicatedTable(referencingTableId);
@@ -166,11 +166,11 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 		}
 
 		Oid referencedTableId = constraintForm->confrelid;
-		bool referencedIsDistributed = IsDistributedTable(referencedTableId);
+		bool referencedIsCitus = IsCitusTable(referencedTableId);
 
 		bool selfReferencingTable = (referencingTableId == referencedTableId);
 
-		if (!referencedIsDistributed && !selfReferencingTable)
+		if (!referencedIsCitus && !selfReferencingTable)
 		{
 			ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 							errmsg("cannot create foreign key constraint"),
@@ -447,7 +447,7 @@ ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid relationId)
 		 * We check if the referenced table is a reference table. There cannot be
 		 * any foreign constraint from a distributed table to a local table.
 		 */
-		Assert(IsDistributedTable(referencedTableId));
+		Assert(IsCitusTable(referencedTableId));
 		if (PartitionMethod(referencedTableId) != DISTRIBUTE_BY_NONE)
 		{
 			heapTuple = systable_getnext(scanDescriptor);
@@ -567,7 +567,7 @@ HasForeignKeyToReferenceTable(Oid relationId)
 
 		Oid referencedTableId = constraintForm->confrelid;
 
-		if (!IsDistributedTable(referencedTableId))
+		if (!IsCitusTable(referencedTableId))
 		{
 			heapTuple = systable_getnext(scanDescriptor);
 			continue;

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -410,7 +410,7 @@ static void
 EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnType,
 									  Oid sourceRelationId)
 {
-	DistTableCacheEntry *sourceTableEntry = DistributedTableCacheEntry(sourceRelationId);
+	DistTableCacheEntry *sourceTableEntry = CitusTableCacheEntry(sourceRelationId);
 	char sourceDistributionMethod = sourceTableEntry->partitionMethod;
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -140,7 +140,7 @@ PreprocessIndexStmt(Node *node, const char *createIndexCommand)
 		Relation relation = heap_openrv(createIndexStatement->relation, lockmode);
 		Oid relationId = RelationGetRelid(relation);
 
-		bool isDistributedRelation = IsDistributedTable(relationId);
+		bool isDistributedRelation = IsCitusTable(relationId);
 
 		if (createIndexStatement->relation->schemaname == NULL)
 		{
@@ -249,7 +249,7 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand)
 			relationId = RelationGetRelid(relation);
 		}
 
-		isDistributedRelation = IsDistributedTable(relationId);
+		isDistributedRelation = IsCitusTable(relationId);
 
 		if (reindexStatement->relation->schemaname == NULL)
 		{
@@ -359,7 +359,7 @@ PreprocessDropIndexStmt(Node *node, const char *dropIndexCommand)
 		}
 
 		Oid relationId = IndexGetRelation(indexId, false);
-		bool isDistributedRelation = IsDistributedTable(relationId);
+		bool isDistributedRelation = IsCitusTable(relationId);
 		if (isDistributedRelation)
 		{
 			distributedIndexId = indexId;

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2018,7 +2018,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 
 	/* look up table properties */
 	Relation distributedRelation = heap_open(tableId, RowExclusiveLock);
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(tableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(tableId);
 	partitionMethod = cacheEntry->partitionMethod;
 
 	copyDest->distributedRelation = distributedRelation;
@@ -2587,7 +2587,7 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 											  isFrom ? RowExclusiveLock :
 											  AccessShareLock);
 
-		bool isDistributedRelation = IsDistributedTable(RelationGetRelid(copiedRelation));
+		bool isDistributedRelation = IsCitusTable(RelationGetRelid(copiedRelation));
 
 		/* ensure future lookups hit the same relation */
 		char *schemaName = get_namespace_name(RelationGetNamespace(copiedRelation));

--- a/src/backend/distributed/commands/policy.c
+++ b/src/backend/distributed/commands/policy.c
@@ -34,7 +34,7 @@ PreprocessCreatePolicyStmt(Node *node, const char *queryString)
 	Oid relationId = RangeVarGetRelid(stmt->table,
 									  AccessExclusiveLock,
 									  false);
-	if (IsDistributedTable(relationId))
+	if (IsCitusTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("policies on distributed tables are only supported in "

--- a/src/backend/distributed/commands/rename.c
+++ b/src/backend/distributed/commands/rename.c
@@ -96,7 +96,7 @@ PreprocessRenameStmt(Node *node, const char *renameCommand)
 			return NIL;
 	}
 
-	bool isDistributedRelation = IsDistributedTable(tableRelationId);
+	bool isDistributedRelation = IsCitusTable(tableRelationId);
 	if (!isDistributedRelation)
 	{
 		return NIL;

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -84,7 +84,7 @@ PreprocessDropSchemaStmt(Node *node, const char *queryString)
 			Oid relationId = get_relname_relid(relationName, namespaceOid);
 
 			/* we're not interested in non-valid, non-distributed relations */
-			if (relationId == InvalidOid || !IsDistributedTable(relationId))
+			if (relationId == InvalidOid || !IsCitusTable(relationId))
 			{
 				heapTuple = systable_getnext(scanDescriptor);
 				continue;

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -35,7 +35,7 @@ ErrorIfUnsupportedSeqStmt(CreateSeqStmt *createSeqStmt)
 	/* create is easy: just prohibit any distributed OWNED BY */
 	if (OptionsSpecifyOwnedBy(createSeqStmt->options, &ownedByTableId))
 	{
-		if (IsDistributedTable(ownedByTableId))
+		if (IsCitusTable(ownedByTableId))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot create sequences that specify a distributed "
@@ -79,7 +79,7 @@ ErrorIfDistributedAlterSeqOwnedBy(AlterSeqStmt *alterSeqStmt)
 	/* see whether the sequence is already owned by a distributed table */
 	if (sequenceOwned)
 	{
-		hasDistributedOwner = IsDistributedTable(ownedByTableId);
+		hasDistributedOwner = IsCitusTable(ownedByTableId);
 	}
 
 	if (OptionsSpecifyOwnedBy(alterSeqStmt->options, &newOwnedByTableId))
@@ -91,7 +91,7 @@ ErrorIfDistributedAlterSeqOwnedBy(AlterSeqStmt *alterSeqStmt)
 							errmsg("cannot alter OWNED BY option of a sequence "
 								   "already owned by a distributed table")));
 		}
-		else if (!hasDistributedOwner && IsDistributedTable(newOwnedByTableId))
+		else if (!hasDistributedOwner && IsCitusTable(newOwnedByTableId))
 		{
 			/* and don't let local sequences get a distributed OWNED BY */
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -69,7 +69,7 @@ ErrorIfUnsupportedTruncateStmt(TruncateStmt *truncateStatement)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
 		char relationKind = get_rel_relkind(relationId);
-		if (IsDistributedTable(relationId) &&
+		if (IsCitusTable(relationId) &&
 			relationKind == RELKIND_FOREIGN_TABLE)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -94,7 +94,7 @@ EnsurePartitionTableNotReplicatedForTruncate(TruncateStmt *truncateStatement)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
 
-		if (!IsDistributedTable(relationId))
+		if (!IsCitusTable(relationId))
 		{
 			continue;
 		}
@@ -122,7 +122,7 @@ ExecuteTruncateStmtSequentialIfNecessary(TruncateStmt *command)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
 
-		if (IsDistributedTable(relationId) &&
+		if (IsCitusTable(relationId) &&
 			PartitionMethod(relationId) == DISTRIBUTE_BY_NONE &&
 			TableReferenced(relationId))
 		{
@@ -177,7 +177,7 @@ LockTruncatedRelationMetadataInWorkers(TruncateStmt *truncateStatement)
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
 		Oid referencingRelationId = InvalidOid;
 
-		if (!IsDistributedTable(relationId))
+		if (!IsCitusTable(relationId))
 		{
 			continue;
 		}
@@ -189,7 +189,7 @@ LockTruncatedRelationMetadataInWorkers(TruncateStmt *truncateStatement)
 
 		distributedRelationList = lappend_oid(distributedRelationList, relationId);
 
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 		Assert(cacheEntry != NULL);
 
 		List *referencingTableList = cacheEntry->referencingRelationsViaForeignKey;

--- a/src/backend/distributed/commands/vacuum.c
+++ b/src/backend/distributed/commands/vacuum.c
@@ -89,7 +89,7 @@ PostprocessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand)
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, relationIdList)
 	{
-		if (IsDistributedTable(relationId))
+		if (IsCitusTable(relationId))
 		{
 			/*
 			 * VACUUM commands cannot run inside a transaction block, so we use
@@ -148,7 +148,7 @@ IsDistributedVacuumStmt(int vacuumOptions, List *vacuumRelationIdList)
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, vacuumRelationIdList)
 	{
-		if (OidIsValid(relationId) && IsDistributedTable(relationId))
+		if (OidIsValid(relationId) && IsCitusTable(relationId))
 		{
 			distributedRelationCount++;
 		}

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -220,7 +220,7 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 			char *distResultPrefix = distResultPrefixString->data;
 
 			DistTableCacheEntry *targetRelation =
-				DistributedTableCacheEntry(targetRelationId);
+				CitusTableCacheEntry(targetRelationId);
 
 			int partitionColumnIndex =
 				PartitionColumnIndex(insertTargetList, targetRelation->partitionColumn);
@@ -484,7 +484,7 @@ TwoPhaseInsertSelectTaskList(Oid targetRelationId, Query *insertSelectQuery,
 	RangeTblEntry *insertRte = ExtractResultRelationRTE(insertResultQuery);
 	RangeTblEntry *selectRte = ExtractSelectRangeTableEntry(insertResultQuery);
 
-	DistTableCacheEntry *targetCacheEntry = DistributedTableCacheEntry(targetRelationId);
+	DistTableCacheEntry *targetCacheEntry = CitusTableCacheEntry(targetRelationId);
 	int shardCount = targetCacheEntry->shardIntervalArrayLength;
 	uint32 taskIdIndex = 1;
 	uint64 jobId = INVALID_JOB_ID;
@@ -895,7 +895,7 @@ CastExpr(Expr *expr, Oid sourceType, Oid targetType, Oid targetCollation,
 bool
 IsSupportedRedistributionTarget(Oid targetRelationId)
 {
-	DistTableCacheEntry *tableEntry = DistributedTableCacheEntry(targetRelationId);
+	DistTableCacheEntry *tableEntry = CitusTableCacheEntry(targetRelationId);
 
 	/* only range and hash-distributed tables are currently supported */
 	if (tableEntry->partitionMethod != DISTRIBUTE_BY_HASH &&

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -106,7 +106,7 @@ void
 CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 								 int32 replicationFactor, bool useExclusiveConnections)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 	bool colocatedShard = false;
 	List *insertedShardPlacements = NIL;
 

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -222,7 +222,7 @@ master_drop_all_shards(PG_FUNCTION_ARGS)
 	 * The SQL_DROP trigger calls this function even for tables that are
 	 * not distributed. In that case, silently ignore and return -1.
 	 */
-	if (!IsDistributedTable(relationId) || !EnableDDLPropagation)
+	if (!IsCitusTable(relationId) || !EnableDDLPropagation)
 	{
 		PG_RETURN_INT32(-1);
 	}

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -246,7 +246,7 @@ DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId, char *sizeQ
 List *
 GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId)
 {
-	DistTableCacheEntry *distTableCacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *distTableCacheEntry = CitusTableCacheEntry(relationId);
 	List *resultList = NIL;
 
 	int shardIntervalArrayLength = distTableCacheEntry->shardIntervalArrayLength;
@@ -284,7 +284,7 @@ GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId)
 static List *
 ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId)
 {
-	DistTableCacheEntry *distTableCacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *distTableCacheEntry = CitusTableCacheEntry(relationId);
 	List *shardIntervalList = NIL;
 	int shardIntervalArrayLength = distTableCacheEntry->shardIntervalArrayLength;
 
@@ -372,7 +372,7 @@ GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList, char *sizeQuery)
 static void
 ErrorIfNotSuitableToGetSize(Oid relationId)
 {
-	if (!IsDistributedTable(relationId))
+	if (!IsCitusTable(relationId))
 	{
 		char *relationName = get_rel_name(relationId);
 		char *escapedQueryString = quote_literal_cstr(relationName);
@@ -486,7 +486,7 @@ TableShardReplicationFactor(Oid relationId)
 List *
 LoadShardIntervalList(Oid relationId)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	List *shardList = NIL;
 
 	for (int i = 0; i < cacheEntry->shardIntervalArrayLength; i++)
@@ -511,10 +511,10 @@ LoadShardIntervalList(Oid relationId)
 int
 ShardIntervalCount(Oid relationId)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	int shardIntervalCount = 0;
 
-	if (cacheEntry->isDistributedTable)
+	if (cacheEntry->isCitusTable)
 	{
 		shardIntervalCount = cacheEntry->shardIntervalArrayLength;
 	}
@@ -533,7 +533,7 @@ ShardIntervalCount(Oid relationId)
 List *
 LoadShardList(Oid relationId)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	List *shardList = NIL;
 
 	for (int i = 0; i < cacheEntry->shardIntervalArrayLength; i++)

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -103,7 +103,7 @@ master_get_table_metadata(PG_FUNCTION_ARGS)
 	CheckCitusVersion(ERROR);
 
 	/* find partition tuple for partitioned relation */
-	DistTableCacheEntry *partitionEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *partitionEntry = CitusTableCacheEntry(relationId);
 
 	/* create tuple descriptor for return value */
 	TypeFuncClass resultTypeClass = get_call_result_type(fcinfo, NULL,

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -356,7 +356,7 @@ CheckDistributedTable(Oid relationId)
 	/* check that the relationId belongs to a table */
 	EnsureRelationKindSupported(relationId);
 
-	if (!IsDistributedTable(relationId))
+	if (!IsCitusTable(relationId))
 	{
 		ereport(ERROR, (errmsg("relation \"%s\" is not a distributed table",
 							   relationName)));
@@ -558,7 +558,7 @@ static List *
 RelationShardListForShardCreate(ShardInterval *shardInterval)
 {
 	Oid relationId = shardInterval->relationId;
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	List *referencedRelationList = cacheEntry->referencedRelationsViaForeignKey;
 	List *referencingRelationList = cacheEntry->referencingRelationsViaForeignKey;
 	int shardIndex = -1;
@@ -587,7 +587,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 	{
 		uint64 fkeyShardId = INVALID_SHARD_ID;
 
-		if (!IsDistributedTable(fkeyRelationid))
+		if (!IsCitusTable(fkeyRelationid))
 		{
 			/* we're not interested in local tables */
 			continue;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -222,7 +222,7 @@ ClusterHasKnownMetadataWorkers()
 bool
 ShouldSyncTableMetadata(Oid relationId)
 {
-	DistTableCacheEntry *tableEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *tableEntry = CitusTableCacheEntry(relationId);
 
 	bool hashDistributed = (tableEntry->partitionMethod == DISTRIBUTE_BY_HASH);
 	bool streamingReplicated =
@@ -356,7 +356,7 @@ List *
 MetadataCreateCommands(void)
 {
 	List *metadataSnapshotCommandList = NIL;
-	List *distributedTableList = DistributedTableList();
+	List *distributedTableList = CitusTableList();
 	List *propagatedTableList = NIL;
 	bool includeNodesFromOtherClusters = true;
 	List *workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
@@ -391,10 +391,9 @@ MetadataCreateCommands(void)
 		char *tableOwnerResetCommand = TableOwnerResetCommand(relationId);
 
 		/*
-		 * Distributed tables might have dependencies on different objects, since we
-		 * create shards for a distributed table via multiple sessions these objects will
-		 * be created via their own connection and committed immediately so they become
-		 * visible to all sessions creating shards.
+		 * Tables might have dependencies on different objects, since we create shards for
+		 * table via multiple sessions these objects will be created via their own connection
+		 * and committed immediately so they become visible to all sessions creating shards.
 		 */
 		ObjectAddressSet(tableAddress, RelationRelationId, relationId);
 		EnsureDependenciesExistOnAllNodes(&tableAddress);
@@ -467,7 +466,7 @@ MetadataCreateCommands(void)
 List *
 GetDistributedTableDDLEvents(Oid relationId)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 
 	List *commandList = NIL;
 	bool includeSequenceDefaults = true;
@@ -1306,7 +1305,7 @@ static List *
 DetachPartitionCommandList(void)
 {
 	List *detachPartitionCommandList = NIL;
-	List *distributedTableList = DistributedTableList();
+	List *distributedTableList = CitusTableList();
 
 	/* we iterate over all distributed partitioned tables and DETACH their partitions */
 	DistTableCacheEntry *cacheEntry = NULL;

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -793,7 +793,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 	Oid relationId = PG_GETARG_OID(0);
 	EnsureTablePermissions(relationId, ACL_SELECT);
 
-	if (!IsDistributedTable(relationId))
+	if (!IsCitusTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 						errmsg("relation is not distributed")));
@@ -813,7 +813,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 	else if (distributionMethod == DISTRIBUTE_BY_HASH ||
 			 distributionMethod == DISTRIBUTE_BY_RANGE)
 	{
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 
 		/* if given table is not reference table, distributionValue cannot be NULL */
 		if (PG_ARGISNULL(1))

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -364,7 +364,7 @@ ListContainsDistributedTableRTE(List *rangeTableList)
 			continue;
 		}
 
-		if (IsDistributedTable(rangeTableEntry->relid))
+		if (IsCitusTable(rangeTableEntry->relid))
 		{
 			return true;
 		}
@@ -442,7 +442,7 @@ AdjustPartitioningForDistributedPlanning(List *rangeTableList,
 		 * value before and after dropping to the standart_planner.
 		 */
 		if (rangeTableEntry->rtekind == RTE_RELATION &&
-			IsDistributedTable(rangeTableEntry->relid) &&
+			IsCitusTable(rangeTableEntry->relid) &&
 			PartitionedTable(rangeTableEntry->relid))
 		{
 			rangeTableEntry->inh = setPartitionedTablesInherited;
@@ -893,7 +893,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 		Oid targetRelationId = ModifyQueryResultRelationId(query);
 		EnsurePartitionTableNotReplicated(targetRelationId);
 
-		if (InsertSelectIntoDistributedTable(originalQuery))
+		if (InsertSelectIntoCitusTable(originalQuery))
 		{
 			if (hasUnresolvedParams)
 			{
@@ -1871,7 +1871,7 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 	MemoryContext restrictionsMemoryContext = plannerRestrictionContext->memoryContext;
 	MemoryContext oldMemoryContext = MemoryContextSwitchTo(restrictionsMemoryContext);
 
-	bool distributedTable = IsDistributedTable(rte->relid);
+	bool distributedTable = IsCitusTable(rte->relid);
 	bool localTable = !distributedTable;
 
 	RelationRestriction *relationRestriction = palloc0(sizeof(RelationRestriction));
@@ -1897,7 +1897,7 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 	 */
 	if (distributedTable)
 	{
-		cacheEntry = DistributedTableCacheEntry(rte->relid);
+		cacheEntry = CitusTableCacheEntry(rte->relid);
 
 		relationRestrictionContext->allReferenceTables &=
 			(cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
@@ -2420,14 +2420,13 @@ IsLocalReferenceTableJoin(Query *parse, List *rangeTableList)
 			return false;
 		}
 
-		if (!IsDistributedTable(rangeTableEntry->relid))
+		if (!IsCitusTable(rangeTableEntry->relid))
 		{
 			hasLocalTable = true;
 			continue;
 		}
 
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(
-			rangeTableEntry->relid);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(rangeTableEntry->relid);
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{
 			hasReferenceTable = true;
@@ -2492,12 +2491,12 @@ UpdateReferenceTablesWithShard(Node *node, void *context)
 	}
 
 	Oid relationId = newRte->relid;
-	if (!IsDistributedTable(relationId))
+	if (!IsCitusTable(relationId))
 	{
 		return false;
 	}
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	if (cacheEntry->partitionMethod != DISTRIBUTE_BY_NONE)
 	{
 		return false;

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -133,7 +133,7 @@ GeneratePlaceHolderPlannedStmt(Query *parse)
 	result->planTree = (Plan *) plan;
 	result->hasReturning = (parse->returningList != NIL);
 
-	Oid relationId = ExtractFirstDistributedTableId(parse);
+	Oid relationId = ExtractFirstCitusTableId(parse);
 	result->relationOids = list_make1_oid(relationId);
 
 	return result;
@@ -202,7 +202,7 @@ FastPathRouterQuery(Query *query, Node **distributionKeyValue)
 
 	/* we don't want to deal with append/range distributed tables */
 	Oid distributedTableId = rangeTableEntry->relid;
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 	if (!(cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH ||
 		  cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE))
 	{

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -267,7 +267,7 @@ TryToDelegateFunctionCall(DistributedPlanningContext *planContext)
 		return NULL;
 	}
 
-	distTable = DistributedTableCacheEntry(colocatedRelationId);
+	distTable = CitusTableCacheEntry(colocatedRelationId);
 	partitionColumn = distTable->partitionColumn;
 	if (partitionColumn == NULL)
 	{

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -74,22 +74,22 @@ static DeferredErrorMessage * CoordinatorInsertSelectSupported(Query *insertSele
 
 
 /*
- * InsertSelectIntoDistributedTable returns true when the input query is an
- * INSERT INTO ... SELECT kind of query and the target is a distributed
+ * InsertSelectIntoCitusTable returns true when the input query is an
+ * INSERT INTO ... SELECT kind of query and the target is a citus
  * table.
  *
  * Note that the input query should be the original parsetree of
  * the query (i.e., not passed trough the standard planner).
  */
 bool
-InsertSelectIntoDistributedTable(Query *query)
+InsertSelectIntoCitusTable(Query *query)
 {
 	bool insertSelectQuery = CheckInsertSelectQuery(query);
 
 	if (insertSelectQuery)
 	{
 		RangeTblEntry *insertRte = ExtractResultRelationRTE(query);
-		if (IsDistributedTable(insertRte->relid))
+		if (IsCitusTable(insertRte->relid))
 		{
 			return true;
 		}
@@ -112,7 +112,7 @@ InsertSelectIntoLocalTable(Query *query)
 	if (insertSelectQuery)
 	{
 		RangeTblEntry *insertRte = ExtractResultRelationRTE(query);
-		if (!IsDistributedTable(insertRte->relid))
+		if (!IsCitusTable(insertRte->relid))
 		{
 			return true;
 		}
@@ -218,7 +218,7 @@ CreateDistributedInsertSelectPlan(Query *originalQuery,
 	RangeTblEntry *insertRte = ExtractResultRelationRTE(originalQuery);
 	RangeTblEntry *subqueryRte = ExtractSelectRangeTableEntry(originalQuery);
 	Oid targetRelationId = insertRte->relid;
-	DistTableCacheEntry *targetCacheEntry = DistributedTableCacheEntry(targetRelationId);
+	DistTableCacheEntry *targetCacheEntry = CitusTableCacheEntry(targetRelationId);
 	int shardCount = targetCacheEntry->shardIntervalArrayLength;
 	RelationRestrictionContext *relationRestrictionContext =
 		plannerRestrictionContext->relationRestrictionContext;
@@ -319,7 +319,7 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 	ListCell *rangeTableCell = NULL;
 
 	/* we only do this check for INSERT ... SELECT queries */
-	AssertArg(InsertSelectIntoDistributedTable(queryTree));
+	AssertArg(InsertSelectIntoCitusTable(queryTree));
 
 	Query *subquery = subqueryRte->subquery;
 
@@ -426,7 +426,7 @@ RouterModifyTaskForShardInterval(Query *originalQuery, ShardInterval *shardInter
 
 	uint64 shardId = shardInterval->shardId;
 	Oid distributedTableId = shardInterval->relationId;
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 
 	PlannerRestrictionContext *copyOfPlannerRestrictionContext = palloc0(
 		sizeof(PlannerRestrictionContext));
@@ -610,7 +610,7 @@ ReorderInsertSelectTargetLists(Query *originalQuery, RangeTblEntry *insertRte,
 	Index insertTableId = 1;
 	int targetEntryIndex = 0;
 
-	AssertArg(InsertSelectIntoDistributedTable(originalQuery));
+	AssertArg(InsertSelectIntoCitusTable(originalQuery));
 
 	Query *subquery = subqueryRte->subquery;
 

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -1380,7 +1380,7 @@ PartitionColumn(Oid relationId, uint32 rangeTableId)
 Var *
 DistPartitionKey(Oid relationId)
 {
-	DistTableCacheEntry *partitionEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *partitionEntry = CitusTableCacheEntry(relationId);
 
 	/* reference tables do not have partition column */
 	if (partitionEntry->partitionMethod == DISTRIBUTE_BY_NONE)
@@ -1417,7 +1417,7 @@ char
 PartitionMethod(Oid relationId)
 {
 	/* errors out if not a distributed table */
-	DistTableCacheEntry *partitionEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *partitionEntry = CitusTableCacheEntry(relationId);
 
 	char partitionMethod = partitionEntry->partitionMethod;
 
@@ -1430,7 +1430,7 @@ char
 TableReplicationModel(Oid relationId)
 {
 	/* errors out if not a distributed table */
-	DistTableCacheEntry *partitionEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *partitionEntry = CitusTableCacheEntry(relationId);
 
 	char replicationModel = partitionEntry->replicationModel;
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -284,8 +284,7 @@ TargetListOnPartitionColumn(Query *query, List *targetEntryList)
 		 * If the expression belongs to a reference table continue searching for
 		 * other partition keys.
 		 */
-		if (IsDistributedTable(relationId) && PartitionMethod(relationId) ==
-			DISTRIBUTE_BY_NONE)
+		if (IsCitusTable(relationId) && PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
 		{
 			continue;
 		}
@@ -437,7 +436,7 @@ IsDistributedTableRTE(Node *node)
 	}
 
 	Oid relationId = rangeTableEntry->relid;
-	if (!IsDistributedTable(relationId) ||
+	if (!IsCitusTable(relationId) ||
 		PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
 	{
 		return false;

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -1950,7 +1950,7 @@ BuildMapMergeJob(Query *jobQuery, List *dependentJobList, Var *partitionKey,
 	else if (partitionType == SINGLE_HASH_PARTITION_TYPE || partitionType ==
 			 RANGE_PARTITION_TYPE)
 	{
-		DistTableCacheEntry *cache = DistributedTableCacheEntry(baseRelationId);
+		DistTableCacheEntry *cache = CitusTableCacheEntry(baseRelationId);
 		uint32 shardCount = cache->shardIntervalArrayLength;
 		ShardInterval **sortedShardIntervalArray = cache->sortedShardIntervalArray;
 
@@ -2177,7 +2177,7 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		List *prunedShardList = (List *) lfirst(prunedRelationShardCell);
 		ListCell *shardIntervalCell = NULL;
 
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{
 			continue;
@@ -2309,7 +2309,7 @@ ErrorIfUnsupportedShardDistribution(Query *query)
 		}
 		else
 		{
-			DistTableCacheEntry *distTableEntry = DistributedTableCacheEntry(relationId);
+			DistTableCacheEntry *distTableEntry = CitusTableCacheEntry(relationId);
 			if (distTableEntry->hasOverlappingShardInterval)
 			{
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2415,7 +2415,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 		Oid relationId = relationRestriction->relationId;
 		ShardInterval *shardInterval = NULL;
 
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{
 			/* reference table only has one shard */
@@ -2509,8 +2509,8 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 bool
 CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
 {
-	DistTableCacheEntry *firstTableCache = DistributedTableCacheEntry(firstRelationId);
-	DistTableCacheEntry *secondTableCache = DistributedTableCacheEntry(secondRelationId);
+	DistTableCacheEntry *firstTableCache = CitusTableCacheEntry(firstRelationId);
+	DistTableCacheEntry *secondTableCache = CitusTableCacheEntry(secondRelationId);
 
 	ShardInterval **sortedFirstIntervalArray = firstTableCache->sortedShardIntervalArray;
 	ShardInterval **sortedSecondIntervalArray =
@@ -3904,7 +3904,7 @@ bool
 ShardIntervalsOverlap(ShardInterval *firstInterval, ShardInterval *secondInterval)
 {
 	DistTableCacheEntry *intervalRelation =
-		DistributedTableCacheEntry(firstInterval->relationId);
+		CitusTableCacheEntry(firstInterval->relationId);
 
 	Assert(intervalRelation->partitionMethod != DISTRIBUTE_BY_NONE);
 

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1431,7 +1431,7 @@ HasRecurringTuples(Node *node, RecurringTuplesType *recurType)
 		if (rangeTableEntry->rtekind == RTE_RELATION)
 		{
 			Oid relationId = rangeTableEntry->relid;
-			if (IsDistributedTable(relationId) &&
+			if (IsCitusTable(relationId) &&
 				PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
 			{
 				*recurType = RECURRING_TUPLES_REFERENCE_TABLE;

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -1069,7 +1069,7 @@ IsLocalTableRTE(Node *node)
 	}
 
 	Oid relationId = rangeTableEntry->relid;
-	if (IsDistributedTable(relationId))
+	if (IsCitusTable(relationId))
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -1400,7 +1400,7 @@ AddRteRelationToAttributeEquivalenceClass(AttributeEquivalenceClass **
 	Oid relationId = rangeTableEntry->relid;
 
 	/* we don't consider local tables in the equality on columns */
-	if (!IsDistributedTable(relationId))
+	if (!IsCitusTable(relationId))
 	{
 		return;
 	}
@@ -1721,7 +1721,7 @@ DistributedRelationIdList(Query *query)
 		TableEntry *tableEntry = (TableEntry *) lfirst(tableEntryCell);
 		Oid relationId = tableEntry->relationId;
 
-		if (!IsDistributedTable(relationId))
+		if (!IsCitusTable(relationId))
 		{
 			continue;
 		}

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -294,7 +294,7 @@ List *
 PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 			Const **partitionValueConst)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	int shardCount = cacheEntry->shardIntervalArrayLength;
 	char partitionMethod = cacheEntry->partitionMethod;
 	ClauseWalkerContext context = { 0 };

--- a/src/backend/distributed/test/deparse_shard_query.c
+++ b/src/backend/distributed/test/deparse_shard_query.c
@@ -59,7 +59,7 @@ deparse_shard_query_test(PG_FUNCTION_ARGS)
 			StringInfo buffer = makeStringInfo();
 
 			/* reoreder the target list only for INSERT .. SELECT queries */
-			if (InsertSelectIntoDistributedTable(query))
+			if (InsertSelectIntoCitusTable(query))
 			{
 				RangeTblEntry *insertRte = linitial(query->rtable);
 				RangeTblEntry *subqueryRte = lsecond(query->rtable);

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -64,7 +64,7 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 	Job *job = distributedPlan->workerJob;
 	List *taskList = job->taskList;
 
-	DistTableCacheEntry *targetRelation = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *targetRelation = CitusTableCacheEntry(relationId);
 
 	/*
 	 * Here SELECT query's target list should match column list of target relation,
@@ -132,7 +132,7 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 	Job *job = distributedPlan->workerJob;
 	List *taskList = job->taskList;
 
-	DistTableCacheEntry *targetRelation = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *targetRelation = CitusTableCacheEntry(relationId);
 
 	/*
 	 * Here SELECT query's target list should match column list of target relation,

--- a/src/backend/distributed/test/distribution_metadata.c
+++ b/src/backend/distributed/test/distribution_metadata.c
@@ -198,9 +198,9 @@ Datum
 is_distributed_table(PG_FUNCTION_ARGS)
 {
 	Oid distributedTableId = PG_GETARG_OID(0);
-	bool isDistributedTable = IsDistributedTable(distributedTableId);
+	bool isCitusTable = IsCitusTable(distributedTableId);
 
-	PG_RETURN_BOOL(isDistributedTable);
+	PG_RETURN_BOOL(isCitusTable);
 }
 
 

--- a/src/backend/distributed/test/foreign_key_relationship_query.c
+++ b/src/backend/distributed/test/foreign_key_relationship_query.c
@@ -38,7 +38,7 @@ get_referencing_relation_id_list(PG_FUNCTION_ARGS)
 	if (SRF_IS_FIRSTCALL())
 	{
 		Oid relationId = PG_GETARG_OID(0);
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 		List *refList = cacheEntry->referencingRelationsViaForeignKey;
 
 		/* create a function context for cross-call persistence */
@@ -89,7 +89,7 @@ get_referenced_relation_id_list(PG_FUNCTION_ARGS)
 	if (SRF_IS_FIRSTCALL())
 	{
 		Oid relationId = PG_GETARG_OID(0);
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 		List *refList = cacheEntry->referencedRelationsViaForeignKey;
 
 		/* create a function context for cross-call persistence */

--- a/src/backend/distributed/test/prune_shard_list.c
+++ b/src/backend/distributed/test/prune_shard_list.c
@@ -241,7 +241,7 @@ SortedShardIntervalArray(Oid distributedTableId)
 {
 	Oid shardIdTypeId = INT8OID;
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 	ShardInterval **shardIntervalArray = cacheEntry->sortedShardIntervalArray;
 	int shardIdCount = cacheEntry->shardIntervalArrayLength;
 	Datum *shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -685,12 +685,12 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 	Oid conflictingReferencingRelationId = InvalidOid;
 	ShardPlacementAccessType conflictingAccessType = PLACEMENT_ACCESS_SELECT;
 
-	if (!EnforceForeignKeyRestrictions || !IsDistributedTable(relationId))
+	if (!EnforceForeignKeyRestrictions || !IsCitusTable(relationId))
 	{
 		return;
 	}
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 
 	if (!(cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE &&
 		  cacheEntry->referencingRelationsViaForeignKey != NIL))
@@ -806,12 +806,12 @@ CheckConflictingParallelRelationAccesses(Oid relationId, ShardPlacementAccessTyp
 	Oid conflictingReferencingRelationId = InvalidOid;
 	ShardPlacementAccessType conflictingAccessType = PLACEMENT_ACCESS_SELECT;
 
-	if (!EnforceForeignKeyRestrictions || !IsDistributedTable(relationId))
+	if (!EnforceForeignKeyRestrictions || !IsCitusTable(relationId))
 	{
 		return;
 	}
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	if (!(cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH &&
 		  cacheEntry->referencedRelationsViaForeignKey != NIL))
 	{
@@ -882,7 +882,7 @@ HoldsConflictingLockWithReferencedRelations(Oid relationId, ShardPlacementAccess
 											ShardPlacementAccessType *
 											conflictingAccessMode)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 
 	Oid referencedRelation = InvalidOid;
 	foreach_oid(referencedRelation, cacheEntry->referencedRelationsViaForeignKey)
@@ -947,7 +947,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 											 ShardPlacementAccessType *
 											 conflictingAccessMode)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	bool holdsConflictingLocks = false;
 
 	Assert(PartitionMethod(relationId) == DISTRIBUTE_BY_NONE);
@@ -959,7 +959,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 		 * We're only interested in foreign keys to reference tables from
 		 * hash distributed tables.
 		 */
-		if (!IsDistributedTable(referencingRelation) ||
+		if (!IsCitusTable(referencingRelation) ||
 			PartitionMethod(referencingRelation) != DISTRIBUTE_BY_HASH)
 		{
 			continue;

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -546,10 +546,10 @@ GetNextColocationId()
 void
 CheckReplicationModel(Oid sourceRelationId, Oid targetRelationId)
 {
-	DistTableCacheEntry *sourceTableEntry = DistributedTableCacheEntry(sourceRelationId);
+	DistTableCacheEntry *sourceTableEntry = CitusTableCacheEntry(sourceRelationId);
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 
-	DistTableCacheEntry *targetTableEntry = DistributedTableCacheEntry(targetRelationId);
+	DistTableCacheEntry *targetTableEntry = CitusTableCacheEntry(targetRelationId);
 	char targetReplicationModel = targetTableEntry->replicationModel;
 
 	if (sourceReplicationModel != targetReplicationModel)
@@ -690,7 +690,7 @@ UpdateRelationColocationGroup(Oid distributedRelationId, uint32 colocationId)
 uint32
 TableColocationId(Oid distributedTableId)
 {
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 
 	return cacheEntry->colocationId;
 }
@@ -836,7 +836,7 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	Oid distributedTableId = shardInterval->relationId;
 	List *colocatedShardList = NIL;
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 	char partitionMethod = cacheEntry->partitionMethod;
 
 	/*
@@ -864,7 +864,7 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	foreach_oid(colocatedTableId, colocatedTableList)
 	{
 		DistTableCacheEntry *colocatedTableCacheEntry =
-			DistributedTableCacheEntry(colocatedTableId);
+			CitusTableCacheEntry(colocatedTableId);
 
 		/*
 		 * Since we iterate over co-located tables, shard count of each table should be
@@ -966,7 +966,7 @@ ColocatedTableId(Oid colocationId)
 uint64
 ColocatedShardIdInRelation(Oid relationId, int shardIndex)
 {
-	DistTableCacheEntry *tableCacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *tableCacheEntry = CitusTableCacheEntry(relationId);
 
 	return tableCacheEntry->sortedShardIntervalArray[shardIndex]->shardId;
 }

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -60,7 +60,7 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 	EnsureCoordinator();
 	EnsureTableOwner(relationId);
 
-	if (!IsDistributedTable(relationId))
+	if (!IsCitusTable(relationId))
 	{
 		char *relationName = get_rel_name(relationId);
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -70,7 +70,7 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 								"create_reference_table('%s');", relationName)));
 	}
 
-	DistTableCacheEntry *tableEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *tableEntry = CitusTableCacheEntry(relationId);
 
 	if (tableEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 	{
@@ -463,7 +463,7 @@ ReferenceTableOidList()
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, distTableOidList)
 	{
-		DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+		DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 
 		if (cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
 		{

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -360,13 +360,12 @@ static void
 SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 {
 	ShardInterval *shardInterval = LoadShardInterval(shardId);
-	Oid distributedTableId = shardInterval->relationId;
-	DistTableCacheEntry *distributedTable = DistributedTableCacheEntry(
-		distributedTableId);
-	uint32 colocationId = distributedTable->colocationId;
+	Oid citusTableId = shardInterval->relationId;
+	DistTableCacheEntry *citusTable = CitusTableCacheEntry(citusTableId);
+	uint32 colocationId = citusTable->colocationId;
 
 	if (colocationId == INVALID_COLOCATION_ID ||
-		distributedTable->partitionMethod != DISTRIBUTE_BY_HASH)
+		citusTable->partitionMethod != DISTRIBUTE_BY_HASH)
 	{
 		SET_LOCKTAG_SHARD_METADATA_RESOURCE(*tag, MyDatabaseId, shardId);
 	}
@@ -391,7 +390,7 @@ LockReferencedReferenceShardDistributionMetadata(uint64 shardId, LOCKMODE lockMo
 {
 	Oid relationId = RelationIdForShard(shardId);
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 	List *referencedRelationList = cacheEntry->referencedRelationsViaForeignKey;
 	List *shardIntervalList = GetSortedReferenceShardIntervals(referencedRelationList);
 
@@ -421,7 +420,7 @@ LockReferencedReferenceShardResources(uint64 shardId, LOCKMODE lockMode)
 {
 	Oid relationId = RelationIdForShard(shardId);
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(relationId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(relationId);
 
 	/*
 	 * Note that referencedRelationsViaForeignKey contains transitively referenced

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -239,7 +239,7 @@ ShardIndex(ShardInterval *shardInterval)
 	Oid distributedTableId = shardInterval->relationId;
 	Datum shardMinValue = shardInterval->minValue;
 
-	DistTableCacheEntry *cacheEntry = DistributedTableCacheEntry(distributedTableId);
+	DistTableCacheEntry *cacheEntry = CitusTableCacheEntry(distributedTableId);
 	char partitionMethod = cacheEntry->partitionMethod;
 
 	/*

--- a/src/include/distributed/insert_select_planner.h
+++ b/src/include/distributed/insert_select_planner.h
@@ -23,7 +23,7 @@
 #include "nodes/plannodes.h"
 
 
-extern bool InsertSelectIntoDistributedTable(Query *query);
+extern bool InsertSelectIntoCitusTable(Query *query);
 extern bool CheckInsertSelectQuery(Query *query);
 extern bool InsertSelectIntoLocalTable(Query *query);
 extern Query * ReorderInsertSelectTargetLists(Query *originalQuery,

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -52,7 +52,7 @@ typedef struct
 	 */
 	bool isValid;
 
-	bool isDistributedTable;
+	bool isCitusTable;
 	bool hasUninitializedShardInterval;
 	bool hasUniformHashDistribution; /* valid for hash partitioned tables */
 	bool hasOverlappingShardInterval;
@@ -117,15 +117,15 @@ typedef struct DistObjectCacheEntry
 } DistObjectCacheEntry;
 
 
-extern bool IsDistributedTable(Oid relationId);
-extern List * DistributedTableList(void);
+extern bool IsCitusTable(Oid relationId);
+extern List * CitusTableList(void);
 extern ShardInterval * LoadShardInterval(uint64 shardId);
 extern Oid RelationIdForShard(uint64 shardId);
 extern bool ReferenceTableShardId(uint64 shardId);
 extern ShardPlacement * FindShardPlacementOnGroup(int32 groupId, uint64 shardId);
 extern GroupShardPlacement * LoadGroupShardPlacement(uint64 shardId, uint64 placementId);
 extern ShardPlacement * LoadShardPlacement(uint64 shardId, uint64 placementId);
-extern DistTableCacheEntry * DistributedTableCacheEntry(Oid distributedRelationId);
+extern DistTableCacheEntry * CitusTableCacheEntry(Oid distributedRelationId);
 extern DistObjectCacheEntry * LookupDistObjectCacheEntry(Oid classid, Oid objid, int32
 														 objsubid);
 extern int32 GetLocalGroupId(void);

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -65,7 +65,7 @@ extern List * ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rte
 extern RelationRestrictionContext * CopyRelationRestrictionContext(
 	RelationRestrictionContext *oldContext);
 
-extern Oid ExtractFirstDistributedTableId(Query *query);
+extern Oid ExtractFirstCitusTableId(Query *query);
 extern RangeTblEntry * ExtractSelectRangeTableEntry(Query *query);
 extern Oid ModifyQueryResultRelationId(Query *query);
 extern RangeTblEntry * ExtractResultRelationRTE(Query *query);


### PR DESCRIPTION
Given IsDistributedTableRTE, there's ambiguity in what DistributedTable means

Elsewhere we used DistributedTable to include reference tables
Marco suggested we use CitusTable for distributed & reference tables

So renaming:
- IsDistributedTable -> IsCitusTable
- IsDistributedTableViaCatalog -> IsCitusTableViaCatalog
- DistributedTableCacheEntry -> CitusTableCacheEntry
- DistributedTableList -> CitusTableList
- isDistributedTable -> isCitusTable
- InsertSelectIntoDistributedTable -> InsertSelectIntoCitusTable
- ExtractFirstDistributedTableId -> ExtractFirstCitusTableId

This came up with #3568 where I was renaming `IsDistributedTableRTE` to `IsDistributedNonReferenceTableRTE`