### PR TITLE
not append the delimiter to the end in StringJoin

### DIFF
--- a/src/backend/distributed/utils/listutils.c
+++ b/src/backend/distributed/utils/listutils.c
@@ -165,10 +165,15 @@ StringJoin(List *stringList, char delimiter)
 	StringInfo joinedString = makeStringInfo();
 
 	const char *command = NULL;
+	int curIndex = 0;
 	foreach_ptr(command, stringList)
 	{
+		if (curIndex > 0)
+		{
+			appendStringInfoChar(joinedString, delimiter);
+		}
 		appendStringInfoString(joinedString, command);
-		appendStringInfoChar(joinedString, delimiter);
+		curIndex++;
 	}
 
 	return joinedString->data;


### PR DESCRIPTION
StringJoin appends the delimiter at the end of the list as well, however ideally it should not do that since it creates strings as `q1;q2;`. We want the concatenated query string to be `q1;q2`.

It is interesting that no test output changes. 
