### PR TITLE
Lock relations before EnsureTableOwner

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -135,6 +135,14 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 	EnsureCoordinator();
+
+	/*
+	 * Lock target relation with an exclusive lock - there's no way to make
+	 * sense of this table until we've committed, and we don't want multiple
+	 * backends manipulating this relation.
+	 */
+	Relation relation = relation_open(relationId, ExclusiveLock);
+
 	EnsureTableOwner(relationId);
 
 	/*
@@ -145,19 +153,6 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 	 */
 	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
 	EnsureDependenciesExistOnAllNodes(&tableAddress);
-
-	/*
-	 * Lock target relation with an exclusive lock - there's no way to make
-	 * sense of this table until we've committed, and we don't want multiple
-	 * backends manipulating this relation.
-	 */
-	Relation relation = try_relation_open(relationId, ExclusiveLock);
-
-	if (relation == NULL)
-	{
-		ereport(ERROR, (errmsg("could not create distributed table: "
-							   "relation does not exist")));
-	}
 
 	/*
 	 * We should do this check here since the codes in the following lines rely
@@ -202,6 +197,13 @@ create_distributed_table(PG_FUNCTION_ARGS)
 	Oid distributionMethodOid = PG_GETARG_OID(2);
 	text *colocateWithTableNameText = PG_GETARG_TEXT_P(3);
 
+	/*
+	 * Lock target relation with an exclusive lock - there's no way to make
+	 * sense of this table until we've committed, and we don't want multiple
+	 * backends manipulating this relation.
+	 */
+	Relation relation = relation_open(relationId, ExclusiveLock);
+
 	EnsureTableOwner(relationId);
 
 	/*
@@ -212,19 +214,6 @@ create_distributed_table(PG_FUNCTION_ARGS)
 	 */
 	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
 	EnsureDependenciesExistOnAllNodes(&tableAddress);
-
-	/*
-	 * Lock target relation with an exclusive lock - there's no way to make
-	 * sense of this table until we've committed, and we don't want multiple
-	 * backends manipulating this relation.
-	 */
-	Relation relation = try_relation_open(relationId, ExclusiveLock);
-
-	if (relation == NULL)
-	{
-		ereport(ERROR, (errmsg("could not create distributed table: "
-							   "relation does not exist")));
-	}
 
 	/*
 	 * We should do this check here since the codes in the following lines rely
@@ -268,6 +257,14 @@ create_reference_table(PG_FUNCTION_ARGS)
 
 	EnsureCoordinator();
 	CheckCitusVersion(ERROR);
+
+	/*
+	 * Lock target relation with an exclusive lock - there's no way to make
+	 * sense of this table until we've committed, and we don't want multiple
+	 * backends manipulating this relation.
+	 */
+	Relation relation = relation_open(relationId, ExclusiveLock);
+
 	EnsureTableOwner(relationId);
 
 	/*
@@ -278,13 +275,6 @@ create_reference_table(PG_FUNCTION_ARGS)
 	 */
 	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
 	EnsureDependenciesExistOnAllNodes(&tableAddress);
-
-	/*
-	 * Lock target relation with an exclusive lock - there's no way to make
-	 * sense of this table until we've committed, and we don't want multiple
-	 * backends manipulating this relation.
-	 */
-	Relation relation = relation_open(relationId, ExclusiveLock);
 
 	/*
 	 * We should do this check here since the codes in the following lines rely

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -1333,6 +1333,9 @@ EnsureTablePermissions(Oid relationId, AclMode mode)
 /*
  * Check that the current user has owner rights to relationId, error out if
  * not. Superusers are regarded as owners.
+ *
+ * In most cases, caller should have acquired a lock on relation if it wants
+ * to make sure this check still holds after this function returns.
  */
 void
 EnsureTableOwner(Oid relationId)

