### PR TITLE
Fix task->fetchedExplainAnalyzePlan memory issue.

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -694,13 +694,7 @@ AdaptiveExecutor(CitusScanState *scanState)
 	Assert(!scanState->finishedRemoteScan);
 
 	/* Reset Task fields that are only valid for a single execution */
-	Task *task = NULL;
-	foreach_ptr(task, taskList)
-	{
-		task->totalReceivedTupleData = 0;
-		task->fetchedExplainAnalyzePlacementIndex = 0;
-		task->fetchedExplainAnalyzePlan = NULL;
-	}
+	ResetExplainAnalyzeData(taskList);
 
 	scanState->tuplestorestate =
 		tuplestore_begin_heap(randomAccess, interTransactions, work_mem);

--- a/src/include/distributed/multi_explain.h
+++ b/src/include/distributed/multi_explain.h
@@ -26,5 +26,6 @@ extern List * ExplainAnalyzeTaskList(List *originalTaskList,
 									 TupleDestination *defaultTupleDest, TupleDesc
 									 tupleDesc, ParamListInfo params);
 extern bool RequestedForExplainAnalyze(CitusScanState *node);
+extern void ResetExplainAnalyzeData(List *taskList);
 
 #endif /* MULTI_EXPLAIN_H */


### PR DESCRIPTION
We were getting valgrind errors like below:

```
==77681== VALGRINDERROR-BEGIN
==77681== Invalid read of size 1
==77681==    at 0x8E420F: MemoryContextStrdup (mcxt.c:1151)
==77681==    by 0x8E424D: pstrdup (mcxt.c:1163)
==77681==    by 0xE246C7B: CopyNodeTask (citus_copyfuncs.c:336)
==77681==    by 0x699484: _copyExtensibleNode (copyfuncs.c:4723)
==77681==    by 0x699B9C: copyObjectImpl (copyfuncs.c:5163)
==77681==    by 0x69D392: _copyList (copyfuncs.c:4691)
==77681==    by 0x699B7C: copyObjectImpl (copyfuncs.c:5147)
==77681==    by 0xE246699: copyJobInfo (citus_copyfuncs.c:96)
==77681==    by 0xE246803: CopyNodeJob (citus_copyfuncs.c:112)
==77681==    by 0x699484: _copyExtensibleNode (copyfuncs.c:4723)
==77681==    by 0x699B9C: copyObjectImpl (copyfuncs.c:5163)
==77681==    by 0xE246840: CopyNodeDistributedPlan (citus_copyfuncs.c:126)
==77681==  Address 0x1cafbc00 is 26,416 bytes inside a block of size 32,768 free'd
==77681==    at 0x4C2B06D: free (vg_replace_malloc.c:540)
==77681==    by 0x8DA600: AllocSetReset (aset.c:610)
==77681==    by 0x8E281C: MemoryContextResetOnly (mcxt.c:174)
==77681==    by 0x8DA692: AllocSetDelete (aset.c:652)
==77681==    by 0x8E2B5D: MemoryContextDelete (mcxt.c:245)
==77681==    by 0x64CEEB: FreeExecutorState (execUtils.c:228)
==77681==    by 0x641B6F: standard_ExecutorEnd (execMain.c:511)
==77681==    by 0x10AC72F5: pgss_ExecutorEnd (pg_stat_statements.c:956)
==77681==    by 0x641BA6: ExecutorEnd (execMain.c:465)
==77681==    by 0x5D89BE: ExplainOnePlan (explain.c:578)
==77681==    by 0x5F429E: ExplainExecuteQuery (prepare.c:676)
==77681==    by 0x5D8CEB: ExplainOneUtility (explain.c:434)
==77681==  Block was alloc'd at
==77681==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==77681==    by 0x8DB354: AllocSetAlloc (aset.c:914)
==77681==    by 0x8DBE61: AllocSetRealloc (aset.c:1248)
==77681==    by 0x8E3DC9: repalloc (mcxt.c:1057)
==77681==    by 0x67C649: enlargeStringInfo (stringinfo.c:311)
==77681==    by 0x67C70D: appendStringInfo (stringinfo.c:97)
==77681==    by 0xE24859D: OutTask (citus_outfuncs.c:537)
==77681==    by 0x6A9A54: _outExtensibleNode (outfuncs.c:2567)
==77681==    by 0x6AA811: outNode (outfuncs.c:4114)
==77681==    by 0x6AAC21: _outList (outfuncs.c:220)
==77681==    by 0x6A9E11: outNode (outfuncs.c:3634)
==77681==    by 0xE2476D0: OutJobFields (citus_outfuncs.c:340)
```

which is because we allocated `task->fetchedExplainAnalyzePlan` in executor context, but didn't reset its pointer value by end of ExecutorEnd. Resetting its pointer by end of ExecutorEnd turned out to be difficult to be done reliably (because errors can be raised), so instead this PR allocates it in the same memory context as task.

A proper solution would be to not put `fetchedExplainAnalyzePlan` in `struct Task`. Implementing that needs a bigger non-trivial refactor which requires we first handle prepared EXPLAIN ANALYZE in the same code path as other EXPLAIN ANALYZE cases, so we don't have special encapsulation breaking logic for it in `tuple_destination.c` like this line: https://github.com/citusdata/citus/blob/23ffaabe525f3c50f54a1b1b54928c3fd84ae19e/src/backend/distributed/executor/tuple_destination.c#L90

So doing a minimal fix for this issue until we support EXPLAIN ANALYZE for prepared statements properly.