### PR TITLE
Move connection establishment for intermediate results after query execution

### DIFF
--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -274,16 +274,10 @@ RemoteFileDestReceiverStartup(DestReceiver *dest, int operation,
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, initialNodeList)
 	{
+		int flags = 0;
+
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
-
-		/*
-		 * We prefer to use a connection that is not associcated with
-		 * any placements. The reason is that we claim this connection
-		 * exclusively and that would prevent the consecutive DML/DDL
-		 * use the same connection.
-		 */
-		int flags = REQUIRE_SIDECHANNEL;
 
 		MultiConnection *connection = StartNodeConnection(flags, nodeName, nodePort);
 		ClaimConnectionExclusively(connection);

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -52,28 +52,9 @@ enum MultiConnectionMode
 	/* open a connection per (co-located set of) placement(s) */
 	CONNECTION_PER_PLACEMENT = 1 << 3,
 
-	OUTSIDE_TRANSACTION = 1 << 4,
-
-	/* connection has not been used to access data */
-	REQUIRE_SIDECHANNEL = 1 << 5
+	OUTSIDE_TRANSACTION = 1 << 4
 };
 
-/*
- * ConnectionPurpose defines what a connection is used for during the
- * current transaction. This is primarily to not allocate connections
- * that are needed for data access to other purposes.
- */
-typedef enum ConnectionPurpose
-{
-	/* connection can be used for any purpose */
-	CONNECTION_PURPOSE_ANY,
-
-	/* connection can be used to access placements */
-	CONNECTION_PURPOSE_DATA_ACCESS,
-
-	/* connection can be used for auxiliary functions, but not data access */
-	CONNECTION_PURPOSE_SIDECHANNEL
-} ConnectionPurpose;
 
 typedef enum MultiConnectionState
 {
@@ -115,9 +96,6 @@ typedef struct MultiConnection
 
 	/* is the connection currently in use, and shouldn't be used by anything else */
 	bool claimedExclusively;
-
-	/* defines the purpose of the connection */
-	ConnectionPurpose purpose;
 
 	/* time connection establishment was started, for timeout */
 	TimestampTz connectionStart;

--- a/src/test/regress/expected/failure_multi_shard_update_delete.out
+++ b/src/test/regress/expected/failure_multi_shard_update_delete.out
@@ -6,6 +6,7 @@ SET SEARCH_PATH = multi_shard;
 SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 201000;
 SET citus.shard_replication_factor TO 1;
+SET citus.max_adaptive_executor_pool_size TO 1;
 -- do not cache any connections
 SET citus.max_cached_conns_per_worker TO 0;
 SELECT citus.mitmproxy('conn.allow()');

--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -33,7 +33,11 @@ SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series
 (1 row)
 
 SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int, x2 int);
-ERROR:  result "squares" does not exist
+WARNING:  Query could not find the intermediate result file "squares", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
 BEGIN;
 CREATE TABLE interesting_squares (user_id text, interested_in text);
 SELECT create_distributed_table('interesting_squares', 'user_id');
@@ -83,30 +87,20 @@ ORDER BY x;
 (3 rows)
 
 END;
-CREATE FUNCTION raise_failed_execution_int_result(query text) RETURNS void AS $$
-BEGIN
-        EXECUTE query;
-        EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM LIKE '%does not exist%' THEN
-                RAISE 'Task failed to execute';
-        ELSIF SQLERRM LIKE '%could not receive query results%' THEN
-          RAISE 'Task failed to execute';
-        END IF;
-END;
-$$LANGUAGE plpgsql;
--- don't print the worker port
-\set VERBOSITY terse
-SET client_min_messages TO ERROR;
 -- files should now be cleaned up
-SELECT raise_failed_execution_int_result($$
-	SELECT x, x2
-	FROM interesting_squares JOIN (SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x text, x2 int)) squares ON (x = interested_in)
-	WHERE user_id = 'jon'
-	ORDER BY x;
-$$);
-ERROR:  Task failed to execute
-\set VERBOSITY DEFAULT
-SET client_min_messages TO DEFAULT;
+SET client_min_messages TO DEBUG;
+SELECT x, x2
+FROM interesting_squares JOIN (SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x text, x2 int)) squares ON (x = interested_in)
+WHERE user_id = 'jon' OR true
+ORDER BY x;
+DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  Query could not find the intermediate result file "squares", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+DETAIL:  WARNING from localhost:xxxxx
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
+RESET client_min_messages;
 -- try to read the file as text, will fail because of binary encoding
 BEGIN;
 SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,5) s');
