### PR TITLE
Implement EXPLAIN ANALYZE udfs.

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -154,6 +154,7 @@ typedef struct MetadataCacheData
 	Oid unavailableNodeRoleId;
 	Oid pgTableIsVisibleFuncId;
 	Oid citusTableIsVisibleFuncId;
+	Oid jsonbExtractPathFuncId;
 	bool databaseNameValid;
 	char databaseName[NAMEDATALEN];
 } MetadataCacheData;
@@ -2308,6 +2309,24 @@ CitusTableVisibleFuncId(void)
 	}
 
 	return MetadataCache.citusTableIsVisibleFuncId;
+}
+
+
+/*
+ * JsonbExtractPathFuncId returns oid of the jsonb_extract_path function.
+ */
+Oid
+JsonbExtractPathFuncId(void)
+{
+	if (MetadataCache.jsonbExtractPathFuncId == InvalidOid)
+	{
+		const int argCount = 2;
+
+		MetadataCache.jsonbExtractPathFuncId =
+			FunctionOid("pg_catalog", "jsonb_extract_path", argCount);
+	}
+
+	return MetadataCache.jsonbExtractPathFuncId;
 }
 
 

--- a/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
+++ b/src/backend/distributed/sql/citus--9.3-2--9.4-1.sql
@@ -1,3 +1,5 @@
 -- citus--9.3-2--9.4-1
 
 -- bump version to 9.4-1
+#include "udfs/worker_last_saved_explain_analyze/9.4-1.sql"
+#include "udfs/worker_save_query_explain_analyze/9.4-1.sql"

--- a/src/backend/distributed/sql/udfs/worker_last_saved_explain_analyze/9.4-1.sql
+++ b/src/backend/distributed/sql/udfs/worker_last_saved_explain_analyze/9.4-1.sql
@@ -1,0 +1,7 @@
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_last_saved_explain_analyze()
+    RETURNS TEXT
+    LANGUAGE C STRICT
+    AS 'citus';
+COMMENT ON FUNCTION pg_catalog.worker_last_saved_explain_analyze() IS
+    'Returns the saved explain analyze output for the last run query';

--- a/src/backend/distributed/sql/udfs/worker_last_saved_explain_analyze/latest.sql
+++ b/src/backend/distributed/sql/udfs/worker_last_saved_explain_analyze/latest.sql
@@ -1,0 +1,7 @@
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_last_saved_explain_analyze()
+    RETURNS TEXT
+    LANGUAGE C STRICT
+    AS 'citus';
+COMMENT ON FUNCTION pg_catalog.worker_last_saved_explain_analyze() IS
+    'Returns the saved explain analyze output for the last run query';

--- a/src/backend/distributed/sql/udfs/worker_save_query_explain_analyze/9.4-1.sql
+++ b/src/backend/distributed/sql/udfs/worker_save_query_explain_analyze/9.4-1.sql
@@ -1,0 +1,9 @@
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_save_query_explain_analyze(
+      query text, options jsonb)
+    RETURNS SETOF record
+    LANGUAGE C STRICT
+    AS 'citus';
+
+COMMENT ON FUNCTION pg_catalog.worker_save_query_explain_analyze(text, jsonb) IS
+    'Executes and returns results of query while saving its EXPLAIN ANALYZE to be fetched later';

--- a/src/backend/distributed/sql/udfs/worker_save_query_explain_analyze/latest.sql
+++ b/src/backend/distributed/sql/udfs/worker_save_query_explain_analyze/latest.sql
@@ -1,0 +1,9 @@
+
+CREATE OR REPLACE FUNCTION pg_catalog.worker_save_query_explain_analyze(
+      query text, options jsonb)
+    RETURNS SETOF record
+    LANGUAGE C STRICT
+    AS 'citus';
+
+COMMENT ON FUNCTION pg_catalog.worker_save_query_explain_analyze(text, jsonb) IS
+    'Executes and returns results of query while saving its EXPLAIN ANALYZE to be fetched later';

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -28,6 +28,7 @@
 #include "distributed/listutils.h"
 #include "distributed/local_executor.h"
 #include "distributed/multi_executor.h"
+#include "distributed/multi_explain.h"
 #include "distributed/repartition_join_execution.h"
 #include "distributed/transaction_management.h"
 #include "distributed/placement_connection.h"
