### PR TITLE
Execute shard creation as utility tasks

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -856,6 +856,29 @@ ExecuteUtilityTaskList(List *utilityTaskList, bool localExecutionSupported)
 
 
 /*
+ * ExecuteUtilityTaskListExtended is a wrapper around executing task
+ * list for utility commands.
+ */
+uint64
+ExecuteUtilityTaskListExtended(List *utilityTaskList, int poolSize,
+							   bool localExecutionSupported)
+{
+	RowModifyLevel modLevel = ROW_MODIFY_NONE;
+	ExecutionParams *executionParams = CreateBasicExecutionParams(
+		modLevel, utilityTaskList, poolSize, localExecutionSupported
+		);
+
+	bool excludeFromXact = false;
+	executionParams->xactProperties =
+		DecideTransactionPropertiesForTaskList(modLevel, utilityTaskList,
+											   excludeFromXact);
+	executionParams->isUtilityCommand = true;
+
+	return ExecuteTaskListExtended(executionParams);
+}
+
+
+/*
  * ExecuteTaskListOutsideTransaction is a proxy to ExecuteTaskListExtended
  * with defaults for some of the arguments.
  */

--- a/src/backend/distributed/master/master_stage_protocol.c
+++ b/src/backend/distributed/master/master_stage_protocol.c
@@ -550,7 +550,7 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 		poolSize = MaxAdaptiveExecutorPoolSize;
 	}
 	bool localExecutionSupported = true;
-	ExecuteTaskList(ROW_MODIFY_NONE, taskList, poolSize, localExecutionSupported);
+	ExecuteUtilityTaskListExtended(taskList, poolSize, localExecutionSupported);
 }
 
 

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -13,6 +13,8 @@ extern int ExecutorSlowStartInterval;
 extern uint64 ExecuteTaskList(RowModifyLevel modLevel, List *taskList,
 							  int targetPoolSize, bool localExecutionSupported);
 extern uint64 ExecuteUtilityTaskList(List *utilityTaskList, bool localExecutionSupported);
+extern uint64 ExecuteUtilityTaskListExtended(List *utilityTaskList, int poolSize,
+											 bool localExecutionSupported);
 extern uint64 ExecuteTaskListOutsideTransaction(RowModifyLevel modLevel, List *taskList,
 												int targetPoolSize, List *jobIdList);
 


### PR DESCRIPTION
`CreateShardsOnWorkers` currently executes shard creation commands as "regular" tasks via `ExecuteTaskList`, while other code paths that execute DDL use `ExecuteUtilityTaskList`. This caused an assert failure since #3871 introduced the assumption that a task either has a single query (to enable local execution) or is a utility task whose results are ignored. 

The PR addresses it by using utility tasks in `CreateShardsOnWorker` and allowing LocallyExecuteUtilityTask to deal with query strings containing multiple queries.