### PR TITLE
typedef TupleDestination only once

### DIFF
--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -262,7 +262,7 @@ typedef struct TaskQuery
 	}data;
 }TaskQuery;
 
-typedef struct TupleDestination TupleDestination;
+struct TupleDestination;
 
 typedef struct Task
 {
@@ -336,7 +336,7 @@ typedef struct Task
 	 * Destination of tuples generated as a result of executing this task. Can be
 	 * NULL, in which case executor might use a default destination.
 	 */
-	TupleDestination *tupleDest;
+	struct TupleDestination *tupleDest;
 } Task;
 
 

--- a/src/include/distributed/tuple_destination.h
+++ b/src/include/distributed/tuple_destination.h
@@ -27,7 +27,7 @@ typedef struct TupleDestination TupleDestination;
  * accept a queryNumber parameter which denotes the index of the query that
  * tuple belongs to.
  */
-typedef struct TupleDestination
+struct TupleDestination
 {
 	/* putTuple implements custom processing of a tuple */
 	void (*putTuple)(TupleDestination *self, Task *task,
@@ -36,7 +36,7 @@ typedef struct TupleDestination
 
 	/* tupleDescForQuery returns tuple descriptor for a query number. Can return NULL. */
 	TupleDesc (*tupleDescForQuery)(TupleDestination *self, int queryNumber);
-} TupleDestination;
+};
 
 extern TupleDestination * CreateTupleStoreTupleDest(Tuplestorestate *tupleStore, TupleDesc
 													tupleDescriptor);


### PR DESCRIPTION
In some compilers we were getting warnings like:

```
In file included from commands/multi_copy.c:74:
In file included from /Users/hanefi/code/citus/citus/src/include/distributed/local_executor.h:15:
/Users/hanefi/code/citus/citus/src/include/distributed/tuple_destination.h:18:33: warning: redefinition of typedef 'TupleDestination' is a C11 feature [-Wtypedef-redefinition]
typedef struct TupleDestination TupleDestination;
                                ^
/Users/hanefi/code/citus/citus/src/include/distributed/multi_physical_planner.h:265:33: note: previous definition is here
typedef struct TupleDestination TupleDestination;
                                ^
```

and

```
In file included from commands/multi_copy.c:74:
In file included from /Users/hanefi/code/citus/citus/src/include/distributed/local_executor.h:15:
/Users/hanefi/code/citus/citus/src/include/distributed/tuple_destination.h:39:3: warning: redefinition of typedef 'TupleDestination' is a C11 feature [-Wtypedef-redefinition]
} TupleDestination;
  ^
/Users/hanefi/code/citus/citus/src/include/distributed/tuple_destination.h:18:33: note: previous definition is here
typedef struct TupleDestination TupleDestination;
                                ^
```

This PR tries to fix them.
