### PR TITLE
Refactor functions around reference tables into reusable pieces

### DIFF
--- a/src/backend/distributed/commands/local_multi_copy.c
+++ b/src/backend/distributed/commands/local_multi_copy.c
@@ -159,7 +159,7 @@ DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId, CopyStmt *copyStat
 	 */
 	LocalCopyBuffer = buffer;
 
-	Oid shardOid = GetShardLocalTableOid(relationId, shardId);
+	Oid shardOid = GetTableLocalShardOid(relationId, shardId);
 	Relation shard = heap_open(shardOid, RowExclusiveLock);
 	ParseState *pState = make_parsestate(NULL);
 

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -39,7 +39,6 @@
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
-
 /* Local functions forward declarations for unsupported command checks */
 static void ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement);
 static List * InterShardDDLTaskList(Oid leftRelationId, Oid rightRelationId,

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -742,8 +742,8 @@ AlterTableConstraintCheck(QueryDesc *queryDesc)
 
 
 /*
- * IsLocalReferenceTableJoinPlan returns true if the given plan joins local tables
- * with reference table shards.
+ * IsLocalReferenceTableJoinPlan returns true if the given plan joins local
+ * tables with reference table shards.
  *
  * This should be consistent with IsLocalReferenceTableJoin() in distributed_planner.c.
  */
@@ -752,28 +752,12 @@ IsLocalReferenceTableJoinPlan(PlannedStmt *plan)
 {
 	bool hasReferenceTable = false;
 	bool hasLocalTable = false;
-	bool hasReferenceTableReplica = false;
 
 	/*
-	 * We only allow join between reference tables and local tables in the
-	 * coordinator.
+	 * Check if we are in the coordinator and coordinator can have reference
+	 * table placements
 	 */
-	if (!IsCoordinator())
-	{
-		return false;
-	}
-
-	/*
-	 * All groups that have pg_dist_node entries, also have reference
-	 * table replicas.
-	 */
-	PrimaryNodeForGroup(GetLocalGroupId(), &hasReferenceTableReplica);
-
-	/*
-	 * If reference table doesn't have replicas on the coordinator, we don't
-	 * allow joins with local tables.
-	 */
-	if (!hasReferenceTableReplica)
+	if (!CanUseCoordinatorLocalTablesWithReferenceTables())
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -335,7 +335,7 @@ UpdateRelationsToLocalShardTables(Node *node, List *relationShardList)
 		return true;
 	}
 
-	Oid shardOid = GetShardLocalTableOid(relationShard->relationId,
+	Oid shardOid = GetTableLocalShardOid(relationShard->relationId,
 										 relationShard->shardId);
 
 	newRte->relid = shardOid;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -2342,8 +2342,8 @@ HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams)
 
 
 /*
- * IsLocalReferenceTableJoin returns if the given query is a join between
- * reference tables and local tables.
+ * IsLocalReferenceTableJoin returns true if the given query is a valid join
+ * query between reference tables and local tables
  */
 static bool
 IsLocalReferenceTableJoin(Query *parse, List *rangeTableList)
@@ -2352,28 +2352,11 @@ IsLocalReferenceTableJoin(Query *parse, List *rangeTableList)
 	bool hasLocalTable = false;
 	ListCell *rangeTableCell = false;
 
-	bool hasReferenceTableReplica = false;
-
 	/*
-	 * We only allow join between reference tables and local tables in the
-	 * coordinator.
+	 * Check if we are in the coordinator and coordinator can have reference
+	 * table placements
 	 */
-	if (!IsCoordinator())
-	{
-		return false;
-	}
-
-	/*
-	 * All groups that have pg_dist_node entries, also have reference
-	 * table replicas.
-	 */
-	PrimaryNodeForGroup(COORDINATOR_GROUP_ID, &hasReferenceTableReplica);
-
-	/*
-	 * If reference table doesn't have replicas on the coordinator, we don't
-	 * allow joins with local tables.
-	 */
-	if (!hasReferenceTableReplica)
+	if (!CanUseCoordinatorLocalTablesWithReferenceTables())
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -39,6 +39,7 @@
 #include "distributed/query_utils.h"
 #include "distributed/recursive_planning.h"
 #include "distributed/shardinterval_utils.h"
+#include "distributed/shard_utils.h"
 #include "distributed/version_compat.h"
 #include "distributed/worker_shard_visibility.h"
 #include "executor/executor.h"
@@ -2503,14 +2504,7 @@ UpdateReferenceTablesWithShard(Node *node, void *context)
 		return false;
 	}
 
