### PR TITLE
Support EXPLAIN ANALYZE EXECUTE and EXPLAIN EXECUTE

### DIFF
--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -514,6 +514,25 @@ GetTaskQueryType(Task *task)
 
 
 /*
+ * TaskQueryStringAtIndex returns query at given index among the possibly
+ * multiple queries that a task can have.
+ */
+char *
+TaskQueryStringAtIndex(Task *task, int index)
+{
+	Assert(index < task->queryCount);
+
+	int taskQueryType = GetTaskQueryType(task);
+	if (taskQueryType == TASK_QUERY_TEXT_LIST)
+	{
+		return list_nth(task->taskQuery.data.queryStringList, index);
+	}
+
+	return TaskQueryString(task);
+}
+
+
+/*
  * TaskQueryString generates task query string text if missing.
  *
  * For performance reasons, the queryString is generated lazily. For example

--- a/src/include/distributed/deparse_shard_query.h
+++ b/src/include/distributed/deparse_shard_query.h
@@ -27,6 +27,7 @@ extern void SetTaskQueryIfShouldLazyDeparse(Task *task, Query *query);
 extern void SetTaskQueryString(Task *task, char *queryString);
 extern void SetTaskQueryStringList(Task *task, List *queryStringList);
 extern char * TaskQueryString(Task *task);
+extern char * TaskQueryStringAtIndex(Task *task, int index);
 extern bool UpdateRelationsToLocalShardTables(Node *node, List *relationShardList);
 extern int GetTaskQueryType(Task *task);
 

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -146,6 +146,7 @@ extern void ExtractParametersFromParamList(ParamListInfo paramListInfo,
 										   Oid **parameterTypes,
 										   const char ***parameterValues, bool
 										   useOriginalCustomTypeOids);
+extern ParamListInfo ExecutorBoundParams(void);
 
 
 #endif /* MULTI_EXECUTOR_H */

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -1283,23 +1283,23 @@ Custom Scan (Citus Adaptive) (actual rows=3 loops=1)
 PREPARE multi_shard_query_param(int) AS UPDATE lineitem SET l_quantity = $1;
 BEGIN;
 EXPLAIN EXECUTE multi_shard_query_param(5);
-WARNING:  there is no parameter $1
-WARNING:  there is no parameter $1
 Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
   Task Count: 2
   Tasks Shown: One of 2
   ->  Task
-        Error: Could not get remote plan.
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Update on lineitem_290000 lineitem  (cost=0.00..176.00 rows=6000 width=140)
+              ->  Seq Scan on lineitem_290000 lineitem  (cost=0.00..176.00 rows=6000 width=140)
 ROLLBACK;
 BEGIN;
 EXPLAIN (ANALYZE ON, COSTS OFF, TIMING OFF, SUMMARY OFF) EXECUTE multi_shard_query_param(5);
-WARNING:  there is no parameter $1
-WARNING:  there is no parameter $1
 Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
   Task Count: 2
   Tasks Shown: One of 2
   ->  Task
-        Error: Could not get remote plan.
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Update on lineitem_290000 lineitem (actual rows=0 loops=1)
+              ->  Seq Scan on lineitem_290000 lineitem (actual rows=6000 loops=1)
 ROLLBACK;
 \set VERBOSITY DEFAULT
 -- test explain in a transaction with alter table to test we use right connections
@@ -1811,6 +1811,52 @@ SELECT execution_duration BETWEEN 30 AND 200 FROM worker_last_saved_explain_anal
 (1 row)
 
 END;
+--
+-- verify we handle parametrized queries properly
+--
+CREATE TABLE t(a int);
+INSERT INTO t VALUES (1), (2), (3);
+-- simple case
+PREPARE save_explain AS
+SELECT $1, * FROM worker_save_query_explain_analyze('SELECT $1::int', :default_opts) as (a int);
+EXECUTE save_explain(1);
+ ?column? | a
+---------------------------------------------------------------------
+ 1        | 1
+(1 row)
+
+deallocate save_explain;
+-- Call a UDF first to make sure that we handle stacks of executorBoundParams properly.
+--
+-- The prepared statement will first call f() which will force new executor run with new
+-- set of parameters. Then it will call worker_save_query_explain_analyze with a
+-- parametrized query. If we don't have the correct set of parameters here, it will fail.
+CREATE FUNCTION f() RETURNS INT
+AS $$
+PREPARE pp1 AS SELECT $1 WHERE $2 = $3;
+EXECUTE pp1(4, 5, 5);
+deallocate pp1;
+SELECT 1$$ LANGUAGE sql volatile;
+PREPARE save_explain AS
+ SELECT $1, CASE WHEN i < 2 THEN
+             f() = 1
+		    ELSE
+			 EXISTS(SELECT * FROM worker_save_query_explain_analyze('SELECT $1::int', :default_opts) as (a int)
+			        WHERE a = 1)
+			END
+ FROM generate_series(1, 4) i;
+EXECUTE save_explain(1);
+ ?column? | exists
+---------------------------------------------------------------------
+ 1        | t
+ 1        | t
+ 1        | t
+ 1        | t
+(4 rows)
+
+deallocate save_explain;
+DROP FUNCTION f();
+DROP TABLE t;
 SELECT * FROM explain_analyze_test ORDER BY a;
  a |    b
 ---------------------------------------------------------------------
