### PR TITLE
fix flaky log statement in null_parameters

### DIFF
--- a/src/test/regress/expected/null_parameters.out
+++ b/src/test/regress/expected/null_parameters.out
@@ -1575,6 +1575,10 @@ DEBUG:  Plan is router executable
      0
 (1 row)
 
+-- it seems that sometimes the pruning is deferred and sometimes not.
+-- what we care about is that this doesn't crash and the log for this
+-- one shouldn't matter. This is to prevent this test being from flaky.
+SET client_min_messages to ERROR;
 EXECUTE null_select_on_json_param(NULL);
  count
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/null_parameters.sql
+++ b/src/test/regress/sql/null_parameters.sql
@@ -309,6 +309,10 @@ EXECUTE null_select_on_json_param(NULL);
 EXECUTE null_select_on_json_param(NULL);
 EXECUTE null_select_on_json_param(NULL);
 EXECUTE null_select_on_json_param(NULL);
+-- it seems that sometimes the pruning is deferred and sometimes not.
+-- what we care about is that this doesn't crash and the log for this
+-- one shouldn't matter. This is to prevent this test being from flaky.
+SET client_min_messages to ERROR;
 EXECUTE null_select_on_json_param(NULL);
 
 SET client_min_messages TO ERROR;


### PR DESCRIPTION
It seems that sometimes the pruning is deferred and sometimes not with
this statement. What we care in this test is to see that it doesn't
crash. I think we don't care about the log statement for this line. So
it makes sense to not log this statement, and care about the result.
