### PR TITLE
Clean up task-tracker related comments documentation tests

### DIFF
--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -71,8 +71,6 @@
  *  There are also a few limitations/trade-offs that are worth mentioning.
  *  - The local execution on multiple shards might be slow because the execution
  *  has to happen one task at a time (e.g., no parallelism).
- *  - The local execution cannot be mixed with the executors other than adaptive,
- *  namely task-tracker executor.
  *  - Related with the previous item, COPY command cannot be mixed with local
  *  execution in a transaction. The implication of that is any part of INSERT..SELECT
  *  via coordinator cannot happen via the local execution.

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -3,8 +3,8 @@
  * multi_server_executor.c
  *
  * Function definitions for distributed task execution for adaptive
- * and task-tracker executors, and routines common to both. The common
- * routines are implement backend-side logic; and they trigger executions
+ * executor.
+ * routines are implemented backend-side logic; and they trigger executions
  * on the client-side via function hooks that they load.
  *
  * Copyright (c) Citus Data, Inc.

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1357,8 +1357,7 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
 
 /*
  * FinalizeNonRouterPlan gets the distributed custom scan plan, and creates the
- * final master select plan on the top of this distributed plan for adaptive
- * and task-tracker executors.
+ * final master select plan on the top of this distributed plan for adaptive executor.
  */
 static PlannedStmt *
 FinalizeNonRouterPlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4610,8 +4610,10 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 			uint32 mapTaskNodePort = mapTaskPlacement->nodePort;
 
 			/*
-			 * If replication factor is 1, then we know that we will use the first and
-			 * the only placement.
+			 * We will use the first node even if replication factor is greater than 1
+			 * When replication factor is greater than 1 and there
+			 * is a connection problem to the node that has done the map task, we will get
+			 * an error in fetch task execution.
 			 */
 			StringInfo mapFetchQueryString = makeStringInfo();
 			appendStringInfo(mapFetchQueryString, MAP_OUTPUT_FETCH_COMMAND,

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4611,9 +4611,7 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 
 			/*
 			 * If replication factor is 1, then we know that we will use the first and
-			 * the only placement. If task tracker is used, then it will regenerate the
-			 * query string because if there are multiple placements then it does not
-			 * know in which placement the parent map task was successful.
+			 * the only placement.
 			 */
 			StringInfo mapFetchQueryString = makeStringInfo();
 			appendStringInfo(mapFetchQueryString, MAP_OUTPUT_FETCH_COMMAND,

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -25,9 +25,6 @@
  *   subqueries if the subquery can be executed on each shard by replacing
  *   table names with shard names and concatenating the result.
  *
- * - Task-tracker queries that can be executed through a tree of
- *   re-partitioning operations.
- *
  *   These queries have very limited SQL support and only support basic
  *   inner joins and subqueries without joins.
  *

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1249,10 +1249,7 @@ RegisterCitusConfigVariables(void)
 		gettext_noop("The master node chooses between two different executor types "
 					 "when executing a distributed query.The adaptive executor is "
 					 "optimal for simple key-value lookup queries and queries that "
-					 "involve aggregations and/or co-located joins on multiple shards. "
-					 "The task-tracker executor is optimal for long-running, complex "
-					 "queries that touch thousands of shards and/or that involve table "
-					 "repartitioning."),
+					 "involve aggregations and/or co-located joins on multiple shards. "),
 		&TaskExecutorType,
 		MULTI_EXECUTOR_ADAPTIVE,
 		task_executor_type_options,
@@ -1262,7 +1259,7 @@ RegisterCitusConfigVariables(void)
 
 	DefineCustomBoolVariable(
 		"citus.enable_repartition_joins",
-		gettext_noop("Allows Citus to use task-tracker executor when necessary."),
+		gettext_noop("Allows Citus to repartition data between nodes."),
 		NULL,
 		&EnableRepartitionJoins,
 		false,

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -2,10 +2,8 @@
  *
  * task_tracker_protocol.c
  *
- * The task tracker background process runs on every worker node. The following
- * routines allow for the master node to assign tasks to the task tracker, check
- * these tasks' statuses, and remove these tasks when they are no longer needed.
- *
+ * The methods in the file are deprecated.
+ * 
  * Copyright (c) Citus Data, Inc.
  *
  * $Id$
@@ -25,11 +23,7 @@ PG_FUNCTION_INFO_V1(task_tracker_cleanup_job);
 PG_FUNCTION_INFO_V1(task_tracker_conninfo_cache_invalidate);
 
 
-/*
- * task_tracker_assign_task creates a new task in the shared hash or updates an
- * already existing task. The function also creates a schema for the job if it
- * doesn't already exist.
- */
+/* This UDF is deprecated.*/
 Datum
 task_tracker_assign_task(PG_FUNCTION_ARGS)
 {
@@ -39,7 +33,7 @@ task_tracker_assign_task(PG_FUNCTION_ARGS)
 }
 
 
-/* Returns the task status of an already existing task. */
+/* This UDF is deprecated.*/
 Datum
 task_tracker_task_status(PG_FUNCTION_ARGS)
 {
@@ -49,10 +43,7 @@ task_tracker_task_status(PG_FUNCTION_ARGS)
 }
 
 
-/*
- * task_tracker_cleanup_job finds all tasks for the given job, and cleans up
- * files, connections, and shared hash enties associated with these tasks.
- */
+/* This UDF is deprecated.*/
 Datum
 task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 {
@@ -62,13 +53,7 @@ task_tracker_cleanup_job(PG_FUNCTION_ARGS)
 }
 
 
-/*
- * task_tracker_conninfo_cache_invalidate is a trigger function that signals to
- * the task tracker to refresh its conn params cache after an authinfo change.
- *
- * NB: We decided there is little point in checking permissions here, there
- * are much easier ways to waste CPU than causing cache invalidations.
- */
+/* This UDF is deprecated.*/
 Datum
 task_tracker_conninfo_cache_invalidate(PG_FUNCTION_ARGS)
 {

--- a/src/backend/distributed/worker/task_tracker_protocol.c
+++ b/src/backend/distributed/worker/task_tracker_protocol.c
@@ -3,7 +3,7 @@
  * task_tracker_protocol.c
  *
  * The methods in the file are deprecated.
- * 
+ *
  * Copyright (c) Citus Data, Inc.
  *
  * $Id$

--- a/src/backend/distributed/worker/worker_merge_protocol.c
+++ b/src/backend/distributed/worker/worker_merge_protocol.c
@@ -163,7 +163,7 @@ worker_repartition_cleanup(PG_FUNCTION_ARGS)
 
 /*
  * worker_merge_files_into_table creates a task table within the job's schema,
- * which should have already been created by the task tracker protocol, and
+ * which should have already been created by repartition join execution, and
  * copies files in its task directory into this table. If the schema doesn't
  * exist, the function defaults to the 'public' schema. Note that, unlike
  * partitioning functions, this function is not always idempotent. On success,
@@ -200,8 +200,8 @@ worker_merge_files_into_table(PG_FUNCTION_ARGS)
 	}
 
 	/*
-	 * If the schema for the job isn't already created by the task tracker
-	 * protocol, we fall to using the default 'public' schema.
+	 * If the schema for the job isn't already created by the repartition join
+	 * execution, we fall to using the default 'public' schema.
 	 */
 	bool schemaExists = JobSchemaExists(jobSchemaName);
 	if (!schemaExists)
@@ -245,18 +245,7 @@ worker_merge_files_into_table(PG_FUNCTION_ARGS)
 }
 
 
-/*
- * worker_merge_files_and_run_query creates a merge task table within the job's
- * schema, which should have already been created by the task tracker protocol.
- * It copies files in its task directory into this table. Then it runs final
- * query to create result table of the job.
- *
- * Note that here we followed a different approach to create a task table for merge
- * files than worker_merge_files_into_table(). In future we should unify these
- * two approaches. For this purpose creating a directory_fdw extension and using
- * it would make sense. Then we can merge files with a query or without query
- * through directory_fdw.
- */
+/* This UDF is deprecated.*/
 Datum
 worker_merge_files_and_run_query(PG_FUNCTION_ARGS)
 {

--- a/src/backend/distributed/worker/worker_partition_protocol.c
+++ b/src/backend/distributed/worker/worker_partition_protocol.c
@@ -372,10 +372,6 @@ ArrayObjectCount(ArrayType *arrayObject)
 StringInfo
 InitTaskDirectory(uint64 jobId, uint32 taskId)
 {
-	/*
-	 * If the task tracker assigned this task (regular case), the tracker should
-	 * have already created the job directory.
-	 */
 	StringInfo jobDirectoryName = JobDirectoryName(jobId);
 	StringInfo taskDirectoryName = TaskDirectoryName(jobId, taskId);
 

--- a/src/backend/distributed/worker/worker_sql_task_protocol.c
+++ b/src/backend/distributed/worker/worker_sql_task_protocol.c
@@ -2,7 +2,7 @@
  *
  * worker_sql_task_protocol.c
  *
- * Routines for executing SQL tasks during task-tracker execution.
+ * Routines for executing SQL tasks.
  *
  * Copyright (c) Citus Data, Inc.
  *

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -42,7 +42,7 @@ output_files := $(patsubst $(citus_abs_srcdir)/output/%.source,expected/%.out, $
 # intermediate, for muscle memory backward compatibility.
 check: check-full
 # check-full triggers all tests that ought to be run routinely
-check-full: check-multi check-multi-mx check-multi-task-tracker-extra check-worker check-follower-cluster check-failure
+check-full: check-multi check-multi-mx check-worker check-follower-cluster check-failure
 
 
 ISOLATION_DEPDIR=.deps/isolation

--- a/src/test/regress/expected/isolation_append_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_append_copy_vs_all.out
@@ -52,14 +52,14 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY append_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -392,13 +392,13 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-copy s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY append_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -52,14 +52,14 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -485,13 +485,13 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-copy s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 

--- a/src/test/regress/expected/isolation_partitioned_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_partitioned_copy_vs_all.out
@@ -52,14 +52,14 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -328,13 +328,13 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-copy s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY partitioned_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 

--- a/src/test/regress/expected/isolation_range_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_range_copy_vs_all.out
@@ -52,14 +52,14 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY range_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -406,13 +406,13 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-copy s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY range_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 

--- a/src/test/regress/expected/isolation_reference_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_reference_copy_vs_all.out
@@ -52,14 +52,14 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-copy s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-copy s2-adaptive-select s1-commit s1-select-count
 create_reference_table
 
 
 step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5  && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-task-tracker-select:
+step s2-adaptive-select:
 		SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data
@@ -374,13 +374,13 @@ count
 
 10
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-copy s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-copy s1-commit s1-select-count
 create_reference_table
 
 
 step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
 		SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id             data           int_data       id             data           int_data

--- a/src/test/regress/expected/isolation_select_vs_all.out
+++ b/src/test/regress/expected/isolation_select_vs_all.out
@@ -50,7 +50,7 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-router-select s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-router-select s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
@@ -60,7 +60,7 @@ step s1-router-select: SELECT * FROM select_append WHERE id = 1;
 id             data           int_data
 
 1               b             1
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -138,7 +138,7 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-real-time-select s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-real-time-select s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
@@ -152,7 +152,7 @@ id             data           int_data
 2               c             2
 3               d             3
 4               e             4
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -172,13 +172,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-router-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-router-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -202,13 +202,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-real-time-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-real-time-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -236,13 +236,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -253,7 +253,7 @@ id             data           int_data       id             data           int_d
 2               c             2              2               c             2
 3               d             3              3               d             3
 4               e             4              4               e             4
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1765,13 +1765,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-insert s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-insert s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1792,13 +1792,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-insert-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-insert-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1819,13 +1819,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-update s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-update s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1846,13 +1846,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-delete s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-delete s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1873,13 +1873,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-truncate s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-truncate s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1901,13 +1901,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-drop s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-drop s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1927,13 +1927,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-ddl-create-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1959,14 +1959,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-task-tracker-select s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-adaptive-select s2-ddl-drop-index s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -1993,13 +1993,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2025,13 +2025,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-add-column s1-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-ddl-add-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2058,14 +2058,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-task-tracker-select s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-adaptive-select s2-ddl-drop-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2092,13 +2092,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-ddl-rename-column s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2125,13 +2125,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-table-size s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-table-size s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2155,13 +2155,13 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-task-tracker-select s2-master-modify-multiple-shards s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-adaptive-select s2-master-modify-multiple-shards s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2182,14 +2182,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-task-tracker-select s2-distribute-table s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-adaptive-select s2-distribute-table s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-drop: DROP TABLE select_append;
 step s1-create-non-distributed-table: CREATE TABLE select_append(id integer, data text, int_data int);
 step s1-begin: BEGIN;
-step s1-task-tracker-select:
+step s1-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2208,14 +2208,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-insert s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-insert s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert: INSERT INTO select_append VALUES(0, 'k', 0);
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2235,14 +2235,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-insert-select s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-insert-select s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-insert-select: INSERT INTO select_append SELECT * FROM select_append;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2262,14 +2262,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-update s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-update s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-update: UPDATE select_append SET data = 'l' WHERE id = 0;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2289,14 +2289,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-delete s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-delete s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-delete: DELETE FROM select_append WHERE id = 1;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2316,19 +2316,19 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-truncate s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-truncate s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-truncate: TRUNCATE select_append;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
-step s2-task-tracker-select: <... completed>
+step s2-adaptive-select: <... completed>
 id             data           int_data       id             data           int_data
 
 step s1-select-count: SELECT COUNT(*) FROM select_append;
@@ -2339,34 +2339,34 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-drop s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-drop s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-drop: DROP TABLE select_append;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
-step s2-task-tracker-select: <... completed>
-error in steps s1-commit s2-task-tracker-select: ERROR:  relation "select_append" does not exist
+step s2-adaptive-select: <... completed>
+error in steps s1-commit s2-adaptive-select: ERROR:  relation "select_append" does not exist
 step s1-select-count: SELECT COUNT(*) FROM select_append;
 ERROR:  relation "select_append" does not exist
 restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-task-tracker-select s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-ddl-create-index s2-adaptive-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2391,7 +2391,7 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-task-tracker-select s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-ddl-create-index s1-begin s1-ddl-drop-index s2-adaptive-select s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 
 
@@ -2399,12 +2399,12 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 
 step s1-ddl-create-index: CREATE INDEX select_append_index ON select_append(id);
 step s1-begin: BEGIN;
 step s1-ddl-drop-index: DROP INDEX select_append_index;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
-step s2-task-tracker-select: <... completed>
+step s2-adaptive-select: <... completed>
 id             data           int_data       id             data           int_data
 
 0               a             0              0               a             0
@@ -2425,19 +2425,19 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-task-tracker-select s1-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s1-begin s1-ddl-add-column s2-adaptive-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
-step s2-task-tracker-select: <... completed>
+step s2-adaptive-select: <... completed>
 id             data           int_data       new_column     id             data           int_data       new_column
 
 0               a             0              0              0               a             0              0
@@ -2458,7 +2458,7 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-task-tracker-select s1-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s1-ddl-add-column s1-begin s1-ddl-drop-column s2-adaptive-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
 
@@ -2466,12 +2466,12 @@ step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 
 step s1-ddl-add-column: ALTER TABLE select_append ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
 step s1-ddl-drop-column: ALTER TABLE select_append DROP new_column;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
-step s2-task-tracker-select: <... completed>
+step s2-adaptive-select: <... completed>
 id             data           int_data       id             data           int_data
 
 0               a             0              0               a             0
@@ -2492,19 +2492,19 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-task-tracker-select s1-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s1-begin s1-ddl-rename-column s2-adaptive-select s1-commit s1-select-count s1-show-columns
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-ddl-rename-column: ALTER TABLE select_append RENAME data TO new_column;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
  <waiting ...>
 step s1-commit: COMMIT;
-step s2-task-tracker-select: <... completed>
+step s2-adaptive-select: <... completed>
 id             new_column     int_data       id             new_column     int_data
 
 0               a             0              0               a             0
@@ -2525,7 +2525,7 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-table-size s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-table-size s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
@@ -2535,7 +2535,7 @@ step s1-table-size: SELECT citus_total_relation_size('select_append');
 citus_total_relation_size
 
 32768
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2555,14 +2555,14 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-initialize s1-begin s1-master-modify-multiple-shards s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
 step s1-initialize: COPY select_append FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-master-modify-multiple-shards: DELETE FROM select_append;
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
@@ -2582,7 +2582,7 @@ restore_isolation_tester_func
 
 
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-task-tracker-select s1-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-begin s1-distribute-table s2-adaptive-select s1-commit s1-select-count
 create_distributed_table
 
 
@@ -2593,7 +2593,7 @@ step s1-distribute-table: SELECT create_distributed_table('select_append', 'id',
 create_distributed_table
 
 
-step s2-task-tracker-select:
+step s2-adaptive-select:
   SET citus.enable_repartition_joins TO ON;
  SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 

--- a/src/test/regress/expected/limit_intermediate_size.out
+++ b/src/test/regress/expected/limit_intermediate_size.out
@@ -15,7 +15,7 @@ ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size 
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 SET citus.max_intermediate_result_size TO 9;
--- regular task-tracker CTE should fail
+-- regular adaptive CTE should fail
 WITH cte AS
 (
 	SELECT
@@ -203,7 +203,7 @@ SELECT * FROM cte4 ORDER BY 1,2,3,4,5 LIMIT 5;
        1 | Wed Nov 22 21:06:57.457147 2017 |       4 |       3 |       2 |
 (5 rows)
 
--- regular task-tracker CTE, should work since -1 disables the limit
+-- regular adaptive CTE, should work since -1 disables the limit
 WITH cte AS
 (
 	SELECT

--- a/src/test/regress/expected/limit_intermediate_size.out
+++ b/src/test/regress/expected/limit_intermediate_size.out
@@ -15,7 +15,6 @@ ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size 
 DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
 HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
 SET citus.max_intermediate_result_size TO 9;
--- regular adaptive CTE should fail
 WITH cte AS
 (
 	SELECT
@@ -203,7 +202,7 @@ SELECT * FROM cte4 ORDER BY 1,2,3,4,5 LIMIT 5;
        1 | Wed Nov 22 21:06:57.457147 2017 |       4 |       3 |       2 |
 (5 rows)
 
--- regular adaptive CTE, should work since -1 disables the limit
+-- regular adaptive executor CTE, should work since -1 disables the limit
 WITH cte AS
 (
 	SELECT

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -1401,7 +1401,7 @@ ROLLBACK;
 BEGIN;
 	DELETE FROM distributed_table WHERE key = 500;
 NOTICE:  executing the command locally: DELETE FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE (key OPERATOR(pg_catalog.=) 500)
-	SET LOCAL citus.task_executor_type = 'task-tracker';
+	
 	SELECT count(*) FROM distributed_table;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE true
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE true
@@ -1414,7 +1414,7 @@ ROLLBACK;
 -- local execution should not be executed locally
 -- becase a task-tracker query has already been executed
 BEGIN;
-	SET LOCAL citus.task_executor_type = 'task-tracker';
+	
 	SET LOCAL client_min_messages TO INFO;
 	SELECT count(*) FROM distributed_table;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE true

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -1397,11 +1397,9 @@ NOTICE:  executing the command locally: DELETE FROM local_shard_execution.refere
 	DELETE FROM reference_table;
 NOTICE:  executing the command locally: DELETE FROM local_shard_execution.reference_table_1470000 reference_table
 ROLLBACK;
--- adaptive select execution
 BEGIN;
 	DELETE FROM distributed_table WHERE key = 500;
 NOTICE:  executing the command locally: DELETE FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE (key OPERATOR(pg_catalog.=) 500)
-	
 	SELECT count(*) FROM distributed_table;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE true
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE true
@@ -1411,10 +1409,7 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 (1 row)
 
 ROLLBACK;
--- local execution should not be executed locally
--- becase a adaptive query has already been executed
 BEGIN;
-	
 	SET LOCAL client_min_messages TO INFO;
 	SELECT count(*) FROM distributed_table;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shard_execution.distributed_table_1470001 distributed_table WHERE true

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -1397,7 +1397,7 @@ NOTICE:  executing the command locally: DELETE FROM local_shard_execution.refere
 	DELETE FROM reference_table;
 NOTICE:  executing the command locally: DELETE FROM local_shard_execution.reference_table_1470000 reference_table
 ROLLBACK;
--- task-tracker select execution
+-- adaptive select execution
 BEGIN;
 	DELETE FROM distributed_table WHERE key = 500;
 NOTICE:  executing the command locally: DELETE FROM local_shard_execution.distributed_table_1470003 distributed_table WHERE (key OPERATOR(pg_catalog.=) 500)
@@ -1412,7 +1412,7 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 
 ROLLBACK;
 -- local execution should not be executed locally
--- becase a task-tracker query has already been executed
+-- becase a adaptive query has already been executed
 BEGIN;
 	
 	SET LOCAL client_min_messages TO INFO;

--- a/src/test/regress/expected/multi_cross_shard.out
+++ b/src/test/regress/expected/multi_cross_shard.out
@@ -172,7 +172,6 @@ INSERT INTO tt1 VALUES(1, 'Ahmet');
 INSERT INTO tt1 VALUES(2, 'Mehmet');
 INSERT INTO tt2 VALUES(1, 'Ahmet', 5);
 INSERT INTO tt2 VALUES(2, 'Mehmet', 15);
--- Should notice since it is a adaptive query
 SELECT tt1.id, tt2.count from tt1,tt2 where tt1.id = tt2.id ORDER BY 1;
 NOTICE:  multi-task query about to be executed
 HINT:  Queries are split to multiple tasks if they have to be split into several queries on the workers.

--- a/src/test/regress/expected/multi_cross_shard.out
+++ b/src/test/regress/expected/multi_cross_shard.out
@@ -145,7 +145,6 @@ SELECT * FROM raw_table WHERE ID = 1;
   1 |          20
 (2 rows)
 
--- Task tracker query test
 CREATE TABLE tt1
 (
 	id int,

--- a/src/test/regress/expected/multi_cross_shard.out
+++ b/src/test/regress/expected/multi_cross_shard.out
@@ -172,7 +172,7 @@ INSERT INTO tt1 VALUES(1, 'Ahmet');
 INSERT INTO tt1 VALUES(2, 'Mehmet');
 INSERT INTO tt2 VALUES(1, 'Ahmet', 5);
 INSERT INTO tt2 VALUES(2, 'Mehmet', 15);
--- Should notice since it is a task-tracker query
+-- Should notice since it is a adaptive query
 SELECT tt1.id, tt2.count from tt1,tt2 where tt1.id = tt2.id ORDER BY 1;
 NOTICE:  multi-task query about to be executed
 HINT:  Queries are split to multiple tasks if they have to be split into several queries on the workers.

--- a/src/test/regress/expected/multi_join_order_additional.out
+++ b/src/test/regress/expected/multi_join_order_additional.out
@@ -5,7 +5,7 @@ SET citus.next_shard_id TO 650000;
 -- Set configuration to print table join order and pruned shards
 SET citus.explain_distributed_queries TO off;
 SET citus.log_multi_join_order TO TRUE;
-SET citus.task_executor_type = 'task-tracker'; -- can't explain all queries otherwise
+SET citus.task_executor_type = 'adaptive'; -- can't explain all queries otherwise
 SET citus.enable_repartition_joins to ON;
 SET citus.shard_count to 2;
 SET citus.shard_replication_factor to 1;

--- a/src/test/regress/expected/multi_join_order_additional.out
+++ b/src/test/regress/expected/multi_join_order_additional.out
@@ -5,7 +5,6 @@ SET citus.next_shard_id TO 650000;
 -- Set configuration to print table join order and pruned shards
 SET citus.explain_distributed_queries TO off;
 SET citus.log_multi_join_order TO TRUE;
-SET citus.task_executor_type = 'adaptive'; -- can't explain all queries otherwise
 SET citus.enable_repartition_joins to ON;
 SET citus.shard_count to 2;
 SET citus.shard_replication_factor to 1;

--- a/src/test/regress/expected/multi_join_order_tpch_repartition.out
+++ b/src/test/regress/expected/multi_join_order_tpch_repartition.out
@@ -5,7 +5,7 @@ SET citus.next_shard_id TO 660000;
 -- Enable configuration to print table join order
 SET citus.explain_distributed_queries TO off;
 SET citus.log_multi_join_order TO TRUE;
-SET citus.task_executor_type = 'task-tracker'; -- can't explain all queries otherwise
+SET citus.task_executor_type = 'adaptive'; -- can't explain all queries otherwise
 SET citus.enable_repartition_joins to ON;
 SET client_min_messages TO LOG;
 -- The following queries are basically the same as the ones in tpch_small

--- a/src/test/regress/expected/multi_join_order_tpch_repartition.out
+++ b/src/test/regress/expected/multi_join_order_tpch_repartition.out
@@ -5,7 +5,6 @@ SET citus.next_shard_id TO 660000;
 -- Enable configuration to print table join order
 SET citus.explain_distributed_queries TO off;
 SET citus.log_multi_join_order TO TRUE;
-SET citus.task_executor_type = 'adaptive'; -- can't explain all queries otherwise
 SET citus.enable_repartition_joins to ON;
 SET client_min_messages TO LOG;
 -- The following queries are basically the same as the ones in tpch_small

--- a/src/test/regress/expected/multi_mx_repartition_udt_prepare.out
+++ b/src/test/regress/expected/multi_mx_repartition_udt_prepare.out
@@ -152,7 +152,6 @@ INSERT INTO repartition_udt_other values (10, '(2,1)'::test_udt, 'foo');
 INSERT INTO repartition_udt_other values (11, '(2,2)'::test_udt, 'foo');
 INSERT INTO repartition_udt_other values (12, '(2,3)'::test_udt, 'foo');
 SET client_min_messages = LOG;
-SET citus.task_executor_type = 'adaptive';
 SET citus.enable_repartition_joins to ON;
 -- Query that should result in a repartition
 -- join on int column, and be empty.

--- a/src/test/regress/expected/multi_mx_repartition_udt_prepare.out
+++ b/src/test/regress/expected/multi_mx_repartition_udt_prepare.out
@@ -152,7 +152,7 @@ INSERT INTO repartition_udt_other values (10, '(2,1)'::test_udt, 'foo');
 INSERT INTO repartition_udt_other values (11, '(2,2)'::test_udt, 'foo');
 INSERT INTO repartition_udt_other values (12, '(2,3)'::test_udt, 'foo');
 SET client_min_messages = LOG;
-SET citus.task_executor_type = 'task-tracker';
+SET citus.task_executor_type = 'adaptive';
 SET citus.enable_repartition_joins to ON;
 -- Query that should result in a repartition
 -- join on int column, and be empty.

--- a/src/test/regress/expected/multi_mx_router_planner.out
+++ b/src/test/regress/expected/multi_mx_router_planner.out
@@ -1418,13 +1418,6 @@ SET client_min_messages to 'DEBUG2';
 CREATE MATERIALIZED VIEW mv_articles_hash_mx_error AS
 	SELECT * FROM articles_hash_mx WHERE author_id in (1,2);
 DEBUG:  Router planner cannot handle multi-shard select queries
--- router planner/executor is disabled for adaptive executor
--- following query is router plannable, but router planner is disabled
--- TODO: Uncomment once we fix adaptive issue
-----SELECT id
---	FROM articles_hash_mx
---	WHERE author_id = 1;
--- insert query is router plannable even under adaptive
 INSERT INTO articles_hash_mx VALUES (51,  1, 'amateus', 1814);
 DEBUG:  Creating router plan
 DEBUG:  query has a single distribution column value: 1

--- a/src/test/regress/expected/multi_mx_router_planner.out
+++ b/src/test/regress/expected/multi_mx_router_planner.out
@@ -1418,13 +1418,13 @@ SET client_min_messages to 'DEBUG2';
 CREATE MATERIALIZED VIEW mv_articles_hash_mx_error AS
 	SELECT * FROM articles_hash_mx WHERE author_id in (1,2);
 DEBUG:  Router planner cannot handle multi-shard select queries
--- router planner/executor is disabled for task-tracker executor
+-- router planner/executor is disabled for adaptive executor
 -- following query is router plannable, but router planner is disabled
--- TODO: Uncomment once we fix task-tracker issue
+-- TODO: Uncomment once we fix adaptive issue
 ----SELECT id
 --	FROM articles_hash_mx
 --	WHERE author_id = 1;
--- insert query is router plannable even under task-tracker
+-- insert query is router plannable even under adaptive
 INSERT INTO articles_hash_mx VALUES (51,  1, 'amateus', 1814);
 DEBUG:  Creating router plan
 DEBUG:  query has a single distribution column value: 1

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1299,7 +1299,7 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
 (3 rows)
 
 COMMIT;
--- test locks on task-tracker SELECT
+-- test locks on adaptive SELECT
 BEGIN;
 SELECT * FROM partitioning_locks AS pl1 JOIN partitioning_locks AS pl2 ON pl1.id = pl2.ref_id ORDER BY 1, 2;
  id | ref_id | time | id | ref_id | time

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1299,7 +1299,6 @@ SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass
 (3 rows)
 
 COMMIT;
--- test locks on adaptive SELECT
 BEGIN;
 SELECT * FROM partitioning_locks AS pl1 JOIN partitioning_locks AS pl2 ON pl1.id = pl2.ref_id ORDER BY 1, 2;
  id | ref_id | time | id | ref_id | time

--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -739,7 +739,6 @@ SELECT real_time_partition_column_select(6);
  (6,)
 (4 rows)
 
--- check adaptive executor
 CREATE FUNCTION task_tracker_non_partition_column_select(value_arg int)
 	RETURNS TABLE(key int, value int) AS $$
 DECLARE

--- a/src/test/regress/expected/multi_prepare_plsql.out
+++ b/src/test/regress/expected/multi_prepare_plsql.out
@@ -739,7 +739,7 @@ SELECT real_time_partition_column_select(6);
  (6,)
 (4 rows)
 
--- check task-tracker executor
+-- check adaptive executor
 CREATE FUNCTION task_tracker_non_partition_column_select(value_arg int)
 	RETURNS TABLE(key int, value int) AS $$
 DECLARE

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -763,7 +763,7 @@ EXECUTE prepared_real_time_partition_column_select(6);
    6 |
 (4 rows)
 
--- check task-tracker executor
+-- check adaptive executor
 PREPARE prepared_task_tracker_non_partition_column_select(int) AS
 	SELECT
 		prepare_table.key,

--- a/src/test/regress/expected/multi_prepare_sql.out
+++ b/src/test/regress/expected/multi_prepare_sql.out
@@ -763,7 +763,6 @@ EXECUTE prepared_real_time_partition_column_select(6);
    6 |
 (4 rows)
 
--- check adaptive executor
 PREPARE prepared_task_tracker_non_partition_column_select(int) AS
 	SELECT
 		prepare_table.key,

--- a/src/test/regress/expected/multi_repartition_join_planning.out
+++ b/src/test/regress/expected/multi_repartition_join_planning.out
@@ -3,8 +3,7 @@
 --
 -- Tests that cover repartition join planning. Note that we explicitly start a
 -- transaction block here so that we don't emit debug messages with changing
--- transaction ids in them. Also, we set the executor type to task tracker
--- executor here, as we cannot run repartition jobs with real time executor.
+-- transaction ids in them.
 SET citus.next_shard_id TO 690000;
 SET citus.enable_unique_job_ids TO off;
 SET citus.enable_repartition_joins to ON;

--- a/src/test/regress/expected/multi_repartition_join_pruning.out
+++ b/src/test/regress/expected/multi_repartition_join_pruning.out
@@ -1,9 +1,7 @@
 --
 -- MULTI_REPARTITION_JOIN_PRUNING
 --
--- Tests covering partition and join-pruning for repartition joins. Note that we
--- set executor type to task tracker executor here, as we cannot run repartition
--- jobs with real time executor.
+-- Tests covering partition and join-pruning for repartition joins.
 SET citus.next_shard_id TO 700000;
 SET client_min_messages TO DEBUG2;
 SET citus.enable_repartition_joins to ON;

--- a/src/test/regress/expected/multi_repartition_udt.out
+++ b/src/test/regress/expected/multi_repartition_udt.out
@@ -164,7 +164,7 @@ SELECT * FROM repartition_udt JOIN repartition_udt_other
 (0 rows)
 
 -- Query that should result in a repartition join on UDT column.
-SET citus.task_executor_type = 'task-tracker';
+SET citus.task_executor_type = 'adaptive';
 SET citus.log_multi_join_order = true;
 EXPLAIN (COSTS OFF)
 SELECT * FROM repartition_udt JOIN repartition_udt_other

--- a/src/test/regress/expected/multi_repartition_udt.out
+++ b/src/test/regress/expected/multi_repartition_udt.out
@@ -164,7 +164,6 @@ SELECT * FROM repartition_udt JOIN repartition_udt_other
 (0 rows)
 
 -- Query that should result in a repartition join on UDT column.
-SET citus.task_executor_type = 'adaptive';
 SET citus.log_multi_join_order = true;
 EXPLAIN (COSTS OFF)
 SELECT * FROM repartition_udt JOIN repartition_udt_other

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -2278,7 +2278,7 @@ SELECT * FROM mv_articles_hash_data ORDER BY 1, 2, 3, 4;
  42 |         2 | ausable      |      15885
 (10 rows)
 
--- router planner/executor is now enabled for task-tracker executor
+-- router planner/executor is now enabled for adaptive executor
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1
@@ -2294,7 +2294,7 @@ DEBUG:  query has a single distribution column value: 1
  41
 (5 rows)
 
--- insert query is router plannable even under task-tracker
+-- insert query is router plannable even under adaptive
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 DEBUG:  Creating router plan
 DEBUG:  query has a single distribution column value: 1

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -2278,7 +2278,6 @@ SELECT * FROM mv_articles_hash_data ORDER BY 1, 2, 3, 4;
  42 |         2 | ausable      |      15885
 (10 rows)
 
--- router planner/executor is now enabled for adaptive executor
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1
@@ -2294,7 +2293,6 @@ DEBUG:  query has a single distribution column value: 1
  41
 (5 rows)
 
--- insert query is router plannable even under adaptive
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 DEBUG:  Creating router plan
 DEBUG:  query has a single distribution column value: 1

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -1995,7 +1995,7 @@ SELECT * FROM mv_articles_hash_empty;
  41 |         1 | aznavour     |      11814
 (5 rows)
 
--- fast-path router planner/executor is enabled for task-tracker executor
+-- fast-path router planner/executor is enabled for adaptive executor
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1;
@@ -2011,7 +2011,7 @@ DEBUG:  query has a single distribution column value: 1
  41
 (5 rows)
 
--- insert query is router plannable even under task-tracker
+-- insert query is router plannable even under adaptive
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 DEBUG:  Creating router plan
 DEBUG:  query has a single distribution column value: 1

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -1995,7 +1995,6 @@ SELECT * FROM mv_articles_hash_empty;
  41 |         1 | aznavour     |      11814
 (5 rows)
 
--- fast-path router planner/executor is enabled for adaptive executor
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1;
@@ -2011,7 +2010,6 @@ DEBUG:  query has a single distribution column value: 1
  41
 (5 rows)
 
--- insert query is router plannable even under adaptive
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 DEBUG:  Creating router plan
 DEBUG:  query has a single distribution column value: 1

--- a/src/test/regress/expected/multi_simple_queries_0.out
+++ b/src/test/regress/expected/multi_simple_queries_0.out
@@ -215,12 +215,12 @@ SELECT * FROM articles, position('om' in 'Thomas') ORDER BY 2 DESC, 1 DESC, 3 DE
 
 -- subqueries are supported in WHERE clause in Citus even if the relations are not distributed
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
-ERROR:  Complex subqueries and CTEs are not supported when task_executor_type is set to 'task-tracker'
+ERROR:  Complex subqueries and CTEs are not supported when task_executor_type is set to 'adaptive'
 -- subqueries are supported in FROM clause
 SELECT articles.id,test.word_count
 FROM articles, (SELECT id, word_count FROM articles) AS test WHERE test.id = articles.id
 ORDER BY articles.id;
-ERROR:  Complex subqueries and CTEs are not supported when task_executor_type is set to 'task-tracker'
+ERROR:  Complex subqueries and CTEs are not supported when task_executor_type is set to 'adaptive'
 -- subqueries are not supported in SELECT clause
 SELECT a.title AS name, (SELECT a2.id FROM articles_single_shard a2 WHERE a.id = a2.id  LIMIT 1)
 						 AS special_price FROM articles a;

--- a/src/test/regress/expected/single_hash_repartition_join.out
+++ b/src/test/regress/expected/single_hash_repartition_join.out
@@ -519,7 +519,7 @@ SELECT create_distributed_table('dist_1', 'a');
 (1 row)
 
 INSERT INTO dist_1 SELECT x,10-x FROM generate_series(1,10) x;
-SET citus.task_executor_type to 'task-tracker';
+SET citus.task_executor_type to 'adaptive';
 SELECT COUNT(*) FROM dist_1 f, dist_1 s WHERE f.a = s.b;
  count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/single_hash_repartition_join.out
+++ b/src/test/regress/expected/single_hash_repartition_join.out
@@ -519,7 +519,6 @@ SELECT create_distributed_table('dist_1', 'a');
 (1 row)
 
 INSERT INTO dist_1 SELECT x,10-x FROM generate_series(1,10) x;
-SET citus.task_executor_type to 'adaptive';
 SELECT COUNT(*) FROM dist_1 f, dist_1 s WHERE f.a = s.b;
  count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -266,8 +266,6 @@ SELECT count(*) FROM test WHERE false GROUP BY GROUPING SETS (x,y);
 (0 rows)
 
 RESET citus.task_assignment_policy;
--- single node task tracker tests:
-SET citus.task_executor_type to 'task-tracker';
 SELECT count(*) FROM test;
  count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/with_executors.out
+++ b/src/test/regress/expected/with_executors.out
@@ -375,7 +375,7 @@ SELECT count(*) FROM cte, users_table where cte.count=user_id;
      0
 (1 row)
 
-SET citus.task_executor_type='task-tracker';
+
 -- CTEs shouldn't be able to terminate a task-tracker query
 WITH cte_1 AS (
 	SELECT

--- a/src/test/regress/expected/with_executors.out
+++ b/src/test/regress/expected/with_executors.out
@@ -1,4 +1,4 @@
--- Confirm we can use local, router, real-time, and task-tracker execution
+-- Confirm we can use local, router, real-time, and adaptive execution
 CREATE SCHEMA with_executors;
 SET search_path TO with_executors, public;
 SET citus.enable_repartition_joins TO on;
@@ -152,7 +152,7 @@ SELECT * FROM cte WHERE uid=1 ORDER BY 2 LIMIT 5;
    1 |          0
 (5 rows)
 
--- CTEs should be able to use task-tracker queries
+-- CTEs should be able to use adaptive queries
 WITH cte AS (
 	WITH task_tracker_1 AS (
 		SELECT
@@ -376,7 +376,7 @@ SELECT count(*) FROM cte, users_table where cte.count=user_id;
 (1 row)
 
 
--- CTEs shouldn't be able to terminate a task-tracker query
+-- CTEs shouldn't be able to terminate a adaptive query
 WITH cte_1 AS (
 	SELECT
 		u_table.user_id as u_id, e_table.event_type

--- a/src/test/regress/expected/with_executors.out
+++ b/src/test/regress/expected/with_executors.out
@@ -1,4 +1,4 @@
--- Confirm we can use local, router, real-time, and adaptive execution
+-- Confirm we can use local, and adaptive execution
 CREATE SCHEMA with_executors;
 SET search_path TO with_executors, public;
 SET citus.enable_repartition_joins TO on;
@@ -152,7 +152,7 @@ SELECT * FROM cte WHERE uid=1 ORDER BY 2 LIMIT 5;
    1 |          0
 (5 rows)
 
--- CTEs should be able to use adaptive queries
+-- CTEs should be able to use adaptive executor
 WITH cte AS (
 	WITH task_tracker_1 AS (
 		SELECT
@@ -375,8 +375,6 @@ SELECT count(*) FROM cte, users_table where cte.count=user_id;
      0
 (1 row)
 
-
--- CTEs shouldn't be able to terminate a adaptive query
 WITH cte_1 AS (
 	SELECT
 		u_table.user_id as u_id, e_table.event_type

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -409,7 +409,6 @@ push(@pgOptions, '-c', "wal_level=logical");
 # Citus options set for the tests
 push(@pgOptions, '-c', "citus.shard_count=4");
 push(@pgOptions, '-c', "citus.shard_max_size=1500kB");
-push(@pgOptions, '-c', "citus.max_running_tasks_per_node=4");
 push(@pgOptions, '-c', "citus.repartition_join_bucket_count_per_node=2");
 push(@pgOptions, '-c', "citus.expire_cached_shards=on");
 push(@pgOptions, '-c', "citus.sort_returning=on");

--- a/src/test/regress/spec/isolation_append_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_append_copy_vs_all.spec
@@ -24,7 +24,7 @@ step "s1-copy" { COPY append_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && 
 step "s1-copy-additional-column" { COPY append_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM append_copy WHERE id = 1; }
 step "s1-real-time-select" { SELECT * FROM append_copy ORDER BY 1, 2; }
-step "s1-task-tracker-select"
+step "s1-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -57,7 +57,7 @@ step "s2-copy" { COPY append_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && 
 step "s2-copy-additional-column" { COPY append_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM append_copy WHERE id = 1; }
 step "s2-real-time-select" { SELECT * FROM append_copy ORDER BY 1, 2; }
-step "s2-task-tracker-select"
+step "s2-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM append_copy AS t1 JOIN append_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -85,7 +85,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-selec
 // permutations - COPY first
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-adaptive-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
@@ -106,7 +106,7 @@ permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-copy" "s2
 // permutations - COPY second
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/spec/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_hash_copy_vs_all.spec
@@ -24,7 +24,7 @@ step "s1-copy" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && ec
 step "s1-copy-additional-column" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM hash_copy WHERE id = 1; }
 step "s1-real-time-select" { SELECT * FROM hash_copy ORDER BY 1, 2; }
-step "s1-task-tracker-select"
+step "s1-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -64,7 +64,7 @@ step "s2-copy" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && ec
 step "s2-copy-additional-column" { COPY hash_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM hash_copy WHERE id = 1; }
 step "s2-real-time-select" { SELECT * FROM hash_copy ORDER BY 1, 2; }
-step "s2-task-tracker-select"
+step "s2-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -92,7 +92,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-selec
 // permutations - COPY first
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-adaptive-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
@@ -119,7 +119,7 @@ permutation "s1-recreate-with-replication-2" "s1-initialize" "s1-begin" "s1-copy
 // permutations - COPY second
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/spec/isolation_partitioned_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_partitioned_copy_vs_all.spec
@@ -27,7 +27,7 @@ step "s1-copy" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 
 step "s1-copy-additional-column" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM partitioned_copy WHERE id = 1; }
 step "s1-real-time-select" { SELECT * FROM partitioned_copy ORDER BY 1, 2; }
-step "s1-task-tracker-select"
+step "s1-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -60,7 +60,7 @@ step "s2-copy" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 
 step "s2-copy-additional-column" { COPY partitioned_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM partitioned_copy WHERE id = 1; }
 step "s2-real-time-select" { SELECT * FROM partitioned_copy ORDER BY 1, 2; }
-step "s2-task-tracker-select"
+step "s2-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM partitioned_copy AS t1 JOIN partitioned_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -88,7 +88,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-selec
 // permutations - COPY first
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-adaptive-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
@@ -106,7 +106,7 @@ permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begi
 // permutations - COPY second
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/spec/isolation_range_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_range_copy_vs_all.spec
@@ -24,7 +24,7 @@ step "s1-copy" { COPY range_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && e
 step "s1-copy-additional-column" { COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM range_copy WHERE id = 1; }
 step "s1-real-time-select" { SELECT * FROM range_copy ORDER BY 1, 2; }
-step "s1-task-tracker-select"
+step "s1-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -59,7 +59,7 @@ step "s2-copy" { COPY range_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && e
 step "s2-copy-additional-column" { COPY range_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM range_copy WHERE id = 1; }
 step "s2-real-time-select" { SELECT * FROM range_copy ORDER BY 1, 2; }
-step "s2-task-tracker-select"
+step "s2-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM range_copy AS t1 JOIN range_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -88,7 +88,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-selec
 // permutations - COPY first
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-adaptive-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
@@ -110,7 +110,7 @@ permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-copy" "s2
 // permutations - COPY second
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/spec/isolation_reference_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_reference_copy_vs_all.spec
@@ -24,7 +24,7 @@ step "s1-copy" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5  && echo 6, g, 6
 step "s1-copy-additional-column" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s1-router-select" { SELECT * FROM reference_copy WHERE id = 1; }
 step "s1-real-time-select" { SELECT * FROM reference_copy ORDER BY 1, 2; }
-step "s1-task-tracker-select"
+step "s1-adaptive-select"
 {
 		SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
@@ -56,7 +56,7 @@ step "s2-copy" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 
 step "s2-copy-additional-column" { COPY reference_copy FROM PROGRAM 'echo 5, f, 5, 5 && echo 6, g, 6, 6 && echo 7, h, 7, 7 && echo 8, i, 8, 8 && echo 9, j, 9, 9' WITH CSV; }
 step "s2-router-select" { SELECT * FROM reference_copy WHERE id = 1; }
 step "s2-real-time-select" { SELECT * FROM reference_copy ORDER BY 1, 2; }
-step "s2-task-tracker-select"
+step "s2-adaptive-select"
 {
 		SELECT * FROM reference_copy AS t1 JOIN reference_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 }
@@ -85,7 +85,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-copy" "s1-commit" "s1-selec
 // permutations - COPY first
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-adaptive-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-insert-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-update" "s1-commit" "s1-select-count"
@@ -105,7 +105,7 @@ permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begi
 // permutations - COPY second
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-copy" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-copy" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-copy" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-update" "s2-copy" "s1-commit" "s1-select-count"

--- a/src/test/regress/spec/isolation_select_vs_all.spec
+++ b/src/test/regress/spec/isolation_select_vs_all.spec
@@ -31,7 +31,7 @@ step "s1-disable-binary-protocol" {
 }
 step "s1-router-select" { SELECT * FROM select_append WHERE id = 1; }
 step "s1-real-time-select" { SELECT * FROM select_append ORDER BY 1, 2; }
-step "s1-task-tracker-select"
+step "s1-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -62,7 +62,7 @@ step "s1-commit" { COMMIT; }
 session "s2"
 step "s2-router-select" { SELECT * FROM select_append WHERE id = 1; }
 step "s2-real-time-select" { SELECT * FROM select_append ORDER BY 1, 2; }
-step "s2-task-tracker-select"
+step "s2-adaptive-select"
 {
 		SET citus.enable_repartition_joins TO ON;
 	SELECT * FROM select_append AS t1 JOIN select_append AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
@@ -88,13 +88,13 @@ step "s2-distribute-table" { SELECT create_distributed_table('select_append', 'i
 // permutations - SELECT vs SELECT
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-adaptive-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-router-select" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-router-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-real-time-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-real-time-select" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-router-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-real-time-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-adaptive-select" "s1-commit" "s1-select-count"
 
 // permutations - router SELECT first
 permutation "s1-initialize" "s1-begin" "s1-router-select" "s2-insert" "s1-commit" "s1-select-count"
@@ -166,35 +166,35 @@ permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-real-time-select" "s1
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-real-time-select" "s1-commit" "s1-select-count"
 permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-real-time-select" "s1-commit" "s1-select-count"
 
-// permutations - task-tracker SELECT first
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-insert" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-insert-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-update" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-delete" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-truncate" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-drop" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-task-tracker-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-table-size" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-task-tracker-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-task-tracker-select" "s2-distribute-table" "s1-commit" "s1-select-count"
+// permutations - adaptive SELECT first
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-insert" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-insert-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-update" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-delete" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-truncate" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-drop" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-adaptive-select" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-adaptive-select" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-table-size" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-adaptive-select" "s2-master-modify-multiple-shards" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-adaptive-select" "s2-distribute-table" "s1-commit" "s1-select-count"
 
-// permutations - task-tracker SELECT second
-permutation "s1-initialize" "s1-begin" "s1-insert" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-update" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-delete" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-drop" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-columns"
-permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-columns"
-permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-task-tracker-select" "s1-commit" "s1-select-count" "s1-show-columns"
-permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-task-tracker-select" "s1-commit" "s1-select-count"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-task-tracker-select" "s1-commit" "s1-select-count"
+// permutations - adaptive SELECT second
+permutation "s1-initialize" "s1-begin" "s1-insert" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-insert-select" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-update" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-delete" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-truncate" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-drop" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-ddl-create-index" "s2-adaptive-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-ddl-drop-index" "s2-adaptive-select" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-ddl-add-column" "s2-adaptive-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-ddl-drop-column" "s2-adaptive-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-ddl-rename-column" "s2-adaptive-select" "s1-commit" "s1-select-count" "s1-show-columns"
+permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-adaptive-select" "s1-commit" "s1-select-count"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-begin" "s1-distribute-table" "s2-adaptive-select" "s1-commit" "s1-select-count"

--- a/src/test/regress/sql/limit_intermediate_size.sql
+++ b/src/test/regress/sql/limit_intermediate_size.sql
@@ -16,7 +16,6 @@ SELECT cte.user_id, cte.value_2 FROM cte,cte2 ORDER BY 1,2 LIMIT 10;
 
 
 SET citus.max_intermediate_result_size TO 9;
--- regular task-tracker CTE should fail
 WITH cte AS
 (
 	SELECT
@@ -172,7 +171,7 @@ cte4 AS (
 SELECT * FROM cte UNION ALL
 SELECT * FROM cte4 ORDER BY 1,2,3,4,5 LIMIT 5;
 
--- regular task-tracker CTE, should work since -1 disables the limit
+-- regular adaptive executor CTE, should work since -1 disables the limit
 WITH cte AS
 (
 	SELECT

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -695,19 +695,13 @@ BEGIN;
 ROLLBACK;
 
 
--- task-tracker select execution
 BEGIN;
 	DELETE FROM distributed_table WHERE key = 500;
-
-	SET LOCAL citus.task_executor_type = 'task-tracker';
 
 	SELECT count(*) FROM distributed_table;
 ROLLBACK;
 
--- local execution should not be executed locally
--- becase a task-tracker query has already been executed
 BEGIN;
-	SET LOCAL citus.task_executor_type = 'task-tracker';
 	SET LOCAL client_min_messages TO INFO;
 	SELECT count(*) FROM distributed_table;
 	SET LOCAL client_min_messages TO LOG;

--- a/src/test/regress/sql/multi_cross_shard.sql
+++ b/src/test/regress/sql/multi_cross_shard.sql
@@ -90,7 +90,6 @@ SET citus.multi_task_query_log_level TO notice;
 -- Shouldn't log since it is a router select query
 SELECT * FROM raw_table WHERE ID = 1;
 
--- Task tracker query test
 CREATE TABLE tt1
 (
 	id int,
@@ -113,7 +112,6 @@ INSERT INTO tt1 VALUES(2, 'Mehmet');
 INSERT INTO tt2 VALUES(1, 'Ahmet', 5);
 INSERT INTO tt2 VALUES(2, 'Mehmet', 15);
 
--- Should notice since it is a task-tracker query
 SELECT tt1.id, tt2.count from tt1,tt2 where tt1.id = tt2.id ORDER BY 1;
 
 SET citus.task_executor_type to DEFAULT;

--- a/src/test/regress/sql/multi_join_order_additional.sql
+++ b/src/test/regress/sql/multi_join_order_additional.sql
@@ -9,7 +9,6 @@ SET citus.next_shard_id TO 650000;
 
 SET citus.explain_distributed_queries TO off;
 SET citus.log_multi_join_order TO TRUE;
-SET citus.task_executor_type = 'task-tracker'; -- can't explain all queries otherwise
 SET citus.enable_repartition_joins to ON;
 SET citus.shard_count to 2;
 SET citus.shard_replication_factor to 1;

--- a/src/test/regress/sql/multi_join_order_tpch_repartition.sql
+++ b/src/test/regress/sql/multi_join_order_tpch_repartition.sql
@@ -10,7 +10,6 @@ SET citus.next_shard_id TO 660000;
 
 SET citus.explain_distributed_queries TO off;
 SET citus.log_multi_join_order TO TRUE;
-SET citus.task_executor_type = 'task-tracker'; -- can't explain all queries otherwise
 SET citus.enable_repartition_joins to ON;
 SET client_min_messages TO LOG;
 

--- a/src/test/regress/sql/multi_mx_repartition_udt_prepare.sql
+++ b/src/test/regress/sql/multi_mx_repartition_udt_prepare.sql
@@ -182,7 +182,6 @@ INSERT INTO repartition_udt_other values (11, '(2,2)'::test_udt, 'foo');
 INSERT INTO repartition_udt_other values (12, '(2,3)'::test_udt, 'foo');
 
 SET client_min_messages = LOG;
-SET citus.task_executor_type = 'task-tracker';
 SET citus.enable_repartition_joins to ON;
 
 -- Query that should result in a repartition

--- a/src/test/regress/sql/multi_mx_router_planner.sql
+++ b/src/test/regress/sql/multi_mx_router_planner.sql
@@ -641,15 +641,6 @@ SET client_min_messages to 'DEBUG2';
 CREATE MATERIALIZED VIEW mv_articles_hash_mx_error AS
 	SELECT * FROM articles_hash_mx WHERE author_id in (1,2);
 
--- router planner/executor is disabled for task-tracker executor
--- following query is router plannable, but router planner is disabled
-
--- TODO: Uncomment once we fix task-tracker issue
-----SELECT id
---	FROM articles_hash_mx
---	WHERE author_id = 1;
-
--- insert query is router plannable even under task-tracker
 INSERT INTO articles_hash_mx VALUES (51,  1, 'amateus', 1814);
 
 -- verify insert is successfull (not router plannable and executable)

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -863,7 +863,6 @@ SELECT * FROM partitioning_locks ORDER BY 1, 2;
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;
 COMMIT;
 
--- test locks on task-tracker SELECT
 BEGIN;
 SELECT * FROM partitioning_locks AS pl1 JOIN partitioning_locks AS pl2 ON pl1.id = pl2.ref_id ORDER BY 1, 2;
 SELECT relation::regclass, locktype, mode FROM pg_locks WHERE relation::regclass::text LIKE 'partitioning_locks%' AND pid = pg_backend_pid() ORDER BY 1, 2, 3;

--- a/src/test/regress/sql/multi_prepare_plsql.sql
+++ b/src/test/regress/sql/multi_prepare_plsql.sql
@@ -362,8 +362,6 @@ SELECT real_time_partition_column_select(4);
 SELECT real_time_partition_column_select(5);
 SELECT real_time_partition_column_select(6);
 
--- check task-tracker executor
-
 CREATE FUNCTION task_tracker_non_partition_column_select(value_arg int)
 	RETURNS TABLE(key int, value int) AS $$
 DECLARE

--- a/src/test/regress/sql/multi_prepare_sql.sql
+++ b/src/test/regress/sql/multi_prepare_sql.sql
@@ -393,8 +393,6 @@ EXECUTE prepared_real_time_partition_column_select(4);
 EXECUTE prepared_real_time_partition_column_select(5);
 EXECUTE prepared_real_time_partition_column_select(6);
 
--- check task-tracker executor
-
 PREPARE prepared_task_tracker_non_partition_column_select(int) AS
 	SELECT
 		prepare_table.key,

--- a/src/test/regress/sql/multi_repartition_join_planning.sql
+++ b/src/test/regress/sql/multi_repartition_join_planning.sql
@@ -3,8 +3,7 @@
 --
 -- Tests that cover repartition join planning. Note that we explicitly start a
 -- transaction block here so that we don't emit debug messages with changing
--- transaction ids in them. Also, we set the executor type to task tracker
--- executor here, as we cannot run repartition jobs with real time executor.
+-- transaction ids in them.
 
 
 SET citus.next_shard_id TO 690000;

--- a/src/test/regress/sql/multi_repartition_join_pruning.sql
+++ b/src/test/regress/sql/multi_repartition_join_pruning.sql
@@ -1,9 +1,7 @@
 --
 -- MULTI_REPARTITION_JOIN_PRUNING
 --
--- Tests covering partition and join-pruning for repartition joins. Note that we
--- set executor type to task tracker executor here, as we cannot run repartition
--- jobs with real time executor.
+-- Tests covering partition and join-pruning for repartition joins.
 
 
 SET citus.next_shard_id TO 700000;

--- a/src/test/regress/sql/multi_repartition_udt.sql
+++ b/src/test/regress/sql/multi_repartition_udt.sql
@@ -190,7 +190,6 @@ SELECT * FROM repartition_udt JOIN repartition_udt_other
 	WHERE repartition_udt.pk = 1;
 
 -- Query that should result in a repartition join on UDT column.
-SET citus.task_executor_type = 'task-tracker';
 SET citus.log_multi_join_order = true;
 
 EXPLAIN (COSTS OFF)

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -1113,13 +1113,11 @@ CREATE MATERIALIZED VIEW mv_articles_hash_data AS
 	SELECT * FROM articles_hash WHERE author_id in (1,2);
 SELECT * FROM mv_articles_hash_data ORDER BY 1, 2, 3, 4;
 
--- router planner/executor is now enabled for task-tracker executor
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1
 	ORDER BY 1;
 
--- insert query is router plannable even under task-tracker
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 
 -- verify insert is successful (not router plannable and executable)

--- a/src/test/regress/sql/multi_router_planner_fast_path.sql
+++ b/src/test/regress/sql/multi_router_planner_fast_path.sql
@@ -805,12 +805,10 @@ CREATE MATERIALIZED VIEW mv_articles_hash_empty AS
 SELECT * FROM mv_articles_hash_empty;
 
 
--- fast-path router planner/executor is enabled for task-tracker executor
 SELECT id
 	FROM articles_hash
 	WHERE author_id = 1;
 
--- insert query is router plannable even under task-tracker
 INSERT INTO articles_hash VALUES (51, 1, 'amateus', 1814), (52, 1, 'second amateus', 2824);
 
 -- verify insert is successfull (not router plannable and executable)

--- a/src/test/regress/sql/single_hash_repartition_join.sql
+++ b/src/test/regress/sql/single_hash_repartition_join.sql
@@ -151,7 +151,6 @@ CREATE TABLE dist_1 (a int , b int);
 SELECT create_distributed_table('dist_1', 'a');
 INSERT INTO dist_1 SELECT x,10-x FROM generate_series(1,10) x;
 
-SET citus.task_executor_type to 'task-tracker';
 SELECT COUNT(*) FROM dist_1 f, dist_1 s WHERE f.a = s.b;
 
 SET client_min_messages TO ERROR;

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -115,8 +115,6 @@ SELECT count(*) FROM test WHERE false;
 SELECT count(*) FROM test WHERE false GROUP BY GROUPING SETS (x,y);
 RESET citus.task_assignment_policy;
 
--- single node task tracker tests:
-SET citus.task_executor_type to 'task-tracker';
 SELECT count(*) FROM test;
 
 -- INSERT SELECT from distributed table to local table

--- a/src/test/regress/sql/with_executors.sql
+++ b/src/test/regress/sql/with_executors.sql
@@ -1,4 +1,4 @@
--- Confirm we can use local, router, real-time, and task-tracker execution
+-- Confirm we can use local, and adaptive execution
 
 CREATE SCHEMA with_executors;
 SET search_path TO with_executors, public;
@@ -105,7 +105,7 @@ WITH cte AS (
 SELECT * FROM cte WHERE uid=1 ORDER BY 2 LIMIT 5;
 
 
--- CTEs should be able to use task-tracker queries
+-- CTEs should be able to use adaptive executor
 WITH cte AS (
 	WITH task_tracker_1 AS (
 		SELECT
@@ -294,8 +294,6 @@ WITH cte AS (
 SELECT count(*) FROM cte, users_table where cte.count=user_id;
 
 
-SET citus.task_executor_type='task-tracker';
--- CTEs shouldn't be able to terminate a task-tracker query
 WITH cte_1 AS (
 	SELECT
 		u_table.user_id as u_id, e_table.event_type


### PR DESCRIPTION
Currently there is only one executor, so `task_executor_type` doesn't do anything. We might want to remove it with a major version.

This PR removes some comments, documentation, tests related to task tracker. 
