### PR TITLE
Don't push expressions to workers when aggregating without GROUP BY.

### DIFF
--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -79,6 +79,9 @@ BuildExtendedOpNodeProperties(MultiExtendedOp *extendedOpNode,
 								 hasNonPartitionColumnDistinctAgg,
 								 extendedOpNode->onlyPushableWindowFunctions);
 
+	extendedOpNodeProperties.hasGroupBy = extendedOpNode->groupClauseList != NIL;
+	extendedOpNodeProperties.hasAggregate = TargetListHasAggregates(targetList);
+
 	extendedOpNodeProperties.groupedByDisjointPartitionColumn =
 		groupedByDisjointPartitionColumn;
 	extendedOpNodeProperties.repartitionSubquery = repartitionSubquery;

--- a/src/include/distributed/extended_op_node_utils.h
+++ b/src/include/distributed/extended_op_node_utils.h
@@ -31,6 +31,12 @@ typedef struct ExtendedOpNodeProperties
 	bool onlyPushableWindowFunctions;
 	bool pullUpIntermediateRows;
 	bool pushDownGroupingAndHaving;
+
+	/* indicates whether the MultiExtendedOp has a GROUP BY */
+	bool hasGroupBy;
+
+	/* indicates whether the MultiExtendedOp has an aggregate on the target list */
+	bool hasAggregate;
 } ExtendedOpNodeProperties;
 
 

--- a/src/include/distributed/multi_logical_optimizer.h
+++ b/src/include/distributed/multi_logical_optimizer.h
@@ -176,5 +176,6 @@ extern void FindReferencedTableColumn(Expr *columnExpression, List *parentQueryL
 									  Query *query, Oid *relationId, Var **column);
 extern char * WorkerColumnName(AttrNumber resno);
 extern bool IsGroupBySubsetOfDistinct(List *groupClauses, List *distinctClauses);
