### PR TITLE
Try copying shard intervals out of cache for long lived borrow

### DIFF
--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -210,8 +210,37 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 							 distSelectJob->jobId);
 			char *distResultPrefix = distResultPrefixString->data;
 
-			CitusTableCacheEntry *targetRelation =
+			CitusTableCacheEntry *cachedTargetRelation =
 				GetCitusTableCacheEntry(targetRelationId);
+			CitusTableCacheEntry *targetRelation = palloc(sizeof(CitusTableCacheEntry));
+			*targetRelation = *cachedTargetRelation;
+
+#if PG_USE_ASSERT_CHECKING
+
+			/*
+			 * These fields aren't used in the code which follows,
+			 * therefore in assert builds NULL these fields to
+			 * segfault if they were to be used.
+			 */
+			targetRelation->partitionKeySTring = NULL;
+			targetRelation->shardIntervalCompareFunction = NULL;
+			targetRelation->hashFunction = NULL;
+			targetRelation->arrayOfPlacementArrayLengths = NULL;
+			targetRelation->arrayOfPlacementArrays = NULL;
+			targetRelation->referencedRelationViaForeignKey = NULL;
+			targetRelation->referencingRelationsViaForeignKey = NULL;
+#endif
+			targetRelation->partitionColumn = copyObject(
+				cachedTargetRelation->partitionColumn);
+			targetRelation->sortedShardIntervalArray =
+				palloc(targetRelation->shardIntervalArrayLength * sizeof(ShardInterval));
+			for (int shardIndex = 0; shardIndex <
+				 targetRelation->shardIntervalArrayLength; shardIndex++)
+			{
+				targetRelation->sortedShardIntervalArray[shardIndex] =
+					CopyShardInterval(
+						cachedTargetRelation->sortedShardIntervalArray[shardIndex]);
+			}
 
 			int partitionColumnIndex =
 				PartitionColumnIndex(insertTargetList, targetRelation->partitionColumn);


### PR DESCRIPTION
This is only the 2nd commit from #3771. The first commit is a bit of a mess, a bit of me lashing out about how much of a mess patching over this issue is, whereas the 2nd commit seems to actually address the case we're hitting on CI with a relatively precise change