### PR TITLE
Prototype: Enable no name indexes on citus tables

### DIFF
--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -49,6 +49,7 @@ static char * ChooseIndexName(const char *tabname, Oid namespaceId,
 							  List *colnames, List *exclusionOpNames,
 							  bool primary, bool isconstraint);
 static char * ChooseIndexNameAddition(List *colnames);
+
 /* Local functions forward declarations for helper functions */
 static List * CreateIndexTaskList(Oid relationId, IndexStmt *indexStmt);
 static List * CreateReindexTaskList(Oid relationId, ReindexStmt *reindexStmt);
@@ -204,52 +205,59 @@ PreprocessIndexStmt(Node *node, const char *createIndexCommand)
  * names are unique so we don't get a conflicting-attribute-names error.
  *
  * Returns a List of plain strings (char *, not String nodes).
- * 
+ *
  * (Directly copied from postgres/commands/indexcmds.c)
  */
 static List *
 ChooseIndexColumnNames(List *indexElems)
 {
-	List	   *result = NIL;
-	ListCell   *lc;
+	List *result = NIL;
+	ListCell *lc;
 
 	foreach(lc, indexElems)
 	{
-		IndexElem  *ielem = (IndexElem *) lfirst(lc);
+		IndexElem *ielem = (IndexElem *) lfirst(lc);
 		const char *origname;
-		const char *curname;
-		int			i;
-		char		buf[NAMEDATALEN];
+		int i;
+		char buf[NAMEDATALEN];
 
 		/* Get the preliminary name from the IndexElem */
 		if (ielem->indexcolname)
+		{
 			origname = ielem->indexcolname; /* caller-specified name */
+		}
 		else if (ielem->name)
+		{
 			origname = ielem->name; /* simple column reference */
+		}
 		else
-			origname = "expr";	/* default name for expression */
+		{
+			origname = "expr";  /* default name for expression */
+		}
 
 		/* If it conflicts with any previous column, tweak it */
-		curname = origname;
+		const char *curname = origname;
 		for (i = 1;; i++)
 		{
-			ListCell   *lc2;
-			char		nbuf[32];
-			int			nlen;
+			ListCell *lc2;
+			char nbuf[32];
 
 			foreach(lc2, result)
 			{
 				if (strcmp(curname, (char *) lfirst(lc2)) == 0)
+				{
 					break;
+				}
 			}
 			if (lc2 == NULL)
-				break;			/* found nonconflicting name */
-
+			{
+				break;          /* found nonconflicting name */
+			}
 			sprintf(nbuf, "%d", i);
 
 			/* Ensure generated names are shorter than NAMEDATALEN */
-			nlen = pg_mbcliplen(origname, strlen(origname),
-								NAMEDATALEN - 1 - strlen(nbuf));
+			int nlen = pg_mbcliplen(origname, strlen(origname),
+									NAMEDATALEN - 1 - strlen(nbuf));
 			memcpy(buf, origname, nlen);
 			strcpy(buf + nlen, nbuf);
 			curname = buf;
@@ -272,7 +280,7 @@ ChooseIndexName(const char *tabname, Oid namespaceId,
 				List *colnames, List *exclusionOpNames,
 				bool primary, bool isconstraint)
 {
-	char	   *indexname;
+	char *indexname;
 
 	if (primary)
 	{
@@ -322,15 +330,15 @@ ChooseIndexName(const char *tabname, Oid namespaceId,
  *
  * XXX See also ChooseForeignKeyConstraintNameAddition and
  * ChooseExtendedStatisticNameAddition.
- * 
+ *
  * (Directly copied from postgres/commands/indexcmds.c)
  */
 static char *
 ChooseIndexNameAddition(List *colnames)
 {
-	char		buf[NAMEDATALEN * 2];
-	int			buflen = 0;
-	ListCell   *lc;
+	char buf[NAMEDATALEN * 2];
+	int buflen = 0;
+	ListCell *lc;
 
 	buf[0] = '\0';
 	foreach(lc, colnames)
@@ -338,7 +346,9 @@ ChooseIndexNameAddition(List *colnames)
 		const char *name = (const char *) lfirst(lc);
 
 		if (buflen > 0)
-			buf[buflen++] = '_';	/* insert _ between names */
+		{
+			buf[buflen++] = '_';    /* insert _ between names */
+		}
 
 		/*
 		 * At this point we have buflen <= NAMEDATALEN.  name should be less
@@ -347,7 +357,9 @@ ChooseIndexNameAddition(List *colnames)
 		strlcpy(buf + buflen, name, NAMEDATALEN);
 		buflen += strlen(buf + buflen);
 		if (buflen >= NAMEDATALEN)
+		{
 			break;
+		}
 	}
 	return pstrdup(buf);
 }

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -253,13 +253,13 @@ ChooseIndexColumnNames(List *indexElems)
 			{
 				break;          /* found nonconflicting name */
 			}
-			sprintf(nbuf, "%d", i);
+			SafeSnprintf(nbuf, 32, "%d", i);
 
 			/* Ensure generated names are shorter than NAMEDATALEN */
 			int nlen = pg_mbcliplen(origname, strlen(origname),
 									NAMEDATALEN - 1 - strlen(nbuf));
-			memcpy(buf, origname, nlen);
-			strcpy(buf + nlen, nbuf);
+			memcpy_s(buf, NAMEDATALEN, origname, nlen);
+			strcpy_s(buf + nlen, NAMEDATALEN - nlen, nbuf);
 			curname = buf;
 		}
 

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -129,7 +129,7 @@ SELECT count(*) FROM pg_indexes WHERE tablename = (SELECT relname FROM pg_class 
 SELECT count(*) FROM pg_indexes WHERE tablename LIKE 'index_test_hash%';
  count
 ---------------------------------------------------------------------
-    32
+    40
 (1 row)
 
 SELECT count(*) FROM pg_indexes WHERE tablename LIKE 'index_test_range%';
@@ -173,12 +173,15 @@ ERROR:  data type bigint has no default operator class for access method "gist"
 HINT:  You must specify an operator class for the index or define a default operator class for the data type.
 CREATE INDEX try_index ON lineitem (non_existent_column);
 ERROR:  column "non_existent_column" does not exist
+-- show that we support indexes without names
 CREATE INDEX ON lineitem (l_orderkey);
-ERROR:  creating index without a name on a distributed table is currently unsupported
+CREATE UNIQUE INDEX ON index_test_hash(a);
+CREATE INDEX CONCURRENTLY ON lineitem USING hash (l_shipdate);
 -- Verify that none of failed indexes got created on the master node
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
  schemaname |    tablename     |             indexname              | tablespace |                                                          indexdef
 ---------------------------------------------------------------------
+ public     | index_test_hash  | index_test_hash_a_idx              |            | CREATE UNIQUE INDEX index_test_hash_a_idx ON public.index_test_hash USING btree (a)
  public     | index_test_hash  | index_test_hash_index_a            |            | CREATE UNIQUE INDEX index_test_hash_index_a ON public.index_test_hash USING btree (a)
  public     | index_test_hash  | index_test_hash_index_a_b          |            | CREATE UNIQUE INDEX index_test_hash_index_a_b ON public.index_test_hash USING btree (a, b)
  public     | index_test_hash  | index_test_hash_index_a_b_c        |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c ON public.index_test_hash USING btree (a) INCLUDE (b, c)
@@ -188,6 +191,8 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | index_test_range | index_test_range_index_a_b_partial |            | CREATE UNIQUE INDEX index_test_range_index_a_b_partial ON public.index_test_range USING btree (a, b) WHERE (c IS NOT NULL)
  public     | lineitem         | lineitem_colref_index              |            | CREATE INDEX lineitem_colref_index ON public.lineitem USING btree (record_ne(lineitem.*, NULL::record))
  public     | lineitem         | lineitem_concurrently_index        |            | CREATE INDEX lineitem_concurrently_index ON public.lineitem USING btree (l_orderkey)
+ public     | lineitem         | lineitem_l_orderkey_idx            |            | CREATE INDEX lineitem_l_orderkey_idx ON public.lineitem USING btree (l_orderkey)
+ public     | lineitem         | lineitem_l_shipdate_idx            |            | CREATE INDEX lineitem_l_shipdate_idx ON public.lineitem USING hash (l_shipdate)
  public     | lineitem         | lineitem_orderkey_hash_index       |            | CREATE INDEX lineitem_orderkey_hash_index ON public.lineitem USING hash (l_partkey)
  public     | lineitem         | lineitem_orderkey_index            |            | CREATE INDEX lineitem_orderkey_index ON public.lineitem USING btree (l_orderkey)
  public     | lineitem         | lineitem_orderkey_index_new        |            | CREATE INDEX lineitem_orderkey_index_new ON public.lineitem USING btree (l_orderkey)
@@ -195,7 +200,7 @@ SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_t
  public     | lineitem         | lineitem_partkey_desc_index        |            | CREATE INDEX lineitem_partkey_desc_index ON public.lineitem USING btree (l_partkey DESC)
  public     | lineitem         | lineitem_pkey                      |            | CREATE UNIQUE INDEX lineitem_pkey ON public.lineitem USING btree (l_orderkey, l_linenumber)
  public     | lineitem         | lineitem_time_index                |            | CREATE INDEX lineitem_time_index ON public.lineitem USING btree (l_shipdate)
-(16 rows)
+(19 rows)
 
 --
 -- REINDEX
@@ -236,26 +241,39 @@ DROP INDEX index_test_hash_index_a_b_partial;
 DROP INDEX CONCURRENTLY lineitem_concurrently_index;
 -- Verify that all the indexes are dropped from the master and one worker node.
 -- As there's a primary key, so exclude those from this check.
-SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%';
- indrelid | indexrelid
+SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%' ORDER BY 1,2;
+ indrelid |       indexrelid
 ---------------------------------------------------------------------
-(0 rows)
+ lineitem | lineitem_l_orderkey_idx
+ lineitem | lineitem_l_shipdate_idx
+(2 rows)
 
 SELECT * FROM pg_indexes WHERE tablename LIKE 'index_test_%' ORDER BY indexname;
  schemaname |    tablename    |          indexname          | tablespace |                                                 indexdef
 ---------------------------------------------------------------------
+ public     | index_test_hash | index_test_hash_a_idx       |            | CREATE UNIQUE INDEX index_test_hash_a_idx ON public.index_test_hash USING btree (a)
  public     | index_test_hash | index_test_hash_index_a_b_c |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c ON public.index_test_hash USING btree (a) INCLUDE (b, c)
-(1 row)
+(2 rows)
 
 \c - - - :worker_1_port
-SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%';
- indrelid | indexrelid
+SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%' ORDER BY 1,2;
+    indrelid     |           indexrelid
 ---------------------------------------------------------------------
-(0 rows)
+ lineitem_290000 | lineitem_l_orderkey_idx_290000
+ lineitem_290000 | lineitem_l_shipdate_idx_290000
+(2 rows)
 
 SELECT * FROM pg_indexes WHERE tablename LIKE 'index_test_%' ORDER BY indexname;
  schemaname |       tablename        |             indexname              | tablespace |                                                        indexdef
 ---------------------------------------------------------------------
+ public     | index_test_hash_102082 | index_test_hash_a_idx_102082       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102082 ON public.index_test_hash_102082 USING btree (a)
+ public     | index_test_hash_102083 | index_test_hash_a_idx_102083       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102083 ON public.index_test_hash_102083 USING btree (a)
+ public     | index_test_hash_102084 | index_test_hash_a_idx_102084       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102084 ON public.index_test_hash_102084 USING btree (a)
+ public     | index_test_hash_102085 | index_test_hash_a_idx_102085       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102085 ON public.index_test_hash_102085 USING btree (a)
+ public     | index_test_hash_102086 | index_test_hash_a_idx_102086       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102086 ON public.index_test_hash_102086 USING btree (a)
+ public     | index_test_hash_102087 | index_test_hash_a_idx_102087       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102087 ON public.index_test_hash_102087 USING btree (a)
+ public     | index_test_hash_102088 | index_test_hash_a_idx_102088       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102088 ON public.index_test_hash_102088 USING btree (a)
+ public     | index_test_hash_102089 | index_test_hash_a_idx_102089       |            | CREATE UNIQUE INDEX index_test_hash_a_idx_102089 ON public.index_test_hash_102089 USING btree (a)
  public     | index_test_hash_102082 | index_test_hash_index_a_b_c_102082 |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c_102082 ON public.index_test_hash_102082 USING btree (a) INCLUDE (b, c)
  public     | index_test_hash_102083 | index_test_hash_index_a_b_c_102083 |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c_102083 ON public.index_test_hash_102083 USING btree (a) INCLUDE (b, c)
  public     | index_test_hash_102084 | index_test_hash_index_a_b_c_102084 |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c_102084 ON public.index_test_hash_102084 USING btree (a) INCLUDE (b, c)
@@ -264,7 +282,15 @@ SELECT * FROM pg_indexes WHERE tablename LIKE 'index_test_%' ORDER BY indexname;
  public     | index_test_hash_102087 | index_test_hash_index_a_b_c_102087 |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c_102087 ON public.index_test_hash_102087 USING btree (a) INCLUDE (b, c)
  public     | index_test_hash_102088 | index_test_hash_index_a_b_c_102088 |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c_102088 ON public.index_test_hash_102088 USING btree (a) INCLUDE (b, c)
  public     | index_test_hash_102089 | index_test_hash_index_a_b_c_102089 |            | CREATE UNIQUE INDEX index_test_hash_index_a_b_c_102089 ON public.index_test_hash_102089 USING btree (a) INCLUDE (b, c)
-(8 rows)
+ public     | index_test_hash_102082 | lineitem_orderkey_index_102082     |            | CREATE INDEX lineitem_orderkey_index_102082 ON public.index_test_hash_102082 USING btree (a)
+ public     | index_test_hash_102083 | lineitem_orderkey_index_102083     |            | CREATE INDEX lineitem_orderkey_index_102083 ON public.index_test_hash_102083 USING btree (a)
+ public     | index_test_hash_102084 | lineitem_orderkey_index_102084     |            | CREATE INDEX lineitem_orderkey_index_102084 ON public.index_test_hash_102084 USING btree (a)
+ public     | index_test_hash_102085 | lineitem_orderkey_index_102085     |            | CREATE INDEX lineitem_orderkey_index_102085 ON public.index_test_hash_102085 USING btree (a)
+ public     | index_test_hash_102086 | lineitem_orderkey_index_102086     |            | CREATE INDEX lineitem_orderkey_index_102086 ON public.index_test_hash_102086 USING btree (a)
+ public     | index_test_hash_102087 | lineitem_orderkey_index_102087     |            | CREATE INDEX lineitem_orderkey_index_102087 ON public.index_test_hash_102087 USING btree (a)
+ public     | index_test_hash_102088 | lineitem_orderkey_index_102088     |            | CREATE INDEX lineitem_orderkey_index_102088 ON public.index_test_hash_102088 USING btree (a)
+ public     | index_test_hash_102089 | lineitem_orderkey_index_102089     |            | CREATE INDEX lineitem_orderkey_index_102089 ON public.index_test_hash_102089 USING btree (a)
+(24 rows)
 
 -- create index that will conflict with master operations
 CREATE INDEX CONCURRENTLY ith_b_idx_102089 ON index_test_hash_102089(b);

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -105,7 +105,11 @@ CREATE UNIQUE INDEX try_unique_append_index_a_b ON index_test_append(a,b);
 CREATE INDEX lineitem_orderkey_index ON lineitem (l_orderkey);
 CREATE INDEX try_index ON lineitem USING gist (l_orderkey);
 CREATE INDEX try_index ON lineitem (non_existent_column);
+
+-- show that we support indexes without names
 CREATE INDEX ON lineitem (l_orderkey);
+CREATE UNIQUE INDEX ON index_test_hash(a);
+CREATE INDEX CONCURRENTLY ON lineitem USING hash (l_shipdate);
 
 -- Verify that none of failed indexes got created on the master node
 SELECT * FROM pg_indexes WHERE tablename = 'lineitem' or tablename like 'index_test_%' ORDER BY indexname;
@@ -154,10 +158,10 @@ DROP INDEX CONCURRENTLY lineitem_concurrently_index;
 
 -- Verify that all the indexes are dropped from the master and one worker node.
 -- As there's a primary key, so exclude those from this check.
-SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%';
+SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%' ORDER BY 1,2;
 SELECT * FROM pg_indexes WHERE tablename LIKE 'index_test_%' ORDER BY indexname;
 \c - - - :worker_1_port
-SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%';
+SELECT indrelid::regclass, indexrelid::regclass FROM pg_index WHERE indrelid = (SELECT relname FROM pg_class WHERE relname LIKE 'lineitem%' ORDER BY relname LIMIT 1)::regclass AND NOT indisprimary AND indexrelid::regclass::text NOT LIKE 'lineitem_time_index%' ORDER BY 1,2;
 SELECT * FROM pg_indexes WHERE tablename LIKE 'index_test_%' ORDER BY indexname;
 
 -- create index that will conflict with master operations


### PR DESCRIPTION
DESCRIPTION: Adds no-name index support for citus tables

First three commits copy (and indent) the necessary code from postgres to be able to assign a default name for unnamed indexes.
Last commit allows indexes without names on citus tables 87bc81c

TODO:
- [ ] Maybe add a few more tests around CREATE INDEX ?

Question:
- [ ] Should I copy postgres code to somewhere around ruleutils or to a new file ?

Merging this pr would also allow such `CREATE INDEX` commands on incoming citus local tables.

Fixes #312