### PR TITLE
Simplify and fix issues in intermediate result pruning

### DIFF
--- a/src/backend/distributed/planner/multi_master_planner.c
+++ b/src/backend/distributed/planner/multi_master_planner.c
@@ -207,10 +207,6 @@ BuildSelectStatementViaStdPlanner(Query *masterQuery, List *masterTargetList,
 	remoteScan->custom_scan_tlist = copyObject(masterTargetList);
 	remoteScan->scan.plan.targetlist = copyObject(masterTargetList);
 
-	/* probably want to do this where we add sublinks to the master plan */
-	masterQuery->hasSubLinks = checkExprHasSubLink((Node *) masterQuery);
-	Assert(masterQuery->hasWindowFuncs == contain_window_function((Node *) masterQuery));
-
 	/*
 	 * We will overwrite the alias of the rangetable which describes the custom scan.
 	 * Ideally we would have set the correct column names and alias on the range table in

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -732,6 +732,9 @@ BuildJobQuery(MultiNode *multiNode, List *dependentJobList)
 	jobQuery->hasDistinctOn = hasDistinctOn;
 	jobQuery->windowClause = windowClause;
 	jobQuery->hasWindowFuncs = hasWindowFuncs;
+	jobQuery->hasSubLinks = checkExprHasSubLink((Node *) jobQuery);
+
+	Assert(jobQuery->hasWindowFuncs == contain_window_function((Node *) jobQuery));
 
 	return jobQuery;
 }
@@ -1271,6 +1274,7 @@ QueryJoinTree(MultiNode *multiNode, List *dependentJobList, List **rangeTableLis
 																	funcColumnTypes,
 																	funcColumnTypeMods,
 																	funcCollations);
+
 			RangeTblRef *rangeTableRef = makeNode(RangeTblRef);
 
 			rangeTableRef->rtindex = list_length(*rangeTableList) + 1;
@@ -1604,6 +1608,7 @@ BuildSubqueryJobQuery(MultiNode *multiNode)
 	jobQuery->distinctClause = distinctClause;
 	jobQuery->hasWindowFuncs = hasWindowFuncs;
 	jobQuery->windowClause = windowClause;
+	jobQuery->hasSubLinks = checkExprHasSubLink((Node *) jobQuery);
 
 	return jobQuery;
 }

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -141,7 +141,7 @@ CopyNodeUsedDistributedSubPlan(COPYFUNC_ARGS)
 	DECLARE_FROM_AND_NEW_NODE(UsedDistributedSubPlan);
 
 	COPY_STRING_FIELD(subPlanId);
-	COPY_SCALAR_FIELD(locationMask);
+	COPY_SCALAR_FIELD(accessType);
 }
 
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -222,7 +222,7 @@ OutUsedDistributedSubPlan(OUTFUNC_ARGS)
 	WRITE_NODE_TYPE("USEDDISTRIBUTEDSUBPLAN");
 
 	WRITE_STRING_FIELD(subPlanId);
-	WRITE_INT_FIELD(locationMask);
+	WRITE_ENUM_FIELD(accessType, SubPlanAccessType);
 }
 
 

--- a/src/include/distributed/intermediate_result_pruning.h
+++ b/src/include/distributed/intermediate_result_pruning.h
@@ -20,7 +20,7 @@
 
 extern bool LogIntermediateResults;
 
-extern List * FindSubPlansUsedInNode(Node *node);
+extern List * FindSubPlanUsages(DistributedPlan *plan);
 extern List * FindAllWorkerNodesUsingSubplan(HTAB *intermediateResultsHash,
 											 char *resultId);
 extern HTAB * MakeIntermediateResultHTAB(void);
@@ -28,9 +28,5 @@ extern void RecordSubplanExecutionsOnNodes(HTAB *intermediateResultsHash,
 										   DistributedPlan *distributedPlan);
 extern IntermediateResultsHashEntry * SearchIntermediateResult(HTAB *resultsHash,
 															   char *resultId);
-
-/* utility functions related to UsedSubPlans */
-extern List * MergeUsedSubPlanLists(List *leftSubPlanList, List *rightSubPlanList);
-extern void UpdateUsedPlanListLocation(List *subPlanList, int localtionMask);
 
 #endif /* INTERMEDIATE_RESULT_PRUNING_H */

--- a/src/test/regress/expected/intermediate_result_pruning.out
+++ b/src/test/regress/expected/intermediate_result_pruning.out
@@ -1031,6 +1031,37 @@ DEBUG:  Subplan XXX_4 will be sent to localhost:xxxxx
  100
 (1 row)
 
+RESET citus.task_assignment_policy;
+-- Insert..select is planned differently, make sure we have results everywhere.
+-- We put the insert..select in a CTE here to prevent the CTE from being moved
+-- into the select, which would follow the regular code path for select.
+WITH stats AS (
+  SELECT count(key) m FROM table_3
+),
+inserts AS (
+  INSERT INTO table_2
+  SELECT key, count(*)
+  FROM table_1
+  WHERE key > (SELECT m FROM stats)
+  GROUP BY key
+  HAVING count(*) < (SELECT m FROM stats)
+  LIMIT 1
+  RETURNING *
+) SELECT count(*) FROM inserts;
+DEBUG:  generating subplan XXX_1 for CTE stats: SELECT count(key) AS m FROM intermediate_result_pruning.table_3
+DEBUG:  generating subplan XXX_2 for CTE inserts: INSERT INTO intermediate_result_pruning.table_2 (key, value) SELECT key, count(*) AS count FROM intermediate_result_pruning.table_1 WHERE (key OPERATOR(pg_catalog.>) (SELECT stats.m FROM (SELECT intermediate_result.m FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(m bigint)) stats)) GROUP BY key HAVING (count(*) OPERATOR(pg_catalog.<) (SELECT stats.m FROM (SELECT intermediate_result.m FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(m bigint)) stats)) LIMIT 1 RETURNING table_2.key, table_2.value
+DEBUG:  LIMIT clauses are not allowed in distributed INSERT ... SELECT queries
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.key, intermediate_result.value FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(key integer, value text)) inserts
+DEBUG:  Subplan XXX_1 will be written to local file
+DEBUG:  Subplan XXX_1 will be sent to localhost:xxxxx
+DEBUG:  Subplan XXX_1 will be sent to localhost:xxxxx
+DEBUG:  Subplan XXX_2 will be written to local file
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
 SET citus.task_assignment_policy to DEFAULT;
 SET client_min_messages TO DEFAULT;
 DROP TABLE table_1, table_2, table_3, ref_table, accounts, stats, range_partitioned;

