### PR TITLE
Correctly handle non-constant LIMIT/OFFSET clauses

### DIFF
--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1024,6 +1024,17 @@ DeferErrorIfQueryNotSupported(Query *queryTree)
 		errorHint = filterHint;
 	}
 
+	if (FindNodeCheck((Node *) queryTree->limitCount, IsNodeSubquery))
+	{
+		preconditionsSatisfied = false;
+		errorMessage = "subquery in LIMIT is not supported in multi-shard queries";
+	}
+
+	if (FindNodeCheck((Node *) queryTree->limitOffset, IsNodeSubquery))
+	{
+		preconditionsSatisfied = false;
+		errorMessage = "subquery in OFFSET is not supported in multi-shard queries";
+	}
 
 	/* finally check and error out if not satisfied */
 	if (!preconditionsSatisfied)

--- a/src/test/regress/expected/multi_limit_clause.out
+++ b/src/test/regress/expected/multi_limit_clause.out
@@ -520,4 +520,41 @@ SELECT
 (1 row)
 
 SET client_min_messages TO NOTICE;
+-- non constants should not push down
+CREATE OR REPLACE FUNCTION my_limit()
+RETURNS INT AS $$
+BEGIN
+  RETURN 5;
+END; $$ language plpgsql VOLATILE;
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT my_limit();
+ l_orderkey
+---------------------------------------------------------------------
+          1
+          1
+          1
+          1
+          1
+(5 rows)
+
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limit();
+ l_orderkey
+---------------------------------------------------------------------
+          1
+          2
+          3
+          3
+          3
+          3
+          3
+          3
+          4
+          5
+(10 rows)
+
+DROP FUNCTION my_limit();
+-- subqueries should error out
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
+ERROR:  subquery in LIMIT is not supported in multi-shard queries
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
+ERROR:  subquery in OFFSET is not supported in multi-shard queries
 DROP TABLE lineitem_hash;

--- a/src/test/regress/sql/multi_limit_clause.sql
+++ b/src/test/regress/sql/multi_limit_clause.sql
@@ -223,4 +223,21 @@ SELECT
 	LIMIT 5;
 
 SET client_min_messages TO NOTICE;
+
+-- non constants should not push down
+CREATE OR REPLACE FUNCTION my_limit()
+RETURNS INT AS $$
+BEGIN
+  RETURN 5;
+END; $$ language plpgsql VOLATILE;
+
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT my_limit();
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limit();
+
+DROP FUNCTION my_limit();
+
+-- subqueries should error out
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
+
 DROP TABLE lineitem_hash;


### PR DESCRIPTION
DESCRIPTION: Fixes an issue that could crashes when using a non-constant limit clause

This PR ensures that we only push down constant limit clauses and error out when the LIMIT/OFFSET contains a sublink, which currently results a segmentation fault.

Fixes #2976 