### PR TITLE
Prep routing modifying ctes

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -164,7 +164,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		TupleDesc tupleDesc = CallStmtResultDesc(callStmt);
 		TupleTableSlot *slot = MakeSingleTupleTableSlotCompat(tupleDesc,
 															  &TTSOpsMinimalTuple);
-		bool hasReturning = true;
+		bool expectResults = true;
 		Task *task = CitusMakeNode(Task);
 
 		task->jobId = INVALID_JOB_ID;
@@ -196,7 +196,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 			);
 		executionParams->tupleStore = tupleStore;
 		executionParams->tupleDescriptor = tupleDesc;
-		executionParams->hasReturning = hasReturning;
+		executionParams->expectResults = expectResults;
 		executionParams->xactProperties = xactProperties;
 		ExecuteTaskListExtended(executionParams);
 

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -300,7 +300,7 @@ GetDistributionArgIndex(Oid functionOid, char *distributionArgumentName,
 	}
 
 	/*
-	 * The user didn't provid "$paramIndex" but potentially the name of the paramater.
+	 * The user didn't provid "$paramIndex" but potentially the name of the parameter.
 	 * So, loop over the arguments and try to find the argument name that matches
 	 * the parameter that user provided.
 	 */

--- a/src/backend/distributed/executor/distributed_execution_locks.c
+++ b/src/backend/distributed/executor/distributed_execution_locks.c
@@ -358,7 +358,7 @@ AcquireExecutorShardLocksForRelationRowLockList(List *relationRowLockList)
 	}
 
 	/*
-	 * If lock clause exists and it effects any reference table, we need to get
+	 * If lock clause exists and it affects any reference table, we need to get
 	 * lock on shard resource. Type of lock is determined by the type of row lock
 	 * given in the query. If the type of row lock is either FOR NO KEY UPDATE or
 	 * FOR UPDATE we get ExclusiveLock on shard resource. We get ShareLock if it

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -402,7 +402,7 @@ static Tuplestorestate *
 ExecuteSelectTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor,
 								 bool errorOnAnyFailure)
 {
-	bool hasReturning = true;
+	bool expectResults = true;
 	int targetPoolSize = MaxAdaptiveExecutorPoolSize;
 	bool randomAccess = true;
 	bool interTransactions = false;
@@ -428,7 +428,7 @@ ExecuteSelectTasksIntoTupleStore(List *taskList, TupleDesc resultDescriptor,
 	executionParams->tupleDescriptor = resultDescriptor;
 	executionParams->tupleStore = resultStore;
 	executionParams->xactProperties = xactProperties;
-	executionParams->hasReturning = hasReturning;
+	executionParams->expectResults = expectResults;
 
 	ExecuteTaskListExtended(executionParams);
 
@@ -556,7 +556,7 @@ FragmentTransferTaskList(List *fragmentListTransfers)
 		SetPlacementNodeMetadata(targetPlacement, workerNode);
 
 		Task *task = CitusMakeNode(Task);
-		task->taskType = SELECT_TASK;
+		task->taskType = READ_TASK;
 		SetTaskQueryString(task, QueryStringForFragmentsTransfer(fragmentsTransfer));
 		task->taskPlacementList = list_make1(targetPlacement);
 

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -133,7 +133,7 @@ CoordinatorInsertSelectExecScanInternal(CustomScanState *node)
 		RangeTblEntry *insertRte = ExtractResultRelationRTE(insertSelectQuery);
 		Oid targetRelationId = insertRte->relid;
 		char *intermediateResultIdPrefix = distributedPlan->intermediateResultIdPrefix;
-		bool hasReturning = distributedPlan->hasReturning;
+		bool hasReturning = distributedPlan->expectResults;
 		HTAB *shardStateHash = NULL;
 
 		/* select query to execute */

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -635,7 +635,7 @@ TopLevelTask(Task *task)
 	 * SQL tasks can only appear at the top level in our query tree. Further, no
 	 * other task type can appear at the top level in our tree.
 	 */
-	if (task->taskType == SELECT_TASK)
+	if (task->taskType == READ_TASK)
 	{
 		topLevelTask = true;
 	}
