### PR TITLE
Add a simple python script to generate a new test

### DIFF
--- a/src/test/regress/bin/create_test.py
+++ b/src/test/regress/bin/create_test.py
@@ -18,7 +18,7 @@ SET citus.next_shard_id TO {shard_id};
 
 -- add tests here
 
-\\set VERBOSITY terse
+SET client_min_messages TO WARNING;
 DROP SCHEMA {test_name} CASCADE;
 """
 

--- a/src/test/regress/bin/create_test.py
+++ b/src/test/regress/bin/create_test.py
@@ -4,11 +4,8 @@ import sys
 import random
 import os
 
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
-
 if len(sys.argv) != 2:
-    eprint("ERROR: Expected the name of the new test as an argument, such as:\n"
+    print("ERROR: Expected the name of the new test as an argument, such as:\n"
            "src/test/regress/bin/create_test.py my_awesome_test")
     sys.exit(1)
 
@@ -18,7 +15,7 @@ regress_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 filename = os.path.join(regress_dir, 'sql', f"{test_name}.sql")
 
 if os.path.isfile(filename):
-    eprint(f"ERROR: test file '{filename}' already exists")
+    print(f"ERROR: test file '{filename}' already exists")
     sys.exit(1)
 
 shard_id = random.randint(1, 999999) * 100

--- a/src/test/regress/bin/create_test.py
+++ b/src/test/regress/bin/create_test.py
@@ -5,14 +5,16 @@ import random
 import os
 
 if len(sys.argv) != 2:
-    print("ERROR: Expected the name of the new test as an argument, such as:\n"
-           "src/test/regress/bin/create_test.py my_awesome_test")
+    print(
+        "ERROR: Expected the name of the new test as an argument, such as:\n"
+        "src/test/regress/bin/create_test.py my_awesome_test"
+    )
     sys.exit(1)
 
 test_name = sys.argv[1]
 
 regress_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-filename = os.path.join(regress_dir, 'sql', f"{test_name}.sql")
+filename = os.path.join(regress_dir, "sql", f"{test_name}.sql")
 
 if os.path.isfile(filename):
     print(f"ERROR: test file '{filename}' already exists")

--- a/src/test/regress/bin/create_test.py
+++ b/src/test/regress/bin/create_test.py
@@ -4,15 +4,22 @@ import sys
 import random
 import os
 
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
 if len(sys.argv) != 2:
-    raise Exception("Expected the name of the new test as an argument")
+    eprint("ERROR: Expected the name of the new test as an argument, such as:\n"
+           "src/test/regress/bin/create_test.py my_awesome_test")
+    sys.exit(1)
 
 test_name = sys.argv[1]
 
-filename = f"src/test/regress/sql/{test_name}.sql"
+regress_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+filename = os.path.join(regress_dir, 'sql', f"{test_name}.sql")
 
 if os.path.isfile(filename):
-    raise Exception(f"test file '{filename}' already exists")
+    eprint(f"ERROR: test file '{filename}' already exists")
+    sys.exit(1)
 
 shard_id = random.randint(1, 999999) * 100
 
@@ -32,5 +39,5 @@ DROP SCHEMA {test_name} CASCADE;
 with open(filename, "w") as f:
     f.write(contents)
 
-
+print(f"Created {filename}")
 print(f"Don't forget to add '{test_name}' in multi_schedule somewhere")

--- a/src/test/regress/bin/create_test.py
+++ b/src/test/regress/bin/create_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+import random
+
+if len(sys.argv) != 2:
+    raise Exception("Expected a single argument, not more not less")
+
+test_name = sys.argv[1]
+
+shard_id = random.randint(1, 999999) * 100
+
+contents = f"""CREATE SCHEMA {test_name};
+SET search_path TO {test_name};
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO {shard_id};
+
+-- add tests here
+
+\\set VERBOSITY terse
+DROP SCHEMA {test_name} CASCADE;
+"""
+
+
+with open(f"src/test/regress/sql/{test_name}.sql", "w") as f:
+    f.write(contents)
+
+
+print(f"Don't forget to add \"{test_name}\" in multi_schedule somewhere")

--- a/src/test/regress/bin/create_test.py
+++ b/src/test/regress/bin/create_test.py
@@ -2,11 +2,17 @@
 
 import sys
 import random
+import os
 
 if len(sys.argv) != 2:
-    raise Exception("Expected a single argument, not more not less")
+    raise Exception("Expected the name of the new test as an argument")
 
 test_name = sys.argv[1]
+
+filename = f"src/test/regress/sql/{test_name}.sql"
+
+if os.path.isfile(filename):
+    raise Exception(f"test file '{filename}' already exists")
 
 shard_id = random.randint(1, 999999) * 100
 
@@ -23,8 +29,8 @@ DROP SCHEMA {test_name} CASCADE;
 """
 
 
-with open(f"src/test/regress/sql/{test_name}.sql", "w") as f:
+with open(filename, "w") as f:
     f.write(contents)
 
 
-print(f"Don't forget to add \"{test_name}\" in multi_schedule somewhere")
+print(f"Don't forget to add '{test_name}' in multi_schedule somewhere")


### PR DESCRIPTION
The current default citus settings for tests are not really best
practice anymore. However, we keep them because lots of tests depend on
them.

I noticed that I created the same test harness for new tests I added all
the time. This is a simple script that generates that harness, given a
name for the test.

To run:
```bash
src/test/regress/bin/create_test.py my_awesome_test
```