### PR TITLE
decrease log level in multi router planner fast path test

### DIFF
--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -215,7 +215,11 @@ test: multi_transaction_recovery
 # multi_router_planner creates hash partitioned tables.
 # ---------
 test: multi_copy fast_path_router_modify pg_dump
-test: multi_router_planner multi_router_planner_fast_path null_parameters
+test: multi_router_planner
+# These 2 tests have prepared statements which sometimes get invalidated by concurrent tests,
+# changing the debug output. We should not run them in parallel with others
+test: null_parameters
+test: multi_router_planner_fast_path
 
 # ----------
 # multi_large_shardid loads more lineitem data using high shard identifiers


### PR DESCRIPTION
It seems that we have a flaky log when calling author_articles_max_id.
I suspect that this is related to postgres not us. Sometimes the second
call also hits the fast router plan, and then we get:

```diff
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan is router executable
```

We had a similar problem with null_parameters test. Not sure if there is
a better solution here.
