### PR TITLE
GetConnParams: Set runtimeParamStart before setting keywords/values to avoid out of bounds access

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -262,6 +262,13 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	};
 
 	/*
+	 * remember where global/GUC params end and runtime ones start, all entries after this
+	 * point should be allocated in context and will be freed upon
+	 * FreeConnParamsHashEntryFields
+	 */
+	*runtimeParamStart = ConnParams.size;
+
+	/*
 	 * Declare local params for readability;
 	 *
 	 * assignment is done directly to not loose the pointers if any of the later
@@ -279,7 +286,6 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 	/* auth keywords will begin after global and runtime ones are appended */
 	Index authParamsIdx = ConnParams.size + lengthof(runtimeKeywords);
 
-
 	if (ConnParams.size + lengthof(runtimeKeywords) >= ConnParams.maxSize)
 	{
 		/* hopefully this error is only seen by developers */
@@ -296,13 +302,6 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 		connKeywords[paramIndex] = ConnParams.keywords[paramIndex];
 		connValues[paramIndex] = ConnParams.values[paramIndex];
 	}
-
-	/*
-	 * remember where global/GUC params end and runtime ones start, all entries after this
-	 * point should be allocated in context and will be freed upon
-	 * FreeConnParamsHashEntryFields
-	 */
-	*runtimeParamStart = ConnParams.size;
 
 	/* second step: begin after global params and copy runtime params into our context */
 	for (Index runtimeParamIndex = 0;


### PR DESCRIPTION
Not sure how to test this, if someone could get JIT access to the VM this segfault happened on maybe they could check the coredump. I cannot JIT

Fixes #3716 
