### PR TITLE
Check the removeType in IsDropCitusStmt

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -669,7 +669,7 @@ ShouldPropagateExtensionCommand(Node *parseTree)
 	{
 		return false;
 	}
-	else if (IsDropCitusStmt(parseTree))
+	else if (IsDropCitusExtensionStmt(parseTree))
 	{
 		return false;
 	}
@@ -718,21 +718,28 @@ IsCreateAlterExtensionUpdateCitusStmt(Node *parseTree)
 
 
 /*
- * IsDropCitusStmt iterates the objects to be dropped in a drop statement
- * and try to find citus there.
+ * IsDropCitusExtensionStmt iterates the objects to be dropped in a drop statement
+ * and try to find citus extension there.
  */
 bool
-IsDropCitusStmt(Node *parseTree)
+IsDropCitusExtensionStmt(Node *parseTree)
 {
 	/* if it is not a DropStmt, it is needless to search for citus */
 	if (!IsA(parseTree, DropStmt))
 	{
 		return false;
 	}
+	DropStmt *dropStmt = (DropStmt *) parseTree;
 
-	/* now that we have a DropStmt, check if citus is among the objects to dropped */
+	/* check if the drop command is a DROP EXTENSION command */
+	if (dropStmt->removeType != OBJECT_EXTENSION)
+	{
+		return false;
+	}
+
+	/* now that we have a DropStmt, check if citus extension is among the objects to dropped */
 	Value *objectName;
-	foreach_ptr(objectName, ((DropStmt *) parseTree)->objects)
+	foreach_ptr(objectName, dropStmt->objects)
 	{
 		const char *extensionName = strVal(objectName);
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -458,7 +458,7 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		}
 	}
 
-	if (IsDropCitusStmt(parsetree))
+	if (IsDropCitusExtensionStmt(parsetree))
 	{
 		StopMaintenanceDaemon(MyDatabaseId);
 	}
@@ -628,7 +628,7 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		PostprocessVacuumStmt(vacuumStmt, queryString);
 	}
 
-	if (!IsDropCitusStmt(parsetree) && !IsA(parsetree, DropdbStmt))
+	if (!IsDropCitusExtensionStmt(parsetree) && !IsA(parsetree, DropdbStmt))
 	{
 		/*
 		 * Ensure value is valid, we can't do some checks during CREATE

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -73,7 +73,7 @@ extern ObjectAddress DefineCollationStmtObjectAddress(Node *stmt, bool missing_o
 extern List * PostprocessDefineCollationStmt(Node *stmt, const char *queryString);
 
 /* extension.c - forward declarations */
-extern bool IsDropCitusStmt(Node *parsetree);
+extern bool IsDropCitusExtensionStmt(Node *parsetree);
 extern bool IsCreateAlterExtensionUpdateCitusStmt(Node *parsetree);
 extern void ErrorIfUnstableCreateOrAlterExtensionStmt(Node *parsetree);
 extern List * PostprocessCreateExtensionStmt(Node *stmt, const char *queryString);


### PR DESCRIPTION
We should check the remove type in IsDropCitusStmt because if the remove
type is not OBJECT_EXTENSION then the stored objects in
dropStmt->objects may not be of type Value. This was crashing PG-13.

Fixes #3856.


