### PR TITLE
Use block_writes for replicate_reference_tables

### DIFF
--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -216,7 +216,7 @@ EnsureReferenceTablesExistOnAllNodes(void)
 			StringInfo placementCopyCommand =
 				CopyShardPlacementToWorkerNodeQuery(sourceShardPlacement,
 													newWorkerNode,
-													TRANSFER_MODE_AUTOMATIC);
+													TRANSFER_MODE_BLOCK_WRITES);
 			ExecuteCriticalRemoteCommand(connection, placementCopyCommand->data);
 			RemoteTransactionCommit(connection);
 		}

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -114,3 +114,5 @@ s/pg_catalog.citus_extradata_container\([0-9]+/pg_catalog.citus_extradata_contai
 
 # ignore referene table replication messages
 /replicating reference table.*$/d
+
+s/Citus.*currently supports/Citus currently supports/g

--- a/src/test/regress/expected/foreign_key_to_reference_table.out
+++ b/src/test/regress/expected/foreign_key_to_reference_table.out
@@ -318,7 +318,7 @@ SELECT create_distributed_table('referencing_table', 'ref_id');
 
 ALTER TABLE referencing_table ADD CONSTRAINT fkey_ref FOREIGN KEY (id) REFERENCES referenced_table(id);
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus Community Edition currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+DETAIL:  Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
 HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 SELECT * FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%' ORDER BY 1,2,3;
  name | relid | refd_relid
@@ -336,7 +336,7 @@ SELECT create_distributed_table('referencing_table', 'ref_id');
 
 ALTER TABLE referencing_table ADD COLUMN referencing_col int REFERENCES referenced_table(id) ON DELETE SET NULL;
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus Community Edition currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+DETAIL:  Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
 HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 SELECT * FROM table_fkeys_in_workers WHERE relid LIKE 'fkey_reference_table.%' AND refd_relid LIKE 'fkey_reference_table.%' ORDER BY 1,2,3;
  name | relid | refd_relid

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -42,7 +42,7 @@ DROP TABLE referencing_table;
 CREATE TABLE self_referencing_table(id int, ref_id int, PRIMARY KEY (id, ref_id), FOREIGN KEY(id,ref_id) REFERENCES self_referencing_table(id, ref_id));
 SELECT create_distributed_table('self_referencing_table', 'id', 'hash');
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus Community Edition currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+DETAIL:  Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
 HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 DROP TABLE self_referencing_table;
 CREATE TABLE self_referencing_table(id int, ref_id int, PRIMARY KEY (id, ref_id));
@@ -54,7 +54,7 @@ SELECT create_distributed_table('self_referencing_table', 'id', 'hash');
 
 ALTER TABLE self_referencing_table ADD CONSTRAINT fkey FOREIGN KEY(id,ref_id) REFERENCES self_referencing_table(id, ref_id);
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus Community Edition currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+DETAIL:  Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
 HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 DROP TABLE self_referencing_table;
 -- test foreign constraint creation on NOT co-located tables
@@ -81,7 +81,7 @@ DROP TABLE referencing_table;
 CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id));
 SELECT create_distributed_table('referencing_table', 'ref_id', 'hash');
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus Community Edition currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+DETAIL:  Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
 HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 DROP TABLE referencing_table;
 DROP TABLE referenced_table;

--- a/src/test/regress/expected/replicated_partitioned_table.out
+++ b/src/test/regress/expected/replicated_partitioned_table.out
@@ -157,7 +157,7 @@ ADD CONSTRAINT
 REFERENCES
 	fkey_test(key) ON DELETE CASCADE;
 ERROR:  cannot create foreign key constraint
-DETAIL:  Citus Community Edition currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
+DETAIL:  Citus currently supports foreign key constraints only for "citus.shard_replication_factor = 1".
 HINT:  Please change "citus.shard_replication_factor to 1". To learn more about using foreign keys with other replication factors, please contact us at https://citusdata.com/about/contact_us.
 -- we should be able to attach and detach partitions
 -- given that those DDLs are on the parent table


### PR DESCRIPTION
We previously used `prefer_logical` transfer mode in https://github.com/citusdata/citus/pull/3770, but that can cause deadlocks, so going with `block_writes` for now.

An example of a deadlock is:

Run `SELECT upgrade_to_reference_table('replicate_reference_table_hash');`, which gets a transactionid `ExclusiveLock` (as expected), and then opens a connection to localhost to copy shards using logical replication. The logical replication code runs the following query which tries to get a transactionid `ShareLock` on the same transaction:

```sql
SELECT DISTINCT t.schemaname, t.tablename                           
          FROM pg_catalog.pg_publication_tables t                           
         WHERE t.pubname IN ('citus_shard_move_publication')
```

This PR also adds some normalization rules to normalize enterprise/community edition error messages.