### PR TITLE
Refactor dependency resolution and resolve from pg_shdepend

### DIFF
--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -806,4 +806,6 @@ DependencyDefinitionObjectAddress(DependencyDefinition *definition)
 			return address;
 		}
 	}
+
+	ereport(ERROR, (errmsg("unsupported dependency definition mode")));
 }

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -239,8 +239,6 @@ static void
 recurse_pg_depend(ObjectAddress target, expandFn expand, followFn follow, applyFn apply,
 				  ObjectAddressCollector *collector)
 {
-	List *dependenyDefinitionList = NIL;
-
 	if (TargetObjectVisited(collector, target))
 	{
 		/* prevent infinite loops due to circular dependencies */
@@ -249,7 +247,7 @@ recurse_pg_depend(ObjectAddress target, expandFn expand, followFn follow, applyF
 
 	MarkObjectVisited(collector, target);
 
-	dependenyDefinitionList = DependencyDefinitionFromPgDepend(target);
+	List *dependenyDefinitionList = DependencyDefinitionFromPgDepend(target);
 	dependenyDefinitionList = list_concat(dependenyDefinitionList,
 										  DependencyDefinitionFromPgShDepend(target));
 
@@ -349,7 +347,7 @@ DependencyDefinitionFromPgShDepend(ObjectAddress target)
 	Relation shdepRel = heap_open(SharedDependRelationId, AccessShareLock);
 
 	/*
-	 * Scan pg_depend for dbid = $1 AND classid = $2 AND objid = $3 using
+	 * Scan pg_shdepend for dbid = $1 AND classid = $2 AND objid = $3 using
 	 * pg_shdepend_depender_index
 	 */
 	ScanKeyInit(&key[0], Anum_pg_shdepend_dbid, BTEqualStrategyNumber, F_OIDEQ,


### PR DESCRIPTION
DESCRIPTION: Refactor dependency resolution and resolve from pg_shdepend

This PR refactors how dependencies are resolved by not assuming solely a `pg_depend` record describing the dependency. Instead we keep a definition of the dependency around which records how the dependency is resolved. This can be one of the following ways
 - `pg_depend`, data will contain a copy of the `pg_depend` record
 - `pg_shdepend`, data will contain a copy of the `pg_shdepend` record
 - `ObjectAddress`, data will contain only an `ObjectAddress` describing a dependency

Irregardless of way the dependency was found it will always be able to get to the address of the dependency as that is the most important property.

For some checks we can inspect the source where the dependency was found and perform a deep inspection to decide if we want to follow the dependency. This is important to not distribute dependencies coming from extensions for example.