### PR TITLE
Isolate each test schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
 
 
 
-  test-11_check-van-mx:
+  test-11_check-van:
     docker:
       - image: 'citus/exttester-11:latest'
     working_directory: /home/circleci/project
@@ -91,12 +91,13 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-van-mx)'
-          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla check-multi-mx'
+          name: 'Install and Test (check-van)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla'
           no_output_timeout: 2m
       - codecov/upload:
-          flags: 'test_11,vanilla,mx'
-  test-11_check-iso-work-fol:
+          flags: 'test_11,vanilla'
+
+  test-11_check-mx:
     docker:
       - image: 'citus/exttester-11:latest'
     working_directory: /home/circleci/project
@@ -104,11 +105,39 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-iso-work-fol)'
-          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation check-worker'
+          name: 'Install and Test (check-mx)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi-mx'
           no_output_timeout: 2m
       - codecov/upload:
-          flags: 'test_11,isolation,worker'
+          flags: 'test_11,mx'
+
+  test-11_check-work:
+    docker:
+      - image: 'citus/exttester-11:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: 'Install and Test (check-work)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-worker'
+          no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_11,worker'
+
+  test-11_check-iso:
+    docker:
+      - image: 'citus/exttester-11:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: 'Install and Test (check-iso)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation'
+          no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_11,isolation'
   test-11_check-fol:
     docker:
       - image: 'citus/exttester-11:latest'
@@ -181,7 +210,7 @@ jobs:
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_12,multi'
-  test-12_check-van-mx:
+  test-12_check-van:
     docker:
       - image: 'citus/exttester-12:latest'
     working_directory: /home/circleci/project
@@ -189,12 +218,27 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-van-mx)'
-          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla check-multi-mx'
+          name: 'Install and Test (check-van)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla'
           no_output_timeout: 2m
       - codecov/upload:
-          flags: 'test_12,vanilla,mx'
-  test-12_check-iso-work-fol:
+          flags: 'test_12,vanilla'
+
+  test-12_check-mx:
+    docker:
+      - image: 'citus/exttester-12:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: 'Install and Test (check-mx)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi-mx'
+          no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_12,mx'
+
+  test-12_check-iso:
     docker:
       - image: 'citus/exttester-12:latest'
     working_directory: /home/circleci/project
@@ -202,11 +246,26 @@ jobs:
       - attach_workspace:
            at: .
       - run:
-          name: 'Install and Test (check-iso-work-fol)'
-          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation check-worker'
+          name: 'Install and Test (check-iso)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation'
           no_output_timeout: 2m
       - codecov/upload:
-          flags: 'test_12,isolation,worker'
+          flags: 'test_12,isolation'
+
+  test-12_check-work:
+    docker:
+      - image: 'citus/exttester-12:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+           at: .
+      - run:
+          name: 'Install and Test (check-work)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-worker'
+          no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_12,worker'
+
   test-12_check-fol:
     docker:
       - image: 'citus/exttester-12:latest'
@@ -278,7 +337,7 @@ jobs:
       - codecov/upload:
           flags: 'test_13,multi'
 
-  test-13_check-van-mx:
+  test-13_check-mx:
     docker:
       - image: 'citus/exttester-13:latest'
     working_directory: /home/circleci/project
@@ -286,12 +345,27 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-van-mx)'
-          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla check-multi-mx'
+          name: 'Install and Test (check-mx)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi-mx'
           no_output_timeout: 2m
       - codecov/upload:
-          flags: 'test_13,vanilla,mx'
-  test-13_check-iso-work-fol:
+          flags: 'test_13,mx'
+
+  test-13_check-van:
+    docker:
+      - image: 'citus/exttester-13:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: 'Install and Test (check-van)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla'
+          no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_13,vanilla'
+
+  test-13_check-work:
     docker:
       - image: 'citus/exttester-13:latest'
     working_directory: /home/circleci/project
@@ -299,11 +373,26 @@ jobs:
       - attach_workspace:
            at: .
       - run:
-          name: 'Install and Test (check-iso-work-fol)'
-          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation check-worker'
+          name: 'Install and Test (check-work)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-worker'
           no_output_timeout: 2m
       - codecov/upload:
-          flags: 'test_13,isolation,worker'
+          flags: 'test_13,worker'
+
+  test-13_check-iso:
+    docker:
+      - image: 'citus/exttester-13:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+           at: .
+      - run:
+          name: 'Install and Test (check-iso)'
+          command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation'
+          no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_13,isolation'
+
   test-13_check-fol:
     docker:
       - image: 'citus/exttester-13:latest'
