### PR TITLE
Ensure metadata is synced on master_copy_shard_placement(..., do_repair := false)

### DIFF
--- a/src/test/regress/expected/master_copy_shard_placement.out
+++ b/src/test/regress/expected/master_copy_shard_placement.out
@@ -4,7 +4,7 @@ SET search_path TO mcsp;
 SET citus.next_shard_id TO 8139000;
 SET citus.shard_replication_factor TO 1;
 SET citus.replication_model TO 'statement';
-CREATE TABLE ref_table(a int);
+CREATE TABLE ref_table(a int, b text unique);
 SELECT create_reference_table('ref_table');
  create_reference_table
 ---------------------------------------------------------------------
@@ -62,6 +62,18 @@ SELECT master_copy_shard_placement(
            'localhost', :worker_2_port,
            do_repair := false);
 ERROR:  shard xxxxx already exists in the target node
+-- verify we error out if table has foreign key constraints
+INSERT INTO ref_table SELECT 1, value FROM data;
+ALTER TABLE data ADD CONSTRAINT distfk FOREIGN KEY (value) REFERENCES ref_table (b) MATCH FULL;
+SELECT master_copy_shard_placement(
+           get_shard_id_for_distribution_column('data', 'key-1'),
+           'localhost', :worker_2_port,
+           'localhost', :worker_1_port,
+           do_repair := false);
+ERROR:  cannot create foreign key constraint
+DETAIL:  This shard has foreign constraints on it. Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
+ALTER TABLE data DROP CONSTRAINT distfk;
 -- replicate shard that contains key-1
 SELECT master_copy_shard_placement(
            get_shard_id_for_distribution_column('data', 'key-1'),

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -848,7 +848,8 @@ SELECT min(result) = max(result) AS consistent FROM run_command_on_placements('r
 (1 row)
 
 SET client_min_messages TO WARNING;
-SELECT count(*) AS ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass \gset
+SELECT shardid AS ref_table_shard FROM pg_dist_shard WHERE logicalrelid = 'ref_table'::regclass \gset
+SELECT count(*) AS ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard \gset
 -- remove reference table replica from worker 2
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
  ?column?
@@ -856,7 +857,7 @@ SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
         1
 (1 row)
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
  ?column?
 ---------------------------------------------------------------------
        -1
@@ -871,7 +872,7 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
         1
 (1 row)
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
  ?column?
 ---------------------------------------------------------------------
         0
@@ -890,7 +891,7 @@ SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
         1
 (1 row)
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
  ?column?
 ---------------------------------------------------------------------
        -1
@@ -902,7 +903,7 @@ SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
         1
 (1 row)
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
  ?column?
 ---------------------------------------------------------------------
         0
@@ -912,6 +913,105 @@ SELECT min(result) = max(result) AS consistent FROM run_command_on_placements('r
  consistent
 ---------------------------------------------------------------------
  t
+(1 row)
+
+-- test that metadata is synced when master_copy_shard_placement replicates
+-- reference table shards
+SET citus.replicate_reference_tables_on_activate TO off;
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SET citus.replication_model TO streaming;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT master_copy_shard_placement(
+           :ref_table_shard,
+           'localhost', :worker_1_port,
+           'localhost', :worker_2_port,
+           do_repair := false,
+           transfer_mode := 'block_writes');
+ master_copy_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT result::int - :ref_table_placements
+FROM run_command_on_workers('SELECT count(*) FROM pg_dist_placement a, pg_dist_shard b, pg_class c WHERE a.shardid=b.shardid AND b.logicalrelid=c.oid AND c.relname=''ref_table''')
+WHERE nodeport=:worker_1_port;
+ ?column?
+---------------------------------------------------------------------
+        0
+(1 row)
+
+-- test that metadata is synced on replicate_reference_tables
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT replicate_reference_tables();
+ replicate_reference_tables
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT result::int - :ref_table_placements
+FROM run_command_on_workers('SELECT count(*) FROM pg_dist_placement a, pg_dist_shard b, pg_class c WHERE a.shardid=b.shardid AND b.logicalrelid=c.oid AND c.relname=''ref_table''')
+WHERE nodeport=:worker_1_port;
+ ?column?
+---------------------------------------------------------------------
+        0
+(1 row)
+
+-- join the reference table with a distributed table from worker 1
+-- to verify that metadata for worker 2 placements have been synced
+-- to worker 1.
+CREATE TABLE dist_table(a int, b int);
+SELECT create_distributed_table('dist_table', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dist_table SELECT i, i * i FROM generate_series(1, 20) i;
+TRUNCATE ref_table;
+INSERT INTO ref_table SELECT 2 * i FROM generate_series(1, 5) i;
+\c - - - :worker_1_port
+SET search_path TO replicate_reference_table;
+SELECT array_agg(dist_table.b ORDER BY ref_table.a)
+FROM ref_table, dist_table
+WHERE ref_table.a = dist_table.a;
+    array_agg
+---------------------------------------------------------------------
+ {4,16,36,64,100}
+(1 row)
+
+\c - - - :master_port
+SET search_path TO replicate_reference_table;
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
 (1 row)
 
 -- test adding an invalid node while we have reference tables to replicate

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -551,31 +551,88 @@ SELECT min(result) = max(result) AS consistent FROM run_command_on_placements('r
 
 SET client_min_messages TO WARNING;
 
-SELECT count(*) AS ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass \gset
+SELECT shardid AS ref_table_shard FROM pg_dist_shard WHERE logicalrelid = 'ref_table'::regclass \gset
+
+SELECT count(*) AS ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard \gset
 
 -- remove reference table replica from worker 2
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
 
 -- test setting citus.replicate_reference_tables_on_activate to on
 -- master_add_node
 SET citus.replicate_reference_tables_on_activate TO on;
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
 
 -- master_activate_node
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
 SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
 
 SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
 
-SELECT count(*) - :ref_table_placements FROM pg_dist_shard NATURAL JOIN pg_dist_shard_placement WHERE logicalrelid = 'ref_table'::regclass;
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
 
 SELECT min(result) = max(result) AS consistent FROM run_command_on_placements('ref_table', 'SELECT sum(a) FROM %s');
+
+-- test that metadata is synced when master_copy_shard_placement replicates
+-- reference table shards
+SET citus.replicate_reference_tables_on_activate TO off;
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+
+SET citus.replication_model TO streaming;
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+
+SELECT master_copy_shard_placement(
+           :ref_table_shard,
+           'localhost', :worker_1_port,
+           'localhost', :worker_2_port,
+           do_repair := false,
+           transfer_mode := 'block_writes');
+
+SELECT result::int - :ref_table_placements
+FROM run_command_on_workers('SELECT count(*) FROM pg_dist_placement a, pg_dist_shard b, pg_class c WHERE a.shardid=b.shardid AND b.logicalrelid=c.oid AND c.relname=''ref_table''')
+WHERE nodeport=:worker_1_port;
+
+-- test that metadata is synced on replicate_reference_tables
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+
+SELECT replicate_reference_tables();
+
+SELECT result::int - :ref_table_placements
+FROM run_command_on_workers('SELECT count(*) FROM pg_dist_placement a, pg_dist_shard b, pg_class c WHERE a.shardid=b.shardid AND b.logicalrelid=c.oid AND c.relname=''ref_table''')
+WHERE nodeport=:worker_1_port;
+
+-- join the reference table with a distributed table from worker 1
+-- to verify that metadata for worker 2 placements have been synced
+-- to worker 1.
+
+CREATE TABLE dist_table(a int, b int);
+SELECT create_distributed_table('dist_table', 'a');
+INSERT INTO dist_table SELECT i, i * i FROM generate_series(1, 20) i;
+
+TRUNCATE ref_table;
+INSERT INTO ref_table SELECT 2 * i FROM generate_series(1, 5) i;
+
+\c - - - :worker_1_port
+
+SET search_path TO replicate_reference_table;
+
+SELECT array_agg(dist_table.b ORDER BY ref_table.a)
+FROM ref_table, dist_table
+WHERE ref_table.a = dist_table.a;
+
+\c - - - :master_port
+
+SET search_path TO replicate_reference_table;
+
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
 
 -- test adding an invalid node while we have reference tables to replicate
 -- set client message level to ERROR and verbosity to terse to supporess


### PR DESCRIPTION
https://github.com/citusdata/citus/pull/3637 moved reference table replication to shard creation instead of node activation. But it didn't work on MX because `master_copy_shard_placement()` didn't sync the copied shard's metadata to MX nodes. This PR fixes that.

First commit is just a refactoring to make it easier to see what is going on in `ReplicateColocatedShardPlacement`. Second commit fixes the actual issue.