### PR TITLE
use an enum for local execution status

### DIFF
--- a/src/backend/distributed/commands/local_multi_copy.c
+++ b/src/backend/distributed/commands/local_multi_copy.c
@@ -64,7 +64,7 @@ WriteTupleToLocalShard(TupleTableSlot *slot, CitusCopyDestReceiver *copyDest, in
 	 * Since we are doing a local copy, the following statements should
 	 * use local execution to see the changes
 	 */
-	TransactionAccessedLocalPlacement = true;
+	SetLocalExecutionStatus(LOCAL_EXECUTION_REQUIRED);
 
 	bool isBinaryCopy = localCopyOutState->binary;
 	if (ShouldAddBinaryHeaders(localCopyOutState->fe_msgbuf, isBinaryCopy))

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2029,7 +2029,7 @@ ShouldExecuteCopyLocally(bool isIntermediateResult)
 		return false;
 	}
 
-	if (TransactionAccessedLocalPlacement)
+	if (CurrentLocalExecutionStatus == LOCAL_EXECUTION_REQUIRED)
 	{
 		/*
 		 * For various reasons, including the transaction visibility
@@ -2052,7 +2052,8 @@ ShouldExecuteCopyLocally(bool isIntermediateResult)
 	}
 
 	/* if we connected to the localhost via a connection, we might not be able to see some previous changes that are done via the connection */
-	return !TransactionConnectedToLocalGroup && IsMultiStatementTransaction();
+	return CurrentLocalExecutionStatus != LOCAL_EXECUTION_DISABLED &&
+		   IsMultiStatementTransaction();
 }
 
 
@@ -3294,7 +3295,7 @@ InitializeCopyShardState(CopyShardState *shardState,
 			 */
 			if (!isCopyToIntermediateFile)
 			{
-				TransactionConnectedToLocalGroup = true;
+				SetLocalExecutionStatus(LOCAL_EXECUTION_DISABLED);
 			}
 		}
 

--- a/src/backend/distributed/executor/repartition_join_execution.c
+++ b/src/backend/distributed/executor/repartition_join_execution.c
@@ -83,10 +83,11 @@ static void
 EnsureCompatibleLocalExecutionState(List *taskList)
 {
 	/*
-	 * We have TransactionAccessedLocalPlacement check here to avoid unnecessarily
+	 * We have LOCAL_EXECUTION_REQUIRED check here to avoid unnecessarily
 	 * iterating the task list in AnyTaskAccessesLocalNode.
 	 */
-	if (TransactionAccessedLocalPlacement && AnyTaskAccessesLocalNode(taskList))
+	if (CurrentLocalExecutionStatus == LOCAL_EXECUTION_REQUIRED &&
+		AnyTaskAccessesLocalNode(taskList))
 	{
 		ErrorIfTransactionAccessedPlacementsLocally();
 	}

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -458,7 +458,7 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 
 				if (isLocalShardPlacement)
 				{
-					TransactionConnectedToLocalGroup = true;
+					SetLocalExecutionStatus(LOCAL_EXECUTION_DISABLED);
 				}
 			}
 

--- a/src/backend/distributed/planner/local_plan_cache.c
+++ b/src/backend/distributed/planner/local_plan_cache.c
@@ -179,7 +179,7 @@ IsLocalPlanCachingSupported(Job *currentJob, DistributedPlan *originalDistribute
 		return false;
 	}
 
-	if (TransactionConnectedToLocalGroup)
+	if (CurrentLocalExecutionStatus == LOCAL_EXECUTION_DISABLED)
 	{
 		/* transaction already connected to localhost */
 		return false;

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -445,8 +445,7 @@ ResetGlobalVariables()
 {
 	CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 	XactModificationLevel = XACT_MODIFICATION_NONE;
-	TransactionAccessedLocalPlacement = false;
-	TransactionConnectedToLocalGroup = false;
+	SetLocalExecutionStatus(LOCAL_EXECUTION_OPTIONAL);
 	dlist_init(&InProgressTransactions);
 	activeSetStmts = NULL;
 	CoordinatedTransactionUses2PC = false;

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -17,8 +17,14 @@
 extern bool EnableLocalExecution;
 extern bool LogLocalCommands;
 
-extern bool TransactionAccessedLocalPlacement;
-extern bool TransactionConnectedToLocalGroup;
+typedef enum LocalExecutionStatus
+{
+	LOCAL_EXECUTION_REQUIRED,
+	LOCAL_EXECUTION_OPTIONAL,
+	LOCAL_EXECUTION_DISABLED
+} LocalExecutionStatus;
+
+extern enum LocalExecutionStatus CurrentLocalExecutionStatus;
 
 /* extern function declarations */
 extern uint64 ExecuteLocalTaskList(List *taskList,
@@ -35,5 +41,6 @@ extern bool AnyTaskAccessesLocalNode(List *taskList);
 extern bool TaskAccessesLocalNode(Task *task);
 extern void ErrorIfTransactionAccessedPlacementsLocally(void);
 extern void DisableLocalExecution(void);
+extern void SetLocalExecutionStatus(LocalExecutionStatus newStatus);
 
 #endif /* LOCAL_EXECUTION_H */


### PR DESCRIPTION
We have two variables that are related to local execution status.
TransactionAccessedLocalPlacement and
TransactionConnectedToLocalGroup. Only one of these fields should be
set, however we didn't have any check for this contraint and it was
error prone.

What those two variables are used is that we are trying to understand if
we should use local execution, the current session, or if we should be
using a connection to execute the current query, therefore the tasks. In
the enum, now it is more clear what these variables mean.

Also, now we have a method to change the local execution status. The
method will error if we are trying to transition from a state to a wrong
state. This will help us avoid problems.
