### PR TITLE
Create a macro SLOW_START_DISABLED

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -165,6 +165,8 @@
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 
+#define SLOW_START_DISABLED 0
+
 
 /*
  * DistributedExecution represents the execution of a distributed query
@@ -2257,7 +2259,7 @@ ManageWorkerPool(WorkerPool *workerPool)
 		 */
 		newConnectionCount = Min(newConnectionsForReadyTasks, maxNewConnectionCount);
 
-		if (newConnectionCount > 0 && ExecutorSlowStartInterval > 0)
+		if (newConnectionCount > 0 && ExecutorSlowStartInterval != SLOW_START_DISABLED)
 		{
 			if (MillisecondsPassedSince(workerPool->lastConnectionOpenTime) >=
 				ExecutorSlowStartInterval)


### PR DESCRIPTION
When ExecutorSlowStartInterval is set to 0, it has a special meaning
that we do not want to use slow start. Therefore, in the code we have
checks such as ExecutorSlowStartInterval > 0 to understand if it is
enabled or not. However, this is kind of subtle, and it creates an extra
mapping in our mind. Therefore, I thought that using a variable for the
special value removes the mapping and makes it easier to understand.
