### PR TITLE
Do not traverse query tree one more time in distributed planner

### DIFF
--- a/src/backend/distributed/commands/local_multi_copy.c
+++ b/src/backend/distributed/commands/local_multi_copy.c
@@ -159,7 +159,7 @@ DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId, CopyStmt *copyStat
 	 */
 	LocalCopyBuffer = buffer;
 
-	Oid shardOid = GetShardLocalTableOid(relationId, shardId);
+	Oid shardOid = GetTableLocalShardOid(relationId, shardId);
 	Relation shard = heap_open(shardOid, RowExclusiveLock);
 	ParseState *pState = make_parsestate(NULL);
 

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -339,7 +339,7 @@ UpdateRelationsToLocalShardTables(Node *node, List *relationShardList)
 		return true;
 	}
 
-	Oid shardOid = GetShardLocalTableOid(relationShard->relationId,
+	Oid shardOid = GetTableLocalShardOid(relationShard->relationId,
 										 relationShard->shardId);
 
 	newRte->relid = shardOid;

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -186,6 +186,7 @@ typedef struct CitusCustomScanPath
 extern PlannedStmt * distributed_planner(Query *parse, int cursorOptions,
 										 ParamListInfo boundParams);
 extern List * ExtractRangeTableEntryList(Query *query);
+extern List * ExtractReferenceTableRTEList(List *rteList);
 extern bool NeedsDistributedPlanning(Query *query);
 extern struct DistributedPlan * GetDistributedPlan(CustomScan *node);
 extern void multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,

--- a/src/include/distributed/shard_utils.h
+++ b/src/include/distributed/shard_utils.h
@@ -13,6 +13,7 @@
 
 #include "postgres.h"
 
-extern Oid GetShardLocalTableOid(Oid distRelId, uint64 shardId);
+extern Oid GetTableLocalShardOid(Oid citusTableOid, uint64 shardId);
+extern Oid GetReferenceTableLocalShardOid(Oid referenceTableOid);
 
 #endif /* SHARD_UTILS_H */


### PR DESCRIPTION
This pr aims to:
* Do not traverse query tree one more time in distributed planner
* Implement helper function to get reference table shard relation OID (cherry-picked from another pr https://github.com/citusdata/citus/pull/3645) & use it in above

(Actually there could be more changes to be made to `distributed_planner` to prevent traversing query tree RTEs multiple times as well, but in a more available time.)