### PR TITLE
Remove metadata locks from size functions

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -301,18 +301,6 @@ ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId)
 			 placementIndex++)
 		{
 			GroupShardPlacement *placement = &placementArray[placementIndex];
-			uint64 shardId = placement->shardId;
-
-			bool metadataLock = TryLockShardDistributionMetadata(shardId, ShareLock);
-
-			/* if the lock is not acquired warn the user */
-			if (metadataLock == false)
-			{
-				ereport(WARNING, (errcode(ERRCODE_LOCK_NOT_AVAILABLE),
-								  errmsg("lock is not acquired, size of shard "
-										 UINT64_FORMAT " will be ignored", shardId)));
-				continue;
-			}
 
 			if (placement->groupId == workerNode->groupId)
 			{


### PR DESCRIPTION
DESCRIPTION: Adds support for querying distributed table sizes concurrently

We used to take locks on shard metadata for querying distributed table sizes. That means we cannot see the sizes of reference tables during master_add_node since all shards will be locked.

This PR removes the locks used in the UDFs below:
- citus_total_relation_size
- citus_relation_size
- citus_table_size

Fixes: #3379 