@@ -395,9 +484,13 @@ workflows:
 
       - test-11_check-multi:
           requires: [build]
-      - test-11_check-van-mx:
+      - test-11_check-van:
           requires: [build]
-      - test-11_check-iso-work-fol:
+      - test-11_check-iso:
+          requires: [build]
+      - test-11_check-mx:
+          requires: [build]
+      - test-11_check-work:
           requires: [build]
       - test-11_check-fol:
           requires: [build]
@@ -406,9 +499,13 @@ workflows:
 
       - test-12_check-multi:
           requires: [build]
-      - test-12_check-van-mx:
+      - test-12_check-van:
           requires: [build]
-      - test-12_check-iso-work-fol:
+      - test-12_check-iso:
+          requires: [build]
+      - test-12_check-mx:
+          requires: [build]
+      - test-12_check-work:
           requires: [build]
       - test-12_check-fol:
           requires: [build]
@@ -417,9 +514,13 @@ workflows:
 
       - test-13_check-multi:
           requires: [build]
-      - test-13_check-van-mx:
+      - test-13_check-van:
           requires: [build]
-      - test-13_check-iso-work-fol:
+      - test-13_check-iso:
+          requires: [build]
+      - test-13_check-mx:
+          requires: [build]
+      - test-13_check-work:
           requires: [build]
       - test-13_check-fol:
           requires: [build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
 
 
 
-  test-11_check-van:
+  test-11_check-vanilla:
     docker:
       - image: 'citus/exttester-11:latest'
     working_directory: /home/circleci/project
@@ -91,7 +91,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-van)'
+          name: 'Install and Test (check-vanilla)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla'
           no_output_timeout: 2m
       - codecov/upload:
@@ -111,7 +111,7 @@ jobs:
       - codecov/upload:
           flags: 'test_11,mx'
 
-  test-11_check-work:
+  test-11_check-worker:
     docker:
       - image: 'citus/exttester-11:latest'
     working_directory: /home/circleci/project
@@ -119,13 +119,13 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-work)'
+          name: 'Install and Test (check-worker)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-worker'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_11,worker'
 
-  test-11_check-iso:
+  test-11_check-isolation:
     docker:
       - image: 'citus/exttester-11:latest'
     working_directory: /home/circleci/project
@@ -133,12 +133,12 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-iso)'
+          name: 'Install and Test (check-isolation)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_11,isolation'
-  test-11_check-fol:
+  test-11_check-follower-cluster:
     docker:
       - image: 'citus/exttester-11:latest'
     working_directory: /home/circleci/project
@@ -149,7 +149,7 @@ jobs:
           name: 'Enable core dumps'
           command: 'ulimit -c unlimited'
       - run:
-          name: 'Install and Test (fol)'
+          name: 'Install and Test (follower-cluster)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-follower-cluster'
           no_output_timeout: 2m
       - run:
@@ -158,7 +158,7 @@ jobs:
             cp core.* /tmp/core_dumps
           when: on_fail
       - codecov/upload:
-          flags: 'test_11,follower'
+          flags: 'test_11,follower-cluster'
       - store_artifacts:
           path: '/tmp/core_dumps'
   test-11_check-failure:
@@ -210,7 +210,7 @@ jobs:
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_12,multi'
-  test-12_check-van:
+  test-12_check-vanilla:
     docker:
       - image: 'citus/exttester-12:latest'
     working_directory: /home/circleci/project
@@ -218,7 +218,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-van)'
+          name: 'Install and Test (check-vanilla)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla'
           no_output_timeout: 2m
       - codecov/upload:
@@ -238,7 +238,7 @@ jobs:
       - codecov/upload:
           flags: 'test_12,mx'
 
-  test-12_check-iso:
+  test-12_check-isolation:
     docker:
       - image: 'citus/exttester-12:latest'
     working_directory: /home/circleci/project
@@ -246,13 +246,13 @@ jobs:
       - attach_workspace:
            at: .
       - run:
-          name: 'Install and Test (check-iso)'
+          name: 'Install and Test (check-isolation)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_12,isolation'
 
-  test-12_check-work:
+  test-12_check-worker:
     docker:
       - image: 'citus/exttester-12:latest'
     working_directory: /home/circleci/project
@@ -260,13 +260,13 @@ jobs:
       - attach_workspace:
            at: .
       - run:
-          name: 'Install and Test (check-work)'
+          name: 'Install and Test (check-worker)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-worker'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_12,worker'
 
-  test-12_check-fol:
+  test-12_check-follower-cluster:
     docker:
       - image: 'citus/exttester-12:latest'
     working_directory: /home/circleci/project
