### PR TITLE
Ignore changes in configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ lib*.pc
 /src/Makefile.custom
 /compile_commands.json
 
+# Autoconf version may vary
+configure
+
 # temporary files vim creates
 *.swp
 


### PR DESCRIPTION
Ignore changes that `make reindent` does on `configure` file as Autoconf version may differ across the developers