### PR TITLE
Add a job to check if merge to enterprise master would fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,15 @@ jobs:
            install-and-test-ext --target check-citus-upgrade-mixed --citus-pre-tar /install-pg11-citusv8.3.0.tar
           no_output_timeout: 2m
 
-
+  check-merge-to-enterprise:
+    docker:
+      - image: buildpack-deps:stretch
+    working_directory: /home/circleci/project  
+    steps:
+      - checkout
+      - run:
+          command: |
+            sh ./src/test/scripts/check_enterprise_merge.sh
 
 
 
@@ -242,35 +250,36 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-      - check-style
-      - check-sql-snapshots
+      - check-merge-to-enterprise
+      # - build
+      # - check-style
+      # - check-sql-snapshots
 
-      - test-11_check-multi:
-          requires: [build]
-      - test-11_check-tt-van-mx:
-          requires: [build]
-      - test-11_check-iso-work-fol:
-          requires: [build]
-      - test-11_check-fol:
-          requires: [build]
-      - test-11_check-failure:
-          requires: [build]
+      # - test-11_check-multi:
+      #     requires: [build]
+      # - test-11_check-tt-van-mx:
+      #     requires: [build]
+      # - test-11_check-iso-work-fol:
+      #     requires: [build]
+      # - test-11_check-fol:
+      #     requires: [build]
+      # - test-11_check-failure:
+      #     requires: [build]
 
-      - test-12_check-multi:
-          requires: [build]
-      - test-12_check-tt-van-mx:
-          requires: [build]
-      - test-12_check-iso-work-fol:
-          requires: [build]
-      - test-12_check-fol:
-          requires: [build]
-      - test-12_check-failure:
-          requires: [build]
+      # - test-12_check-multi:
+      #     requires: [build]
+      # - test-12_check-tt-van-mx:
+      #     requires: [build]
+      # - test-12_check-iso-work-fol:
+      #     requires: [build]
+      # - test-12_check-fol:
+      #     requires: [build]
+      # - test-12_check-failure:
+      #     requires: [build]
 
-      - test-11-12_check-pg-upgrade:
-          requires: [build]
+      # - test-11-12_check-pg-upgrade:
+      #     requires: [build]
 
-      - test-11_check-citus-upgrade:
-          requires: [build]
+      # - test-11_check-citus-upgrade:
+      #     requires: [build]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
       - checkout
       - run:
           command: |
-            sh ./src/test/scripts/check_enterprise_merge.sh
+            ./src/test/scripts/check_enterprise_merge.sh
 
 
 
@@ -251,35 +251,35 @@ workflows:
   build_and_test:
     jobs:
       - check-merge-to-enterprise
-      # - build
-      # - check-style
-      # - check-sql-snapshots
+      - build
+      - check-style
+      - check-sql-snapshots
 
-      # - test-11_check-multi:
-      #     requires: [build]
-      # - test-11_check-tt-van-mx:
-      #     requires: [build]
-      # - test-11_check-iso-work-fol:
-      #     requires: [build]
-      # - test-11_check-fol:
-      #     requires: [build]
-      # - test-11_check-failure:
-      #     requires: [build]
+      - test-11_check-multi:
+          requires: [build]
+      - test-11_check-tt-van-mx:
+          requires: [build]
+      - test-11_check-iso-work-fol:
+          requires: [build]
+      - test-11_check-fol:
+          requires: [build]
+      - test-11_check-failure:
+          requires: [build]
 
-      # - test-12_check-multi:
-      #     requires: [build]
-      # - test-12_check-tt-van-mx:
-      #     requires: [build]
-      # - test-12_check-iso-work-fol:
-      #     requires: [build]
-      # - test-12_check-fol:
-      #     requires: [build]
-      # - test-12_check-failure:
-      #     requires: [build]
+      - test-12_check-multi:
+          requires: [build]
+      - test-12_check-tt-van-mx:
+          requires: [build]
+      - test-12_check-iso-work-fol:
+          requires: [build]
+      - test-12_check-fol:
+          requires: [build]
+      - test-12_check-failure:
+          requires: [build]
 
