### PR TITLE
Refactor incrementing shared connection counters

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -386,7 +386,7 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
 		 *
 		 * Still, we keep track of the connnection counter.
 		 */
-		IncrementSharedConnectionCounter(hostname, port);
+		ForceIncrementSharedConnectionCounter(hostname, port);
 	}
 
 

--- a/src/include/distributed/shared_connection_stats.h
+++ b/src/include/distributed/shared_connection_stats.h
@@ -21,6 +21,6 @@ extern int GetMaxSharedPoolSize(void);
 extern bool TryToIncrementSharedConnectionCounter(const char *hostname, int port);
 extern void WaitLoopForSharedConnection(const char *hostname, int port);
 extern void DecrementSharedConnectionCounter(const char *hostname, int port);
-extern void IncrementSharedConnectionCounter(const char *hostname, int port);
+extern void ForceIncrementSharedConnectionCounter(const char *hostname, int port);
 
 #endif /* SHARED_CONNECTION_STATS_H */


### PR DESCRIPTION
There were two methods to increment the shared connection counters.
- IncrementSharedConnectionCounter
- TryToIncrementSharedConnectionCounter

They had most of the code in common therefore it makes sense to create a
method to remove the duplication. Also As
IncrementSharedConnectionCounter was forcing the increment it is renamed
in that way.

