### PR TITLE
Allow subqueries in LIMIT/OFFSET

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -579,6 +579,7 @@ TaskTrackerCreateScan(CustomScan *scan)
 	scanState->distributedPlan = GetDistributedPlan(scan);
 
 	scanState->customScanState.methods = &TaskTrackerCustomExecMethods;
+	scanState->PreExecScan = &CitusPreExecScan;
 
 	return (Node *) scanState;
 }

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -2894,7 +2894,6 @@ TaskTrackerExecScan(CustomScanState *node)
 		DistributedPlan *distributedPlan = scanState->distributedPlan;
 		Job *workerJob = distributedPlan->workerJob;
 		Query *jobQuery = workerJob->jobQuery;
-		elog(WARNING, "query %s", nodeToString(distributedPlan->masterQuery));
 
 		ErrorIfTransactionAccessedPlacementsLocally();
 		DisableLocalExecution();

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -2894,6 +2894,7 @@ TaskTrackerExecScan(CustomScanState *node)
 		DistributedPlan *distributedPlan = scanState->distributedPlan;
 		Job *workerJob = distributedPlan->workerJob;
 		Query *jobQuery = workerJob->jobQuery;
+		elog(WARNING, "query %s", nodeToString(distributedPlan->masterQuery));
 
 		ErrorIfTransactionAccessedPlacementsLocally();
 		DisableLocalExecution();

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -258,14 +258,8 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 			planContext.plan = standard_planner(planContext.query,
 												planContext.cursorOptions,
 												planContext.boundParams);
-
 			if (needsDistributedPlanning)
 			{
-				/*
-				 * standard_planner rewrites simple queries like 'select 10' to PARAM_EXEC nodes,
-				 * which we're unable to handle. Meanwhile we only optimize rewrites to Const.
-				 * So deoptimize non-Const LIMIT/OFFSET, standard_planner will handle it again later.
-				 */
 				result = PlanDistributedStmt(&planContext, rteIdCounter);
 			}
 			else if ((result = TryToDelegateFunctionCall(&planContext)) == NULL)

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -266,19 +266,6 @@ distributed_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 				 * which we're unable to handle. Meanwhile we only optimize rewrites to Const.
 				 * So deoptimize non-Const LIMIT/OFFSET, standard_planner will handle it again later.
 				 */
