### PR TITLE
Fix distributing tables owned by extensions

### DIFF
--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -632,6 +632,20 @@ SupportedDependencyByCitus(const ObjectAddress *address)
 
 
 /*
+ * IsTableOwnedByExtension returns whether the table with the given relation ID is
+ * owned by an extension.
+ */
+bool
+IsTableOwnedByExtension(Oid relationId)
+{
+	ObjectAddress tableAddress = { 0 };
+	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
+
+	return IsObjectAddressOwnedByExtension(&tableAddress, NULL);
+}
+
+
+/*
  * IsObjectAddressOwnedByExtension returns whether or not the object is owned by an
  * extension. It is assumed that an object having a dependency on an extension is created
  * by that extension and therefore owned by that extension.

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -22,6 +22,7 @@ extern bool IsObjectDistributed(const ObjectAddress *address);
 extern bool ClusterHasDistributedFunctionWithDistArgument(void);
 extern void MarkObjectDistributed(const ObjectAddress *distAddress);
 extern void UnmarkObjectDistributed(const ObjectAddress *address);
+extern bool IsTableOwnedByExtension(Oid relationId);
 extern bool IsObjectAddressOwnedByExtension(const ObjectAddress *target,
 											ObjectAddress *extensionAddress);
 

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -32,7 +32,6 @@ extern void StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort);
 extern bool ClusterHasKnownMetadataWorkers(void);
 extern bool ShouldSyncTableMetadata(Oid relationId);
 extern List * MetadataCreateCommands(void);
-extern List * GetDistributedTableDDLEvents(Oid relationId);
 extern List * MetadataDropCommands(void);
 extern char * DistributionCreateCommand(CitusTableCacheEntry *cacheEntry);
 extern char * DistributionDeleteCommand(const char *schemaName,

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -317,3 +317,8 @@ WHERE col1 = 132;
 
 DROP TABLE data_load_test1, data_load_test2;
 END;
+-- distributing catalog tables is not supported
+SELECT create_distributed_table('pg_class', 'relname');
+ERROR:  cannot distribute catalog tables
+SELECT create_reference_table('pg_class');
+ERROR:  cannot distribute catalog tables

--- a/src/test/regress/expected/multi_mx_ddl.out
+++ b/src/test/regress/expected/multi_mx_ddl.out
@@ -243,3 +243,65 @@ SELECT :worker_1_lastval = :worker_2_lastval;
 -- the type of sequences can't be changed
 ALTER TABLE mx_sequence ALTER value TYPE BIGINT;
 ALTER TABLE mx_sequence ALTER value TYPE INT;
+-- test distributed tables owned by extension
+CREATE TABLE seg_test (x int);
+INSERT INTO seg_test VALUES (42);
+-- pretend this table belongs to an extension
+CREATE EXTENSION seg;
+ALTER EXTENSION seg ADD TABLE seg_test;
+NOTICE:  Citus does not propagate adding/dropping member objects
+HINT:  You can add/drop the member objects on the workers as well.
+\c - - - :worker_1_port
+-- pretend the extension created the table on the worker as well
+CREATE TABLE seg_test (x int);
+ALTER EXTENSION seg ADD TABLE seg_test;
+NOTICE:  Citus does not propagate adding/dropping member objects
+HINT:  You can add/drop the member objects on the workers as well.
+\c - - - :worker_2_port
+-- pretend the extension created the table on the worker as well
+CREATE TABLE seg_test (x int);
+ALTER EXTENSION seg ADD TABLE seg_test;
+NOTICE:  Citus does not propagate adding/dropping member objects
+HINT:  You can add/drop the member objects on the workers as well.
+\c - - - :master_port
+-- sync table metadata, but skip CREATE TABLE
+SET citus.shard_replication_factor TO 1;
+SET citus.shard_count TO 4;
+SET citus.replication_model TO streaming;
+SELECT create_distributed_table('seg_test', 'x');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.seg_test$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+\c - - - :worker_1_port
+-- should be able to see contents from worker
+SELECT * FROM seg_test;
+ x
+---------------------------------------------------------------------
+ 42
+(1 row)
+
+\c - - - :master_port
+-- test metadata sync in the presence of an extension-owned table
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+\c - - - :worker_1_port
+-- should be able to see contents from worker
+SELECT * FROM seg_test;
+ x
+---------------------------------------------------------------------
+ 42
+(1 row)
+
+\c - - - :master_port
+-- also drops table on both worker and master
+DROP EXTENSION seg CASCADE;

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -201,3 +201,7 @@ WHERE col1 = 132;
 
 DROP TABLE data_load_test1, data_load_test2;
 END;
+
+-- distributing catalog tables is not supported
+SELECT create_distributed_table('pg_class', 'relname');
+SELECT create_reference_table('pg_class');


### PR DESCRIPTION
DESCRIPTION: Fixes metadata syncing issues when distributing tables owned by an extension

We allow users to call create_reference_table or create_distributed_table on a table owned by an extension, which may have been unintentional, but it can be useful for sharing extension metadata across servers in combination with metadata syncing - provided that the extension accesses the tables via SQL. However, metadata syncing breaks when distributing a table created by an extension because the table already exists on the workers. This PR fixes the metadata syncing by skipping table creation commands for tables owned by extensions, such that only pg_dist_* records are synced.