### PR TITLE
Ignore safestringlib sourcefiles in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,6 +11,8 @@ coverage:
     - "src/backend/distributed/utils/citus_outfuncs.c"
     - "src/backend/distributed/deparser/ruleutils_*.c"
     - "src/include/distributed/citus_nodes.h"
+    - "src/backend/distributed/safeclib"
+    - "vendor"
 
   status:
     project:


### PR DESCRIPTION
This is not our code, so we don't care about the coverage our tests generate
for it.