### PR TITLE
add execution params struct

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -187,10 +187,15 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		};
 
 		bool localExecutionSupported = true;
-		ExecuteTaskListExtended(ROW_MODIFY_NONE, list_make1(task),
-								tupleDesc, tupleStore, hasReturning,
-								MaxAdaptiveExecutorPoolSize,
-								&xactProperties, NIL, localExecutionSupported);
+		ExecutionParams *executionParams = CreateBasicExecutionParams(
+			ROW_MODIFY_NONE, list_make1(task), MaxAdaptiveExecutorPoolSize,
+			localExecutionSupported
+			);
+		executionParams->tupleStore = tupleStore;
+		executionParams->tupleDescriptor = tupleDesc;
+		executionParams->hasReturning = hasReturning;
+		executionParams->xactProperties = xactProperties;
+		ExecuteTaskListExtended(executionParams);
 
 		while (tuplestore_gettupleslot(tupleStore, true, false, slot))
 		{

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -422,9 +422,15 @@ ExecuteSelectTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor,
 	 * query string for the local placement.
 	 */
 	bool localExecutionSupported = false;
-	ExecuteTaskListExtended(ROW_MODIFY_READONLY, taskList, resultDescriptor,
-							resultStore, hasReturning, targetPoolSize, &xactProperties,
-							NIL, localExecutionSupported);
+	ExecutionParams *executionParams = CreateBasicExecutionParams(
+		ROW_MODIFY_READONLY, taskList, targetPoolSize, localExecutionSupported
+		);
+	executionParams->tupleDescriptor = resultDescriptor;
+	executionParams->tupleStore = resultStore;
+	executionParams->xactProperties = xactProperties;
+	executionParams->hasReturning = hasReturning;
+
+	ExecuteTaskListExtended(executionParams);
 
 	return resultStore;
 }

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -74,13 +74,48 @@ extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint
 							 bool execute_once);
 extern void AdaptiveExecutorPreExecutorRun(CitusScanState *scanState);
 extern TupleTableSlot * AdaptiveExecutor(CitusScanState *scanState);
-extern uint64 ExecuteTaskListExtended(RowModifyLevel modLevel, List *taskList,
-									  TupleDesc tupleDescriptor,
-									  Tuplestorestate *tupleStore,
-									  bool hasReturning, int targetPoolSize,
-									  TransactionProperties *xactProperties,
-									  List *jobIdList,
-									  bool localExecutionSupported);
+
+/*
+ * ExecutionParams contains parameters that are used during the execution.
+ * Some of these can be the zero value if it is not needed during the execution.
+ */
+typedef struct ExecutionParams
+{
+	/* modLevel is the access level for rows.*/
+	RowModifyLevel modLevel;
+
+	/* taskList contains the tasks for the execution.*/
+	List *taskList;
+
+	/* tupleDescriptor contains the description for the result tuples.*/
+	TupleDesc tupleDescriptor;
+
+	/* tupleStore is where the results will be stored for this execution */
+	Tuplestorestate *tupleStore;
+
+	/* hasReturning is true if this execution will return some result. */
+	bool hasReturning;
+
+	/* targetPoolSize is the maximum amount of connections per worker */
+	int targetPoolSize;
+
+	/* xactProperties contains properties for transactions, such as if we should use 2pc. */
+	TransactionProperties xactProperties;
+
+	/* jobIdList contains all job ids for the execution */
+	List *jobIdList;
+
+	/* localExecutionSupported is true if we can use local execution, if it is false
+	 * local execution will not be used. */
+	bool localExecutionSupported;
+} ExecutionParams;
+
+ExecutionParams * CreateBasicExecutionParams(RowModifyLevel modLevel,
+											 List *taskList,
+											 int targetPoolSize,
+											 bool localExecutionSupported);
+
+extern uint64 ExecuteTaskListExtended(ExecutionParams *executionParams);
 extern uint64 ExecuteTaskListIntoTupleStore(RowModifyLevel modLevel, List *taskList,
 											TupleDesc tupleDescriptor,
 											Tuplestorestate *tupleStore,


### PR DESCRIPTION
We had 9+ parameters in some of the functions related to execution.
Execution params is created to simplify this a bit so that we can set
only the fields that we are interested in and it is easier to read.

