### PR TITLE
use macros for pg versions instead of hardcoded values

### DIFF
--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -24,6 +24,7 @@
 #include "distributed/multi_executor.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/worker_create_or_replace.h"
+#include "distributed/pg_version_constants.h"
 #include "distributed/worker_manager.h"
 #include "parser/parse_type.h"
 #include "utils/builtins.h"
@@ -59,7 +60,7 @@ CreateCollationDDLInternal(Oid collationId, Oid *collowner, char **quotedCollati
 	const char *collctype;
 	const char *collname;
 	Oid collnamespace;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	bool collisdeterministic;
 #endif
 
@@ -75,7 +76,7 @@ CreateCollationDDLInternal(Oid collationId, Oid *collowner, char **quotedCollati
 	collctype = NameStr(collationForm->collctype);
 	collnamespace = collationForm->collnamespace;
 	collname = NameStr(collationForm->collname);
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	collisdeterministic = collationForm->collisdeterministic;
 #endif
 
@@ -116,7 +117,7 @@ CreateCollationDDLInternal(Oid collationId, Oid *collowner, char **quotedCollati
 						 quote_literal_cstr(collctype));
 	}
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	if (!collisdeterministic)
 	{
 		appendStringInfoString(&collationNameDef, ", deterministic = false");

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -12,10 +12,12 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "access/htup_details.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_constraint.h"
-#if (PG_VERSION_NUM >= 120000)
+#if (PG_VERSION_NUM >= PG_VERSION_12)
 #include "access/genam.h"
 #endif
 #include "catalog/pg_type.h"

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -19,7 +19,9 @@
 #include "miscadmin.h"
 #include "funcapi.h"
 
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #endif
 #include "access/htup_details.h"
@@ -670,7 +672,7 @@ GetAggregateDDLCommand(const RegProcedure funcOid, bool useCreateOrReplace)
 	const char *name = NameStr(proc->proname);
 	const char *nsp = get_namespace_name(proc->pronamespace);
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	if (useCreateOrReplace)
 	{
 		appendStringInfo(&buf, "CREATE OR REPLACE AGGREGATE %s(",
@@ -974,7 +976,7 @@ GetAggregateDDLCommand(const RegProcedure funcOid, bool useCreateOrReplace)
 	ReleaseSysCache(aggtup);
 	ReleaseSysCache(proctup);
 
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 	if (useCreateOrReplace)
 	{
 		return WrapCreateOrReplace(buf.data);

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -10,7 +10,8 @@
 
 #include "postgres.h"
 
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #endif
 #include "access/htup_details.h"
@@ -70,7 +71,7 @@ struct DropRelationCallbackState
  */
 struct ReindexIndexCallbackState
 {
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	bool concurrent;
 #endif
 	Oid locked_table_oid;
@@ -213,7 +214,7 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand)
 		Relation relation = NULL;
 		Oid relationId = InvalidOid;
 		bool isCitusRelation = false;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		LOCKMODE lockmode = reindexStatement->concurrent ? ShareUpdateExclusiveLock :
 							AccessExclusiveLock;
 #else
@@ -228,7 +229,7 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand)
 		{
 			Oid indOid;
 			struct ReindexIndexCallbackState state;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			state.concurrent = reindexStatement->concurrent;
 #endif
 			state.locked_table_oid = InvalidOid;
@@ -281,7 +282,7 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand)
 		{
 			DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 			ddlJob->targetRelationId = relationId;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			ddlJob->concurrentIndexCmd = reindexStatement->concurrent;
 #else
 			ddlJob->concurrentIndexCmd = false;
@@ -702,7 +703,7 @@ RangeVarCallbackForReindexIndex(const RangeVar *relation, Oid relId, Oid oldRelI
 	 * non-concurrent case and table locks used by index_concurrently_*() for
 	 * concurrent case.
 	 */
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	table_lockmode = state->concurrent ? ShareUpdateExclusiveLock : ShareLock;
 #else
 	table_lockmode = ShareLock;

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -55,6 +55,8 @@
 #include <netinet/in.h> /* for htons */
 #include <string.h>
 
+#include "distributed/pg_version_constants.h"
+
 #include "access/htup_details.h"
 #include "access/htup.h"
 #include "access/sdir.h"
@@ -413,7 +415,7 @@ CopyToExistingShards(CopyStmt *copyStatement, char *completionTag)
 		char *columnName = NameStr(currentColumn->attname);
 
 		if (currentColumn->attisdropped
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			|| currentColumn->attgenerated == ATTRIBUTE_GENERATED_STORED
 #endif
 			)
@@ -873,7 +875,7 @@ CanUseBinaryCopyFormat(TupleDesc tupleDescription)
 		Oid typeId = InvalidOid;
 
 		if (currentColumn->attisdropped
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			|| currentColumn->attgenerated == ATTRIBUTE_GENERATED_STORED
 #endif
 			)
@@ -1322,7 +1324,7 @@ TypeArrayFromTupleDescriptor(TupleDesc tupleDescriptor)
 	{
 		Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, columnIndex);
 		if (attr->attisdropped
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			|| attr->attgenerated == ATTRIBUTE_GENERATED_STORED
 #endif
 			)
@@ -1494,7 +1496,7 @@ AppendCopyRowData(Datum *valueArray, bool *isNullArray, TupleDesc rowDescriptor,
 		}
 
 		if (currentColumn->attisdropped
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			|| currentColumn->attgenerated == ATTRIBUTE_GENERATED_STORED
 #endif
 			)
@@ -1617,7 +1619,7 @@ AvailableColumnCount(TupleDesc tupleDescriptor)
 		Form_pg_attribute currentColumn = TupleDescAttr(tupleDescriptor, columnIndex);
 
 		if (!currentColumn->attisdropped
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			&& currentColumn->attgenerated != ATTRIBUTE_GENERATED_STORED
 #endif
 			)
@@ -2726,7 +2728,7 @@ ProcessCopyStmt(CopyStmt *copyStatement, char *completionTag, const char *queryS
 		{
 			if (copyStatement->is_from)
 			{
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 				if (copyStatement->whereClause)
 				{
 					ereport(ERROR, (errmsg(

--- a/src/backend/distributed/commands/role.c
+++ b/src/backend/distributed/commands/role.c
@@ -10,9 +10,11 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "access/heapam.h"
 #include "access/htup_details.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/table.h"
 #endif
 #include "catalog/catalog.h"
@@ -404,7 +406,7 @@ GenerateAlterRoleIfExistsCommandAllRoles()
 	List *commands = NIL;
 	const char *alterRoleQuery = NULL;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	TableScanDesc scan = table_beginscan_catalog(pgAuthId, 0, NULL);
 #else
 	HeapScanDesc scan = heap_beginscan_catalog(pgAuthId, 0, NULL);
@@ -447,7 +449,7 @@ GenerateAlterRoleSetIfExistsCommands()
 	List *alterRoleSetQueries = NIL;
 
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	TableScanDesc scan = table_beginscan_catalog(DbRoleSetting, 0, NULL);
 #else
 	HeapScanDesc scan = heap_beginscan_catalog(DbRoleSetting, 0, NULL);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -9,8 +9,8 @@
  */
 
 #include "postgres.h"
-
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #endif
 #include "access/htup_details.h"

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -43,6 +43,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "access/genam.h"
 #include "access/htup_details.h"
 #include "access/xact.h"
@@ -345,7 +347,7 @@ PreprocessAlterEnumStmt(Node *node, const char *queryString)
 	 * creating a DDLTaksList we won't return anything here. During the processing phase
 	 * we directly connect to workers and execute the commands remotely.
 	 */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 	if (AlterEnumIsAddValue(castNode(AlterEnumStmt, node)))
 	{
 		/*
@@ -391,7 +393,7 @@ PostprocessAlterEnumStmt(Node *node, const char *queryString)
 	 * From pg12 and up we use the normal infrastructure and create the ddl jobs during
 	 * planning.
 	 */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 	AlterEnumStmt *stmt = castNode(AlterEnumStmt, node);
 	ObjectAddress typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
 	if (!ShouldPropagateObject(&typeAddress))

--- a/src/backend/distributed/commands/vacuum.c
+++ b/src/backend/distributed/commands/vacuum.c
@@ -10,7 +10,9 @@
 
 #include "postgres.h"
 
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "commands/defrem.h"
 #endif
 #include "commands/vacuum.h"
@@ -33,7 +35,7 @@
 typedef struct CitusVacuumParams
 {
 	int options;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	VacOptTernaryValue truncate;
 	VacOptTernaryValue index_cleanup;
 #endif
@@ -279,7 +281,7 @@ DeparseVacuumStmtPrefix(CitusVacuumParams vacuumParams)
 
 	/* if no flags remain, exit early */
 	if (vacuumFlags == 0
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		&& vacuumParams.truncate == VACOPT_TERNARY_DEFAULT &&
 		vacuumParams.index_cleanup == VACOPT_TERNARY_DEFAULT
 #endif
@@ -316,7 +318,7 @@ DeparseVacuumStmtPrefix(CitusVacuumParams vacuumParams)
 		appendStringInfoString(vacuumPrefix, "VERBOSE,");
 	}
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	if (vacuumFlags & VACOPT_SKIP_LOCKED)
 	{
 		appendStringInfoString(vacuumPrefix, "SKIP_LOCKED,");
@@ -415,7 +417,7 @@ ExtractVacuumTargetRels(VacuumStmt *vacuumStmt)
 /*
  * VacuumStmtParams returns a CitusVacuumParams based on the supplied VacuumStmt.
  */
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 
 /*
  * This is mostly ExecVacuum from Postgres's commands/vacuum.c

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -10,6 +10,8 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include <stddef.h>
 
 #include "access/attnum.h"
@@ -129,7 +131,7 @@ get_extension_schema(Oid ext_oid)
 	rel = heap_open(ExtensionRelationId, AccessShareLock);
 
 	ScanKeyInit(&entry[0],
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 				Anum_pg_extension_oid,
 #else
 				ObjectIdAttributeNumber,
@@ -356,7 +358,7 @@ pg_get_tableschemadef_string(Oid tableRelationId, bool includeSequenceDefaults)
 					defaultString = deparse_expression(defaultNode, defaultContext,
 													   false, false);
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 					if (attributeForm->attgenerated == ATTRIBUTE_GENERATED_STORED)
 					{
 						appendStringInfo(&buffer, " GENERATED ALWAYS AS (%s) STORED",
@@ -705,7 +707,7 @@ deparse_shard_reindex_statement(ReindexStmt *origStmt, Oid distrelid, int64 shar
 {
 	ReindexStmt *reindexStmt = copyObject(origStmt); /* copy to avoid modifications */
 	char *relationName = NULL;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	const char *concurrentlyString = reindexStmt->concurrent ? "CONCURRENTLY " : "";
 #else
 	const char *concurrentlyString = "";

--- a/src/backend/distributed/deparser/ruleutils_11.c
+++ b/src/backend/distributed/deparser/ruleutils_11.c
@@ -17,7 +17,9 @@
 
 #include "postgres.h"
 
-#if (PG_VERSION_NUM >= 110000) && (PG_VERSION_NUM < 120000)
+#include "distributed/pg_version_constants.h"
+
+#if (PG_VERSION_NUM >= PG_VERSION_11) && (PG_VERSION_NUM < PG_VERSION_12)
 
 #include <ctype.h>
 #include <unistd.h>
@@ -7994,4 +7996,4 @@ get_range_partbound_string(List *bound_datums)
 	return buf->data;
 }
 
-#endif /* (PG_VERSION_NUM >= 110000) && (PG_VERSION_NUM < 120000) */
+#endif /* (PG_VERSION_NUM >= PG_VERSION_11) && (PG_VERSION_NUM < PG_VERSION_12) */

--- a/src/backend/distributed/deparser/ruleutils_12.c
+++ b/src/backend/distributed/deparser/ruleutils_12.c
@@ -16,8 +16,9 @@
  */
 
 #include "postgres.h"
+#include "distributed/pg_version_constants.h"
 
-#if (PG_VERSION_NUM >= 120000) && (PG_VERSION_NUM < 130000)
+#if (PG_VERSION_NUM >= PG_VERSION_12) && (PG_VERSION_NUM < PG_VERSION_13)
 
 #include <ctype.h>
 #include <unistd.h>
@@ -7995,4 +7996,4 @@ get_range_partbound_string(List *bound_datums)
 	return buf->data;
 }
 
-#endif /* (PG_VERSION_NUM >= 120000) && (PG_VERSION_NUM < 130000) */
+#endif /* (PG_VERSION_NUM >= PG_VERSION_12) && (PG_VERSION_NUM < PG_VERSION_13) */

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -9,6 +9,8 @@
  */
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "miscadmin.h"
 
 #include "commands/copy.h"
@@ -32,7 +34,7 @@
 #include "distributed/worker_protocol.h"
 #include "executor/executor.h"
 #include "nodes/makefuncs.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/planner.h"
@@ -164,7 +166,7 @@ CitusBeginScan(CustomScanState *node, EState *estate, int eflags)
 
 	CitusScanState *scanState = (CitusScanState *) node;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 
 	/*
 	 * Since we are using a tuplestore we cannot use the virtual tuples postgres had

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -7,6 +7,9 @@
  *
  *-------------------------------------------------------------------------
  */
+
+#include "distributed/pg_version_constants.h"
+
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -323,7 +326,7 @@ ExecutePartitionTaskList(List *taskList, CitusTableCacheEntry *targetRelation)
 	Tuplestorestate *resultStore = NULL;
 	int resultColumnCount = 4;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount);
 #else
 	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount, false);
@@ -610,7 +613,7 @@ ExecuteFetchTaskList(List *taskList)
 	Tuplestorestate *resultStore = NULL;
 	int resultColumnCount = 1;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount);
 #else
 	resultDescriptor = CreateTemplateTupleDesc(resultColumnCount, false);

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -76,6 +76,8 @@
 #include "postgres.h"
 #include "miscadmin.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "distributed/commands/utility_hook.h"
 #include "distributed/citus_custom_scan.h"
 #include "distributed/citus_ruleutils.h"
@@ -92,7 +94,7 @@
 #include "distributed/worker_protocol.h"
 #include "executor/tstoreReceiver.h"
 #include "executor/tuptable.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/planner.h"

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -10,6 +10,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "miscadmin.h"
 
 #include "access/xact.h"
@@ -184,7 +186,7 @@ CitusExecutorRun(QueryDesc *queryDesc,
 			EState *estate = queryDesc->estate;
 
 			estate->es_processed = 0;
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 			estate->es_lastoid = InvalidOid;
 #endif
 

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -14,6 +14,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "c.h"
 #include "fmgr.h"
 #include "libpq-fe.h"
@@ -45,7 +48,7 @@
 #include "distributed/worker_protocol.h"
 #include "distributed/worker_transaction.h"
 #include "lib/stringinfo.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/nodeFuncs.h"
 #endif
 #include "nodes/nodes.h"
@@ -53,7 +56,7 @@
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
 #include "optimizer/clauses.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #include "optimizer/optimizer.h"
 #else

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -15,7 +15,9 @@
 #include "libpq-fe.h"
 #include "miscadmin.h"
 
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #endif
 #include "access/htup_details.h"

--- a/src/backend/distributed/master/master_modify_multiple_shards.c
+++ b/src/backend/distributed/master/master_modify_multiple_shards.c
@@ -15,6 +15,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "funcapi.h"
 #include "libpq-fe.h"
 #include "miscadmin.h"
@@ -45,7 +48,7 @@
 #include "distributed/worker_protocol.h"
 #include "distributed/worker_transaction.h"
 #include "optimizer/clauses.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/predtest.h"

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -12,6 +12,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "c.h"
 #include "fmgr.h"
 #include "funcapi.h"
@@ -463,7 +466,7 @@ master_get_active_worker_nodes(PG_FUNCTION_ARGS)
 		 * This tuple descriptor must match the output parameters declared for
 		 * the function in pg_proc.
 		 */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 		tupleDescriptor = CreateTemplateTupleDesc(WORKER_NODE_FIELDS, false);
 #else
 		tupleDescriptor = CreateTemplateTupleDesc(WORKER_NODE_FIELDS);

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -9,6 +9,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "miscadmin.h"
 
 #include "access/genam.h"
@@ -102,7 +105,7 @@ ObjectExists(const ObjectAddress *address)
 		HeapTuple objtup;
 		Relation catalog = heap_open(address->classId, AccessShareLock);
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		objtup = get_catalog_object_by_oid(catalog, get_object_attnum_oid(
 											   address->classId), address->objectId);
 #else

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -7,6 +7,8 @@
  *-------------------------------------------------------------------------
  */
 
+#include "distributed/pg_version_constants.h"
+
 #include "stdint.h"
 #include "postgres.h"
 #include "libpq-fe.h"
@@ -2446,7 +2448,7 @@ LookupTypeOid(char *typeNameString)
 		return InvalidOid;
 	}
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	nodeRoleTypId = ((Form_pg_type) GETSTRUCT(tup))->oid;
 #else
 	nodeRoleTypId = HeapTupleGetOid(tup);

--- a/src/backend/distributed/planner/cte_inline.c
+++ b/src/backend/distributed/planner/cte_inline.c
@@ -14,10 +14,11 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+#include "distributed/pg_version_constants.h"
 
 #include "distributed/cte_inline.h"
 #include "nodes/nodeFuncs.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/cost.h"
@@ -25,7 +26,7 @@
 #endif
 #include "rewrite/rewriteManip.h"
 
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 
 /* copy & paste from PG 12 */
 #define PG_12_QTW_EXAMINE_RTES_BEFORE 0x10
@@ -232,7 +233,7 @@ PostgreSQLCTEInlineCondition(CommonTableExpr *cte, CmdType cmdType)
 	 * will be inlined even if multiply referenced.
 	 */
 	if (
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		(cte->ctematerialized == CTEMaterializeNever ||
 		 (cte->ctematerialized == CTEMaterializeDefault &&
 		  cte->cterefcount == 1)) &&
@@ -298,7 +299,7 @@ inline_cte_walker(Node *node, inline_cte_walker_context *context)
 		 * query_tree_walker would descend into the newly inlined CTE query,
 		 * which we don't want.
 		 */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 		(void) pg_12_query_tree_walker(query, inline_cte_walker, context,
 									   PG_12_QTW_EXAMINE_RTES_AFTER);
 #else
@@ -411,7 +412,7 @@ contain_dml_walker(Node *node, void *context)
 }
 
 
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 /*
  * pg_12_query_tree_walker is copied from Postgres 12's source
  * code. The only difference between query_tree_walker the new

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -8,6 +8,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "funcapi.h"
 
 #include <float.h>
@@ -46,7 +49,7 @@
 #include "nodes/nodeFuncs.h"
 #include "parser/parsetree.h"
 #include "parser/parse_type.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #include "optimizer/plancat.h"
 #else
@@ -772,7 +775,7 @@ InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
 	/* after inlining, we shouldn't have any inlinable CTEs */
 	Assert(!QueryTreeContainsInlinableCTE(copyOfOriginalQuery));
 
-	#if PG_VERSION_NUM < 120000
+	#if PG_VERSION_NUM < PG_VERSION_12
 	Query *query = planContext->query;
 
 	/*
@@ -798,7 +801,7 @@ InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
 														  planContext->
 														  plannerRestrictionContext);
 
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 
 	/*
 	 * Set back the original query, in case the planning failed and we need to go
@@ -1591,7 +1594,7 @@ BlessRecordExpression(Expr *expr)
 		ListCell *argCell = NULL;
 		int currentResno = 1;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		rowTupleDesc = CreateTemplateTupleDesc(list_length(rowExpr->args));
 #else
 		rowTupleDesc = CreateTemplateTupleDesc(list_length(rowExpr->args), false);
@@ -2033,7 +2036,7 @@ AdjustReadIntermediateResultsCostInternal(RelOptInfo *relOptInfo, List *columnTy
 	double rowSizeEstimate = 0;
 	double rowCountEstimate = 0.;
 	double ioCost = 0.;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	QualCost funcCost = { 0., 0. };
 #else
 	double funcCost = 0.;
@@ -2096,13 +2099,13 @@ AdjustReadIntermediateResultsCostInternal(RelOptInfo *relOptInfo, List *columnTy
 
 
 		/* add the cost of parsing a column */
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		add_function_cost(NULL, inputFunctionId, NULL, &funcCost);
 #else
 		funcCost += get_func_cost(inputFunctionId);
 #endif
 	}
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	rowCost += funcCost.per_tuple;
 #else
 	rowCost += funcCost * cpu_operator_cost;
@@ -2121,7 +2124,7 @@ AdjustReadIntermediateResultsCostInternal(RelOptInfo *relOptInfo, List *columnTy
 	path->rows = rowCountEstimate;
 	path->total_cost = rowCountEstimate * rowCost + ioCost;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	path->startup_cost = funcCost.startup + relOptInfo->baserestrictcost.startup;
 #endif
 }

--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -9,13 +9,14 @@
  */
 
 #include "postgres.h"
+#include "distributed/pg_version_constants.h"
 
 #include "distributed/extended_op_node_utils.h"
 #include "distributed/listutils.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_logical_optimizer.h"
 #include "distributed/pg_dist_partition.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/var.h"

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -34,6 +34,8 @@
  */
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "distributed/distributed_planner.h"
 #include "distributed/insert_select_planner.h"
 #include "distributed/multi_physical_planner.h" /* only to use some utility functions */
@@ -42,13 +44,13 @@
 #include "distributed/pg_dist_partition.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/shard_pruning.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/makefuncs.h"
 #endif
 #include "nodes/nodeFuncs.h"
 #include "nodes/parsenodes.h"
 #include "nodes/pg_list.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/clauses.h"

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -12,6 +12,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
@@ -41,7 +43,7 @@
 #include "nodes/primnodes.h"
 #include "optimizer/clauses.h"
 #include "parser/parse_coerce.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "parser/parsetree.h"
 #endif
 #include "miscadmin.h"
@@ -157,7 +159,7 @@ TryToDelegateFunctionCall(DistributedPlanningContext *planContext)
 
 	if (joinTree->fromlist != NIL)
 	{
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 
 		/*
 		 * In pg12's planning phase empty FROMs are represented with an RTE_RESULT.

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -10,6 +10,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "catalog/pg_class.h"
 #include "distributed/citus_clauses.h"
 #include "distributed/citus_ruleutils.h"
@@ -35,7 +37,7 @@
 #include "optimizer/planner.h"
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/var.h"

--- a/src/backend/distributed/planner/local_plan_cache.c
+++ b/src/backend/distributed/planner/local_plan_cache.c
@@ -9,13 +9,15 @@
  */
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "distributed/listutils.h"
 #include "distributed/local_executor.h"
 #include "distributed/local_plan_cache.h"
 #include "distributed/deparse_shard_query.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/metadata_cache.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/planner.h"

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -12,6 +12,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include <limits.h>
 
 #include "access/nbtree.h"
@@ -25,7 +28,7 @@
 #include "distributed/pg_dist_partition.h"
 #include "distributed/worker_protocol.h"
 #include "lib/stringinfo.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/var.h"

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -12,6 +12,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include <math.h>
 
 #include "access/genam.h"
@@ -43,7 +46,7 @@
 #include "nodes/print.h"
 #include "optimizer/clauses.h"
 #include "optimizer/tlist.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/var.h"
@@ -3311,7 +3314,7 @@ AggregateFunctionOid(const char *functionName, Oid inputType)
 			if (procForm->proargtypes.values[0] == inputType ||
 				procForm->proargtypes.values[0] == ANYELEMENTOID)
 			{
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 				functionOid = HeapTupleGetOid(heapTuple);
 #else
 				functionOid = procForm->oid;

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -14,6 +14,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "access/heapam.h"
 #include "access/nbtree.h"
 #include "catalog/pg_am.h"
@@ -35,7 +37,7 @@
 #include "distributed/version_compat.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #include "optimizer/optimizer.h"
 #else

--- a/src/backend/distributed/planner/multi_master_planner.c
+++ b/src/backend/distributed/planner/multi_master_planner.c
@@ -13,6 +13,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "catalog/pg_type.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/listutils.h"
@@ -303,7 +305,7 @@ FindCitusExtradataContainerRTE(Node *node, RangeTblEntry **result)
 	}
 	else if (IsA(node, Query))
 	{
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		const int flags = QTW_EXAMINE_RTES_BEFORE;
 #else
 		const int flags = QTW_EXAMINE_RTES;

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -13,6 +13,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include <math.h>
 #include <stdint.h>
 
@@ -57,7 +59,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/clauses.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #include "optimizer/optimizer.h"
 #else

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -12,6 +12,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include <stddef.h>
 
 #include "access/stratnum.h"
@@ -60,7 +62,7 @@
 #include "optimizer/joininfo.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "optimizer/optimizer.h"
 #else
 #include "optimizer/var.h"
@@ -711,7 +713,7 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 			queryTableCount++;
 		}
 		else if (rangeTableEntry->rtekind == RTE_VALUES
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 				 || rangeTableEntry->rtekind == RTE_RESULT
 #endif
 				 )

--- a/src/backend/distributed/planner/postgres_planning_functions.c
+++ b/src/backend/distributed/planner/postgres_planning_functions.c
@@ -13,9 +13,11 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "distributed/multi_master_planner.h"
 #include "nodes/plannodes.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/nodeFuncs.h"
 #include "optimizer/optimizer.h"
 #else
@@ -29,7 +31,7 @@
  * src/backend/optimizer/plan/createplan.c.
  */
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 
 /*
  * distinctList is a list of SortGroupClauses, identifying the targetlist items

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -21,6 +21,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "distributed/citus_clauses.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/deparse_shard_query.h"
@@ -35,7 +37,7 @@
 #include "distributed/relation_restriction_equivalence.h"
 #include "distributed/version_compat.h"
 #include "nodes/nodeFuncs.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/makefuncs.h"
 #include "optimizer/optimizer.h"
 #else
@@ -226,7 +228,7 @@ HasEmptyJoinTree(Query *query)
 		return true;
 	}
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	else if (list_length(query->rtable) == 1)
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) linitial(query->rtable);
@@ -1087,7 +1089,7 @@ DeferErrorIfUnsupportedTableCombination(Query *queryTree)
 		 */
 		if (rangeTableEntry->rtekind == RTE_RELATION ||
 			rangeTableEntry->rtekind == RTE_SUBQUERY
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 			|| rangeTableEntry->rtekind == RTE_RESULT
 #endif
 			)
@@ -1474,7 +1476,7 @@ HasRecurringTuples(Node *node, RecurringTuplesType *recurType)
 			 */
 			return true;
 		}
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		else if (rangeTableEntry->rtekind == RTE_RESULT)
 		{
 			*recurType = RECURRING_TUPLES_EMPTY_JOIN_TREE;

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -50,6 +50,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "funcapi.h"
 
 #include "catalog/pg_type.h"
@@ -81,7 +84,7 @@
 #include "nodes/nodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -10,6 +10,8 @@
  */
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "distributed/colocation_utils.h"
 #include "distributed/distributed_planner.h"
 #include "distributed/listutils.h"
@@ -22,7 +24,7 @@
 #include "nodes/nodeFuncs.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -65,6 +65,9 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "fmgr.h"
 
 #include "distributed/shard_pruning.h"
@@ -183,7 +186,7 @@ typedef struct PendingPruningInstance
 	PruningTreeNode *continueAt;
 } PendingPruningInstance;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 typedef union \
 { \
 	FunctionCallInfoBaseData fcinfo; \

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -808,7 +808,7 @@ RegisterCitusConfigVariables(void)
 
 	/*
 	 * We shouldn't need this variable after we drop support to PostgreSQL 11 and
-	 * below. So, noting it here with PG_VERSION_NUM < 120000
+	 * below. So, noting it here with PG_VERSION_NUM < PG_VERSION_12
 	 */
 	DefineCustomBoolVariable(
 		"citus.enable_cte_inlining",

--- a/src/backend/distributed/test/blackhole_am.c
+++ b/src/backend/distributed/test/blackhole_am.c
@@ -22,7 +22,9 @@
 /* *INDENT-OFF* */
 #include "postgres.h"
 
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_12
 
 #include "access/tableam.h"
 #include "access/heapam.h"

--- a/src/backend/distributed/test/fake_fdw.c
+++ b/src/backend/distributed/test/fake_fdw.c
@@ -11,6 +11,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "c.h"
 #include "fmgr.h"
 
@@ -22,7 +25,7 @@
 #include "nodes/nodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/plannodes.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/backend/distributed/test/prune_shard_list.c
+++ b/src/backend/distributed/test/prune_shard_list.c
@@ -11,6 +11,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "c.h"
 #include "fmgr.h"
 
@@ -25,7 +28,7 @@
 #include "distributed/multi_physical_planner.h"
 #include "distributed/resource_lock.h"
 #include "distributed/shard_pruning.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #endif

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -11,6 +11,9 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "miscadmin.h"
 
 #include "funcapi.h"
@@ -28,7 +31,7 @@
 #include "distributed/tuplestore.h"
 #include "nodes/execnodes.h"
 #include "postmaster/autovacuum.h" /* to access autovacuum_max_workers */
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "replication/walsender.h"
 #endif
 #include "storage/ipc.h"
@@ -581,7 +584,7 @@ TotalProcCount(void)
 	 */
 	totalProcs = maxBackends + NUM_AUXILIARY_PROCS + max_prepared_xacts;
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	totalProcs += max_wal_senders;
 #endif
 

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -13,13 +13,16 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "miscadmin.h"
 #include "libpq-fe.h"
 
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #endif
 #include "access/heapam.h"

--- a/src/backend/distributed/utils/citus_nodefuncs.c
+++ b/src/backend/distributed/utils/citus_nodefuncs.c
@@ -10,6 +10,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "catalog/pg_type.h"
 #include "distributed/citus_nodes.h"
 #include "distributed/citus_nodefuncs.h"
@@ -307,7 +309,7 @@ GetRangeTblKind(RangeTblEntry *rte)
 		case RTE_JOIN:
 		case RTE_VALUES:
 		case RTE_CTE:
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 		case RTE_RESULT:
 #endif
 			{

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -18,6 +18,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include <ctype.h>
 
 #include "distributed/citus_nodefuncs.h"
@@ -31,7 +33,7 @@
 #include "distributed/master_metadata_utility.h"
 #include "lib/stringinfo.h"
 #include "nodes/plannodes.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/backend/distributed/utils/citus_safe_lib.c
+++ b/src/backend/distributed/utils/citus_safe_lib.c
@@ -14,6 +14,8 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "safe_lib.h"
 
 #include <limits.h>
@@ -26,7 +28,7 @@
  * case use the copied one from pg11_snprintf.c
  * NOTE: Whenever removing this section also remove pg11_snprintf.c
  */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 extern int pg11_vsnprintf(char *str, size_t count, const char *fmt, va_list args);
 #define citus_vsnprintf pg11_vsnprintf
 #else

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -12,12 +12,14 @@
 
 #include "postgres.h"
 
-#if PG_VERSION_NUM >= 120000
+#include "distributed/pg_version_constants.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #endif
 #include "access/htup_details.h"
 #include "access/stratnum.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/table.h"
 #endif
 #include "catalog/pg_constraint.h"

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -6,6 +6,8 @@
  */
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
@@ -22,7 +24,7 @@
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
 #include "pgstat.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "partitioning/partdesc.h"
 #endif
 #include "utils/builtins.h"

--- a/src/backend/distributed/utils/pg11_snprintf.c
+++ b/src/backend/distributed/utils/pg11_snprintf.c
@@ -33,6 +33,9 @@
 
 #include "c.h"
 
+#include "distributed/pg_version_constants.h"
+
+
 #include <ctype.h>
 #ifdef _MSC_VER
 #include <float.h>				/* for _isnan */
@@ -45,7 +48,7 @@
 #include <sys/param.h>
 
 /* Include this file only for PG11 and only when USE_REPL_SNPRINTF is not set */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 #ifndef USE_REPL_SNPRINTF
 /*
  * We used to use the platform's NL_ARGMAX here, but that's a bad idea,
@@ -1178,4 +1181,4 @@ trailing_pad(int *padlen, PrintfTarget *target)
 	}
 }
 #endif /* USE_REPL_SNPRINTF */
-#endif /* PG_VERSION_NUM < 120000 */
+#endif /* PG_VERSION_NUM < PG_VERSION_12 */

--- a/src/backend/distributed/worker/worker_merge_protocol.c
+++ b/src/backend/distributed/worker/worker_merge_protocol.c
@@ -14,10 +14,13 @@
  */
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "funcapi.h"
 #include "miscadmin.h"
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "access/genam.h"
 #include "access/table.h"
 #endif
@@ -307,7 +310,7 @@ Datum
 worker_cleanup_job_schema_cache(PG_FUNCTION_ARGS)
 {
 	Relation pgNamespace = NULL;
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	TableScanDesc scanDescriptor = NULL;
 #else
 	HeapScanDesc scanDescriptor = NULL;
@@ -319,7 +322,7 @@ worker_cleanup_job_schema_cache(PG_FUNCTION_ARGS)
 	CheckCitusVersion(ERROR);
 
 	pgNamespace = heap_open(NamespaceRelationId, AccessExclusiveLock);
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 	scanDescriptor = table_beginscan_catalog(pgNamespace, scanKeyCount, scanKey);
 #else
 	scanDescriptor = heap_beginscan_catalog(pgNamespace, scanKeyCount, scanKey);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -12,9 +12,11 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "nodes/plannodes.h"
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/include/distributed/hash_helpers.h
+++ b/src/include/distributed/hash_helpers.h
@@ -11,10 +11,12 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "utils/hsearch.h"
 
 /* pg12 includes this exact implementation of hash_combine */
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < PG_VERSION_12
 
 /*
  * Combine two hash values, resulting in another hash value, with decent bit

--- a/src/include/distributed/multi_master_planner.h
+++ b/src/include/distributed/multi_master_planner.h
@@ -18,7 +18,7 @@
 #include "nodes/parsenodes.h"
 #include "nodes/plannodes.h"
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -15,6 +15,9 @@
 #define MULTI_PHYSICAL_PLANNER_H
 
 #include "postgres.h"
+
+#include "distributed/pg_version_constants.h"
+
 #include "c.h"
 
 #include "datatype/timestamp.h"
@@ -59,7 +62,7 @@ typedef enum CitusRTEKind
 	CITUS_RTE_VALUES = RTE_VALUES,      /* VALUES (<exprlist>), (<exprlist>), ... */
 	CITUS_RTE_CTE = RTE_CTE,            /* common table expr (WITH list element) */
 	CITUS_RTE_NAMEDTUPLESTORE = RTE_NAMEDTUPLESTORE, /* tuplestore, e.g. for triggers */
-#if (PG_VERSION_NUM >= 120000)
+#if (PG_VERSION_NUM >= PG_VERSION_12)
 	CITUS_RTE_RESULT = RTE_RESULT,      /* RTE represents an empty FROM clause */
 #endif
 	CITUS_RTE_SHARD,

--- a/src/include/distributed/pg_version_constants.h
+++ b/src/include/distributed/pg_version_constants.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_version_constants.h
+ *	   pg version related constants.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PG_VERSION_CONSTANTS
+#define PG_VERSION_CONSTANTS
+
+#define PG_VERSION_11 110000
+#define PG_VERSION_12 120000
+#define PG_VERSION_13 130000
+
+#endif   /* PG_VERSION_CONSTANTS */

--- a/src/include/distributed/recursive_planning.h
+++ b/src/include/distributed/recursive_planning.h
@@ -10,13 +10,13 @@
 #ifndef RECURSIVE_PLANNING_H
 #define RECURSIVE_PLANNING_H
 
-
+#include "distributed/pg_version_constants.h"
 #include "distributed/errormessage.h"
 #include "distributed/log_utils.h"
 #include "distributed/relation_restriction_equivalence.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 #include "nodes/pathnodes.h"
 #else
 #include "nodes/relation.h"

--- a/src/include/distributed/version_compat.h
+++ b/src/include/distributed/version_compat.h
@@ -13,16 +13,18 @@
 
 #include "postgres.h"
 
+#include "distributed/pg_version_constants.h"
+
 #include "commands/explain.h"
 #include "catalog/namespace.h"
 #include "distributed/citus_safe_lib.h"
 #include "nodes/parsenodes.h"
 #include "parser/parse_func.h"
-#if (PG_VERSION_NUM >= 120000)
+#if (PG_VERSION_NUM >= PG_VERSION_12)
 #include "optimizer/optimizer.h"
 #endif
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= PG_VERSION_12
 
 #define MakeSingleTupleTableSlotCompat MakeSingleTupleTableSlot
 #define AllocSetContextCreateExtended AllocSetContextCreateInternal


### PR DESCRIPTION
3 Macros are defined for removing the hardcoded pg versions.
PG_VERSION_11, PG_VERSION_12 and PG_VERSION_13.

This makes header orders somewhat different in some files, but the order of  headers shouldn't matter. 
