### PR TITLE
Defer reference table replication

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -344,6 +344,12 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 	EnsureRelationCanBeDistributed(relationId, distributionColumn, distributionMethod,
 								   colocationId, replicationModel, viaDeprecatedAPI);
 
+	/*
+	 * Make sure that existing reference tables have been replicated to all the nodes
+	 * such that we can create foreign keys and joins work immediately after creation.
+	 */
+	EnsureReferenceTablesExistOnAllNodes();
+
 	/* we need to calculate these variables before creating distributed metadata */
 	bool localTableEmpty = LocalTableEmpty(relationId);
 	Oid colocatedTableId = ColocatedTableId(colocationId);

--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -86,6 +86,8 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	ObjectAddressSet(tableAddress, RelationRelationId, distributedTableId);
 	EnsureDependenciesExistOnAllNodes(&tableAddress);
 
+	EnsureReferenceTablesExistOnAllNodes();
+
 	CreateShardsWithRoundRobinPolicy(distributedTableId, shardCount, replicationFactor,
 									 useExclusiveConnections);
 

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -50,15 +50,26 @@
 
 /* local function forward declarations */
 static char LookupShardTransferMode(Oid shardReplicationModeOid);
+static void ErrorIfTableCannotBeReplicated(Oid relationId);
 static void RepairShardPlacement(int64 shardId, const char *sourceNodeName,
 								 int32 sourceNodePort, const char *targetNodeName,
 								 int32 targetNodePort);
+static void ReplicateColocatedShardPlacement(int64 shardId, char *sourceNodeName,
+											 int32 sourceNodePort, char *targetNodeName,
+											 int32 targetNodePort,
+											 char shardReplicationMode);
+static void CopyColocatedShardPlacement(int64 shardId, char *sourceNodeName,
+										int32 sourceNodePort, char *targetNodeName,
+										int32 targetNodePort);
 static List * CopyPartitionShardsCommandList(ShardInterval *shardInterval,
 											 const char *sourceNodeName,
 											 int32 sourceNodePort);
 static void EnsureShardCanBeRepaired(int64 shardId, const char *sourceNodeName,
 									 int32 sourceNodePort, const char *targetNodeName,
 									 int32 targetNodePort);
+static void EnsureShardCanBeCopied(int64 shardId, const char *sourceNodeName,
+								   int32 sourceNodePort, const char *targetNodeName,
+								   int32 targetNodePort);
 static List * RecreateTableDDLCommandList(Oid relationId);
 static List * WorkerApplyShardDDLCommandList(List *ddlCommandList, int64 shardId);
 
@@ -87,31 +98,37 @@ master_copy_shard_placement(PG_FUNCTION_ARGS)
 	int32 targetNodePort = PG_GETARG_INT32(4);
 	bool doRepair = PG_GETARG_BOOL(5);
 	Oid shardReplicationModeOid = PG_GETARG_OID(6);
-	char shardReplicationMode = LookupShardTransferMode(shardReplicationModeOid);
 
 	char *sourceNodeName = text_to_cstring(sourceNodeNameText);
 	char *targetNodeName = text_to_cstring(targetNodeNameText);
 
+	CheckCitusVersion(ERROR);
+	EnsureCoordinator();
+
+	char shardReplicationMode = LookupShardTransferMode(shardReplicationModeOid);
+	if (shardReplicationMode == TRANSFER_MODE_FORCE_LOGICAL)
+	{
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("using logical replication in "
+							   "master_copy_shard_placement() requires Citus "
+							   "Enterprise")));
+	}
+
+	ShardInterval *shardInterval = LoadShardInterval(shardId);
+	ErrorIfTableCannotBeReplicated(shardInterval->relationId);
+
 	if (!doRepair)
 	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("master_copy_shard_placement() "
-							   "with do not repair functionality "
-							   "is only supported on Citus Enterprise")));
+		ReplicateColocatedShardPlacement(shardId, sourceNodeName, sourceNodePort,
+										 targetNodeName, targetNodePort,
+										 shardReplicationMode);
 	}
-	else if (shardReplicationMode == TRANSFER_MODE_FORCE_LOGICAL)
+	else
 	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("using logical replication with repair functionality "
-							   "is currently not supported")));
+		/* RepairShardPlacement function repairs only given shard */
+		RepairShardPlacement(shardId, sourceNodeName, sourceNodePort, targetNodeName,
+							 targetNodePort);
 	}
-
-	EnsureCoordinator();
-	CheckCitusVersion(ERROR);
-
-	/* RepairShardPlacement function repairs only given shard */
-	RepairShardPlacement(shardId, sourceNodeName, sourceNodePort, targetNodeName,
-						 targetNodePort);
 
 	PG_RETURN_VOID();
 }
