### PR TITLE
return early in ExecuteTaskListExtended in error case

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -961,11 +961,8 @@ ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
 	if (localExecutionSupported && ShouldExecuteTasksLocally(taskList))
 	{
 		bool readOnlyPlan = false;
-
-		/* set local (if any) & remote tasks */
 		ExtractLocalAndRemoteTasks(readOnlyPlan, taskList, &localTaskList,
 								   &remoteTaskList);
-		locallyProcessedRows += ExecuteLocalTaskList(localTaskList, tupleStore);
 	}
 	else
 	{
@@ -982,6 +979,8 @@ ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
 	{
 		ErrorIfTransactionAccessedPlacementsLocally();
 	}
+
+	locallyProcessedRows += ExecuteLocalTaskList(localTaskList, tupleStore);
 
 	if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
 	{

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -136,6 +136,10 @@ static void LocallyExecuteUdfTaskQuery(Query *localUdfCommandQuery);
 uint64
 ExecuteLocalTaskList(List *taskList, Tuplestorestate *tupleStoreState)
 {
+	if (list_length(taskList) == 0)
+	{
+		return 0;
+	}
 	DistributedPlan *distributedPlan = NULL;
 	ParamListInfo paramListInfo = NULL;
 	return ExecuteLocalTaskListExtended(taskList, paramListInfo, distributedPlan,


### PR DESCRIPTION
It is possible to return an error in ExecuteTaskListExtended after
performing local execution with the current structure. However there is
no point in execution the local tasks if we are going to return an error
later. So the local execution is moved after the error check.
