### PR TITLE
BuildRoutesForInsert: avoid incorrectly typed datums from implicitly coerced constants

### DIFF
--- a/src/test/regress/expected/multi_simple_queries.out
+++ b/src/test/regress/expected/multi_simple_queries.out
@@ -4,6 +4,21 @@ SET citus.next_shard_id TO 850000;
 -- We've bunch of other tests that triggers fast-path-router
 SET citus.enable_fast_path_router_planner TO false;
 SET citus.coordinator_aggregation_strategy TO 'disabled';
+-- Test that we can insert an integer literal into a numeric column
+CREATE TABLE numeric_test (id numeric(6, 0), val int);
+SELECT create_distributed_table('numeric_test', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO numeric_test VALUES (21, 87) RETURNING *;
+ id | val
+---------------------------------------------------------------------
+ 21 |  87
+(1 row)
+
+DROP TABLE numeric_test;
 -- ===================================================================
 -- test end-to-end query functionality
 -- ===================================================================

--- a/src/test/regress/expected/multi_simple_queries_0.out
+++ b/src/test/regress/expected/multi_simple_queries_0.out
@@ -4,6 +4,21 @@ SET citus.next_shard_id TO 850000;
 -- We've bunch of other tests that triggers fast-path-router
 SET citus.enable_fast_path_router_planner TO false;
 SET citus.coordinator_aggregation_strategy TO 'disabled';
+-- Test that we can insert an integer literal into a numeric column
+CREATE TABLE numeric_test (id numeric(6, 0), val int);
+SELECT create_distributed_table('numeric_test', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO numeric_test VALUES (21, 87) RETURNING *;
+ id | val
+---------------------------------------------------------------------
+ 21 |  87
+(1 row)
+
+DROP TABLE numeric_test;
 -- ===================================================================
 -- test end-to-end query functionality
 -- ===================================================================

--- a/src/test/regress/sql/multi_simple_queries.sql
+++ b/src/test/regress/sql/multi_simple_queries.sql
@@ -7,6 +7,12 @@ SET citus.next_shard_id TO 850000;
 SET citus.enable_fast_path_router_planner TO false;
 SET citus.coordinator_aggregation_strategy TO 'disabled';
 
+-- Test that we can insert an integer literal into a numeric column
+CREATE TABLE numeric_test (id numeric(6, 0), val int);
+SELECT create_distributed_table('numeric_test', 'id');
+INSERT INTO numeric_test VALUES (21, 87) RETURNING *;
+DROP TABLE numeric_test;
+
 -- ===================================================================
 -- test end-to-end query functionality
 -- ===================================================================


### PR DESCRIPTION
DESCRIPTION: Avoid segfaulting when inserting implicitly coerced constants
