### PR TITLE
Throttle connections to the worker  nodes

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -64,7 +64,6 @@
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
-
 bool EnableDDLPropagation = true; /* ddl propagation is enabled */
 PropSetCmdBehavior PropagateSetCommands = PROPSETCMD_NONE; /* SET prop off */
 static bool shouldInvalidateForeignKeyGraph = false;

--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -1,0 +1,217 @@
+/*-------------------------------------------------------------------------
+ *
+ * shared_connection_stats.c
+ *   Keeps track of the number of connections to remote nodes across
+ *   backends. The primary goal is to prevent excessive number of
+ *   connections (typically > max_connections) to any worker node.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "pgstat.h"
+
+#include "libpq-fe.h"
+
+#include "miscadmin.h"
+
+#include "access/hash.h"
+
+#include "distributed/connection_management.h"
+#include "distributed/shared_connection_stats.h"
+#include "utils/hashutils.h"
+#include "utils/hsearch.h"
+#include "storage/ipc.h"
+
+
+/*
+ * The data structure used to store data in shared memory. This data structure only
+ * used for storing the lock. The actual statistics about the connections are stored
+ * in the hashmap, which is allocated separately, as Postgres provides different APIs
+ * for allocating hashmaps in the shared memory.
+ */
+typedef struct ConnectionStatsSharedData
+{
+	int sharedConnectionHashTrancheId;
+	char *sharedConnectionHashTrancheName;
+	LWLock sharedConnectionHashLock;
+} ConnectionStatsSharedData;
+
+typedef struct SharedConnStatsHashKey
+{
+	/*
+	 * Using nodeId (over hostname/hostport) make the tracking resiliant to
+	 * master_update_node(). Plus, requires a little less memory.
+	 */
+	uint32 nodeId;
+
+	/*
+	 * Given that citus.shared_max_pool_size can be defined per database, we
+	 * should keep track of shared connections per database.
+	 */
+	char database[NAMEDATALEN];
+} SharedConnStatsHashKey;
+
+/* hash entry for per worker stats */
+typedef struct SharedConnStatsHashEntry
+{
+	SharedConnStatsHashKey key;
+
+	int connectionCount;
+} SharedConnStatsHashEntry;
+
+
+/*
+ * Controlled via a GUC.
+ *
+ * By default, Citus tracks 1024 worker nodes, which is already
+ * very unlikely number of worker nodes. Given that the shared
+ * memory required per worker is pretty small (~120 Bytes), we think it
+ * is a good default that wouldn't hurt any users in any dimension.
+ */
+int MaxTrackedWorkerNodes = 1024;
+
+/* the following two structs used for accessing shared memory */
+static HTAB *SharedConnStatsHash = NULL;
+static ConnectionStatsSharedData *ConnectionStatsSharedState = NULL;
+
+
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+
+
+/* local function declarations */
+static void SharedConnectionStatsShmemInit(void);
+static size_t SharedConnectionStatsShmemSize(void);
+static int SharedConnectionHashCompare(const void *a, const void *b, Size keysize);
+static uint32 SharedConnectionHashHash(const void *key, Size keysize);
+
+
+/*
+ * InitializeSharedConnectionStats requests the necessary shared memory
+ * from Postgres and sets up the shared memory startup hook.
+ */
+void
+InitializeSharedConnectionStats(void)
+{
+	/* allocate shared memory */
+	if (!IsUnderPostmaster)
+	{
+		RequestAddinShmemSpace(SharedConnectionStatsShmemSize());
+	}
+
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = SharedConnectionStatsShmemInit;
+}
+
+
+/*
+ * SharedConnectionStatsShmemSize returns the size that should be allocated
+ * on the shared memory for shared connection stats.
+ */
+static size_t
+SharedConnectionStatsShmemSize(void)
+{
+	Size size = 0;
+
+	size = add_size(size, sizeof(ConnectionStatsSharedData));
+	size = add_size(size, mul_size(sizeof(LWLock), MaxTrackedWorkerNodes));
+
+	Size hashSize = hash_estimate_size(MaxTrackedWorkerNodes,
+									   sizeof(SharedConnStatsHashEntry));
+
+	size = add_size(size, hashSize);
+
+	return size;
+}
+
+
+/*
+ * SharedConnectionStatsShmemInit initializes the shared memory used
+ * for keeping track of connection stats across backends.
+ */
+static void
+SharedConnectionStatsShmemInit(void)
+{
+	bool alreadyInitialized = false;
+	HASHCTL info;
+
+	/* create (nodeId,database) -> [counter] */
+	memset(&info, 0, sizeof(info));
+	info.keysize = sizeof(SharedConnStatsHashKey);
+	info.entrysize = sizeof(SharedConnStatsHashEntry);
+	info.hash = SharedConnectionHashHash;
+	info.match = SharedConnectionHashCompare;
+	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_COMPARE);
+
+	/*
+	 * Currently the lock isn't required because allocation only happens at
+	 * startup in postmaster, but it doesn't hurt, and makes things more
+	 * consistent with other extensions.
+	 */
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+
+	ConnectionStatsSharedState =
+		(ConnectionStatsSharedData *) ShmemInitStruct(
+			"Shared Connection Stats Data",
+			sizeof(ConnectionStatsSharedData),
+			&alreadyInitialized);
+
+	if (!alreadyInitialized)
+	{
+		ConnectionStatsSharedState->sharedConnectionHashTrancheId = LWLockNewTrancheId();
+		ConnectionStatsSharedState->sharedConnectionHashTrancheName =
+			"Shared Connection Tracking Hash Tranche";
+		LWLockRegisterTranche(ConnectionStatsSharedState->sharedConnectionHashTrancheId,
+							  ConnectionStatsSharedState->sharedConnectionHashTrancheName);
+
+		LWLockInitialize(&ConnectionStatsSharedState->sharedConnectionHashLock,
+						 ConnectionStatsSharedState->sharedConnectionHashTrancheId);
+	}
+
+	/*  allocate hash table */
+	SharedConnStatsHash =
+		ShmemInitHash("Shared Conn. Stats Hash", MaxTrackedWorkerNodes,
+					  MaxTrackedWorkerNodes, &info, hashFlags);
+
+	LWLockRelease(AddinShmemInitLock);
+
+	Assert(SharedConnStatsHash != NULL);
+	Assert(ConnectionStatsSharedState->sharedConnectionHashTrancheId != 0);
+
+	if (prev_shmem_startup_hook != NULL)
+	{
+		prev_shmem_startup_hook();
+	}
+}
+
+
+static uint32
+SharedConnectionHashHash(const void *key, Size keysize)
+{
+	SharedConnStatsHashKey *entry = (SharedConnStatsHashKey *) key;
+
+	uint32 hash = hash_uint32(entry->nodeId);
+	hash = hash_combine(hash, string_hash(entry->database, NAMEDATALEN));
+
+	return hash;
+}
+
+
+static int
+SharedConnectionHashCompare(const void *a, const void *b, Size keysize)
+{
+	SharedConnStatsHashKey *ca = (SharedConnStatsHashKey *) a;
+	SharedConnStatsHashKey *cb = (SharedConnStatsHashKey *) b;
+
+	if (ca->nodeId != cb->nodeId ||
+		strncmp(ca->database, cb->database, NAMEDATALEN) != 0)
+	{
+		return 1;
+	}
+	else
+	{
+		return 0;
+	}
+}

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -56,6 +56,7 @@
 #include "distributed/reference_table_utils.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/run_from_same_connection.h"
