### PR TITLE
Prefer make install-all instead of make-install in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ why we ask this as well as instructions for how to proceed, see the
   cd citus
   ./configure
   make
-  make install
+  make install-all
   cd src/test/regress
   make check
   ```
@@ -61,7 +61,7 @@ why we ask this as well as instructions for how to proceed, see the
   cd citus
   ./configure
   make
-  sudo make install
+  sudo make install-all
   cd src/test/regress
   make check
   ```
@@ -103,7 +103,7 @@ why we ask this as well as instructions for how to proceed, see the
   cd citus
   PG_CONFIG=/usr/pgsql-11/bin/pg_config ./configure
   make
-  sudo make install
+  sudo make install-all
   cd src/test/regress
   make check
   ```


### PR DESCRIPTION
Users need to install downgrade scripts as well for `multi_extension` test to pass.
Fixes https://github.com/citusdata/citus/issues/4081

Maybe we can consider backporting this to release-9.3 & release-9.4 branches ?
