### PR TITLE
Unify node sort ordering

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1931,16 +1931,8 @@ WorkerPoolCompare(const void *lhsKey, const void *rhsKey)
 	const WorkerPool *workerLhs = *(const WorkerPool **) lhsKey;
 	const WorkerPool *workerRhs = *(const WorkerPool **) rhsKey;
 
-	int nameCompare = strncmp(workerLhs->nodeName, workerRhs->nodeName,
-							  WORKER_LENGTH);
-
-	if (nameCompare != 0)
-	{
-		return nameCompare;
-	}
-
-	int portCompare = workerLhs->nodePort - workerRhs->nodePort;
-	return portCompare;
+	return NodeNamePortCompare(workerLhs->nodeName, workerRhs->nodeName,
+							   workerLhs->nodePort, workerRhs->nodePort);
 }
 
 

--- a/src/backend/distributed/operations/worker_node_manager.c
+++ b/src/backend/distributed/operations/worker_node_manager.c
@@ -584,15 +584,30 @@ WorkerNodeCompare(const void *lhsKey, const void *rhsKey, Size keySize)
 	const WorkerNode *workerLhs = (const WorkerNode *) lhsKey;
 	const WorkerNode *workerRhs = (const WorkerNode *) rhsKey;
 
+	return NodeNamePortCompare(workerLhs->workerName, workerRhs->workerName,
+							   workerLhs->workerPort, workerRhs->workerPort);
+}
 
-	int nameCompare = strncmp(workerLhs->workerName, workerRhs->workerName,
-							  WORKER_LENGTH);
+
+/*
+ * NodeNamePortCompare implements the common logic for comparing two nodes
+ * with their given nodeNames and ports.
+ *
+ * This function is useful for ensuring consistency of sort operations between
+ * different representations of nodes in the cluster such as WorkerNode and
+ * WorkerPool.
+ */
+int
+NodeNamePortCompare(const char *workerLhsName, const char *workerRhsName,
+					int workerLhsPort, int workerRhsPort)
+{
+	int nameCompare = strncmp(workerLhsName, workerRhsName, WORKER_LENGTH);
 	if (nameCompare != 0)
 	{
 		return nameCompare;
 	}
 
-	int portCompare = workerLhs->workerPort - workerRhs->workerPort;
+	int portCompare = workerLhsPort - workerRhsPort;
 	return portCompare;
 }
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,5 +96,7 @@ extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 /* Function declarations for worker node utilities */
 extern int CompareWorkerNodes(const void *leftElement, const void *rightElement);
 extern int WorkerNodeCompare(const void *lhsKey, const void *rhsKey, Size keySize);
+extern int NodeNamePortCompare(const char *workerLhsName, const char *workerRhsName,
+							   int workerLhsPort, int workerRhsPort);
 
 #endif   /* WORKER_MANAGER_H */


### PR DESCRIPTION
The executor relies on WorkerPool, and many other places rely on WorkerNode.
With this commit, we make sure that they are sorted via the same function/logic.

Preparation for #4034, make that PR smaller.