### PR TITLE
Temporarily disable connection leak tests that fail a lot

### DIFF
--- a/src/test/regress/expected/ensure_no_shared_connection_leak.out
+++ b/src/test/regress/expected/ensure_no_shared_connection_leak.out
@@ -133,17 +133,12 @@ ORDER BY 1;
 
 -- now, ensure this from the workers perspective
 -- we should only see the connection/backend that is running the command below
-SELECT
-	result, success
-FROM
-	run_command_on_workers($$select count(*) from pg_stat_activity WHERE backend_type = 'client backend';$$)
-ORDER BY 1, 2;
- result | success
----------------------------------------------------------------------
- 1      | t
- 1      | t
-(2 rows)
-
+-- TODO: Enable again once this is not failing randomly anymore
+-- SELECT
+-- 	result, success
+-- FROM
+-- 	run_command_on_workers($$select count(*) from pg_stat_activity WHERE backend_type = 'client backend';$$)
+-- ORDER BY 1, 2;
 -- in case other tests relies on these setting, reset them
 ALTER SYSTEM RESET citus.distributed_deadlock_detection_factor;
 ALTER SYSTEM RESET citus.recover_2pc_interval;

--- a/src/test/regress/sql/ensure_no_shared_connection_leak.sql
+++ b/src/test/regress/sql/ensure_no_shared_connection_leak.sql
@@ -67,11 +67,12 @@ ORDER BY 1;
 
 -- now, ensure this from the workers perspective
 -- we should only see the connection/backend that is running the command below
-SELECT
-	result, success
-FROM
-	run_command_on_workers($$select count(*) from pg_stat_activity WHERE backend_type = 'client backend';$$)
-ORDER BY 1, 2;
+-- TODO: Enable again once this is not failing randomly anymore
+-- SELECT
+-- 	result, success
+-- FROM
+-- 	run_command_on_workers($$select count(*) from pg_stat_activity WHERE backend_type = 'client backend';$$)
+-- ORDER BY 1, 2;
 
 
 -- in case other tests relies on these setting, reset them


### PR DESCRIPTION
We have some leak tests that keep failing. These failures indicate problems
that should be fixed, but continuing to run them while we know they are failing
often has no benefit. This disables them temporarily, so we do not have to
rerun CI as often.

@pykello can you look at the interemediate data leak failures?

@onderkalaci can you look at the connection leak failures?

Multi intermediate data leak failures:
1. https://app.circleci.com/pipelines/github/citusdata/citus/9299/workflows/bc4515bb-4c46-44e0-bf09-b0dd485a173a/jobs/131957
2. https://app.circleci.com/pipelines/github/citusdata/citus/9290/workflows/ae5346f0-6e35-4053-b8ab-d0c690c4f18e/jobs/131804
3. https://app.circleci.com/pipelines/github/citusdata/citus/9278/workflows/f3da6bba-fc68-4b2c-b64d-ab9d0c94ec41/jobs/131595
4. https://app.circleci.com/pipelines/github/citusdata/citus/9270/workflows/072898b5-1c77-40a4-9da8-d2982ed78bc4/jobs/131476
5. https://app.circleci.com/pipelines/github/citusdata/citus/9267/workflows/bac2c4c3-5e1e-456f-9a5f-db6e69f4aec8/jobs/131422
6. https://app.circleci.com/pipelines/github/citusdata/citus/9265/workflows/d422de91-7d0f-4787-b447-5f248f3c6c5e/jobs/131377

MX connection leak failures:
1. https://app.circleci.com/pipelines/github/citusdata/citus/9296/workflows/e36d1088-662a-4f60-acec-293132632c2f/jobs/131908/steps
2. https://app.circleci.com/pipelines/github/citusdata/citus/9258/workflows/37659d82-2c5b-495e-b0e7-905811e30444/jobs/131299

Failure connection leak failures:
1. https://app.circleci.com/pipelines/github/citusdata/citus/9297/workflows/c0ebc326-8c93-468f-8b70-f470bd492fb9/jobs/131920
2. https://app.circleci.com/pipelines/github/citusdata/citus/9283/workflows/9af154d0-ff96-4c5d-ae19-81faae1e0c18/jobs/131668