### PR TITLE
Explain analyze prototype

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -28,6 +28,7 @@
 #include "distributed/local_executor.h"
 #include "distributed/local_plan_cache.h"
 #include "distributed/multi_executor.h"
+#include "distributed/multi_explain.h"
 #include "distributed/multi_server_executor.h"
 #include "distributed/multi_router_planner.h"
 #include "distributed/query_stats.h"
@@ -235,6 +236,11 @@ TupleTableSlot *
 CitusExecScan(CustomScanState *node)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
+
+	if (RequestedForExplainPlan(node))
+	{
+		InstallExplainAnalyzeHooks(scanState->distributedPlan->workerJob->taskList);
+	}
 
 	if (!scanState->finishedRemoteScan)
 	{

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -136,7 +136,6 @@ CitusExecutorStart(QueryDesc *queryDesc, int eflags)
 		 */
 		if (queryDesc->totaltime == NULL)
 		{
-
 			MemoryContext oldcxt = MemoryContextSwitchTo(queryDesc->estate->es_query_cxt);
 			queryDesc->totaltime = InstrAlloc(1, INSTRUMENT_ALL);
 			MemoryContextSwitchTo(oldcxt);
@@ -250,6 +249,7 @@ CitusExecutorRun(QueryDesc *queryDesc,
 	}
 	PG_END_TRY();
 }
+
 
 void
 CitusExecutorEnd(QueryDesc *queryDesc)

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -359,7 +359,6 @@ CitusExecutorEnd(QueryDesc *queryDesc)
 	es->timing = TaskExplainOptions.timing;
 	es->summary = TaskExplainOptions.summary;
 	es->format = TaskExplainOptions.format;
-	es->settings = false;
 
 	ExplainBeginOutput(es);
 	ExplainPrintPlan(es, queryDesc);

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -399,6 +399,27 @@ RemoteExplain(Task *task, ExplainState *es)
 
 	RemoteExplainPlan *remotePlan = (RemoteExplainPlan *) palloc0(
 		sizeof(RemoteExplainPlan));
+
+	if (es->analyze && task->savedPlan)
+	{
+		/* get the first token */
+		char *token = strtok(task->savedPlan->data, "\n");
+
+		/* walk through other tokens */
+		while (token != NULL)
+		{
+			StringInfo line = makeStringInfo();
+			appendStringInfoString(line, token);
+			remotePlan->explainOutputList = lappend(remotePlan->explainOutputList, line);
+
+			token = strtok(NULL, "\n");
+		}
+
+		remotePlan->placementIndex = 0;
+
+		return remotePlan;
+	}
+
 	StringInfo explainQuery = BuildRemoteExplainQuery(TaskQueryStringForAllPlacements(
 														  task),
 													  es);
@@ -679,5 +700,3 @@ ExplainOneQuery(Query *query, int cursorOptions,
 					   &planduration);
 	}
 }
-
-

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -69,7 +69,8 @@ bool ExplainDistributedQueries = true;
 bool ExplainAllTasks = false;
 bool ExplainWorkerQuery = false;
 
-typedef struct {
+typedef struct
+{
 	bool verbose;
 	bool costs;
 	bool buffers;
@@ -80,10 +81,10 @@ typedef struct {
 } ExplainOptions;
 
 static bool SaveTaskExplainPlans = false;
-static ExplainOptions TaskExplainOptions = {0, 0, 0, 0, 0, EXPLAIN_FORMAT_TEXT};
+static ExplainOptions TaskExplainOptions = { 0, 0, 0, 0, 0, EXPLAIN_FORMAT_TEXT };
 static StringInfo SavedExplainPlan = NULL;
 
-static ExplainOptions CurrentExplainOptions = {0, 0, 0, 0, 0, EXPLAIN_FORMAT_TEXT};
+static ExplainOptions CurrentExplainOptions = { 0, 0, 0, 0, 0, EXPLAIN_FORMAT_TEXT };
 
 
 /* Result for a single remote EXPLAIN command */
@@ -687,10 +688,10 @@ ShouldSaveQueryExplain(QueryDesc *queryDesc, int eflags)
 	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
 
 	return SaveTaskExplainPlans &&
-			ExecutorLevel == 0 &&
-			!IsParallelWorker() &&
-			(eflags & EXEC_FLAG_EXPLAIN_ONLY) == 0 &&
-			!IsCitusPlan(plannedStmt->planTree);
+		   ExecutorLevel == 0 &&
+		   !IsParallelWorker() &&
+		   (eflags & EXEC_FLAG_EXPLAIN_ONLY) == 0 &&
+		   !IsCitusPlan(plannedStmt->planTree);
 }
 
 
@@ -723,7 +724,9 @@ SaveQueryExplain(QueryDesc *queryDesc)
 	ExplainPrintPlan(es, queryDesc);
 
 	if (es->costs)
+	{
 		ExplainPrintJITSummary(es, queryDesc);
+	}
 
 	ExplainEndOutput(es);
 
@@ -756,11 +759,13 @@ InstallExplainAnalyzeHooks(List *taskList)
 	}
 }
 
