### PR TITLE
UDF to truncate local data after distributing table

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1340,6 +1340,18 @@ DoCopyFromLocalTableIntoShards(Relation distributedRelation,
 		ereport(DEBUG1, (errmsg("Copied " UINT64_FORMAT " rows", rowsCopied)));
 	}
 
+	if (rowsCopied > 0)
+	{
+		char *qualifiedRelationName =
+			generate_qualified_relation_name(RelationGetRelid(distributedRelation));
+		ereport(NOTICE, (errmsg("copying the data has completed"),
+						 errdetail("The local data in the table is longer visible, "
+								   "but is still on disk."),
+						 errhint("To remove the local data, run: SELECT "
+								 "truncate_local_data_after_distributing_table($$%s$$)",
+								 qualifiedRelationName)));
+	}
+
 	MemoryContextSwitchTo(oldContext);
 
 	/* finish reading from the local table */

--- a/src/backend/distributed/master/master_truncate.c
+++ b/src/backend/distributed/master/master_truncate.c
@@ -10,13 +10,16 @@
  */
 
 #include "postgres.h"
+#include "miscadmin.h"
 
 #include <stddef.h>
 
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
+#include "distributed/citus_ruleutils.h"
 #include "distributed/commands/utility_hook.h"
 #include "distributed/deparse_shard_query.h"
+#include "distributed/foreign_key_relationship.h"
 #include "distributed/listutils.h"
 #include "distributed/master_metadata_utility.h"
 #include "distributed/master_protocol.h"
@@ -26,6 +29,7 @@
 #include "distributed/resource_lock.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
+#include "utils/regproc.h"
 #include "utils/rel.h"
 
 static List * TruncateTaskList(Oid relationId);
@@ -33,6 +37,9 @@ static List * TruncateTaskList(Oid relationId);
 
 /* exports for SQL callable functions */
 PG_FUNCTION_INFO_V1(citus_truncate_trigger);
+PG_FUNCTION_INFO_V1(truncate_local_data_after_distributing_table);
+
+void EnsureLocalTableCanBeTruncated(Oid relationId);
 
 
 /*
@@ -138,4 +145,77 @@ TruncateTaskList(Oid relationId)
 	}
 
 	return taskList;
+}
+
+
+/*
+ * truncate_local_data_after_distributing_table truncates the local records of a distributed table.
+ *
+ * The main advantage of this function is to truncate all local records after creating a
+ * distributed table, and prevent constraints from failing due to outdated local records.
+ */
+Datum
+truncate_local_data_after_distributing_table(PG_FUNCTION_ARGS)
+{
+	Oid relationId = PG_GETARG_OID(0);
+
+	CheckCitusVersion(ERROR);
+	EnsureCoordinator();
+	EnsureLocalTableCanBeTruncated(relationId);
+
+	TruncateStmt *truncateStmt = makeNode(TruncateStmt);
+
+	char *relationName = generate_qualified_relation_name(relationId);
+	List *names = stringToQualifiedNameList(relationName);
+	truncateStmt->relations = list_make1(makeRangeVarFromNameList(names));
+	truncateStmt->restart_seqs = false;
+	truncateStmt->behavior = DROP_CASCADE;
+
+	set_config_option("citus.enable_ddl_propagation", "false",
+					  (superuser() ? PGC_SUSET : PGC_USERSET), PGC_S_SESSION,
+					  GUC_ACTION_LOCAL, true, 0, false);
+	ExecuteTruncate(truncateStmt);
+	set_config_option("citus.enable_ddl_propagation", "true",
+					  (superuser() ? PGC_SUSET : PGC_USERSET), PGC_S_SESSION,
+					  GUC_ACTION_LOCAL, true, 0, false);
+
+	PG_RETURN_VOID();
+}
+
+
+/*
+ * EnsureLocalTableCanBeTruncated performs the necessary checks to make sure it
+ * is safe to truncate the local table of a distributed table
+ */
+void
+EnsureLocalTableCanBeTruncated(Oid relationId)
+{
+	/* error out if the relation is not a distributed table */
+	if (!IsCitusTable(relationId))
+	{
+		ereport(ERROR, (errmsg("supplied parameter is not a distributed relation"),
+						errdetail("This UDF only truncates local records of distributed "
+								  "tables.")));
+	}
+
+	/* make sure there are no foreign key references from a local table */
+	SetForeignConstraintRelationshipGraphInvalid();
+	List *referencingRelationList = ReferencingRelationIdList(relationId);
+
+	Oid referencingRelation = InvalidOid;
+	foreach_oid(referencingRelation, referencingRelationList)
+	{
+		/* we do not truncate a table if there is a local table referencing it */
+		if (!IsCitusTable(referencingRelation))
+		{
+			char *referencedRelationName = get_rel_name(relationId);
+			char *referencingRelationName = get_rel_name(referencingRelation);
+
+			ereport(ERROR, (errmsg("cannot truncate a table referenced in a "
+								   "foreign key constraint by a local table"),
+							errdetail("Table \"%s\" references \"%s\"",
+									  referencingRelationName,
+									  referencedRelationName)));
+		}
+	}
 }

