### PR TITLE
Change CreateShardsWithRoundRobinPolicy's lock on pg_dist_node to ShareLock

### DIFF
--- a/src/backend/distributed/master/master_create_shards.c
+++ b/src/backend/distributed/master/master_create_shards.c
@@ -167,7 +167,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	uint64 hashTokenIncrement = HASH_TOKEN_COUNT / shardCount;
 
 	/* don't allow concurrent node list changes that require an exclusive lock */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
+	LockRelationOid(DistNodeRelationId(), ShareLock);
 
 	/* load and sort the worker node list for deterministic placement */
 	List *workerNodeList = DistributedTablePlacementNodeList(NoLock);


### PR DESCRIPTION
`create_reference_table` and `upgrade_to_reference_table` take ShareLocks on pg_dist_node. What is the reason for `create_distributed_table` to be blocked by them?