### PR TITLE
Replicate reference tables before master_create_empty_shard

### DIFF
--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -43,6 +43,7 @@
 #include "distributed/pg_dist_partition.h"
 #include "distributed/pg_dist_shard.h"
 #include "distributed/placement_connection.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/remote_commands.h"
 #include "distributed/resource_lock.h"
@@ -107,6 +108,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	 */
 	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
 	EnsureDependenciesExistOnAllNodes(&tableAddress);
+	EnsureReferenceTablesExistOnAllNodes();
 
 	/* don't allow the table to be dropped */
 	LockRelationOid(relationId, AccessShareLock);

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -863,6 +863,45 @@ SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shard
        -1
 (1 row)
 
+-- verify that master_create_empty_shard replicates reference table shards
+CREATE TABLE range_table(a int);
+SELECT create_distributed_table('range_table', 'a', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
+ ?column?
+---------------------------------------------------------------------
+       -1
+(1 row)
+
+SELECT 1 FROM master_create_empty_shard('range_table');
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
+ ?column?
+---------------------------------------------------------------------
+        0
+(1 row)
+
+DROP TABLE range_table;
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
 -- test setting citus.replicate_reference_tables_on_activate to on
 -- master_add_node
 SET citus.replicate_reference_tables_on_activate TO on;

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -560,6 +560,19 @@ SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
 
 SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
 
+-- verify that master_create_empty_shard replicates reference table shards
+CREATE TABLE range_table(a int);
+SELECT create_distributed_table('range_table', 'a', 'range');
+
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
+SELECT 1 FROM master_create_empty_shard('range_table');
+SELECT count(*) - :ref_table_placements FROM pg_dist_shard_placement WHERE shardid = :ref_table_shard;
+
+DROP TABLE range_table;
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+
 -- test setting citus.replicate_reference_tables_on_activate to on
 -- master_add_node
 SET citus.replicate_reference_tables_on_activate TO on;


### PR DESCRIPTION
We should make sure reference tables are replicated to all nodes before creating shards.