### PR TITLE
 Avoid calling GetCitusTableCacheEntry on a relationId for which we already have a live cache entry reference

### DIFF
--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -210,8 +210,37 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 							 distSelectJob->jobId);
 			char *distResultPrefix = distResultPrefixString->data;
 
-			CitusTableCacheEntry *targetRelation =
+			CitusTableCacheEntry *cachedTargetRelation =
 				GetCitusTableCacheEntry(targetRelationId);
+			CitusTableCacheEntry *targetRelation = palloc(sizeof(CitusTableCacheEntry));
+			*targetRelation = *cachedTargetRelation;
+
+#if PG_USE_ASSERT_CHECKING
+
+			/*
+			 * These fields aren't used in the code which follows,
+			 * therefore in assert builds NULL these fields to
+			 * segfault if they were to be used.
+			 */
+			targetRelation->partitionKeySTring = NULL;
+			targetRelation->shardIntervalCompareFunction = NULL;
+			targetRelation->hashFunction = NULL;
+			targetRelation->arrayOfPlacementArrayLengths = NULL;
+			targetRelation->arrayOfPlacementArrays = NULL;
+			targetRelation->referencedRelationViaForeignKey = NULL;
+			targetRelation->referencingRelationsViaForeignKey = NULL;
+#endif
+			targetRelation->partitionColumn = copyObject(
+				cachedTargetRelation->partitionColumn);
+			targetRelation->sortedShardIntervalArray =
+				palloc(targetRelation->shardIntervalArrayLength * sizeof(ShardInterval));
+			for (int shardIndex = 0; shardIndex <
+				 targetRelation->shardIntervalArrayLength; shardIndex++)
+			{
+				targetRelation->sortedShardIntervalArray[shardIndex] =
+					CopyShardInterval(
+						cachedTargetRelation->sortedShardIntervalArray[shardIndex]);
+			}
 
 			int partitionColumnIndex =
 				PartitionColumnIndex(insertTargetList, targetRelation->partitionColumn);

--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -565,6 +565,9 @@ CopyShardInterval(ShardInterval *srcInterval)
 	destInterval->shardId = srcInterval->shardId;
 	destInterval->shardIndex = srcInterval->shardIndex;
 
