### PR TITLE
retry vanilla tests if they fail once more

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -128,6 +128,11 @@ check-isolation-base: all  $(isolation_test_files)
 	-- $(MULTI_REGRESS_OPTS) $(EXTRA_TESTS)
 
 check-vanilla: all
+	# it is possible that sometimes vanilla tests will fail, which is related to postgres.
+	# So we try it once more if it fails to prevent some failures in our CI.
+	${MAKE} check-vanilla-internal  || ${MAKE} check-vanilla-internal
+
+check-vanilla-internal:
 	$(pg_regress_multi_check) --load-extension=citus --vanillatest
 
 check-multi-mx: all


### PR DESCRIPTION
As we don't own the vanilla tests, it makes sense to retry vanilla tests when they fail.

Related to #3598.