### PR TITLE
fix flappy tests due to indeterministic order of test output

### DIFF
--- a/src/test/regress/expected/anonymous_columns.out
+++ b/src/test/regress/expected/anonymous_columns.out
@@ -9,14 +9,14 @@ SELECT create_distributed_table('t0', 'a');
 (1 row)
 
 INSERT INTO t0 VALUES (1, 2, 'hello'), (2, 4, 'world');
-SELECT "?column?" FROM t0;
+SELECT "?column?" FROM t0 ORDER BY 1;
  ?column?
 ---------------------------------------------------------------------
  hello
  world
 (2 rows)
 
-WITH a AS (SELECT * FROM t0) SELECT "?column?" FROM a;
+WITH a AS (SELECT * FROM t0) SELECT "?column?" FROM a ORDER BY 1;
  ?column?
 ---------------------------------------------------------------------
  hello
@@ -78,50 +78,50 @@ WITH a AS (SELECT '','' FROM t0 WHERE a = 42) SELECT * FROM a, a b;
 (0 rows)
 
 -- test with explicit subqueries
-SELECT * FROM (SELECT a, '' FROM t0 GROUP BY a ) as foo;
+SELECT * FROM (SELECT a, '' FROM t0 GROUP BY a) as foo ORDER BY 1;
  a | ?column?
 ---------------------------------------------------------------------
  1 |
  2 |
 (2 rows)
 
-SELECT * FROM (SELECT a, '', '' FROM t0 GROUP BY a ) as foo;
+SELECT * FROM (SELECT a, '', '' FROM t0 GROUP BY a ) as foo ORDER BY 1;
  a | ?column? | ?column?
 ---------------------------------------------------------------------
  1 |          |
  2 |          |
 (2 rows)
 
-SELECT * FROM (SELECT b, '' FROM t0 GROUP BY b ) as foo;
+SELECT * FROM (SELECT b, '' FROM t0 GROUP BY b ) as foo ORDER BY 1;
  b | ?column?
 ---------------------------------------------------------------------
- 4 |
  2 |
+ 4 |
 (2 rows)
 
-SELECT * FROM (SELECT b, '', '' FROM t0 GROUP BY b ) as foo;
+SELECT * FROM (SELECT b, '', '' FROM t0 GROUP BY b ) as foo ORDER BY 1;
  b | ?column? | ?column?
 ---------------------------------------------------------------------
- 4 |          |
  2 |          |
+ 4 |          |
 (2 rows)
 
 -- some tests that follow very similar codeoaths
-SELECT a + 1 FROM t0;
+SELECT a + 1 FROM t0 ORDER BY 1;
  ?column?
 ---------------------------------------------------------------------
         2
         3
 (2 rows)
 
-SELECT a + 1, a - 1 FROM t0;
+SELECT a + 1, a - 1 FROM t0 ORDER BY 1;
  ?column? | ?column?
 ---------------------------------------------------------------------
         2 |        0
         3 |        1
 (2 rows)
 
-WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1;
+WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1 ORDER BY 1::text;
  ?column?
 ---------------------------------------------------------------------
  1

--- a/src/test/regress/sql/anonymous_columns.sql
+++ b/src/test/regress/sql/anonymous_columns.sql
@@ -7,9 +7,9 @@ CREATE TABLE t0 (a int PRIMARY KEY, b int, "?column?" text);
 SELECT create_distributed_table('t0', 'a');
 INSERT INTO t0 VALUES (1, 2, 'hello'), (2, 4, 'world');
 
-SELECT "?column?" FROM t0;
+SELECT "?column?" FROM t0 ORDER BY 1;
 
-WITH a AS (SELECT * FROM t0) SELECT "?column?" FROM a;
+WITH a AS (SELECT * FROM t0) SELECT "?column?" FROM a ORDER BY 1;
 WITH a AS (SELECT '' FROM t0) SELECT * FROM a;
 
 -- test CTE's that could be rewritten as subquery
@@ -24,15 +24,15 @@ WITH a AS (SELECT '' FROM t0 WHERE a = 1) SELECT * FROM a, a b;
 WITH a AS (SELECT '','' FROM t0 WHERE a = 42) SELECT * FROM a, a b;
 
 -- test with explicit subqueries
-SELECT * FROM (SELECT a, '' FROM t0 GROUP BY a ) as foo;
-SELECT * FROM (SELECT a, '', '' FROM t0 GROUP BY a ) as foo;
-SELECT * FROM (SELECT b, '' FROM t0 GROUP BY b ) as foo;
-SELECT * FROM (SELECT b, '', '' FROM t0 GROUP BY b ) as foo;
+SELECT * FROM (SELECT a, '' FROM t0 GROUP BY a) as foo ORDER BY 1;
+SELECT * FROM (SELECT a, '', '' FROM t0 GROUP BY a ) as foo ORDER BY 1;
+SELECT * FROM (SELECT b, '' FROM t0 GROUP BY b ) as foo ORDER BY 1;
+SELECT * FROM (SELECT b, '', '' FROM t0 GROUP BY b ) as foo ORDER BY 1;
 
 -- some tests that follow very similar codeoaths
-SELECT a + 1 FROM t0;
-SELECT a + 1, a - 1 FROM t0;
-WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1;
+SELECT a + 1 FROM t0 ORDER BY 1;
+SELECT a + 1, a - 1 FROM t0 ORDER BY 1;
+WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1 ORDER BY 1::text;
 
 -- clean up after test
 SET client_min_messages TO WARNING;


### PR DESCRIPTION
As reported on #4011 https://github.com/citusdata/citus/pull/4011/files#r453804702 some of the tests were flapping due to an indeterministic order for test outputs.

This PR makes the test output ordered for all tests returning non-zero rows.

Needs to be backported to 9.2, 9.3, 9.4