### PR TITLE
Re-enable isolation test for reference tables + distributed deadlock detection

### DIFF
--- a/src/test/regress/expected/isolation_distributed_deadlock_detection.out
+++ b/src/test/regress/expected/isolation_distributed_deadlock_detection.out
@@ -90,10 +90,10 @@ step s2-begin:
   BEGIN;
 
 step s1-set-2pc:
- set citus.multi_shard_commit_protocol TO '2pc';
+	set citus.multi_shard_commit_protocol TO '2pc';
 
 step s2-set-2pc:
- set citus.multi_shard_commit_protocol TO '2pc';
+	set citus.multi_shard_commit_protocol TO '2pc';
 
 step s1-update-1:
   UPDATE deadlock_detection_test SET some_val = 1 WHERE user_id = 1;
@@ -152,7 +152,7 @@ check_distributed_deadlocks
 
 f
 step s2-upsert-select-all:
- INSERT INTO deadlock_detection_test SELECT * FROM deadlock_detection_test ON CONFLICT(user_id) DO UPDATE SET some_val = deadlock_detection_test.some_val + 5 RETURNING *;
+	INSERT INTO deadlock_detection_test SELECT * FROM deadlock_detection_test ON CONFLICT(user_id) DO UPDATE SET some_val = deadlock_detection_test.some_val + 5 RETURNING *;
  <waiting ...>
 step deadlock-checker-call:
   SELECT check_distributed_deadlocks();
@@ -193,7 +193,7 @@ check_distributed_deadlocks
 
 f
 step s2-ddl:
- ALTER TABLE deadlock_detection_test ADD COLUMN test_col INT;
+	ALTER TABLE deadlock_detection_test ADD COLUMN test_col INT;
  <waiting ...>
 step deadlock-checker-call:
   SELECT check_distributed_deadlocks();
@@ -239,6 +239,41 @@ t
 step s2-insert-dist-10: <... completed>
 step s1-insert-local-10: <... completed>
 error in steps deadlock-checker-call s2-insert-dist-10 s1-insert-local-10: ERROR:  canceling the transaction since it was involved in a distributed deadlock
+step s1-commit:
+  COMMIT;
+
+step s2-commit:
+  COMMIT;
+
+
+starting permutation: s1-begin s2-begin s2-insert-ref-10 s1-insert-ref-11 s1-insert-ref-10 s2-insert-ref-11 deadlock-checker-call s1-commit s2-commit
+step s1-begin:
+  BEGIN;
+
+step s2-begin:
+  BEGIN;
+
+step s2-insert-ref-10:
+  INSERT INTO deadlock_detection_reference VALUES (10, 10);
+
+step s1-insert-ref-11:
+  INSERT INTO deadlock_detection_reference VALUES (11, 11);
+
+step s1-insert-ref-10:
+  INSERT INTO deadlock_detection_reference VALUES (10, 10);
+ <waiting ...>
+step s2-insert-ref-11:
+  INSERT INTO deadlock_detection_reference VALUES (11, 11);
+ <waiting ...>
+step deadlock-checker-call:
+  SELECT check_distributed_deadlocks();
+
+check_distributed_deadlocks
+
+t
+step s1-insert-ref-10: <... completed>
+step s2-insert-ref-11: <... completed>
+error in steps deadlock-checker-call s1-insert-ref-10 s2-insert-ref-11: ERROR:  canceling the transaction since it was involved in a distributed deadlock
 step s1-commit:
   COMMIT;
 

--- a/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
@@ -67,13 +67,13 @@ step s1-update-ref-table:
     update ref_table set a = a + 1;
 
 step s2-sleep:
- SELECT pg_sleep(0.5);
+	SELECT pg_sleep(0.5);
 
 pg_sleep
 
 
 step s2-view-dist:
- SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, master_query_host_name, master_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname
 
@@ -84,7 +84,7 @@ coordinator_host57636          coordinator_host57636          idle in transactio
     update ref_table set a = a + 1;
 localhost      57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
 step s2-view-worker:
- SELECT query, query_hostname, query_hostport, master_query_host_name,
+	SELECT query, query_hostname, query_hostport, master_query_host_name,
            master_query_host_port, state, wait_event_type, wait_event, usename, datname
     FROM citus_worker_stat_activity
     WHERE query NOT ILIKE '%pg_prepared_xacts%' AND
@@ -94,10 +94,10 @@ step s2-view-worker:
 
 query          query_hostname query_hostport master_query_host_namemaster_query_host_portstate          wait_event_typewait_event     usename        datname
 
-UPDATE public.ref_table_1400154 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
-UPDATE public.ref_table_1400154 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
-UPDATE public.ref_table_1400154 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)coordinator_host57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
-UPDATE public.ref_table_1400154 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)localhost      57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+UPDATE public.ref_table_1400163 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)localhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+UPDATE public.ref_table_1400163 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)localhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+UPDATE public.ref_table_1400163 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)coordinator_host57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+UPDATE public.ref_table_1400163 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)localhost      57636          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
 step s2-end:
     END;
 
@@ -122,9 +122,9 @@ step s1-update-ref-table:
     update ref_table set a = a + 1;
 
 step s2-active-transactions:
- -- Admin should be able to see all transactions
- SELECT count(*) FROM get_all_active_transactions();
- SELECT count(*) FROM get_global_active_transactions();
+	-- Admin should be able to see all transactions
+	SELECT count(*) FROM get_all_active_transactions();
+	SELECT count(*) FROM get_global_active_transactions();
 
 count
 

--- a/src/test/regress/spec/isolation_distributed_deadlock_detection.spec
+++ b/src/test/regress/spec/isolation_distributed_deadlock_detection.spec
@@ -398,9 +398,7 @@ permutation "s1-begin" "s2-begin" "s1-update-1" "s2-update-2" "s1-update-2" "dea
 permutation "s1-begin" "s2-begin" "s1-insert-dist-10" "s2-insert-local-10" "s2-insert-dist-10" "s1-insert-local-10" "deadlock-checker-call" "s1-commit" "s2-commit"
 
 // daedlock with reference tables only
-// this test fails way too often in our CI. The failure is order related failure, so disabling it
-// for now seems a good option.
-//permutation "s1-begin" "s2-begin" "s2-insert-ref-10" "s1-insert-ref-11" "s2-insert-ref-11" "s1-insert-ref-10" "deadlock-checker-call" "s1-commit" "s2-commit"
+permutation "s1-begin" "s2-begin" "s2-insert-ref-10" "s1-insert-ref-11" "s1-insert-ref-10" "s2-insert-ref-11" "deadlock-checker-call" "s1-commit" "s2-commit"
 
 // deadlock with referecen + distributed tables
 permutation "s1-begin" "s2-begin" "s2-insert-ref-10" "s1-update-1" "deadlock-checker-call" "s2-update-1" "s1-insert-ref-10" "deadlock-checker-call" "s1-commit" "s2-commit"


### PR DESCRIPTION
Well, this time changed the order slightly, re-run the test for 4 times and all passed isolation tests. It was surprising how it used to fail, as all the file is filled with the same pattern of permutations.

Let's re-add, if it fails again, I'll think more on how to fix properly.


Fixes #3684