### PR TITLE
Implement method to decide appropriate lock mode for the query

### DIFF
--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -241,10 +241,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 		if (localPlan != NULL)
 		{
 			Query *jobQuery = distributedPlan->workerJob->jobQuery;
-			LOCKMODE lockMode =
-				IsModifyCommand(jobQuery) ? RowExclusiveLock : (jobQuery->hasForUpdate ?
-																RowShareLock :
-																AccessShareLock);
+			LOCKMODE lockMode = GetQueryLockMode(jobQuery);
 
 			Oid relationId = InvalidOid;
 			foreach_oid(relationId, localPlan->relationOids)

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -528,6 +528,28 @@ GetRTEIdentity(RangeTblEntry *rte)
 
 
 /*
+ * GetQueryLockMode returns the necessary lock mode to be acquired for the
+ * given query. (See comment written in RangeTblEntry->rellockmode)
+ */
+LOCKMODE
+GetQueryLockMode(Query *query)
+{
+	if (IsModifyCommand(query))
+	{
+		return RowExclusiveLock;
+	}
+	else if (query->hasForUpdate)
+	{
+		return RowShareLock;
+	}
+	else
+	{
+		return AccessShareLock;
+	}
+}
+
+
+/*
  * IsModifyCommand returns true if the query performs modifications, false
  * otherwise.
  */

--- a/src/backend/distributed/planner/local_plan_cache.c
+++ b/src/backend/distributed/planner/local_plan_cache.c
@@ -61,9 +61,7 @@ CacheLocalPlanForShardQuery(Task *task, DistributedPlan *originalDistributedPlan
 
 	UpdateRelationsToLocalShardTables((Node *) shardQuery, task->relationShardList);
 
-	LOCKMODE lockMode =
-		IsModifyCommand(shardQuery) ? RowExclusiveLock : (shardQuery->hasForUpdate ?
-														  RowShareLock : AccessShareLock);
+	LOCKMODE lockMode = GetQueryLockMode(shardQuery);
 
 	/* fast path queries can only have a single RTE by definition */
 	RangeTblEntry *rangeTableEntry = (RangeTblEntry *) linitial(shardQuery->rtable);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -203,6 +203,7 @@ extern Node * ResolveExternalParams(Node *inputNode, ParamListInfo boundParams);
 extern bool IsMultiTaskPlan(struct DistributedPlan *distributedPlan);
 extern RangeTblEntry * RemoteScanRangeTableEntry(List *columnNameList);
 extern int GetRTEIdentity(RangeTblEntry *rte);
+extern LOCKMODE GetQueryLockMode(Query *query);
 extern int32 BlessRecordExpression(Expr *expr);
 extern void DissuadePlannerFromUsingPlan(PlannedStmt *plan);
 extern PlannedStmt * FinalizePlan(PlannedStmt *localPlan,


### PR DESCRIPTION
If we want to get necessary lockmode for a relation `RangeVar` within a query, we can get the lockmode easily from the `RangeVar` itself (if pg version >= 12).

However, if we want to decide to the lockmode appropriate for the "query",  we need to derive this information as such according to the code comment from `RangeTblEntry` struct.

```c
* rellockmode is really LOCKMODE, but it's declared int to avoid having
* to include lock-related headers here.  It must be RowExclusiveLock if
* the RTE is an INSERT/UPDATE/DELETE target, else RowShareLock if the RTE
* is a SELECT FOR UPDATE/FOR SHARE target, else AccessShareLock.
```

