### PR TITLE
Remove all GetWorkerNodeCount() references

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -2979,20 +2979,6 @@ GetWorkerNodeHash(void)
 
 
 /*
- * GetWorkerNodeCount returns the number of worker nodes
- *
- * If the Worker Node cache is not (yet) valid, it is first rebuilt.
- */
-int
-GetWorkerNodeCount(void)
-{
-	PrepareWorkerNodeCache();
-
-	return WorkerNodeCount;
-}
-
-
-/*
  * PrepareWorkerNodeCache makes sure the worker node data from pg_dist_node is cached,
  * if it is not already cached.
  */

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -158,7 +158,6 @@ extern char LookupDistributionMethod(Oid distributionMethodOid);
 
 /* access WorkerNodeHash */
 extern HTAB * GetWorkerNodeHash(void);
-extern int GetWorkerNodeCount(void);
 extern WorkerNode * LookupNodeByNodeId(uint32 nodeId);
 extern WorkerNode * ForceLookupNodeByNodeId(uint32 nodeId);
 extern WorkerNode * LookupNodeForGroup(int32 groupId);


### PR DESCRIPTION
As @onderkalaci suggested in https://github.com/citusdata/citus/pull/3564#discussion_r388270858 removing the definition of `GetWorkerNodeCount()` that can potentially cause misunderstandings.

I can advise using `ActiveReadableWorkerNodeCount()` that returns the number of active primaries is a safer alternative than `GetWorkerNodeCount()` that returns the total number of workers containing inactives, primaries, and unavailable nodes. I introduced a bug #3556 and in the bugfix #3564 removed the single usage of said function