-				if (planContext.query->limitCount &&
-					!IsA(planContext.query->limitCount, Const))
-				{
-					planContext.query->limitCount = planContext.originalQuery->limitCount;
-				}
-
-				if (planContext.query->limitOffset &&
-					!IsA(planContext.query->limitOffset, Const))
-				{
-					planContext.query->limitOffset =
-						planContext.originalQuery->limitOffset;
-				}
-
 				result = PlanDistributedStmt(&planContext, rteIdCounter);
 			}
 			else if ((result = TryToDelegateFunctionCall(&planContext)) == NULL)

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -1486,6 +1486,8 @@ MasterExtendedOpNode(MultiExtendedOp *originalOpNode,
 	masterExtendedOpNode->sortClauseList = originalOpNode->sortClauseList;
 	masterExtendedOpNode->distinctClause = originalOpNode->distinctClause;
 	masterExtendedOpNode->hasDistinctOn = originalOpNode->hasDistinctOn;
+	masterExtendedOpNode->originalLimitCount = originalOpNode->originalLimitCount;
+	masterExtendedOpNode->originalLimitOffset = originalOpNode->originalLimitOffset;
 	masterExtendedOpNode->limitCount = originalOpNode->limitCount;
 	masterExtendedOpNode->limitOffset = originalOpNode->limitOffset;
 	masterExtendedOpNode->havingQual = newHavingQual;
@@ -2314,6 +2316,7 @@ WorkerExtendedOpNode(MultiExtendedOp *originalOpNode,
 	workerExtendedOpNode->hasWindowFuncs = queryWindowClause.hasWindowFunctions;
 	workerExtendedOpNode->windowClause = queryWindowClause.workerWindowClauseList;
 	workerExtendedOpNode->sortClauseList = queryOrderByLimit.workerSortClauseList;
+	workerExtendedOpNode->originalLimitCount = queryOrderByLimit.workerLimitCount;
 	workerExtendedOpNode->limitCount = queryOrderByLimit.workerLimitCount;
 
 	return workerExtendedOpNode;

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1013,18 +1013,6 @@ DeferErrorIfQueryNotSupported(Query *queryTree)
 		errorHint = filterHint;
 	}
 
-	if (FindNodeCheck((Node *) queryTree->limitCount, IsNodeSubquery))
-	{
-		preconditionsSatisfied = false;
-		errorMessage = "subquery in LIMIT is not supported in multi-shard queries";
-	}
-
-	if (FindNodeCheck((Node *) queryTree->limitOffset, IsNodeSubquery))
-	{
-		preconditionsSatisfied = false;
-		errorMessage = "subquery in OFFSET is not supported in multi-shard queries";
-	}
-
 	/* finally check and error out if not satisfied */
 	if (!preconditionsSatisfied)
 	{

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -672,7 +672,7 @@ MultiNodeTree(Query *originalQuery, Query *queryTree)
 	 * If we have a subquery, build a multi table node for the subquery and
 	 * add a collect node on top of the multi table node.
 	 */
-	List *subqueryEntryList = SubqueryEntryList(originalQuery);
+	List *subqueryEntryList = SubqueryEntryList(queryTree);
 	if (subqueryEntryList != NIL)
 	{
 		MultiCollect *subqueryCollectNode = CitusMakeNode(MultiCollect);

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -666,8 +666,8 @@ BuildJobQuery(MultiNode *multiNode, List *dependentJobList)
 	{
 		MultiExtendedOp *extendedOp = (MultiExtendedOp *) linitial(extendedOpNodeList);
 
-		limitCount = extendedOp->limitCount;
-		limitOffset = extendedOp->limitOffset;
+		limitCount = extendedOp->originalLimitCount;
+		limitOffset = extendedOp->originalLimitOffset;
 		sortClauseList = extendedOp->sortClauseList;
 		havingQual = extendedOp->havingQual;
 	}
@@ -814,8 +814,8 @@ BuildReduceQuery(MultiExtendedOp *extendedOpNode, List *dependentJobList)
 	reduceQuery->jointree = joinTree;
 	reduceQuery->sortClause = extendedOpNode->sortClauseList;
 	reduceQuery->groupClause = extendedOpNode->groupClauseList;
-	reduceQuery->limitOffset = extendedOpNode->limitOffset;
-	reduceQuery->limitCount = extendedOpNode->limitCount;
+	reduceQuery->limitOffset = extendedOpNode->originalLimitOffset;
+	reduceQuery->limitCount = extendedOpNode->originalLimitCount;
 	reduceQuery->havingQual = extendedOpNode->havingQual;
 	reduceQuery->hasAggs = contain_aggs_of_level((Node *) targetList, 0);
 
@@ -1551,8 +1551,8 @@ BuildSubqueryJobQuery(MultiNode *multiNode)
 	{
 		MultiExtendedOp *extendedOp = (MultiExtendedOp *) linitial(extendedOpNodeList);
 
-		limitCount = extendedOp->limitCount;
-		limitOffset = extendedOp->limitOffset;
+		limitCount = extendedOp->originalLimitCount;
+		limitOffset = extendedOp->originalLimitOffset;
 		sortClauseList = extendedOp->sortClauseList;
 		havingQual = extendedOp->havingQual;
 		distinctClause = extendedOp->distinctClause;

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1665,10 +1665,6 @@ SubqueryPushdownMultiNodeTree(Query *originalQuery)
 	 * expression on the LIMIT and OFFSET clauses. Note that logical optimizer
 	 * expects those clauses to be already evaluated.
 	 */
-	extendedOpNode->originalLimitCount =
-		PartiallyEvaluateExpression(extendedOpNode->originalLimitCount, NULL);
-	extendedOpNode->originalLimitOffset =
-		PartiallyEvaluateExpression(extendedOpNode->originalLimitOffset, NULL);
 	extendedOpNode->limitCount =
 		PartiallyEvaluateExpression(extendedOpNode->limitCount, NULL);
 	extendedOpNode->limitOffset =

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -551,7 +551,7 @@ SubqueryMultiNodeTree(Query *originalQuery, Query *queryTree,
 		}
 
 		/* all checks have passed, safe to create the multi plan */
-		multiQueryNode = MultiNodeTree(queryTree);
+		multiQueryNode = MultiNodeTree(originalQuery, queryTree);
 	}
 
 	Assert(multiQueryNode != NULL);
@@ -1623,7 +1623,7 @@ SubqueryPushdownMultiNodeTree(Query *originalQuery)
 	 * distinguish between aggregates and expressions; and we address this later
 	 * in the logical optimizer.
 	 */
-	MultiExtendedOp *extendedOpNode = MultiExtendedOpNode(queryTree, originalQuery);
+	MultiExtendedOp *extendedOpNode = MultiExtendedOpNode(originalQuery, queryTree);
 
 	/*
 	 * Postgres standard planner converts having qual node to a list of and
@@ -1665,6 +1665,10 @@ SubqueryPushdownMultiNodeTree(Query *originalQuery)
 	 * expression on the LIMIT and OFFSET clauses. Note that logical optimizer
 	 * expects those clauses to be already evaluated.
 	 */
+	extendedOpNode->originalLimitCount =
+		PartiallyEvaluateExpression(extendedOpNode->originalLimitCount, NULL);
+	extendedOpNode->originalLimitOffset =
+		PartiallyEvaluateExpression(extendedOpNode->originalLimitOffset, NULL);
 	extendedOpNode->limitCount =
 		PartiallyEvaluateExpression(extendedOpNode->limitCount, NULL);
 	extendedOpNode->limitOffset =

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -331,6 +331,16 @@ RecursivelyPlanSubqueriesAndCTEs(Query *query, RecursivePlanningContext *context
 		RecursivelyPlanAllSubqueries(query->havingQual, context);
 	}
 
+	if (query->limitCount != NULL)
+	{
+		RecursivelyPlanAllSubqueries(query->limitCount, context);
+	}
+
+	if (query->limitOffset != NULL)
+	{
+		RecursivelyPlanAllSubqueries(query->limitOffset, context);
+	}
+
 	/*
 	 * If the query doesn't have distribution key equality,
 	 * recursively plan some of its subqueries.

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -172,6 +172,8 @@ typedef struct MultiExtendedOp
 	List *targetList;
 	List *groupClauseList;
 	List *sortClauseList;
+	Node *originalLimitCount;
+	Node *originalLimitOffset;
 	Node *limitCount;
 	Node *limitOffset;
 	Node *havingQual;
@@ -219,10 +221,10 @@ extern List * pull_var_clause_default(Node *node);
 extern bool OperatorImplementsEquality(Oid opno);
 extern DeferredErrorMessage * DeferErrorIfUnsupportedClause(List *clauseList);
 extern MultiProject * MultiProjectNode(List *targetEntryList);
-extern MultiExtendedOp * MultiExtendedOpNode(Query *queryTree, Query *originalQuery);
+extern MultiExtendedOp * MultiExtendedOpNode(Query *originalQuery, Query *queryTree);
 extern DeferredErrorMessage * DeferErrorIfUnsupportedSubqueryRepartition(Query *
 																		 subqueryTree);
-extern MultiNode * MultiNodeTree(Query *queryTree);
+extern MultiNode * MultiNodeTree(Query *originalQuery, Query *queryTree);
 
 
 #endif   /* MULTI_LOGICAL_PLANNER_H */

--- a/src/test/regress/expected/multi_limit_clause.out
+++ b/src/test/regress/expected/multi_limit_clause.out
@@ -553,8 +553,40 @@ SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limi
 
 DROP FUNCTION my_limit();
 -- subqueries should error out
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem_hash) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
+ l_orderkey
+---------------------------------------------------------------------
+       8997
+(1 row)
+
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
-ERROR:  subquery in LIMIT is not supported in multi-shard queries
+ l_orderkey
+---------------------------------------------------------------------
+          1
+          1
+          1
+          1
+          1
+          1
+          2
+          3
+          3
+          3
+(10 rows)
+
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
-ERROR:  subquery in OFFSET is not supported in multi-shard queries
+ l_orderkey
+---------------------------------------------------------------------
+          3
+          3
+          3
+          4
+          5
+          5
+          5
+          6
+          7
+          7
+(10 rows)
+
 DROP TABLE lineitem_hash;

--- a/src/test/regress/expected/multi_limit_clause.out
+++ b/src/test/regress/expected/multi_limit_clause.out
@@ -552,8 +552,14 @@ SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limi
 (10 rows)
 
 DROP FUNCTION my_limit();
--- subqueries should error out
-SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem_hash) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
+SET citus.task_executor_type TO 'task-tracker';
+WITH cte AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4) SELECT * FROM cte ORDER BY 1 LIMIT (SELECT min(l_linenumber) FROM lineitem);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
  l_orderkey
 ---------------------------------------------------------------------
        8997
