### PR TITLE
ruleutils: use get_rtable_name for deparsing resultRelation

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_11.c
+++ b/src/backend/distributed/deparser/ruleutils_11.c
@@ -3036,7 +3036,7 @@ get_insert_query_def(Query *query, deparse_context *context)
 	/* INSERT requires AS keyword for target alias */
 	if (rte->alias != NULL)
 		appendStringInfo(buf, "AS %s ",
-						 quote_identifier(rte->alias->aliasname));
+						 quote_identifier(get_rtable_name(query->resultRelation, context)));
 
 	/*
 	 * Add the insert-column-names list.  Any indirection decoration needed on
@@ -3235,7 +3235,7 @@ get_update_query_def(Query *query, deparse_context *context)
 
 		if(rte->eref != NULL)
 			appendStringInfo(buf, " %s",
-					quote_identifier(rte->eref->aliasname));
+					quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 	else
 	{
@@ -3247,7 +3247,7 @@ get_update_query_def(Query *query, deparse_context *context)
 
 		if (rte->alias != NULL)
 			appendStringInfo(buf, " %s",
-							 quote_identifier(rte->alias->aliasname));
+							 quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 
 	appendStringInfoString(buf, " SET ");
@@ -3467,7 +3467,7 @@ get_delete_query_def(Query *query, deparse_context *context)
 
 		if(rte->eref != NULL)
 			appendStringInfo(buf, " %s",
-					quote_identifier(rte->eref->aliasname));
+					quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 	else
 	{
@@ -3479,7 +3479,7 @@ get_delete_query_def(Query *query, deparse_context *context)
 
 		if (rte->alias != NULL)
 			appendStringInfo(buf, " %s",
-							 quote_identifier(rte->alias->aliasname));
+							 quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 
 	/* Add the USING clause if given */

--- a/src/backend/distributed/deparser/ruleutils_12.c
+++ b/src/backend/distributed/deparser/ruleutils_12.c
@@ -3048,7 +3048,7 @@ get_insert_query_def(Query *query, deparse_context *context)
 	/* INSERT requires AS keyword for target alias */
 	if (rte->alias != NULL)
 		appendStringInfo(buf, "AS %s ",
-						 quote_identifier(rte->alias->aliasname));
+						 quote_identifier(get_rtable_name(query->resultRelation, context)));
 
 	/*
 	 * Add the insert-column-names list.  Any indirection decoration needed on
@@ -3247,7 +3247,7 @@ get_update_query_def(Query *query, deparse_context *context)
 
 		if(rte->eref != NULL)
 			appendStringInfo(buf, " %s",
-					quote_identifier(rte->eref->aliasname));
+					quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 	else
 	{
@@ -3259,7 +3259,7 @@ get_update_query_def(Query *query, deparse_context *context)
 
 		if (rte->alias != NULL)
 			appendStringInfo(buf, " %s",
-							 quote_identifier(rte->alias->aliasname));
+							 quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 
 	appendStringInfoString(buf, " SET ");
@@ -3479,7 +3479,7 @@ get_delete_query_def(Query *query, deparse_context *context)
 
 		if(rte->eref != NULL)
 			appendStringInfo(buf, " %s",
-					quote_identifier(rte->eref->aliasname));
+					quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 	else
 	{
@@ -3491,7 +3491,7 @@ get_delete_query_def(Query *query, deparse_context *context)
 
 		if (rte->alias != NULL)
 			appendStringInfo(buf, " %s",
-							 quote_identifier(rte->alias->aliasname));
+							 quote_identifier(get_rtable_name(query->resultRelation, context)));
 	}
 
 	/* Add the USING clause if given */

--- a/src/test/regress/expected/with_modifying.out
+++ b/src/test/regress/expected/with_modifying.out
@@ -964,6 +964,64 @@ DETAIL:  distribution column value: 1
 (1 row)
 
 RESET client_min_messages;
+-- https://github.com/citusdata/citus/issues/3975
+WITH mb AS (INSERT INTO modify_table VALUES (3, 3) RETURNING NULL, NULL) SELECT * FROM modify_table WHERE id = 3;
+ id | val
+---------------------------------------------------------------------
+  3 |   3
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL) SELECT * FROM modify_table WHERE id = 3;
+ id | val
+---------------------------------------------------------------------
+  3 |   3
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL) SELECT * FROM modify_table, mb WHERE id = 3;
+ERROR:  column mb.?column? does not exist
+CONTEXT:  while executing command on localhost:xxxxx
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL, NULL) SELECT * FROM modify_table WHERE id = 3;
+ id | val
+---------------------------------------------------------------------
+  3 |   3
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL, NULL) SELECT * FROM modify_table, mb WHERE id = 3;
+ id | val | ?column? | ?column?
+---------------------------------------------------------------------
+  3 |   3 |          |
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL alias) SELECT * FROM modify_table WHERE id = 3;
+ id | val
+---------------------------------------------------------------------
+  3 |   3
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL alias) SELECT * FROM modify_table, mb WHERE id = 3;
+ id | val | alias
+---------------------------------------------------------------------
+  3 |   3 |
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING val) SELECT * FROM modify_table WHERE id = 3;
+ id | val
+---------------------------------------------------------------------
+  3 |   3
+(1 row)
+
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING val) SELECT * FROM modify_table, mb WHERE id = 3;
+ id | val | val
+---------------------------------------------------------------------
+  3 |   3 |   3
+(1 row)
+
+WITH mb AS (DELETE FROM modify_table WHERE id = 3 RETURNING NULL, NULL) SELECT * FROM modify_table WHERE id = 3;
+ id | val
+---------------------------------------------------------------------
+  3 |   3
+(1 row)
+
 \set VERBOSITY terse
 DROP SCHEMA with_modifying CASCADE;
 NOTICE:  drop cascades to 9 other objects

--- a/src/test/regress/sql/with_modifying.sql
+++ b/src/test/regress/sql/with_modifying.sql
@@ -539,5 +539,17 @@ WITH mu AS (WITH allref AS (SELECT id a FROM anchor_table) UPDATE modify_table S
 WITH mu AS (WITH allref AS (SELECT now() a FROM anchor_table) UPDATE modify_table SET val = 3 WHERE id = 1 AND now() IN (SELECT a FROM allref) RETURNING id+1) SELECT count(*) FROM mu;
 RESET client_min_messages;
 
+-- https://github.com/citusdata/citus/issues/3975
+WITH mb AS (INSERT INTO modify_table VALUES (3, 3) RETURNING NULL, NULL) SELECT * FROM modify_table WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL) SELECT * FROM modify_table WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL) SELECT * FROM modify_table, mb WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL, NULL) SELECT * FROM modify_table WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL, NULL) SELECT * FROM modify_table, mb WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL alias) SELECT * FROM modify_table WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING NULL alias) SELECT * FROM modify_table, mb WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING val) SELECT * FROM modify_table WHERE id = 3;
+WITH mb AS (UPDATE modify_table SET val = 3 WHERE id = 3 RETURNING val) SELECT * FROM modify_table, mb WHERE id = 3;
+WITH mb AS (DELETE FROM modify_table WHERE id = 3 RETURNING NULL, NULL) SELECT * FROM modify_table WHERE id = 3;
+
 \set VERBOSITY terse
 DROP SCHEMA with_modifying CASCADE;


### PR DESCRIPTION
Deparsing doesn't always preserve aliases, `get_rtable_name` accounts for this

Second test case is still not correct. Could use more test coverage of other DMLs which this PR fixes

Fixes #3975