+#include "distributed/shared_connection_stats.h"
 #include "distributed/query_pushdown_planning.h"
 #include "distributed/time_constants.h"
 #include "distributed/query_stats.h"
@@ -271,6 +272,7 @@ _PG_init(void)
 	InitializeConnectionManagement();
 	InitPlacementConnectionManagement();
 	InitializeCitusQueryStats();
+	InitializeSharedConnectionStats();
 
 	atexit(CitusBackendAtExit);
 
@@ -1010,6 +1012,23 @@ RegisterCitusConfigVariables(void)
 		PGC_POSTMASTER,
 		GUC_STANDARD,
 		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"citus.max_tracked_worker_nodes",
+		gettext_noop("Sets the maximum number of worker tracked."),
+		gettext_noop("Citus doesn't have any limitations in terms of the "
+					 "number of worker nodes allowed in the cluster. But, "
+					 "Citus keeps some information about the worker nodes "
+					 "in the shared memory for certain optimizations. The "
+					 "optimizations are enforced up to this number of worker "
+					 "nodes. Any additional worker nodes may not benefit from"
+					 "the optimizations."),
+		&MaxTrackedWorkerNodes,
+		1024, 256, INT_MAX,
+		PGC_POSTMASTER,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
 
 	DefineCustomIntVariable(
 		"citus.max_running_tasks_per_node",

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -73,6 +73,7 @@
 #include "distributed/adaptive_executor.h"
 #include "port/atomics.h"
 #include "postmaster/postmaster.h"
+#include "storage/ipc.h"
 #include "optimizer/planner.h"
 #include "optimizer/paths.h"
 #include "tcop/tcopprot.h"
@@ -89,9 +90,10 @@ static char *CitusVersion = CITUS_VERSION;
 
 void _PG_init(void);
 
-static void CitusBackendAtExit(void);
 static void ResizeStackToMaximumDepth(void);
 static void multi_log_hook(ErrorData *edata);
+static void RegisterConnectionCleanup(void);
+static void CitusCleanupConnectionsAtExit(int code, Datum arg);
 static void CreateRequiredDirectories(void);
 static void RegisterCitusConfigVariables(void);
 static bool ErrorIfNotASuitableDeadlockFactor(double *newval, void **extra,
@@ -99,6 +101,7 @@ static bool ErrorIfNotASuitableDeadlockFactor(double *newval, void **extra,
 static bool WarnIfDeprecatedExecutorUsed(int *newval, void **extra, GucSource source);
 static bool NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source);
 static void NodeConninfoGucAssignHook(const char *newval, void *extra);
+static const char * MaxSharedPoolSizeGucShowHook(void);
 static bool StatisticsCollectionGucCheckHook(bool *newval, void **extra, GucSource
 											 source);
 
@@ -274,26 +277,12 @@ _PG_init(void)
 	InitializeCitusQueryStats();
 	InitializeSharedConnectionStats();
 
-	atexit(CitusBackendAtExit);
-
 	/* enable modification of pg_catalog tables during pg_upgrade */
 	if (IsBinaryUpgrade)
 	{
 		SetConfigOption("allow_system_table_mods", "true", PGC_POSTMASTER,
 						PGC_S_OVERRIDE);
 	}
-}
-
-
-/*
- * CitusBackendAtExit is called atexit of the backend for the purposes of
- * any clean-up needed.
- */
-static void
-CitusBackendAtExit(void)
-{
-	/* properly close all the cached connections */
-	ShutdownAllConnections();
 }
 
 
@@ -382,6 +371,37 @@ StartupCitusBackend(void)
 {
 	InitializeMaintenanceDaemonBackend();
 	InitializeBackendData();
+	RegisterConnectionCleanup();
+}
+
+
+/*
+ * RegisterConnectionCleanup cleans up any resources left at the end of the
+ * session. We prefer to cleanup before shared memory exit to make sure that
+ * this session properly releases anything hold in the shared memory.
+ */
+static void
+RegisterConnectionCleanup(void)
+{
+	static bool registeredCleanup = false;
+	if (registeredCleanup == false)
+	{
+		before_shmem_exit(CitusCleanupConnectionsAtExit, 0);
+
+		registeredCleanup = true;
+	}
+}
+
+
+/*
+ * CitusCleanupConnectionsAtExit is called before_shmem_exit() of the
+ * backend for the purposes of any clean-up needed.
+ */
+static void
+CitusCleanupConnectionsAtExit(int code, Datum arg)
+{
+	/* properly close all the cached connections */
+	ShutdownAllConnections();
 }
 
 
@@ -931,15 +951,34 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
+		"citus.max_shared_pool_size",
+		gettext_noop("Sets the maximum number of connections allowed per worker node "
+					 "across all the backends from this node. Setting to -1 disables "
+					 "connections throttling. Setting to 0 makes it auto-adjust, meaning "
+					 "equal to max_connections on the coordinator."),
+		gettext_noop("As a rule of thumb, the value should be at most equal to the "
+					 "max_connections on the remote nodes."),
+		&MaxSharedPoolSize,
+		0, -1, INT_MAX,
+		PGC_SIGHUP,
+		GUC_SUPERUSER_ONLY,
+		NULL, NULL, MaxSharedPoolSizeGucShowHook);
+
+	DefineCustomIntVariable(
 		"citus.max_worker_nodes_tracked",
 		gettext_noop("Sets the maximum number of worker nodes that are tracked."),
 		gettext_noop("Worker nodes' network locations, their membership and "
 					 "health status are tracked in a shared hash table on "
 					 "the master node. This configuration value limits the "
 					 "size of the hash table, and consequently the maximum "
-					 "number of worker nodes that can be tracked."),
+					 "number of worker nodes that can be tracked."
+					 "Citus keeps some information about the worker nodes "
+					 "in the shared memory for certain optimizations. The "
+					 "optimizations are enforced up to this number of worker "
+					 "nodes. Any additional worker nodes may not benefit from"
+					 "the optimizations."),
 		&MaxWorkerNodesTracked,
