### PR TITLE
Skip dependency setup on coordinator node

### DIFF
--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -4,18 +4,6 @@ SET client_min_messages TO DEBUG;
 SET citus.next_shard_id TO 1570000;
 SET citus.replicate_reference_tables_on_activate TO off;
 SELECT * FROM master_add_node('localhost', :master_port, groupid := 0);
-DEBUG:  schema "public" already exists, skipping
-DETAIL:  from localhost:xxxxx
-DEBUG:  extension "plpgsql" already exists, skipping
-DETAIL:  from localhost:xxxxx
-DEBUG:  schema "citus_mx_test_schema" already exists, skipping
-DETAIL:  from localhost:xxxxx
-DEBUG:  schema "citus_mx_test_schema_join_1" already exists, skipping
-DETAIL:  from localhost:xxxxx
-DEBUG:  schema "citus_mx_test_schema_join_2" already exists, skipping
-DETAIL:  from localhost:xxxxx
-DEBUG:  schema "citus_mx_schema_for_xacts" already exists, skipping
-DETAIL:  from localhost:xxxxx
  master_add_node
 ---------------------------------------------------------------------
               32

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -427,6 +427,18 @@ ROLLBACK;
 -- see https://github.com/citusdata/citus/issues/3279
 ALTER TABLE squares DROP COLUMN b;
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (8000000, 'replicate_ref_to_coordinator', 'ALTER TABLE squares DROP COLUMN b;')
+-- verify that we replicate the reference tables that are distributed before
+-- adding the coordinator as a worker.
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+-- add the coordinator as a worker node and verify that the reference tables are replicated
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
+NOTICE:  Replicating reference table "squares" to the node localhost:xxxxx
+NOTICE:  Replicating reference table "numbers" to the node localhost:xxxxx
 -- clean-up
 SET client_min_messages TO ERROR;
 DROP SCHEMA replicate_ref_to_coordinator CASCADE;

--- a/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
+++ b/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
@@ -250,6 +250,12 @@ ROLLBACK;
 -- see https://github.com/citusdata/citus/issues/3279
 ALTER TABLE squares DROP COLUMN b;
 
+-- verify that we replicate the reference tables that are distributed before
+-- adding the coordinator as a worker.
+SELECT master_remove_node('localhost', :master_port);
+
+-- add the coordinator as a worker node and verify that the reference tables are replicated
+SELECT master_add_node('localhost', :master_port, groupid => 0) AS master_nodeid \gset
 
 -- clean-up
 SET client_min_messages TO ERROR;


### PR DESCRIPTION
If we run `master_add_node()` with group ID set to zero, we want to skip dependency creation on the coordinator as all the dependencies should already be there.

We can potentially run into deadlocks if one tries to alter distributed objects and add the coordinator as a worker. This aims to solve that potential deadlocks

fixes #3781