### PR TITLE
add a utility to get shard oid from relation oid and shard id

### DIFF
--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -22,6 +22,7 @@
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/multi_router_planner.h"
+#include "distributed/shard_utils.h"
 #include "distributed/version_compat.h"
 #include "lib/stringinfo.h"
 #include "nodes/makefuncs.h"
@@ -334,15 +335,9 @@ UpdateRelationsToLocalShardTables(Node *node, List *relationShardList)
 		return true;
 	}
 
-	uint64 shardId = relationShard->shardId;
-	Oid relationId = relationShard->relationId;
+	Oid shardOid = GetShardOid(relationShard->relationId, relationShard->shardId);
 
-	char *relationName = get_rel_name(relationId);
-	AppendShardIdToName(&relationName, shardId);
-
-	Oid schemaId = get_rel_namespace(relationId);
-
-	newRte->relid = get_relname_relid(relationName, schemaId);
+	newRte->relid = shardOid;
 
 	return false;
 }

--- a/src/backend/distributed/utils/shard_utils.c
+++ b/src/backend/distributed/utils/shard_utils.c
@@ -1,0 +1,31 @@
+/*-------------------------------------------------------------------------
+ *
+ * shard_utils.c
+ *
+ * This file contains functions to perform useful operations on shards.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "utils/lsyscache.h"
+
+#include "distributed/relay_utility.h"
+#include "distributed/shard_utils.h"
+
+/*
+ * GetShardOid returns the oid of the shard from the given distributed relation
+ * with the shardid.
+ */
+Oid
+GetShardOid(Oid distRelId, uint64 shardId)
+{
+	char *relationName = get_rel_name(distRelId);
+	AppendShardIdToName(&relationName, shardId);
+
+	Oid schemaId = get_rel_namespace(distRelId);
+
+	return get_relname_relid(relationName, schemaId);
+}

--- a/src/include/distributed/shard_utils.h
+++ b/src/include/distributed/shard_utils.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * shard_utils.h
+ *   Utilities related to shards.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef SHARD_UTILS_H
+#define SHARD_UTILS_H
+
+#include "postgres.h"
+
+extern Oid GetShardOid(Oid distRelId, uint64 shardId);
+
+#endif /* SHARD_UTILS_H */


### PR DESCRIPTION
This method is used in local copy execution as well, but since this piece of the code is not related to it, creating a separate PR for it.

Probably some of the existing methods related to shards can go into this file in a separate PR.