@@ -172,6 +189,47 @@ BlockWritesToShardList(List *shardList)
 
 
 /*
+ * ErrorIfTableCannotBeReplicated function errors out if the given table is not suitable
+ * for its shard being replicated. There are 2 cases in which shard replication is not
+ * allowed:
+ *
+ * 1) MX tables, since RF=1 is a must MX tables
+ * 2) Reference tables, since the shard should already exist in all workers
+ */
+static void
+ErrorIfTableCannotBeReplicated(Oid relationId)
+{
+	bool shouldSyncMetadata = ShouldSyncTableMetadata(relationId);
+
+	if (shouldSyncMetadata)
+	{
+		CitusTableCacheEntry *tableEntry = LookupCitusTableCacheEntry(relationId);
+		char *relationName = get_rel_name(relationId);
+		StringInfo errorDetailString = makeStringInfo();
+
+		if (tableEntry->replicationModel == REPLICATION_MODEL_STREAMING)
+		{
+			appendStringInfo(errorDetailString,
+							 "Table %s is streaming replicated. Shards "
+							 "of streaming replicated tables cannot "
+							 "be copied", relationName);
+		}
+		else if (tableEntry->partitionMethod == DISTRIBUTE_BY_NONE)
+		{
+			appendStringInfo(errorDetailString, "Table %s is a reference table. Shards "
+												"of reference tables cannot be copied",
+							 relationName);
+			return;
+		}
+
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("cannot copy shard"),
+						errdetail("%s", errorDetailString->data)));
+	}
+}
+
+
+/*
  * LookupShardTransferMode maps the oids of citus.shard_transfer_mode enum
  * values to a char.
  */
