### PR TITLE
Copy honors `citus.max_shared_pool_size`

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -3575,6 +3575,13 @@ CopyGetPlacementConnection(HTAB *connectionStateHash, ShardPlacement *placement,
 																		 NULL);
 	if (connection != NULL)
 	{
+		/*
+		 * Errors are supposed to cause immediate aborts (i.e. we don't
+		 * want to/can't invalidate placements), mark the connection as
+		 * critical so later errors cause failures.
+		 */
+		MarkRemoteTransactionCritical(connection);
+
 		return connection;
 	}
 
@@ -3596,13 +3603,6 @@ CopyGetPlacementConnection(HTAB *connectionStateHash, ShardPlacement *placement,
 		connection = GetLeastUtilisedCopyConnection(copyConnectionStateList,
 													nodeName,
 													nodePort);
-
-		/*
-		 * Errors are supposed to cause immediate aborts (i.e. we don't
-		 * want to/can't invalidate placements), mark the connection as
-		 * critical so later errors cause failures.
-		 */
-		MarkRemoteTransactionCritical(connection);
 
 		return connection;
 	}
@@ -3637,13 +3637,6 @@ CopyGetPlacementConnection(HTAB *connectionStateHash, ShardPlacement *placement,
 		connection = GetLeastUtilisedCopyConnection(copyConnectionStateList,
 													nodeName,
 													nodePort);
-
-		/*
-		 * Errors are supposed to cause immediate aborts (i.e. we don't
-		 * want to/can't invalidate placements), mark the connection as
-		 * critical so later errors cause failures.
-		 */
-		MarkRemoteTransactionCritical(connection);
 
 		return connection;
 	}

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -3607,7 +3607,7 @@ CopyGetPlacementConnection(HTAB *connectionStateHash, ShardPlacement *placement,
 	 * reached)
 	 */
 	int adaptiveConnectionManagementFlag =
-		AdaptiveConnectionManagementFlag(list_length(connectionStateList));
+		AdaptiveConnectionManagementFlag(list_length(copyConnectionStateList));
 	connectionFlags |= adaptiveConnectionManagementFlag;
 
 	/*
@@ -3629,7 +3629,7 @@ CopyGetPlacementConnection(HTAB *connectionStateHash, ShardPlacement *placement,
 		 * connection with least utilization.
 		 */
 		connection =
