### PR TITLE
Remove SwallowErrors

### DIFF
--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -662,9 +662,20 @@ RemoveIntermediateResultsDirectory(void)
 {
 	if (CreatedResultsDirectory)
 	{
-		CitusRemoveDirectory(IntermediateResultsDirectory());
-
-		CreatedResultsDirectory = false;
+		/* this routine is called during transaction abort, we do want to finish the abort
+		 * even if we fail to remove the files, warnings will be shown if it failed anyway
+		 */
+		if (CitusRemoveDirectory(IntermediateResultsDirectory(), WARNING))
+		{
+			/*
+			 * TODO verify if it is ok to keep this variable set to true if the removal
+			 * failed during xact abort. This is the same behaviour as we had with
+			 * SwallowError, however I guess the next transaction will have a different
+			 * return value for IntermediateResultsDirectory() in the next xact.
+			 * If that is the case we should just always set this variable to false.
+			 */
+			CreatedResultsDirectory = false;
+		}
 	}
 }
 

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -186,7 +186,7 @@ void
 RemoveJobDirectory(uint64 jobId)
 {
 	StringInfo jobDirectoryName = MasterJobDirectoryName(jobId);
-	CitusRemoveDirectory(jobDirectoryName->data);
+	CitusRemoveDirectory(jobDirectoryName->data, ERROR);
 
 	ResourceOwnerForgetJobDirectory(CurrentResourceOwner, jobId);
 }

--- a/src/backend/distributed/test/file_utils.c
+++ b/src/backend/distributed/test/file_utils.c
@@ -23,7 +23,7 @@ citus_rm_job_directory(PG_FUNCTION_ARGS)
 	appendStringInfo(jobCacheDirectory, "base/%s/%s%0*" INT64_MODIFIER "u",
 					 PG_JOB_CACHE_DIR, JOB_DIRECTORY_PREFIX,
 					 MIN_JOB_DIRNAME_WIDTH, jobId);
-	CitusRemoveDirectory(jobCacheDirectory->data);
+	CitusRemoveDirectory(jobCacheDirectory->data, ERROR);
 	FreeStringInfo(jobCacheDirectory);
 
 	PG_RETURN_VOID();

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -108,7 +108,6 @@ static void ResetShardPlacementTransactionState(void);
 static void AdjustMaxPreparedTransactions(void);
 static void PushSubXact(SubTransactionId subId);
 static void PopSubXact(SubTransactionId subId);
-static void SwallowErrors(void (*func)());
 static bool MaybeExecutingUDF(void);
 static void ResetGlobalVariables(void);
 
@@ -281,7 +280,7 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 				 * RemoveIntermediateResultsDirectory.
 				 */
 				AtEOXact_Files(false);
-				SwallowErrors(RemoveIntermediateResultsDirectory);
+				RemoveIntermediateResultsDirectory();
 			}
 			ResetShardPlacementTransactionState();
 
@@ -635,51 +634,6 @@ ActiveSubXactContexts(void)
 	}
 
 	return reversedSubXactStates;
-}
-
-
-/*
- * If an ERROR is thrown while processing a transaction the ABORT handler is called.
- * ERRORS thrown during ABORT are not treated any differently, the ABORT handler is also
- * called during processing of those. If an ERROR was raised the first time through it's
- * unlikely that the second try will succeed; more likely that an ERROR will be thrown
- * again. This loop continues until Postgres notices and PANICs, complaining about a stack
- * overflow.
- *
- * Instead of looping and crashing, SwallowErrors lets us attempt to continue running the
- * ABORT logic. This wouldn't be safe in most other parts of the codebase, in
- * approximately none of the places where we emit ERROR do we first clean up after
- * ourselves! It's fine inside the ABORT handler though; Postgres is going to clean
- * everything up before control passes back to us.
- */
-static void
-SwallowErrors(void (*func)())
-{
-	MemoryContext savedContext = CurrentMemoryContext;
-
-	PG_TRY();
-	{
-		func();
-	}
-	PG_CATCH();
-	{
-		ErrorData *edata = CopyErrorData();
-
-		/* don't try to intercept PANIC or FATAL, let those breeze past us */
-		if (edata->elevel != ERROR)
-		{
-			PG_RE_THROW();
-		}
-
-		/* turn the ERROR into a WARNING and emit it */
-		edata->elevel = WARNING;
-		ThrowErrorData(edata);
-
-		/* leave the error handling system */
-		FlushErrorState();
-		MemoryContextSwitchTo(savedContext);
-	}
-	PG_END_TRY();
 }
 
 