--- a/src/backend/distributed/sql/citus--9.2-4--9.3-2.sql
+++ b/src/backend/distributed/sql/citus--9.2-4--9.3-2.sql
@@ -7,6 +7,7 @@
 #include "udfs/replicate_reference_tables/9.3-2.sql"
 #include "udfs/citus_remote_connection_stats/9.3-2.sql"
 #include "udfs/worker_create_or_alter_role/9.3-2.sql"
+#include "udfs/truncate_local_data_after_distributing_table/9.3-2.sql"
 
 -- add citus extension owner as a distributed object, if not already in there
 INSERT INTO citus.pg_dist_object SELECT

--- a/src/backend/distributed/sql/udfs/truncate_local_data_after_distributing_table/9.3-2.sql
+++ b/src/backend/distributed/sql/udfs/truncate_local_data_after_distributing_table/9.3-2.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION truncate_local_data_after_distributing_table(function_name regclass)
+  RETURNS void
+  LANGUAGE C CALLED ON NULL INPUT
+  AS 'MODULE_PATHNAME', $$truncate_local_data_after_distributing_table$$;
+
+COMMENT ON FUNCTION truncate_local_data_after_distributing_table(function_name regclass)
+  IS 'truncates local records of a distributed table';

--- a/src/backend/distributed/sql/udfs/truncate_local_data_after_distributing_table/latest.sql
+++ b/src/backend/distributed/sql/udfs/truncate_local_data_after_distributing_table/latest.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION truncate_local_data_after_distributing_table(function_name regclass)
+  RETURNS void
+  LANGUAGE C CALLED ON NULL INPUT
+  AS 'MODULE_PATHNAME', $$truncate_local_data_after_distributing_table$$;
+
+COMMENT ON FUNCTION truncate_local_data_after_distributing_table(function_name regclass)
+  IS 'truncates local records of a distributed table';

