### PR TITLE
Distribute custom aggregates with multiple arguments

### DIFF
--- a/src/backend/distributed/utils/aggregate_utils.c
+++ b/src/backend/distributed/utils/aggregate_utils.c
@@ -292,7 +292,7 @@ CreateAggregationArgumentContext(FunctionCallInfo fcinfo, int argumentIndex)
 	if (RECORDOID == get_fn_expr_argtype(fcinfo->flinfo, argumentIndex))
 	{
 		/* Initialize context to handle aggregation argument combined into tuple/record */
-		if (fcinfo->args[argumentIndex].isnull)
+		if (fcGetArgNull(fcinfo, argumentIndex))
 		{
 			ereport(ERROR, (errmsg("worker_partial_agg_sfunc: null record input"),
 							errhint("Elements of record may be null")));

--- a/src/backend/distributed/utils/aggregate_utils.c
+++ b/src/backend/distributed/utils/aggregate_utils.c
@@ -493,7 +493,7 @@ worker_partial_agg_sfunc(PG_FUNCTION_ARGS)
 		InitFunctionCallInfoData(*innerFcinfo, &info, 2, fcinfo->fncollation,
 								 fcinfo->context, fcinfo->resultinfo);
 		fcSetArgExt(innerFcinfo, 0, box->value, box->valueNull);
-		fcSetArgExt(innerFcinfo, argumentIndex, fcGetArgValue(fcinfo, 2),
+		fcSetArgExt(innerFcinfo, 1, fcGetArgValue(fcinfo, 2),
 					fcGetArgNull(fcinfo, 2));
 	}
 

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -302,6 +302,174 @@ select binstragg(col1, col2) from txttbl;
  zzzz
 (1 row)
 
+create table users_table (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+select create_distributed_table('users_table', 'user_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+create table events_table (user_id int, time timestamp, event_type int, value_2 int, value_3 float, value_4 bigint);
+select create_distributed_table('events_table', 'user_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+insert into users_table select i % 10000, timestamp '2014-01-10 20:00:00' +
+       i * (timestamp '2014-01-20 20:00:00' -
+                   timestamp '2014-01-10 10:00:00'),i, i % 100, i % 5 from generate_series(0, 1000) i;
+insert into events_table select i % 10000, timestamp '2014-01-10 20:00:00' +
+       i * (timestamp '2014-01-20 20:00:00' -
+                   timestamp '2014-01-10 10:00:00'),i, i % 100, i % 5 from generate_series(0, 10000) i;
+-- query with window functions, the agg. inside the window functions
+select value_3, to_char(date_trunc('day', time), 'YYYYMMDD') as time, rank() over my_win as my_rank
+from events_table
+group by
+    value_3, date_trunc('day', time)
+    WINDOW my_win as (partition by regr_syy(event_type%10, value_2)::int order by count(*) desc)
+order by 1,2,3
+limit 5;
+ value_3 |   time   | my_rank
+---------------------------------------------------------------------
+       0 | 20140110 |       1
+       0 | 20140303 |       1
+       0 | 20140425 |       1
+       0 | 20140616 |       1
+       0 | 20140807 |       1
+(5 rows)
+
+-- query with window functions, the agg. outside the window functions
+select regr_syy(event_type%10, value_2)::int, value_3, to_char(date_trunc('day', time), 'YYYYMMDD') as time, rank() over my_win as my_rank
+from events_table
+group by
+    value_3, date_trunc('day', time)
+    WINDOW my_win as (partition by value_3 order by count(*) desc)
+order by 1,2,3
+limit 5;
+ regr_syy | value_3 |   time   | my_rank
+---------------------------------------------------------------------
+        0 |       0 | 20140110 |       1
+        0 |       0 | 20140303 |       1
+        0 |       0 | 20140425 |       1
+        0 |       0 | 20140616 |       1
+        0 |       0 | 20140807 |       1
+(5 rows)
+
+-- query with only order by
+select regr_syy(event_type%10, value_2)::int
+from events_table
+order by 1 desc;
+ regr_syy
+---------------------------------------------------------------------
+    82520
+(1 row)
+
+-- query with group by + target list + order by
+select count(*), regr_syy(event_type%10, value_2)::int
+from events_table
+group by value_3
+order by 2 desc;
+ count | regr_syy
+---------------------------------------------------------------------
+  2001 |    12506
+  2000 |    12500
+  2000 |    12500
+  2000 |    12500
+  2000 |    12500
+(5 rows)
+
+-- query with group by + order by
+select count(*)
+from events_table
+group by value_3
+order by regr_syy(event_type%10, value_2)::int desc;
+ count
+---------------------------------------------------------------------
+  2001
+  2000
+  2000
+  2000
+  2000
+(5 rows)
+
+-- query with basic join
+select regr_syy(u1.user_id, u2.user_id)::int
+from users_table  u1, events_table u2
+where u1.user_id = u2.user_id;
+ regr_syy
+---------------------------------------------------------------------
+ 83833250
+(1 row)
+
+-- agg. with filter with columns
+select regr_syy(u1.user_id, u2.user_id) filter (where u1.value_1 < 5)::numeric(10,3)
+from users_table  u1, events_table u2
+where u1.user_id = u2.user_id;
+ regr_syy
+---------------------------------------------------------------------
+   13.333
+(1 row)
+
+-- agg with filter and group by
+select regr_syy(u1.user_id, u2.user_id) filter (where (u1.value_1) < 5)::numeric(10,3)
+from users_table  u1, events_table u2
+where u1.user_id = u2.user_id
+group by u1.value_3;
+ regr_syy
+---------------------------------------------------------------------
+    0.000
+    0.000
+    0.000
+    0.000
+    0.000
+(5 rows)
+
+-- agg. with filter with consts
+select regr_syy(u1.user_id, u2.user_id) filter (where '0300030' LIKE '%3%')::int
+from users_table  u1, events_table u2
+where u1.user_id = u2.user_id;
+ regr_syy
+---------------------------------------------------------------------
+ 83833250
+(1 row)
+
+-- multiple aggs with filters
+select regr_syy(u1.user_id, u2.user_id) filter (where u1.value_1 < 5)::numeric(10,3), regr_syy(u1.value_1, u2.value_2) filter (where u1.user_id < 5)::numeric(10,3)
+from users_table  u1, events_table u2
+where u1.user_id = u2.user_id;
+ regr_syy | regr_syy
+---------------------------------------------------------------------
+   13.333 |   13.333
+(1 row)
+
+-- query with where false
+select regr_syy(u1.user_id, u2.user_id) filter (where u1.value_1 < 5)::numeric(10,3), regr_syy(u1.value_1, u2.value_2) filter (where u1.user_id < 5)::numeric(10,3)
+from users_table  u1, events_table u2
+where 1=0;
+ regr_syy | regr_syy
+---------------------------------------------------------------------
+          |
+(1 row)
+
+-- a CTE forced to be planned recursively (via OFFSET 0)
+with cte_1 as
+(
+    select
+        regr_syy(u1.user_id, u2.user_id) filter (where u1.value_1 < 5)::numeric(10,3), regr_syy(u1.value_1, u2.value_2) filter (where u1.user_id < 5)::numeric(10,3)
+    from users_table  u1, events_table u2
+    where u1.user_id = u2.user_id
+    OFFSET 0
+)
+select
+*
+from
+cte_1;
+ regr_syy | regr_syy
+---------------------------------------------------------------------
+   13.333 |   13.333
+(1 row)
+
 -- Test https://github.com/citusdata/citus/issues/3446
 set citus.coordinator_aggregation_strategy to 'row-gather';
 select id, stddev(val) from aggdata group by id order by 1;

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -51,6 +51,63 @@ select create_distributed_function('sum2_strict(int)');
 
 (1 row)
 
+-- user-defined aggregates with multiple-parameters
+create function psum_sfunc(s int, x int, y int)
+returns int immutable language plpgsql as $$
+begin return coalesce(s,0) + coalesce(x*y+3,1);
+end;
+$$;
+create  function psum_sfunc_strict(s int, x int, y int)
+returns int immutable strict language plpgsql as $$
+begin return coalesce(s,0) + coalesce(x*y+3,1);
+end;
+$$;
+create function psum_combinefunc(s1 int, s2 int)
+returns int immutable language plpgsql as $$
+begin return coalesce(s1,0) + coalesce(s2,0);
+end;
+$$;
+create function psum_combinefunc_strict(s1 int, s2 int)
+returns int immutable strict language plpgsql as $$
+begin return coalesce(s1,0) + coalesce(s2,0);
+end;
+$$;
+create function psum_finalfunc(x int)
+returns int immutable language plpgsql as $$
+begin return x * 2;
+end;
+$$;
+create function psum_finalfunc_strict(x int)
+returns int immutable strict language plpgsql as $$
+begin return x * 2;
+end;
+$$;
+create aggregate psum(int, int)(
+    sfunc=psum_sfunc,
+    combinefunc=psum_combinefunc,
+    finalfunc=psum_finalfunc,
+    stype=int
+);
+create aggregate psum_strict(int, int)(
+    sfunc=psum_sfunc_strict,
+    combinefunc=psum_combinefunc_strict,
+    finalfunc=psum_finalfunc_strict,
+    stype=int,
+    initcond=0
+);
+select create_distributed_function('psum(int,int)');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+select create_distributed_function('psum_strict(int,int)');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+-- generate test data
 create table aggdata (id int, key int, val int, valf float8);
 select create_distributed_table('aggdata', 'id');
  create_distributed_table
@@ -59,16 +116,16 @@ select create_distributed_table('aggdata', 'id');
 (1 row)
 
 insert into aggdata (id, key, val, valf) values (1, 1, 2, 11.2), (2, 1, NULL, 2.1), (3, 2, 2, 3.22), (4, 2, 3, 4.23), (5, 2, 5, 5.25), (6, 3, 4, 63.4), (7, 5, NULL, 75), (8, 6, NULL, NULL), (9, 6, NULL, 96), (10, 7, 8, 1078), (11, 9, 0, 1.19);
-select key, sum2(val), sum2_strict(val), stddev(valf) from aggdata group by key order by key;
- key | sum2 | sum2_strict |      stddev
+select key, sum2(val), sum2_strict(val), stddev(valf)::numeric(10,5), psum(val, valf::int), psum_strict(val, valf::int) from aggdata group by key order by key;
+ key | sum2 | sum2_strict | stddev  | psum  | psum_strict
 ---------------------------------------------------------------------
-   1 |      |           4 | 6.43467170879758
-   2 |   20 |          20 | 1.01500410508201
-   3 |    8 |           8 |
-   5 |      |             |
-   6 |      |             |
-   7 |   16 |          16 |
-   9 |    0 |           0 |
+   1 |      |           4 | 6.43467 |    52 |          50
+   2 |   20 |          20 | 1.01500 |   104 |         104
+   3 |    8 |           8 |         |   510 |         510
+   5 |      |             |         |     2 |           0
+   6 |      |             |         |     4 |           0
+   7 |   16 |          16 |         | 17254 |       17254
+   9 |    0 |           0 |         |     6 |           6
 (7 rows)
 
 -- FILTER supported
@@ -85,46 +142,164 @@ select key, sum2(val) filter (where valf < 5), sum2_strict(val) filter (where va
 (7 rows)
 
 -- DISTINCT unsupported, unless grouped by partition key
-select key, sum2(distinct val), sum2_strict(distinct val) from aggdata group by key order by key;
+select key, sum2(distinct val), sum2_strict(distinct val), psum(distinct val, valf::int), psum_strict(distinct val, valf::int) from aggdata group by key order by key;
 ERROR:  cannot compute aggregate (distinct)
 DETAIL:  table partitioning is unsuitable for aggregate (distinct)
-select id, sum2(distinct val), sum2_strict(distinct val) from aggdata group by id order by id;
- id | sum2 | sum2_strict
+select id, sum2(distinct val), sum2_strict(distinct val), psum(distinct val, valf::int), psum_strict(distinct val, valf::int) from aggdata group by id order by id;
+ id | sum2 | sum2_strict | psum  | psum_strict
 ---------------------------------------------------------------------
-  1 |    4 |           4
-  2 |      |
-  3 |    4 |           4
-  4 |    6 |           6
-  5 |   10 |          10
-  6 |    8 |           8
-  7 |      |
-  8 |      |
-  9 |      |
- 10 |   16 |          16
- 11 |    0 |           0
+  1 |    4 |           4 |    50 |          50
+  2 |      |             |     2 |           0
+  3 |    4 |           4 |    18 |          18
+  4 |    6 |           6 |    30 |          30
+  5 |   10 |          10 |    56 |          56
+  6 |    8 |           8 |   510 |         510
+  7 |      |             |     2 |           0
+  8 |      |             |     2 |           0
+  9 |      |             |     2 |           0
+ 10 |   16 |          16 | 17254 |       17254
+ 11 |    0 |           0 |     6 |           6
 (11 rows)
 
 -- ORDER BY unsupported
-select key, sum2(val order by valf), sum2_strict(val order by valf) from aggdata group by key order by key;
+select key, sum2(val order by valf), sum2_strict(val order by valf), psum(val, valf::int order by valf), psum_strict(val, valf::int order by valf) from aggdata group by key order by key;
 ERROR:  unsupported aggregate function sum2
 -- Test handling a lack of intermediate results
-select sum2(val), sum2_strict(val) from aggdata where valf = 0;
- sum2 | sum2_strict
+select sum2(val), sum2_strict(val), psum(val, valf::int), psum_strict(val, valf::int) from aggdata where valf = 0;
+ sum2 | sum2_strict | psum | psum_strict
 ---------------------------------------------------------------------
-    0 |
+    0 |             |    0 |           0
 (1 row)
 
 -- Test HAVING
-select key, stddev(valf) from aggdata group by key having stddev(valf) > 2 order by key;
- key |      stddev
+select key, stddev(valf)::numeric(10,5) from aggdata group by key having stddev(valf) > 2 order by key;
+ key | stddev
 ---------------------------------------------------------------------
-   1 | 6.43467170879758
+   1 | 6.43467
 (1 row)
 
-select key, stddev(valf) from aggdata group by key having stddev(val::float8) > 1 order by key;
- key |      stddev
+select key, stddev(valf)::numeric(10,5) from aggdata group by key having stddev(val::float8) > 1 order by key;
+ key | stddev
 ---------------------------------------------------------------------
-   2 | 1.01500410508201
+   2 | 1.01500
+(1 row)
+
+select key, corr(valf,valf+val)::numeric(10,5) from aggdata group by key having corr(valf,valf+val) < 1 order by key;
+ key |  corr
+---------------------------------------------------------------------
+   2 | 0.99367
+(1 row)
+
+select key, corr(valf,valf+val)::numeric(10,5) from aggdata group by key having corr(valf::float8,valf+val) < 1 order by key;
+ key |  corr
+---------------------------------------------------------------------
+   2 | 0.99367
+(1 row)
+
+-- Previously aggregated on master, pushed down to workers with multi-parameter support
+select floor(val/2), corr(valf, valf + val)::numeric(10,5) from aggdata group by floor(val/2) order by 1;
+ floor |  corr
+---------------------------------------------------------------------
+     0 |
+     1 | 0.99181
+     2 | 1.00000
+     4 |
+       |
+(5 rows)
+
+select floor(val/2), corr(valf, valf + val)::numeric(10,5) from aggdata group by floor(val/2) having corr(valf + val, val) < 1 order by 1;
+ floor |  corr
+---------------------------------------------------------------------
+     1 | 0.99181
+     2 | 1.00000
+(2 rows)
+
+-- built-in binary aggregates for statistics
+select regr_count(valf,val)::numeric(10,5)from aggdata;
+ regr_count
+---------------------------------------------------------------------
+    7.00000
+(1 row)
+
+select regr_sxx(valf,val)::numeric(10,5) from aggdata;
+ regr_sxx
+---------------------------------------------------------------------
+ 39.71429
+(1 row)
+
+select regr_syy(valf,val)::numeric(10,3) from aggdata;
+  regr_syy
+---------------------------------------------------------------------
+ 971900.680
+(1 row)
+
+select regr_sxy(valf,val)::numeric(10,5) from aggdata;
+  regr_sxy
+---------------------------------------------------------------------
+ 4945.98571
+(1 row)
+
+select regr_avgx(valf,val)::numeric(10,5), regr_avgy(valf,val)::numeric(10,5) from aggdata;
+ regr_avgx | regr_avgy
+---------------------------------------------------------------------
+   3.42857 | 166.64143
+(1 row)
+
+select regr_r2(valf,val)::numeric(10,5) from aggdata;
+ regr_r2
+---------------------------------------------------------------------
+ 0.63378
+(1 row)
+
+select regr_slope(valf,val)::numeric(10,5), regr_intercept(valf,val)::numeric(10,5) from aggdata;
+ regr_slope | regr_intercept
+---------------------------------------------------------------------
+  124.53921 |     -260.35014
+(1 row)
+
+select covar_pop(valf,val)::numeric(10,5), covar_samp(valf,val)::numeric(10,5) from aggdata;
+ covar_pop | covar_samp
+---------------------------------------------------------------------
+ 706.56939 |  824.33095
+(1 row)
+
+-- binary string aggregation
+create function binstragg_sfunc(s text, e1 text, e2 text)
+returns text immutable language plpgsql as $$
+begin case when coalesce(e1,'') > coalesce(s,'') and coalesce(e1,'') > coalesce(e2,'') then return e1;
+           when coalesce(e2,'') > coalesce(s,'') and coalesce(e2,'') > coalesce(e1,'') then return e2;
+           else return s;
+      end case;
+end;
+$$;
+create function binstragg_combinefunc(s1 text, s2 text)
+returns text immutable language plpgsql as $$
+begin if coalesce(s1,'') > coalesce(s2,'') then return s1; else return s2; end if;
+end;
+$$;
+create aggregate binstragg(text, text)(
+    sfunc=binstragg_sfunc,
+    combinefunc=binstragg_combinefunc,
+    stype=text
+);
+select create_distributed_function('binstragg(text,text)');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+create table txttbl(id int, col1 text, col2 text);
+select create_distributed_table('txttbl', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+insert into txttbl values (1, 'aaaa', 'bbbb'), (2, 'cccc', 'dddd'), (3, 'eeee', 'ffff'), (4, 'gggg', 'hhhh'), (5, 'iiii', 'jjjj'), (6, 'kkkk', 'llll'), (7, 'mmmm', 'nnnn'), (8, 'oooo', 'pppp'), (9, 'qqqq', 'rrrr'), (10, 'ssss', 'tttt'), (11, 'uuuu', 'vvvv'), (12, 'wwww', 'xxxx'), (13, 'yyyy', 'zzzz');
+select binstragg(col1, col2) from txttbl;
+ binstragg
+---------------------------------------------------------------------
+ zzzz
 (1 row)
 
 -- Test https://github.com/citusdata/citus/issues/3446
@@ -363,23 +538,6 @@ select key, percentile_cont(key/10.0) within group(order by val) from aggdata gr
    9 |               0
 (7 rows)
 
-select floor(val/2), corr(valf, valf + val) from aggdata group by floor(val/2) order by 1;
- floor |       corr
----------------------------------------------------------------------
-     0 |
-     1 | 0.991808518376741
-     2 |                 1
-     4 |
-       |
-(5 rows)
-
-select floor(val/2), corr(valf, valf + val) from aggdata group by floor(val/2) having corr(valf + val, val) < 1 order by 1;
- floor |       corr
----------------------------------------------------------------------
-     1 | 0.991808518376741
-     2 |                 1
-(2 rows)
-
 select array_agg(val order by valf) from aggdata;
               array_agg
 ---------------------------------------------------------------------
@@ -459,7 +617,7 @@ create table nulltable(id int);
 insert into nulltable values (0);
 -- These cases are not type correct
 select pg_catalog.worker_partial_agg('string_agg(text,text)'::regprocedure, id) from nulltable;
-ERROR:  worker_partial_agg_sfunc cannot type check aggregates taking anything other than 1 argument
+ERROR:  worker_partial_agg_sfunc could not confirm type correctness
 select pg_catalog.worker_partial_agg('sum(int8)'::regprocedure, id) from nulltable;
 ERROR:  worker_partial_agg_sfunc could not confirm type correctness
 select pg_catalog.coord_combine_agg('sum(float8)'::regprocedure, id::text::cstring, null::text) from nulltable;


### PR DESCRIPTION
DESCRIPTION: Enable custom aggregates with multiple parameters to be executed on workers. 

#2921 introduces distributed execution of custom aggregates. One of the limitations of this feature is that only aggregate functions with a single aggregation parameter can be pushed to worker nodes. Aim of this change is to remove that limitation and support handling of multi-parameter aggregates. 

Resolves: #3997
See also: #2921