--- a/src/backend/distributed/worker/task_tracker.c
+++ b/src/backend/distributed/worker/task_tracker.c
@@ -347,7 +347,7 @@ TrackerCleanupJobDirectories(void)
 	StringInfo jobCacheDirectory = makeStringInfo();
 	appendStringInfo(jobCacheDirectory, "base/%s", PG_JOB_CACHE_DIR);
 
-	CitusRemoveDirectory(jobCacheDirectory->data);
+	CitusRemoveDirectory(jobCacheDirectory->data, ERROR);
 	CitusCreateDirectory(jobCacheDirectory);
 
 	FreeStringInfo(jobCacheDirectory);
@@ -1028,7 +1028,7 @@ ManageWorkerTask(WorkerTask *workerTask, HTAB *WorkerTasksHash)
 			if (workerTask->taskId == JOB_CLEANUP_TASK_ID)
 			{
 				StringInfo jobDirectoryName = JobDirectoryName(workerTask->jobId);
-				CitusRemoveDirectory(jobDirectoryName->data);
+				CitusRemoveDirectory(jobDirectoryName->data, ERROR);
 			}
 
 			workerTask->taskStatus = TASK_TO_REMOVE;

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -231,7 +231,7 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 	 * schema drop call can block if another process is creating the schema or
 	 * writing to a table within the schema.
 	 */
-	CitusRemoveDirectory(jobDirectoryName->data);
+	CitusRemoveDirectory(jobDirectoryName->data, ERROR);
 
 	RemoveJobSchema(jobSchemaName);
 	UnlockJobResource(jobId, AccessExclusiveLock);

--- a/src/backend/distributed/worker/worker_merge_protocol.c
+++ b/src/backend/distributed/worker/worker_merge_protocol.c
@@ -100,7 +100,7 @@ worker_repartition_cleanup(PG_FUNCTION_ARGS)
 	Oid schemaId = get_namespace_oid(jobSchemaName->data, false);
 
 	EnsureSchemaOwner(schemaId);
-	CitusRemoveDirectory(jobDirectoryName->data);
+	CitusRemoveDirectory(jobDirectoryName->data, ERROR);
 	RemoveJobSchema(jobSchemaName);
 	PG_RETURN_VOID();
 }

--- a/src/include/distributed/worker_protocol.h
+++ b/src/include/distributed/worker_protocol.h
@@ -117,7 +117,7 @@ extern bool CacheDirectoryElement(const char *filename);
 extern bool JobDirectoryElement(const char *filename);
 extern bool DirectoryExists(StringInfo directoryName);
 extern void CitusCreateDirectory(StringInfo directoryName);
-extern void CitusRemoveDirectory(const char *filename);
+extern bool CitusRemoveDirectory(const char *filename, int elevel);
 extern StringInfo InitTaskDirectory(uint64 jobId, uint32 taskId);
 extern void RemoveJobSchema(StringInfo schemaName);
 extern Datum * DeconstructArrayObject(ArrayType *arrayObject);


### PR DESCRIPTION
DESCRIPTION: Prevent potential crash/poison of backend in xact abort

Replaces: #3618 

Instead of fixing SwallowErrors we allow the user to provide the level for which failures need to be logged. We return true if the removal of the files succeeded, false otherwise. If `elevel` is set to `ERROR` it will throw and rollback the stack whenever something goes wrong.