### PR TITLE
Duplicate grouping on worker whenever possible

### DIFF
--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -453,8 +453,11 @@ HashAggregate
         Tasks Shown: One of 2
         ->  Task
               Node: host=localhost port=xxxxx dbname=regression
-              ->  Seq Scan on public.lineitem_290000 lineitem
+              ->  HashAggregate
                     Output: l_quantity, l_quantity
+                    Group Key: lineitem.l_quantity
+                    ->  Seq Scan on public.lineitem_290000 lineitem
+                          Output: l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
 -- Subquery pushdown tests with explain
 EXPLAIN (COSTS OFF)
 SELECT

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -747,7 +747,7 @@ RESET citus.subquery_pushdown;
 VACUUM ANALYZE users_table;
 -- explain tests
 EXPLAIN (COSTS FALSE) SELECT user_id FROM recent_selected_users GROUP BY 1 ORDER BY 1;
-                                                              QUERY PLAN
+                                                                 QUERY PLAN
 ---------------------------------------------------------------------
  Sort
    Sort Key: remote_scan.user_id
@@ -758,17 +758,19 @@ EXPLAIN (COSTS FALSE) SELECT user_id FROM recent_selected_users GROUP BY 1 ORDER
                Tasks Shown: One of 4
                ->  Task
                      Node: host=localhost port=xxxxx dbname=regression
-                     ->  Nested Loop
-                           Join Filter: (users_table.user_id = users_table_1.user_id)
-                           ->  Sort
-                                 Sort Key: (max(users_table_1."time")) DESC
-                                 ->  HashAggregate
-                                       Group Key: users_table_1.user_id
-                                       Filter: (max(users_table_1."time") > '2017-11-23 16:20:33.264457'::timestamp without time zone)
-                                       ->  Seq Scan on users_table_1400256 users_table_1
-                           ->  Seq Scan on users_table_1400256 users_table
-                                 Filter: ((value_1 >= 1) AND (value_1 < 3))
-(19 rows)
+                     ->  HashAggregate
+                           Group Key: users_table.user_id
+                           ->  Nested Loop
+                                 Join Filter: (users_table.user_id = users_table_1.user_id)
+                                 ->  Sort
+                                       Sort Key: (max(users_table_1."time")) DESC
+                                       ->  HashAggregate
+                                             Group Key: users_table_1.user_id
+                                             Filter: (max(users_table_1."time") > '2017-11-23 16:20:33.264457'::timestamp without time zone)
+                                             ->  Seq Scan on users_table_1400256 users_table_1
+                                 ->  Seq Scan on users_table_1400256 users_table
+                                       Filter: ((value_1 >= 1) AND (value_1 < 3))
+(21 rows)
 
 EXPLAIN (COSTS FALSE) SELECT *
 	FROM (


### PR DESCRIPTION
This is possible whenever we aren't pulling up intermediate rows

We want to do this because this was done in 9.2,
some queries rely on the performance of grouping causing distinct values

This change was introduced when implementing window functions on coordinator

Fixes #3721 
