### PR TITLE
IsReferenceTable, ShardIntervalCount: remove misleading isCitusTable check

### DIFF
--- a/src/backend/distributed/master/master_metadata_utility.c
+++ b/src/backend/distributed/master/master_metadata_utility.c
@@ -489,21 +489,14 @@ LoadShardIntervalList(Oid relationId)
 
 /*
  * ShardIntervalCount returns number of shard intervals for a given distributed table.
- * The function returns 0 if table is not distributed, or no shards can be found for
- * the given relation id.
+ * The function returns 0 if no shards can be found for the given relation id.
  */
 int
 ShardIntervalCount(Oid relationId)
 {
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-	int shardIntervalCount = 0;
 
-	if (cacheEntry->isCitusTable)
-	{
-		shardIntervalCount = cacheEntry->shardIntervalArrayLength;
-	}
-
-	return shardIntervalCount;
+	return cacheEntry->shardIntervalArrayLength;
 }
 
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -29,6 +29,7 @@
 #include "distributed/multi_logical_optimizer.h"
 #include "distributed/multi_logical_planner.h"
 #include "distributed/multi_physical_planner.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/relation_restriction_equivalence.h"
 #include "distributed/query_pushdown_planning.h"
 #include "distributed/query_utils.h"
@@ -466,7 +467,7 @@ IsReferenceTableRTE(Node *node)
 {
 	Oid relationId = NodeTryGetRteRelid(node);
 	return relationId != InvalidOid && IsCitusTable(relationId) &&
-		   PartitionMethod(relationId) == DISTRIBUTE_BY_NONE;
+		   IsReferenceTable(relationId);
 }
 
 

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -66,11 +66,6 @@ IsReferenceTable(Oid relationId)
 {
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 
-	if (!tableEntry->isCitusTable)
-	{
-		return false;
-	}
-
 	if (tableEntry->partitionMethod != DISTRIBUTE_BY_NONE)
 	{
 		return false;


### PR DESCRIPTION
GetCitusTableCacheEntry raises an error if relationId is not distributed

Considered updating these functions to function as advertised (return 0/false on non distributed table), but decided to stick with a PR which doesn't change behavior