+
 static void
 SendExplainParams(Task *task, MultiConnection *connection)
 {
 	StringInfo query = makeStringInfo();
-	appendStringInfo(query, "SELECT save_explain_output_for_next_query(true, %s, %s, %s, %s, %s, %d)",
+	appendStringInfo(query,
+					 "SELECT save_explain_output_for_next_query(true, %s, %s, %s, %s, %s, %d)",
 					 CurrentExplainOptions.verbose ? "true" : "false",
 					 CurrentExplainOptions.costs ? "true" : "false",
 					 CurrentExplainOptions.timing ? "true" : "false",
@@ -780,7 +785,8 @@ static void
 FetchTaskExplainPlan(Task *task, MultiConnection *connection)
 {
 	PGresult *planResult = NULL;
-	int execResult = ExecuteOptionalRemoteCommand(connection, "SELECT last_saved_plan();", &planResult);
+	int execResult = ExecuteOptionalRemoteCommand(connection, "SELECT last_saved_plan();",
+												  &planResult);
 	if (execResult == RESPONSE_OKAY)
 	{
 		List *planList = ReadFirstColumnAsText(planResult);
@@ -814,6 +820,7 @@ last_saved_plan(PG_FUNCTION_ARGS)
 	}
 }
 
+
 PG_FUNCTION_INFO_V1(save_explain_output_for_next_query);
 Datum
 save_explain_output_for_next_query(PG_FUNCTION_ARGS)
@@ -844,8 +851,8 @@ CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
 	CurrentExplainOptions.query = ExplainWorkerQuery;
 
 	/* rest is copied from ExplainOneQuery() */
-	instr_time	planstart,
-				planduration;
+	instr_time planstart,
+			   planduration;
 
 	INSTR_TIME_SET_CURRENT(planstart);
 
@@ -857,8 +864,9 @@ CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
 
 	/* run it (if needed) and produce output */
 	ExplainOnePlan(plan, into, es, queryString, params, queryEnv,
-					&planduration);
+				   &planduration);
 }
+
 
 /* below are private functions copied from explain.c */
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -679,3 +679,5 @@ ExplainOneQuery(Query *query, int cursorOptions,
 					   &planduration);
 	}
 }
+
+

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -221,7 +221,8 @@ _PG_init(void)
 	 * duties. For simplicity insist that all hooks are previously unused.
 	 */
 	if (planner_hook != NULL || ProcessUtility_hook != NULL ||
-		ExecutorStart_hook != NULL || ExecutorRun_hook != NULL)
+		ExecutorStart_hook != NULL || ExecutorRun_hook != NULL ||
+		ExecutorEnd_hook != NULL)
 	{
 		ereport(ERROR, (errmsg("Citus has to be loaded first"),
 						errhint("Place citus at the beginning of "
@@ -267,6 +268,7 @@ _PG_init(void)
 	set_join_pathlist_hook = multi_join_restriction_hook;
 	ExecutorStart_hook = CitusExecutorStart;
 	ExecutorRun_hook = CitusExecutorRun;
+	ExecutorEnd_hook = CitusExecutorEnd;
 
 	/* register hook for error messages */
 	emit_log_hook = multi_log_hook;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -266,6 +266,7 @@ _PG_init(void)
 	/* register for planner hook */
 	set_rel_pathlist_hook = multi_relation_restriction_hook;
 	set_join_pathlist_hook = multi_join_restriction_hook;
+	ExplainOneQuery_hook = CitusExplainOneQuery;
 	ExecutorStart_hook = CitusExecutorStart;
 	ExecutorRun_hook = CitusExecutorRun;
 	ExecutorEnd_hook = CitusExecutorEnd;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1455,6 +1455,16 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.explain_worker_query",
+		NULL,
+		NULL,
+		&ExplainWorkerQuery,
+		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	/* warn about config items in the citus namespace that are not registered above */
 	EmitWarningsOnPlaceholders("citus");
 }

--- a/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
+++ b/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
@@ -9,7 +9,8 @@ CREATE OR REPLACE FUNCTION last_saved_plan()
 
 CREATE OR REPLACE FUNCTION save_explain_output_for_next_query(
       save_enabled boolean, verbose boolean, costs boolean,
-      timing boolean, summary boolean, format integer)
+      timing boolean, summary boolean, query boolean,
+      format integer)
     RETURNS VOID
     LANGUAGE C STRICT
     AS 'citus';

--- a/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
+++ b/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
@@ -6,3 +6,10 @@ CREATE OR REPLACE FUNCTION last_saved_plan()
     RETURNS TEXT
     LANGUAGE C STRICT
     AS 'citus';
+
+CREATE OR REPLACE FUNCTION save_explain_output_for_next_query(
+      save_enabled boolean, verbose boolean, costs boolean,
+      timing boolean, summary boolean, format integer)
+    RETURNS VOID
+    LANGUAGE C STRICT
+    AS 'citus';

--- a/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
+++ b/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
@@ -1,3 +1,8 @@
 -- citus--9.3-2--9.4-1
 
 -- bump version to 9.4-1
+
+CREATE OR REPLACE FUNCTION last_saved_plan()
+    RETURNS TEXT
+    LANGUAGE C STRICT
+    AS 'citus';

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -72,6 +72,7 @@ extern int ExecutorLevel;
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 							 bool execute_once);
+extern void CitusExecutorEnd(QueryDesc *queryDesc);
 extern void AdaptiveExecutorPreExecutorRun(CitusScanState *scanState);
 extern TupleTableSlot * AdaptiveExecutor(CitusScanState *scanState);
 

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -69,9 +69,6 @@ extern bool SortReturning;
 extern int ExecutorLevel;
 
 
-extern void CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
-					ExplainState *es, const char *queryString, ParamListInfo params,
-					QueryEnvironment *queryEnv);
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 							 bool execute_once);

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -69,6 +69,9 @@ extern bool SortReturning;
 extern int ExecutorLevel;
 
 
