### PR TITLE
rename citus hammerdb branch prefix as citus_hammerdb

### DIFF
--- a/src/test/hammerdb/README.md
+++ b/src/test/hammerdb/README.md
@@ -19,7 +19,7 @@ git push origin tpcc_benchmark/improve/adaptive_executor # the tpcc benchmark jo
 
 You will see the results in a branch in [https://github.com/citusdata/release-test-results](https://github.com/citusdata/release-test-results).
 
-The branch name will be something like: `delete_me/citusbot_tpcc_benchmark_rg/<date>/<date>`.
+The branch name will be something like: `citus_github_push/citusbot_tpcc_benchmark_rg/<date>/<date>`.
 
 On success, which is the vast majority of the cases, the resource groups on Azure which are automatically created for this purpose are deleted automatically. On failure, you need to manually drop the resource groups named: `citusbot_ch_benchmark_rg` and `citusbot_tpcc_benchmark_rg`. To check whether the job failed, go to Azure portal and search for these resource group names. If the resource group doesn't have any virtual machines or the virtual machines don't have any CPU/Memory load at all, it is highly possible that the job failed. Delete the resource groups and re-try with another branch.
 

--- a/src/test/hammerdb/run_hammerdb.sh
+++ b/src/test/hammerdb/run_hammerdb.sh
@@ -32,7 +32,7 @@ ssh-add
 ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
 
 now=$(date +"%m_%d_%Y_%s")
-new_branch_name=delete_me/"${rg}"/"${now}"
+new_branch_name=citus_github_push/"${rg}"/"${now}"
 git checkout -b "${new_branch_name}"
 
 cd ./fabfile/hammerdb_confs


### PR DESCRIPTION
When we are using hammerdb jobs, the job creates a branch on test
automation, since that branch should be deleted, it would have
`delete_me` prefix, however since the result branch on
release-test-results will have the test automation branch as prefix, it
will also have `delete_me` prefix, which seems a bit confusing.

This PR updates it as citus_hammerdb.

