### PR TITLE
Refactor: Use TupleDestination API for partitioning in insert/select.

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -28,6 +28,7 @@
 #include "distributed/adaptive_executor.h"
 #include "distributed/remote_commands.h"
 #include "distributed/shard_pruning.h"
+#include "distributed/tuple_destination.h"
 #include "distributed/version_compat.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_log_messages.h"
@@ -193,8 +194,8 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 			ROW_MODIFY_NONE, list_make1(task), MaxAdaptiveExecutorPoolSize,
 			localExecutionSupported
 			);
-		executionParams->tupleStore = tupleStore;
-		executionParams->tupleDescriptor = tupleDesc;
+		executionParams->tupleDestination = CreateTupleStoreTupleDest(tupleStore,
+																	  tupleDesc);
 		executionParams->expectResults = expectResults;
 		executionParams->xactProperties = xactProperties;
 		ExecuteTaskListExtended(executionParams);

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -228,7 +228,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 
 		if (isUtilityCommand)
 		{
-			LocallyExecuteUtilityTask(TaskQueryStringForAllPlacements(task));
+			LocallyExecuteUtilityTask(TaskQueryString(task));
 			continue;
 		}
 
@@ -280,7 +280,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 				continue;
 			}
 
-			Query *shardQuery = ParseQueryString(TaskQueryStringForAllPlacements(task),
+			Query *shardQuery = ParseQueryString(TaskQueryString(task),
 												 taskParameterTypes,
 												 taskNumParams);
 
@@ -301,7 +301,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 		char *shardQueryString = NULL;
 		if (GetTaskQueryType(task) == TASK_QUERY_TEXT)
 		{
-			shardQueryString = TaskQueryStringForAllPlacements(task);
+			shardQueryString = TaskQueryString(task);
 		}
 		else
 		{
@@ -431,7 +431,7 @@ LogLocalCommand(Task *task)
 	}
 
 	ereport(NOTICE, (errmsg("executing the command locally: %s",
-							ApplyLogRedaction(TaskQueryStringForAllPlacements(task)))));
+							ApplyLogRedaction(TaskQueryString(task)))));
 }
 
 

--- a/src/backend/distributed/executor/multi_task_tracker_executor.c
+++ b/src/backend/distributed/executor/multi_task_tracker_executor.c
@@ -1579,8 +1579,7 @@ TrackerQueueSqlTask(TaskTracker *taskTracker, Task *task)
 	 */
 
 	StringInfo sqlTaskQueryString = makeStringInfo();
-	char *escapedTaskQueryString = quote_literal_cstr(TaskQueryStringForAllPlacements(
-														  task));
+	char *escapedTaskQueryString = quote_literal_cstr(TaskQueryString(task));
 
 	if (BinaryMasterCopyFormat)
 	{
@@ -1616,7 +1615,7 @@ TrackerQueueTask(TaskTracker *taskTracker, Task *task)
 
 	/* wrap a task assignment query outside the original query */
 	StringInfo taskAssignmentQuery =
-		TaskAssignmentQuery(task, TaskQueryStringForAllPlacements(task));
+		TaskAssignmentQuery(task, TaskQueryString(task));
 
 	TrackerTaskState *taskState = TaskStateHashEnter(taskStateHash, task->jobId,
 													 task->taskId);
@@ -2753,7 +2752,7 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 			{
 				/* assign through task tracker to manage resource utilization */
 				StringInfo jobCleanupQuery = TaskAssignmentQuery(
-					jobCleanupTask, TaskQueryStringForAllPlacements(jobCleanupTask));
+					jobCleanupTask, TaskQueryString(jobCleanupTask));
 
 				jobCleanupQuerySent = MultiClientSendQuery(taskTracker->connectionId,
 														   jobCleanupQuery->data);
@@ -2832,7 +2831,7 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 											 nodeName, nodePort, (int) queryStatus),
 									  errhint("Manually clean job resources on node "
 											  "\"%s:%u\" by running \"%s\" ", nodeName,
-											  nodePort, TaskQueryStringForAllPlacements(
+											  nodePort, TaskQueryString(
 												  jobCleanupTask))));
 				}
 				else
