### PR TITLE
Fixes a bug that causes some DML queries containing aggregates to fail

### DIFF
--- a/src/test/regress/expected/multi_function_evaluation.out
+++ b/src/test/regress/expected/multi_function_evaluation.out
@@ -163,9 +163,31 @@ DELETE
 FROM table_1
 WHERE key >= (SELECT min(KEY) FROM table_1)
 AND value > now() - interval '1 hour';
+CREATE OR REPLACE FUNCTION stable_squared(int)
+RETURNS int STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+	RAISE NOTICE 'stable_fn called';
+	RETURN $1 * $1;
+END;
+$function$;
+SELECT create_distributed_function('stable_squared(int)');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+UPDATE example SET value = timestamp '10-10-2000 00:00'
+FROM (SELECT key, stable_squared(count(*)::int) y FROM example GROUP BY key) a WHERE example.key = a.key;
+UPDATE example SET value = timestamp '10-10-2000 00:00'
+FROM (SELECT key, stable_squared((count(*) OVER ())::int) y FROM example GROUP BY key) a WHERE example.key = a.key;
+UPDATE example SET value = timestamp '10-10-2000 00:00'
+FROM (SELECT key, stable_squared(grouping(key)) y FROM example GROUP BY key) a WHERE example.key = a.key;
 DROP SCHEMA multi_function_evaluation CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to table example
 drop cascades to sequence example_value_seq
 drop cascades to function stable_fn()
 drop cascades to table table_1
+drop cascades to function stable_squared(integer)


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that causes some DML queries containing aggregates to fail

When an aggregate appears in an expression that meets the `ShouldEvaluateExpression` conditions, we incorrectly try to evaluate the aggregate. This PR adds a check to prevent this.

Fixes #3660