### PR TITLE
Fail if merge to enterprise causes compilation issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
 
   check-merge-to-enterprise:
     docker:
-      - image: buildpack-deps:buster
+      - image: citus/extbuilder:13beta3
     working_directory: /home/circleci/project
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
 
   check-merge-to-enterprise:
     docker:
-      - image: buildpack-deps:stretch
+      - image: buildpack-deps:buster
     working_directory: /home/circleci/project
     steps:
       - checkout

--- a/ci/README.md
+++ b/ci/README.md
@@ -51,11 +51,13 @@ following:
 This check exists to make sure that we can always merge the `master` branch of
 `community` into the `enterprise-master` branch of the `enterprise` repo.
 There are two conditions in which this check passes:
-1. There are no merge conflicts between your PR branch and `enterprise-master`.
+
+1. There are no merge conflicts between your PR branch and `enterprise-master` and after this merge the code compiles.
 2. There are merge conflicts, but there is a branch with the same name in the
    enterprise repo that:
    1. Contains the last commit of the community branch with the same name.
    2. Merges cleanly into `enterprise-master`
+3. After merging, the code can be compiled.
 
 If the job already passes, you are done, nothing further required! Otherwise
 follow the below steps.

--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -22,6 +22,14 @@ source ci/ci_helpers.sh
 # are not shown in CI output (even though it's also filtered out by CircleCI)
 set -x
 
+check_compile () {
+    ./configure --without-libcurl
+    make install -j10
+}
+
+apt-get update
+apt-get install -y postgresql-server-dev-all postgresql-common
+
 # Clone current git repo (which should be community) to a temporary working
 # directory and go there
 GIT_DIR_ROOT="$(git rev-parse --show-toplevel)"
@@ -48,6 +56,8 @@ git checkout "enterprise/enterprise-master"
 
 if git merge --no-commit "origin/$PR_BRANCH"; then
     echo "INFO: community PR branch could be merged into enterprise-master, so everything is good"
+    # check that we can compile after the merge
+    check_compile
     exit 0
 fi
 
@@ -73,3 +83,5 @@ fi
 # Now check if we can merge the enterprise PR into enterprise-master without
 # issues.
 git merge --no-commit "enterprise/$PR_BRANCH"
+# check that we can compile after the merge
+check_compile

--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -23,12 +23,10 @@ source ci/ci_helpers.sh
 set -x
 
 check_compile () {
+    echo "INFO: checking if merged code can be compiled"
     ./configure --without-libcurl
-    make install -j10
+    make -j10
 }
-
-apt-get update
-apt-get install -y postgresql-server-dev-all postgresql-common
 
 # Clone current git repo (which should be community) to a temporary working
 # directory and go there
@@ -55,7 +53,7 @@ git fetch enterprise enterprise-master
 git checkout "enterprise/enterprise-master"
 
 if git merge --no-commit "origin/$PR_BRANCH"; then
-    echo "INFO: community PR branch could be merged into enterprise-master, so everything is good"
+    echo "INFO: community PR branch could be merged into enterprise-master"
     # check that we can compile after the merge
     check_compile
     exit 0

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -83,7 +83,7 @@
 /*
  * once every LOG_PER_TUPLE_AMOUNT, the copy will be logged.
  */
-#define LOG_PER_TUPLE_AMOUNT 1000000
+// #define LOG_PER_TUPLE_AMOUNT 1000000
 
 /* Replication model to use when creating distributed tables */
 int ReplicationModel = REPLICATION_MODEL_COORDINATOR;

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -83,7 +83,7 @@
 /*
  * once every LOG_PER_TUPLE_AMOUNT, the copy will be logged.
  */
-// #define LOG_PER_TUPLE_AMOUNT 1000000
+#define LOG_PER_TUPLE_AMOUNT 1000000
 
 /* Replication model to use when creating distributed tables */
 int ReplicationModel = REPLICATION_MODEL_COORDINATOR;


### PR DESCRIPTION
Fixes #4024.


The reason I changed the tag to `buster` is because it has postgres 11 whereas stretch has 9.6 which we dont compile with.

Example failure: https://circleci.com/gh/citusdata/citus/142143