@@ -589,4 +595,66 @@ SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT
           7
 (10 rows)
 
-DROP TABLE lineitem_hash;
+RESET citus.task_executor_type;
+WITH cte AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4) SELECT * FROM cte ORDER BY 1 LIMIT (SELECT min(l_linenumber) FROM lineitem);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
+ l_orderkey
+---------------------------------------------------------------------
+       8997
+(1 row)
+
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
+ l_orderkey
+---------------------------------------------------------------------
+          1
+          1
+          1
+          1
+          1
+          1
+          2
+          3
+          3
+          3
+(10 rows)
+
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
+ l_orderkey
+---------------------------------------------------------------------
+          3
+          3
+          3
+          4
+          5
+          5
+          5
+          6
+          7
+          7
+(10 rows)
+
+-- test insert/select executor with recursively planned subquery in LIMIT
+CREATE TABLE insertselect_test (id int, key int);
+SELECT create_distributed_table('insertselect_test', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO insertselect_test
+SELECT l_orderkey, l_linenumber
+FROM lineitem_hash
+ORDER BY 1, 2
+LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
+SELECT * FROM insertselect_test;
+  id  | key
+---------------------------------------------------------------------
+ 8997 |   2
+(1 row)
+
+DROP TABLE lineitem_hash, insertselect_test;

--- a/src/test/regress/sql/multi_limit_clause.sql
+++ b/src/test/regress/sql/multi_limit_clause.sql
@@ -237,7 +237,14 @@ SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limi
 DROP FUNCTION my_limit();
 
 -- subqueries should error out
-SELECT min(l_linenumber) FROM lineitem;
+select count(*) from lineitem;
+set citus.task_executor_type to 'task-tracker';
+set client_min_messages to debug4;
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
+reset client_min_messages;
+reset citus.task_executor_type;
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);