+extern void CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
+					ExplainState *es, const char *queryString, ParamListInfo params,
+					QueryEnvironment *queryEnv);
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 							 bool execute_once);

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -21,8 +21,9 @@ extern bool ExplainWorkerQuery;
 extern void InstallExplainAnalyzeHooks(List *taskList);
 extern bool RequestedForExplainPlan(CustomScanState *node);
 extern void CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
-					ExplainState *es, const char *queryString, ParamListInfo params,
-					QueryEnvironment *queryEnv);
+								 ExplainState *es, const char *queryString, ParamListInfo
+								 params,
+								 QueryEnvironment *queryEnv);
 extern bool ShouldSaveQueryExplain(QueryDesc *queryDesc, int eflags);
 extern void SaveQueryExplain(QueryDesc *queryDesc);
 

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -16,4 +16,8 @@
 extern bool ExplainDistributedQueries;
 extern bool ExplainAllTasks;
 
+
+extern void InstallExplainAnalyzeHooks(List *taskList);
+extern bool RequestedForExplainPlan(CustomScanState *node);
+
 #endif /* MULTI_EXPLAIN_H */

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -15,9 +15,16 @@
 /* Config variables managed via guc.c to explain distributed query plans */
 extern bool ExplainDistributedQueries;
 extern bool ExplainAllTasks;
+extern bool ExplainWorkerQuery;
 
 
 extern void InstallExplainAnalyzeHooks(List *taskList);
 extern bool RequestedForExplainPlan(CustomScanState *node);
+extern void CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
+					ExplainState *es, const char *queryString, ParamListInfo params,
+					QueryEnvironment *queryEnv);
+extern bool ShouldSaveQueryExplain(QueryDesc *queryDesc, int eflags);
+extern void SaveQueryExplain(QueryDesc *queryDesc);
+
 
 #endif /* MULTI_EXPLAIN_H */

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -259,8 +259,11 @@ typedef struct TaskQuery
 		 * when we want to access each query string.
 		 */
 		List *queryStringList;
-	}data;
-}TaskQuery;
+	} data;
+} TaskQuery;
+
+typedef struct MultiConnection MultiConnection;
+typedef struct Task Task;
 
 typedef struct Task
 {
@@ -325,6 +328,15 @@ typedef struct Task
 	 * query.
 	 */
 	bool parametersInQueryStringResolved;
+
+
+	/*
+	 * Hooks to execute just before and just after the task is executed. Currently
+	 * these are used for EXPLAIN ANALYZE. "connection" is the connection on which
+	 * task is executed.
+	 */
+	void (*preExecutionHook)(Task *task, MultiConnection *connection);
+	void (*postExecutionHook)(Task *task, MultiConnection *connection);
 } Task;
 
 

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -275,6 +275,8 @@ typedef struct Task
 	 */
 	TaskQuery taskQuery;
 
+	StringInfo savedPlan;
+
 	Oid anchorDistributedTableId;     /* only applies to insert tasks */
 	uint64 anchorShardId;       /* only applies to compute tasks */
 	List *taskPlacementList;    /* only applies to compute tasks */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -1341,3 +1341,19 @@ SELECT true AS valid FROM explain_xml($$
   SELECT * FROM result JOIN series ON (s = l_quantity) JOIN orders_hash_part ON (s = o_orderkey)
 $$);
 t
