### PR TITLE
Implement TupleDestination to allow custom processing of task results.

### DIFF
--- a/src/backend/distributed/executor/tuple_destination.c
+++ b/src/backend/distributed/executor/tuple_destination.c
@@ -1,0 +1,230 @@
+#include "postgres.h"
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "distributed/tuple_destination.h"
+
+/*
+ * TupleStoreTupleDestination is internal representation of a TupleDestination
+ * which forwards tuples to a tuple store.
+ */
+typedef struct TupleStoreTupleDestination
+{
+	TupleDestination pub;
+
+	/* destination of tuples */
+	Tuplestorestate *tupleStore;
+
+	/* how does tuples look like? */
+	TupleDesc tupleDesc;
+} TupleStoreTupleDestination;
+
+/*
+ * TupleDestDestReceiver is internal representation of a DestReceiver which
+ * forards tuples to a tuple destination.
+ */
+typedef struct TupleDestDestReceiver
+{
+	DestReceiver pub;
+	TupleDestination *tupleDest;
+
+	/* parameters to pass to tupleDest->putTuple() */
+	Task *task;
+	int placementIndex;
+} TupleDestDestReceiver;
+
+
+/* forward declarations for local functions */
+static void TupleStoreTupleDestPutTuple(TupleDestination *self, Task *task,
+										int placementIndex, int queryNumber,
+										HeapTuple heapTuple);
+static TupleDesc TupleStoreTupleDestTupleDescForQuery(TupleDestination *self, int
+													  queryNumber);
+static void TupleDestNonePutTuple(TupleDestination *self, Task *task,
+								  int placementIndex, int queryNumber,
+								  HeapTuple heapTuple);
+static TupleDesc TupleDestNoneTupleDescForQuery(TupleDestination *self, int queryNumber);
+static void TupleDestDestReceiverStartup(DestReceiver *copyDest, int operation,
+										 TupleDesc inputTupleDesc);
+static bool TupleDestDestReceiverReceive(TupleTableSlot *slot,
+										 DestReceiver *copyDest);
+static void TupleDestDestReceiverShutdown(DestReceiver *destReceiver);
+static void TupleDestDestReceiverDestroy(DestReceiver *destReceiver);
+
+
+/*
+ * CreateTupleStoreTupleDest creates a TupleDestination which forwards tuples to
+ * a tupleStore.
+ */
+TupleDestination *
+CreateTupleStoreTupleDest(Tuplestorestate *tupleStore, TupleDesc tupleDescriptor)
+{
+	TupleStoreTupleDestination *tupleStoreTupleDest = palloc0(
+		sizeof(TupleStoreTupleDestination));
+	tupleStoreTupleDest->tupleStore = tupleStore;
+	tupleStoreTupleDest->tupleDesc = tupleDescriptor;
+	tupleStoreTupleDest->pub.putTuple = TupleStoreTupleDestPutTuple;
+	tupleStoreTupleDest->pub.tupleDescForQuery =
+		TupleStoreTupleDestTupleDescForQuery;
+
+	return (TupleDestination *) tupleStoreTupleDest;
+}
+
+
+/*
+ * TupleStoreTupleDestPutTuple implements TupleDestination->putTuple for
+ * TupleStoreTupleDestination.
+ */
+static void
+TupleStoreTupleDestPutTuple(TupleDestination *self, Task *task,
+							int placementIndex, int queryNumber,
+							HeapTuple heapTuple)
+{
+	TupleStoreTupleDestination *tupleDest = (TupleStoreTupleDestination *) self;
+	tuplestore_puttuple(tupleDest->tupleStore, heapTuple);
+}
+
+
+/*
+ * TupleStoreTupleDestTupleDescForQuery implements TupleDestination->TupleDescForQuery
+ * for TupleStoreTupleDestination.
+ */
+static TupleDesc
+TupleStoreTupleDestTupleDescForQuery(TupleDestination *self, int queryNumber)
+{
+	Assert(queryNumber == 0);
+
+	TupleStoreTupleDestination *tupleDest = (TupleStoreTupleDestination *) self;
+
+	return tupleDest->tupleDesc;
+}
+
+
+/*
+ * CreateTupleDestNone creates a tuple destination which ignores the tuples.
+ */
+TupleDestination *
+CreateTupleDestNone(void)
+{
+	TupleDestination *tupleDest = palloc0(
+		sizeof(TupleDestination));
+	tupleDest->putTuple = TupleDestNonePutTuple;
+	tupleDest->tupleDescForQuery = TupleDestNoneTupleDescForQuery;
+
+	return (TupleDestination *) tupleDest;
+}
+
+
+/*
+ * TupleStoreTupleDestPutTuple implements TupleDestination->putTuple for
+ * no-op tuple destination.
+ */
+static void
+TupleDestNonePutTuple(TupleDestination *self, Task *task,
+					  int placementIndex, int queryNumber,
+					  HeapTuple heapTuple)
+{
+	/* nothing to do */
+}
+
+
+/*
+ * TupleStoreTupleDestTupleDescForQuery implements TupleDestination->TupleDescForQuery
+ * for no-op tuple destination.
+ */
+static TupleDesc
+TupleDestNoneTupleDescForQuery(TupleDestination *self, int queryNumber)
+{
+	return NULL;
+}
+
+
+/*
+ * CreateTupleDestDestReceiver creates a dest receiver which forwards tuples
+ * to a tuple destination.
+ */
+DestReceiver *
+CreateTupleDestDestReceiver(TupleDestination *tupleDest, Task *task, int placementIndex)
+{
+	TupleDestDestReceiver *destReceiver = palloc0(sizeof(TupleDestDestReceiver));
+	destReceiver->pub.rStartup = TupleDestDestReceiverStartup;
+	destReceiver->pub.receiveSlot = TupleDestDestReceiverReceive;
+	destReceiver->pub.rShutdown = TupleDestDestReceiverShutdown;
+	destReceiver->pub.rDestroy = TupleDestDestReceiverDestroy;
+
+	destReceiver->tupleDest = tupleDest;
+	destReceiver->task = task;
+	destReceiver->placementIndex = placementIndex;
+
+	return (DestReceiver *) destReceiver;
+}
+
+
+/*
+ * TupleDestDestReceiverStartup implements DestReceiver->rStartup for
+ * TupleDestDestReceiver.
+ */
+static void
+TupleDestDestReceiverStartup(DestReceiver *destReceiver, int operation,
+							 TupleDesc inputTupleDesc)
+{
+	/* nothing to do */
+}
+
+
+/*
+ * TupleDestDestReceiverStartup implements DestReceiver->receiveSlot for
+ * TupleDestDestReceiver.
+ */
+static bool
+TupleDestDestReceiverReceive(TupleTableSlot *slot,
+							 DestReceiver *destReceiver)
+{
+	TupleDestDestReceiver *tupleDestReceiver = (TupleDestDestReceiver *) destReceiver;
+	TupleDestination *tupleDest = tupleDestReceiver->tupleDest;
+	Task *task = tupleDestReceiver->task;
+	int placementIndex = tupleDestReceiver->placementIndex;
+
+	/*
+	 * DestReceiver doesn't support multiple result sets with different shapes.
+	 */
+	Assert(task->queryCount == 1);
+	int queryNumber = 0;
+
+#if PG_VERSION_NUM >= PG_VERSION_12
+	HeapTuple heapTuple = ExecFetchSlotHeapTuple(slot, true, NULL);
+#else
+	HeapTuple heapTuple = ExecFetchSlotTuple(slot);
+#endif
+
+	tupleDest->putTuple(tupleDest, task, placementIndex, queryNumber, heapTuple);
+
+	return true;
+}
+
+
+/*
+ * TupleDestDestReceiverStartup implements DestReceiver->rShutdown for
+ * TupleDestDestReceiver.
+ */
+static void
+TupleDestDestReceiverShutdown(DestReceiver *destReceiver)
+{
+	/* nothing to do */
+}
+
+
+/*
+ * TupleDestDestReceiverStartup implements DestReceiver->rDestroy for
+ * TupleDestDestReceiver.
+ */
+static void
+TupleDestDestReceiverDestroy(DestReceiver *destReceiver)
+{
+	/* nothing to do */
+}

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -428,6 +428,7 @@ SetTaskQueryIfShouldLazyDeparse(Task *task, Query *query)
 	{
 		task->taskQuery.queryType = TASK_QUERY_OBJECT;
 		task->taskQuery.data.jobQueryReferenceForLazyDeparsing = query;
+		task->queryCount = 1;
 		return;
 	}
 
