### PR TITLE
Fix comments of helper functions that set local config values

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -4421,9 +4421,9 @@ RebuildWaitEventSetFlags(WaitEventSet *waitEventSet, List *sessionList)
 
 
 /*
- * SetLocalForceMaxQueryParallelization simply a C interface for
- * setting the following:
- *      SET LOCAL citus.multi_shard_modify_mode TO on;
+ * SetLocalForceMaxQueryParallelization is simply a C interface for setting
+ * the following:
+ *      SET LOCAL citus.force_max_query_parallelization TO on;
  */
 void
 SetLocalForceMaxQueryParallelization(void)

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -794,8 +794,7 @@ ErrorIfTransactionAccessedPlacementsLocally(void)
 
 
 /*
- * DisableLocalExecution simply a C interface for
- * setting the following:
+ * DisableLocalExecution is simply a C interface for setting the following:
  *      SET LOCAL citus.enable_local_execution TO off;
  */
 void

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -642,8 +642,8 @@ ExecutePlanIntoDestReceiver(PlannedStmt *queryPlan, ParamListInfo params,
 
 
 /*
- * SetLocalMultiShardModifyModeToSequential simply a C interface for
- * setting the following:
+ * SetLocalMultiShardModifyModeToSequential is simply a C interface for setting
+ * the following:
  *      SET LOCAL citus.multi_shard_modify_mode = 'sequential';
  */
 void


### PR DESCRIPTION
I wanted to fix for a wrong and misleading comment, and ended up improving some similar helper function comments.