### PR TITLE
not wait forever in multi_extension test

### DIFF
--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -15,7 +15,8 @@ DECLARE
    activity record;
 BEGIN
     DO 'BEGIN END'; -- Force maintenance daemon to start
-    LOOP
+    -- we don't want to wait forever; loop will exit after 20 seconds
+    FOR i IN 1 .. 200 LOOP
         PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
         WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
@@ -25,6 +26,8 @@ BEGIN
             PERFORM pg_sleep(0.1);
         END IF ;
     END LOOP;
+    -- fail if we reach the end of this loop
+    raise 'Waited too long for maintenance daemon to start';
 END;
 $$;
 $definition$ create_function_test_maintenance_worker

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -18,7 +18,8 @@ DECLARE
    activity record;
 BEGIN
     DO 'BEGIN END'; -- Force maintenance daemon to start
-    LOOP
+    -- we don't want to wait forever; loop will exit after 20 seconds
+    FOR i IN 1 .. 200 LOOP
         PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
         WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
@@ -28,6 +29,8 @@ BEGIN
             PERFORM pg_sleep(0.1);
         END IF ;
     END LOOP;
+    -- fail if we reach the end of this loop
+    raise 'Waited too long for maintenance daemon to start';
 END;
 $$;
 $definition$ create_function_test_maintenance_worker


### PR DESCRIPTION
Often in CI we would get a timeout reached error in our tests. The timeout would happen after 10 mins as that is the default timeout in circleci. I have changed it to 2 mins as there wasn't any point in waiting for 10 mins for that to happen in this PR: #3681. 

I realized that multi_extension test would get stuck a lot, therefore getting the timeout. It seems that this is probably because of the infinite loop. Hopefully this change will raise an error instead of getting stuck in an infinite loop after 20 seconds.

When we get the error, we will at least know why the test failed.