@@ -2851,7 +2850,7 @@ TrackerHashCleanupJob(HTAB *taskTrackerHash, Task *jobCleanupTask)
 										 nodePort, (int) resultStatus),
 								  errhint("Manually clean job resources on node "
 										  "\"%s:%u\" by running \"%s\" ", nodeName,
-										  nodePort, TaskQueryStringForAllPlacements(
+										  nodePort, TaskQueryString(
 											  jobCleanupTask))));
 			}
 			else

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -450,8 +450,7 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 				 * connect to that node to drop the shard placement over that
 				 * remote connection.
 				 */
-				const char *dropShardPlacementCommand = TaskQueryStringForAllPlacements(
-					task);
+				const char *dropShardPlacementCommand = TaskQueryString(task);
 				ExecuteDropShardPlacementCommandRemotely(shardPlacement,
 														 relationName,
 														 dropShardPlacementCommand);

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -606,9 +606,7 @@ FetchRemoteExplainFromWorkers(Task *task, ExplainState *es)
 	RemoteExplainPlan *remotePlan = (RemoteExplainPlan *) palloc0(
 		sizeof(RemoteExplainPlan));
 
-	StringInfo explainQuery = BuildRemoteExplainQuery(TaskQueryStringForAllPlacements(
-														  task),
-													  es);
+	StringInfo explainQuery = BuildRemoteExplainQuery(TaskQueryString(task), es);
 
 	/*
 	 * Use a coordinated transaction to ensure that we open a transaction block
@@ -694,7 +692,7 @@ ExplainTask(CitusScanState *scanState, Task *task, int placementIndex,
 
 	if (es->verbose)
 	{
-		const char *queryText = TaskQueryStringForAllPlacements(task);
+		const char *queryText = TaskQueryString(task);
 		ExplainPropertyText("Query", queryText, es);
 	}
 
@@ -1312,7 +1310,7 @@ ExplainAnalyzeTaskList(List *originalTaskList,
 		}
 
 		Task *explainAnalyzeTask = copyObject(originalTask);
-		const char *queryString = TaskQueryStringForAllPlacements(explainAnalyzeTask);
+		const char *queryString = TaskQueryString(explainAnalyzeTask);
 		char *wrappedQuery = WrapQueryForExplainAnalyze(queryString, tupleDesc);
 		char *fetchQuery =
 			"SELECT explain_analyze_output FROM worker_last_saved_explain_analyze()";

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4534,7 +4534,7 @@ CreateMapQueryString(MapMergeJob *mapMergeJob, Task *filterTask,
 
 	/* wrap repartition query string around filter query string */
 	StringInfo mapQueryString = makeStringInfo();
-	char *filterQueryString = TaskQueryStringForAllPlacements(filterTask);
+	char *filterQueryString = TaskQueryString(filterTask);
 	char *filterQueryEscapedText = quote_literal_cstr(filterQueryString);
 	PartitionType partitionType = mapMergeJob->partitionType;
 

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -284,12 +284,6 @@ CopyTaskQuery(Task *newnode, Task *from)
 			break;
 		}
 
