### PR TITLE
Properly terminate connections at the end session

### DIFF
--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -221,6 +221,7 @@ extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 const char *database);
 extern void CloseNodeConnectionsAfterTransaction(char *nodeName, int nodePort);
 extern void CloseConnection(MultiConnection *connection);
+extern void ShutdownAllConnections(void);
 extern void ShutdownConnection(MultiConnection *connection);
 
 /* dealing with a connection */


### PR DESCRIPTION
Citus coordinator (or MX nodes) caches `citus.max_cached_conns_per_worker` connections
per node. This means that, those connections are not terminated after each statement.
Instead, cached to avoid the cost of re-establishment. This is crucial for OLTP performance.

The problem with that approach is that, we never properly handle the termination of
those cached connections. For instance, when a session on the coordinator disconnects,
you'd see the following logs on the workers:

```
2020-03-20 09:13:39.454 CET [64028] LOG:  could not receive data from client: Connection reset by peer
```

With this patch, we're terminating the cached connections properly at the end of the connection.

An example from Postgres code that does almost the same thing: https://github.com/postgres/postgres/blob/1933ae629e7b706c6c23673a381e778819db307d/src/bin/pg_basebackup/pg_receivewal.c#L57-L62

And, this will be useful while implementing #3116. 

Fixes #3630