@@ -352,6 +353,9 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 
 		case XACT_EVENT_PREPARE:
 		{
+			/* we need to reset SavedExplainPlan before TopTransactionContext is deleted */
+			FreeSavedExplainPlan();
+
 			/*
 			 * This callback is only relevant for worker queries since
 			 * distributed queries cannot be executed with 2PC, see
@@ -459,6 +463,7 @@ ResetGlobalVariables()
 	CurrentCoordinatedTransactionState = COORD_TRANS_NONE;
 	XactModificationLevel = XACT_MODIFICATION_NONE;
 	SetLocalExecutionStatus(LOCAL_EXECUTION_OPTIONAL);
+	FreeSavedExplainPlan();
 	dlist_init(&InProgressTransactions);
 	activeSetStmts = NULL;
 	CoordinatedTransactionUses2PC = false;

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -205,6 +205,7 @@ extern Oid CitusAnyValueFunctionId(void);
 extern Oid CitusTextSendAsJsonbFunctionId(void);
 extern Oid PgTableVisibleFuncId(void);
 extern Oid CitusTableVisibleFuncId(void);
+extern Oid JsonbExtractPathFuncId(void);
 
 /* enum oids */
 extern Oid PrimaryNodeRoleId(void);

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -16,4 +16,6 @@
 extern bool ExplainDistributedQueries;
 extern bool ExplainAllTasks;
 
+extern void FreeSavedExplainPlan(void);
+
 #endif /* MULTI_EXPLAIN_H */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -1341,3 +1341,340 @@ SELECT true AS valid FROM explain_xml($$
   SELECT * FROM result JOIN series ON (s = l_quantity) JOIN orders_hash_part ON (s = o_orderkey)
 $$);
 t
