### PR TITLE
Set distributePlan->relationIdList when it is needed

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1276,6 +1276,9 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
 	CustomScan *customScan = makeNode(CustomScan);
 	MultiExecutorType executorType = MULTI_EXECUTOR_INVALID_FIRST;
 
+	/* this field is used in JobExecutorType */
+	distributedPlan->relationIdList = localPlan->relationOids;
+
 	if (!distributedPlan->planningError)
 	{
 		executorType = JobExecutorType(distributedPlan);
@@ -1322,7 +1325,6 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
 		}
 	}
 
-	distributedPlan->relationIdList = localPlan->relationOids;
 	distributedPlan->queryId = localPlan->queryId;
 
 	Node *distributedPlanData = (Node *) distributedPlan;


### PR DESCRIPTION
It seems that we were setting the distributedPlan->relationIdList after
JobExecutorType is called, which would choose task-tracker if
replication factor > 1 and there is a repartition query. However, it
uses relationIdList to decide if the query has a repartition query, and
since it was not set yet, it would always think it is not a repartition
query and would choose adaptive executor when it should choose
task-tracker.
