### PR TITLE
Disallow long changelog entries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
           name: 'Check if changed'
           command: git diff --exit-code
       - run:
+          name: 'Check for lengths of changelog entries'
+          command: ci/disallow_long_changelog_entries.sh
+      - run:
           name: 'Check for banned C API usage'
           command: ci/banned.h.sh
   check-sql-snapshots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,7 +1072,7 @@
 
 * Adds user-facing UDFs for locking shard resources and metadata
 
-* Refactors connection and transaction management; giving a consistent experience
+* Refactors connection and transaction management; giving consistent experience
 
 * Enhances `COPY` with fully transactional semantics
 
@@ -1088,7 +1088,7 @@
 
 * Enhances `SERIAL` compatibility with MX tables
 
-* Adds an `node_connection_timeout` parameter to control node connection timeouts
+* Adds `node_connection_timeout` parameter to control node connection timeouts
 
 * Adds `enable_deadlock_prevention` setting to permit multi-node transactions
 

--- a/ci/disallow_long_changelog_entries.sh
+++ b/ci/disallow_long_changelog_entries.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+set -eu
+
+# Having changelog items with entries that are longer than 80 characters are forbidden.
+# Find all lines with disallowed length, and for all such lines store
+#  - line number
+#  - length of the line
+#  - the line content
+too_long_lines=$(awk 'length() > 80 {print NR,"(",length(),"characters ) :",$0}' CHANGELOG.md)
+
+if [[ -n $too_long_lines ]]
+then
+    echo "We allow at most 80 characters in CHANGELOG.md."
+    echo "${too_long_lines}"
+    exit 1
+fi

--- a/ci/fix_style.sh
+++ b/ci/fix_style.sh
@@ -11,5 +11,6 @@ cd ${cidir}/..
 ci/editorconfig.sh
 ci/remove_useless_declarations.sh
 ci/disallow_c_comments_in_migrations.sh
+ci/disallow_long_changelog_entries.sh
 
 citus_indent . --quiet


### PR DESCRIPTION
We frequently feel the need check changelog entries manually to make sure all of them are shorter than 81 characters. This PR adds a CI job that checks the entry lengths and reports if we have entries that are too long.

The failing test output on master:
```
We allow at most 80 characters in CHANGELOG.md.
1067 ( 81 characters ) : * Refactors connection and transaction management; giving a consistent experience
1083 ( 81 characters ) : * Adds an `node_connection_timeout` parameter to control node connection timeouts
```

I also updated these items in a separate commit to make sure tests can pass