+-- test EXPLAIN ANALYZE works fine with primary keys
+CREATE TABLE explain_pk(a int primary key, b int);
+SELECT create_distributed_table('explain_pk', 'a');
+
+EXPLAIN (COSTS off, ANALYZE on, TIMING off, SUMMARY off) INSERT INTO explain_pk VALUES (1, 2), (2, 3);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on explain_pk_570004 citus_table_alias (actual rows=0 loops=1)
+              ->  Result (actual rows=1 loops=1)
+SELECT * FROM explain_pk ORDER BY 1;
+1|2
+2|3
+DROP TABLE explain_pk;

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -289,6 +289,27 @@ Sort (actual rows=50 loops=1)
                     ->  HashAggregate (actual rows=50 loops=1)
                           Group Key: l_quantity
                           ->  Seq Scan on lineitem_290000 lineitem (actual rows=6000 loops=1)
+-- Test query text output
+BEGIN;
+SET LOCAL citus.explain_worker_query TO true;
+EXPLAIN (COSTS FALSE, ANALYZE TRUE, TIMING FALSE, SUMMARY FALSE)
+	SELECT l_quantity, count(*) count_quantity FROM lineitem
+	GROUP BY l_quantity ORDER BY count_quantity, l_quantity;
+Sort (actual rows=50 loops=1)
+  Sort Key: (COALESCE((pg_catalog.sum(remote_scan.count_quantity))::bigint, '0'::bigint)), remote_scan.l_quantity
+  Sort Method: quicksort  Memory: 27kB
+  ->  HashAggregate (actual rows=50 loops=1)
+        Group Key: remote_scan.l_quantity
+        ->  Custom Scan (Citus Adaptive) (actual rows=100 loops=1)
+              Task Count: 2
+              Tasks Shown: One of 2
+              ->  Task
+                    Node: host=localhost port=xxxxx dbname=regression
+                    ->  Query Text: SELECT l_quantity, count(*) AS count_quantity FROM lineitem_290000 lineitem WHERE true GROUP BY l_quantity
+                        HashAggregate (actual rows=50 loops=1)
+                          Group Key: l_quantity
+                          ->  Seq Scan on lineitem_290000 lineitem (actual rows=6000 loops=1)
+END;
 -- Test verbose
 EXPLAIN (COSTS FALSE, VERBOSE TRUE)
 	SELECT sum(l_quantity) / avg(l_quantity) FROM lineitem;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -85,6 +85,14 @@ EXPLAIN (COSTS FALSE, ANALYZE TRUE, TIMING FALSE, SUMMARY FALSE)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity;
 
+-- Test query text output
+BEGIN;
+SET LOCAL citus.explain_worker_query TO true;
+EXPLAIN (COSTS FALSE, ANALYZE TRUE, TIMING FALSE, SUMMARY FALSE)
+	SELECT l_quantity, count(*) count_quantity FROM lineitem
+	GROUP BY l_quantity ORDER BY count_quantity, l_quantity;
+END;
+
 -- Test verbose
 EXPLAIN (COSTS FALSE, VERBOSE TRUE)
 	SELECT sum(l_quantity) / avg(l_quantity) FROM lineitem;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -595,3 +595,10 @@ SELECT true AS valid FROM explain_xml($$
   )
   SELECT * FROM result JOIN series ON (s = l_quantity) JOIN orders_hash_part ON (s = o_orderkey)
 $$);
+
+-- test EXPLAIN ANALYZE works fine with primary keys
+CREATE TABLE explain_pk(a int primary key, b int);
+SELECT create_distributed_table('explain_pk', 'a');
+EXPLAIN (COSTS off, ANALYZE on, TIMING off, SUMMARY off) INSERT INTO explain_pk VALUES (1, 2), (2, 3);
+SELECT * FROM explain_pk ORDER BY 1;
+DROP TABLE explain_pk;


### PR DESCRIPTION
Does the EXPLAIN ANALYZE at the same time as execution, so avoids executing twice.

When running query through explain analyze, we tell the worker to also save the explain plan by a call to `save_explain_output_for_next_query`. After query finishes execution, we fetch the saved explain plan by calling `last_saved_plan()` and save it in the corresponding task.

Fixes #3519, #2347, #2613, #621.

TODO:
- [ ] reorganize code and add comments
- [ ] Don't use unsafe `strtok`
- [ ] Memory clean-up of saved plan at transaction end.
- [ ] Better naming?
- [ ] Show query text for `ANALYZE off` if asked for.
- [ ] Set placement index correctly.
