### PR TITLE
Reference counted metadata optimization: allow bypassing reference counting

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -811,9 +811,9 @@ static void
 EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 							  Oid distributionColumnType, Oid sourceRelationId)
 {
-	CitusTableCacheEntryRef *sourceTableRef = GetCitusTableCacheEntry(sourceRelationId);
+	CitusTableCacheEntry *sourceTable = GetCitusTableCacheEntryDirect(sourceRelationId);
 
-	char sourceDistributionMethod = sourceTableRef->cacheEntry->partitionMethod;
+	char sourceDistributionMethod = sourceTable->partitionMethod;
 	if (sourceDistributionMethod != DISTRIBUTE_BY_HASH)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -822,11 +822,10 @@ EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 								  "for hash distributed tables.")));
 	}
 
-	char sourceReplicationModel = sourceTableRef->cacheEntry->replicationModel;
-	Oid sourceDistributionColumnType =
-		sourceTableRef->cacheEntry->partitionColumn->vartype;
+	char sourceReplicationModel = sourceTable->replicationModel;
+	Oid sourceDistributionColumnType = sourceTable->partitionColumn->vartype;
 
-	ReleaseTableCacheEntry(sourceTableRef);
+	sourceTable = NULL;
 
 	if (sourceReplicationModel != replicationModel)
 	{

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -413,10 +413,10 @@ static void
 EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnType,
 									  Oid sourceRelationId)
 {
-	CitusTableCacheEntryRef *sourceTableRef = GetCitusTableCacheEntry(sourceRelationId);
-	char sourceDistributionMethod = sourceTableRef->cacheEntry->partitionMethod;
-	char sourceReplicationModel = sourceTableRef->cacheEntry->replicationModel;
-	ReleaseTableCacheEntry(sourceTableRef);
+	CitusTableCacheEntry *sourceTable = GetCitusTableCacheEntryDirect(sourceRelationId);
+	char sourceDistributionMethod = sourceTable->partitionMethod;
+	char sourceReplicationModel = sourceTable->replicationModel;
+	sourceTable = NULL;
 
 	if (sourceDistributionMethod != DISTRIBUTE_BY_HASH)
 	{

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -188,17 +188,16 @@ LockTruncatedRelationMetadataInWorkers(TruncateStmt *truncateStatement)
 
 		distributedRelationList = lappend_oid(distributedRelationList, relationId);
 
-		CitusTableCacheEntryRef *cacheRef = GetCitusTableCacheEntry(relationId);
+		CitusTableCacheEntry *cacheEntry =
+			GetCitusTableCacheEntryDirect(relationId);
+		List *referencingTableList = cacheEntry->referencingRelationsViaForeignKey;
+		cacheEntry = NULL;
 
-		List *referencingTableList =
-			cacheRef->cacheEntry->referencingRelationsViaForeignKey;
 		foreach_oid(referencingRelationId, referencingTableList)
 		{
 			distributedRelationList = list_append_unique_oid(distributedRelationList,
 															 referencingRelationId);
 		}
-
-		ReleaseTableCacheEntry(cacheRef);
 	}
 
 	if (distributedRelationList != NIL)

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -221,16 +221,16 @@ ClusterHasKnownMetadataWorkers()
 bool
 ShouldSyncTableMetadata(Oid relationId)
 {
-	CitusTableCacheEntryRef *tableRef = GetCitusTableCacheEntry(relationId);
+	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntryDirect(relationId);
+	char partitionMethod = cacheEntry->partitionMethod;
+	char replicationModel = cacheEntry->replicationModel;
+	cacheEntry = NULL;
 
-	bool hashDistributed = (tableRef->cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH);
-	bool streamingReplicated =
-		(tableRef->cacheEntry->replicationModel == REPLICATION_MODEL_STREAMING);
+	bool hashDistributed = (partitionMethod == DISTRIBUTE_BY_HASH);
+	bool streamingReplicated = (replicationModel == REPLICATION_MODEL_STREAMING);
 
 	bool mxTable = (streamingReplicated && hashDistributed);
-	bool referenceTable = (tableRef->cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
-
-	ReleaseTableCacheEntry(tableRef);
+	bool referenceTable = (partitionMethod == DISTRIBUTE_BY_NONE);
 
 	if (mxTable || referenceTable)
 	{

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1857,14 +1857,13 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 	 * We're also keeping track of whether all participant
 	 * tables are reference tables.
 	 */
-	if (distributedTable)
+	if (distributedTable && relationRestrictionContext->allReferenceTables)
 	{
-		CitusTableCacheEntryRef *cacheRef = GetCitusTableCacheEntry(rte->relid);
+		CitusTableCacheEntry *cacheEntry =
+			GetCitusTableCacheEntryDirect(rte->relid);
 
-		relationRestrictionContext->allReferenceTables &=
-			(cacheRef->cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
-
-		ReleaseTableCacheEntry(cacheRef);
+		relationRestrictionContext->allReferenceTables =
+			(cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
 	}
 
 	relationRestrictionContext->relationRestrictionList =

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -770,11 +770,10 @@ UpdateRelationColocationGroup(Oid distributedRelationId, uint32 colocationId)
 uint32
 TableColocationId(Oid distributedTableId)
 {
-	CitusTableCacheEntryRef *cacheRef = GetCitusTableCacheEntry(distributedTableId);
+	CitusTableCacheEntry *cacheEntry =
+		GetCitusTableCacheEntryDirect(distributedTableId);
 
-	uint32 colocationId = cacheRef->cacheEntry->colocationId;
-	ReleaseTableCacheEntry(cacheRef);
-	return colocationId;
+	return cacheEntry->colocationId;
 }
 
 
@@ -918,11 +917,12 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	Oid distributedTableId = shardInterval->relationId;
 	List *colocatedShardList = NIL;
 
-	CitusTableCacheEntryRef *cacheRef = GetCitusTableCacheEntry(distributedTableId);
-	char partitionMethod = cacheRef->cacheEntry->partitionMethod;
+	CitusTableCacheEntry *cacheEntry =
+		GetCitusTableCacheEntryDirect(distributedTableId);
+	char partitionMethod = cacheEntry->partitionMethod;
 	int shardIntervalArrayLength PG_USED_FOR_ASSERTS_ONLY =
-		cacheRef->cacheEntry->shardIntervalArrayLength;
-	ReleaseTableCacheEntry(cacheRef);
+		cacheEntry->shardIntervalArrayLength;
+	cacheEntry = NULL;
 
 	/*
 	 * If distribution type of the table is not hash or reference, each shard of

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -390,11 +390,14 @@ SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 {
 	ShardInterval *shardInterval = LoadShardInterval(shardId);
 	Oid citusTableId = shardInterval->relationId;
-	CitusTableCacheEntryRef *citusTableRef = GetCitusTableCacheEntry(citusTableId);
-	uint32 colocationId = citusTableRef->cacheEntry->colocationId;
+	CitusTableCacheEntry *cacheEntry =
+		GetCitusTableCacheEntryDirect(citusTableId);
+	uint32 colocationId = cacheEntry->colocationId;
+	char partitionMethod = cacheEntry->partitionMethod;
+	cacheEntry = NULL;
 
 	if (colocationId == INVALID_COLOCATION_ID ||
-		citusTableRef->cacheEntry->partitionMethod != DISTRIBUTE_BY_HASH)
+		partitionMethod != DISTRIBUTE_BY_HASH)
 	{
 		SET_LOCKTAG_SHARD_METADATA_RESOURCE(*tag, MyDatabaseId, shardId);
 	}
@@ -403,8 +406,6 @@ SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 		SET_LOCKTAG_COLOCATED_SHARDS_METADATA_RESOURCE(*tag, MyDatabaseId, colocationId,
 													   shardInterval->shardIndex);
 	}
-
-	ReleaseTableCacheEntry(citusTableRef);
 }
 
 

--- a/src/backend/distributed/utils/shard_utils.c
+++ b/src/backend/distributed/utils/shard_utils.c
@@ -46,16 +46,15 @@ GetTableLocalShardOid(Oid citusTableOid, uint64 shardId)
 Oid
 GetReferenceTableLocalShardOid(Oid referenceTableOid)
 {
-	CitusTableCacheEntryRef *tableRef = GetCitusTableCacheEntry(referenceTableOid);
+	CitusTableCacheEntry *cacheEntry =
+		GetCitusTableCacheEntryDirect(referenceTableOid);
 
 	/* given OID should belong to a valid reference table */
-	Assert(tableRef->cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
+	Assert(cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
 
 	const ShardInterval *shardInterval =
-		tableRef->cacheEntry->sortedShardIntervalArray[0];
+		cacheEntry->sortedShardIntervalArray[0];
 	uint64 referenceTableShardId = shardInterval->shardId;
-
-	ReleaseTableCacheEntry(tableRef);
 
 	return GetTableLocalShardOid(referenceTableOid, referenceTableShardId);
 }

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -134,6 +134,7 @@ extern Var * ForceDistPartitionKey(Oid relationOid);
 extern ShardPlacement * FindShardPlacementOnGroup(int32 groupId, uint64 shardId);
 extern GroupShardPlacement * LoadGroupShardPlacement(uint64 shardId, uint64 placementId);
 extern ShardPlacement * LoadShardPlacement(uint64 shardId, uint64 placementId);
+extern CitusTableCacheEntry * GetCitusTableCacheEntryDirect(Oid distributedRelationId);
 extern CitusTableCacheEntryRef * GetCitusTableCacheEntry(Oid distributedRelationId);
 extern DistObjectCacheEntry * LookupDistObjectCacheEntry(Oid classid, Oid objid, int32
 														 objsubid);


### PR DESCRIPTION
2nd take on trying to recoup ~10% perf tax of #3677

Maybe having every reference hook into memory context cleanup costs too much

Expose directly accessing short lived cache entries

tpcc nopm results:
This branch: 341202
vs master: 357303