-		2048, 8, INT_MAX,
+		2048, 1024, INT_MAX,
 		PGC_POSTMASTER,
 		GUC_STANDARD,
 		NULL, NULL, NULL);
@@ -1012,23 +1051,6 @@ RegisterCitusConfigVariables(void)
 		PGC_POSTMASTER,
 		GUC_STANDARD,
 		NULL, NULL, NULL);
-
-	DefineCustomIntVariable(
-		"citus.max_tracked_worker_nodes",
-		gettext_noop("Sets the maximum number of worker tracked."),
-		gettext_noop("Citus doesn't have any limitations in terms of the "
-					 "number of worker nodes allowed in the cluster. But, "
-					 "Citus keeps some information about the worker nodes "
-					 "in the shared memory for certain optimizations. The "
-					 "optimizations are enforced up to this number of worker "
-					 "nodes. Any additional worker nodes may not benefit from"
-					 "the optimizations."),
-		&MaxTrackedWorkerNodes,
-		1024, 256, INT_MAX,
-		PGC_POSTMASTER,
-		GUC_STANDARD,
-		NULL, NULL, NULL);
-
 
 	DefineCustomIntVariable(
 		"citus.max_running_tasks_per_node",
@@ -1536,6 +1558,28 @@ NodeConninfoGucAssignHook(const char *newval, void *extra)
 	 * be unencrypted when the user doesn't want that.
 	 */
 	CloseAllConnectionsAfterTransaction();
+}
+
+
+/*
+ * MaxSharedPoolSizeGucShowHook overrides the value that is shown to the
+ * user when the default value has not been set.
+ */
+static const char *
+MaxSharedPoolSizeGucShowHook(void)
+{
+	StringInfo newvalue = makeStringInfo();
+
+	if (MaxSharedPoolSize == 0)
+	{
+		appendStringInfo(newvalue, "%d", GetMaxSharedPoolSize());
+	}
+	else
+	{
+		appendStringInfo(newvalue, "%d", MaxSharedPoolSize);
+	}
+
+	return (const char *) newvalue->data;
 }
 
 

--- a/src/backend/distributed/sql/citus--9.2-4--9.3-2.sql
+++ b/src/backend/distributed/sql/citus--9.2-4--9.3-2.sql
@@ -5,3 +5,4 @@
 #include "udfs/citus_extradata_container/9.3-2.sql"
 #include "udfs/update_distributed_table_colocation/9.3-2.sql"
 #include "udfs/replicate_reference_tables/9.3-2.sql"
+#include "udfs/citus_remote_connection_stats/9.3-2.sql"

--- a/src/backend/distributed/sql/citus--9.3-1--9.3-2.sql
+++ b/src/backend/distributed/sql/citus--9.3-1--9.3-2.sql
@@ -1,0 +1,1 @@
+#include "udfs/citus_remote_connection_stats/9.3-2.sql"

--- a/src/backend/distributed/sql/citus--9.3-1--9.3-2.sql
+++ b/src/backend/distributed/sql/citus--9.3-1--9.3-2.sql
@@ -1,1 +1,0 @@
-#include "udfs/citus_remote_connection_stats/9.3-2.sql"

--- a/src/backend/distributed/sql/udfs/citus_remote_connection_stats/9.3-2.sql
+++ b/src/backend/distributed/sql/udfs/citus_remote_connection_stats/9.3-2.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
+	RETURNS SETOF RECORD
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', $$citus_remote_connection_stats$$;
+ COMMENT ON FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
+     IS 'returns statistics about remote connections';

