### PR TITLE
Add CI job for checking missing downgrade scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
       - run:
           name: 'Check for banned C API usage'
           command: ci/banned.h.sh
+      - run:
+          name: 'Check for missing downgrade scripts'
+          command: ci/check_migration_files.sh
   check-sql-snapshots:
     docker:
       - image: 'citus/extbuilder:latest'

--- a/ci/check_migration_files.sh
+++ b/ci/check_migration_files.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+set -euo pipefail
+# This file checks for the existence of downgrade scripts for every upgrade script that is changed in the branch.
+
+# list of migration files, and early exit if no migration scripts are touched
+migration_files=$(git diff --name-only origin/master | grep "src/backend/distributed/sql/citus--.*sql") || exit 0
+ret_value=0
+
+for file in $migration_files
+do
+    # There should always be 2 matches, and no need to avoid splitting here
+    # shellcheck disable=SC2207
+    versions=($(grep -Eo "\d\.\d-\d" <<< "$file"))
+
+    from_version=${versions[0]};
+    to_version=${versions[1]};
+
+    reverted_migration_file="src/backend/distributed/sql/citus--$to_version--$from_version.sql"
+
+    # check for the existence of reverted migration scripts
+    if [[ $(grep -xc reverted_migration_file <<< "$migration_files") == 0 ]]
+    then
+        echo "$file is updated, but $reverted_migration_file is missing in branch"
+        ret_value=1
+    fi
+done
+
+exit $ret_value;


### PR DESCRIPTION
This is a CI script to make sure if `citus--X--Y.sql` is updated on a branch, `citus--Y--X.sql` should be updated as well. Thus making all future schema changes to be coupled with appropriate downgrade scripts.

When working on #3927 we discussed the idea for a CI check for making sure we create downgrade scripts in the future whenever we introduce some schema changes in a migration script. However #3927 introduces only downgrade scripts that does not check the tests there.

Related: https://github.com/citusdata/citus/pull/3927#issuecomment-647577494 https://github.com/citusdata/citus/pull/3927#issuecomment-647588980