### PR TITLE
Don't check-merge-to-enterprise for release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,12 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - check-merge-to-enterprise
+      - check-merge-to-enterprise:
+          filters:
+            branches:
+              ignore:
+                - /release-[0-9]+\.[0-9]+.*/ # match with releaseX.Y.*
+
       - build
       - check-style
       - check-sql-snapshots


### PR DESCRIPTION
As we always bump versions in release branches to x.y.z, `check-merge-to-enterprise` will never succeed as we always have x.y-devel versions in master branches. This pr is needed before releasing 9.4
