### PR TITLE
Failed to sync CREATE TYPE command to MX 

### DIFF
--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -712,15 +712,13 @@ RecreateCompositeTypeStmt(Oid typeOid)
 /*
  * attributeFormToColumnDef returns a ColumnDef * describing the field and its property
  * for a pg_attribute entry.
- *
- * Note: Current implementation is only covering the features supported by composite types
  */
 static ColumnDef *
 attributeFormToColumnDef(Form_pg_attribute attributeForm)
 {
 	return makeColumnDef(NameStr(attributeForm->attname),
 						 attributeForm->atttypid,
-						 -1,
+						 attributeForm->atttypmod,
 						 attributeForm->attcollation);
 }
 

--- a/src/backend/distributed/deparser/deparse_type_stmts.c
+++ b/src/backend/distributed/deparser/deparse_type_stmts.c
@@ -378,8 +378,11 @@ AppendColumnDefList(StringInfo str, List *columnDefs)
 static void
 AppendColumnDef(StringInfo str, ColumnDef *columnDef)
 {
-	Oid typeOid = LookupTypeNameOid(NULL, columnDef->typeName, false);
+	int32 typmod;
+	Oid typeOid;
 	Oid collationOid = GetColumnDefCollation(NULL, columnDef, typeOid);
+	bits16 formatFlags = FORMAT_TYPE_TYPEMOD_GIVEN | FORMAT_TYPE_FORCE_QUALIFY;
+	typenameTypeIdAndMod(NULL, columnDef->typeName, &typeOid, &typmod);
 
 	Assert(!columnDef->is_not_null); /* not null is not supported on composite types */
 
@@ -388,7 +391,7 @@ AppendColumnDef(StringInfo str, ColumnDef *columnDef)
 		appendStringInfo(str, "%s ", quote_identifier(columnDef->colname));
 	}
 
