### PR TITLE
Implement PushOverrideEmptySearchPath 

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -26,6 +26,7 @@
 #include "distributed/listutils.h"
 #include "distributed/master_protocol.h"
 #include "distributed/multi_join_order.h"
+#include "distributed/namespace_utils.h"
 #include "distributed/reference_table_utils.h"
 #include "distributed/version_compat.h"
 #include "utils/fmgroids.h"
@@ -469,15 +470,7 @@ GetForeignConstraintCommandsInternal(Oid relationId, int flags)
 
 	List *foreignKeyCommands = NIL;
 
-	/*
-	 * Set search_path to NIL so that all objects outside of pg_catalog will be
-	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
-	 */
-	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	Oid foreignKeyOid = InvalidOid;
 	foreach_oid(foreignKeyOid, foreignKeyOids)

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -25,6 +25,7 @@
 #include "distributed/commands.h"
 #include "distributed/listutils.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/namespace_utils.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 
@@ -38,15 +39,7 @@ GetExplicitTriggerCommandList(Oid relationId)
 {
 	List *createTriggerCommandList = NIL;
 
-	/*
-	 * Set search_path to NIL so that all objects outside of pg_catalog will be
-	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
-	 */
-	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	List *triggerIdList = GetExplicitTriggerIdList(relationId);
 

--- a/src/backend/distributed/deparser/ruleutils_11.c
+++ b/src/backend/distributed/deparser/ruleutils_11.c
@@ -52,6 +52,7 @@
 #include "common/keywords.h"
 #include "distributed/citus_nodefuncs.h"
 #include "distributed/citus_ruleutils.h"
+#include "distributed/namespace_utils.h"
 #include "executor/spi.h"
 #include "foreign/foreign.h"
 #include "funcapi.h"
@@ -465,18 +466,9 @@ pg_get_rule_expr(Node *expression)
 {
 	bool showImplicitCasts = true;
 	deparse_context context;
-	OverrideSearchPath *overridePath = NULL;
 	StringInfo buffer = makeStringInfo();
 
-	/*
-	 * Set search_path to NIL so that all objects outside of pg_catalog will be
-	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
-	 */
-	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	context.buf = buffer;
 	context.namespaces = NIL;
@@ -1925,8 +1917,6 @@ get_query_def_extended(Query *query, StringInfo buf, List *parentnamespace,
 	deparse_context context;
 	deparse_namespace dpns;
 
-	OverrideSearchPath *overridePath = NULL;
-
 	/* Guard against excessively long or deeply-nested queries */
 	CHECK_FOR_INTERRUPTS();
 	check_stack_depth();
@@ -1942,15 +1932,7 @@ get_query_def_extended(Query *query, StringInfo buf, List *parentnamespace,
 	 */
 	AcquireRewriteLocks(query, false, false);
 
-	/*
-	 * Set search_path to NIL so that all objects outside of pg_catalog will be
-	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
-	 */
-	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	context.buf = buf;
 	context.namespaces = lcons(&dpns, list_copy(parentnamespace));

--- a/src/backend/distributed/master/master_node_protocol.c
+++ b/src/backend/distributed/master/master_node_protocol.c
@@ -46,6 +46,7 @@
 #include "distributed/master_protocol.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/metadata_sync.h"
+#include "distributed/namespace_utils.h"
 #include "distributed/pg_dist_shard.h"
 #include "distributed/worker_manager.h"
 #include "foreign/foreign.h"
@@ -590,15 +591,7 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 {
 	List *tableDDLEventList = NIL;
 
-	/*
-	 * Set search_path to NIL so that all objects outside of pg_catalog will be
-	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
-	 */
-	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	/* if foreign table, fetch extension and server definitions */
 	char tableType = get_rel_relkind(relationId);
@@ -649,15 +642,7 @@ GetTableIndexAndConstraintCommands(Oid relationId)
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 1;
 
-	/*
-	 * Set search_path to NIL so that all objects outside of pg_catalog will be
-	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
-	 */
-	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	/* open system catalog and scan all indexes that belong to this table */
 	Relation pgIndex = heap_open(IndexRelationId, AccessShareLock);

--- a/src/backend/distributed/utils/namespace_utils.c
+++ b/src/backend/distributed/utils/namespace_utils.c
@@ -1,0 +1,30 @@
+/*-------------------------------------------------------------------------
+ *
+ * namespace_utils.c
+ *
+ * Utility functions related to namespace changes.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "catalog/namespace.h"
+#include "distributed/namespace_utils.h"
+
+/*
+ * PushOverrideEmptySearchPath pushes search_path to be NIL and sets addCatalog to
+ * true so that all objects outside of pg_catalog will be schema-prefixed.
+ * Afterwards, PopOverrideSearchPath can be used to revert the search_path back.
+ */
+void
+PushOverrideEmptySearchPath(MemoryContext memoryContext)
+{
+	OverrideSearchPath *overridePath = GetOverrideSearchPath(memoryContext);
+	overridePath->schemas = NIL;
+	overridePath->addCatalog = true;
+
+	PushOverrideSearchPath(overridePath);
+}

--- a/src/include/distributed/namespace_utils.h
+++ b/src/include/distributed/namespace_utils.h
@@ -1,0 +1,15 @@
+/*-------------------------------------------------------------------------
+ *
+ * namespace_utils.h
+ *	  Utility function declarations related to namespace changes.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef NAMESPACE_UTILS_H
+#define NAMESPACE_UTILS_H
+
+extern void PushOverrideEmptySearchPath(MemoryContext memoryContext);
+
+#endif /* NAMESPACE_UTILS_H */


### PR DESCRIPTION
To reduce code duplication, implement function that pushes `search_path`
to be `NIL` and sets `addCatalog` to `true` so that all objects outside of
`pg_catalog` will be schema-prefixed.
