### PR TITLE
Fixes CREATE INDEX CONCURRENTLY bug

### DIFF
--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -86,15 +86,16 @@ CREATE INDEX IF NOT EXISTS lineitem_orderkey_index on index_test_hash(a);
 NOTICE:  relation "lineitem_orderkey_index" already exists, skipping
 -- Verify that we can create indexes concurrently
 CREATE INDEX CONCURRENTLY lineitem_concurrently_index ON lineitem (l_orderkey);
+-- Verify that no-name local CREATE INDEX CONCURRENTLY works
+CREATE TABLE local_table (id integer, name text);
+CREATE INDEX CONCURRENTLY ON local_table(id);
 -- Verify that we warn out on CLUSTER command for distributed tables and no parameter
 CLUSTER index_test_hash USING index_test_hash_index_a;
 WARNING:  not propagating CLUSTER command to worker nodes
 CLUSTER;
 WARNING:  not propagating CLUSTER command to worker nodes
--- Verify that no-name local CREATE INDEX CONCURRENTLY works
-CREATE TABLE local_table (id integer, name text);
-CREATE INDEX CONCURRENTLY local_table_index ON local_table(id);
 -- Vefify we don't warn out on CLUSTER command for local tables
+CREATE INDEX CONCURRENTLY local_table_index ON local_table(id);
 CLUSTER local_table USING local_table_index;
 DROP TABLE local_table;
 -- Verify that all indexes got created on the master node and one of the workers

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -64,15 +64,16 @@ CREATE INDEX IF NOT EXISTS lineitem_orderkey_index on index_test_hash(a);
 -- Verify that we can create indexes concurrently
 CREATE INDEX CONCURRENTLY lineitem_concurrently_index ON lineitem (l_orderkey);
 
+-- Verify that no-name local CREATE INDEX CONCURRENTLY works
+CREATE TABLE local_table (id integer, name text);
+CREATE INDEX CONCURRENTLY ON local_table(id);
+
 -- Verify that we warn out on CLUSTER command for distributed tables and no parameter
 CLUSTER index_test_hash USING index_test_hash_index_a;
 CLUSTER;
 
--- Verify that no-name local CREATE INDEX CONCURRENTLY works
-CREATE TABLE local_table (id integer, name text);
-CREATE INDEX CONCURRENTLY local_table_index ON local_table(id);
-
 -- Vefify we don't warn out on CLUSTER command for local tables
+CREATE INDEX CONCURRENTLY local_table_index ON local_table(id);
 CLUSTER local_table USING local_table_index;
 
 DROP TABLE local_table;


### PR DESCRIPTION
DESCRIPTION: Fixes the CREATE INDEX CONCURRENTLY with no index name on a local table bug.

Fixes #4057 