@@ -1063,7 +1063,7 @@ ManageTaskExecution(TaskTracker *taskTracker, TaskTracker *sourceTaskTracker,
 			 * We finally queue this task for execution. Note that we queue sql and
 			 * other tasks slightly differently.
 			 */
-			if (taskType == SELECT_TASK)
+			if (taskType == READ_TASK)
 			{
 				TrackerQueueSqlTask(taskTracker, task);
 			}
@@ -1253,7 +1253,7 @@ ManageTransmitExecution(TaskTracker *transmitTracker,
 	TransmitExecStatus *transmitStatusArray = taskExecution->transmitStatusArray;
 	TransmitExecStatus currentTransmitStatus = transmitStatusArray[currentNodeIndex];
 	TransmitExecStatus nextTransmitStatus = EXEC_TRANSMIT_INVALID_FIRST;
-	Assert(task->taskType == SELECT_TASK);
+	Assert(task->taskType == READ_TASK);
 
 	switch (currentTransmitStatus)
 	{
@@ -1852,7 +1852,7 @@ ConstrainedNonMergeTaskList(List *taskAndExecutionList, Task *task)
 	List *dependentTaskList = NIL;
 
 	TaskType taskType = task->taskType;
-	if (taskType == SELECT_TASK || taskType == MAP_TASK)
+	if (taskType == READ_TASK || taskType == MAP_TASK)
 	{
 		upstreamTask = task;
 		dependentTaskList = upstreamTask->dependentTaskList;
@@ -1928,7 +1928,7 @@ ConstrainedMergeTaskList(List *taskAndExecutionList, Task *task)
 	 * given task is a SQL or map task, we simply need to find its merge task
 	 * dependencies -- if any.
 	 */
-	if (taskType == SELECT_TASK || taskType == MAP_TASK)
+	if (taskType == READ_TASK || taskType == MAP_TASK)
 	{
 		constrainedMergeTaskList = MergeTaskList(task->dependentTaskList);
 	}
@@ -2008,7 +2008,7 @@ ReassignTaskList(List *taskList)
 		TaskExecution *taskExecution = task->taskExecution;
 
 		bool transmitCompleted = TransmitExecutionCompleted(taskExecution);
-		if ((task->taskType == SELECT_TASK) && transmitCompleted)
+		if ((task->taskType == READ_TASK) && transmitCompleted)
 		{
 			completedTaskList = lappend(completedTaskList, task);
 		}

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -575,17 +575,6 @@ IsUpdateOrDelete(Query *query)
 
 
 /*
- * IsModifyDistributedPlan returns true if the multi plan performs modifications,
- * false otherwise.
- */
-bool
-IsModifyDistributedPlan(DistributedPlan *distributedPlan)
-{
-	return distributedPlan->modLevel > ROW_MODIFY_READONLY;
-}
-
-
-/*
  * PlanFastPathDistributedStmt creates a distributed planned statement using
  * the FastPathPlanner.
  */
@@ -805,7 +794,7 @@ InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
 	/* after inlining, we shouldn't have any inlinable CTEs */
 	Assert(!QueryTreeContainsInlinableCTE(copyOfOriginalQuery));
 
-	#if PG_VERSION_NUM < PG_VERSION_12
+#if PG_VERSION_NUM < PG_VERSION_12
 	Query *query = planContext->query;
 
 	/*

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -367,7 +367,7 @@ TryToDelegateFunctionCall(DistributedPlanningContext *planContext)
 	ereport(DEBUG1, (errmsg("pushing down the function call")));
 
 	task = CitusMakeNode(Task);
-	task->taskType = SELECT_TASK;
+	task->taskType = READ_TASK;
 	task->taskPlacementList = placementList;
 	SetTaskQueryIfShouldLazyDeparse(task, planContext->query);
 	task->anchorShardId = shardInterval->shardId;
@@ -382,7 +382,7 @@ TryToDelegateFunctionCall(DistributedPlanningContext *planContext)
 	distributedPlan->workerJob = job;
 	distributedPlan->masterQuery = NULL;
 	distributedPlan->routerExecutable = true;
-	distributedPlan->hasReturning = false;
+	distributedPlan->expectResults = true;
 
 	/* worker will take care of any necessary locking, treat query as read-only */
 	distributedPlan->modLevel = ROW_MODIFY_READONLY;

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -297,13 +297,8 @@ CreateDistributedInsertSelectPlan(Query *originalQuery,
 	distributedPlan->workerJob = workerJob;
 	distributedPlan->masterQuery = NULL;
 	distributedPlan->routerExecutable = true;
-	distributedPlan->hasReturning = false;
+	distributedPlan->expectResults = originalQuery->returningList != NIL;
 	distributedPlan->targetRelationId = targetRelationId;
-
-	if (originalQuery->returningList != NIL)
-	{
-		distributedPlan->hasReturning = true;
-	}
 
 	return distributedPlan;
 }
@@ -1135,7 +1130,7 @@ CreateCoordinatorInsertSelectPlan(uint64 planId, Query *parse)
 	}
 
 	distributedPlan->insertSelectQuery = insertSelectQuery;
-	distributedPlan->hasReturning = insertSelectQuery->returningList != NIL;
+	distributedPlan->expectResults = insertSelectQuery->returningList != NIL;
 	distributedPlan->intermediateResultIdPrefix = InsertSelectResultIdPrefix(planId);
 	distributedPlan->targetRelationId = targetRelationId;
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -263,6 +263,7 @@ CreatePhysicalDistributedPlan(MultiTreeRoot *multiTree,
 	distributedPlan->masterQuery = masterQuery;
 	distributedPlan->routerExecutable = DistributedPlanRouterExecutable(distributedPlan);
 	distributedPlan->modLevel = ROW_MODIFY_READONLY;
+	distributedPlan->expectResults = true;
 
 	return distributedPlan;
 }
@@ -2216,7 +2217,7 @@ BuildJobTreeTaskList(Job *jobTree, PlannerRestrictionContext *plannerRestriction
 			sqlTaskList = QueryPushdownSqlTaskList(job->jobQuery, job->jobId,
 												   plannerRestrictionContext->
 												   relationRestrictionContext,
-												   prunedRelationShardList, SELECT_TASK,
+												   prunedRelationShardList, READ_TASK,
 												   false);
 		}
 		else
@@ -2249,7 +2250,7 @@ BuildJobTreeTaskList(Job *jobTree, PlannerRestrictionContext *plannerRestriction
 			Task *assignedSqlTask = (Task *) lfirst(assignedSqlTaskCell);
 
 			/* we don't support parameters in the physical planner */
-			if (assignedSqlTask->taskType == SELECT_TASK)
+			if (assignedSqlTask->taskType == READ_TASK)
 			{
 				assignedSqlTask->parametersInQueryStringResolved =
 					job->parametersInJobQueryResolved;
@@ -2679,7 +2680,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 	Task *subqueryTask = CreateBasicTask(jobId, taskId, taskType, NULL);
 
 	if ((taskType == MODIFY_TASK && !modifyRequiresMasterEvaluation) ||
-		taskType == SELECT_TASK)
+		taskType == READ_TASK)
 	{
 		pg_get_query_def(taskQuery, queryString);
 		ereport(DEBUG4, (errmsg("distributed statement: %s",
@@ -2973,7 +2974,7 @@ SqlTaskList(Job *job)
 		StringInfo sqlQueryString = makeStringInfo();
 		pg_get_query_def(taskQuery, sqlQueryString);
 
-		Task *sqlTask = CreateBasicTask(jobId, taskIdIndex, SELECT_TASK,
+		Task *sqlTask = CreateBasicTask(jobId, taskIdIndex, READ_TASK,
 										sqlQueryString->data);
 		sqlTask->dependentTaskList = dataFetchTaskList;
 		sqlTask->relationShardList = BuildRelationShardList(fragmentRangeTableList,
@@ -5794,7 +5795,7 @@ AssignDataFetchDependencies(List *taskList)
 		ListCell *dependentTaskCell = NULL;
 
 		Assert(task->taskPlacementList != NIL);
-		Assert(task->taskType == SELECT_TASK || task->taskType == MERGE_TASK);
+		Assert(task->taskType == READ_TASK || task->taskType == MERGE_TASK);
 
 		foreach(dependentTaskCell, dependentTaskList)
 		{

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -288,7 +288,7 @@ RecordParallelRelationAccessForTaskList(List *taskList)
 	 */
 	Task *firstTask = linitial(taskList);
 
-	if (firstTask->taskType == SELECT_TASK)
+	if (firstTask->taskType == READ_TASK)
 	{
 		RecordRelationParallelSelectAccessForTask(firstTask);
 	}

--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -71,7 +71,7 @@ ExecuteMasterEvaluableFunctionsAndParameters(Query *query, PlanState *planState)
 
 
 /*
- * ExecuteMasterEvaluableParameters evaluates external paramaters that can be
+ * ExecuteMasterEvaluableParameters evaluates external parameters that can be
  * resolved to a constant.
  */
 void
@@ -87,7 +87,7 @@ ExecuteMasterEvaluableParameters(Query *query, PlanState *planState)
 
 
 /*
- * PartiallyEvaluateExpression descend into an expression tree to evaluate
+ * PartiallyEvaluateExpression descends into an expression tree to evaluate
  * expressions that can be resolved to a constant on the master. Expressions
  * containing a Var are skipped, since the value of the Var is not known
  * on the master.

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -120,7 +120,7 @@ CopyNodeDistributedPlan(COPYFUNC_ARGS)
 
 	COPY_SCALAR_FIELD(planId);
 	COPY_SCALAR_FIELD(modLevel);
-	COPY_SCALAR_FIELD(hasReturning);
+	COPY_SCALAR_FIELD(expectResults);
 	COPY_SCALAR_FIELD(routerExecutable);
 
 	COPY_NODE_FIELD(workerJob);

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -184,7 +184,7 @@ OutDistributedPlan(OUTFUNC_ARGS)
 
 	WRITE_UINT64_FIELD(planId);
 	WRITE_ENUM_FIELD(modLevel, RowModifyLevel);
-	WRITE_BOOL_FIELD(hasReturning);
+	WRITE_BOOL_FIELD(expectResults);
 	WRITE_BOOL_FIELD(routerExecutable);
 
 	WRITE_NODE_FIELD(workerJob);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -198,7 +198,6 @@ extern void multi_join_restriction_hook(PlannerInfo *root,
 										JoinPathExtraData *extra);
 extern bool HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams);
 extern bool IsModifyCommand(Query *query);
-extern bool IsModifyDistributedPlan(struct DistributedPlan *distributedPlan);
 extern void EnsurePartitionTableNotReplicated(Oid relationId);
 extern Node * ResolveExternalParams(Node *inputNode, ParamListInfo boundParams);
 extern bool IsMultiTaskPlan(struct DistributedPlan *distributedPlan);

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -93,8 +93,8 @@ typedef struct ExecutionParams
 	/* tupleStore is where the results will be stored for this execution */
 	Tuplestorestate *tupleStore;
 
-	/* hasReturning is true if this execution will return some result. */
-	bool hasReturning;
+	/* expectResults is true if this execution will return some result. */
+	bool expectResults;
 
 	/* targetPoolSize is the maximum amount of connections per worker */
 	int targetPoolSize;

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -81,7 +81,7 @@ typedef enum
 typedef enum
 {
 	TASK_TYPE_INVALID_FIRST,
-	SELECT_TASK,
+	READ_TASK,
 	MAP_TASK,
 	MERGE_TASK,
 	MAP_OUTPUT_FETCH_TASK,
@@ -364,8 +364,11 @@ typedef struct DistributedPlan
 	/* specifies nature of modifications in query */
 	RowModifyLevel modLevel;
 
-	/* specifies whether a DML command has a RETURNING */
-	bool hasReturning;
+	/*
+	 * specifies whether plan returns results,
+	 * either as a SELECT or a DML which has RETURNING.
+	 */
+	bool expectResults;
 
 	/* a router executable query is executed entirely on a worker */
 	bool routerExecutable;


### PR DESCRIPTION
Refactoring for #3654 

The only thing which is tricky is changing `hasReturning` to `expectResults`, which is true now for `SELECT`s. This change happens in a single commit near the end

Rationales:
- `SELECT_TASK` isn't an accurate description when it implies `ROW_MODIFY_READONLY` which it's possible for a SELECT to not have given modifying CTEs
- `modLevel` or `hasReturning` should never be used to infer `originalQuery->commandType`