@@ -314,7 +308,11 @@ SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_seri
 (1 row)
 
 SELECT * FROM read_intermediate_results(ARRAY['squares_1']::text[], 'binary') AS res (x int, x2 int);
-ERROR:  result "squares_1" does not exist
+WARNING:  Query could not find the intermediate result file "squares_1", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
 -- error behaviour, and also check that results are deleted on rollback
 BEGIN;
 SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_series(1,3) s');
@@ -325,10 +323,24 @@ SELECT create_intermediate_result('squares_1', 'SELECT s, s*s FROM generate_seri
 
 SAVEPOINT s1;
 SELECT * FROM read_intermediate_results(ARRAY['notexistingfile', 'squares_1'], 'binary') AS res (x int, x2 int);
-ERROR:  result "notexistingfile" does not exist
+WARNING:  Query could not find the intermediate result file "notexistingfile", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+ 1 |  1
+ 2 |  4
+ 3 |  9
+(3 rows)
+
 ROLLBACK TO SAVEPOINT s1;
 SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'notexistingfile'], 'binary') AS res (x int, x2 int);
-ERROR:  result "notexistingfile" does not exist
+WARNING:  Query could not find the intermediate result file "notexistingfile", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+ 1 |  1
+ 2 |  4
+ 3 |  9
+(3 rows)
+
 ROLLBACK TO SAVEPOINT s1;
 SELECT * FROM read_intermediate_results(ARRAY['squares_1', NULL], 'binary') AS res (x int, x2 int);
 ERROR:  null array element not allowed in this context
@@ -348,7 +360,11 @@ SELECT count(*) FROM read_intermediate_results(ARRAY[]::text[], 'binary') AS res
 
 END;
 SELECT * FROM read_intermediate_results(ARRAY['squares_1']::text[], 'binary') AS res (x int, x2 int);
-ERROR:  result "squares_1" does not exist
+WARNING:  Query could not find the intermediate result file "squares_1", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
 -- Test non-binary format: read_intermediate_results(..., 'text')
 BEGIN;
 -- ROW(...) types switch the output format to text
@@ -481,7 +497,12 @@ SELECT store_intermediate_result_on_node('localhost', :worker_1_port,
 SAVEPOINT s1;
 -- results aren't available on coordinator yet
 SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
-ERROR:  result "squares_1" does not exist
+WARNING:  Query could not find the intermediate result file "squares_1", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+WARNING:  Query could not find the intermediate result file "squares_2", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
 ROLLBACK TO SAVEPOINT s1;
 -- fetch from worker 2 should fail
 SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_2_port);
@@ -490,7 +511,12 @@ CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK TO SAVEPOINT s1;
 -- still, results aren't available on coordinator yet
 SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
-ERROR:  result "squares_1" does not exist
+WARNING:  Query could not find the intermediate result file "squares_1", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+WARNING:  Query could not find the intermediate result file "squares_2", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
 ROLLBACK TO SAVEPOINT s1;
 -- fetch from worker 1 should succeed
 SELECT * FROM fetch_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'localhost', :worker_1_port);
@@ -538,11 +564,15 @@ ERROR:  worker array object cannot contain null values
 END;
 -- results should have been deleted after transaction commit
 SELECT * FROM read_intermediate_results(ARRAY['squares_1', 'squares_2']::text[], 'binary') AS res (x int, x2 int);
-ERROR:  result "squares_1" does not exist
+WARNING:  Query could not find the intermediate result file "squares_1", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+WARNING:  Query could not find the intermediate result file "squares_2", it was mostly likely deleted due to an error in a parallel process within the same distributed transaction
+ x | x2
+---------------------------------------------------------------------
+(0 rows)
+
 DROP SCHEMA intermediate_results CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table interesting_squares
-drop cascades to function raise_failed_execution_int_result(text)
 drop cascades to type square_type
 drop cascades to table stored_squares
 drop cascades to table squares

