### PR TITLE
 Remove the entries from the shared connection counter hash when no connections remain

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -295,9 +295,6 @@ master_disable_node(PG_FUNCTION_ARGS)
 	bool onlyConsiderActivePlacements = false;
 	MemoryContext savedContext = CurrentMemoryContext;
 
-	/* remove the shared connection counters to have some space */
-	RemoveInactiveNodesFromSharedConnections();
-
 	PG_TRY();
 	{
 		if (NodeIsPrimary(workerNode))
@@ -634,9 +631,6 @@ ActivateNode(char *nodeName, int nodePort)
 {
 	bool isActive = true;
 
-	/* remove the shared connection counters to have some space */
-	RemoveInactiveNodesFromSharedConnections();
-
 	/* take an exclusive lock on pg_dist_node to serialize pg_dist_node changes */
 	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
 
@@ -677,9 +671,6 @@ master_update_node(PG_FUNCTION_ARGS)
 	BackgroundWorkerHandle *handle = NULL;
 
 	CheckCitusVersion(ERROR);
-
-	/* remove the shared connection counters to have some space */
-	RemoveInactiveNodesFromSharedConnections();
 
 	WorkerNode *workerNodeWithSameAddress = FindWorkerNodeAnyCluster(newNodeNameString,
 																	 newNodePort);
@@ -1049,9 +1040,6 @@ ReadDistNode(bool includeNodesFromOtherClusters)
 static void
 RemoveNodeFromCluster(char *nodeName, int32 nodePort)
 {
-	/* remove the shared connection counters to have some space */
-	RemoveInactiveNodesFromSharedConnections();
-
 	WorkerNode *workerNode = ModifiableWorkerNode(nodeName, nodePort);
 	if (NodeIsPrimary(workerNode))
 	{

--- a/src/include/distributed/shared_connection_stats.h
+++ b/src/include/distributed/shared_connection_stats.h
@@ -17,7 +17,6 @@ extern int MaxSharedPoolSize;
 extern void InitializeSharedConnectionStats(void);
 extern void WaitForSharedConnection(void);
 extern void WakeupWaiterBackendsForSharedConnection(void);
-extern void RemoveInactiveNodesFromSharedConnections(void);
 extern int GetMaxSharedPoolSize(void);
 extern bool TryToIncrementSharedConnectionCounter(const char *hostname, int port);
 extern void WaitLoopForSharedConnection(const char *hostname, int port);

--- a/src/test/regress/expected/ensure_no_shared_connection_leak.out
+++ b/src/test/regress/expected/ensure_no_shared_connection_leak.out
@@ -129,9 +129,7 @@ WHERE
 ORDER BY 1;
  no_connection_to_node
 ---------------------------------------------------------------------
- t
- t
-(2 rows)
+(0 rows)
 
 -- now, ensure this from the workers perspective
 -- we should only see the connection/backend that is running the command below

--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -60,9 +60,7 @@ ORDER BY
 	hostname, port;
  connection_count_to_node
 ---------------------------------------------------------------------
-                        0
-                        0
-(2 rows)
+(0 rows)
 
 -- single shard queries require single connection per node
 BEGIN;
@@ -106,9 +104,7 @@ ORDER BY
 	hostname, port;
  connection_count_to_node
 ---------------------------------------------------------------------
-                        0
-                        0
-(2 rows)
+(0 rows)
 
 -- executor is only allowed to establish a single connection per node
 BEGIN;
@@ -147,9 +143,7 @@ ORDER BY
 	hostname, port;
  connection_count_to_node
 ---------------------------------------------------------------------
-                        0
-                        0
-(2 rows)
+(0 rows)
 
 -- sequential mode is allowed to establish a single connection per node
 BEGIN;
@@ -188,9 +182,7 @@ ORDER BY
 	hostname, port;
  connection_count_to_node
 ---------------------------------------------------------------------
-                        0
-                        0
-(2 rows)
+(0 rows)
 
 -- now, decrease the shared pool size, and still force
 -- one connection per placement


### PR DESCRIPTION
We initially considered removing entries just before any change to
pg_dist_node. However, that ended-up being very complex and making
MX even more complex.

Instead, we're switching to a simpler solution, where we remove entries
when the counter gets to 0.

With certain workloads, this may have some performance penalty. But, two
notes on that:
 - When counter == 0, it implies that the cluster is not busy
 - With cached connections, that's not possible