### PR TITLE
read database name inside the function

### DIFF
--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -7,7 +7,7 @@
 -- not done yet.
 SET citus.next_shard_id TO 580000;
 SELECT $definition$
-CREATE OR REPLACE FUNCTION test.maintenance_worker(p_dbname text DEFAULT current_database())
+CREATE OR REPLACE FUNCTION test.maintenance_worker()
     RETURNS pg_stat_activity
     LANGUAGE plpgsql
 AS $$
@@ -19,7 +19,7 @@ BEGIN
     FOR i IN 1 .. 200 LOOP
         PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = current_database();
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE
@@ -127,7 +127,7 @@ ALTER EXTENSION citus UPDATE TO '9.2-4';
  * but we do not support explicitly updating it to to 9.3-1.
  * Hence below update (to 9.3-1) command should fail.
  */
- ALTER EXTENSION citus UPDATE TO '9.3-1';
+ALTER EXTENSION citus UPDATE TO '9.3-1';
 ERROR:  extension "citus" has no update path from version "9.2-4" to version "9.3-1"
 ALTER EXTENSION citus UPDATE TO '9.3-2';
 -- show running version

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -10,7 +10,7 @@
 SET citus.next_shard_id TO 580000;
 
 SELECT $definition$
-CREATE OR REPLACE FUNCTION test.maintenance_worker(p_dbname text DEFAULT current_database())
+CREATE OR REPLACE FUNCTION test.maintenance_worker()
     RETURNS pg_stat_activity
     LANGUAGE plpgsql
 AS $$
@@ -22,7 +22,7 @@ BEGIN
     FOR i IN 1 .. 200 LOOP
         PERFORM pg_stat_clear_snapshot();
         SELECT * INTO activity FROM pg_stat_activity
-        WHERE application_name = 'Citus Maintenance Daemon' AND datname = p_dbname;
+        WHERE application_name = 'Citus Maintenance Daemon' AND datname = current_database();
         IF activity.pid IS NOT NULL THEN
             RETURN activity;
         ELSE


### PR DESCRIPTION
Multi extension test would get stuck often, it is resolved with #3702. Now we will know why it fails, instead of it getting stuck. However it still fails often, and we need to fix it. Looking at the file it seems that we are waiting for maintenance daemon to start. My guess is that for some reason current_database() could return something we don't expect temporarily but as we get it in the parameter we won't be able to update it. This PR moves that from the parameter inside the function so that hopefully we don't get this failure. This change doesn't have a lot of rationality behind it, it is just an attempt to fix it. If it fixes it, I dont 100% know why. But this test fails a lot so it is good to at least try I guess. 