### PR TITLE
Don't segfault on queries using GROUPING

### DIFF
--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -225,13 +225,12 @@ HasNonPartitionColumnDistinctAgg(List *targetEntryList, Node *havingQual,
 		ListCell *varCell = NULL;
 		bool isPartitionColumn = false;
 
-		if (IsA(targetNode, Var))
+		if (!IsA(targetNode, Aggref))
 		{
 			continue;
 		}
 
-		Assert(IsA(targetNode, Aggref));
-		Aggref *targetAgg = (Aggref *) targetNode;
+		Aggref *targetAgg = castNode(Aggref, targetNode);
 		if (targetAgg->aggdistinct == NIL)
 		{
 			continue;

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -82,6 +82,7 @@ static bool IsReadIntermediateResultFunction(Node *node);
 static bool IsReadIntermediateResultArrayFunction(Node *node);
 static bool IsCitusExtraDataContainerFunc(Node *node);
 static bool IsFunctionWithOid(Node *node, Oid funcOid);
+static bool IsGroupingFunc(Node *node);
 static bool ExtractFromExpressionWalker(Node *node,
 										QualifierWalkerContext *walkerContext);
 static List * MultiTableNodeList(List *tableEntryList, List *rangeTableList);
@@ -885,6 +886,16 @@ IsFunctionWithOid(Node *node, Oid funcOid)
 
 
 /*
+ * IsGroupingFunc returns whether node is a GroupingFunc.
+ */
+static bool
+IsGroupingFunc(Node *node)
+{
+	return IsA(node, GroupingFunc);
+}
+
+
+/*
  * FindIntermediateResultIdIfExists extracts the id of the intermediate result
  * if the given RTE contains a read_intermediate_results function, NULL otherwise
  */
@@ -975,6 +986,13 @@ DeferErrorIfQueryNotSupported(Query *queryTree)
 		preconditionsSatisfied = false;
 		errorMessage = "could not run distributed query with GROUPING SETS, CUBE, "
 					   "or ROLLUP";
+		errorHint = filterHint;
+	}
+
+	if (FindNodeCheck((Node *) queryTree, IsGroupingFunc))
+	{
+		preconditionsSatisfied = false;
+		errorMessage = "could not run distributed query with GROUPING";
 		errorHint = filterHint;
 	}
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -1017,7 +1017,7 @@ AddAnyValueAggregates(Node *node, void *context)
 			}
 		}
 	}
-	if (IsA(node, Aggref))
+	if (IsA(node, Aggref) || IsA(node, GroupingFunc))
 	{
 		return node;
 	}

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -432,6 +432,21 @@ select key, count(distinct aggdata)
 from aggdata group by key order by 1, 2;
 ERROR:  type "aggregate_support.aggdata" does not exist
 CONTEXT:  while executing command on localhost:xxxxx
+-- GROUPING parses to GroupingFunc, distinct from Aggref
+-- These three queries represent edge cases implementation would have to consider
+-- For now we error out of all three
+select grouping(id)
+from aggdata group by id order by 1 limit 3;
+ERROR:  could not run distributed query with GROUPING
+HINT:  Consider using an equality filter on the distributed table's partition column.
+select key, grouping(val)
+from aggdata group by key, val order by 1, 2;
+ERROR:  could not run distributed query with GROUPING
+HINT:  Consider using an equality filter on the distributed table's partition column.
+select key, grouping(val), sum(distinct valf)
+from aggdata group by key, val order by 1, 2;
+ERROR:  could not run distributed query with GROUPING
+HINT:  Consider using an equality filter on the distributed table's partition column.
 -- Test https://github.com/citusdata/citus/issues/3328
 create table nulltable(id int);
 insert into nulltable values (0);

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -204,6 +204,19 @@ RESET citus.task_executor_type;
 select key, count(distinct aggdata)
 from aggdata group by key order by 1, 2;
 
+-- GROUPING parses to GroupingFunc, distinct from Aggref
+-- These three queries represent edge cases implementation would have to consider
+-- For now we error out of all three
+select grouping(id)
+from aggdata group by id order by 1 limit 3;
+
+select key, grouping(val)
+from aggdata group by key, val order by 1, 2;
+
+select key, grouping(val), sum(distinct valf)
+from aggdata group by key, val order by 1, 2;
+
+
 -- Test https://github.com/citusdata/citus/issues/3328
 create table nulltable(id int);
 insert into nulltable values (0);


### PR DESCRIPTION
GROUPING will always return 0 outside of GROUPING SETS, CUBE, or ROLLUP
Since we don't support those, it makes sense to reject GROUPING in queries

DESCRIPTION: Raise an error instead of segfaulting for queries using `GROUPING`

Included some `IsA` checks which shouldn't get hit now that we error out, but which I felt were correct to include

Considered adding support even though it'd always resolve to 0 right now, but implementation in `multi_logical_optimizer` to make sure `grouping` is computed on the side with `GROUP BY` was non trivial