--- a/src/backend/distributed/sql/udfs/citus_remote_connection_stats/9.3-2.sql
+++ b/src/backend/distributed/sql/udfs/citus_remote_connection_stats/9.3-2.sql
@@ -1,6 +1,22 @@
-CREATE OR REPLACE FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
-	RETURNS SETOF RECORD
-	LANGUAGE C STRICT
-	AS 'MODULE_PATHNAME', $$citus_remote_connection_stats$$;
- COMMENT ON FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
+CREATE OR REPLACE FUNCTION pg_catalog.citus_remote_connection_stats(
+	OUT hostname text,
+	OUT port int,
+	OUT database_name text,
+	OUT connection_count_to_node int)
+RETURNS SETOF RECORD
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_remote_connection_stats$$;
+
+COMMENT ON FUNCTION pg_catalog.citus_remote_connection_stats(
+	OUT hostname text,
+	OUT port int,
+	OUT database_name text,
+	OUT connection_count_to_node int)
      IS 'returns statistics about remote connections';
+
+REVOKE ALL ON FUNCTION pg_catalog.citus_remote_connection_stats(
+		OUT hostname text,
+		OUT port int,
+		OUT database_name text,
+		OUT connection_count_to_node int)
+FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_remote_connection_stats/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_remote_connection_stats/latest.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
+	RETURNS SETOF RECORD
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', $$citus_remote_connection_stats$$;
+ COMMENT ON FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
+     IS 'returns statistics about remote connections';

--- a/src/backend/distributed/sql/udfs/citus_remote_connection_stats/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_remote_connection_stats/latest.sql
@@ -1,6 +1,22 @@
-CREATE OR REPLACE FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
-	RETURNS SETOF RECORD
-	LANGUAGE C STRICT
-	AS 'MODULE_PATHNAME', $$citus_remote_connection_stats$$;
- COMMENT ON FUNCTION citus_remote_connection_stats(OUT node_id int, OUT database_name text, OUT connection_count_to_node int)
+CREATE OR REPLACE FUNCTION pg_catalog.citus_remote_connection_stats(
+	OUT hostname text,
+	OUT port int,
+	OUT database_name text,
+	OUT connection_count_to_node int)
+RETURNS SETOF RECORD
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_remote_connection_stats$$;
+
+COMMENT ON FUNCTION pg_catalog.citus_remote_connection_stats(
+	OUT hostname text,
+	OUT port int,
+	OUT database_name text,
+	OUT connection_count_to_node int)
      IS 'returns statistics about remote connections';
+
+REVOKE ALL ON FUNCTION pg_catalog.citus_remote_connection_stats(
+		OUT hostname text,
+		OUT port int,
+		OUT database_name text,
+		OUT connection_count_to_node int)
+FROM PUBLIC;

--- a/src/backend/distributed/test/shared_connection_counters.c
+++ b/src/backend/distributed/test/shared_connection_counters.c
@@ -1,0 +1,66 @@
+/*-------------------------------------------------------------------------
+ *
+ * test/src/sequential_execution.c
+ *
+ * This file contains functions to test setting citus.multi_shard_modify_mode
+ * GUC.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "miscadmin.h"
+#include "fmgr.h"
+
+#include "distributed/shared_connection_stats.h"
+#include "distributed/listutils.h"
+#include "nodes/parsenodes.h"
+#include "utils/guc.h"
+
+/* exports for SQL callable functions */
+PG_FUNCTION_INFO_V1(wake_up_connection_pool_waiters);
+PG_FUNCTION_INFO_V1(set_max_shared_pool_size);
+
+
+/*
+ * wake_up_waiters_backends is a SQL
+ * interface for testing WakeupWaiterBackendsForSharedConnection().
+ */
+Datum
+wake_up_connection_pool_waiters(PG_FUNCTION_ARGS)
+{
+	WakeupWaiterBackendsForSharedConnection();
+
+	PG_RETURN_VOID();
+}
+
+
+/*
+ * set_max_shared_pool_size is a SQL
+ * interface for setting MaxSharedPoolSize. We use this function in isolation
+ * tester where ALTER SYSTEM is not allowed.
+ */
+Datum
+set_max_shared_pool_size(PG_FUNCTION_ARGS)
+{
+	int value = PG_GETARG_INT32(0);
+
+	AlterSystemStmt *alterSystemStmt = palloc0(sizeof(AlterSystemStmt));
+
+	A_Const *aConstValue = makeNode(A_Const);
+
+	aConstValue->val = *makeInteger(value);
+	alterSystemStmt->setstmt = makeNode(VariableSetStmt);
+	alterSystemStmt->setstmt->name = "citus.max_shared_pool_size";
+	alterSystemStmt->setstmt->is_local = false;
+	alterSystemStmt->setstmt->kind = VAR_SET_VALUE;
+	alterSystemStmt->setstmt->args = list_make1(aConstValue);
+
+	AlterSystemSetConfigFile(alterSystemStmt);
+
+	kill(PostmasterPid, SIGHUP);
+
+	PG_RETURN_VOID();
+}

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -31,6 +31,7 @@
 #include "distributed/repartition_join_execution.h"
 #include "distributed/transaction_management.h"
 #include "distributed/placement_connection.h"
+#include "distributed/shared_connection_stats.h"
 #include "distributed/subplan_execution.h"
 #include "distributed/version_compat.h"
 #include "utils/hsearch.h"

