### PR TITLE
Release less locks in metadata_cache.c

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -996,7 +996,7 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 	}
 
 	systable_endscan(pgDistObjectScan);
-	relation_close(pgDistObjectRel, AccessShareLock);
+	relation_close(pgDistObjectRel, NoLock);
 
 	return cacheEntry;
 }
@@ -1183,7 +1183,7 @@ BuildCachedShardList(CitusTableCacheEntry *cacheEntry)
 			arrayIndex++;
 		}
 
-		heap_close(distShardRelation, AccessShareLock);
+		heap_close(distShardRelation, NoLock);
 
 		ShardInterval *firstShardInterval = shardIntervalArray[0];
 		bool foundInCache = false;
@@ -3555,7 +3555,7 @@ DistTableOidList(void)
 	}
 
 	systable_endscan(scanDescriptor);
-	heap_close(pgDistPartition, AccessShareLock);
+	heap_close(pgDistPartition, NoLock);
 
 	return distTableOidList;
 }
@@ -3656,7 +3656,7 @@ LookupDistShardTuples(Oid relationId)
 	}
 
 	systable_endscan(scanDescriptor);
-	heap_close(pgDistShard, AccessShareLock);
+	heap_close(pgDistShard, NoLock);
 
 	return distShardTupleList;
 }


### PR DESCRIPTION
In discussion with @jeff-davis he advised that we should be relying more heavily on postgres locking rather than invalidation messages

While reviewing the code, it was noticed that we're not maintaining locks when we release tuples. This shouldn't be done if we're going to continue reading the values we read, which is the case for `sortedShardIntervalArray`

This PR implements stricter locking

Trying to come up with a reproducible test. `insert_select_executor.c`'s `CoordinatorInsertSelectExecScanInternal` has the two `GetCitusTableCacheEntry` calls in separate conditional blocks. However `ExecutePartitionTaskList` looks like something where `partition_index` could cause trouble due to lock being released while we assume it'll return an in bounds index