-	appendStringInfo(str, "%s", format_type_be_qualified(typeOid));
+	appendStringInfo(str, "%s", format_type_extended(typeOid, typmod, formatFlags));
 
 	if (OidIsValid(collationOid))
 	{

--- a/src/backend/distributed/deparser/deparse_type_stmts.c
+++ b/src/backend/distributed/deparser/deparse_type_stmts.c
@@ -378,8 +378,8 @@ AppendColumnDefList(StringInfo str, List *columnDefs)
 static void
 AppendColumnDef(StringInfo str, ColumnDef *columnDef)
 {
-	int32 typmod;
-	Oid typeOid;
+	int32 typmod = 0;
+	Oid typeOid = InvalidOid;
 	bits16 formatFlags = FORMAT_TYPE_TYPEMOD_GIVEN | FORMAT_TYPE_FORCE_QUALIFY;
 
 	typenameTypeIdAndMod(NULL, columnDef->typeName, &typeOid, &typmod);

--- a/src/backend/distributed/deparser/deparse_type_stmts.c
+++ b/src/backend/distributed/deparser/deparse_type_stmts.c
@@ -380,9 +380,10 @@ AppendColumnDef(StringInfo str, ColumnDef *columnDef)
 {
 	int32 typmod;
 	Oid typeOid;
-	Oid collationOid = GetColumnDefCollation(NULL, columnDef, typeOid);
 	bits16 formatFlags = FORMAT_TYPE_TYPEMOD_GIVEN | FORMAT_TYPE_FORCE_QUALIFY;
+
 	typenameTypeIdAndMod(NULL, columnDef->typeName, &typeOid, &typmod);
+	Oid collationOid = GetColumnDefCollation(NULL, columnDef, typeOid);
 
 	Assert(!columnDef->is_not_null); /* not null is not supported on composite types */
 

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -14,7 +14,7 @@ CREATE SCHEMA type_tests2 AUTHORIZATION typeuser; -- to test creation in a speci
 SET search_path TO type_tests;
 SET citus.shard_count TO 4;
 -- single statement transactions with a simple type used in a table
-CREATE TYPE tc1 AS (a int, b int);
+CREATE TYPE tc1 AS (a int, b varchar(20));
 CREATE TABLE t1 (a int PRIMARY KEY, b tc1);
 SELECT create_distributed_table('t1','a');
  create_distributed_table
@@ -22,7 +22,7 @@ SELECT create_distributed_table('t1','a');
 
 (1 row)
 
-INSERT INTO t1 VALUES (1, (2,3)::tc1);
+INSERT INTO t1 VALUES (1, (2,'3')::tc1);
 SELECT * FROM t1;
  a |   b
 ---------------------------------------------------------------------
@@ -30,10 +30,18 @@ SELECT * FROM t1;
 (1 row)
 
 ALTER TYPE tc1 RENAME TO tc1_newname;
-INSERT INTO t1 VALUES (3, (4,5)::tc1_newname); -- insert with a cast would fail if the rename didn't propagate
+INSERT INTO t1 VALUES (3, (4,'5')::tc1_newname); -- insert with a cast would fail if the rename didn't propagate
 ALTER TYPE tc1_newname SET SCHEMA type_tests2;
-INSERT INTO t1 VALUES (6, (7,8)::type_tests2.tc1_newname); -- insert with a cast would fail if the rename didn't propagate
--- single statement transactions with a an enum used in a table
+INSERT INTO t1 VALUES (6, (7,'8')::type_tests2.tc1_newname); -- insert with a cast would fail if the rename didn't propagate
+-- verify typmod was propagated
+SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum = 2 AND attrelid = (SELECT typrelid FROM pg_type WHERE typname = 'tc1_newname');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,24)
+ (localhost,57638,t,24)
+(2 rows)
+
+-- single statement transactions with an enum used in a table
 CREATE TYPE te1 AS ENUM ('one', 'two', 'three');
 CREATE TABLE t2 (a int PRIMARY KEY, b te1);
 SELECT create_distributed_table('t2','a');
@@ -65,7 +73,7 @@ ALTER TYPE te1_newname SET SCHEMA type_tests2;
 INSERT INTO t2 VALUES (3, 'three'::type_tests2.te1_newname);
 -- transaction block with simple type
 BEGIN;
-CREATE TYPE tc2 AS (a int, b int);
+CREATE TYPE tc2 AS (a varchar(10), b int);
 CREATE TABLE t3 (a int PRIMARY KEY, b tc2);
 SELECT create_distributed_table('t3','a');
  create_distributed_table
@@ -73,12 +81,20 @@ SELECT create_distributed_table('t3','a');
 
 (1 row)
 
-INSERT INTO t3 VALUES (4, (5,6)::tc2);
+INSERT INTO t3 VALUES (4, ('5',6)::tc2);
 SELECT * FROM t3;
  a |   b
 ---------------------------------------------------------------------
  4 | (5,6)
 (1 row)
+
+-- verify typmod was propagated
+SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum = 1 AND attrelid = (SELECT typrelid FROM pg_type WHERE typname = 'tc2');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,14)
+ (localhost,57638,t,14)
+(2 rows)
 
 COMMIT;
 -- transaction block with simple type

--- a/src/test/regress/expected/multi_mx_create_type.out
+++ b/src/test/regress/expected/multi_mx_create_type.out
@@ -1,0 +1,36 @@
+-- Tests related to create type
+
+CREATE TYPE create_order_delegator_t AS (
+     out_w_tax decimal(4, 4),
+     out_d_tax decimal(4, 4),
+     out_o_id integer,
+     out_c_discount decimal(4, 4),
+     out_c_last varchar(16),
+     out_c_credit char(2),
+     out_o_entry_d timestamp
+);
+
+\d create_order_delegator_t
+               Composite type "public.create_order_delegator_t"
+     Column     |            Type             | Collation | Nullable | Default
+----------------+-----------------------------+-----------+----------+---------
+ out_w_tax      | numeric(4,4)                |           |          |
+ out_d_tax      | numeric(4,4)                |           |          |
+ out_o_id       | integer                     |           |          |
+ out_c_discount | numeric(4,4)                |           |          |
+ out_c_last     | character varying(16)       |           |          |
+ out_c_credit   | character(2)                |           |          |
+ out_o_entry_d  | timestamp without time zone |           |          |
+
+\c - - - :worker_1_port
+\d create_order_delegator_t
+               Composite type "public.create_order_delegator_t"
+     Column     |            Type             | Collation | Nullable | Default
+----------------+-----------------------------+-----------+----------+---------
+ out_w_tax      | numeric(4,4)                |           |          |
+ out_d_tax      | numeric(4,4)                |           |          |
+ out_o_id       | integer                     |           |          |
+ out_c_discount | numeric(4,4)                |           |          |
+ out_c_last     | character varying(16)       |           |          |
+ out_c_credit   | character(2)                |           |          |
+ out_o_entry_d  | timestamp without time zone |           |          |

--- a/src/test/regress/expected/multi_mx_create_type.out
+++ b/src/test/regress/expected/multi_mx_create_type.out
@@ -1,5 +1,4 @@
 -- Tests related to create type
-
 CREATE TYPE create_order_delegator_t AS (
      out_w_tax decimal(4, 4),
      out_d_tax decimal(4, 4),
@@ -9,11 +8,10 @@ CREATE TYPE create_order_delegator_t AS (
      out_c_credit char(2),
      out_o_entry_d timestamp
 );
-
 \d create_order_delegator_t
                Composite type "public.create_order_delegator_t"
      Column     |            Type             | Collation | Nullable | Default
-----------------+-----------------------------+-----------+----------+---------
+---------------------------------------------------------------------
  out_w_tax      | numeric(4,4)                |           |          |
  out_d_tax      | numeric(4,4)                |           |          |
  out_o_id       | integer                     |           |          |
@@ -26,7 +24,7 @@ CREATE TYPE create_order_delegator_t AS (
 \d create_order_delegator_t
                Composite type "public.create_order_delegator_t"
      Column     |            Type             | Collation | Nullable | Default
-----------------+-----------------------------+-----------+----------+---------
+---------------------------------------------------------------------
  out_w_tax      | numeric(4,4)                |           |          |
  out_d_tax      | numeric(4,4)                |           |          |
  out_o_id       | integer                     |           |          |
@@ -34,3 +32,4 @@ CREATE TYPE create_order_delegator_t AS (
  out_c_last     | character varying(16)       |           |          |
  out_c_credit   | character(2)                |           |          |
  out_o_entry_d  | timestamp without time zone |           |          |
+

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -21,6 +21,7 @@ test: multi_mx_function_table_reference
 test: multi_test_catalog_views
 
 # the following test has to be run sequentially
+test: multi_mx_create_type
 test: multi_mx_create_table
 test: multi_mx_hide_shard_names
 test: multi_mx_add_coordinator

--- a/src/test/regress/sql/multi_mx_create_type.sql
+++ b/src/test/regress/sql/multi_mx_create_type.sql
@@ -1,0 +1,16 @@
+-- Tests related to create type
+
+CREATE TYPE create_order_delegator_t AS (
+     out_w_tax decimal(4, 4),
+     out_d_tax decimal(4, 4),
+     out_o_id integer,
+     out_c_discount decimal(4, 4),
+     out_c_last varchar(16),
+     out_c_credit char(2),
+     out_o_entry_d timestamp
+);
+
+\d create_order_delegator_t
+
+\c - - - :worker_1_port
+\d create_order_delegator_t

--- a/src/test/regress/sql/multi_mx_create_type.sql
+++ b/src/test/regress/sql/multi_mx_create_type.sql
@@ -14,3 +14,4 @@ CREATE TYPE create_order_delegator_t AS (
 
 \c - - - :worker_1_port
 \d create_order_delegator_t
+


### PR DESCRIPTION
## Scenario
When executing CREATE TYPE mytype AS (name varchar(16)) on coordinator, MX will receive wrong command CREATE TYPE mytype AS (name character varying).

## Root cause
In AppendColumnDef function, it use format_type_be_qualified to deparse column type definition, but it will wrongly convert varchar(16) to character varying.

## Fix approach
The correct approach to deparse varchar(16) is to use format_type_extended, this function could reserve typemod information.

## Issue
CREATE TYPE command sync from coordinator to MX wrongly #3646 