-		case TASK_QUERY_TEXT_PER_PLACEMENT:
-		{
-			COPY_STRING_LIST(taskQuery.data.perPlacementQueryStrings);
-			break;
-		}
-
 		case TASK_QUERY_TEXT_LIST:
 		{
 			COPY_STRING_LIST(taskQuery.data.queryStringList);

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -490,12 +490,6 @@ static void WriteTaskQuery(OUTFUNC_ARGS) {
 			break;
 		}
 
-		case TASK_QUERY_TEXT_PER_PLACEMENT:
-		{
-			WRITE_NODE_FIELD(taskQuery.data.perPlacementQueryStrings);
-			break;
-		}
-
 		case TASK_QUERY_TEXT_LIST:
 		{
 			WRITE_NODE_FIELD(taskQuery.data.queryStringList);

--- a/src/include/distributed/deparse_shard_query.h
+++ b/src/include/distributed/deparse_shard_query.h
@@ -26,10 +26,7 @@ extern bool UpdateRelationToShardNames(Node *node, List *relationShardList);
 extern void SetTaskQueryIfShouldLazyDeparse(Task *task, Query *query);
 extern void SetTaskQueryString(Task *task, char *queryString);
 extern void SetTaskQueryStringList(Task *task, List *queryStringList);
-extern void SetTaskPerPlacementQueryStrings(Task *task,
-											List *perPlacementQueryStringList);
-extern char * TaskQueryStringForAllPlacements(Task *task);
-extern char * TaskQueryStringForPlacement(Task *task, int placementIndex);
+extern char * TaskQueryString(Task *task);
 extern bool UpdateRelationsToLocalShardTables(Node *node, List *relationShardList);
 extern int GetTaskQueryType(Task *task);
 

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -17,6 +17,7 @@
 #include "distributed/citus_custom_scan.h"
 #include "distributed/multi_physical_planner.h"
 #include "distributed/multi_server_executor.h"
+#include "distributed/tuple_destination.h"
 
 
 /* managed via guc.c */
@@ -87,11 +88,8 @@ typedef struct ExecutionParams
 	/* taskList contains the tasks for the execution.*/
 	List *taskList;
 
-	/* tupleDescriptor contains the description for the result tuples.*/
-	TupleDesc tupleDescriptor;
-
-	/* tupleStore is where the results will be stored for this execution */
-	Tuplestorestate *tupleStore;
+	/* where to forward each tuple received */
+	TupleDestination *tupleDestination;
 
 	/* expectResults is true if this execution will return some result. */
 	bool expectResults;
@@ -120,10 +118,9 @@ ExecutionParams * CreateBasicExecutionParams(RowModifyLevel modLevel,
 											 bool localExecutionSupported);
 
 extern uint64 ExecuteTaskListExtended(ExecutionParams *executionParams);
-extern uint64 ExecuteTaskListIntoTupleStore(RowModifyLevel modLevel, List *taskList,
-											TupleDesc tupleDescriptor,
-											Tuplestorestate *tupleStore,
-											bool expectResults);
+extern uint64 ExecuteTaskListIntoTupleDest(RowModifyLevel modLevel, List *taskList,
+										   TupleDestination *tupleDest,
+										   bool expectResults);
 extern bool IsCitusCustomState(PlanState *planState);
 extern TupleTableSlot * CitusExecScan(CustomScanState *node);
 extern TupleTableSlot * ReturnTupleFromTuplestore(CitusScanState *scanState);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -208,7 +208,6 @@ typedef enum TaskQueryType
 	TASK_QUERY_NULL,
 	TASK_QUERY_TEXT,
 	TASK_QUERY_OBJECT,
-	TASK_QUERY_TEXT_PER_PLACEMENT,
 	TASK_QUERY_TEXT_LIST
 } TaskQueryType;
 
@@ -238,19 +237,14 @@ typedef struct TaskQuery
 
 		/*
 		 * In almost all cases queryStringLazy should be read only indirectly by
-		 * using TaskQueryStringForAllPlacements(). This will populate the field if only the
+		 * using TaskQueryString(). This will populate the field if only the
 		 * jobQueryReferenceForLazyDeparsing field is not NULL.
 		 *
 		 * This field should only be set by using SetTaskQueryString() (or as a
-		 * side effect from TaskQueryStringForAllPlacements()). Otherwise it might not be in sync
+		 * side effect from TaskQueryString()). Otherwise it might not be in sync
 		 * with jobQueryReferenceForLazyDeparsing.
 		 */
 		char *queryStringLazy;
-
-		/*
-		 * perPlacementQueryStrings is used when we have different query strings for each placement.
-		 */
-		List *perPlacementQueryStrings;
 
 		/*
 		 * queryStringList contains query strings. They should be


### PR DESCRIPTION
Removes the need for `TASK_QUERY_TEXT_PER_PLACEMENT`, which makes the code easier to understand.

In `WrapTasksForPartitioning()` we used to create a different query string per placement which contained Id of the node executed that the query successfully. With the new TupleDestination API, we don't need this anymore since the `putTuple()` method contains `placementIndex` which can be used to get the node Id.

It also makes how we can convert a task to use `TASK_QUERY_TEXT_LIST` more straightforward, which we do in EXPLAIN ANALYZE. This refactor is part of a bigger refactor which aims to facilitate support for `EXPLAIN ANALYZE EXECUTE`.
