### PR TITLE
ShardIdIndexSlot: store id to index in a hash table to avoid linear scan in LookupShardIndex

### DIFF
--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -66,6 +66,9 @@ typedef struct
 	int shardIntervalArrayLength;
 	ShardInterval **sortedShardIntervalArray;
 
+	/* map of shardId to index in sortedShardIntervalArray */
+	HTAB *shardIdIndexHash;
+
 	/* comparator for partition column's type, NULL if DISTRIBUTE_BY_NONE */
 	FmgrInfo *shardColumnCompareFunction;
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -37,6 +37,11 @@ extern int ReadFromSecondaries;
  */
 #define GROUP_ID_UPGRADING -2
 
+
+/* internal type used by metadata_cache.c to cache shard indexes */
+struct ShardIdIndexSlot;
+
+
 /*
  * Representation of a table's metadata that is frequently used for
  * distributed execution. Cached.
@@ -67,7 +72,7 @@ typedef struct
 	ShardInterval **sortedShardIntervalArray;
 
 	/* map of shardId to index in sortedShardIntervalArray */
-	HTAB *shardIdIndexHash;
+	struct ShardIdIndexSlot *shardIdIndexHash;
 
 	/* comparator for partition column's type, NULL if DISTRIBUTE_BY_NONE */
 	FmgrInfo *shardColumnCompareFunction;


### PR DESCRIPTION
Trying to recoup ~10% perf tax of #3677

Also wanted to see if check-merge-to-enterprise would be skipped when not merging to master

Next thing to look into would be whether reference counting hooks are being too expensive & we need an API that gives direct references for when we only want to copy out some ints from the cache entry

[Based on tpcc benchmarks,](https://github.com/citusdata/release-test-results/commit/dc45b5d8538bba081bad603cb0d20c46a13871e3)
master: 390957 NOPM
release-cache-entry: 368954 NOPM
release-cache-entry-cache-index: 366508 NOPM

So this isn't succeeding, maybe if I throw together a simpler hash table implementation for what amounts to a hash table that doesn't have to deal with deletes or updates or growth etc

*(edit: above written re first commit)*

Linear probing hand rolled table: 345162
vs master: 361789