### PR TITLE
use RelationGetPartitionDesc to be more safe

### DIFF
--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -287,14 +287,14 @@ PartitionList(Oid parentRelationId)
 
 		ereport(ERROR, (errmsg("\"%s\" is not a parent table", relationName)));
 	}
+	PartitionDesc partDesc = RelationGetPartitionDesc(rel);
+	Assert(partDesc != NULL);
 
-	Assert(rel->rd_partdesc != NULL);
-
-	int partitionCount = rel->rd_partdesc->nparts;
+	int partitionCount = partDesc->nparts;
 	for (int partitionIndex = 0; partitionIndex < partitionCount; ++partitionIndex)
 	{
 		partitionList =
-			lappend_oid(partitionList, rel->rd_partdesc->oids[partitionIndex]);
+			lappend_oid(partitionList, partDesc->oids[partitionIndex]);
 	}
 
 	/* keep the lock */


### PR DESCRIPTION
For getting the partition desc, we should use `RelationGetPartitionDesc`
method so that even if it is NULL, it will be initialized in the method.

This crashes PG13.

```c
PartitionDesc
RelationGetPartitionDesc(Relation rel)
{
	if (rel->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
		return NULL;

	if (unlikely(rel->rd_partdesc == NULL))
		RelationBuildPartitionDesc(rel);

	return rel->rd_partdesc;
}
```