@@ -217,6 +275,7 @@ RepairShardPlacement(int64 shardId, const char *sourceNodeName, int32 sourceNode
 
 	char relationKind = get_rel_relkind(distributedTableId);
 	char *tableOwner = TableOwner(shardInterval->relationId);
+	bool missingOk = false;
 
 
 	/* prevent table from being dropped */
@@ -314,10 +373,187 @@ RepairShardPlacement(int64 shardId, const char *sourceNodeName, int32 sourceNode
 
 	/* after successful repair, we update shard state as healthy*/
 	List *placementList = ShardPlacementList(shardId);
-	ShardPlacement *placement = ForceSearchShardPlacementInList(placementList,
-																targetNodeName,
-																targetNodePort);
+	ShardPlacement *placement = SearchShardPlacementInList(placementList, targetNodeName,
+														   targetNodePort,
+														   missingOk);
 	UpdateShardPlacementState(placement->placementId, SHARD_STATE_ACTIVE);
+}
+
+
+/*
+ * ReplicateColocatedShardPlacement replicated given shard and its colocated shards
+ * from a source node to target node.
+ */
+static void
+ReplicateColocatedShardPlacement(int64 shardId, char *sourceNodeName,
+								 int32 sourceNodePort, char *targetNodeName,
+								 int32 targetNodePort, char shardReplicationMode)
+{
+	ShardInterval *shardInterval = LoadShardInterval(shardId);
+	Oid distributedTableId = shardInterval->relationId;
+
+	List *colocatedTableList = ColocatedTableList(distributedTableId);
+	List *colocatedShardList = ColocatedShardIntervalList(shardInterval);
+	ListCell *colocatedTableCell = NULL;
+	ListCell *colocatedShardCell = NULL;
+
+
+	foreach(colocatedTableCell, colocatedTableList)
+	{
+		Oid colocatedTableId = lfirst_oid(colocatedTableCell);
+		char relationKind = '\0';
+
+		/* check that user has owner rights in all co-located tables */
+		EnsureTableOwner(colocatedTableId);
+
+		relationKind = get_rel_relkind(colocatedTableId);
+		if (relationKind == RELKIND_FOREIGN_TABLE)
+		{
+			char *relationName = get_rel_name(colocatedTableId);
+			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("cannot repair shard"),
+							errdetail("Table %s is a foreign table. Repairing "
+									  "shards backed by foreign tables is "
+									  "not supported.", relationName)));
+		}
+
+		List *foreignConstraintCommandList = GetTableForeignConstraintCommands(
+			colocatedTableId);
+
+		if (foreignConstraintCommandList != NIL &&
+			PartitionMethod(colocatedTableId) != DISTRIBUTE_BY_NONE)
+		{
+			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("cannot create foreign key constraint"),
+							errdetail("This shard has foreign constraints on it. "
+									  "Citus currently supports "
+									  "foreign key constraints only for "
+									  "\"citus.shard_replication_factor = 1\"."),
+							errhint("Please change \"citus.shard_replication_factor to "
+									"1\". To learn more about using foreign keys with "
+									"other replication factors, please contact us at "
+									"https://citusdata.com/about/contact_us.")));
+		}
+	}
+
+	/*
+	 * We sort colocatedShardList so that lock operations will not cause any
+	 * deadlocks.
+	 */
+	colocatedShardList = SortList(colocatedShardList, CompareShardIntervalsById);
+	foreach(colocatedShardCell, colocatedShardList)
+	{
+		ShardInterval *colocatedShard = (ShardInterval *) lfirst(colocatedShardCell);
+		uint64 colocatedShardId = colocatedShard->shardId;
+
+		/*
+		 * For shard copy, there should be healthy placement in source node and no
+		 * placement in the target node.
+		 */
+		EnsureShardCanBeCopied(colocatedShardId, sourceNodeName, sourceNodePort,
+							   targetNodeName, targetNodePort);
+	}
+
+	BlockWritesToShardList(colocatedShardList);
+
+	/*
+	 * CopyColocatedShardPlacement function copies given shard with its co-located
+	 * shards.
+	 */
+	CopyColocatedShardPlacement(shardId, sourceNodeName, sourceNodePort,
+								targetNodeName, targetNodePort);
+}
+
+
+/*
+ * CopyColocatedShardPlacement copies a shard along with its co-located shards from a
+ * source node to target node. CopyShardPlacement does not make any checks about state
+ * of the shards. It is caller's responsibility to make those checks if they are
+ * necessary.
+ */
+static void
+CopyColocatedShardPlacement(int64 shardId, char *sourceNodeName, int32 sourceNodePort,
+							char *targetNodeName, int32 targetNodePort)
+{
+	ShardInterval *shardInterval = LoadShardInterval(shardId);
+	List *colocatedShardList = ColocatedShardIntervalList(shardInterval);
+	ListCell *colocatedShardCell = NULL;
+
+	/* iterate through the colocated shards and copy each */
+	foreach(colocatedShardCell, colocatedShardList)
+	{
+		ShardInterval *colocatedShard = (ShardInterval *) lfirst(colocatedShardCell);
+		bool includeDataCopy = true;
+
+		if (PartitionedTable(colocatedShard->relationId))
+		{
+			/* partitioned tables contain no data */
+			includeDataCopy = false;
+		}
+
+		List *ddlCommandList = CopyShardCommandList(colocatedShard, sourceNodeName,
+													sourceNodePort, includeDataCopy);
+		char *tableOwner = TableOwner(colocatedShard->relationId);
+
+		SendCommandListToWorkerInSingleTransaction(targetNodeName, targetNodePort,
+												   tableOwner, ddlCommandList);
+	}
+
+
+	/*
+	 * Once all shards are created, we can recreate relationships between shards.
+	 *
+	 * Iterate through the colocated shards and create the foreign constraints and
+	 * attach child tables to their parents in a partitioning hierarchy.
+	 *
+	 * Note: After implementing foreign constraints from distributed to reference
+	 * tables, we have decided to not create foreign constraints from hash
+	 * distributed to reference tables at this stage for nonblocking rebalancer.
+	 * We just create the co-located ones here. We add the foreign constraints
+	 * from hash distributed to reference tables after being completely done with
+	 * the copy procedure inside LogicallyReplicateShards. The reason is that,
+	 * the reference tables have placements in both source and target workers and
+	 * the copied shard would get updated twice because of a cascading DML coming
+	 * from both of the placements.
+	 */
+	foreach(colocatedShardCell, colocatedShardList)
+	{
+		List *colocatedShardForeignConstraintCommandList = NIL;
+		List *referenceTableForeignConstraintList = NIL;
+		ShardInterval *colocatedShard = (ShardInterval *) lfirst(colocatedShardCell);
+		char *tableOwner = TableOwner(colocatedShard->relationId);
+
+		CopyShardForeignConstraintCommandListGrouped(colocatedShard,
+													 &
+													 colocatedShardForeignConstraintCommandList,
+													 &referenceTableForeignConstraintList);
+
+		List *commandList = list_concat(colocatedShardForeignConstraintCommandList,
+										referenceTableForeignConstraintList);
+
+		if (PartitionTable(colocatedShard->relationId))
+		{
+			char *attachPartitionCommand =
+				GenerateAttachShardPartitionCommand(colocatedShard);
+
+			commandList = lappend(commandList, attachPartitionCommand);
+		}
+
+		SendCommandListToWorkerInSingleTransaction(targetNodeName, targetNodePort,
+												   tableOwner, commandList);
+	}
+
+	/* finally insert the placements to pg_dist_placement */
+	foreach(colocatedShardCell, colocatedShardList)
+	{
+		ShardInterval *colocatedShard = (ShardInterval *) lfirst(colocatedShardCell);
+		uint64 colocatedShardId = colocatedShard->shardId;
+		uint32 groupId = GroupForNode(targetNodeName, targetNodePort);
+
+		InsertShardPlacementRow(colocatedShardId, INVALID_PLACEMENT_ID,
+								SHARD_STATE_ACTIVE, ShardLength(colocatedShardId),
+								groupId);
+	}
 }
 
 
@@ -369,19 +605,23 @@ EnsureShardCanBeRepaired(int64 shardId, const char *sourceNodeName, int32 source
 						 const char *targetNodeName, int32 targetNodePort)
 {
 	List *shardPlacementList = ShardPlacementList(shardId);
+	bool missingSourceOk = false;
+	bool missingTargetOk = false;
 
-	ShardPlacement *sourcePlacement = ForceSearchShardPlacementInList(shardPlacementList,
-																	  sourceNodeName,
-																	  sourceNodePort);
+	ShardPlacement *sourcePlacement = SearchShardPlacementInList(shardPlacementList,
+																 sourceNodeName,
+																 sourceNodePort,
+																 missingSourceOk);
 	if (sourcePlacement->shardState != SHARD_STATE_ACTIVE)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("source placement must be in active state")));
 	}
 
