### PR TITLE
Fix non deterministic collation test to work with ancient libicu versions

### DIFF
--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -389,7 +389,7 @@ SELECT DISTINCT y FROM test;
 -- non deterministic collations
 CREATE COLLATION test_pg12.case_insensitive (
 	provider = icu,
-	locale = 'und-u-ks-level2',
+	locale = '@colStrength=secondary',
 	deterministic = false
 );
 CREATE TABLE col_test (

--- a/src/test/regress/sql/pg12.sql
+++ b/src/test/regress/sql/pg12.sql
@@ -263,7 +263,7 @@ SELECT DISTINCT y FROM test;
 -- non deterministic collations
 CREATE COLLATION test_pg12.case_insensitive (
 	provider = icu,
-	locale = 'und-u-ks-level2',
+	locale = '@colStrength=secondary',
 	deterministic = false
 );
 


### PR DESCRIPTION
CentOS 7's libicu is too old for und-u-ks-level2

@colStrength=secondary works with both older & newer versions of libicu

Fixes #4096 