### PR TITLE
citus_evaluate_expression: call expand_function_arguments beforehand to avoid segfaulting on implicit parameters

### DIFF
--- a/src/test/regress/expected/multi_function_evaluation.out
+++ b/src/test/regress/expected/multi_function_evaluation.out
@@ -220,10 +220,27 @@ NOTICE:  stable_fn called
 DETAIL:  from localhost:xxxxx
 NOTICE:  stable_fn called
 DETAIL:  from localhost:xxxxx
+-- https://github.com/citusdata/citus/issues/3939
+CREATE TABLE test_table(id int);
+SELECT create_distributed_table('test_table', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE OR REPLACE FUNCTION f(val text DEFAULT 'default')
+RETURNS int AS $$ BEGIN RETURN length(val); END; $$ LANGUAGE 'plpgsql' IMMUTABLE;
+INSERT INTO test_table VALUES (f('test'));
+INSERT INTO test_table VALUES (f());
+INSERT INTO test_table VALUES (f(f()::text));
+SELECT * FROM test_table ORDER BY 1;
+ id
+---------------------------------------------------------------------
+  1
+  4
+  7
+(3 rows)
+
+\set VERBOSITY terse
 DROP SCHEMA multi_function_evaluation CASCADE;
-NOTICE:  drop cascades to 5 other objects
-DETAIL:  drop cascades to table example
-drop cascades to sequence example_value_seq
-drop cascades to function stable_fn()
-drop cascades to table table_1
-drop cascades to function stable_squared(integer)
+NOTICE:  drop cascades to 7 other objects

--- a/src/test/regress/sql/multi_function_evaluation.sql
+++ b/src/test/regress/sql/multi_function_evaluation.sql
@@ -165,4 +165,18 @@ FROM (SELECT key, stable_squared((count(*) OVER ())::int) y FROM example GROUP B
 UPDATE example SET value = timestamp '10-10-2000 00:00'
 FROM (SELECT key, stable_squared(grouping(key)) y FROM example GROUP BY key) a WHERE example.key = a.key;
 
+-- https://github.com/citusdata/citus/issues/3939
+CREATE TABLE test_table(id int);
+SELECT create_distributed_table('test_table', 'id');
+
+CREATE OR REPLACE FUNCTION f(val text DEFAULT 'default')
+RETURNS int AS $$ BEGIN RETURN length(val); END; $$ LANGUAGE 'plpgsql' IMMUTABLE;
+
+INSERT INTO test_table VALUES (f('test'));
+INSERT INTO test_table VALUES (f());
+INSERT INTO test_table VALUES (f(f()::text));
+
+SELECT * FROM test_table ORDER BY 1;
+
+\set VERBOSITY terse
 DROP SCHEMA multi_function_evaluation CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fix segfault when evaluating function calls with default parameters on coordinator

Fix #3939