--- a/src/include/distributed/shared_connection_stats.h
+++ b/src/include/distributed/shared_connection_stats.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * shared_connection_stats.h
+ *   Central management of connections and their life-cycle
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef SHARED_CONNECTION_STATS_H
+#define SHARED_CONNECTION_STATS_H
+
+extern int MaxTrackedWorkerNodes;
+
+extern void InitializeSharedConnectionStats(void);
+
+#endif /* SHARED_CONNECTION_STATS_H */

--- a/src/include/distributed/shared_connection_stats.h
+++ b/src/include/distributed/shared_connection_stats.h
@@ -11,8 +11,17 @@
 #ifndef SHARED_CONNECTION_STATS_H
 #define SHARED_CONNECTION_STATS_H
 
-extern int MaxTrackedWorkerNodes;
+extern int MaxSharedPoolSize;
+
 
 extern void InitializeSharedConnectionStats(void);
+extern void WaitForSharedConnection(void);
+extern void WakeupWaiterBackendsForSharedConnection(void);
+extern void RemoveInactiveNodesFromSharedConnections(void);
+extern int GetMaxSharedPoolSize(void);
+extern bool TryToIncrementSharedConnectionCounter(const char *hostname, int port);
+extern void WaitLoopForSharedConnection(const char *hostname, int port);
+extern void DecrementSharedConnectionCounter(const char *hostname, int port);
+extern void IncrementSharedConnectionCounter(const char *hostname, int port);
 
 #endif /* SHARED_CONNECTION_STATS_H */

