### PR TITLE
Split list of configuration values properly

### DIFF
--- a/src/backend/distributed/deparser/qualify_role_stmt.c
+++ b/src/backend/distributed/deparser/qualify_role_stmt.c
@@ -56,5 +56,5 @@ QualifyVarSetCurrent(VariableSetStmt *setStmt)
 	char *configValue = GetConfigOptionByName(configurationName, NULL, false);
 
 	setStmt->kind = VAR_SET_VALUE;
-	setStmt->args = list_make1(MakeSetStatementArgument(configurationName, configValue));
+	setStmt->args = list_make1(MakeSetStatementArguments(configurationName, configValue));
 }

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -99,7 +99,8 @@ extern void QualifyAlterFunctionDependsStmt(Node *stmt);
 extern char * DeparseAlterRoleStmt(Node *stmt);
 extern char * DeparseAlterRoleSetStmt(Node *stmt);
 
-extern Node * MakeSetStatementArgument(char *configurationName, char *configurationValue);
+extern List * MakeSetStatementArguments(char *configurationName,
+										char *configurationValue);
 extern void QualifyAlterRoleSetStmt(Node *stmt);
 
 /* forward declarations for deparse_extension_stmts.c */

--- a/src/test/regress/expected/alter_role_propagation.out
+++ b/src/test/regress/expected/alter_role_propagation.out
@@ -1,4 +1,5 @@
 CREATE SCHEMA alter_role;
+CREATE SCHEMA ",CitUs,.TeeN!?";
 -- test if the passowrd of the extension owner can be upgraded
 ALTER ROLE CURRENT_USER PASSWORD 'password123' VALID UNTIL 'infinity';
 SELECT run_command_on_workers($$SELECT row(rolname, rolsuper, rolinherit,  rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, rolpassword, EXTRACT (year FROM rolvaliduntil)) FROM pg_authid WHERE rolname = current_user$$);
@@ -111,6 +112,12 @@ SELECT run_command_on_workers('SHOW enable_hashagg');
  (localhost,57638,t,off)
 (1 row)
 
+-- provide a list of values in a supported configuration
+ALTER ROLE CURRENT_USER SET search_path TO ",CitUs,.TeeN!?", alter_role, public;
+-- test user defined GUCs that appear to be a list, but instead a single string
+ALTER ROLE ALL SET public.myguc TO "Hello, World";
+-- test for configuration values that should not be downcased even when unquoted
+ALTER ROLE CURRENT_USER SET lc_messages TO 'C';
 -- add worker and check all settings are copied
 SELECT 1 FROM master_add_node('localhost', :worker_1_port);
  ?column?
@@ -137,6 +144,27 @@ SELECT run_command_on_workers('SHOW enable_hashagg');
 ---------------------------------------------------------------------
  (localhost,57637,t,off)
  (localhost,57638,t,off)
+(2 rows)
+
+SELECT run_command_on_workers('SHOW search_path');
+                    run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,""",CitUs,.TeeN!?"", alter_role, public")
+ (localhost,57638,t,""",CitUs,.TeeN!?"", alter_role, public")
+(2 rows)
+
+SELECT run_command_on_workers('SHOW lc_messages');
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,C)
+ (localhost,57638,t,C)
+(2 rows)
+
+SELECT run_command_on_workers('SHOW public.myguc');
+       run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"Hello, World")
+ (localhost,57638,t,"Hello, World")
 (2 rows)
 
 -- reset to default values
@@ -226,4 +254,4 @@ SELECT run_command_on_workers('SHOW enable_hashjoin');
  (localhost,57638,t,on)
 (2 rows)
 
-DROP SCHEMA alter_role CASCADE;
+DROP SCHEMA alter_role, ",CitUs,.TeeN!?" CASCADE;

--- a/src/test/regress/sql/alter_role_propagation.sql
+++ b/src/test/regress/sql/alter_role_propagation.sql
@@ -1,4 +1,5 @@
 CREATE SCHEMA alter_role;
+CREATE SCHEMA ",CitUs,.TeeN!?";
 
 -- test if the passowrd of the extension owner can be upgraded
 ALTER ROLE CURRENT_USER PASSWORD 'password123' VALID UNTIL 'infinity';
@@ -35,11 +36,22 @@ SELECT run_command_on_workers('SHOW enable_indexonlyscan');
 ALTER ROLE CURRENT_USER SET enable_hashagg TO FALSE;
 SELECT run_command_on_workers('SHOW enable_hashagg');
 
+-- provide a list of values in a supported configuration
+ALTER ROLE CURRENT_USER SET search_path TO ",CitUs,.TeeN!?", alter_role, public;
+-- test user defined GUCs that appear to be a list, but instead a single string
+ALTER ROLE ALL SET public.myguc TO "Hello, World";
+
+-- test for configuration values that should not be downcased even when unquoted
+ALTER ROLE CURRENT_USER SET lc_messages TO 'C';
+
 -- add worker and check all settings are copied
 SELECT 1 FROM master_add_node('localhost', :worker_1_port);
 SELECT run_command_on_workers('SHOW enable_hashjoin');
 SELECT run_command_on_workers('SHOW enable_indexonlyscan');
 SELECT run_command_on_workers('SHOW enable_hashagg');
+SELECT run_command_on_workers('SHOW search_path');
+SELECT run_command_on_workers('SHOW lc_messages');
+SELECT run_command_on_workers('SHOW public.myguc');
 
 -- reset to default values
 ALTER ROLE CURRENT_USER RESET enable_hashagg;
@@ -70,4 +82,4 @@ SELECT run_command_on_workers('SHOW enable_hashjoin');
 ALTER ROLE ALL RESET enable_hashjoin;
 SELECT run_command_on_workers('SHOW enable_hashjoin');
 
-DROP SCHEMA alter_role CASCADE;
+DROP SCHEMA alter_role, ",CitUs,.TeeN!?" CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug with lists of configuration values in ALTER ROLE SET statements

An `ALTER ROLE <user> SET <config>=<value>` statement can have a list of values for supported configs. When a new node is added, we can potentially treat the value as a single string and this can result in differing configuration defaults across the cluster.

TODO:
- [x] Allow commas and other characters in the list items.
- [x] Remove banned `memmove()` calls with safer alternatives

Fixes #4012