-			GetLeastUtilisedCopyConnection(connectionStateList, nodeName, nodePort);
+			GetLeastUtilisedCopyConnection(copyConnectionStateList, nodeName, nodePort);
 		Assert(connection != NULL);
 
 		return connection;

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -820,7 +820,7 @@ OpenCopyConnectionsForNewShards(CopyStmt *copyStatement,
 		 * This code-path doesn't support optional connections, so we don't expect
 		 * NULL connections.
 		 */
-		Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+		Assert(connection != NULL);
 
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
 		{
@@ -2998,7 +2998,7 @@ CitusCopyTo(CopyStmt *copyStatement, char *completionTag)
 			 * This code-path doesn't support optional connections, so we don't expect
 			 * NULL connections.
 			 */
-			Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+			Assert(connection != NULL);
 
 			if (placementIndex == list_length(shardPlacementList) - 1)
 			{

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -3624,7 +3624,7 @@ CopyGetPlacementConnection(HTAB *connectionStateHash, ShardPlacement *placement,
 	if (placement->partitionMethod == DISTRIBUTE_BY_HASH &&
 		MultiShardConnectionType != SEQUENTIAL_CONNECTION)
 	{
-		connectionFlags |= CONNECTION_PER_PLACEMENT;
+		connectionFlags |= REQUIRE_CLEAN_CONNECTION;
 	}
 
 	connection = GetPlacementConnection(connectionFlags, placement, nodeUser);

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -260,7 +260,7 @@ static MultiConnection * GetLeastUtilisedCopyConnection(List *connectionStateLis
 														char *nodeName, int nodePort);
 static List * ConnectionStateList(HTAB *connectionStateHash);
 static List * ConnectionStateListToNode(HTAB *connectionStateHash,
-										char *hostname, int port);
+										const char *hostname, int32 port);
 static void InitializeCopyShardState(CopyShardState *shardState,
 									 HTAB *connectionStateHash,
 									 uint64 shardId, bool stopOnFailure, bool
@@ -3348,10 +3348,10 @@ ConnectionStateList(HTAB *connectionStateHash)
 
 /*
  * ConnectionStateListToNode returns all CopyConnectionState structures in
- * the given hash.
+ * the given hash for a given hostname and port values.
  */
 static List *
-ConnectionStateListToNode(HTAB *connectionStateHash, char *hostname, int port)
+ConnectionStateListToNode(HTAB *connectionStateHash, const char *hostname, int32 port)
 {
 	List *connectionStateList = NIL;
 	HASH_SEQ_STATUS status;

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -210,9 +210,11 @@ GetPlacementConnection(uint32 flags, ShardPlacement *placement, const char *user
 {
 	MultiConnection *connection = StartPlacementConnection(flags, placement, userName);
 
-
 	if (connection == NULL)
 	{
+		/* connection can only be NULL for optional connections */
+		Assert((flags & OPTIONAL_CONNECTION));
+
 		return NULL;
 	}
 
@@ -302,6 +304,9 @@ StartPlacementListConnection(uint32 flags, List *placementAccessList,
 														   userName, NULL);
 		if (chosenConnection == NULL)
 		{
+			/* connection can only be NULL for optional connections */
+			Assert((flags & OPTIONAL_CONNECTION));
+
 			return NULL;
 		}
 

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -1178,12 +1178,11 @@ InitPlacementConnectionManagement(void)
 
 
 /*
- * UseConnectionPerPlacement returns whether we should use as separate connection
- * per placement even if another connection is idle. We mostly use this in testing
- * scenarios.
+ * ShouldUseCleanConnection returns whether we should force a new connection if
+ * existing connections accessed non-co-located placements on the workers.
  */
 bool
-UseConnectionPerPlacement(void)
+ShouldUseCleanConnection(void)
 {
 	return ForceMaxQueryParallelization &&
 		   MultiShardConnectionType != SEQUENTIAL_CONNECTION;

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -1178,11 +1178,12 @@ InitPlacementConnectionManagement(void)
 
 
 /*
- * ShouldUseCleanConnection returns whether we should force a new connection if
- * existing connections accessed non-co-located placements on the workers.
+ * UseConnectionPerPlacement returns whether we should use as separate connection
+ * per placement even if another connection is idle. We mostly use this in testing
+ * scenarios.
  */
 bool
-ShouldUseCleanConnection(void)
+UseConnectionPerPlacement(void)
 {
 	return ForceMaxQueryParallelization &&
 		   MultiShardConnectionType != SEQUENTIAL_CONNECTION;

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -310,17 +310,17 @@ StartPlacementListConnection(uint32 flags, List *placementAccessList,
 			return NULL;
 		}
 
-		if ((flags & CONNECTION_PER_PLACEMENT) &&
+		if ((flags & REQUIRE_CLEAN_CONNECTION) &&
 			ConnectionAccessedDifferentPlacement(chosenConnection, placement))
 		{
 			/*
 			 * Cached connection accessed a non-co-located placement in the same
-			 * table or co-location group, while the caller asked for a connection
-			 * per placement. Open a new connection instead.
+			 * table or co-location group, while the caller asked for a clean
+			 * connection. Open a new connection instead.
 			 *
 			 * We use this for situations in which we want to use a different
 			 * connection for every placement, such as COPY. If we blindly returned
-			 * a cached conection that already modified a different, non-co-located
+			 * a cached connection that already modified a different, non-co-located
 			 * placement B in the same table or in a table with the same co-location
 			 * ID as the current placement, then we'd no longer able to write to
 			 * placement B later in the COPY.

--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -590,10 +590,14 @@ SharedConnectionStatsShmemInit(void)
 
 
 /*
- * ConnectionFlagForSharedConnectionStats returns the connection flag that
+ * AdaptiveConnectionManagementFlag returns the appropriate connection flag
+ * for any given activeConnectionCount to remote nodes.
+ *
+ * This function should only be called if the code-path is capable of handling
+ * optional connections.
  */
 int
-ConnectionFlagForSharedConnectionStats(int currentSessionConnectionCount)
+AdaptiveConnectionManagementFlag(int activeConnectionCount)
 {
 	if (UseConnectionPerPlacement())
 	{
@@ -608,7 +612,7 @@ ConnectionFlagForSharedConnectionStats(int currentSessionConnectionCount)
 		 */
 		return 0;
 	}
-	else if (ShouldWaitForConnection(currentSessionConnectionCount))
+	else if (ShouldWaitForConnection(activeConnectionCount))
 	{
 		/*
 		 * We need this connection to finish the execution. If it is not
@@ -620,8 +624,8 @@ ConnectionFlagForSharedConnectionStats(int currentSessionConnectionCount)
 	else
 	{
 		/*
-		 * The executor can finish the execution with a single connection,
-		 * remaining are optional. If the executor can get more connections,
+		 * The exectuion can be finished the execution with a single connection,
+		 * remaining are optional. If the execution can get more connections,
 		 * it can increase the parallelism.
 		 */
 		return OPTIONAL_CONNECTION;

--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -599,7 +599,7 @@ SharedConnectionStatsShmemInit(void)
 int
 AdaptiveConnectionManagementFlag(int activeConnectionCount)
 {
-	if (ShouldUseCleanConnection())
+	if (UseConnectionPerPlacement())
 	{
 		/*
 		 * User wants one connection per placement, so no throttling is desired

--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -599,7 +599,7 @@ SharedConnectionStatsShmemInit(void)
 int
 AdaptiveConnectionManagementFlag(int activeConnectionCount)
 {
-	if (UseConnectionPerPlacement())
+	if (ShouldUseCleanConnection())
 	{
 		/*
 		 * User wants one connection per placement, so no throttling is desired

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -140,6 +140,7 @@
 #include "distributed/connection_management.h"
 #include "distributed/commands/multi_copy.h"
 #include "distributed/deparse_shard_query.h"
+#include "distributed/shared_connection_stats.h"
 #include "distributed/distributed_execution_locks.h"
 #include "distributed/listutils.h"
 #include "distributed/local_executor.h"
@@ -597,14 +598,12 @@ static bool TaskListRequires2PC(List *taskList);
 static bool SelectForUpdateOnReferenceTable(List *taskList);
 static void AssignTasksToConnectionsOrWorkerPool(DistributedExecution *execution);
 static void UnclaimAllSessionConnections(List *sessionList);
-static bool UseConnectionPerPlacement(void);
 static PlacementExecutionOrder ExecutionOrderForTask(RowModifyLevel modLevel, Task *task);
 static WorkerPool * FindOrCreateWorkerPool(DistributedExecution *execution,
 										   char *nodeName, int nodePort);
 static WorkerSession * FindOrCreateWorkerSession(WorkerPool *workerPool,
 												 MultiConnection *connection);
 static void ManageWorkerPool(WorkerPool *workerPool);
-static bool ShouldWaitForConnection(WorkerPool *workerPool);
 static void CheckConnectionTimeout(WorkerPool *workerPool);
 static int UsableConnectionCount(WorkerPool *workerPool);
 static long NextEventTimeout(DistributedExecution *execution);
@@ -2486,36 +2485,14 @@ ManageWorkerPool(WorkerPool *workerPool)
 			connectionFlags |= OUTSIDE_TRANSACTION;
 		}
 
-		if (UseConnectionPerPlacement())
-		{
-			/*
-			 * User wants one connection per placement, so no throttling is desired
-			 * and we do not set any flags.
-			 *
-			 * The primary reason for this is that allowing multiple backends to use
-			 * connection per placement could lead to unresolved self deadlocks. In other
-			 * words, each backend may stuck waiting for other backends to get a slot
-			 * in the shared connection counters.
-			 */
-		}
-		else if (ShouldWaitForConnection(workerPool))
-		{
-			/*
-			 * We need this connection to finish the execution. If it is not
-			 * available based on the current number of connections to the worker
-			 * then wait for it.
-			 */
-			connectionFlags |= WAIT_FOR_CONNECTION;
-		}
-		else
-		{
-			/*
-			 * The executor can finish the execution with a single connection,
-			 * remaining are optional. If the executor can get more connections,
-			 * it can increase the parallelism.
-			 */
-			connectionFlags |= OPTIONAL_CONNECTION;
-		}
+		/*
+		 * Enforce the requirements for adaptive connection connection
+		 * management (a.k.a., throttle connections if citus.max_shared_pool_size
+		 * reached)
+		 */
+		int sharedConnectionFlag =
+			ConnectionFlagForSharedConnectionStats(list_length(workerPool->sessionList));
+		connectionFlags |= sharedConnectionFlag;
 
 		/* open a new connection to the worker */
 		MultiConnection *connection = StartNodeUserDatabaseConnection(connectionFlags,
@@ -2562,42 +2539,6 @@ ManageWorkerPool(WorkerPool *workerPool)
 
 	INSTR_TIME_SET_CURRENT(workerPool->lastConnectionOpenTime);
 	execution->rebuildWaitEventSet = true;
-}
-
-
-/*
- * ShouldWaitForConnection returns true if the workerPool should wait to
- * get the next connection until one slot is empty within
- * citus.max_shared_pool_size on the worker. Note that, if there is an
- * empty slot, the connection will not wait anyway.
- */
-static bool
-ShouldWaitForConnection(WorkerPool *workerPool)
-{
-	if (list_length(workerPool->sessionList) == 0)
-	{
-		/*
-		 * We definitely need at least 1 connection to finish the execution.
-		 * All single shard queries hit here with the default settings.
-		 */
-		return true;
-	}
-
-	if (list_length(workerPool->sessionList) < MaxCachedConnectionsPerWorker)
-	{
-		/*
-		 * Until this session caches MaxCachedConnectionsPerWorker connections,
-		 * this might lead some optional connections to be considered as non-optional
-		 * when MaxCachedConnectionsPerWorker > 1.
-		 *
-		 * However, once the session caches MaxCachedConnectionsPerWorker (which is
-		 * the second transaction executed in the session), Citus would utilize the
-		 * cached connections as much as possible.
-		 */
-		return true;
-	}
-
-	return false;
 }
 
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2402,7 +2402,7 @@ ManageWorkerPool(WorkerPool *workerPool)
 		return;
 	}
 
-	if (ShouldUseCleanConnection())
+	if (UseConnectionPerPlacement())
 	{
 		int unusedConnectionCount = workerPool->unusedConnectionCount;
 
@@ -2567,7 +2567,7 @@ CheckConnectionTimeout(WorkerPool *workerPool)
 	 * restrictions. In this case, make sure that we get all the connections
 	 * established.
 	 */
-	if (ShouldUseCleanConnection())
+	if (UseConnectionPerPlacement())
 	{
 		requiredActiveConnectionCount = initiatedConnectionCount;
 	}
@@ -3292,7 +3292,7 @@ PopPlacementExecution(WorkerSession *session)
 	TaskPlacementExecution *placementExecution = PopAssignedPlacementExecution(session);
 	if (placementExecution == NULL)
 	{
-		if (session->commandsSent > 0 && ShouldUseCleanConnection())
+		if (session->commandsSent > 0 && UseConnectionPerPlacement())
 		{
 			/*
 			 * Only send one command per connection if force_max_query_parallelisation
@@ -3877,7 +3877,7 @@ WorkerPoolFailed(WorkerPool *workerPool)
 	 * to establish multiple new connection to other workers and the query
 	 * can only succeed if all those connections are established.
 	 */
-	if (ShouldUseCleanConnection())
+	if (UseConnectionPerPlacement())
 	{
 		List *workerList = workerPool->distributedExecution->workerList;
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2490,9 +2490,9 @@ ManageWorkerPool(WorkerPool *workerPool)
 		 * management (a.k.a., throttle connections if citus.max_shared_pool_size
 		 * reached)
 		 */
-		int sharedConnectionFlag =
-			ConnectionFlagForSharedConnectionStats(list_length(workerPool->sessionList));
-		connectionFlags |= sharedConnectionFlag;
+		int adaptiveConnectionManagementFlag =
+			AdaptiveConnectionManagementFlag(list_length(workerPool->sessionList));
+		connectionFlags |= adaptiveConnectionManagementFlag;
 
 		/* open a new connection to the worker */
 		MultiConnection *connection = StartNodeUserDatabaseConnection(connectionFlags,

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1961,19 +1961,6 @@ SetAttributeInputMetadata(DistributedExecution *execution,
 
 
 /*
- * UseConnectionPerPlacement returns whether we should use a separate connection
- * per placement even if another connection is idle. We mostly use this in testing
- * scenarios.
- */
-static bool
-UseConnectionPerPlacement(void)
-{
-	return ForceMaxQueryParallelization &&
-		   MultiShardConnectionType != SEQUENTIAL_CONNECTION;
-}
-
-
-/*
  * ExecutionOrderForTask gives the appropriate execution order for a task.
  */
 static PlacementExecutionOrder

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2402,7 +2402,7 @@ ManageWorkerPool(WorkerPool *workerPool)
 		return;
 	}
 
-	if (UseConnectionPerPlacement())
+	if (ShouldUseCleanConnection())
 	{
 		int unusedConnectionCount = workerPool->unusedConnectionCount;
 
@@ -2567,7 +2567,7 @@ CheckConnectionTimeout(WorkerPool *workerPool)
 	 * restrictions. In this case, make sure that we get all the connections
 	 * established.
 	 */
-	if (UseConnectionPerPlacement())
+	if (ShouldUseCleanConnection())
 	{
 		requiredActiveConnectionCount = initiatedConnectionCount;
 	}
@@ -3292,7 +3292,7 @@ PopPlacementExecution(WorkerSession *session)
 	TaskPlacementExecution *placementExecution = PopAssignedPlacementExecution(session);
 	if (placementExecution == NULL)
 	{
-		if (session->commandsSent > 0 && UseConnectionPerPlacement())
+		if (session->commandsSent > 0 && ShouldUseCleanConnection())
 		{
 			/*
 			 * Only send one command per connection if force_max_query_parallelisation
@@ -3877,7 +3877,7 @@ WorkerPoolFailed(WorkerPool *workerPool)
 	 * to establish multiple new connection to other workers and the query
 	 * can only succeed if all those connections are established.
 	 */
-	if (UseConnectionPerPlacement())
+	if (ShouldUseCleanConnection())
 	{
 		List *workerList = workerPool->distributedExecution->workerList;
 

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -546,6 +546,12 @@ ExecuteDropShardPlacementCommandRemotely(ShardPlacement *shardPlacement,
 														 shardPlacement,
 														 NULL);
 
+	/*
+	 * This code-path doesn't support optional connections, so we don't expect
+	 * NULL connections.
+	 */
+	Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+
 	RemoteTransactionBeginIfNecessary(connection);
 
 	if (PQstatus(connection->pgConn) != CONNECTION_OK)

--- a/src/backend/distributed/master/master_delete_protocol.c
+++ b/src/backend/distributed/master/master_delete_protocol.c
@@ -550,7 +550,7 @@ ExecuteDropShardPlacementCommandRemotely(ShardPlacement *shardPlacement,
 	 * This code-path doesn't support optional connections, so we don't expect
 	 * NULL connections.
 	 */
-	Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+	Assert(connection != NULL);
 
 	RemoteTransactionBeginIfNecessary(connection);
 

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -300,7 +300,7 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 		 * This code-path doesn't support optional connections, so we don't expect
 		 * NULL connections.
 		 */
-		Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+		Assert(connection != NULL);
 
 		PGresult *queryResult = NULL;
 
@@ -874,7 +874,7 @@ WorkerShardStats(ShardPlacement *placement, Oid relationId, const char *shardNam
 	 * This code-path doesn't support optional connections, so we don't expect
 	 * NULL connections.
 	 */
-	Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+	Assert(connection != NULL);
 
 	*shardSize = 0;
 	*shardMinValue = NULL;

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -628,6 +628,12 @@ FetchRemoteExplainFromWorkers(Task *task, ExplainState *es)
 		MultiConnection *connection = GetPlacementConnection(connectionFlags,
 															 taskPlacement, NULL);
 
+		/*
+		 * This code-path doesn't support optional connections, so we don't expect
+		 * NULL connections.
+		 */
+		Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+
 		/* try other placements if we fail to connect this one */
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
 		{

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -632,7 +632,7 @@ FetchRemoteExplainFromWorkers(Task *task, ExplainState *es)
 		 * This code-path doesn't support optional connections, so we don't expect
 		 * NULL connections.
 		 */
-		Assert(connection != NULL && (connectionFlags & OPTIONAL_CONNECTION) == 0);
+		Assert(connection != NULL);
 
 		/* try other placements if we fail to connect this one */
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -46,8 +46,12 @@ enum MultiConnectionMode
 
 	FOR_DML = 1 << 2,
 
-	/* open a connection per (co-located set of) placement(s) */
-	CONNECTION_PER_PLACEMENT = 1 << 3,
+	/*
+	 * During COPY we do not want to use a connection that accessed non-co-located
+	 * placements. If there is a connection that did not access another placement,
+	 * then use it. Otherwise open a new clean connection.
+	 */
+	REQUIRE_CLEAN_CONNECTION = 1 << 3,
 
 	OUTSIDE_TRANSACTION = 1 << 4,
 

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -75,6 +75,7 @@ extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint
 extern void AdaptiveExecutorPreExecutorRun(CitusScanState *scanState);
 extern TupleTableSlot * AdaptiveExecutor(CitusScanState *scanState);
 
+
 /*
  * ExecutionParams contains parameters that are used during the execution.
  * Some of these can be the zero value if it is not needed during the execution.

--- a/src/include/distributed/placement_connection.h
+++ b/src/include/distributed/placement_connection.h
@@ -43,4 +43,6 @@ extern void InitPlacementConnectionManagement(void);
 extern bool ConnectionModifiedPlacement(MultiConnection *connection);
 extern bool ConnectionUsedForAnyPlacements(MultiConnection *connection);
 
+extern bool UseConnectionPerPlacement(void);
+
 #endif /* PLACEMENT_CONNECTION_H */

--- a/src/include/distributed/placement_connection.h
+++ b/src/include/distributed/placement_connection.h
@@ -43,6 +43,6 @@ extern void InitPlacementConnectionManagement(void);
 extern bool ConnectionModifiedPlacement(MultiConnection *connection);
 extern bool ConnectionUsedForAnyPlacements(MultiConnection *connection);
 
-extern bool UseConnectionPerPlacement(void);
+extern bool ShouldUseCleanConnection(void);
 
 #endif /* PLACEMENT_CONNECTION_H */

--- a/src/include/distributed/placement_connection.h
+++ b/src/include/distributed/placement_connection.h
@@ -43,6 +43,6 @@ extern void InitPlacementConnectionManagement(void);
 extern bool ConnectionModifiedPlacement(MultiConnection *connection);
 extern bool ConnectionUsedForAnyPlacements(MultiConnection *connection);
 
-extern bool ShouldUseCleanConnection(void);
+extern bool UseConnectionPerPlacement(void);
 
 #endif /* PLACEMENT_CONNECTION_H */

--- a/src/include/distributed/shared_connection_stats.h
+++ b/src/include/distributed/shared_connection_stats.h
@@ -22,5 +22,6 @@ extern bool TryToIncrementSharedConnectionCounter(const char *hostname, int port
 extern void WaitLoopForSharedConnection(const char *hostname, int port);
 extern void DecrementSharedConnectionCounter(const char *hostname, int port);
 extern void IncrementSharedConnectionCounter(const char *hostname, int port);
+extern int ConnectionFlagForSharedConnectionStats(int currentSessionConnectionCount);
 
 #endif /* SHARED_CONNECTION_STATS_H */

--- a/src/include/distributed/shared_connection_stats.h
+++ b/src/include/distributed/shared_connection_stats.h
@@ -22,6 +22,6 @@ extern bool TryToIncrementSharedConnectionCounter(const char *hostname, int port
 extern void WaitLoopForSharedConnection(const char *hostname, int port);
 extern void DecrementSharedConnectionCounter(const char *hostname, int port);
 extern void IncrementSharedConnectionCounter(const char *hostname, int port);
-extern int ConnectionFlagForSharedConnectionStats(int currentSessionConnectionCount);
+extern int AdaptiveConnectionManagementFlag(int activeConnectionCount);
 
 #endif /* SHARED_CONNECTION_STATS_H */

--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -340,6 +340,52 @@ COPY test FROM STDIN;
 (2 rows)
 
 ROLLBACK;
+-- now, show that COPY doesn't open more connections than the shared_pool_size
+-- now, decrease the shared pool size, and show that COPY doesn't exceed that
+ALTER SYSTEM SET citus.max_shared_pool_size TO 3;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+COPY test FROM STDIN;
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        3
+                        3
+(2 rows)
+
+ROLLBACK;
+ALTER SYSTEM RESET citus.max_shared_pool_size;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
 -- now show that when max_cached_conns_per_worker > 1
 -- Citus forces the first execution to open at least 2
 -- connections that are cached. Later, that 2 cached

--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -373,6 +373,117 @@ COPY test FROM PROGRAM 'seq 32';
 (2 rows)
 
 ROLLBACK;
+-- INSERT SELECT with RETURNING/ON CONFLICT clauses should honor shared_pool_size
+-- in underlying COPY commands
+BEGIN;
+	SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+	INSERT INTO test SELECT i FROM generate_series(0,10) i RETURNING *;
+ a
+---------------------------------------------------------------------
+  0
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(11 rows)
+
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        3
+                        3
+(2 rows)
+
+ROLLBACK;
+-- COPY operations to range partitioned tables will honor max_shared_pool_size
+-- as we use a single connection to each worker
+CREATE TABLE range_table(a int);
+SELECT create_distributed_table('range_table', 'a', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CALL public.create_range_partitioned_shards('range_table',
+                                            '{0,25,50,76}',
+                                            '{24,49,75,200}');
+BEGIN;
+	SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+	COPY range_table FROM PROGRAM 'seq 32';
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        1
+                        1
+(2 rows)
+
+ROLLBACK;
+-- COPY operations to reference tables will use one connection per worker
+-- so we will always honor max_shared_pool_size.
+CREATE TABLE ref_table(a int);
+SELECT create_reference_table('ref_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+	SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+	COPY ref_table FROM PROGRAM 'seq 32';
+	SELECT
+		connection_count_to_node
+	FROM
+		citus_remote_connection_stats()
+	WHERE
+		port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+		database_name = 'regression'
+	ORDER BY
+		hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+                        1
+                        1
+(2 rows)
+
+ROLLBACK;
+-- reset max_shared_pool_size to default
 ALTER SYSTEM RESET citus.max_shared_pool_size;
 SELECT pg_reload_conf();
  pg_reload_conf
@@ -445,5 +556,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+BEGIN;
+SET LOCAL client_min_messages TO WARNING;
 DROP SCHEMA shared_connection_stats CASCADE;
-NOTICE:  drop cascades to table test
+COMMIT;

--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -323,7 +323,7 @@ COMMIT;
 BEGIN;
 	-- now allow at most 2 connections for COPY
 	SET LOCAL citus.max_adaptive_executor_pool_size TO 2;
-COPY test FROM STDIN;
+    COPY test FROM PROGRAM 'seq 32';
 	SELECT
 		connection_count_to_node
 	FROM
@@ -356,7 +356,7 @@ SELECT pg_sleep(0.1);
 (1 row)
 
 BEGIN;
-COPY test FROM STDIN;
+COPY test FROM PROGRAM 'seq 32';
 	SELECT
 		connection_count_to_node
 	FROM

--- a/src/test/regress/sql/shared_connection_stats.sql
+++ b/src/test/regress/sql/shared_connection_stats.sql
@@ -193,40 +193,7 @@ COMMIT;
 BEGIN;
 	-- now allow at most 2 connections for COPY
 	SET LOCAL citus.max_adaptive_executor_pool_size TO 2;
-COPY test FROM STDIN;
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21
-22
-23
-24
-25
-26
-27
-28
-29
-30
-31
-32
-\.
+    COPY test FROM PROGRAM 'seq 32';
 
 	SELECT
 		connection_count_to_node
@@ -248,40 +215,7 @@ SELECT pg_sleep(0.1);
 
 BEGIN;
 
-COPY test FROM STDIN;
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21
-22
-23
-24
-25
-26
-27
-28
-29
-30
-31
-32
-\.
+COPY test FROM PROGRAM 'seq 32';
 
 	SELECT
 		connection_count_to_node


### PR DESCRIPTION
DESCRIPTION: Improves COPY by honoring max_shared_pool_size config

Simply rely on the existing infrastructure. 

TODO:
- [x] One thing that I'm not very satisfied here is that we may pass `CONNECTION_PER_PLACEMENT` and `OPTIONAL_CONNECTION` flags at the same time. That feels a little counter intuitive, any suggestion to improve  that is  welcome. 
- [x] Do we need to do anything specific for `append/range/reference` tables?
- [x] Are  there any edge cases with sequential mode?

Fixes #3894