--- a/src/backend/distributed/master/master_repair_shards.c
+++ b/src/backend/distributed/master/master_repair_shards.c
@@ -395,6 +395,9 @@ ReplicateColocatedShardPlacement(int64 shardId, char *sourceNodeName,
 	{
 		char relationKind = '\0';
 
+		/* lock the relation to ensure its owner won't change concurrently*/
+		LockRelationOid(colocatedTableId, AccessShareLock);
+
 		/* check that user has owner rights in all co-located tables */
 		EnsureTableOwner(colocatedTableId);
 

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -80,6 +80,10 @@ mark_tables_colocated(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 	EnsureCoordinator();
+
+	/* lock relation to ensure its owner won't change */
+	LockRelationOid(sourceRelationId, AccessShareLock);
+
 	EnsureTableOwner(sourceRelationId);
 
 	Datum *relationIdDatumArray = DeconstructArrayObject(relationIdArrayObject);
@@ -87,6 +91,9 @@ mark_tables_colocated(PG_FUNCTION_ARGS)
 	for (int relationIndex = 0; relationIndex < relationCount; relationIndex++)
 	{
 		Oid nextRelationOid = DatumGetObjectId(relationIdDatumArray[relationIndex]);
+
+		/* lock relation to ensure its owner won't change */
+		LockRelationOid(sourceRelationId, AccessShareLock);
 
 		/* we require that the user either owns all tables or is superuser */
 		EnsureTableOwner(nextRelationOid);
@@ -111,6 +118,10 @@ update_distributed_table_colocation(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 	EnsureCoordinator();
+
+	/* lock relation to ensure its owner won't change */
+	LockRelationOid(targetRelationId, AccessShareLock);
+
 	EnsureTableOwner(targetRelationId);
 	EnsureHashDistributedTable(targetRelationId);
 

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -58,6 +58,9 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 
 	CheckCitusVersion(ERROR);
 	EnsureCoordinator();
+
+	LockRelationOid(relationId, AccessExclusiveLock);
+
 	EnsureTableOwner(relationId);
 
 	if (!IsCitusTable(relationId))
@@ -90,8 +93,6 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 								  "replicated tables but \"%s\" is streaming replicated",
 								  relationName)));
 	}
-
-	LockRelationOid(relationId, AccessExclusiveLock);
 
 	List *shardIntervalList = LoadShardIntervalList(relationId);
 	if (list_length(shardIntervalList) != 1)

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -108,3 +108,6 @@ s/repartitioned_results_[0-9]+/repartitioned_results_xxxxx/g
 # ignore first parameter for citus_extradata_container due to differences between pg11 and pg12
 # can be removed when we remove PG_VERSION_NUM >= 120000
 s/pg_catalog.citus_extradata_container\([0-9]+/pg_catalog.citus_extradata_container\(XXX/g
+
+# ignore oid in "could not open ..." messages
+s/ERROR:  could not open relation with OID [0-9]+/ERROR:  could not open relation with OID xxxxx/g

--- a/src/test/regress/expected/isolation_drop_vs_all.out
+++ b/src/test/regress/expected/isolation_drop_vs_all.out
@@ -195,7 +195,7 @@ step s1-drop: DROP TABLE drop_hash;
 step s2-distribute-table: SELECT create_distributed_table('drop_hash', 'id'); <waiting ...>
 step s1-commit: COMMIT;
 step s2-distribute-table: <... completed>
-error in steps s1-commit s2-distribute-table: ERROR:  could not create distributed table: relation does not exist
+error in steps s1-commit s2-distribute-table: ERROR:  could not open relation with OID xxxxx
 step s2-commit: COMMIT;
 step s1-select-count: SELECT COUNT(*) FROM drop_hash;
 ERROR:  relation "drop_hash" does not exist

--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -218,7 +218,7 @@ SELECT column_to_column_name('pg_dist_node'::regclass,'{FROMEXPR :fromlist ({RAN
 ERROR:  not a valid column
 -- test column_name_to_column with illegal arguments
 SELECT column_name_to_column(1204127312,'');
-ERROR:  could not open relation with OID 1204127312
+ERROR:  could not open relation with OID xxxxx
 SELECT column_name_to_column('customers','notacolumn');
 ERROR:  column "notacolumn" of relation "customers" does not exist
 -- make one huge shard and manually inspect shard row


### PR DESCRIPTION
Otherwise we are creating a small window for a race condition where a user might not be the owner anymore but still does the requested operation.

This also fixes few other race conditions. Like when calling `upgrade_to_reference_table()`, we were doing some checks before locking the relation. Those checks weren't guaranteed to still hold when we were taking the locks.