-	ShardPlacement *targetPlacement = ForceSearchShardPlacementInList(shardPlacementList,
-																	  targetNodeName,
-																	  targetNodePort);
+	ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
+																 targetNodeName,
+																 targetNodePort,
+																 missingTargetOk);
 	if (targetPlacement->shardState != SHARD_STATE_INACTIVE)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -391,46 +631,77 @@ EnsureShardCanBeRepaired(int64 shardId, const char *sourceNodeName, int32 source
 
 
 /*
- * SearchShardPlacementInList searches a provided list for a shard placement with the
- * specified node name and port. This function returns NULL if no such
- * placement exists in the provided list.
+ * EnsureShardCanBeCopied checks if the given shard has a healthy placement in the source
+ * node and no placements in the target node.
  */
-ShardPlacement *
-SearchShardPlacementInList(List *shardPlacementList, const char *nodeName,
-						   uint32 nodePort)
+static void
+EnsureShardCanBeCopied(int64 shardId, const char *sourceNodeName, int32 sourceNodePort,
+					   const char *targetNodeName, int32 targetNodePort)
 {
-	ShardPlacement *shardPlacement = NULL;
-	foreach_ptr(shardPlacement, shardPlacementList)
+	List *shardPlacementList = ShardPlacementList(shardId);
+	bool missingSourceOk = false;
+	bool missingTargetOk = true;
+
+	ShardPlacement *sourcePlacement = SearchShardPlacementInList(shardPlacementList,
+																 sourceNodeName,
+																 sourceNodePort,
+																 missingSourceOk);
+	if (sourcePlacement->shardState != SHARD_STATE_ACTIVE)
 	{
-		if (strncmp(nodeName, shardPlacement->nodeName, MAX_NODE_LENGTH) == 0 &&
-			nodePort == shardPlacement->nodePort)
-		{
-			return shardPlacement;
-		}
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("source placement must be in active state")));
 	}
-	return NULL;
+
+	ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
+																 targetNodeName,
+																 targetNodePort,
+																 missingTargetOk);
+	if (targetPlacement != NULL)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("shard %ld already exist in target placement", shardId)));
+	}
 }
 
 
 /*
- * ForceSearchShardPlacementInList searches a provided list for a shard
- * placement with the specified node name and port. This function throws an
- * error if no such placement exists in the provided list.
+ * SearchShardPlacementInList searches a provided list for a shard placement with the
+ * specified node name and port. If missingOk is set to true, this function returns NULL
+ * if no such placement exists in the provided list, otherwise it throws an error.
  */
 ShardPlacement *
-ForceSearchShardPlacementInList(List *shardPlacementList, const char *nodeName,
-								uint32 nodePort)
+SearchShardPlacementInList(List *shardPlacementList, const char *nodeName,
+						   uint32 nodePort, bool missingOk)
 {
-	ShardPlacement *placement = SearchShardPlacementInList(shardPlacementList, nodeName,
-														   nodePort);
-	if (placement == NULL)
+	ListCell *shardPlacementCell = NULL;
+	ShardPlacement *matchingPlacement = NULL;
+
+	foreach(shardPlacementCell, shardPlacementList)
 	{
+		ShardPlacement *shardPlacement = lfirst(shardPlacementCell);
+
+		if (strncmp(nodeName, shardPlacement->nodeName, MAX_NODE_LENGTH) == 0 &&
+			nodePort == shardPlacement->nodePort)
+		{
+			matchingPlacement = shardPlacement;
+			break;
+		}
+	}
+
+	if (matchingPlacement == NULL)
+	{
+		if (missingOk)
+		{
+			return NULL;
+		}
+
 		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
 						errmsg("could not find placement matching \"%s:%d\"",
 							   nodeName, nodePort),
 						errhint("Confirm the placement still exists and try again.")));
 	}
-	return placement;
+
+	return matchingPlacement;
 }
 
 
