### PR TITLE
not wait forever in upgrade distributed function before

### DIFF
--- a/src/test/regress/expected/upgrade_distributed_function_before.out
+++ b/src/test/regress/expected/upgrade_distributed_function_before.out
@@ -27,7 +27,7 @@ SELECT create_distributed_function('count_values(int)', '$1', colocate_with:='t1
 (1 row)
 
 -- make sure that the metadata synced before running the queries
-SELECT wait_until_metadata_sync();
+SELECT wait_until_metadata_sync(5000);
  wait_until_metadata_sync
 ---------------------------------------------------------------------
 

--- a/src/test/regress/sql/upgrade_distributed_function_before.sql
+++ b/src/test/regress/sql/upgrade_distributed_function_before.sql
@@ -20,7 +20,7 @@ $$ LANGUAGE plpgsql;
 SELECT create_distributed_function('count_values(int)', '$1', colocate_with:='t1');
 
 -- make sure that the metadata synced before running the queries
-SELECT wait_until_metadata_sync();
+SELECT wait_until_metadata_sync(5000);
 SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE isactive AND noderole = 'primary';
 SET client_min_messages TO DEBUG1;
 


### PR DESCRIPTION
I realized that sometimes pg upgrade job would get stuck, looking at the tests it seems that in `upgrade_distributed_function_before` schedule we have `wait_until_metadata_sync`, when not given any argument it waits forever, so this might be why it is getting stuck.