--- a/src/test/regress/expected/ensure_no_shared_connection_leak.out
+++ b/src/test/regress/expected/ensure_no_shared_connection_leak.out
@@ -1,0 +1,160 @@
+-- this test file is intended to be called at the end
+-- of any test schedule, ensuring that there is not
+-- leak/wrong calculation of the connection stats
+-- in the shared memory
+CREATE SCHEMA ensure_no_shared_connection_leak;
+SET search_path TO ensure_no_shared_connection_leak;
+-- set the cached connections to zero
+-- and execute a distributed query so that
+-- we end up with zero cached connections afterwards
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- disable deadlock detection and re-trigger 2PC recovery
+-- once more when citus.max_cached_conns_per_worker is zero
+-- so that we can be sure that the connections established for
+-- maintanince daemon is closed properly.
+-- this is to prevent random failures in the tests (otherwise, we
+-- might see connections established for this operations)
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+-- now that last 2PC recovery is done, we're good to disable it
+ALTER SYSTEM SET citus.recover_2pc_interval TO '-1';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+CREATE TABLE test (a int);
+SELECT create_distributed_table('test', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- in case of MX, we should prevent deadlock detection and
+-- 2PC recover from the workers as well
+\c - - - :worker_1_port
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER SYSTEM SET citus.recover_2pc_interval TO '-1';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\c - - - :worker_2_port
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER SYSTEM SET citus.recover_2pc_interval TO '-1';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\c - - - :master_port
+SET search_path TO ensure_no_shared_connection_leak;
+-- ensure that we only have at most citus.max_cached_conns_per_worker
+-- connections per node
+select
+	(connection_count_to_node = 0) as no_connection_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY 1;
+ no_connection_to_node
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+-- now, ensure this from the workers perspective
+-- we should only see the connection/backend that is running the command below
+SELECT
+	result, success
+FROM
+	run_command_on_workers($$select count(*) from pg_stat_activity WHERE backend_type = 'client backend';$$)
+ORDER BY 1, 2;
+ result | success
+---------------------------------------------------------------------
+ 1      | t
+ 1      | t
+(2 rows)
+
+-- in case other tests relies on these setting, reset them
+ALTER SYSTEM RESET citus.distributed_deadlock_detection_factor;
+ALTER SYSTEM RESET citus.recover_2pc_interval;
+ALTER SYSTEM RESET citus.max_cached_conns_per_worker;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP SCHEMA ensure_no_shared_connection_leak CASCADE;
+NOTICE:  drop cascades to table test

--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -1,0 +1,391 @@
+CREATE SCHEMA shared_connection_stats;
+SET search_path TO shared_connection_stats;
+-- set the cached connections to zero
+-- and execute a distributed query so that
+-- we end up with zero cached connections afterwards
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- disable deadlock detection and re-trigger 2PC recovery
+-- once more when citus.max_cached_conns_per_worker is zero
+-- so that we can be sure that the connections established for
+-- maintanince daemon is closed properly.
+-- this is to prevent random failures in the tests (otherwise, we
+-- might see connections established for this operations)
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+-- now that last 2PC recovery is done, we're good to disable it
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1h';
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE test (a int);
+SELECT create_distributed_table('test', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO test SELECT i FROM generate_series(0,100)i;
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        0
+                        0
+(2 rows)
+
+-- single shard queries require single connection per node
+BEGIN;
+	SELECT count(*) FROM test WHERE a = 1;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+	SELECT count(*) FROM test WHERE a = 2;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        1
+                        1
+(2 rows)
+
+COMMIT;
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        0
+                        0
+(2 rows)
+
+-- executor is only allowed to establish a single connection per node
+BEGIN;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 1;
+	SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        1
+                        1
+(2 rows)
+
+COMMIT;
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        0
+                        0
+(2 rows)
+
+-- sequential mode is allowed to establish a single connection per node
+BEGIN;
+	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
+	SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        1
+                        1
+(2 rows)
+
+COMMIT;
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        0
+                        0
+(2 rows)
+
+-- now, decrease the shared pool size, and still force
+-- one connection per placement
+ALTER SYSTEM SET citus.max_shared_pool_size TO 5;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+	SET LOCAL citus.node_connection_timeout TO 1000;
+	SET LOCAL citus.force_max_query_parallelization TO ON;
+	SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+COMMIT;
+-- pg_sleep forces almost 1 connection per placement
+-- now, some of the optional connections would be skipped,
+-- and only 5 connections are used per node
+BEGIN;
+	SELECT count(*), pg_sleep(0.1) FROM test;
+ count | pg_sleep
+---------------------------------------------------------------------
+   101 |
+(1 row)
+
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        5
+                        5
+(2 rows)
+
+COMMIT;
+SHOW citus.max_shared_pool_size;
+ citus.max_shared_pool_size
+---------------------------------------------------------------------
+ 5
+(1 row)
+
+-- by default max_shared_pool_size equals to max_connections;
+ALTER SYSTEM RESET citus.max_shared_pool_size;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+SHOW citus.max_shared_pool_size;
+ citus.max_shared_pool_size
+---------------------------------------------------------------------
+ 100
+(1 row)
+
+SHOW max_connections;
+ max_connections
+---------------------------------------------------------------------
+ 100
+(1 row)
+
+-- now, each node gets 16 connections as we force 1 connection per placement
+BEGIN;
+	SET LOCAL citus.force_max_query_parallelization TO ON;
+	SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                       16
+                       16
+(2 rows)
+
+COMMIT;
+BEGIN;
+	-- now allow at most 1 connection, and ensure that intermediate
+	-- results don't require any extra connections
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 1;
+	SET LOCAL citus.task_assignment_policy TO "round-robin";
+	SELECT cnt FROM (SELECT count(*) as cnt, random() FROM test LIMIT 1) as foo;
+ cnt
+---------------------------------------------------------------------
+ 101
+(1 row)
+
+	-- queries with intermediate results don't use any extra connections
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        1
+                        1
+(2 rows)
+
+COMMIT;
+-- now show that when max_cached_conns_per_worker > 1
+-- Citus forces the first execution to open at least 2
+-- connections that are cached. Later, that 2 cached
+-- connections are user
+BEGIN;
+	SET LOCAL citus.max_cached_conns_per_worker TO 2;
+	SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+	SELECT
+		connection_count_to_node >= 2
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ ?column?
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+	SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+	SELECT
+		connection_count_to_node >= 2
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ ?column?
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+COMMIT;
+-- in case other tests relies on these setting, reset them
+ALTER SYSTEM RESET citus.distributed_deadlock_detection_factor;
+ALTER SYSTEM RESET citus.recover_2pc_interval;
+ALTER SYSTEM RESET citus.max_cached_conns_per_worker;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP SCHEMA shared_connection_stats CASCADE;
+NOTICE:  drop cascades to table test

--- a/src/test/regress/expected/shared_connection_waits.out
+++ b/src/test/regress/expected/shared_connection_waits.out
@@ -1,0 +1,33 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s3-lower-pool-size s1-begin s1-count-slow s3-increase-pool-size s2-select s1-commit
+step s3-lower-pool-size:
+	SELECT set_max_shared_pool_size(5);
+
+set_max_shared_pool_size
+
+
+step s1-begin:
+	BEGIN;
+
+step s1-count-slow:
+	SELECT pg_sleep(0.1), count(*) FROM test;
+
+pg_sleep       count
+
+               101
+step s3-increase-pool-size:
+	SELECT set_max_shared_pool_size(100);
+
+set_max_shared_pool_size
+
+
+step s2-select:
+       SELECT count(*) FROM test;
+
+count
+
+101
+step s1-commit:
+	COMMIT;
+

--- a/src/test/regress/failure_schedule
+++ b/src/test/regress/failure_schedule
@@ -37,3 +37,9 @@ test: failure_connection_establishment
 
 # test that no tests leaked intermediate results. This should always be last
 test: ensure_no_intermediate_data_leak
+
+# ---------
+# ensures that we never leak any connection counts
+# in the shared memory
+# --------
+test: ensure_no_shared_connection_leak

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -62,6 +62,7 @@ test: isolation_validate_vs_insert
 test: isolation_insert_select_conflict
 test: isolation_ref2ref_foreign_keys
 test: isolation_multiuser_locking
+test: shared_connection_waits
 
 # MX tests
 test: isolation_reference_on_mx

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -50,3 +50,9 @@ test: locally_execute_intermediate_results
 
 # test that no tests leaked intermediate results. This should always be last
 test: ensure_no_intermediate_data_leak
+
+# ---------
+# ensures that we never leak any connection counts
+# in the shared memory
+# --------
+test: ensure_no_shared_connection_leak

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -341,7 +341,19 @@ test: distributed_procedure
 # ---------
 test: multi_deparse_function multi_deparse_procedure
 
+# --------
+# cannot be run in parallel with any other tests as it checks
+# statistics across sessions
+# --------
+test: shared_connection_stats
+
 # ---------
 # test that no tests leaked intermediate results. This should always be last
 # ---------
 test: ensure_no_intermediate_data_leak
+
+# ---------
+# ensures that we never leak any connection counts
+# in the shared memory
+# --------
+test: ensure_no_shared_connection_leak

--- a/src/test/regress/multi_task_tracker_extra_schedule
+++ b/src/test/regress/multi_task_tracker_extra_schedule
@@ -115,3 +115,9 @@ test: multi_schema_support
 # test that no tests leaked intermediate results. This should always be last
 # ----------
 test: ensure_no_intermediate_data_leak
+
+# ---------
+# ensures that we never leak any connection counts
+# in the shared memory
+# --------
+test: ensure_no_shared_connection_leak

--- a/src/test/regress/spec/shared_connection_waits.spec
+++ b/src/test/regress/spec/shared_connection_waits.spec
@@ -1,0 +1,65 @@
+setup
+{
+   CREATE OR REPLACE FUNCTION wake_up_connection_pool_waiters()
+   RETURNS void
+   LANGUAGE C STABLE STRICT
+   AS 'citus', $$wake_up_connection_pool_waiters$$;
+
+   CREATE OR REPLACE FUNCTION set_max_shared_pool_size(int)
+   RETURNS void
+   LANGUAGE C STABLE STRICT
+   AS 'citus', $$set_max_shared_pool_size$$;
+
+   CREATE TABLE test (a int, b  int);
+   SET citus.shard_count TO 32;
+   SELECT create_distributed_table('test', 'a');
+   INSERT INTO test SELECT i, i FROM generate_series(0,100)i;
+}
+
+teardown
+{
+
+	 SELECT set_max_shared_pool_size(100);
+	DROP FUNCTION wake_up_connection_pool_waiters();
+	DROP FUNCTION set_max_shared_pool_size(int);
+}
+
+session "s1"
+
+
+step "s1-begin"
+{
+	BEGIN;
+}
+
+step "s1-count-slow"
+{
+	SELECT pg_sleep(0.1), count(*) FROM test;
+}
+
+step "s1-commit"
+{
+	COMMIT;
+}
+
+session "s2"
+
+step "s2-select"
+{
+       SELECT count(*) FROM test;
+}
+
+session "s3"
+
+step "s3-lower-pool-size"
+{
+	SELECT set_max_shared_pool_size(5);
+}
+
+step "s3-increase-pool-size"
+{
+	SELECT set_max_shared_pool_size(100);
+}
+
+permutation "s3-lower-pool-size" "s1-begin" "s1-count-slow" "s3-increase-pool-size" "s2-select" "s1-commit"
+

--- a/src/test/regress/sql/ensure_no_shared_connection_leak.sql
+++ b/src/test/regress/sql/ensure_no_shared_connection_leak.sql
@@ -1,0 +1,83 @@
+-- this test file is intended to be called at the end
+-- of any test schedule, ensuring that there is not
+-- leak/wrong calculation of the connection stats
+-- in the shared memory
+CREATE SCHEMA ensure_no_shared_connection_leak;
+SET search_path TO ensure_no_shared_connection_leak;
+
+-- set the cached connections to zero
+-- and execute a distributed query so that
+-- we end up with zero cached connections afterwards
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+
+-- disable deadlock detection and re-trigger 2PC recovery
+-- once more when citus.max_cached_conns_per_worker is zero
+-- so that we can be sure that the connections established for
+-- maintanince daemon is closed properly.
+-- this is to prevent random failures in the tests (otherwise, we
+-- might see connections established for this operations)
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.1);
+
+-- now that last 2PC recovery is done, we're good to disable it
+ALTER SYSTEM SET citus.recover_2pc_interval TO '-1';
+SELECT pg_reload_conf();
+
+CREATE TABLE test (a int);
+SELECT create_distributed_table('test', 'a');
+SELECT count(*) FROM test;
+
+-- in case of MX, we should prevent deadlock detection and
+-- 2PC recover from the workers as well
+\c - - - :worker_1_port
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.1);
+ALTER SYSTEM SET citus.recover_2pc_interval TO '-1';
+SELECT pg_reload_conf();
+\c - - - :worker_2_port
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.1);
+ALTER SYSTEM SET citus.recover_2pc_interval TO '-1';
+SELECT pg_reload_conf();
+
+\c - - - :master_port
+SET search_path TO ensure_no_shared_connection_leak;
+
+-- ensure that we only have at most citus.max_cached_conns_per_worker
+-- connections per node
+select
+	(connection_count_to_node = 0) as no_connection_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY 1;
+
+-- now, ensure this from the workers perspective
+-- we should only see the connection/backend that is running the command below
+SELECT
+	result, success
+FROM
+	run_command_on_workers($$select count(*) from pg_stat_activity WHERE backend_type = 'client backend';$$)
+ORDER BY 1, 2;
+
+
+-- in case other tests relies on these setting, reset them
+ALTER SYSTEM RESET citus.distributed_deadlock_detection_factor;
+ALTER SYSTEM RESET citus.recover_2pc_interval;
+ALTER SYSTEM RESET citus.max_cached_conns_per_worker;
+SELECT pg_reload_conf();
+
+DROP SCHEMA ensure_no_shared_connection_leak CASCADE;

