### PR TITLE
multi_copy.c: remove tableMetadata

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2133,9 +2133,6 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	 */
 	SerializeNonCommutativeWrites(shardIntervalList, RowExclusiveLock);
 
-	/* keep the table metadata to avoid looking it up for every tuple */
-	copyDest->tableMetadata = cacheEntry;
-
 	UseCoordinatedTransaction();
 
 	if (cacheEntry->replicationModel == REPLICATION_MODEL_2PC ||
@@ -2480,8 +2477,9 @@ ShardIdForTuple(CitusCopyDestReceiver *copyDest, Datum *columnValues, bool *colu
 	 * For reference table, this function blindly returns the tables single
 	 * shard.
 	 */
-	ShardInterval *shardInterval = FindShardInterval(partitionColumnValue,
-													 copyDest->tableMetadata);
+	CitusTableCacheEntry *cacheEntry =
+		GetCitusTableCacheEntry(copyDest->distributedRelationId);
+	ShardInterval *shardInterval = FindShardInterval(partitionColumnValue, cacheEntry);
 	if (shardInterval == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -88,9 +88,6 @@ typedef struct CitusCopyDestReceiver
 	List *columnNameList;
 	int partitionColumnIndex;
 
-	/* distributed table metadata */
-	CitusTableCacheEntry *tableMetadata;
-
 	/* open relation handle */
 	Relation distributedRelation;
 


### PR DESCRIPTION
I created a branch [check-for-invalid-cache](https://github.com/citusdata/citus/commit/eff2eb973e5bbab47db389682b08c15041784395), this was able to hit errors:
https://app.circleci.com/pipelines/github/citusdata/citus/7706/workflows/bead06b4-97f1-4f90-8bbd-f6d9de058bcb/jobs/108946
https://app.circleci.com/pipelines/github/citusdata/citus/7706/workflows/bead06b4-97f1-4f90-8bbd-f6d9de058bcb/jobs/108939

May be related to #3581 