--- a/src/test/regress/expected/with_basics.out
+++ b/src/test/regress/expected/with_basics.out
@@ -1011,6 +1011,11 @@ LEFT JOIN
         WHERE d1.user_id = d2.user_id )) AS bar USING (user_id);
 ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries and CTEs cannot be in the outer part of the outer join
+-- some test  with failures
+WITH a AS (SELECT * FROM users_table LIMIT 10)
+	SELECT user_id/0 FROM users_table JOIN a USING (user_id);
+ERROR:  division by zero
+CONTEXT:  while executing command on localhost:xxxxx
 RESET citus.enable_cte_inlining;
 DROP VIEW basic_view;
 DROP VIEW cte_view;

--- a/src/test/regress/sql/failure_multi_shard_update_delete.sql
+++ b/src/test/regress/sql/failure_multi_shard_update_delete.sql
@@ -7,6 +7,7 @@ SET SEARCH_PATH = multi_shard;
 SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 201000;
 SET citus.shard_replication_factor TO 1;
+SET citus.max_adaptive_executor_pool_size TO 1;
 
 -- do not cache any connections
 SET citus.max_cached_conns_per_worker TO 0;

--- a/src/test/regress/sql/intermediate_results.sql
+++ b/src/test/regress/sql/intermediate_results.sql
@@ -44,34 +44,14 @@ JOIN (SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x int,
 ORDER BY x;
 END;
 
-
-CREATE FUNCTION raise_failed_execution_int_result(query text) RETURNS void AS $$
-BEGIN
-        EXECUTE query;
-        EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM LIKE '%does not exist%' THEN
-                RAISE 'Task failed to execute';
-        ELSIF SQLERRM LIKE '%could not receive query results%' THEN
-          RAISE 'Task failed to execute';
-        END IF;
-END;
-$$LANGUAGE plpgsql;
-
--- don't print the worker port
-\set VERBOSITY terse
-SET client_min_messages TO ERROR;
-
 -- files should now be cleaned up
-SELECT raise_failed_execution_int_result($$
-	SELECT x, x2
-	FROM interesting_squares JOIN (SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x text, x2 int)) squares ON (x = interested_in)
-	WHERE user_id = 'jon'
-	ORDER BY x;
-$$);
+SET client_min_messages TO DEBUG;
+SELECT x, x2
+FROM interesting_squares JOIN (SELECT * FROM read_intermediate_result('squares', 'binary') AS res (x text, x2 int)) squares ON (x = interested_in)
+WHERE user_id = 'jon' OR true
+ORDER BY x;
 
-\set VERBOSITY DEFAULT
-SET client_min_messages TO DEFAULT;
-
+RESET client_min_messages;
 -- try to read the file as text, will fail because of binary encoding
 BEGIN;
 SELECT create_intermediate_result('squares', 'SELECT s, s*s FROM generate_series(1,5) s');

--- a/src/test/regress/sql/with_basics.sql
+++ b/src/test/regress/sql/with_basics.sql
@@ -695,8 +695,11 @@ LEFT JOIN
         FROM distinct_undistribured d2
         WHERE d1.user_id = d2.user_id )) AS bar USING (user_id);
 
-RESET citus.enable_cte_inlining;
+-- some test  with failures
+WITH a AS (SELECT * FROM users_table LIMIT 10)
+	SELECT user_id/0 FROM users_table JOIN a USING (user_id);
 
+RESET citus.enable_cte_inlining;
 
 DROP VIEW basic_view;
 DROP VIEW cte_view;


### PR DESCRIPTION
DESCRIPTION: Do not use an extra connection for intermediate result multi-casts

When we have a query like the following:

```SQL
WITH a AS (SELECT * FROM foo LIMIT 10) SELECT max(x) FROM a JOIN bar 2 USING (y);
```

Citus currently opens side channels for doing the 
        `COPY "1_1"` FROM STDIN (format 'result') 

before starting the execution of 
        `SELECT * FROM foo LIMIT 10` 

Since we need at least 1 connection per worker to do 
        `SELECT * FROM foo LIMIT 10` 
We need to have 2 connections to worker in order to broadcast the results.

However, we don't actually send a single row over the side channel until the 
execution of `SELECT * FROM foo LIMIT 10` is completely done (and connections 
unclaimed) and the results are written to a tuple store. We could actually 
reuse the same connection for doing the `COPY "1_1"` FROM STDIN (format 'result').

Fixes #2418