### PR TITLE
Make FindAvailableConnection() more strict

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -450,6 +450,15 @@ FindAvailableConnection(dlist_head *connections, uint32 flags)
 			continue;
 		}
 
+		if (connection->initilizationState != POOL_STATE_INITIALIZED)
+		{
+			/*
+			 * If the connection has not been initialized, it should not be
+			 * considered as available.
+			 */
+			continue;
+		}
+
 		return connection;
 	}
 


### PR DESCRIPTION
With adaptive connection management, we might have some connections
which are not fully initialized. Those connections should not be
qualified as available.

Preparation for #4034, make that PR smaller.