### PR TITLE
Improve performance of metadata cache

### DIFF
--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -213,6 +213,11 @@ CitusExecutorRun(QueryDesc *queryDesc,
 
 		if (ExecutorLevel == 0 && PlannerLevel == 0)
 		{
+			/*
+			 * We are leaving Citus code so no one should have any references to
+			 * cache entries. Release them now to not hold onto memory in long
+			 * transactions.
+			 */
 			CitusTableCacheFlushInvalidatedEntries();
 		}
 	}
@@ -224,11 +229,6 @@ CitusExecutorRun(QueryDesc *queryDesc,
 		}
 
 		ExecutorLevel--;
-
-		if (ExecutorLevel == 0 && PlannerLevel == 0)
-		{
-			CitusTableCacheFlushInvalidatedEntries();
-		}
 
 		PG_RE_THROW();
 	}

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -776,7 +776,7 @@ LookupShardIdCacheEntry(int64 shardId)
 	InitializeCaches();
 
 	ShardIdCacheEntry *shardEntry =
-		hash_search(DistTableCacheHash, &shardId, HASH_FIND, &foundInCache);
+		hash_search(ShardIdCacheHash, &shardId, HASH_FIND, &foundInCache);
 
 	if (!foundInCache)
 	{

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -109,6 +109,7 @@ typedef struct CitusTableCacheEntrySlot
  */
 typedef struct ShardIdCacheEntry
 {
+	/* hash key, needs to be first */
 	uint64 shardId;
 
 	/* pointer to the table entry to which this shard currently belongs */
@@ -298,14 +299,7 @@ EnsureModificationsCanRun(void)
 bool
 IsCitusTable(Oid relationId)
 {
-	CitusTableCacheEntry *cacheEntry = LookupCitusTableCacheEntry(relationId);
-
-	if (!cacheEntry)
-	{
-		return false;
-	}
-
-	return true;
+	return LookupCitusTableCacheEntry(relationId) != NULL;
 }
 
 
@@ -841,7 +835,8 @@ GetCitusTableCacheEntry(Oid distributedRelationId)
 
 /*
  * GetCitusTableCacheEntry returns the distributed table metadata for the
- * passed relationId. For efficiency it caches lookups.
+ * passed relationId. For efficiency it caches lookups. This function returns
+ * NULL if the relation isn't a distributed table.
  */
 static CitusTableCacheEntry *
 LookupCitusTableCacheEntry(Oid relationId)
@@ -1058,6 +1053,7 @@ LookupDistObjectCacheEntry(Oid classid, Oid objid, int32 objsubid)
 /*
  * BuildCitusTableCacheEntry is a helper routine for
  * LookupCitusTableCacheEntry() for building the cache contents.
+ * This function returns NULL if the relation isn't a distributed table.
  */
 static CitusTableCacheEntry *
 BuildCitusTableCacheEntry(Oid relationId)

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -181,9 +181,10 @@ static bool citusVersionKnownCompatible = false;
 /* Hash table for informations about each partition */
 static HTAB *DistTableCacheHash = NULL;
 static List *DistTableCacheExpired = NIL;
-static HTAB *ShardIdCacheHash = NULL;
 
 /* Hash table for informations about each shard */
+static HTAB *ShardIdCacheHash = NULL;
+
 static MemoryContext MetadataCacheMemoryContext = NULL;
 
 /* Hash table for information about each object */
@@ -1329,14 +1330,13 @@ BuildCachedShardList(CitusTableCacheEntry *cacheEntry)
 		ShardInterval *shardInterval = sortedShardIntervalArray[shardIndex];
 		int64 shardId = shardInterval->shardId;
 		int placementOffset = 0;
-		bool foundShardIdInCache = false;
 
 		/*
 		 * Enable quick lookups of this shard ID by adding it to ShardIdCacheHash
 		 * or overwriting the previous values.
 		 */
 		ShardIdCacheEntry *shardIdCacheEntry =
-			hash_search(ShardIdCacheHash, &shardId, HASH_ENTER, &foundShardIdInCache);
+			hash_search(ShardIdCacheHash, &shardId, HASH_ENTER, NULL);
 
 		shardIdCacheEntry->tableEntry = cacheEntry;
 		shardIdCacheEntry->shardIndex = shardIndex;

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -111,7 +111,7 @@ typedef struct ShardIdCacheEntry
 {
 	uint64 shardId;
 
-	/* pointer to the table entry which this shard currently belongs */
+	/* pointer to the table entry to which this shard currently belongs */
 	CitusTableCacheEntry *tableEntry;
 
 	/* index of the shard interval in the sortedShardIntervalArray of the table entry */
@@ -206,7 +206,6 @@ static ScanKeyData DistObjectScanKey[3];
 /* local function forward declarations */
 static bool IsCitusTableViaCatalog(Oid relationId);
 static ShardIdCacheEntry * LookupShardIdCacheEntry(int64 shardId);
-static CitusTableCacheEntry * LookupCitusTableCacheEntry(Oid relationId);
 static CitusTableCacheEntry * LookupCitusTableCacheEntry(Oid relationId);
 static CitusTableCacheEntry * BuildCitusTableCacheEntry(Oid relationId);
 static void BuildCachedShardList(CitusTableCacheEntry *cacheEntry);
@@ -720,9 +719,8 @@ ShardPlacementList(uint64 shardId)
 static void
 InitializeTableCacheEntry(int64 shardId)
 {
-	/*
-	 */
-	Oid relationId = LookupShardRelationFromCatalog(shardId, false);
+	bool missingOk = false;
+	Oid relationId = LookupShardRelationFromCatalog(shardId, missingOk);
 
 	/* trigger building the cache for the shard id */
 	GetCitusTableCacheEntry(relationId);

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -171,7 +171,7 @@ RelationIsAKnownShard(Oid shardRelationId, bool onlySearchPath)
 	}
 
 	/* try to get the relation id */
-	Oid relationId = LookupShardRelation(shardId, true);
+	Oid relationId = LookupShardRelationFromCatalog(shardId, true);
 	if (!OidIsValid(relationId))
 	{
 		/* there is no such relation */

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -73,9 +73,6 @@ typedef struct
 	int shardIntervalArrayLength;
 	ShardInterval **sortedShardIntervalArray;
 
-	/* map of shardId to index in sortedShardIntervalArray */
-	struct ShardIdIndexSlot *shardIdIndexHash;
-
 	/* comparator for partition column's type, NULL if DISTRIBUTE_BY_NONE */
 	FmgrInfo *shardColumnCompareFunction;
 
@@ -140,7 +137,7 @@ extern int32 GetLocalGroupId(void);
 extern List * DistTableOidList(void);
 extern List * ReferenceTableOidList(void);
 extern void CitusTableCacheFlushInvalidatedEntries(void);
-extern Oid LookupShardRelation(int64 shardId, bool missing_ok);
+extern Oid LookupShardRelationFromCatalog(int64 shardId, bool missing_ok);
 extern List * ShardPlacementList(uint64 shardId);
 extern void CitusInvalidateRelcacheByRelid(Oid relationId);
 extern void CitusInvalidateRelcacheByShardId(int64 shardId);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -38,10 +38,6 @@ extern int ReadFromSecondaries;
 #define GROUP_ID_UPGRADING -2
 
 
-/* internal type used by metadata_cache.c to cache shard indexes */
-struct ShardIdIndexSlot;
-
-
 /*
  * Representation of a table's metadata that is frequently used for
  * distributed execution. Cached.
@@ -57,7 +53,6 @@ typedef struct
 	 */
 	bool isValid;
 
-	bool isCitusTable;
 	bool hasUninitializedShardInterval;
 	bool hasUniformHashDistribution; /* valid for hash partitioned tables */
 	bool hasOverlappingShardInterval;


### PR DESCRIPTION
#3866 removed the shard ID hash in metadata_cache.c to simplify cache management, but we observed a significant performance regression that was being masked by the performance improvement provided by #3654 in our benchmarks, but #3654 only applies to specific workloads.

This PR brings back the shard ID cache as it existed before #3866 with some extra measures to handle invalidation. When we load a table entry, we overwrite ShardIdCacheEntry->tableEntry pointers for all the shards in that table, though it's possible that the table no longer contains the old shard ID or the table entry is never reloaded, which would leave a dangling pointer once the table entry is freed. To handle that case, we remove all shard ID cache entries that point exactly to that table entry when a table is freed (at the end of the transaction or any call to CitusTableCacheFlushInvalidatedEntries).