### PR TITLE
(WIP) Don't push down constants to workers

### DIFF
--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -486,5 +486,39 @@ select pg_catalog.coord_combine_agg('avg(float8)'::regprocedure, ARRAY[id,id,id]
 
 (1 row)
 
+-- Test that we don't crash with empty resultset
+-- See https://github.com/citusdata/citus/issues/3953
+CREATE TABLE t1 (a int PRIMARY KEY, b int);
+CREATE TABLE t2 (a int PRIMARY KEY, b int);
+SELECT create_distributed_table('t1','a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT 'foo' as foo, count(distinct b) FROM t1;
+ foo | count
+---------------------------------------------------------------------
+ foo |     0
+(1 row)
+
+SELECT 'foo' as foo, count(distinct b) FROM t2;
+ foo | count
+---------------------------------------------------------------------
+ foo |     0
+(1 row)
+
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t1;
+ foo | string_agg
+---------------------------------------------------------------------
+ foo |
+(1 row)
+
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t2;
+ foo | string_agg
+---------------------------------------------------------------------
+ foo |
+(1 row)
+
 set client_min_messages to error;
 drop schema aggregate_support cascade;

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -229,5 +229,15 @@ select pg_catalog.worker_partial_agg('sum(int)'::regprocedure, id) from nulltabl
 select pg_catalog.coord_combine_agg('sum(float8)'::regprocedure, id::text::cstring, null::float8) from nulltable;
 select pg_catalog.coord_combine_agg('avg(float8)'::regprocedure, ARRAY[id,id,id]::text::cstring, null::float8) from nulltable;
 
+-- Test that we don't crash with empty resultset
+-- See https://github.com/citusdata/citus/issues/3953
+CREATE TABLE t1 (a int PRIMARY KEY, b int);
+CREATE TABLE t2 (a int PRIMARY KEY, b int);
+SELECT create_distributed_table('t1','a');
+SELECT 'foo' as foo, count(distinct b) FROM t1;
+SELECT 'foo' as foo, count(distinct b) FROM t2;
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t1;
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t2;
+
 set client_min_messages to error;
 drop schema aggregate_support cascade;


### PR DESCRIPTION
DESCRIPTION: Fix a crash when aggregating empty tables.

Fixes #3953

Previously, we always pushed down constants in target list to the workers, and created `Var` reference to the tuple returned by workers. This worked fine most of the time, except when the worker queries returned 0 rows, but coordinator query needed to generate at least a row, in which case since the `Var` reference didn't has any tuples to refer to, we crashed, as in #3953.

This situation can happen for aggregations where the aggregate is not pushed down to workers, and instead we fetch the rows from workers and do the aggregation on the coordinator. An example query is:

```sql
SELECT 'const value', count(distinct non_distribution_column) FROM distributed_table;
```

In this case because we need to count distinct values of a non distribution column, we cannot push the count(distinct) to workers and need to pull all rows to the coordinator.