--- a/src/test/regress/expected/multi_subquery.out
+++ b/src/test/regress/expected/multi_subquery.out
@@ -911,8 +911,16 @@ RESET citus.coordinator_aggregation_strategy;
 SELECT t1.event_type FROM events_table t1
 GROUP BY t1.event_type HAVING t1.event_type > corr(t1.value_3, t1.value_2 + (SELECT t2.value_2 FROM users_table t2 ORDER BY 1 DESC LIMIT 1))
 ORDER BY 1;
-ERROR:  result "68_1" does not exist
-CONTEXT:  while executing command on localhost:xxxxx
+ event_type
+---------------------------------------------------------------------
+          0
+          1
+          2
+          3
+          4
+          5
+(6 rows)
+
 SELECT t1.event_type FROM events_table t1
 GROUP BY t1.event_type HAVING t1.event_type * 5 > sum(distinct t1.value_3)
 ORDER BY 1;

--- a/src/test/regress/expected/window_functions.out
+++ b/src/test/regress/expected/window_functions.out
@@ -196,6 +196,20 @@ ORDER BY
 (6 rows)
 
 DROP VIEW users_view, window_view;
+-- window functions along with subquery in HAVING
+SELECT
+	user_id, count (user_id) OVER (PARTITION BY user_id)
+FROM
+	users_table
+GROUP BY
+	user_id HAVING avg(value_1) < (SELECT min(k_no) FROM users_ref_test_table)
+ORDER BY 1 DESC,2 DESC
+LIMIT 1;
+ user_id | count
+---------------------------------------------------------------------
+       6 |     1
+(1 row)
+
 -- window function uses columns from two different tables
 SELECT
 	DISTINCT ON (events_table.user_id, rnk) events_table.user_id, rank() OVER my_win AS rnk

--- a/src/test/regress/sql/window_functions.sql
+++ b/src/test/regress/sql/window_functions.sql
@@ -110,6 +110,16 @@ ORDER BY
 
 DROP VIEW users_view, window_view;
 
+-- window functions along with subquery in HAVING
+SELECT
+	user_id, count (user_id) OVER (PARTITION BY user_id)
+FROM
+	users_table
+GROUP BY
+	user_id HAVING avg(value_1) < (SELECT min(k_no) FROM users_ref_test_table)
+ORDER BY 1 DESC,2 DESC
+LIMIT 1;
+
 -- window function uses columns from two different tables
 SELECT
 	DISTINCT ON (events_table.user_id, rnk) events_table.user_id, rank() OVER my_win AS rnk


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that could cause failures in queries with subqueries or CTEs

Follow up on #3709. This cut a bit deeper than I expected.

After this PR we explicitly find subplans in the masterQuery (local) and the jobQuery (remote) instead of only looking at having in the original query (?). The masterQuery gets rewritten by standard_planner, so I moved building `usedSubPlanNodeList` to just before the standard_planner call. To make sure we descend into sublinks correctly, I moved setting masterQuery->hasSubLinks into the physical planner, where it was supposed to be all along.

At some point we may want to make a copy of the original masterQuery instead of keeping the rewritten one, but since it wasn't strictly necessary here I'll leave the for another day.

A bunch of code was dealing with de-duplication in `usedSubPlanNodeList`, which seems unnecessary since we map all matching subplan IDs to the same `IntermediateResultsHashEntry ` in `RecordSubplanExecutionsOnNodes` and the de-duplication logic mostly just moves work from `RecordSubplanExecutionsOnNodes` to `FindSubPlansUsedInNode`. I removed this code.

While working on the changes I found a crash in INSERT..SELECT in combination with intermediate results (#3717). This PR addresses that issue by sending the intermediate results that are used in the SELECT part everywhere, since we currently do planning for the SELECT part in the executor, so we cannot easily do proper pruning.

Fixes #3708
Fixes #3717 
Closes #3709