### PR TITLE
Replace words that have bad associations

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -915,7 +915,7 @@ NodeDDLTaskList(TargetWorkerSet targets, List *commands)
 	{
 		/*
 		 * if there are no nodes we don't have to plan any ddl tasks. Planning them would
-		 * cause a hang in the executor.
+		 * cause the executor to stop responding.
 		 */
 		return NIL;
 	}

--- a/src/backend/distributed/utils/enable_ssl.c
+++ b/src/backend/distributed/utils/enable_ssl.c
@@ -367,8 +367,8 @@ CreateCertificate(EVP_PKEY *privateKey)
 	 * Postgres does not check the validity on the certificates, but we can't omit the
 	 * dates either to create a certificate that can be parsed. We settled on a validity
 	 * of 0 seconds. When postgres would fix the validity check in a future version it
-	 * would fail right after an upgrade instead of setting a time bomb till certificate
-	 * expiration date.
+	 * would fail right after an upgrade. Instead of working until the certificate
+	 * expiration date and then suddenly erroring out.
 	 */
 	X509_gmtime_adj(X509_get_notBefore(certificate), 0);
 	X509_gmtime_adj(X509_get_notAfter(certificate), 0);

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -96,7 +96,7 @@ typedef enum MultiConnectionStructInitializationState
 } MultiConnectionStructInitializationState;
 
 
-/* declaring this directly above makes uncrustify go crazy */
+/* declaring this directly above causes uncrustify to format it badly */
 typedef enum MultiConnectionMode MultiConnectionMode;
 
 typedef struct MultiConnection


### PR DESCRIPTION
We had a few words in our codebase that static analysis flagged as having bad
associations.