### PR TITLE
remove no-op check in TaskListRequires2PC

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1481,8 +1481,7 @@ TaskListRequires2PC(List *taskList)
 
 	if (task->taskType == DDL_TASK)
 	{
-		if (MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC ||
-			task->replicationModel == REPLICATION_MODEL_2PC)
+		if (MultiShardCommitProtocol == COMMIT_PROTOCOL_2PC)
 		{
 			return true;
 		}


### PR DESCRIPTION
We already return true if replication model is REPLICATION_MODEL_2PC at
the very beginning of the function, hence the check later is not used.
