### PR TITLE
Also check aggregates in havingQual when scanning for non pushdownable aggregates

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -3504,6 +3504,7 @@ RequiresIntermediateRowPullUp(MultiNode *logicalPlanNode)
 	MultiExtendedOp *extendedOpNode = (MultiExtendedOp *) linitial(opNodeList);
 
 	List *targetList = extendedOpNode->targetList;
+	Node *havingQual = extendedOpNode->havingQual;
 
 	/*
 	 * PVC_REJECT_PLACEHOLDERS is implicit if PVC_INCLUDE_PLACEHOLDERS isn't
@@ -3511,6 +3512,8 @@ RequiresIntermediateRowPullUp(MultiNode *logicalPlanNode)
 	 */
 	List *expressionList = pull_var_clause((Node *) targetList, PVC_INCLUDE_AGGREGATES |
 										   PVC_INCLUDE_WINDOWFUNCS);
+	expressionList = list_concat(expressionList,
+								 pull_var_clause(havingQual, PVC_INCLUDE_AGGREGATES));
 
 	Node *expression = NULL;
 	foreach_ptr(expression, expressionList)
@@ -3547,6 +3550,7 @@ DeferErrorIfContainsNonPushdownableAggregate(MultiNode *logicalPlanNode)
 	MultiExtendedOp *extendedOpNode = (MultiExtendedOp *) linitial(opNodeList);
 
 	List *targetList = extendedOpNode->targetList;
+	Node *havingQual = extendedOpNode->havingQual;
 
 	/*
 	 * PVC_REJECT_PLACEHOLDERS is implicit if PVC_INCLUDE_PLACEHOLDERS isn't
@@ -3554,6 +3558,8 @@ DeferErrorIfContainsNonPushdownableAggregate(MultiNode *logicalPlanNode)
 	 */
 	List *expressionList = pull_var_clause((Node *) targetList, PVC_INCLUDE_AGGREGATES |
 										   PVC_INCLUDE_WINDOWFUNCS);
+	expressionList = list_concat(expressionList,
+								 pull_var_clause(havingQual, PVC_INCLUDE_AGGREGATES));
 
 	ListCell *expressionCell = NULL;
 	foreach(expressionCell, expressionList)

--- a/src/test/regress/expected/multi_subquery.out
+++ b/src/test/regress/expected/multi_subquery.out
@@ -903,6 +903,28 @@ SELECT t1.event_type FROM events_table t1
 GROUP BY t1.event_type HAVING t1.event_type > avg(2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
 ORDER BY 1;
 ERROR:  cannot handle unplanned sub-select
+SELECT t1.event_type FROM events_table t1
+GROUP BY t1.event_type HAVING t1.event_type > avg(t1.value_2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
+ORDER BY 1;
+ERROR:  cannot handle unplanned sub-select
+RESET citus.coordinator_aggregation_strategy;
+SELECT t1.event_type FROM events_table t1
+GROUP BY t1.event_type HAVING t1.event_type > corr(t1.value_3, t1.value_2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
+ORDER BY 1;
+ERROR:  result "68_1" does not exist
+CONTEXT:  while executing command on localhost:xxxxx
+SELECT t1.event_type FROM events_table t1
+GROUP BY t1.event_type HAVING t1.event_type * 5 > sum(distinct t1.value_3)
+ORDER BY 1;
+ event_type
+---------------------------------------------------------------------
+          3
+          4
+          5
+          6
+(4 rows)
+
+SET citus.coordinator_aggregation_strategy TO 'disabled';
 -- Test https://github.com/citusdata/citus/issues/3433
 CREATE TABLE keyval1 (key int, value int);
 SELECT create_distributed_table('keyval1', 'key');

--- a/src/test/regress/sql/multi_subquery.sql
+++ b/src/test/regress/sql/multi_subquery.sql
@@ -641,6 +641,20 @@ SELECT t1.event_type FROM events_table t1
 GROUP BY t1.event_type HAVING t1.event_type > avg(2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
 ORDER BY 1;
 
+SELECT t1.event_type FROM events_table t1
+GROUP BY t1.event_type HAVING t1.event_type > avg(t1.value_2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
+ORDER BY 1;
+
+RESET citus.coordinator_aggregation_strategy;
+SELECT t1.event_type FROM events_table t1
+GROUP BY t1.event_type HAVING t1.event_type > corr(t1.value_3, t1.value_2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
+ORDER BY 1;
+
+SELECT t1.event_type FROM events_table t1
+GROUP BY t1.event_type HAVING t1.event_type * 5 > sum(distinct t1.value_3)
+ORDER BY 1;
+SET citus.coordinator_aggregation_strategy TO 'disabled';
+
 -- Test https://github.com/citusdata/citus/issues/3433
 CREATE TABLE keyval1 (key int, value int);
 SELECT create_distributed_table('keyval1', 'key');


### PR DESCRIPTION
Came across this while coming up with test cases,
'result "68_1" does not exist' I'll seek to address in a future PR,
for now avoid segfault

DESCRIPTION: Fix possible segfault when non pushdownable aggregates are solely used in `HAVING`

Segfault was caused by pullUpIntermediateRows being false & then `HAVING` giving us an aggregate with `AGGREGATE_CUSTOM_ROW_GATHER` which then has us calling `AggregateFunctionOid(NULL)`. Another situation would be something like `sum(distinct x)` in HAVING, where we'd just end up doing the wrong thing before