@@ -1829,6 +1875,7 @@ SET client_min_messages TO WARNING;
 SELECT create_distributed_table('explain_analyze_test', 'a');
 
 \set default_analyze_flags '(ANALYZE on, COSTS off, TIMING off, SUMMARY off)'
+\set default_explain_flags '(ANALYZE off, COSTS off, TIMING off, SUMMARY off)'
 -- router SELECT
 EXPLAIN :default_analyze_flags SELECT * FROM explain_analyze_test WHERE a = 1;
 Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
@@ -2339,6 +2386,20 @@ Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
         ->  Aggregate (actual rows=1 loops=1)
               ->  Function Scan on read_intermediate_result intermediate_result (actual rows=10 loops=1)
 ROLLBACK;
+-- https://github.com/citusdata/citus/issues/4074
+prepare ref_select(int) AS select * from ref_table where 1 = $1;
+explain :default_analyze_flags execute ref_select(1);
+Custom Scan (Citus Adaptive) (actual rows=10 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 11 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 11 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Result (actual rows=10 loops=1)
+              One-Time Filter: (1 = $1)
+              ->  Seq Scan on ref_table_570021 ref_table (actual rows=10 loops=1)
+deallocate ref_select;
 DROP TABLE ref_table, dist_table;
 -- test EXPLAIN ANALYZE with different replication factors
 SET citus.shard_count = 2;
@@ -2600,3 +2661,255 @@ Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
               Filter: (a = 1)
               Rows Removed by Filter: 3
 DROP TABLE dist_table_rep1, dist_table_rep2;
+-- https://github.com/citusdata/citus/issues/2009
+CREATE TABLE simple (id integer, name text);
+SELECT create_distributed_table('simple', 'id');
+
+PREPARE simple_router AS SELECT *, $1 FROM simple WHERE id = 1;
+EXPLAIN :default_explain_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+EXPLAIN :default_analyze_flags EXECUTE simple_router(1);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+              Filter: (id = 1)
+deallocate simple_router;
+-- prepared multi-row insert
+PREPARE insert_query AS INSERT INTO simple VALUES ($1, 2), (2, $2);
+EXPLAIN :default_explain_flags EXECUTE insert_query(3, 4);
+Custom Scan (Citus Adaptive)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on simple_570026 citus_table_alias
+              ->  Result
+EXPLAIN :default_analyze_flags EXECUTE insert_query(3, 4);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on simple_570026 citus_table_alias (actual rows=0 loops=1)
+              ->  Result (actual rows=1 loops=1)
+deallocate insert_query;
+-- prepared updates
+PREPARE update_query AS UPDATE simple SET name=$1 WHERE name=$2;
+EXPLAIN :default_explain_flags EXECUTE update_query('x', 'y');
+Custom Scan (Citus Adaptive)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Update on simple_570026 simple
+              ->  Seq Scan on simple_570026 simple
+                    Filter: (name = 'y'::text)
+EXPLAIN :default_analyze_flags EXECUTE update_query('x', 'y');
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Update on simple_570026 simple (actual rows=0 loops=1)
+              ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+                    Filter: (name = $2)
+                    Rows Removed by Filter: 1
+deallocate update_query;
+-- prepared deletes
+PREPARE delete_query AS DELETE FROM simple WHERE name=$1 OR name=$2;
+EXPLAIN EXECUTE delete_query('x', 'y');
+Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Delete on simple_570026 simple  (cost=0.00..29.05 rows=13 width=6)
+              ->  Seq Scan on simple_570026 simple  (cost=0.00..29.05 rows=13 width=6)
+                    Filter: ((name = 'x'::text) OR (name = 'y'::text))
+EXPLAIN :default_analyze_flags EXECUTE delete_query('x', 'y');
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Delete on simple_570026 simple (actual rows=0 loops=1)
+              ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+                    Filter: ((name = $1) OR (name = $2))
+                    Rows Removed by Filter: 1
+deallocate delete_query;
+-- prepared distributed insert/select
+-- we don't support EXPLAIN for prepared insert/selects of other types.
+PREPARE distributed_insert_select AS INSERT INTO simple SELECT * FROM simple WHERE name IN ($1, $2);
+EXPLAIN :default_explain_flags EXECUTE distributed_insert_select('x', 'y');
+Custom Scan (Citus Adaptive)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on simple_570026 citus_table_alias
+              ->  Seq Scan on simple_570026 simple
+                    Filter: ((name = ANY ('{x,y}'::text[])) AND (worker_hash(id) >= '-2147483648'::integer) AND (worker_hash(id) <= '-1'::integer))
+EXPLAIN :default_analyze_flags EXECUTE distributed_insert_select('x', 'y');
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on simple_570026 citus_table_alias (actual rows=0 loops=1)
+              ->  Seq Scan on simple_570026 simple (actual rows=0 loops=1)
+                    Filter: ((name = ANY (ARRAY[$1, $2])) AND (worker_hash(id) >= '-2147483648'::integer) AND (worker_hash(id) <= '-1'::integer))
+                    Rows Removed by Filter: 1
+deallocate distributed_insert_select;
+-- prepared cte
+BEGIN;
+PREPARE cte_query AS
+WITH keys AS (
+  SELECT count(*) FROM
+   (SELECT DISTINCT l_orderkey, GREATEST(random(), 2) FROM lineitem_hash_part WHERE l_quantity > $1) t
+),
+series AS (
+  SELECT s FROM generate_series(1, $2) s
+),
+delete_result AS (
+  DELETE FROM lineitem_hash_part WHERE l_quantity < $3 RETURNING *
+)
+SELECT s FROM series;
+EXPLAIN :default_explain_flags EXECUTE cte_query(2, 10, -1);
+Custom Scan (Citus Adaptive)
+  ->  Distributed Subplan XXX_1
+        ->  Custom Scan (Citus Adaptive)
+              Task Count: 4
+              Tasks Shown: One of 4
+              ->  Task
+                    Node: host=localhost port=xxxxx dbname=regression
+                    ->  Delete on lineitem_hash_part_360041 lineitem_hash_part
+                          ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part
+                                Filter: (l_quantity < '-1'::numeric)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Function Scan on generate_series s
+EXPLAIN :default_analyze_flags EXECUTE cte_query(2, 10, -1);
+Custom Scan (Citus Adaptive) (actual rows=10 loops=1)
+  ->  Distributed Subplan XXX_1
+        Intermediate Data Size: 0 bytes
+        Result destination: Send to 0 nodes
+        ->  Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+              Task Count: 4
+              Tuple data received from nodes: 0 bytes
+              Tasks Shown: One of 4
+              ->  Task
+                    Tuple data received from node: 0 bytes
+                    Node: host=localhost port=xxxxx dbname=regression
+                    ->  Delete on lineitem_hash_part_360041 lineitem_hash_part (actual rows=0 loops=1)
+                          ->  Seq Scan on lineitem_hash_part_360041 lineitem_hash_part (actual rows=0 loops=1)
+                                Filter: (l_quantity < '-1'::numeric)
+                                Rows Removed by Filter: 2885
+  Task Count: 1
+  Tuple data received from nodes: 11 bytes
+  Tasks Shown: All
+  ->  Task
+        Tuple data received from node: 11 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Function Scan on generate_series s (actual rows=10 loops=1)
+ROLLBACK;
+-- https://github.com/citusdata/citus/issues/2009#issuecomment-653036502
+CREATE TABLE users_table_2 (user_id int primary key, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint);
+SELECT create_reference_table('users_table_2');
+
+PREPARE p4 (int, int) AS insert into users_table_2 ( value_1, user_id) select value_1, user_id + $2  FROM users_table_2 ON CONFLICT (user_id) DO UPDATE SET value_2 = EXCLUDED.value_1 + $1;
+EXPLAIN :default_explain_flags execute p4(20,20);
+Custom Scan (Citus Adaptive)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on users_table_2_570028 citus_table_alias
+              Conflict Resolution: UPDATE
+              Conflict Arbiter Indexes: users_table_2_pkey_570028
+              ->  Seq Scan on users_table_2_570028 users_table_2
+EXPLAIN :default_analyze_flags execute p4(20,20);
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Insert on users_table_2_570028 citus_table_alias (actual rows=0 loops=1)
+              Conflict Resolution: UPDATE
+              Conflict Arbiter Indexes: users_table_2_pkey_570028
+              Tuples Inserted: 0
+              Conflicting Tuples: 0
+              ->  Seq Scan on users_table_2_570028 users_table_2 (actual rows=0 loops=1)
+DROP TABLE simple, users_table_2;


### PR DESCRIPTION
DESCRIPTION: Support EXPLAIN ANALYZE EXECUTE and EXPLAIN EXECUTE.

Fixes #4074, #2009, #982.

To support EXPLAIN ANALYZE EXECUTE:

- Modify the adaptive executor to send queries for multi-query tasks one-by-one, instead of a single semi-colon separated string. This is because `pqSendQueryParams()` doesn't accept multiple queries.
- Modify `worker_save_query_explain_analyze()` to use the bound parameters when executing the task query.

To support EXPLAIN EXECUTE: Fix `FetchRemoteExplainFromWorkers` to send bound params along with the EXPLAIN query.