### PR TITLE
Append IF NOT EXISTS to deparsed CREATE SERVER commands

### DIFF
--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -173,7 +173,8 @@ pg_get_serverdef_string(Oid tableRelationId)
 	StringInfoData buffer = { NULL, 0, 0, 0 };
 	initStringInfo(&buffer);
 
-	appendStringInfo(&buffer, "CREATE SERVER %s", quote_identifier(server->servername));
+	appendStringInfo(&buffer, "CREATE SERVER IF NOT EXISTS %s",
+					 quote_identifier(server->servername));
 	if (server->servertype != NULL)
 	{
 		appendStringInfo(&buffer, " TYPE %s",

--- a/src/test/regress/expected/multi_generate_ddl_commands.out
+++ b/src/test/regress/expected/multi_generate_ddl_commands.out
@@ -163,7 +163,7 @@ SELECT master_get_table_ddl_events('renamed_foreign_table');
 NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
                                                                                    master_get_table_ddl_events
 ---------------------------------------------------------------------
- CREATE SERVER fake_fdw_server FOREIGN DATA WRAPPER fake_fdw
+ CREATE SERVER IF NOT EXISTS fake_fdw_server FOREIGN DATA WRAPPER fake_fdw
  CREATE FOREIGN TABLE public.renamed_foreign_table (id bigint NOT NULL, rename_name character(8) DEFAULT ''::text NOT NULL) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true')
  ALTER TABLE public.renamed_foreign_table OWNER TO postgres
 (3 rows)


### PR DESCRIPTION
Append IF NOT EXISTS to CREATE SERVER commands generated by pg_get_serverdef_string
function when deparsing an existing server object that a foreign table depends in order to
provide possible errors if we will execute the returned DDL command in the same node.