+--
+-- Test EXPLAIN ANALYZE udfs
+--
+\a\t
+\set default_opts '''{"costs": false, "timing": false, "summary": false}'''::jsonb
+CREATE TABLE explain_analyze_test(a int, b text);;
+INSERT INTO explain_analyze_test VALUES (1, 'value 1'), (2, 'value 2'), (3, 'value 3'), (4, 'value 4');
+-- simple select
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', :default_opts) as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze();
+ worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Result (actual rows=1 loops=1)   +
+
+(1 row)
+
+END;
+-- insert into select
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze($Q$
+       INSERT INTO explain_analyze_test SELECT i, i::text FROM generate_series(1, 5) i $Q$,
+	   :default_opts) as (a int);
+ a
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT worker_last_saved_explain_analyze();
+                worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Insert on explain_analyze_test (actual rows=0 loops=1)          +
+   ->  Function Scan on generate_series i (actual rows=5 loops=1)+
+
+(1 row)
+
+ROLLBACK;
+-- select from table
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze($Q$SELECT * FROM explain_analyze_test$Q$,
+	   											:default_opts) as (a int, b text);
+ a |    b
+---------------------------------------------------------------------
+ 1 | value 1
+ 2 | value 2
+ 3 | value 3
+ 4 | value 4
+(4 rows)
+
+SELECT worker_last_saved_explain_analyze();
+            worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Seq Scan on explain_analyze_test (actual rows=4 loops=1)+
+
+(1 row)
+
+ROLLBACK;
+-- insert into with returning
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze($Q$
+       INSERT INTO explain_analyze_test SELECT i, i::text FROM generate_series(1, 5) i
+	   RETURNING a, b$Q$,
+	   :default_opts) as (a int, b text);
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+SELECT worker_last_saved_explain_analyze();
+                worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Insert on explain_analyze_test (actual rows=5 loops=1)          +
+   ->  Function Scan on generate_series i (actual rows=5 loops=1)+
+
+(1 row)
+
+ROLLBACK;
+-- delete with returning
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze($Q$
+       DELETE FROM explain_analyze_test WHERE a % 2 = 0
+	   RETURNING a, b$Q$,
+	   :default_opts) as (a int, b text);
+ a |    b
+---------------------------------------------------------------------
+ 2 | value 2
+ 4 | value 4
+(2 rows)
+
+SELECT worker_last_saved_explain_analyze();
+               worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Delete on explain_analyze_test (actual rows=2 loops=1)        +
+   ->  Seq Scan on explain_analyze_test (actual rows=2 loops=1)+
+         Filter: ((a % 2) = 0)                                 +
+         Rows Removed by Filter: 2                             +
+
+(1 row)
+
+ROLLBACK;
+-- delete without returning
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze($Q$
+       DELETE FROM explain_analyze_test WHERE a % 2 = 0$Q$,
+	   :default_opts) as (a int);
+ a
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT worker_last_saved_explain_analyze();
+               worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Delete on explain_analyze_test (actual rows=0 loops=1)        +
+   ->  Seq Scan on explain_analyze_test (actual rows=2 loops=1)+
+         Filter: ((a % 2) = 0)                                 +
+         Rows Removed by Filter: 2                             +
+
+(1 row)
+
+ROLLBACK;
+-- multiple queries (should ERROR)
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1; SELECT 2', :default_opts) as (a int);
+ERROR:  cannot EXPLAIN ANALYZE multiple queries
+-- error in query
+SELECT * FROM worker_save_query_explain_analyze('SELECT x', :default_opts) as (a int);
+ERROR:  column "x" does not exist
+-- error in format string
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{"format": "invlaid_format"}') as (a int);
+ERROR:  Invalid explain analyze format: "invlaid_format"
+-- test formats
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{"format": "text", "costs": false}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze();
+ worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ Result (actual rows=1 loops=1)   +
+
+(1 row)
+
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{"format": "json", "costs": false}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze();
+ worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ [                                +
+   {                              +
+     "Plan": {                    +
+       "Node Type": "Result",     +
+       "Parallel Aware": false,   +
+       "Actual Rows": 1,          +
+       "Actual Loops": 1          +
+     },                           +
+     "Triggers": [                +
+     ]                            +
+   }                              +
+ ]
+(1 row)
+
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{"format": "xml", "costs": false}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze();
+            worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ <explain xmlns="http://www.postgresql.org/2009/explain">+
+   <Query>                                               +
+     <Plan>                                              +
+       <Node-Type>Result</Node-Type>                     +
+       <Parallel-Aware>false</Parallel-Aware>            +
+       <Actual-Rows>1</Actual-Rows>                      +
+       <Actual-Loops>1</Actual-Loops>                    +
+     </Plan>                                             +
+     <Triggers>                                          +
+     </Triggers>                                         +
+   </Query>                                              +
+ </explain>
+(1 row)
+
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{"format": "yaml", "costs": false}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze();
+ worker_last_saved_explain_analyze
+---------------------------------------------------------------------
+ - Plan:                          +
+     Node Type: "Result"          +
+     Parallel Aware: false        +
+     Actual Rows: 1               +
+     Actual Loops: 1              +
+   Triggers:
+(1 row)
+
+END;
+-- costs on, timing off
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT * FROM explain_analyze_test', '{"timing": false, "costs": true}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+
+SELECT worker_last_saved_explain_analyze() ~ 'Seq Scan.*\(cost=0.00.*\) \(actual rows.*\)';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+END;
+-- costs off, timing on
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT * FROM explain_analyze_test', '{"timing": true, "costs": false}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+
+SELECT worker_last_saved_explain_analyze() ~ 'Seq Scan on explain_analyze_test \(actual time=.* rows=.* loops=1\)';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+END;
+-- summary on
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{"timing": false, "costs": false, "summary": true}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze() ~ 'Planning Time:.*Execution Time:.*';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+END;
+-- buffers on
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT * FROM explain_analyze_test', '{"timing": false, "costs": false, "buffers": true}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+
+SELECT worker_last_saved_explain_analyze() ~ 'Buffers:';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+END;
+-- verbose on
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('SELECT * FROM explain_analyze_test', '{"timing": false, "costs": false, "verbose": true}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+
+SELECT worker_last_saved_explain_analyze() ~ 'Output: a, b';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+END;
+-- make sure deleted at transaction end
+SELECT * FROM worker_save_query_explain_analyze('SELECT 1', '{}') as (a int);
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+SELECT worker_last_saved_explain_analyze() IS NULL;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- should be deleted at the end of prepare commit
+BEGIN;
+SELECT * FROM worker_save_query_explain_analyze('UPDATE explain_analyze_test SET a=1', '{}') as (a int);
+ a
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT worker_last_saved_explain_analyze() IS NOT NULL;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+PREPARE TRANSACTION 'citus_0_1496350_7_0';
+SELECT worker_last_saved_explain_analyze() IS NULL;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+COMMIT PREPARED 'citus_0_1496350_7_0';


### PR DESCRIPTION
Implements worker_save_query_explain_analyze and worker_last_saved_explain_analyze.

`worker_save_query_explain_analyze(query, options)` executes and returns results of query while
saving its EXPLAIN ANALYZE to be fetched later.

`worker_last_saved_explain_analyze()` returns the saved EXPLAIN ANALYZE result.

Note that both calls must be in the same transaction block.

An example usage is:

```sql
BEGIN;
SELECT * FROM worker_save_query_explain_analyze($Q$
       DELETE FROM explain_analyze_test WHERE a % 2 = 0
	   RETURNING a, b$Q$,
	   '{"timing": false, "costs": false}') as (a int, b text);
 a |    b
---------------------------------------------------------------------
 2 | value 2
 4 | value 4
(2 rows)

SELECT worker_last_saved_explain_analyze();
               worker_last_saved_explain_analyze
---------------------------------------------------------------------
 Delete on explain_analyze_test (actual rows=2 loops=1)        +
   ->  Seq Scan on explain_analyze_test (actual rows=2 loops=1)+
         Filter: ((a % 2) = 0)                                 +
         Rows Removed by Filter: 2                             +

(1 row)

ROLLBACK;
```

A later PR will use this and https://github.com/citusdata/citus/pull/3871 to do EXPLAIN ANALYZE at the same time as execution.