### PR TITLE
Fix build issue with GCC Red Hat 10

### DIFF
--- a/src/include/distributed/citus_nodes.h
+++ b/src/include/distributed/citus_nodes.h
@@ -70,7 +70,7 @@ typedef enum CitusNodeTag
 } CitusNodeTag;
 
 
-const char** CitusNodeTagNames;
+extern const char** CitusNodeTagNames;
 
 
 typedef struct CitusNode


### PR DESCRIPTION
* As reported in https://github.com/citusdata/citus/issues/3787, we were having issues while building citus with "GCC Red Hat 10" (maybe in some other versions of gcc as well).
* Fixes "multiple definition of 'CitusNodeTagNames'" error by explicitly specifying storage of `CitusNodeTagNames` to be `extern`.

Fixes https://github.com/citusdata/citus/issues/3787