### PR TITLE
Make building safestringlib on some distros easier

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -7,6 +7,13 @@ safestringlib_builddir = $(citus_top_builddir)/vendor/safestringlib/build
 safestringlib_a = $(safestringlib_builddir)/libsafestring_static.a
 safestringlib_sources = $(wildcard $(safestringlib_srcdir)/safeclib/*)
 
+# Use cmake3 if it exists, otherwise just use the string "cmake" and let bash
+# figure out its exact path later.
+# Using "which cmake" instead will make the error very hard to understand if
+# you have neither "cmake3" or "cmake" in path. In that case the "CMAKE3"
+# variable would be an empty string.
+CMAKE3 = $(shell which cmake3 || echo cmake)
+
 MODULE_big = citus
 EXTENSION = citus
 
@@ -56,7 +63,7 @@ $(safestringlib_a): $(safestringlib_sources)
 	@# Makefile are not used
 	+cd $(safestringlib_builddir) && \
 		export LDFLAGS='' && export CPPFLAGS='' && \
-		cmake $(safestringlib_srcdir) && make
+		$(CMAKE3) $(safestringlib_srcdir) && make
 
 citus.so: $(safestringlib_a)
 


### PR DESCRIPTION
On some distros (e.g. Redhat 7) there is cmake version 2 and cmake version 3,
safestringlib requires cmake version 3. On those distros the binary is called
`cmake3`, so try to use that one before falling back to regular `cmake` binary.