### PR TITLE
EXPLAIN ANALYZE network stats prototype

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1465,6 +1465,16 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.explain_network_stats",
+		NULL,
+		NULL,
+		&ExplainNetworkStats,
+		false,
+		PGC_USERSET,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
 	/* warn about config items in the citus namespace that are not registered above */
 	EmitWarningsOnPlaceholders("citus");
 }

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -16,6 +16,7 @@
 extern bool ExplainDistributedQueries;
 extern bool ExplainAllTasks;
 extern bool ExplainWorkerQuery;
+extern bool ExplainNetworkStats;
 
 
 extern void InstallExplainAnalyzeHooks(List *taskList);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -264,6 +264,7 @@ typedef struct TaskQuery
 
 typedef struct MultiConnection MultiConnection;
 typedef struct Task Task;
+typedef struct ExplainAnalyzePrivate ExplainAnalyzePrivate;
 
 typedef struct Task
 {
@@ -278,8 +279,14 @@ typedef struct Task
 	 */
 	TaskQuery taskQuery;
 
+	ExplainAnalyzePrivate *explainAnalyzePrivate;
+
 	StringInfo savedPlan;
 	int savedPlanPlacementIndex;
+
+	/* execution statistics for EXPLAIN ANALYZE */
+	uint64 bytesSent;
+	uint64 bytesReceived;
 
 	Oid anchorDistributedTableId;     /* only applies to insert tasks */
 	uint64 anchorShardId;       /* only applies to compute tasks */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -1586,4 +1586,36 @@ Aggregate (actual rows=1 loops=1)
                     ->  Result (actual rows=6 loops=1)
                           One-Time Filter: $0
                           ->  Seq Scan on dist_table_570014 dist_table (actual rows=6 loops=1)
+-- test explain_network_stats
+BEGIN;
+SET LOCAL citus.explain_network_stats TO true;
+EXPLAIN (COSTS off, ANALYZE on, TIMING off, SUMMARY off)
+WITH r AS (
+	SELECT random() r, a FROM dist_table
+)
+SELECT count(distinct a) from r NATURAL JOIN ref_table;
+Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+  ->  Distributed Subplan XXX_1
+        ->  Custom Scan (Citus Adaptive) (actual rows=10 loops=1)
+              Task Count: 3
+              Tasks Shown: One of 3
+              ->  Task
+                    Bytes Sent: 96
+                    Bytes Received: 286
+                    Node: host=localhost port=xxxxx dbname=regression
+                    ->  Seq Scan on dist_table_570014 dist_table (actual rows=6 loops=1)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Bytes Sent: 302
+        Bytes Received: 86
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Aggregate (actual rows=1 loops=1)
+              ->  Hash Join (actual rows=10 loops=1)
+                    Hash Cond: (ref_table.a = intermediate_result.a)
+                    ->  Seq Scan on ref_table_570017 ref_table (actual rows=10 loops=1)
+                    ->  Hash (actual rows=10 loops=1)
+                          Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                          ->  Function Scan on read_intermediate_result intermediate_result (actual rows=10 loops=1)
+END;
 DROP TABLE ref_table, dist_table;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -657,4 +657,15 @@ EXPLAIN (COSTS off, ANALYZE on, TIMING off, SUMMARY off)
 SELECT count(distinct a) FROM dist_table
 WHERE EXISTS(SELECT random() FROM dist_table NATURAL JOIN ref_table);
 
+-- test explain_network_stats
+BEGIN;
+SET LOCAL citus.explain_network_stats TO true;
+EXPLAIN (COSTS off, ANALYZE on, TIMING off, SUMMARY off)
+WITH r AS (
+	SELECT random() r, a FROM dist_table
+)
+SELECT count(distinct a) from r NATURAL JOIN ref_table;
+END;
+
+
 DROP TABLE ref_table, dist_table;


### PR DESCRIPTION
The network statistics used here are available in Linux kernel 5.0+ (that is why CI fails), so need to add some configure flags to disable this for previous versions.

See multi_explain.out for effect of this PR.