@@ -456,10 +727,6 @@ CopyShardCommandList(ShardInterval *shardInterval, const char *sourceNodeName,
 	copyShardToNodeCommandsList = list_concat(copyShardToNodeCommandsList,
 											  tableRecreationCommandList);
 
-	/*
-	 * The caller doesn't want to include the COPY command, perhaps using
-	 * logical replication to copy the data.
-	 */
 	if (includeDataCopy)
 	{
 		appendStringInfo(copyShardDataCommand, WORKER_APPEND_TABLE_TO_SHARD,

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -28,6 +28,7 @@
 #include "distributed/metadata_sync.h"
 #include "distributed/multi_join_order.h"
 #include "distributed/multi_partitioning_utils.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/resource_lock.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_protocol.h"
@@ -452,6 +453,19 @@ ReplicateColocatedShardPlacement(int64 shardId, char *sourceNodeName,
 		 */
 		EnsureShardCanBeCopied(colocatedShardId, sourceNodeName, sourceNodePort,
 							   targetNodeName, targetNodePort);
+	}
+
+	if (!IsReferenceTable(distributedTableId))
+	{
+		/*
+		 * When copying a shard to a new node, we should first ensure that reference
+		 * tables are present such that joins work immediately after copying the shard.
+		 * When copying a reference table, we are probably trying to achieve just that.
+		 *
+		 * Since this a long-running operation we do this after the error checks, but
+		 * before taking metadata locks.
+		 */
+		EnsureReferenceTablesExistOnAllNodes();
 	}
 
 	BlockWritesToShardList(colocatedShardList);

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -367,8 +367,6 @@ SetUpDistributedTableDependencies(WorkerNode *newWorkerNode)
 		EnsureNoModificationsHaveBeenDone();
 		ReplicateAllDependenciesToNode(newWorkerNode->workerName,
 									   newWorkerNode->workerPort);
-		ReplicateAllReferenceTablesToNode(newWorkerNode->workerName,
-										  newWorkerNode->workerPort);
 
 		/*
 		 * Let the maintenance daemon do the hard work of syncing the metadata.

--- a/src/backend/distributed/sql/citus--9.2-2--9.3-1.sql
+++ b/src/backend/distributed/sql/citus--9.2-2--9.3-1.sql
@@ -3,3 +3,4 @@
 /* bump version to 9.3-1 */
 
 #include "udfs/citus_extradata_container/9.3-1.sql"
+#include "udfs/replicate_reference_tables/9.3-1.sql"

--- a/src/backend/distributed/sql/udfs/replicate_reference_tables/9.3-1.sql
+++ b/src/backend/distributed/sql/udfs/replicate_reference_tables/9.3-1.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION pg_catalog.replicate_reference_tables()
+  RETURNS VOID
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$replicate_reference_tables$$;
+COMMENT ON FUNCTION pg_catalog.replicate_reference_tables()
+  IS 'replicate reference tables to all nodes';
+REVOKE ALL ON FUNCTION pg_catalog.replicate_reference_tables() FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/replicate_reference_tables/latest.sql
+++ b/src/backend/distributed/sql/udfs/replicate_reference_tables/latest.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION pg_catalog.replicate_reference_tables()
+  RETURNS VOID
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$replicate_reference_tables$$;
+COMMENT ON FUNCTION pg_catalog.replicate_reference_tables()
+  IS 'replicate reference tables to all nodes';
+REVOKE ALL ON FUNCTION pg_catalog.replicate_reference_tables() FROM PUBLIC;

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -270,8 +270,10 @@ ReplicateShardToNode(ShardInterval *shardInterval, char *nodeName, int nodePort)
 		CopyShardCommandList(shardInterval, srcNodeName, srcNodePort, includeData);
 
 	List *shardPlacementList = ShardPlacementList(shardId);
+	bool missingWorkerOk = true;
 	ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
-																 nodeName, nodePort);
+																 nodeName, nodePort,
+																 missingWorkerOk);
 	char *tableOwner = TableOwner(shardInterval->relationId);
 
 	/*

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -24,18 +24,24 @@
 #include "distributed/metadata_sync.h"
 #include "distributed/multi_logical_planner.h"
 #include "distributed/reference_table_utils.h"
+#include "distributed/remote_commands.h"
 #include "distributed/resource_lock.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/transaction_management.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
+#include "postmaster/postmaster.h"
 #include "storage/lmgr.h"
+#include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
 
 /* local function forward declarations */
+static List * WorkersWithoutReferenceTablePlacement(uint64 shardId);
+static void CopyShardPlacementToNewWorkerNode(ShardPlacement *sourceShardPlacement,
+											  WorkerNode *newWorkerNode);
 static void ReplicateSingleShardTableToAllNodes(Oid relationId);
 static void ReplicateShardToAllNodes(ShardInterval *shardInterval);
 static void ReplicateShardToNode(ShardInterval *shardInterval, char *nodeName,
@@ -44,6 +50,173 @@ static void ConvertToReferenceTableMetadata(Oid relationId, uint64 shardId);
 
 /* exports for SQL callable functions */
 PG_FUNCTION_INFO_V1(upgrade_to_reference_table);
+PG_FUNCTION_INFO_V1(replicate_reference_tables);
+
+
+/*
+ * IsReferenceTable returns whether the given relation ID identifies a reference
+ * table.
+ */
+bool
+IsReferenceTable(Oid relationId)
+{
+	CitusTableCacheEntry *tableEntry = LookupCitusTableCacheEntry(relationId);
+
+	if (!tableEntry->isCitusTable)
+	{
+		return false;
+	}
+
+	if (tableEntry->partitionMethod != DISTRIBUTE_BY_NONE)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * replicate_reference_tables is a UDF to ensure that allreference tables are
+ * replicated to all nodes.
+ */
+Datum
+replicate_reference_tables(PG_FUNCTION_ARGS)
+{
+	EnsureReferenceTablesExistOnAllNodes();
+
+	PG_RETURN_VOID();
+}
+
+
+/*
+ * EnsureReferenceTablesExistOnAllNodes ensures that a shard placement for every
+ * reference table exists on all nodes. If a node does not have a set of shard
+ * placements, then master_copy_shard_placement is called in a subtransaction
+ * to pull the data to the new node.
+ */
+void
+EnsureReferenceTablesExistOnAllNodes(void)
+{
+	List *referenceTableIdList = ReferenceTableOidList();
+	if (list_length(referenceTableIdList) == 0)
+	{
+		/* no reference tables exist */
+		return;
+	}
+
+	Oid referenceTableId = linitial_oid(referenceTableIdList);
+	List *shardIntervalList = LoadShardIntervalList(referenceTableId);
+	if (list_length(shardIntervalList) == 0)
+	{
+		/* check for corrupt metadata */
+		ereport(ERROR, (errmsg("reference table \"%s\" does not have a shard",
+							   get_rel_name(referenceTableId))));
+	}
+
+	ShardInterval *shardInterval = (ShardInterval *) linitial(shardIntervalList);
+	uint64 shardId = shardInterval->shardId;
+
+	/* prevent this funcion from running concurrently with itself */
+	int colocationId = TableColocationId(referenceTableId);
+	LockColocationId(colocationId, ExclusiveLock);
+
+	List *newWorkersList = WorkersWithoutReferenceTablePlacement(shardId);
+	if (list_length(newWorkersList) == 0)
+	{
+		/* nothing to do, no need for lock */
+		UnlockColocationId(colocationId, ExclusiveLock);
+		return;
+	}
+
+	/* TODO: ensure reference tables have not been modified in this transaction */
+
+	bool missingOk = false;
+	ShardPlacement *sourceShardPlacement = ActiveShardPlacement(shardId, missingOk);
+	if (sourceShardPlacement == NULL)
+	{
+		/* check for corrupt metadata */
+		ereport(ERROR, (errmsg("reference table shard " UINT64_FORMAT " does not "
+																	  "have an active shard placement",
+							   shardId)));
+	}
+
+	WorkerNode *newWorkerNode = NULL;
+	foreach_ptr(newWorkerNode, newWorkersList)
+	{
+		CopyShardPlacementToNewWorkerNode(sourceShardPlacement, newWorkerNode);
+	}
+
+	/*
+	 * Unblock other backends, they will probably observe that there are no
+	 * more worker nodes without placements, unless nodes were added concurrently
+	 */
+	UnlockColocationId(colocationId, ExclusiveLock);
+}
+
+
+/*
+ * WorkersWithoutReferenceTablePlacement returns a list of workers (WorkerNode) that
+ * do not yet have a placement for the given reference table shard ID, but are
+ * supposed to.
+ */
+static List *
+WorkersWithoutReferenceTablePlacement(uint64 shardId)
+{
+	List *workersWithoutPlacements = NIL;
+
+	List *shardPlacementList = ActiveShardPlacementList(shardId);
+
+	/* we only take an access share lock, otherwise we'll hold up master_add_node */
+	List *workerNodeList = ReferenceTablePlacementNodeList(AccessShareLock);
+	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
+
+	WorkerNode *workerNode = NULL;
+	foreach_ptr(workerNode, workerNodeList)
+	{
+		char *nodeName = workerNode->workerName;
+		uint32 nodePort = workerNode->workerPort;
+		bool missingWorkerOk = true;
+		ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
+																	 nodeName, nodePort,
+																	 missingWorkerOk);
+		if (targetPlacement == NULL)
+		{
+			workersWithoutPlacements = lappend(workersWithoutPlacements, workerNode);
+		}
+	}
+
+	return workersWithoutPlacements;
+}
+
+
+/*
+ * CopyShardPlacementToNewWorkerNode runs master_copy_shard_placement in a
+ * subtransaction by connecting to localhost.
+ */
+static void
+CopyShardPlacementToNewWorkerNode(ShardPlacement *sourceShardPlacement,
+								  WorkerNode *newWorkerNode)
+{
+	int connectionFlags = OUTSIDE_TRANSACTION;
+	StringInfo queryString = makeStringInfo();
+	const char *userName = CitusExtensionOwnerName();
+
+	MultiConnection *connection = GetNodeUserDatabaseConnection(
+		connectionFlags, "localhost", PostPortNumber,
+		userName, NULL);
+
+	appendStringInfo(queryString,
+					 "SELECT master_copy_shard_placement("
+					 UINT64_FORMAT ", %s, %d, %s, %d, do_repair := false)",
+					 sourceShardPlacement->shardId,
+					 quote_literal_cstr(sourceShardPlacement->nodeName),
+					 sourceShardPlacement->nodePort,
+					 quote_literal_cstr(newWorkerNode->workerName),
+					 newWorkerNode->workerPort);
+
+	ExecuteCriticalRemoteCommand(connection, queryString->data);
+}
 
 
 /*
@@ -107,66 +280,6 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 	ReplicateSingleShardTableToAllNodes(relationId);
 
 	PG_RETURN_VOID();
-}
-
-
-/*
- * ReplicateAllReferenceTablesToNode function finds all reference tables and
- * replicates them to the given worker node. It also modifies pg_dist_colocation
- * table to update the replication factor column when necessary. This function
- * skips reference tables if that node already has healthy placement of that
- * reference table to prevent unnecessary data transfer.
- */
-void
-ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort)
-{
-	List *referenceTableList = ReferenceTableOidList();
-
-	/* if there is no reference table, we do not need to replicate anything */
-	if (list_length(referenceTableList) > 0)
-	{
-		List *referenceShardIntervalList = NIL;
-
-		/*
-		 * We sort the reference table list to prevent deadlocks in concurrent
-		 * ReplicateAllReferenceTablesToAllNodes calls.
-		 */
-		referenceTableList = SortList(referenceTableList, CompareOids);
-		Oid referenceTableId = InvalidOid;
-		foreach_oid(referenceTableId, referenceTableList)
-		{
-			List *shardIntervalList = LoadShardIntervalList(referenceTableId);
-			ShardInterval *shardInterval = (ShardInterval *) linitial(shardIntervalList);
-
-			referenceShardIntervalList = lappend(referenceShardIntervalList,
-												 shardInterval);
-		}
-
-		if (ClusterHasKnownMetadataWorkers())
-		{
-			BlockWritesToShardList(referenceShardIntervalList);
-		}
-
-		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, referenceShardIntervalList)
-		{
-			uint64 shardId = shardInterval->shardId;
-
-			LockShardDistributionMetadata(shardId, ExclusiveLock);
-
-			ReplicateShardToNode(shardInterval, nodeName, nodePort);
-		}
-
-		/* create foreign constraints between reference tables */
-		foreach_ptr(shardInterval, referenceShardIntervalList)
-		{
-			char *tableOwner = TableOwner(shardInterval->relationId);
-			List *commandList = CopyShardForeignConstraintCommandList(shardInterval);
-
-			SendCommandListToWorkerInSingleTransaction(nodeName, nodePort, tableOwner,
-													   commandList);
-		}
-	}
 }
 
 

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -320,6 +320,36 @@ IntToLockMode(int mode)
 
 
 /*
+ * LockColocationId returns after acquiring a co-location ID lock, typically used
+ * for rebalancing and replication.
+ */
+void
+LockColocationId(int colocationId, LOCKMODE lockMode)
+{
+	LOCKTAG tag;
+	const bool sessionLock = false;
+	const bool dontWait = false;
+
+	SET_LOCKTAG_REBALANCE_COLOCATION(tag, (int64) colocationId);
+	(void) LockAcquire(&tag, lockMode, sessionLock, dontWait);
+}
+
+
+/*
+ * UnlockColocationId releases a co-location ID lock.
+ */
+void
+UnlockColocationId(int colocationId, LOCKMODE lockMode)
+{
+	LOCKTAG tag;
+	const bool sessionLock = false;
+
+	SET_LOCKTAG_REBALANCE_COLOCATION(tag, (int64) colocationId);
+	LockRelease(&tag, lockMode, sessionLock);
+}
+
+
+/*
  * LockShardDistributionMetadata returns after grabbing a lock for distribution
  * metadata related to the specified shard, blocking if required. Any locks
  * acquired using this method are released at transaction end.

--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -165,9 +165,7 @@ extern void CopyShardForeignConstraintCommandListGrouped(ShardInterval *shardInt
 														 List **
 														 referenceTableForeignConstraintList);
 extern ShardPlacement * SearchShardPlacementInList(List *shardPlacementList,
-												   const char *nodeName, uint32 nodePort);
-extern ShardPlacement * ForceSearchShardPlacementInList(List *shardPlacementList,
-														const char *nodeName,
-														uint32 nodePort);
+												   const char *nodeName, uint32 nodePort,
+												   bool missingOk);
 
 #endif   /* MASTER_PROTOCOL_H */

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -16,8 +16,9 @@
 
 #include "listutils.h"
 