-      # - test-11-12_check-pg-upgrade:
-      #     requires: [build]
+      - test-11-12_check-pg-upgrade:
+          requires: [build]
 
-      # - test-11_check-citus-upgrade:
-      #     requires: [build]
+      - test-11_check-citus-upgrade:
+          requires: [build]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
   check-merge-to-enterprise:
     docker:
       - image: buildpack-deps:stretch
-    working_directory: /home/circleci/project  
+    working_directory: /home/circleci/project
     steps:
       - checkout
       - run:

--- a/src/test/scripts/README.md
+++ b/src/test/scripts/README.md
@@ -1,7 +1,7 @@
 
 # check-merge-to-enterprise Job
 
-When you open a PR on community, if it creates a conflict with enterprise-master, the check-merge-to-enterprise will fail. Say your branch name is `X`, we will refer to `X` on community as `community/X` and on enterprise as `enterprise/X`. In order to make the job pass:
+When you open a PR on community, if it creates a conflict with enterprise-master, the check-merge-to-enterprise will fail. Say your branch name is `X`, we will refer to `X` on community as `community/X` and on enterprise as `enterprise/X`. If the job already passes, you are done, nothing further required! Otherwise follow the below steps:
 
 - You first need to get approval from your reviewer for `community/X`. Only follow the next steps after you are about to merge the branch to community master. Otherwise, the `check-merge-to-enterprise` check might falsely pass. (For example when you added new commits to `community/X` but forgot to update `enterprise/X`).
 - You need to synchronize the same branch, `X` locally on enterprise (ideally don't push yet). For example if `community` is added as a remote in your enterprise repo, you can do the following:

--- a/src/test/scripts/README.md
+++ b/src/test/scripts/README.md
@@ -1,0 +1,25 @@
+
+# check-merge-to-enterprise Job
+
+When you open a PR on community, if it creates a conflict with enterprise-master, the check-merge-to-enterprise will fail. Say your branch name is `X`, we will refer to `X` on community as `community/X` and on enterprise as `enterprise/X`. In order to make the job pass:
+
+- You first need to get approval for `community/X`. Only follow the next steps after you are about to merge the branch to community master. Otherwise, the `check-merge-to-enterprise` check might falsely pass. (For example when you added new commits to `community/X` but forgot to update `enterprise/X`).
+- You need to create the same branch, `X` locally on enterprise side (don't push yet), and merge `enterprise-master` to `enterprise/X`. Solve any conflicts, on enterprise repository:
+
+```bash
+git checkout enterprise-master
+git pull # make sure enterprise-master in your local is up-to-date
+git checkout X
+git merge enterprise-master
+```
+
+- You should push this to enterprise and open a PR so that the job on community will see this branch.
+- You should get approval from the same reviewer for the merge conflict changes on `enterprise/X`.
+- You should rerun the `check-merge-to-enterprise` check on `community/X`. You can use re-run from failed option in circle CI.
+- You can now merge `community/X` to `community/master`.
+- You can merge `enterprise/X` to `enterprise-master`.
+- Manually merge `community master` to `enterprise-master`.
+- You can use `git checkout --ours <conflicting file names>` for all conflicting files. This will use local/our version to resolve the conflicts.
+- Now you can push to `enterprise-master`.
+
+The subsequent PRs on community will be able to pass the `check-merge-to-enterprise` check as long as they don't have a conflict with `enterprise-master`.

--- a/src/test/scripts/README.md
+++ b/src/test/scripts/README.md
@@ -10,16 +10,16 @@ When you open a PR on community, if it creates a conflict with enterprise-master
 git checkout enterprise-master
 git pull # make sure enterprise-master in your local is up-to-date
 git checkout X
-git merge enterprise-master
+git merge origin/enterprise-master # assuming origin is the remote of citus-enterprise
 ```
 
-- You should push this to enterprise and open a PR so that the job on community will see this branch.
+- You should push this to enterprise and open a PR so that the job on community will see this branch. Also this will trigger CI to verify changes are correct.
 - You should get approval for the merge conflict changes on `enterprise/X`, preferably from the same reviewer as they are familiar with the change.
 - You should rerun the `check-merge-to-enterprise` check on `community/X`. You can use re-run from failed option in circle CI.
 - You can now merge `community/X` to `community/master`.
 - You can merge `enterprise/X` to `enterprise-master`.
 - Manually merge `community master` to `enterprise-master`.
 - You can use `git checkout --ours <conflicting file names>` for all conflicting files. This will use local/our version to resolve the conflicts.
-- Now you can push to `enterprise-master`.
+- Now you can push to `enterprise-master`. Now you can rerun the check on `community/master` and it should pass the check.
 
 The subsequent PRs on community will be able to pass the `check-merge-to-enterprise` check as long as they don't have a conflict with `enterprise-master`.

--- a/src/test/scripts/README.md
+++ b/src/test/scripts/README.md
@@ -4,7 +4,15 @@
 When you open a PR on community, if it creates a conflict with enterprise-master, the check-merge-to-enterprise will fail. Say your branch name is `X`, we will refer to `X` on community as `community/X` and on enterprise as `enterprise/X`. In order to make the job pass:
 
 - You first need to get approval from your reviewer for `community/X`. Only follow the next steps after you are about to merge the branch to community master. Otherwise, the `check-merge-to-enterprise` check might falsely pass. (For example when you added new commits to `community/X` but forgot to update `enterprise/X`).
-- You need to synchronize the same branch, `X` locally on enterprise (ideally don't push yet), and merge `enterprise-master` to `enterprise/X`. Solve any conflicts( and make sure to remove any parts that should not be in enterprise even though it doesn't have a conflict), on enterprise repository:
+- You need to synchronize the same branch, `X` locally on enterprise (ideally don't push yet). For example if `community` is added as a remote in your enterprise repo, you can do the following:
+
+```bash
+git fetch --all # this will fetch community/X
+git checkout community/X
+git checkout -b X # now you have X in your enterprise repo, which we refer to as enterprise/X
+```
+
+- You need to merge `enterprise-master` to `enterprise/X`. Solve any conflicts( and make sure to remove any parts that should not be in enterprise even though it doesn't have a conflict), on enterprise repository:
 
 ```bash
 git checkout enterprise-master
@@ -18,7 +26,7 @@ git merge origin/enterprise-master # assuming origin is the remote of citus-ente
 - You should rerun the `check-merge-to-enterprise` check on `community/X`. You can use re-run from failed option in circle CI.
 - You can now merge `community/X` to `community/master`.
 - You can merge `enterprise/X` to `enterprise-master`.
-- Manually merge `community master` to `enterprise-master`.
+- Manually merge `community master` to `enterprise-master`. [https://github.com/citusdata/citus-enterprise/blob/enterprise-master/CONTRIBUTING.md#merging-community-changes-onto-enterprise](https://github.com/citusdata/citus-enterprise/blob/enterprise-master/CONTRIBUTING.md#merging-community-changes-onto-enterprise)
 - You can use `git checkout --ours <conflicting file names>` for all conflicting files. This will use local/our version to resolve the conflicts.
 - Now you can push to `enterprise-master`. Now you can rerun the check on `community/master` and it should pass the check.
 

--- a/src/test/scripts/README.md
+++ b/src/test/scripts/README.md
@@ -3,8 +3,8 @@
 
 When you open a PR on community, if it creates a conflict with enterprise-master, the check-merge-to-enterprise will fail. Say your branch name is `X`, we will refer to `X` on community as `community/X` and on enterprise as `enterprise/X`. In order to make the job pass:
 
-- You first need to get approval for `community/X`. Only follow the next steps after you are about to merge the branch to community master. Otherwise, the `check-merge-to-enterprise` check might falsely pass. (For example when you added new commits to `community/X` but forgot to update `enterprise/X`).
-- You need to create the same branch, `X` locally on enterprise side (don't push yet), and merge `enterprise-master` to `enterprise/X`. Solve any conflicts, on enterprise repository:
+- You first need to get approval from your reviewer for `community/X`. Only follow the next steps after you are about to merge the branch to community master. Otherwise, the `check-merge-to-enterprise` check might falsely pass. (For example when you added new commits to `community/X` but forgot to update `enterprise/X`).
+- You need to synchronize the same branch, `X` locally on enterprise (ideally don't push yet), and merge `enterprise-master` to `enterprise/X`. Solve any conflicts( and make sure to remove any parts that should not be in enterprise even though it doesn't have a conflict), on enterprise repository:
 
 ```bash
 git checkout enterprise-master
@@ -14,7 +14,7 @@ git merge enterprise-master
 ```
 
 - You should push this to enterprise and open a PR so that the job on community will see this branch.
-- You should get approval from the same reviewer for the merge conflict changes on `enterprise/X`.
+- You should get approval for the merge conflict changes on `enterprise/X`, preferably from the same reviewer as they are familiar with the change.
 - You should rerun the `check-merge-to-enterprise` check on `community/X`. You can use re-run from failed option in circle CI.
 - You can now merge `community/X` to `community/master`.
 - You can merge `enterprise/X` to `enterprise-master`.

--- a/src/test/scripts/check_enterprise_merge.sh
+++ b/src/test/scripts/check_enterprise_merge.sh
@@ -25,14 +25,11 @@ cd citus-enterprise
 git config user.email "citus-bot@microsoft.com"
 git config user.name "citus bot"
 
-# reset repostiroy into usable state if script ran before
+# reset repository into usable state if script ran before
 git fetch origin
 git reset --hard
 git checkout enterprise-master
 git reset --hard origin/enterprise-master
-
-# echo commands
-set -x
 
 branch_name="${CIRCLE_BRANCH}"
 

--- a/src/test/scripts/check_enterprise_merge.sh
+++ b/src/test/scripts/check_enterprise_merge.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# fail if trying to reference a variable that is not set.
+set -u
+# exit immediately if a command fails
+set -e
+
+# try_merge sees if we can merge "from" branch to "to" branch
+# it will exit with nonzero code if the merge fails because of conflicts.
+try_merge() {
+    to=$1
+    from=$2
+    git checkout "${to}"
+    # this will exit since -e option is set and it will return non-zero code on conflicts.
+    git merge --no-ff --no-commit "${from}"
+
+}
+
+git config --global user.email "citus-bot@microsoft.com" 
+git config --global user.name "citus bot" 
+
+cd ~
+git clone https://${GIT_USERNAME}:${GIT_TOKEN}@github.com/citusdata/citus-enterprise
+cd citus-enterprise
+git fetch --all
+
+# echo commands
+set -x
+git branch -r --list
+
+branch_name="${CIRCLE_BRANCH}"
+
+# check if the branch on community exists on enterprise
+# the output will not be empty if it does
+if [ `git branch -r --list origin/$branch_name` ]
+then 
+    try_merge enterprise-master origin/$branch_name
+else
+    # add community as a remote 
+    git remote add --no-tags community git@github.com:citusdata/citus.git
+    # prevent pushes to community
+    git remote set-url --push community no-pushing
+    git fetch --all
+    try_merge enterprise-master community/$branch_name
+fi
+
+


### PR DESCRIPTION
Add a job to check if merge to enterprise master would fail.
The job does the following:
- It checks if there is already a branch with the same name on
enterprise, if so it tries to merge it to enterprise master, if the
merge fails the job fails.
- If the branch doesn't exist on the enterprise, it tries to merge the
current branch to enterprise master, it fails if there is any conflict
while merging.

The motivation is that if a branch on community would create a conflict
on enterprise-master, until we create a PR on enterprise that would
solve this conflict, we won't be able to merge the PR on community. This
way we won't have many conflicts when merging to enterprise master and
the author, who has the most context will be responsible for resolving
the conflict when he has the most context, not after 1 month.