@@ -446,11 +447,13 @@ SetTaskQueryString(Task *task, char *queryString)
 	if (queryString == NULL)
 	{
 		task->taskQuery.queryType = TASK_QUERY_NULL;
+		task->queryCount = 0;
 	}
 	else
 	{
 		task->taskQuery.queryType = TASK_QUERY_TEXT;
 		task->taskQuery.data.queryStringLazy = queryString;
+		task->queryCount = 1;
 	}
 }
 
@@ -464,6 +467,7 @@ SetTaskPerPlacementQueryStrings(Task *task, List *perPlacementQueryStringList)
 	Assert(perPlacementQueryStringList != NIL);
 	task->taskQuery.queryType = TASK_QUERY_TEXT_PER_PLACEMENT;
 	task->taskQuery.data.perPlacementQueryStrings = perPlacementQueryStringList;
+	task->queryCount = 1;
 }
 
 
@@ -476,6 +480,7 @@ SetTaskQueryStringList(Task *task, List *queryStringList)
 	Assert(queryStringList != NIL);
 	task->taskQuery.queryType = TASK_QUERY_TEXT_LIST;
 	task->taskQuery.data.queryStringList = queryStringList;
+	task->queryCount = list_length(queryStringList);
 }
 
 

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -327,6 +327,8 @@ CopyNodeTask(COPYFUNC_ARGS)
 	COPY_NODE_FIELD(rowValuesLists);
 	COPY_SCALAR_FIELD(partiallyLocalOrRemote);
 	COPY_SCALAR_FIELD(parametersInQueryStringResolved);
