### PR TITLE
not run local shard copy test in parallel

### DIFF
--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -40,12 +40,13 @@ test: master_evaluation master_evaluation_modify master_evaluation_select
 test: multi_mx_call
 test: multi_mx_function_call_delegation
 test: multi_mx_modifications local_shard_execution
+test: local_shard_copy
 test: multi_mx_transaction_recovery
 test: multi_mx_modifying_xacts
 test: multi_mx_explain
 test: multi_mx_reference_table
 test: multi_mx_insert_select_repartition
-test: locally_execute_intermediate_results local_shard_copy
+test: locally_execute_intermediate_results
 
 # test that no tests leaked intermediate results. This should always be last
 test: ensure_no_intermediate_data_leak


### PR DESCRIPTION
It seems that when logging is enabled we should not run local shard copy
in parallel with other tests. The reason is that it adds coordinator for
reference tables and if the parallel test creates a schema before this
test is run, the schema will be logged. So it is not deterministic.