-	ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[0];
-	uint64 shardId = shardInterval->shardId;
-
-	char *relationName = get_rel_name(relationId);
-	AppendShardIdToName(&relationName, shardId);
-
-	Oid schemaId = get_rel_namespace(relationId);
-	newRte->relid = get_relname_relid(relationName, schemaId);
+	newRte->relid = GetReferenceTableLocalShardOid(relationId);
 
 	/*
 	 * Parser locks relations in addRangeTableEntry(). So we should lock the

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -95,10 +95,10 @@ extern ObjectAddress AlterExtensionUpdateStmtObjectAddress(Node *stmt,
 /* foreign_constraint.c - forward declarations */
 extern bool ConstraintIsAForeignKeyToReferenceTable(char *constraintName,
 													Oid leftRelationId);
-extern void ErrorIfUnsupportedForeignConstraintExists(Relation relation,
-													  char distributionMethod,
-													  Var *distributionColumn,
-													  uint32 colocationId);
+extern void ErrorIfUnsupportedForeignConstraintExists(Relation referencingRelation,
+													  char referencingDistMethod,
+													  Var *referencingDistKey,
+													  uint32 referencingColocationId);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetTableForeignConstraintCommands(Oid relationId);

--- a/src/include/distributed/shard_utils.h
+++ b/src/include/distributed/shard_utils.h
@@ -13,6 +13,7 @@
 
 #include "postgres.h"
 
-extern Oid GetShardLocalTableOid(Oid distRelId, uint64 shardId);
+extern Oid GetTableLocalShardOid(Oid citusTableOid, uint64 shardId);
+extern Oid GetReferenceTableLocalShardOid(Oid referenceTableOid);
 
 #endif /* SHARD_UTILS_H */

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -72,6 +72,7 @@ extern WorkerNode * WorkerGetLocalFirstCandidateNode(List *currentNodeList);
 extern uint32 ActivePrimaryWorkerNodeCount(void);
 extern List * ActivePrimaryWorkerNodeList(LOCKMODE lockMode);
 extern List * ActivePrimaryNodeList(LOCKMODE lockMode);
+extern bool CanUseCoordinatorLocalTablesWithReferenceTables(void);
 extern List * ReferenceTablePlacementNodeList(LOCKMODE lockMode);
 extern List * DistributedTablePlacementNodeList(LOCKMODE lockMode);
 extern bool NodeCanHaveDistTablePlacements(WorkerNode *node);

--- a/src/include/distributed/worker_shard_visibility.h
+++ b/src/include/distributed/worker_shard_visibility.h
@@ -17,7 +17,8 @@ extern bool OverrideTableVisibility;
 
 
 extern void ReplaceTableVisibleFunction(Node *inputNode);
-extern bool RelationIsAKnownShard(Oid shardRelationId, bool onlySearchPath);
+extern bool RelationIsAKnownShard(Oid shardRelationOid, bool onlySearchPath);
+extern Oid GetOwnerRelationOid(Oid shardRelationId, bool onlySearchPath);
 
 
 #endif /* WORKER_SHARD_VISIBILITY_H */


### PR DESCRIPTION
Refactor some functions implemented for reference tables into smaller pieces for reusability and do some rename on variables etc.