+	COPY_SCALAR_FIELD(tupleDest);
+	COPY_SCALAR_FIELD(queryCount);
 }
 
 

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -12,6 +12,13 @@
 #define LOCAL_EXECUTION_H
 
 #include "distributed/citus_custom_scan.h"
+#include "distributed/tuple_destination.h"
+
+/*
+ * Used as TupleDestination->putTuple's placementIndex when executing
+ * local tasks.
+ */
+#define LOCAL_PLACEMENT_INDEX -1
 
 /* enabled with GUCs*/
 extern bool EnableLocalExecution;
@@ -27,13 +34,12 @@ typedef enum LocalExecutionStatus
 extern enum LocalExecutionStatus CurrentLocalExecutionStatus;
 
 /* extern function declarations */
-extern uint64 ExecuteLocalTaskList(List *taskList,
-								   Tuplestorestate *tupleStoreState);
+extern uint64 ExecuteLocalTaskList(List *taskList, TupleDestination *defaultTupleDest);
 extern uint64 ExecuteLocalUtilityTaskList(List *utilityTaskList);
 extern uint64 ExecuteLocalTaskListExtended(List *taskList, ParamListInfo
 										   orig_paramListInfo,
 										   DistributedPlan *distributedPlan,
-										   Tuplestorestate *tupleStoreState,
+										   TupleDestination *defaultTupleDest,
 										   bool isUtilityCommand);
 extern void ExtractLocalAndRemoteTasks(bool readOnlyPlan, List *taskList,
 									   List **localTaskList, List **remoteTaskList);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -262,6 +262,8 @@ typedef struct TaskQuery
 	}data;
 }TaskQuery;
 
+typedef struct TupleDestination TupleDestination;
+
 typedef struct Task
 {
 	CitusNode type;
@@ -274,6 +276,12 @@ typedef struct Task
 	 * so this is abstracted with taskQuery.
 	 */
 	TaskQuery taskQuery;
+
+	/*
+	 * A task can have multiple queries, in which case queryCount will be > 1. If
+	 * a task has more one query, then taskQuery->queryType == TASK_QUERY_TEXT_LIST.
+	 */
+	int queryCount;
 
 	Oid anchorDistributedTableId;     /* only applies to insert tasks */
 	uint64 anchorShardId;       /* only applies to compute tasks */
@@ -323,6 +331,12 @@ typedef struct Task
 	 * query.
 	 */
 	bool parametersInQueryStringResolved;
+
+	/*
+	 * Destination of tuples generated as a result of executing this task. Can be
+	 * NULL, in which case executor might use a default destination.
+	 */
+	TupleDestination *tupleDest;
 } Task;
 
 

--- a/src/include/distributed/tuple_destination.h
+++ b/src/include/distributed/tuple_destination.h
@@ -1,0 +1,47 @@
+/*-------------------------------------------------------------------------
+ *
+ * tuple_destination.h
+ *	  Tuple destination generic struct.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef TUPLE_DESTINATION_H
+#define TUPLE_DESTINATION_H
+
+#include "access/tupdesc.h"
+#include "distributed/multi_physical_planner.h"
+#include "tcop/dest.h"
+#include "utils/tuplestore.h"
+
+typedef struct TupleDestination TupleDestination;
+
+/*
+ * TupleDestination provides a generic interface for where to send tuples.
+ *
+ * Users of the executor can set task->tupleDest for custom processing of
+ * the result tuples.
+ *
+ * Since a task can have multiple queries, methods of TupleDestination also
+ * accept a queryNumber parameter which denotes the index of the query that
+ * tuple belongs to.
+ */
+typedef struct TupleDestination
+{
+	/* putTuple implements custom processing of a tuple */
+	void (*putTuple)(TupleDestination *self, Task *task,
+					 int placementIndex, int queryNumber,
+					 HeapTuple tuple);
+
+	/* tupleDescForQuery returns tuple descriptor for a query number. Can return NULL. */
+	TupleDesc (*tupleDescForQuery)(TupleDestination *self, int queryNumber);
+} TupleDestination;
+
+extern TupleDestination * CreateTupleStoreTupleDest(Tuplestorestate *tupleStore, TupleDesc
+													tupleDescriptor);
+extern TupleDestination * CreateTupleDestNone(void);
+extern DestReceiver * CreateTupleDestDestReceiver(TupleDestination *tupleDest,
+												  Task *task, int placementIndex);
+
+#endif


### PR DESCRIPTION
Implements a new `TupleDestination` interface to allow custom tuple processing per task.

This can be specially useful if a task contains multiple queries. An example of this EXPLAIN
ANALYZE, where it needs to add some UDF calls to the query to fetch the explain output
from worker after fetching the actual query results.

This is a refactoring PR, so it doesn't add new tests.