--- a/src/test/regress/sql/node_conninfo_reload.sql
+++ b/src/test/regress/sql/node_conninfo_reload.sql
@@ -10,7 +10,6 @@ select create_distributed_table('test', 'a');
 
 -- Make sure a connection is opened and cached
 select count(*) from test where a = 0;
-
 show citus.node_conninfo;
 
 -- Set sslmode to something that does not work when connecting
@@ -30,8 +29,8 @@ show citus.node_conninfo;
 
 -- Should work again
 select count(*) from test where a = 0;
-
 ALTER SYSTEM SET citus.node_conninfo = 'sslmode=doesnotexist';
+
 BEGIN;
 -- Should still work (no SIGHUP yet);
 select count(*) from test where a = 0;
@@ -43,19 +42,15 @@ show citus.node_conninfo;
 -- query
 select count(*) from test where a = 0;
 COMMIT;
-
 -- Should fail now with connection error, when transaction is finished
 select count(*) from test where a = 0;
-
 -- Reset it again
 ALTER SYSTEM RESET citus.node_conninfo;
 select pg_reload_conf();
 select pg_sleep(0.1); -- wait for config reload to apply
 show citus.node_conninfo;
-
 -- Should work again
 select count(*) from test where a = 0;
-
 ALTER SYSTEM SET citus.node_conninfo = 'sslmode=doesnotexist';
 BEGIN;
 -- Should still work (no SIGHUP yet);
