### PR TITLE
Copy data from CitusTableCacheEntry more often

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -377,8 +377,7 @@ LoadShardInterval(uint64 shardId)
 		tableEntry->sortedShardIntervalArray[shardEntry->shardIndex];
 
 	/* copy value to return */
-	ShardInterval *shardInterval = (ShardInterval *) palloc0(sizeof(ShardInterval));
-	CopyShardInterval(sourceShardInterval, shardInterval);
+	ShardInterval *shardInterval = CopyShardInterval(sourceShardInterval);
 
 	return shardInterval;
 }
@@ -1172,10 +1171,7 @@ BuildCachedShardList(CitusTableCacheEntry *cacheEntry)
 																intervalTypeMod);
 			MemoryContext oldContext = MemoryContextSwitchTo(MetadataCacheMemoryContext);
 
-			ShardInterval *newShardInterval = (ShardInterval *) palloc0(
-				sizeof(ShardInterval));
-			CopyShardInterval(shardInterval, newShardInterval);
-			shardIntervalArray[arrayIndex] = newShardInterval;
+			shardIntervalArray[arrayIndex] = CopyShardInterval(shardInterval);
 
 			MemoryContextSwitchTo(oldContext);
 
@@ -3388,7 +3384,7 @@ InvalidateForeignRelationGraphCacheCallback(Datum argument, Oid relationId)
  * key graph cache, we use pg_dist_colocation, which is never invalidated for
  * other purposes.
  *
- * We acknowledge that it is not a very intiutive way of implementing this cache
+ * We acknowledge that it is not a very intuitive way of implementing this cache
  * invalidation, but, seems acceptable for now. If this becomes problematic, we
  * could try using a magic oid where we're sure that no relation would ever use
  * that oid.
@@ -3744,8 +3740,8 @@ LookupDistShardTuples(Oid relationId)
 /*
  * LookupShardRelation returns the logical relation oid a shard belongs to.
  *
- * Errors out if the shardId does not exist and missingOk is false. Returns
- * InvalidOid if the shardId does not exist and missingOk is true.
+ * Errors out if the shardId does not exist and missingOk is false.
+ * Returns InvalidOid if the shardId does not exist and missingOk is true.
  */
 Oid
 LookupShardRelation(int64 shardId, bool missingOk)

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -76,15 +76,16 @@
 #include "catalog/pg_am.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_type.h"
-#include "distributed/metadata_cache.h"
 #include "distributed/distributed_planner.h"
+#include "distributed/listutils.h"
+#include "distributed/log_utils.h"
+#include "distributed/metadata_cache.h"
 #include "distributed/multi_join_order.h"
 #include "distributed/multi_physical_planner.h"
-#include "distributed/shardinterval_utils.h"
 #include "distributed/pg_dist_partition.h"
+#include "distributed/shardinterval_utils.h"
 #include "distributed/version_compat.h"
 #include "distributed/worker_protocol.h"
-#include "distributed/log_utils.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
@@ -1358,16 +1359,12 @@ static List *
 DeepCopyShardIntervalList(List *originalShardIntervalList)
 {
 	List *copiedShardIntervalList = NIL;
-	ListCell *shardIntervalCell = NULL;
 
-	foreach(shardIntervalCell, originalShardIntervalList)
+	ShardInterval *originalShardInterval = NULL;
+	foreach_ptr(originalShardInterval, originalShardIntervalList)
 	{
-		ShardInterval *originalShardInterval =
-			(ShardInterval *) lfirst(shardIntervalCell);
-		ShardInterval *copiedShardInterval =
-			(ShardInterval *) palloc0(sizeof(ShardInterval));
+		ShardInterval *copiedShardInterval = CopyShardInterval(originalShardInterval);
 
-		CopyShardInterval(originalShardInterval, copiedShardInterval);
 		copiedShardIntervalList = lappend(copiedShardIntervalList, copiedShardInterval);
 	}
 

--- a/src/backend/distributed/test/foreign_key_relationship_query.c
+++ b/src/backend/distributed/test/foreign_key_relationship_query.c
@@ -39,10 +39,15 @@ get_referencing_relation_id_list(PG_FUNCTION_ARGS)
 	{
 		Oid relationId = PG_GETARG_OID(0);
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-		List *refList = cacheEntry->referencingRelationsViaForeignKey;
 
 		/* create a function context for cross-call persistence */
 		functionContext = SRF_FIRSTCALL_INIT();
+
+		MemoryContext oldContext =
+			MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
+		List *refList = list_copy(
+			cacheEntry->referencingRelationsViaForeignKey);
+		MemoryContextSwitchTo(oldContext);
 
 		foreignRelationCell = list_head(refList);
 		functionContext->user_fctx = foreignRelationCell;
@@ -90,10 +95,14 @@ get_referenced_relation_id_list(PG_FUNCTION_ARGS)
 	{
 		Oid relationId = PG_GETARG_OID(0);
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-		List *refList = cacheEntry->referencedRelationsViaForeignKey;
 
 		/* create a function context for cross-call persistence */
 		functionContext = SRF_FIRSTCALL_INIT();
+
+		MemoryContext oldContext =
+			MemoryContextSwitchTo(functionContext->multi_call_memory_ctx);
+		List *refList = list_copy(cacheEntry->referencedRelationsViaForeignKey);
+		MemoryContextSwitchTo(oldContext);
 
 		foreignRelationCell = list_head(refList);
 		functionContext->user_fctx = foreignRelationCell;

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -929,8 +929,7 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	if ((partitionMethod == DISTRIBUTE_BY_APPEND) ||
 		(partitionMethod == DISTRIBUTE_BY_RANGE))
 	{
-		ShardInterval *copyShardInterval = CitusMakeNode(ShardInterval);
-		CopyShardInterval(shardInterval, copyShardInterval);
+		ShardInterval *copyShardInterval = CopyShardInterval(shardInterval);
 
 		colocatedShardList = lappend(colocatedShardList, copyShardInterval);
 
@@ -959,8 +958,7 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 		ShardInterval *colocatedShardInterval =
 			colocatedTableCacheEntry->sortedShardIntervalArray[shardIntervalIndex];
 
-		ShardInterval *copyShardInterval = CitusMakeNode(ShardInterval);
-		CopyShardInterval(colocatedShardInterval, copyShardInterval);
+		ShardInterval *copyShardInterval = CopyShardInterval(colocatedShardInterval);
 
 		colocatedShardList = lappend(colocatedShardList, copyShardInterval);
 	}

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -101,7 +101,7 @@ extern uint32 TableShardReplicationFactor(Oid relationId);
 extern List * LoadShardIntervalList(Oid relationId);
 extern int ShardIntervalCount(Oid relationId);
 extern List * LoadShardList(Oid relationId);
-extern void CopyShardInterval(ShardInterval *srcInterval, ShardInterval *destInterval);
+extern ShardInterval * CopyShardInterval(ShardInterval *srcInterval);
 extern void CopyShardPlacement(ShardPlacement *srcPlacement,
 							   ShardPlacement *destPlacement);
 extern uint64 ShardLength(uint64 shardId);


### PR DESCRIPTION
This copies over fixes from reference counting branch,
all CitusTableCacheEntry data may be freed when a GetCitusTableCacheEntry call occurs for its relationId

This fix is not complete, but reference counting is being deferred until 9.4

Copied a subset of changes from #3677 

I will be following up with another PR to specifically avoid calling GetCitusTableCacheEntry redundantly in insert-select executor, which I suspect is causing the CI shard id errors #3581 is about. Whereas that PR will be essentially reverted with #3677 *(similar to how it also reverts #3670)*, this PR won't be