--- a/src/test/regress/expected/ch_bench_having.out
+++ b/src/test/regress/expected/ch_bench_having.out
@@ -315,6 +315,9 @@ insert into stock VALUES
 (32, 1, 1, 1, 1, 1, '', '','','','','','','','','','');
 SELECT create_distributed_table('stock','s_w_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$ch_bench_having.stock$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/ch_bench_having_mx.out
+++ b/src/test/regress/expected/ch_bench_having_mx.out
@@ -323,6 +323,9 @@ insert into stock VALUES
 (32, 1, 1, 1, 1, 1, '', '','','','','','','','','','');
 SELECT create_distributed_table('stock','s_w_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$ch_bench_having.stock$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/coordinator_shouldhaveshards.out
+++ b/src/test/regress/expected/coordinator_shouldhaveshards.out
@@ -145,6 +145,9 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 NOTICE:  executing the copy locally for shard xxxxx
 NOTICE:  Copying data from local table...
 NOTICE:  executing the copy locally for shard xxxxx
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$coordinator_shouldhaveshards.dist_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -178,6 +181,9 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 NOTICE:  executing the copy locally for shard xxxxx
 NOTICE:  Copying data from local table...
 NOTICE:  executing the copy locally for shard xxxxx
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$coordinator_shouldhaveshards.dist_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/cte_nested_modification.out
+++ b/src/test/regress/expected/cte_nested_modification.out
@@ -4,6 +4,9 @@ CREATE TABLE tt1(id int, value_1 int);
 INSERT INTO tt1 VALUES(1,2),(2,3),(3,4);
 SELECT create_distributed_table('tt1','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$cte_nested_modifications.tt1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -13,6 +16,9 @@ CREATE TABLE tt2(id int, value_1 int);
 INSERT INTO tt2 VALUES(3,3),(4,4),(5,5);
 SELECT create_distributed_table('tt2','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$cte_nested_modifications.tt2$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/cte_prepared_modify.out
+++ b/src/test/regress/expected/cte_prepared_modify.out
@@ -4,6 +4,9 @@ CREATE TABLE tt1(id int, value_1 int);
 INSERT INTO tt1 VALUES(1,2),(2,3),(3,4);
 SELECT create_distributed_table('tt1','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$cte_prepared_modify.tt1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -13,6 +16,9 @@ CREATE TABLE tt2(id int, value_1 int);
 INSERT INTO tt2 VALUES(3,3),(4,4),(5,5);
 SELECT create_distributed_table('tt2','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$cte_prepared_modify.tt2$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/distributed_collations.out
+++ b/src/test/regress/expected/distributed_collations.out
@@ -35,6 +35,9 @@ CREATE TABLE test_propagate(id int, t1 text COLLATE german_phonebook,
 INSERT INTO test_propagate VALUES (1, 'aesop', U&'\00E4sop'), (2, U&'Vo\1E9Er', 'Vossr');
 SELECT create_distributed_table('test_propagate', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$collation_tests.test_propagate$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/expression_reference_join.out
+++ b/src/test/regress/expected/expression_reference_join.out
@@ -13,6 +13,9 @@ INSERT INTO test VALUES
     (2,2);
 SELECT create_reference_table('ref');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$expression_reference_join.ref$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -20,6 +23,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('test', 'x');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$expression_reference_join.test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -61,6 +61,9 @@ INSERT INTO r1 (id, name) VALUES
 (3,'baz');
 SELECT create_reference_table('r1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$fail_connect.r1$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/failure_create_distributed_table_non_empty.out
+++ b/src/test/regress/expected/failure_create_distributed_table_non_empty.out
@@ -227,6 +227,9 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="COPY").kill()');
 
 SELECT create_distributed_table('test_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$create_distributed_table_non_empty_failure.test_table$$)
 ERROR:  failed to COPY to shard xxxxx on localhost:xxxxx
 SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;
  count
@@ -259,6 +262,9 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="COPY").cancel(' ||  pg_b
 
 SELECT create_distributed_table('test_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$create_distributed_table_non_empty_failure.test_table$$)
 ERROR:  canceling statement due to user request
 SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;
  count

--- a/src/test/regress/expected/failure_create_reference_table.out
+++ b/src/test/regress/expected/failure_create_reference_table.out
@@ -110,6 +110,9 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="COPY 3").kill()');
 
 SELECT create_reference_table('ref_table');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$failure_reference_table.ref_table$$)
 ERROR:  failed to COPY to shard xxxxx on localhost:xxxxx
 SELECT count(*) FROM pg_dist_shard_placement;
  count
@@ -126,6 +129,9 @@ SELECT citus.mitmproxy('conn.onCommandComplete(command="COPY 3").cancel(' || pg_
 
 SELECT create_reference_table('ref_table');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$failure_reference_table.ref_table$$)
 ERROR:  canceling statement due to user request
 SELECT count(*) FROM pg_dist_shard_placement;
  count
@@ -215,6 +221,9 @@ SELECT citus.mitmproxy('conn.onQuery(query="^ROLLBACK").kill()');
 BEGIN;
 SELECT create_reference_table('ref_table');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$failure_reference_table.ref_table$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -239,6 +248,9 @@ SELECT citus.mitmproxy('conn.onQuery(query="^ROLLBACK").cancel(' || pg_backend_p
 BEGIN;
 SELECT create_reference_table('ref_table');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$failure_reference_table.ref_table$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/failure_multi_shard_update_delete.out
+++ b/src/test/regress/expected/failure_multi_shard_update_delete.out
@@ -436,6 +436,9 @@ SELECT citus.mitmproxy('conn.allow()');
 CREATE TABLE t3 AS SELECT * FROM t2;
 SELECT create_distributed_table('t3', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_shard.t3$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -534,6 +537,9 @@ DROP TABLE t3;
 CREATE TABLE t3 AS SELECT * FROM t2;
 SELECT create_distributed_table('t3', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_shard.t3$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -1272,6 +1272,9 @@ BEGIN;
 	INSERT INTO test_table_2 SELECT i, i FROM generate_series(0,100) i;
 	SELECT create_reference_table('test_table_1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_fkey_to_ref_in_tx.test_table_1$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1296,6 +1299,9 @@ BEGIN;
 	INSERT INTO test_table_2 SELECT i, i FROM generate_series(0,100) i;
 	SELECT create_reference_table('test_table_1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_fkey_to_ref_in_tx.test_table_1$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table.out
@@ -746,6 +746,9 @@ INSERT INTO referenced_table VALUES (1,1), (2,2), (3,3);
 INSERT INTO referencing_table VALUES (1,1), (2,2), (3,3);
 SELECT create_reference_table('referenced_table');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$fkey_reference_table.referenced_table$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -1305,6 +1308,9 @@ BEGIN;
   INSERT INTO test_table_2 SELECT i, i FROM generate_series(0,100) i;
   SELECT create_reference_table('test_table_1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$fkey_reference_table.test_table_1$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -502,6 +502,9 @@ SELECT create_reference_table('ref_table');
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1330000, 'local_shard_copy', 'CREATE TABLE local_shard_copy.ref_table (a integer)');SELECT worker_apply_shard_ddl_command (1330000, 'local_shard_copy', 'ALTER TABLE local_shard_copy.ref_table OWNER TO postgres')
 NOTICE:  executing the copy locally for shard xxxxx
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$local_shard_copy.ref_table$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -698,7 +698,9 @@ INSERT INTO partitioning_test VALUES (6, '2012-07-07');
 INSERT INTO partitioning_test VALUES (5, '2013-06-06');
 SELECT create_distributed_table('partitioning_test', 'id', colocate_with:='dist_table');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/materialized_view.out
+++ b/src/test/regress/expected/materialized_view.out
@@ -138,6 +138,9 @@ FROM lineitem_local_to_hash_part, orders_local_to_hash_part, (SELECT SUM(l_exten
 WHERE lineitem_local_to_hash_part.l_orderkey=orders_local_to_hash_part.o_orderkey;
 SELECT create_distributed_table('lineitem_local_to_hash_part', 'l_orderkey');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$materialized_view.lineitem_local_to_hash_part$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -145,6 +148,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('orders_local_to_hash_part', 'o_orderkey');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$materialized_view.orders_local_to_hash_part$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_alter_table_add_constraints.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints.out
@@ -89,7 +89,7 @@ ALTER TABLE products_append ADD CONSTRAINT p_key PRIMARY KEY(product_no);
 WARNING:  table "products_append" has a UNIQUE or EXCLUDE constraint
 DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-partitioned tables cannot be enforced.
 HINT:  Consider using hash partitioning.
---- Error out since first and third rows have the same product_no		
+--- Error out since first and third rows have the same product_no
 \COPY products_append FROM STDIN DELIMITER AS ',';
 ERROR:  duplicate key value violates unique constraint "p_key_1450033"
 DETAIL:  Key (product_no)=(1) already exists.
@@ -176,8 +176,8 @@ ALTER TABLE unique_test_table_append ADD CONSTRAINT unn_id UNIQUE(id);
 WARNING:  table "unique_test_table_append" has a UNIQUE or EXCLUDE constraint
 DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-partitioned tables cannot be enforced.
 HINT:  Consider using hash partitioning.
--- Error out. Table can not have two rows with the same id.		
-\COPY unique_test_table_append FROM STDIN DELIMITER AS ',';		
+-- Error out. Table can not have two rows with the same id.
+\COPY unique_test_table_append FROM STDIN DELIMITER AS ',';
 ERROR:  duplicate key value violates unique constraint "unn_id_1450067"
 DETAIL:  Key (id)=(X) already exists.
 DROP TABLE unique_test_table_append;
@@ -336,7 +336,7 @@ ALTER TABLE products_append ADD CONSTRAINT exc_pno_name EXCLUDE USING btree (pro
 WARNING:  table "products_append" has a UNIQUE or EXCLUDE constraint
 DETAIL:  UNIQUE constraints, EXCLUDE constraints, and PRIMARY KEYs on append-partitioned tables cannot be enforced.
 HINT:  Consider using hash partitioning.
--- Error out since first and third can not pass the exclusion check.		
+-- Error out since first and third can not pass the exclusion check.
 \COPY products_append FROM STDIN DELIMITER AS ',';
 ERROR:  conflicting key value violates exclusion constraint "exc_pno_name_1450135"
 DETAIL:  Key (product_no, name)=(1,  Product_1) conflicts with existing key (product_no, name)=(1,  Product_1).
@@ -560,6 +560,9 @@ INSERT INTO sc3.alter_add_prim_key(x) SELECT generate_series(1,100);
 SET search_path TO 'sc3';
 SELECT create_distributed_table('alter_add_prim_key', 'x');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc3.alter_add_prim_key$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -201,6 +201,9 @@ HINT:  Empty your table before distributing it.
 -- create_distributed_table creates shards and copies data into the distributed table
 SELECT create_distributed_table('data_load_test', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -260,6 +263,9 @@ CREATE TABLE data_load_test (col1 int, col2 text, col3 serial);
 INSERT INTO data_load_test VALUES (132, 'hello');
 SELECT create_distributed_table('data_load_test', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -281,6 +287,9 @@ CREATE TABLE data_load_test1 (col1 int, col2 text, col3 serial);
 INSERT INTO data_load_test1 VALUES (132, 'hello');
 SELECT create_distributed_table('data_load_test1', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -290,6 +299,9 @@ CREATE TABLE data_load_test2 (col1 int, col2 text, col3 serial);
 INSERT INTO data_load_test2 VALUES (132, 'world');
 SELECT create_distributed_table('data_load_test2', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test2$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_create_table_superuser.out
+++ b/src/test/regress/expected/multi_create_table_superuser.out
@@ -237,6 +237,9 @@ CREATE TABLE data_load_test (col1 int, col2 text, col3 serial);
 INSERT INTO data_load_test VALUES (132, 'hello');
 SELECT create_distributed_table('data_load_test', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -251,6 +254,9 @@ CREATE TABLE data_load_test (col1 int, col2 text, col3 serial);
 INSERT INTO data_load_test VALUES (132, 'hello');
 SELECT create_distributed_table('data_load_test', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -264,6 +270,9 @@ CREATE TABLE data_load_test (col1 int, col2 text, col3 serial);
 INSERT INTO data_load_test VALUES (132, 'hello');
 SELECT create_distributed_table('data_load_test', 'col1');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -279,6 +288,9 @@ INSERT INTO data_load_test VALUES (243, 'world', 'hello');
 ALTER TABLE data_load_test DROP COLUMN col1;
 SELECT create_distributed_table('data_load_test', 'col3');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.data_load_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -371,6 +383,9 @@ INSERT INTO rollback_table VALUES(2, 'Name_2');
 INSERT INTO rollback_table VALUES(3, 'Name_3');
 SELECT create_distributed_table('rollback_table','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.rollback_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -498,6 +513,9 @@ CREATE TABLE tt1(id int);
 INSERT INTO tt1 VALUES(1);
 SELECT create_distributed_table('tt1','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.tt1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -554,6 +572,9 @@ CREATE TABLE stage_table (LIKE sample_table);
 \COPY stage_table FROM stdin; -- Note that this operation is a local copy
 SELECT create_distributed_table('stage_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.stage_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -625,6 +646,9 @@ CREATE TABLE sc.ref(a int);
 insert into sc.ref SELECT s FROM generate_series(0, 100) s;
 SELECT create_reference_table('sc.ref');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc.ref$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -634,6 +658,9 @@ CREATE TABLE sc.hash(a int);
 insert into sc.hash SELECT s FROM generate_series(0, 100) s;
 SELECT create_distributed_table('sc.hash', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc.hash$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -647,6 +674,9 @@ CREATE TABLE sc2.hash(a int);
 insert into sc2.hash SELECT s FROM generate_series(0, 100) s;
 SELECT create_distributed_table('sc2.hash', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc2.hash$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -656,6 +686,9 @@ CREATE TABLE sc2.ref(a int);
 insert into sc2.ref SELECT s FROM generate_series(0, 100) s;
 SELECT create_reference_table('sc2.ref');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc2.ref$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -697,6 +730,9 @@ SET search_path = 'sc4';
 ALTER TABLE alter_replica_table REPLICA IDENTITY USING INDEX alter_replica_table_pkey;
 SELECT create_distributed_table('alter_replica_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc4.alter_replica_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -722,6 +758,9 @@ INSERT INTO sc5.alter_replica_table(id) SELECT generate_series(1,100);
 ALTER TABLE sc5.alter_replica_table REPLICA IDENTITY FULL;
 SELECT create_distributed_table('sc5.alter_replica_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc5.alter_replica_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -747,6 +786,9 @@ CREATE UNIQUE INDEX unique_idx ON sc6.alter_replica_table(id);
 ALTER TABLE sc6.alter_replica_table REPLICA IDENTITY USING INDEX unique_idx;
 SELECT create_distributed_table('sc6.alter_replica_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$sc6.alter_replica_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -771,6 +813,9 @@ CREATE UNIQUE INDEX unique_idx ON alter_replica_table(id);
 ALTER TABLE alter_replica_table REPLICA IDENTITY USING INDEX unique_idx;
 SELECT create_distributed_table('alter_replica_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.alter_replica_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -378,6 +378,9 @@ INSERT INTO my_table_with_data VALUES (1,2);
 RESET ROLE;
 SELECT create_distributed_table('my_table_with_data', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.my_table_with_data$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -405,6 +408,9 @@ RESET ROLE;
 SET ROLE read_access;
 SELECT create_distributed_table('my_role_table_with_data', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.my_role_table_with_data$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -561,6 +567,9 @@ RESET ROLE;
 -- now we distribute the table as super user
 SELECT create_distributed_table('full_access_user_schema.t1', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$full_access_user_schema.t1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_mx_partitioning.out
+++ b/src/test/regress/expected/multi_mx_partitioning.out
@@ -26,7 +26,13 @@ INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
 -- distribute partitioned table
 SELECT create_distributed_table('partitioning_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_2009$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_2010$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -134,6 +140,9 @@ INSERT INTO partitioning_test_2012 VALUES (5, '2012-06-06');
 INSERT INTO partitioning_test_2012 VALUES (6, '2012-07-07');
 ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2012 FOR VALUES FROM ('2012-01-01') TO ('2013-01-01');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_2012$$)
 -- see from MX node, attached partition is distributed as well
 \c - - - :worker_1_port
 SELECT

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -28,7 +28,13 @@ INSERT INTO partitioning_hash_test VALUES (4, 4);
 -- distribute partitioned table
 SELECT create_distributed_table('partitioning_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_2009$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_2010$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -36,7 +42,13 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('partitioning_hash_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_hash_test_0$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_hash_test_1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -157,6 +169,9 @@ INSERT INTO partitioning_test_2012 VALUES (5, '2012-06-06');
 INSERT INTO partitioning_test_2012 VALUES (6, '2012-07-07');
 ALTER TABLE partitioning_test ATTACH PARTITION partitioning_test_2012 FOR VALUES FROM ('2012-01-01') TO ('2013-01-01');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_2012$$)
 -- attached partition is distributed as well
 SELECT
 	logicalrelid
@@ -199,6 +214,9 @@ CREATE TABLE partitioning_hash_test_2 (id int, subid int);
 INSERT INTO partitioning_hash_test_2 VALUES (8, 5);
 ALTER TABLE partitioning_hash_test ATTACH PARTITION partitioning_hash_test_2 FOR VALUES WITH (MODULUS 3, REMAINDER 2);
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_hash_test_2$$)
 INSERT INTO partitioning_hash_test VALUES (9, 12);
 -- see the data is loaded to shards
 SELECT * FROM partitioning_test ORDER BY 1;
@@ -412,7 +430,7 @@ SELECT * FROM partitioning_test WHERE id = 9 OR id = 10 ORDER BY 1;
 -- create default partition
 CREATE TABLE partitioning_test_default PARTITION OF partitioning_test DEFAULT;
 \d+ partitioning_test
-                             Table "public.partitioning_test"
+                       Table "public.partitioning_test"
  Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description
 ---------------------------------------------------------------------
  id     | integer |           |          |         | plain   |              |
@@ -692,6 +710,9 @@ CREATE TABLE partitioning_test_reference(id int PRIMARY KEY, subid int);
 INSERT INTO partitioning_test_reference SELECT a, a FROM generate_series(1, 50) a;
 SELECT create_reference_table('partitioning_test_reference');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.partitioning_test_reference$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_real_time_transaction.out
+++ b/src/test/regress/expected/multi_real_time_transaction.out
@@ -207,7 +207,13 @@ INSERT INTO partitioning_test VALUES (1, '2009-06-06');
 INSERT INTO partitioning_test VALUES (2, '2010-07-07');
 SELECT create_distributed_table('partitioning_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_real_time_transaction.partitioning_test_2009$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_real_time_transaction.partitioning_test_2010$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -5,6 +5,9 @@ INSERT INTO reference_table_test VALUES (1, 1.0, '1', '2016-12-01');
 -- create the reference table
 SELECT create_reference_table('reference_table_test');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.reference_table_test$$)
  create_reference_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_shard_update_delete.out
+++ b/src/test/regress/expected/multi_shard_update_delete.out
@@ -227,6 +227,9 @@ CREATE TABLE tt1_1120 partition of tt1 for VALUES FROM (11) to (20);
 INSERT INTO tt1 VALUES (1,11), (3,15), (5,17), (6,19), (8,17), (2,12);
 SELECT create_distributed_table('tt1','id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.tt1_1120$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -341,6 +344,9 @@ INSERT INTO test_table_1 VALUES(2, '2015-02-01 08:31:16', 7);
 INSERT INTO test_table_1 VALUES(3, '2111-01-12 08:35:19', 9);
 SELECT create_distributed_table('test_table_1', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.test_table_1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -793,6 +799,9 @@ INSERT INTO test_table_2 VALUES(2, random());
 INSERT INTO test_table_2 VALUES(3, random());
 SELECT create_distributed_table('test_table_2', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.test_table_2$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_truncate.out
+++ b/src/test/regress/expected/multi_truncate.out
@@ -4,6 +4,16 @@
 SET citus.next_shard_id TO 1210000;
 CREATE SCHEMA multi_truncate;
 SET search_path TO multi_truncate;
+-- helper view that prints out local table names and sizes in the schema
+CREATE VIEW table_sizes AS
+SELECT
+  c.relname as name,
+  pg_catalog.pg_size_pretty(pg_catalog.pg_table_size(c.oid)) as size
+FROM pg_catalog.pg_class c
+     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'r'
+      AND n.nspname = 'multi_truncate'
+ORDER BY 1;
 --
 -- truncate for append distribution
 -- expect all shards to be dropped
@@ -314,7 +324,7 @@ SELECT * FROM test_local_truncate;
 (1 row)
 
 -- Undistribute table
-SELECT master_drop_all_shards('test_local_truncate', 'pubic', 'test_local_truncate');
+SELECT master_drop_all_shards('test_local_truncate', 'public', 'test_local_truncate');
  master_drop_all_shards
 ---------------------------------------------------------------------
                       4
@@ -350,7 +360,7 @@ SELECT * FROM test_local_truncate;
 (1 row)
 
 -- Undistribute table
-SELECT master_drop_all_shards('test_local_truncate', 'pubic', 'test_local_truncate');
+SELECT master_drop_all_shards('test_local_truncate', 'public', 'test_local_truncate');
  master_drop_all_shards
 ---------------------------------------------------------------------
                       4
@@ -364,5 +374,169 @@ SELECT * FROM test_local_truncate;
  1 | 2
 (1 row)
 
+DROP TABLE test_local_truncate;
+-- Test truncate_local_data_after_distributing_table UDF
+CREATE TABLE referenced_table(id int UNIQUE, test_column int);
+INSERT INTO referenced_table SELECT x,x FROM generate_series(1,10000) x;
+CREATE TABLE referencing_table(id int, ref_id int REFERENCES referenced_table(id));
+INSERT INTO referencing_table SELECT * FROM referenced_table;
+-- The following will fail as the table is not distributed
+SELECT truncate_local_data_after_distributing_table('referenced_table');
+ERROR:  supplied parameter is not a distributed relation
+DETAIL:  This UDF only truncates local records of distributed tables.
+-- Test foreign keys from local tables to distributed tables
+-- We can not truncate local tables until all the local foreign keys are removed.
+SELECT create_distributed_table('referenced_table', 'id');
+NOTICE:  Copying data from local table...
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- The following will fail, as local referencing_table has fk references
+SELECT truncate_local_data_after_distributing_table('referenced_table');
+ERROR:  cannot truncate a table referenced in a foreign key constraint by a local table
+DETAIL:  Table "referencing_table" references "referenced_table"
+-- Test foreign keys between distributed tables
+SELECT create_distributed_table('referencing_table', 'ref_id');
+NOTICE:  Copying data from local table...
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+-- The following will no longer fail as the referencing table is now distributed
+SELECT truncate_local_data_after_distributing_table('referenced_table');
+NOTICE:  truncate cascades to table "referencing_table"
+ truncate_local_data_after_distributing_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM table_sizes;
+       name        |  size
+---------------------------------------------------------------------
+ referenced_table  | 0 bytes
+ referencing_table | 0 bytes
+(2 rows)
+
+ROLLBACK;
+-- observe that none of the tables are truncated
+SELECT * FROM table_sizes;
+       name        |  size
+---------------------------------------------------------------------
+ referenced_table  | 384 kB
+ referencing_table | 384 kB
+(2 rows)
+
+-- test that if we truncate the referencing table, only said table is affected
+BEGIN;
+SELECT truncate_local_data_after_distributing_table('referencing_table');
+ truncate_local_data_after_distributing_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM table_sizes;
+       name        |  size
+---------------------------------------------------------------------
+ referenced_table  | 384 kB
+ referencing_table | 0 bytes
+(2 rows)
+
+ROLLBACK;
+-- however if we truncate referenced table, both of the tables get truncated
+-- because we supply the CASCADE option
+-- test that if we truncate the referencing table, only said table is affected
+BEGIN;
+SELECT truncate_local_data_after_distributing_table('referenced_table');
+NOTICE:  truncate cascades to table "referencing_table"
+ truncate_local_data_after_distributing_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM table_sizes;
+       name        |  size
+---------------------------------------------------------------------
+ referenced_table  | 0 bytes
+ referencing_table | 0 bytes
+(2 rows)
+
+ROLLBACK;
+DROP TABLE referencing_table;
+DROP TABLE referenced_table;
+-- test truncating reference tables
+CREATE TABLE ref(id int UNIQUE, data int);
+INSERT INTO ref SELECT x,x FROM generate_series(1,10000) x;
+SELECT create_reference_table('ref');
+NOTICE:  Copying data from local table...
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE dist(id int, ref_id int REFERENCES ref(id));
+INSERT INTO dist SELECT x,x FROM generate_series(1,10000) x;
+-- test that we do not cascade truncates to local referencing tables
+SELECT truncate_local_data_after_distributing_table('ref');
+ERROR:  cannot truncate a table referenced in a foreign key constraint by a local table
+DETAIL:  Table "dist" references "ref"
+-- distribute the table and start testing allowed truncation queries
+SELECT create_distributed_table('dist','id');
+ERROR:  cannot distribute "dist" in sequential mode because it is not empty
+HINT:  If you have manually set citus.multi_shard_modify_mode to 'sequential', try with 'parallel' option. If that is not the case, try distributing local tables when they are empty.
+-- the following should truncate ref and dist
+BEGIN;
+SELECT truncate_local_data_after_distributing_table('ref');
+ERROR:  cannot truncate a table referenced in a foreign key constraint by a local table
+DETAIL:  Table "dist" references "ref"
+SELECT * FROM table_sizes;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- the following should truncate dist table only
+BEGIN;
+SELECT truncate_local_data_after_distributing_table('dist');
+ERROR:  supplied parameter is not a distributed relation
+DETAIL:  This UDF only truncates local records of distributed tables.
+SELECT * FROM table_sizes;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+DROP TABLE ref, dist;
+-- tests for issue 1770
+CREATE TABLE t1(a int, b int);
+INSERT INTO t1 VALUES(1,1);
+SELECT create_distributed_table('t1', 'a');
+NOTICE:  Copying data from local table...
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE t1 ADD CONSTRAINT t1_a_check CHECK(a > 2) NOT VALID;
+-- will error out with "ERROR:  CHECK CONSTRAINT "t1_a_check" is violated by some row"
+ALTER TABLE t1 VALIDATE CONSTRAINT t1_a_check;
+ERROR:  check constraint "t1_a_check" is violated by some row
+-- remove violating row
+DELETE FROM t1 where a = 1;
+-- verify no rows in t1
+SELECT * FROM t1;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+-- this will still error out
+ALTER TABLE t1 VALIDATE CONSTRAINT t1_a_check;
+ERROR:  check constraint "t1_a_check" is violated by some row
+-- The check will pass when the local copies are truncated
+SELECT truncate_local_data_after_distributing_table('t1');
+ truncate_local_data_after_distributing_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE t1 VALIDATE CONSTRAINT t1_a_check;
+DROP VIEW table_sizes;
+DROP TABLE t1;
 DROP SCHEMA multi_truncate CASCADE;
-NOTICE:  drop cascades to table test_local_truncate

--- a/src/test/regress/expected/multi_truncate.out
+++ b/src/test/regress/expected/multi_truncate.out
@@ -307,6 +307,9 @@ CREATE TABLE test_local_truncate (x int, y int);
 INSERT INTO test_local_truncate VALUES (1,2);
 SELECT create_distributed_table('test_local_truncate', 'x', colocate_with => 'none');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_truncate.test_local_truncate$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -343,6 +346,9 @@ CREATE TABLE test_local_truncate (x int, y int);
 INSERT INTO test_local_truncate VALUES (1,2);
 SELECT create_distributed_table('test_local_truncate', 'x', colocate_with => 'none');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_truncate.test_local_truncate$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -388,6 +394,9 @@ DETAIL:  This UDF only truncates local records of distributed tables.
 -- We can not truncate local tables until all the local foreign keys are removed.
 SELECT create_distributed_table('referenced_table', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_truncate.referenced_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -400,6 +409,9 @@ DETAIL:  Table "referencing_table" references "referenced_table"
 -- Test foreign keys between distributed tables
 SELECT create_distributed_table('referencing_table', 'ref_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_truncate.referencing_table$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -472,6 +484,9 @@ CREATE TABLE ref(id int UNIQUE, data int);
 INSERT INTO ref SELECT x,x FROM generate_series(1,10000) x;
 SELECT create_reference_table('ref');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_truncate.ref$$)
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -509,6 +524,9 @@ CREATE TABLE t1(a int, b int);
 INSERT INTO t1 VALUES(1,1);
 SELECT create_distributed_table('t1', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_truncate.t1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -36,6 +36,9 @@ insert into gen1 (id, val1) values (1,4),(3,6),(5,2),(7,2);
 insert into gen2 (id, val1) values (1,4),(3,6),(5,2),(7,2);
 select create_distributed_table('gen1', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_pg12.gen1$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -267,6 +270,9 @@ ERROR:  insert or update on table "collection_users" violates foreign key constr
 DETAIL:  Key (key, collection_id)=(1, 1000) is not present in table "collections_list".
 SELECT create_distributed_table('collections_list', 'key');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_pg12.collections_list_0$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -274,6 +280,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('collection_users', 'key');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_pg12.collection_users$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -292,6 +301,9 @@ CREATE TABLE test (x int, y int);
 INSERT INTO test (x,y) SELECT i,i*3 from generate_series(1, 100) i;
 SELECT create_distributed_table('test', 'x');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_pg12.test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -379,6 +391,9 @@ select create_distributed_table('col_test', 'val');
 ERROR:  Hash distributed partition columns may not use a non deterministic collation
 select create_distributed_table('col_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_pg12.col_test$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/pg_dump.out
+++ b/src/test/regress/expected/pg_dump.out
@@ -58,6 +58,9 @@ drop cascades to table "weird.table"
 -- redistribute the schema
 SELECT create_distributed_table('data', 'key');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$dumper.data$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -65,6 +68,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('"weird.table"', 'key,');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$dumper."weird.table"$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/relation_access_tracking.out
+++ b/src/test/regress/expected/relation_access_tracking.out
@@ -971,6 +971,9 @@ INSERT INTO table_3 SELECT i, i FROM generate_series(0,100) i;
 BEGIN;
 	SELECT create_distributed_table('table_3', 'key');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$access_tracking.table_3$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/replicated_partitioned_table.out
+++ b/src/test/regress/expected/replicated_partitioned_table.out
@@ -27,7 +27,13 @@ INSERT INTO collections (key, ts, collection_id, value) VALUES (4, '2009-01-01',
 -- already existing partitioninong hierarcy
 SELECT create_distributed_table('collections', 'key');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$partitioned_table_replicated.collections_1$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$partitioned_table_replicated.collections_2$$)
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -41,6 +47,9 @@ CREATE TABLE collections_4 AS SELECT * FROM collections LIMIT 0;
 INSERT INTO collections_4 SELECT i, '2009-01-01', 4, i FROM generate_series (0, 10) i;
 ALTER TABLE collections ATTACH PARTITION collections_4 FOR VALUES IN ( 4 );
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$partitioned_table_replicated.collections_4$$)
 -- finally attach a distributed table to a distributed table
 CREATE TABLE collections_5 AS SELECT * FROM collections LIMIT 0;
 SELECT create_distributed_table('collections_5', 'key');

--- a/src/test/regress/expected/sequential_modifications.out
+++ b/src/test/regress/expected/sequential_modifications.out
@@ -293,6 +293,9 @@ CREATE TABLE test_seq_truncate (a int);
 INSERT INTO test_seq_truncate SELECT i FROM generate_series(0, 100) i;
 SELECT create_distributed_table('test_seq_truncate', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$test_seq_ddl.test_seq_truncate$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/subquery_partitioning.out
+++ b/src/test/regress/expected/subquery_partitioning.out
@@ -18,7 +18,13 @@ INSERT INTO partitioning_test_2010 VALUES (4, 4, '2010-03-03');
 SET citus.shard_replication_factor TO 1;
 SELECT create_distributed_table('partitioning_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$subquery_and_partitioning.partitioning_test_2010$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$subquery_and_partitioning.partitioning_test_2017$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/upgrade_basic_after.out
+++ b/src/test/regress/expected/upgrade_basic_after.out
@@ -207,6 +207,9 @@ SELECT * FROM t2 ORDER BY a;
 
 SELECT create_distributed_table('t2', 'a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$upgrade_basic.t2$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/with_partitioning.out
+++ b/src/test/regress/expected/with_partitioning.out
@@ -15,7 +15,13 @@ INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
 -- distribute partitioned table
 SELECT create_distributed_table('with_partitioning.partitioning_test', 'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$with_partitioning.partitioning_test_2010$$)
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$with_partitioning.partitioning_test_2017$$)
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/output/hyperscale_tutorial.source
+++ b/src/test/regress/output/hyperscale_tutorial.source
@@ -205,6 +205,9 @@ CREATE TABLE impressions (
 \copy impressions from '@abs_srcdir@/data/impressions.csv' with csv
 SELECT create_distributed_table('companies',   'id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.companies$$)
  create_distributed_table 
 --------------------------
  
@@ -212,6 +215,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('campaigns',   'company_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.campaigns$$)
  create_distributed_table 
 --------------------------
  
@@ -219,6 +225,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('ads',         'company_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.ads$$)
  create_distributed_table 
 --------------------------
  
@@ -226,6 +235,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('clicks',      'company_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.clicks$$)
  create_distributed_table 
 --------------------------
  
@@ -233,6 +245,9 @@ NOTICE:  Copying data from local table...
 
 SELECT create_distributed_table('impressions', 'company_id');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.impressions$$)
  create_distributed_table 
 --------------------------
  

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -988,6 +988,9 @@ CREATE UNLOGGED TABLE trigger_flush AS
 SELECT 1 AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h FROM generate_series(1,150000) s;
 SELECT create_distributed_table('trigger_flush','a');
 NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.trigger_flush$$)
  create_distributed_table 
 --------------------------
  


### PR DESCRIPTION
DESCRIPTION: Introduces a UDF to truncate local data after distributing a table

When a user distributes a table, we copy the records to relevant shards, and keep the original records in place. This precaution can potentially cause some issues when the schema changes, and those records are outdated.

Related #2624
Workaround for #1770 #2889