### PR TITLE
Add some asserts to pass static analysis

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -193,7 +193,16 @@ GetNodeConnection(uint32 flags, const char *hostname, int32 port)
 MultiConnection *
 StartNodeConnection(uint32 flags, const char *hostname, int32 port)
 {
-	return StartNodeUserDatabaseConnection(flags, hostname, port, NULL, NULL);
+	MultiConnection *connection = StartNodeUserDatabaseConnection(flags, hostname, port,
+																  NULL, NULL);
+
+	/*
+	 * connection can only be NULL for optional connections, which we don't
+	 * support in this codepath.
+	 */
+	Assert((flags & OPTIONAL_CONNECTION) == 0);
+	Assert(connection != NULL);
+	return connection;
 }
 
 
@@ -208,6 +217,13 @@ GetNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
 {
 	MultiConnection *connection = StartNodeUserDatabaseConnection(flags, hostname, port,
 																  user, database);
+
+	/*
+	 * connection can only be NULL for optional connections, which we don't
+	 * support in this codepath.
+	 */
+	Assert((flags & OPTIONAL_CONNECTION) == 0);
+	Assert(connection != NULL);
 
 	FinishConnectionEstablishment(connection);
 
@@ -235,6 +251,13 @@ StartWorkerListConnections(List *workerNodeList, uint32 flags, const char *user,
 		MultiConnection *connection = StartNodeUserDatabaseConnection(connectionFlags,
 																	  nodeName, nodePort,
 																	  user, database);
+
+		/*
+		 * connection can only be NULL for optional connections, which we don't
+		 * support in this codepath.
+		 */
+		Assert((flags & OPTIONAL_CONNECTION) == 0);
+		Assert(connection != NULL);
 
 		connectionList = lappend(connectionList, connection);
 	}

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -294,6 +294,13 @@ StartPlacementListConnection(uint32 flags, List *placementAccessList,
 		chosenConnection = StartNodeUserDatabaseConnection(flags, nodeName, nodePort,
 														   userName, NULL);
 
+		/*
+		 * chosenConnection can only be NULL for optional connections, which we
+		 * don't support in this codepath.
+		 */
+		Assert((flags & OPTIONAL_CONNECTION) == 0);
+		Assert(chosenConnection != NULL);
+
 		if ((flags & CONNECTION_PER_PLACEMENT) &&
 			ConnectionAccessedDifferentPlacement(chosenConnection, placement))
 		{
@@ -313,6 +320,13 @@ StartPlacementListConnection(uint32 flags, List *placementAccessList,
 															   FORCE_NEW_CONNECTION,
 															   nodeName, nodePort,
 															   userName, NULL);
+
+			/*
+			 * chosenConnection can only be NULL for optional connections,
+			 * which we don't support in this codepath.
+			 */
+			Assert((flags & OPTIONAL_CONNECTION) == 0);
+			Assert(chosenConnection != NULL);
 
 			Assert(!ConnectionAccessedDifferentPlacement(chosenConnection, placement));
 		}

--- a/src/backend/distributed/executor/multi_client_executor.c
+++ b/src/backend/distributed/executor/multi_client_executor.c
@@ -150,6 +150,13 @@ MultiClientConnectStart(const char *nodeName, uint32 nodePort, const char *nodeD
 	MultiConnection *connection = StartNodeUserDatabaseConnection(connectionFlags,
 																  nodeName, nodePort,
 																  userName, nodeDatabase);
+
+	/*
+	 * connection can only be NULL for optional connections, which we don't
+	 * support in this codepath.
+	 */
+	Assert((connectionFlags & OPTIONAL_CONNECTION) == 0);
+	Assert(connection != NULL);
 	ConnStatusType connStatusType = PQstatus(connection->pgConn);
 
 	/*

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -409,6 +409,13 @@ OpenConnectionsToWorkersInParallel(TargetWorkerSet targetWorkerSet, const char *
 		MultiConnection *connection = StartNodeUserDatabaseConnection(connectionFlags,
 																	  nodeName, nodePort,
 																	  user, NULL);
+
+		/*
+		 * connection can only be NULL for optional connections, which we don't
+		 * support in this codepath.
+		 */
+		Assert((connectionFlags & OPTIONAL_CONNECTION) == 0);
+		Assert(connection != NULL);
 		connectionList = lappend(connectionList, connection);
 	}
 	return connectionList;
@@ -476,6 +483,12 @@ SendCommandToWorkersParamsInternal(TargetWorkerSet targetWorkerSet, const char *
 																	  nodeName, nodePort,
 																	  user, NULL);
 
+		/*
+		 * connection can only be NULL for optional connections, which we don't
+		 * support in this codepath.
+		 */
+		Assert((connectionFlags & OPTIONAL_CONNECTION) == 0);
+		Assert(connection != NULL);
 		MarkRemoteTransactionCritical(connection);
 
 		connectionList = lappend(connectionList, connection);


### PR DESCRIPTION
Semmle was complaining that `StartNodeUserDatabaseConnection` could return
`NULL` and we were not handling this everywhere. It can only return `NULL`
however when the `OPTIONAL_CONNECTION` is passed as a flag. This only happens
in a specific spot.

This adds some Assert calls in the other places where we call this function
that it does not return `NULL` indeed. In addition to this we also assert that
`OPTIONAL_CONNECTION` is not part of received flags.