+extern bool IsReferenceTable(Oid relationId);
+extern void EnsureReferenceTablesExistOnAllNodes(void);
 extern uint32 CreateReferenceTableColocationId(void);
-extern void ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);
 extern List * ReferenceTableOidList(void);
 extern int CompareOids(const void *leftElement, const void *rightElement);

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -102,6 +102,10 @@ extern void UnlockShardResource(uint64 shardId, LOCKMODE lockmode);
 extern void LockJobResource(uint64 jobId, LOCKMODE lockmode);
 extern void UnlockJobResource(uint64 jobId, LOCKMODE lockmode);
 
+/* Lock a co-location group */
+extern void LockColocationId(int colocationId, LOCKMODE lockMode);
+extern void UnlockColocationId(int colocationId, LOCKMODE lockMode);
+
 /* Lock multiple shards for safe modification */
 extern void LockShardListMetadata(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockShardsInPlacementListMetadata(List *shardPlacementList,

--- a/src/test/regress/expected/master_copy_shard_placement.out
+++ b/src/test/regress/expected/master_copy_shard_placement.out
@@ -1,0 +1,68 @@
+-- Tests for master_copy_shard_placement, which can be used for adding replicas in statement-based replication
+CREATE SCHEMA mcsp;
+SET search_path TO mcsp;
+SET citus.next_shard_id TO 8139000;
+SET citus.shard_replication_factor TO 1;
+SET citus.replicatiOn_model TO 'statement';
+CREATE TABLE data (
+  key text primary key,
+  value text not null,
+  check (value <> '')
+);
+CREATE INDEX ON data (value);
+SELECT create_distributed_table('data','key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE history (
+  key text not null,
+  t timestamptz not null,
+  value text not null
+) PARTITION BY RANGE (t);
+CREATE TABLE history_p1 PARTITION OF history FOR VALUES FROM ('2019-01-01') TO ('2020-01-01');
+CREATE TABLE history_p2 PARTITION OF history FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+SELECT create_distributed_table('history','key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO data VALUES ('key-1', 'value-1');
+INSERT INTO data VALUES ('key-2', 'value-2');
+INSERT INTO history VALUES ('key-1', '2020-02-01', 'old');
+INSERT INTO history VALUES ('key-1', '2019-10-01', 'older');
+-- replicate shard that contains key-1
+SELECT master_copy_shard_placement(
+           get_shard_id_for_distribution_column('data', 'key-1'),
+           'localhost', :worker_2_port,
+           'localhost', :worker_1_port,
+           do_repair := false);
+ master_copy_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+-- forcefully mark the old replica as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3
+WHERE shardid = get_shard_id_for_distribution_column('data', 'key-1') AND nodeport = :worker_2_port;
+UPDATE pg_dist_shard_placement SET shardstate = 3
+WHERE shardid = get_shard_id_for_distribution_column('history', 'key-1') AND nodeport = :worker_2_port;
+-- should still have all data available thanks to new replica
+SELECT count(*) FROM data;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT count(*) FROM history;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+DROP SCHEMA mcsp CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table data
+drop cascades to table history

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -247,7 +247,6 @@ SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extnam
 
 -- and add the other node
 SELECT 1 from master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "ref_table_2" to the node localhost:xxxxx
  ?column?
 ---------------------------------------------------------------------
         1
@@ -443,7 +442,6 @@ BEGIN;
 COMMIT;
 -- add the node back
 SELECT 1 from master_add_node('localhost', :worker_2_port);
-NOTICE:  Replicating reference table "t3" to the node localhost:xxxxx
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -190,7 +190,7 @@ test: multi_complex_count_distinct multi_select_distinct
 test: multi_modifications
 test: multi_distribution_metadata
 test: multi_generate_ddl_commands multi_create_shards multi_prune_shard_list multi_repair_shards
-test: multi_upsert multi_simple_queries multi_data_types
+test: multi_upsert multi_simple_queries multi_data_types master_copy_shard_placement
 # multi_utilities cannot be run in parallel with other tests because it checks
 # global locks
 test: multi_utilities

--- a/src/test/regress/sql/master_copy_shard_placement.sql
+++ b/src/test/regress/sql/master_copy_shard_placement.sql
@@ -1,0 +1,49 @@
+-- Tests for master_copy_shard_placement, which can be used for adding replicas in statement-based replication
+CREATE SCHEMA mcsp;
+SET search_path TO mcsp;
+SET citus.next_shard_id TO 8139000;
+SET citus.shard_replication_factor TO 1;
+SET citus.replicatiOn_model TO 'statement';
+
+CREATE TABLE data (
+  key text primary key,
+  value text not null,
+  check (value <> '')
+);
+CREATE INDEX ON data (value);
+SELECT create_distributed_table('data','key');
+
+CREATE TABLE history (
+  key text not null,
+  t timestamptz not null,
+  value text not null
+) PARTITION BY RANGE (t);
+CREATE TABLE history_p1 PARTITION OF history FOR VALUES FROM ('2019-01-01') TO ('2020-01-01');
+CREATE TABLE history_p2 PARTITION OF history FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+SELECT create_distributed_table('history','key');
+
+INSERT INTO data VALUES ('key-1', 'value-1');
+INSERT INTO data VALUES ('key-2', 'value-2');
+
+INSERT INTO history VALUES ('key-1', '2020-02-01', 'old');
+INSERT INTO history VALUES ('key-1', '2019-10-01', 'older');
+
+-- replicate shard that contains key-1
+SELECT master_copy_shard_placement(
+           get_shard_id_for_distribution_column('data', 'key-1'),
+           'localhost', :worker_2_port,
+           'localhost', :worker_1_port,
+           do_repair := false);
+
+-- forcefully mark the old replica as inactive
+UPDATE pg_dist_shard_placement SET shardstate = 3
+WHERE shardid = get_shard_id_for_distribution_column('data', 'key-1') AND nodeport = :worker_2_port;
+
+UPDATE pg_dist_shard_placement SET shardstate = 3
+WHERE shardid = get_shard_id_for_distribution_column('history', 'key-1') AND nodeport = :worker_2_port;
+
+-- should still have all data available thanks to new replica
+SELECT count(*) FROM data;
+SELECT count(*) FROM history;
+
+DROP SCHEMA mcsp CASCADE;


### PR DESCRIPTION
DESCRIPTION: Defer reference table replication to shard creation time

This PR moves the reference table replication away from master_add_node and into functions that may create shards on new nodes such as `create_distributed_table` using the `master_copy_shard_placement` infrastructure introduced by #3591.