--- a/src/test/regress/sql/multi_limit_clause.sql
+++ b/src/test/regress/sql/multi_limit_clause.sql
@@ -236,17 +236,25 @@ SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limi
 
 DROP FUNCTION my_limit();
 
--- subqueries should error out
-select count(*) from lineitem;
-set citus.task_executor_type to 'task-tracker';
-set client_min_messages to debug4;
+SET citus.task_executor_type TO 'task-tracker';
+WITH cte AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4) SELECT * FROM cte ORDER BY 1 LIMIT (SELECT min(l_linenumber) FROM lineitem);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
-reset client_min_messages;
-reset citus.task_executor_type;
+RESET citus.task_executor_type;
+WITH cte AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4) SELECT * FROM cte ORDER BY 1 LIMIT (SELECT min(l_linenumber) FROM lineitem);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
 
-DROP TABLE lineitem_hash;
+-- test insert/select executor with recursively planned subquery in LIMIT
+CREATE TABLE insertselect_test (id int, key int);
+SELECT create_distributed_table('insertselect_test', 'id');
+INSERT INTO insertselect_test
+SELECT l_orderkey, l_linenumber
+FROM lineitem_hash
+ORDER BY 1, 2
+LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
+SELECT * FROM insertselect_test;
+
+DROP TABLE lineitem_hash, insertselect_test;

--- a/src/test/regress/sql/multi_limit_clause.sql
+++ b/src/test/regress/sql/multi_limit_clause.sql
@@ -237,6 +237,8 @@ SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET my_limi
 DROP FUNCTION my_limit();
 
 -- subqueries should error out
+SELECT min(l_linenumber) FROM lineitem;
+SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT min(l_linenumber) FROM lineitem) OFFSET (SELECT (count(*)/2)::int FROM lineitem_hash);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT (SELECT 10);
 SELECT l_orderkey FROM lineitem_hash ORDER BY l_orderkey LIMIT 10 OFFSET (SELECT 10);
 


### PR DESCRIPTION
#3690 didn't support this because it was segfaulting

DESCRIPTION: Allow subqueries in `LIMIT`/`OFFSET`

Interesting to note that at this line:
https://github.com/citusdata/citus/blob/c8d0e45dd4f9f55a88aa7e39800cb92f0a58c1bc/src/backend/distributed/planner/distributed_planner.c#L1383
I was able to add `finalPlan->paramExecTypes = localPlan->paramExecTypes` to avoid the segfault, but the params were evaluated to `0` instead of `10`

*currently looking into why task-tracker doesn't understand this*