### PR TITLE
fix multi utilities vacuum test

### DIFF
--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -399,6 +399,11 @@ WARNING:  not propagating VACUUM command to worker nodes
 HINT:  Provide a specific table in order to VACUUM distributed tables.
 -- check for multiple table vacuum
 VACUUM dustbunnies, second_dustbunnies;
+\c - - - :worker_1_port
+REFRESH MATERIALIZED VIEW prevcounts;
+\c - - - :worker_2_port
+REFRESH MATERIALIZED VIEW prevcounts;
+\c - - - :master_port
 -- check the current number of vacuum and analyze run on dustbunnies
 SELECT run_command_on_workers($$SELECT wait_for_stats()$$);
  run_command_on_workers

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -295,6 +295,13 @@ VACUUM;
 -- check for multiple table vacuum
 VACUUM dustbunnies, second_dustbunnies;
 
+\c - - - :worker_1_port
+REFRESH MATERIALIZED VIEW prevcounts;
+
+\c - - - :worker_2_port
+REFRESH MATERIALIZED VIEW prevcounts;
+
+\c - - - :master_port
 -- check the current number of vacuum and analyze run on dustbunnies
 SELECT run_command_on_workers($$SELECT wait_for_stats()$$);
 SELECT run_command_on_workers($$SELECT pg_stat_get_vacuum_count(tablename::regclass) from pg_tables where tablename LIKE 'dustbunnies_%' limit 1$$);


### PR DESCRIPTION
This will hopefully fix the error which we get a lot:

```diff
 SELECT run_command_on_workers($$SELECT pg_stat_get_vacuum_count(tablename::regclass) from pg_tables where tablename LIKE 'dustbunnies_%' limit 1$$);
  run_command_on_workers 
 ------------------------
- (localhost,57637,t,4)
+ (localhost,57637,t,3)
  (localhost,57638,t,4)
 (2 rows)
```

My guess of why we get this failure is that we have a wait method, which checks if vacuum count has changed. After that we get the vacuum amount. We store the previous vacuum count in a materialized view:

```sql
CREATE MATERIALIZED VIEW prevcounts AS
SELECT analyze_count, vacuum_count FROM pg_stat_user_tables
WHERE relname='dustbunnies_990002';
```

And we have a method that waits until prevcounts changes. Ideally we should refresh this materialized view after each vacuum. However there was one missing refresh, as we dont refresh, it wouldnt increase it from 3->4 vacuum count therefore it would fail ( as we expect it to be 4). 

Hopefully refreshing it resolves this problem.

