### PR TITLE
fix sorting on string litteral

### DIFF
--- a/src/test/regress/expected/anonymous_columns.out
+++ b/src/test/regress/expected/anonymous_columns.out
@@ -121,7 +121,7 @@ SELECT a + 1, a - 1 FROM t0 ORDER BY 1;
         3 |        1
 (2 rows)
 
-WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1 ORDER BY 1::text;
+WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1 ORDER BY "?column?"::text;
  ?column?
 ---------------------------------------------------------------------
  1

--- a/src/test/regress/sql/anonymous_columns.sql
+++ b/src/test/regress/sql/anonymous_columns.sql
@@ -32,7 +32,7 @@ SELECT * FROM (SELECT b, '', '' FROM t0 GROUP BY b ) as foo ORDER BY 1;
 -- some tests that follow very similar codeoaths
 SELECT a + 1 FROM t0 ORDER BY 1;
 SELECT a + 1, a - 1 FROM t0 ORDER BY 1;
-WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1 ORDER BY 1::text;
+WITH cte1 AS (SELECT row_to_json(row(a))->'f1' FROM t0) SELECT * FROM cte1 ORDER BY "?column?"::text;
 
 -- clean up after test
 SET client_min_messages TO WARNING;


### PR DESCRIPTION
As noted by Talha https://github.com/citusdata/citus/pull/4029#issuecomment-660466972 there was still some sort order flappiness in the test.

The root cause is that sorting on `1::text` sorts on the literal `'1'` which causes sorting to be indeterministic.

This behaviour is consistent with Postgres' behaviour, so no bug on Citus' side.