### PR TITLE
Implement IndexIsImpliedByAConstraint

### DIFF
--- a/src/include/distributed/master_protocol.h
+++ b/src/include/distributed/master_protocol.h
@@ -105,6 +105,7 @@ extern Oid ResolveRelationId(text *relationName, bool missingOk);
 extern List * GetTableDDLEvents(Oid relationId, bool forShardCreation);
 extern List * GetTableCreationCommands(Oid relationId, bool forShardCreation);
 extern List * GetTableIndexAndConstraintCommands(Oid relationId);
+extern bool IndexImpliedByAConstraint(Form_pg_index indexForm);
 extern char ShardStorageType(Oid relationId);
 extern void CheckDistributedTable(Oid relationId);
 extern void CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,


### PR DESCRIPTION
Implement IndexIsImpliedByAConstraint to decide if an index identified by the given
indexForm implied by one of the constraints on the related table or not.