### PR TITLE
Minor refactorings in COPY command execution

### DIFF
--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -301,7 +301,7 @@ StartPlacementListConnection(uint32 flags, List *placementAccessList,
 		Assert((flags & OPTIONAL_CONNECTION) == 0);
 		Assert(chosenConnection != NULL);
 
-		if ((flags & CONNECTION_PER_PLACEMENT) &&
+		if ((flags & REQUIRE_CLEAN_CONNECTION) &&
 			ConnectionAccessedDifferentPlacement(chosenConnection, placement))
 		{
 			/*

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -46,8 +46,8 @@ enum MultiConnectionMode
 
 	FOR_DML = 1 << 2,
 
-	/* open a connection per (co-located set of) placement(s) */
-	CONNECTION_PER_PLACEMENT = 1 << 3,
+	/* connection must not have accessed any non-co-located placements */
+	REQUIRE_CLEAN_CONNECTION = 1 << 3,
 
 	OUTSIDE_TRANSACTION = 1 << 4,
 


### PR DESCRIPTION
1) Rename CONNECTION_PER_PLACEMENT to REQUIRE_CLEAN_CONNECTION. This is
mostly to make things clear as the new name reveals more.

2) We also make sure that mark all the copy connections critical,
even if they are accessed earlier in the transaction

Preparation for #4034, make that PR smaller.

I asked review from @marcocitus as he noted  these changes in the earlier PR.