+extern bool TargetListHasAggregates(List *targetEntryList);
 
 #endif   /* MULTI_LOGICAL_OPTIMIZER_H */

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -486,5 +486,126 @@ select pg_catalog.coord_combine_agg('avg(float8)'::regprocedure, ARRAY[id,id,id]
 
 (1 row)
 
+-- Test that we don't crash with empty resultset
+-- See https://github.com/citusdata/citus/issues/3953
+CREATE TABLE t1 (a int PRIMARY KEY, b int);
+CREATE TABLE t2 (a int PRIMARY KEY, b int);
+SELECT create_distributed_table('t1','a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT 'foo' as foo, count(distinct b) FROM t1;
+ foo | count
+---------------------------------------------------------------------
+ foo |     0
+(1 row)
+
+SELECT 'foo' as foo, count(distinct b) FROM t2;
+ foo | count
+---------------------------------------------------------------------
+ foo |     0
+(1 row)
+
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t1;
+ foo | string_agg
+---------------------------------------------------------------------
+ foo |
+(1 row)
+
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t2;
+ foo | string_agg
+---------------------------------------------------------------------
+ foo |
+(1 row)
+
+CREATE OR REPLACE FUNCTION const_function(int)
+RETURNS int STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+RAISE NOTICE 'stable_fn called';
+RETURN 1;
+END;
+$function$;
+CREATE OR REPLACE FUNCTION square_func_stable(int)
+RETURNS int STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+RETURN $1 * $1;
+END;
+$function$;
+CREATE OR REPLACE FUNCTION square_func(int)
+RETURNS int
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+RETURN $1 * $1;
+END;
+$function$;
+SELECT const_function(1), string_agg(a::character, ',') FROM t1;
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+ const_function | string_agg
+---------------------------------------------------------------------
+              1 |
+(1 row)
+
+SELECT const_function(1), count(b) FROM t1;
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+ const_function | count
+---------------------------------------------------------------------
+              1 |     0
+(1 row)
+
+SELECT const_function(1), count(b), 10 FROM t1;
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+ const_function | count | ?column?
+---------------------------------------------------------------------
+              1 |     0 |       10
+(1 row)
+
+SELECT const_function(1), count(b), const_function(10) FROM t1;
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+ const_function | count | const_function
+---------------------------------------------------------------------
+              1 |     0 |              1
+(1 row)
+
+SELECT square_func(5), string_agg(a::character, ','),const_function(1) FROM t1;
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+ square_func | string_agg | const_function
+---------------------------------------------------------------------
+          25 |            |              1
+(1 row)
+
+SELECT square_func_stable(5), string_agg(a::character, ','),const_function(1) FROM t1;
+NOTICE:  stable_fn called
+CONTEXT:  PL/pgSQL function const_function(integer) line 3 at RAISE
+ square_func_stable | string_agg | const_function
+---------------------------------------------------------------------
+                 25 |            |              1
+(1 row)
+
+-- this will error since the expression will be
+-- pushed down (group by) and the function doesn't exist on workers
+SELECT square_func(5), a FROM t1 GROUP BY a;
+ERROR:  function aggregate_support.square_func(integer) does not exist
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+CONTEXT:  while executing command on localhost:xxxxx
+-- this will error since it has group by even though there is an aggregation
+-- the expression will be pushed down.
+SELECT square_func(5), a, count(a) FROM t1 GROUP BY a;
+ERROR:  function aggregate_support.square_func(integer) does not exist
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+CONTEXT:  while executing command on localhost:xxxxx
 set client_min_messages to error;
 drop schema aggregate_support cascade;

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -229,5 +229,60 @@ select pg_catalog.worker_partial_agg('sum(int)'::regprocedure, id) from nulltabl
 select pg_catalog.coord_combine_agg('sum(float8)'::regprocedure, id::text::cstring, null::float8) from nulltable;
 select pg_catalog.coord_combine_agg('avg(float8)'::regprocedure, ARRAY[id,id,id]::text::cstring, null::float8) from nulltable;
 
+
+-- Test that we don't crash with empty resultset
+-- See https://github.com/citusdata/citus/issues/3953
+CREATE TABLE t1 (a int PRIMARY KEY, b int);
+CREATE TABLE t2 (a int PRIMARY KEY, b int);
+SELECT create_distributed_table('t1','a');
+SELECT 'foo' as foo, count(distinct b) FROM t1;
+SELECT 'foo' as foo, count(distinct b) FROM t2;
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t1;
+SELECT 'foo' as foo, string_agg(distinct a::character varying, ',') FROM t2;
+
+
+CREATE OR REPLACE FUNCTION const_function(int)
+RETURNS int STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+RAISE NOTICE 'stable_fn called';
+RETURN 1;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION square_func_stable(int)
+RETURNS int STABLE
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+RETURN $1 * $1;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION square_func(int)
+RETURNS int
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+RETURN $1 * $1;
+END;
+$function$;
+
+SELECT const_function(1), string_agg(a::character, ',') FROM t1;
+SELECT const_function(1), count(b) FROM t1;
+SELECT const_function(1), count(b), 10 FROM t1;
+SELECT const_function(1), count(b), const_function(10) FROM t1;
+SELECT square_func(5), string_agg(a::character, ','),const_function(1) FROM t1;
+SELECT square_func_stable(5), string_agg(a::character, ','),const_function(1) FROM t1;
+
+-- this will error since the expression will be
+-- pushed down (group by) and the function doesn't exist on workers
+SELECT square_func(5), a FROM t1 GROUP BY a;
+-- this will error since it has group by even though there is an aggregation
+-- the expression will be pushed down.
+SELECT square_func(5), a, count(a) FROM t1 GROUP BY a;
+
+
 set client_min_messages to error;
 drop schema aggregate_support cascade;


### PR DESCRIPTION
DESCRIPTION: Fix a crash when aggregating empty tables.

Fixes #3953

Previously we always pushed down constants in target list to the workers, and created `Var` reference to the tuple returned by workers. This worked fine most of the time, except when the worker queries returned 0 rows, but coordinator query needed to generate at least a row, in which case since the `Var` reference didn't has any tuples to refer to, we crashed, as in #3953.

This situation can happen for aggregations where the aggregate is not pushed down to workers, and instead we fetch the rows from workers and do the aggregation on the coordinator. An example query is:

```sql
SELECT 'const value', count(distinct non_distribution_column) FROM distributed_table;
```

In this case because we need to count distinct values of a non distribution column, we cannot push the count(distinct) to workers and need to pull all rows to the coordinator.

A similar situation can happen when having other expression which doesn't contain `Var` references. For example,

```sql
SELECT func_call(const), count(distinct non_distribution_column) FROM distributed_table;
```

This PR changes the push-down predicate to not push the expressions to workers when aggregating without `GROUP BY`.



