### PR TITLE
Improve error message when creating a foreign key to a local table

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -150,10 +150,18 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 
 		if (!referencedIsCitus && !selfReferencingTable)
 		{
+			char *referencedTableName = get_rel_name(referencedTableId);
+
 			ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							errmsg("cannot create foreign key constraint"),
-							errdetail("Referenced table must be a distributed table"
-									  " or a reference table.")));
+							errmsg("referenced table \"%s\" must be a distributed table"
+								   " or a reference table",
+								   referencedTableName),
+							errdetail("To enforce foreign keys, the referencing and "
+									  "referenced rows need to be stored on the same "
+									  "node."),
+							errhint("You could use SELECT create_reference_table('%s') "
+									"to replicate the referenced table to all nodes",
+									referencedTableName)));
 		}
 
 		/* set referenced table related variables here if table is referencing itself */

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -859,8 +859,9 @@ DROP TABLE reference_table CASCADE;
 NOTICE:  drop cascades to constraint reference_table_second_referencing_column_fkey on table reference_table_second
 CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_local_table(id));
 SELECT create_reference_table('reference_table');
-ERROR:  cannot create foreign key constraint
-DETAIL:  Referenced table must be a distributed table or a reference table.
+ERROR:  referenced table "referenced_local_table" must be a distributed table or a reference table
+DETAIL:  To enforce foreign keys, the referencing and referenced rows need to be stored on the same node.
+HINT:  You could use SELECT create_reference_table('referenced_local_table') to replicate the referenced table to all nodes
 -- test foreign key creation on CREATE TABLE on self referencing reference table
 CREATE TABLE self_referencing_reference_table(
     id int,
@@ -919,8 +920,9 @@ SELECT create_reference_table('reference_table');
 (1 row)
 
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_local_table(id);
-ERROR:  cannot create foreign key constraint
-DETAIL:  Referenced table must be a distributed table or a reference table.
+ERROR:  referenced table "referenced_local_table" must be a distributed table or a reference table
+DETAIL:  To enforce foreign keys, the referencing and referenced rows need to be stored on the same node.
+HINT:  You could use SELECT create_reference_table('referenced_local_table') to replicate the referenced table to all nodes
 -- test foreign key creation on ALTER TABLE on self referencing reference table
 DROP TABLE self_referencing_reference_table;
 CREATE TABLE self_referencing_reference_table(


### PR DESCRIPTION
DESCRIPTION: Improve error message when creating a foreign key to a local table

The current message is not solution-oriented.

(not meant as a 9.4 item)