@@ -277,7 +277,7 @@ jobs:
           name: 'Enable core dumps'
           command: 'ulimit -c unlimited'
       - run:
-          name: 'Install and Test (fol)'
+          name: 'Install and Test (follower-cluster)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-follower-cluster'
           no_output_timeout: 2m
       - run:
@@ -286,7 +286,7 @@ jobs:
             cp core.* /tmp/core_dumps
           when: on_fail
       - codecov/upload:
-          flags: 'test_12,follower'
+          flags: 'test_12,follower-cluster'
       - store_artifacts:
           path: '/tmp/core_dumps'
 
@@ -351,7 +351,7 @@ jobs:
       - codecov/upload:
           flags: 'test_13,mx'
 
-  test-13_check-van:
+  test-13_check-vanilla:
     docker:
       - image: 'citus/exttester-13:latest'
     working_directory: /home/circleci/project
@@ -359,13 +359,13 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install and Test (check-van)'
+          name: 'Install and Test (check-vanilla)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-vanilla'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_13,vanilla'
 
-  test-13_check-work:
+  test-13_check-worker:
     docker:
       - image: 'citus/exttester-13:latest'
     working_directory: /home/circleci/project
@@ -373,13 +373,13 @@ jobs:
       - attach_workspace:
            at: .
       - run:
-          name: 'Install and Test (check-work)'
+          name: 'Install and Test (check-worker)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-worker'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_13,worker'
 
-  test-13_check-iso:
+  test-13_check-isolation:
     docker:
       - image: 'citus/exttester-13:latest'
     working_directory: /home/circleci/project
@@ -387,13 +387,13 @@ jobs:
       - attach_workspace:
            at: .
       - run:
-          name: 'Install and Test (check-iso)'
+          name: 'Install and Test (check-isolation)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-isolation'
           no_output_timeout: 2m
       - codecov/upload:
           flags: 'test_13,isolation'
 
-  test-13_check-fol:
+  test-13_check-follower-cluster:
     docker:
       - image: 'citus/exttester-13:latest'
     working_directory: /home/circleci/project
@@ -404,7 +404,7 @@ jobs:
           name: 'Enable core dumps'
           command: 'ulimit -c unlimited'
       - run:
-          name: 'Install and Test (fol)'
+          name: 'Install and Test (follower-cluster)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-follower-cluster'
           no_output_timeout: 2m
       - run:
@@ -413,7 +413,7 @@ jobs:
             cp core.* /tmp/core_dumps
           when: on_fail
       - codecov/upload:
-          flags: 'test_13,follower'
+          flags: 'test_13,follower-cluster'
       - store_artifacts:
           path: '/tmp/core_dumps'
 
@@ -484,45 +484,45 @@ workflows:
 
       - test-11_check-multi:
           requires: [build]
-      - test-11_check-van:
+      - test-11_check-vanilla:
           requires: [build]
-      - test-11_check-iso:
+      - test-11_check-isolation:
           requires: [build]
       - test-11_check-mx:
           requires: [build]
-      - test-11_check-work:
+      - test-11_check-worker:
           requires: [build]
-      - test-11_check-fol:
+      - test-11_check-follower-cluster:
           requires: [build]
       - test-11_check-failure:
           requires: [build]
 
       - test-12_check-multi:
           requires: [build]
-      - test-12_check-van:
+      - test-12_check-vanilla:
           requires: [build]
-      - test-12_check-iso:
+      - test-12_check-isolation:
           requires: [build]
       - test-12_check-mx:
           requires: [build]
-      - test-12_check-work:
+      - test-12_check-worker:
           requires: [build]
-      - test-12_check-fol:
+      - test-12_check-follower-cluster:
           requires: [build]
       - test-12_check-failure:
           requires: [build]
 
       - test-13_check-multi:
           requires: [build]
-      - test-13_check-van:
+      - test-13_check-vanilla:
           requires: [build]
-      - test-13_check-iso:
+      - test-13_check-isolation:
           requires: [build]
       - test-13_check-mx:
           requires: [build]
-      - test-13_check-work:
+      - test-13_check-worker:
           requires: [build]
-      - test-13_check-fol:
+      - test-13_check-follower-cluster:
           requires: [build]
       - test-13_check-failure:
           requires: [build]


### PR DESCRIPTION
Since we don't have any limitation on parallelism now, it makes sense to
isolate each test schedule so that:
- we can use more parallelism
- we will wait less on retries because if a job fails with multiple
schedules, we needed to rerun all of them.