@@ -68,10 +63,8 @@ show citus.node_conninfo;
 -- query
 select count(*) from test where a = 0;
 COMMIT;
-
 -- Should fail now, when transaction is finished
 select count(*) from test where a = 0;
-
 -- Reset it again
 ALTER SYSTEM RESET citus.node_conninfo;
 select pg_reload_conf();

--- a/src/test/regress/sql/shared_connection_stats.sql
+++ b/src/test/regress/sql/shared_connection_stats.sql
@@ -1,0 +1,228 @@
+CREATE SCHEMA shared_connection_stats;
+SET search_path TO shared_connection_stats;
+
+-- set the cached connections to zero
+-- and execute a distributed query so that
+-- we end up with zero cached connections afterwards
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
+SELECT pg_reload_conf();
+
+-- disable deadlock detection and re-trigger 2PC recovery
+-- once more when citus.max_cached_conns_per_worker is zero
+-- so that we can be sure that the connections established for
+-- maintanince daemon is closed properly.
+-- this is to prevent random failures in the tests (otherwise, we
+-- might see connections established for this operations)
+ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO -1;
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1ms';
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.1);
+
+-- now that last 2PC recovery is done, we're good to disable it
+ALTER SYSTEM SET citus.recover_2pc_interval TO '1h';
+SELECT pg_reload_conf();
+
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE test (a int);
+SELECT create_distributed_table('test', 'a');
+INSERT INTO test SELECT i FROM generate_series(0,100)i;
+
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+
+-- single shard queries require single connection per node
+BEGIN;
+	SELECT count(*) FROM test WHERE a = 1;
+	SELECT count(*) FROM test WHERE a = 2;
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+
+-- executor is only allowed to establish a single connection per node
+BEGIN;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 1;
+	SELECT count(*) FROM test;
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+
+-- sequential mode is allowed to establish a single connection per node
+BEGIN;
+	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
+	SELECT count(*) FROM test;
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+
+-- now, decrease the shared pool size, and still force
+-- one connection per placement
+ALTER SYSTEM SET citus.max_shared_pool_size TO 5;
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.1);
+
+BEGIN;
+	SET LOCAL citus.node_connection_timeout TO 1000;
+	SET LOCAL citus.force_max_query_parallelization TO ON;
+	SELECT count(*) FROM test;
+COMMIT;
+
+-- pg_sleep forces almost 1 connection per placement
+-- now, some of the optional connections would be skipped,
+-- and only 5 connections are used per node
+BEGIN;
+	SELECT count(*), pg_sleep(0.1) FROM test;
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+
+SHOW citus.max_shared_pool_size;
+
+-- by default max_shared_pool_size equals to max_connections;
+ALTER SYSTEM RESET citus.max_shared_pool_size;
+SELECT pg_reload_conf();
+SELECT pg_sleep(0.1);
+
+SHOW citus.max_shared_pool_size;
+SHOW max_connections;
+
+-- now, each node gets 16 connections as we force 1 connection per placement
+BEGIN;
+	SET LOCAL citus.force_max_query_parallelization TO ON;
+	SELECT count(*) FROM test;
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+BEGIN;
+	-- now allow at most 1 connection, and ensure that intermediate
+	-- results don't require any extra connections
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 1;
+	SET LOCAL citus.task_assignment_policy TO "round-robin";
+	SELECT cnt FROM (SELECT count(*) as cnt, random() FROM test LIMIT 1) as foo;
+
+	-- queries with intermediate results don't use any extra connections
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+
+-- now show that when max_cached_conns_per_worker > 1
+-- Citus forces the first execution to open at least 2
+-- connections that are cached. Later, that 2 cached
+-- connections are user
+BEGIN;
+	SET LOCAL citus.max_cached_conns_per_worker TO 2;
+	SELECT count(*) FROM test;
+	SELECT
+		connection_count_to_node >= 2
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+	SELECT count(*) FROM test;
+	SELECT
+		connection_count_to_node >= 2
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+COMMIT;
+
+-- in case other tests relies on these setting, reset them
+ALTER SYSTEM RESET citus.distributed_deadlock_detection_factor;
+ALTER SYSTEM RESET citus.recover_2pc_interval;
+ALTER SYSTEM RESET citus.max_cached_conns_per_worker;
+SELECT pg_reload_conf();
+
+DROP SCHEMA shared_connection_stats CASCADE;


### PR DESCRIPTION
With this commit, we're introducing a new infrastructure to throttle connections to the worker nodes. This infrastructure is useful for multi-shard queries, router queries are have not been affected by this.

The goal is to prevent establishing more than `citus.max_shared_pool_size` number of connections per worker node in total, **across sessions**. 

To do that, we've introduced a new connection flag `OPTIONAL_CONNECTION`. The idea is that some connections are optional such as the second (and further connections) for the adaptive executor. A single connection is enough to finish the distributed execution, the others are useful to execute the query faster. Thus, they can be consider as `optional` connections. When an optional connection is not allowed to the adaptive executor, it simply skips it and continues the execution with the already established connections. However, it'll keep retrying to establish optional connections, in case some slots are open again. 

- [x] Edge cases around `force_max_query_parallelization` and `max_shared_pool_size`. Already have a regression test that is commented out
- [x] Edge cases around pull-push  execution and having concurrent sessions that is  equal to `max_shared_pool_size`. In that case,  we might end-up with some sorts of undetected deadlocks where each backend gets a connection for intermediate results, but none  of them can get a connection to continue the execution in the executor.
- [ ] Trigger a regression test with `WaitOrErrorForSharedConnection`
- [x] Make sure that we don't regress on OLTP performance