### PR TITLE
Retry a failed target once more in regression tests

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -116,15 +116,24 @@ check-empty: all
 	-- $(MULTI_REGRESS_OPTS) $(EXTRA_TESTS)
 
 check-multi: all
+	${MAKE} check-multi-internal  || ${MAKE} check-multi-internal
+
+check-multi-internal:
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
 check-multi-non-adaptive: all
+	${MAKE} check-multi-non-adaptive-internal || ${MAKE} check-multi-non-adaptive-internal
+
+check-multi-non-adaptive-internal:
 	$(pg_regress_multi_check) --load-extension=citus \
 	--server-option=citus.task_executor_type=real-time \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
 check-failure-non-adaptive: all
+	${MAKE} check-failure-non-adaptive-internal  || ${MAKE} check-failure-non-adaptive-internal
+
+check-failure-non-adaptive-internal:
 	$(pg_regress_multi_check) --load-extension=citus --mitmproxy \
 	--server-option=citus.task_executor_type=real-time \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/failure_schedule $(EXTRA_TESTS)
@@ -135,6 +144,9 @@ check-failure-non-adaptive-base: all
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/failure_base_schedule $(EXTRA_TESTS)
 
 check-isolation-non-adaptive: all  $(isolation_test_files)
+	${MAKE} check-isolation-non-adaptive-internal || ${MAKE} check-isolation-non-adaptive-internal
+
+check-isolation-non-adaptive-internal:
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
 	--server-option=citus.task_executor_type=real-time \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/isolation_schedule $(EXTRA_TESTS)
@@ -156,8 +168,12 @@ check-vanilla: all
 	$(pg_regress_multi_check) --load-extension=citus --vanillatest
 
 check-multi-mx: all
+	${MAKE} check-multi-mx-internal  || ${MAKE} check-multi-mx-internal
+
+check-multi-mx-internal:
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_mx_schedule $(EXTRA_TESTS)
+
 
 check-multi-task-tracker-extra: all
 	$(pg_regress_multi_check) --load-extension=citus \
@@ -169,6 +185,9 @@ check-follower-cluster: all
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_follower_schedule $(EXTRA_TESTS)
 
 check-failure: all
+	${MAKE} check-failure-internal  || ${MAKE} check-failure-internal
+
+check-failure-internal:
 	$(pg_regress_multi_check) --load-extension=citus --mitmproxy \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/failure_schedule $(EXTRA_TESTS)
 


### PR DESCRIPTION
We currently have a lot of flaky tests, and I usually find myself
rerunning a failed job with the exactly same code. This happens quite
often and is kind of frustrating. We usually run tests in our local and
we already fix most of the failures in our local, sometimes a test can
indeed fail in circleci but it is not that often.

As a temporary solution to that, this commit reruns the failed target
once more. Circleci currently does not support this feature, so I
thought of adding this to our Makefile.

One downside of this approach is that if a target is indeed failing then
the test will take around 2x longer, however in general this is not the
case and I feel like the benefit of this commit is more than its
downside.