+	/* tableEntry should only be set when cacheEntry points at the shardInterval */
+	destInterval->tableEntry = NULL;
+
 	destInterval->minValue = 0;
 	if (destInterval->minValueExists)
 	{

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -559,7 +559,7 @@ static List *
 RelationShardListForShardCreate(ShardInterval *shardInterval)
 {
 	Oid relationId = shardInterval->relationId;
-	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
+	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntryFromInterval(shardInterval);
 	List *referencedRelationList = cacheEntry->referencedRelationsViaForeignKey;
 	List *referencingRelationList = cacheEntry->referencingRelationsViaForeignKey;
 	int shardIndex = -1;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -223,7 +223,18 @@ bool
 ShouldSyncTableMetadata(Oid relationId)
 {
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
+	return ShouldSyncTableMetadataForCache(tableEntry);
+}
 
+
+/*
+ * ShouldSyncTableMetadataForCache is like ShouldSyncTableMetadata except the caller
+ * supplies a CitusTableCacheEntry to avoid calling GetCitusTableCacheEntry which
+ * might otherwise invalidate pointers for the caller.
+ */
+bool
+ShouldSyncTableMetadataForCache(CitusTableCacheEntry *tableEntry)
+{
 	bool hashDistributed = (tableEntry->partitionMethod == DISTRIBUTE_BY_HASH);
 	bool streamingReplicated =
 		(tableEntry->replicationModel == REPLICATION_MODEL_STREAMING);
@@ -374,7 +385,7 @@ MetadataCreateCommands(void)
 	CitusTableCacheEntry *cacheEntry = NULL;
 	foreach_ptr(cacheEntry, distributedTableList)
 	{
-		if (ShouldSyncTableMetadata(cacheEntry->relationId))
+		if (ShouldSyncTableMetadataForCache(cacheEntry))
 		{
 			propagatedTableList = lappend(propagatedTableList, cacheEntry);
 		}

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -79,7 +79,9 @@ RebuildQueryStrings(Job *workerJob)
 			Query *copiedSubquery = copiedSubqueryRte->subquery;
 
 			/* there are no restrictions to add for reference tables */
-			char partitionMethod = PartitionMethod(shardInterval->relationId);
+			CitusTableCacheEntry *cacheEntry =
+				GetCitusTableCacheEntryFromInterval(shardInterval);
+			char partitionMethod = cacheEntry->partitionMethod;
 			if (partitionMethod != DISTRIBUTE_BY_NONE)
 			{
 				AddShardIntervalRestrictionToSelect(copiedSubquery, shardInterval);

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -1345,6 +1345,29 @@ RightColumnOrNULL(OpExpr *joinClause)
 
 
 /*
+ * PartitionColumnFromCache is like PartitionColumn, but uses a caller supplied
+ * CitusTableCacheEntry. This can be used to avoid a GetCitusTableCacheEntry
+ * call, which may otherwise invalidate pointers the caller depends on.
+ */
+Var *
+PartitionColumnFromCache(CitusTableCacheEntry *cacheEntry, uint32 rangeTableId)
+{
+	if (cacheEntry == NULL ||
+		!cacheEntry->isCitusTable ||
+		cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
+	{
+		return NULL;
+	}
+
+	Var *partitionColumn = copyObject(cacheEntry->partitionColumn);
+	partitionColumn->varno = rangeTableId;
+	partitionColumn->varnoold = rangeTableId;
+
+	return partitionColumn;
+}
+
+
+/*
  * PartitionColumn builds the partition column for the given relation, and sets
  * the partition column's range table references to the given table identifier.
  *

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -303,8 +303,8 @@ CreateSingleTaskRouterPlan(DistributedPlan *distributedPlan, Query *originalQuer
 List *
 ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
 {
-	Oid relationId = shardInterval->relationId;
-	char partitionMethod = PartitionMethod(shardInterval->relationId);
+	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntryFromInterval(shardInterval);
+	char partitionMethod = cacheEntry->partitionMethod;
 	Var *partitionColumn = NULL;
 
 	if (partitionMethod == DISTRIBUTE_BY_HASH)
@@ -315,7 +315,7 @@ ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
 			 DISTRIBUTE_BY_APPEND)
 	{
 		Assert(rteIndex > 0);
-		partitionColumn = PartitionColumn(relationId, rteIndex);
+		partitionColumn = PartitionColumnFromCache(cacheEntry, rteIndex);
 	}
 	else
 	{
@@ -2608,7 +2608,7 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 		return modifyRouteList;
 	}
 
-	Var *partitionColumn = PartitionColumn(distributedTableId, rangeTableId);
+	Var *partitionColumn = PartitionColumnFromCache(cacheEntry, rangeTableId);
 
 	/* get full list of insert values and iterate over them to prune */
 	List *insertValuesList = ExtractInsertValuesList(query, partitionColumn);

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -534,7 +534,9 @@ ReplicateShardToNode(ShardInterval *shardInterval, char *nodeName, int nodePort)
 		 * metadata) will be copied to workers after all reference table changed
 		 * are finished.
 		 */
-		if (ShouldSyncTableMetadata(shardInterval->relationId))
+		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntryFromInterval(
+			shardInterval);
+		if (ShouldSyncTableMetadataForCache(cacheEntry))
 		{
 			char *placementCommand = PlacementUpsertCommand(shardId, placementId,
 															SHARD_STATE_ACTIVE, 0,

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -236,10 +236,9 @@ int
 ShardIndex(ShardInterval *shardInterval)
 {
 	int shardIndex = INVALID_SHARD_INDEX;
-	Oid distributedTableId = shardInterval->relationId;
 	Datum shardMinValue = shardInterval->minValue;
 
-	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(distributedTableId);
+	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntryFromInterval(shardInterval);
 	char partitionMethod = cacheEntry->partitionMethod;
 
 	/*

--- a/src/include/distributed/master_metadata_utility.h
+++ b/src/include/distributed/master_metadata_utility.h
@@ -50,6 +50,7 @@ typedef struct ShardInterval
 	Datum maxValue;     /* a shard's typed max value datum */
 	uint64 shardId;
 	int shardIndex;
+	void *tableEntry;   /* a possibly NULL pointer for reverse cache lookup */
 } ShardInterval;
 
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -126,6 +126,8 @@ extern ShardPlacement * FindShardPlacementOnGroup(int32 groupId, uint64 shardId)
 extern GroupShardPlacement * LoadGroupShardPlacement(uint64 shardId, uint64 placementId);
 extern ShardPlacement * LoadShardPlacement(uint64 shardId, uint64 placementId);
 extern CitusTableCacheEntry * GetCitusTableCacheEntry(Oid distributedRelationId);
+extern CitusTableCacheEntry * GetCitusTableCacheEntryFromInterval(
+	ShardInterval *shardInterval);
 extern DistObjectCacheEntry * LookupDistObjectCacheEntry(Oid classid, Oid objid, int32
 														 objsubid);
 extern int32 GetLocalGroupId(void);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -31,6 +31,7 @@ typedef enum
 extern void StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort);
 extern bool ClusterHasKnownMetadataWorkers(void);
 extern bool ShouldSyncTableMetadata(Oid relationId);
+extern bool ShouldSyncTableMetadataForCache(CitusTableCacheEntry *tableEntry);
 extern List * MetadataCreateCommands(void);
 extern List * GetDistributedTableDDLEvents(Oid relationId);
 extern List * MetadataDropCommands(void);

--- a/src/include/distributed/multi_join_order.h
+++ b/src/include/distributed/multi_join_order.h
@@ -19,6 +19,7 @@
 
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
+#include "metadata_cache.h"
 
 
 /*
@@ -103,6 +104,8 @@ extern OpExpr * SinglePartitionJoinClause(List *partitionColumnList,
 extern OpExpr * DualPartitionJoinClause(List *applicableJoinClauses);
 extern Var * LeftColumnOrNULL(OpExpr *joinClause);
 extern Var * RightColumnOrNULL(OpExpr *joinClause);
+extern Var * PartitionColumnFromCache(CitusTableCacheEntry *cacheEntry, uint32
+									  rangeTableId);
 extern Var * PartitionColumn(Oid relationId, uint32 rangeTableId);
 extern Var * DistPartitionKey(Oid relationId);
 extern Var * ForceDistPartitionKey(Oid relationId);


### PR DESCRIPTION
This builds on #3769