### PR TITLE
Disallow C-style comments in migration files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
           name: 'Check if changed'
           command: git diff --exit-code
       - run:
+          name: 'Check for C-style comments in migration files'
+          command: ci/disallow_c_comments_in_migrations.sh
+      - run:
+          name: 'Check if changed'
+          command: git diff --exit-code
+      - run:
           name: 'Check for banned C API usage'
           command: ci/banned.h.sh
   check-sql-snapshots:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           paths: [.]
   check-style:
     docker:
-      - image: 'citusdata/stylechecker:latest'
+      - image: 'citus/stylechecker:latest'
     steps:
       - checkout
       - run:

--- a/ci/disallow_c_comments_in_migrations.sh
+++ b/ci/disallow_c_comments_in_migrations.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -euo pipefail
+
+# We do not use c-style comments in migration files as the stripped
+# zero-length migration files cause warning during packaging
+# See #3115 for more info
+
+# In this file, we aim to keep the indentation intact by capturing whitespaces,
+# and reusing them if needed. GNU sed unfortunately does not support lookaround assertions.
+
+# /* -> --
+find src/backend/distributed/sql/*.sql -print0 | xargs -0 sed -i 's#/\*#--#g'
+
+# */ -> `` (empty string)
+# remove all whitespaces immediately before the match
+find src/backend/distributed/sql/*.sql -print0 | xargs -0 sed -i 's#\s*\*/\s*##g'
+
+# * -> --
+# keep the indentation
+# allow only whitespaces before the match
+find src/backend/distributed/sql/*.sql -print0 | xargs -0 sed -i 's#^\(\s*\) \*#\1--#g'
+
+# // -> --
+# do not touch http:// or similar by allowing only whitespaces before //
+find src/backend/distributed/sql/*.sql -print0 | xargs -0 sed -i 's#^\(\s*\)//#\1--#g'

--- a/ci/fix_style.sh
+++ b/ci/fix_style.sh
@@ -10,5 +10,6 @@ cd ${cidir}/..
 
 ci/editorconfig.sh
 ci/remove_useless_declarations.sh
+ci/disallow_c_comments_in_migrations.sh
 
 citus_indent . --quiet

--- a/src/backend/distributed/sql/citus--9.2-2--9.2-4.sql
+++ b/src/backend/distributed/sql/citus--9.2-2--9.2-4.sql
@@ -1,2 +1,2 @@
-/* we've some issues with versioning, and we're fixing it by bumping version */
-/* from 9.2-2 to 9.2-4 see #3673 for details */
+-- we've some issues with versioning, and we're fixing it by bumping version
+-- from 9.2-2 to 9.2-4 see #3673 for details

--- a/src/backend/distributed/sql/citus--9.2-4--9.3-2.sql
+++ b/src/backend/distributed/sql/citus--9.2-4--9.3-2.sql
@@ -1,6 +1,6 @@
-/* citus--9.2-4--9.3-2 */
+-- citus--9.2-4--9.3-2
 
-/* bump version to 9.3-2 */
+-- bump version to 9.3-2
 
 #include "udfs/citus_extradata_container/9.3-2.sql"
 #include "udfs/update_distributed_table_colocation/9.3-2.sql"

--- a/src/backend/distributed/sql/citus--9.3-1--9.2-4.sql
+++ b/src/backend/distributed/sql/citus--9.3-1--9.2-4.sql
@@ -1,10 +1,10 @@
-/* citus--9.3-1--9.2-4 */
-/* this is an unusual upgrade path, we are doing it because */
-/* we have accidentally tagged master branch with v9.2-3 */
-/* however master branch was already bumped to v9.3-1 */
-/* with this file, we are undoing the catalog changes that */
-/* have happened between 9.2-2 to 9.3-1, and making 9.2-4 */
-/* as the release that we can */
+-- citus--9.3-1--9.2-4
+-- this is an unusual upgrade path, we are doing it because
+-- we have accidentally tagged master branch with v9.2-3
+-- however master branch was already bumped to v9.3-1
+-- with this file, we are undoing the catalog changes that
+-- have happened between 9.2-2 to 9.3-1, and making 9.2-4
+-- as the release that we can
 
 -- undo the changes for citus_extradata_container that happened on citus 9.3
 DROP FUNCTION IF EXISTS pg_catalog.citus_extradata_container(INTERNAL);


### PR DESCRIPTION
As we started to use C preprocessor, all C-style comments are stripped and we sometimes end up with empty migration scripts.

- Packagers do not like having empty files in packages
- We lose some of the information

I opened #3115 in the past that fixed the zero-length file problem, and this PR aims to add this control to the CI jobs as well as a way to resolve them when we run `make reindent`

---------

On #3115 [Marco said](https://github.com/citusdata/citus/pull/3115#pullrequestreview-304501286):
> Do we have any way to reject new comments that don't follow this format?

I attempted to answer this request