### PR TITLE
Rename FindNodeCheckXXX functions

### DIFF
--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -570,7 +570,7 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 		}
 	}
 
-	if (FindNodeCheck((Node *) queryTree, CitusIsVolatileFunction))
+	if (FindNodeMatchingCheckFunction((Node *) queryTree, CitusIsVolatileFunction))
 	{
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 							 "volatile functions are not allowed in distributed "

--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -141,7 +141,8 @@ AnchorRte(Query *subquery)
 		 * the set operations.
 		 */
 		if (anchorRangeTblEntry == NULL && currentRte->rtekind == RTE_SUBQUERY &&
-			FindNodeCheck((Node *) currentRte->subquery, IsDistributedTableRTE) &&
+			FindNodeMatchingCheckFunction((Node *) currentRte->subquery,
+										  IsDistributedTableRTE) &&
 			currentRte->subquery->setOperations == NULL &&
 			!ContainsUnionSubquery(currentRte->subquery))
 		{

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -376,7 +376,7 @@ ShouldRecursivelyPlanNonColocatedSubqueries(Query *subquery,
 	}
 
 	/* direct joins with local tables are not supported by any of Citus planners */
-	if (FindNodeCheckInRangeTableList(subquery->rtable, IsLocalTableRTE))
+	if (FindNodeMatchingCheckFunctionInRangeTableList(subquery->rtable, IsLocalTableRTE))
 	{
 		return false;
 	}
@@ -636,7 +636,8 @@ ShouldRecursivelyPlanAllSubqueriesInWhere(Query *query)
 		return false;
 	}
 
-	if (FindNodeCheckInRangeTableList(query->rtable, IsDistributedTableRTE))
+	if (FindNodeMatchingCheckFunctionInRangeTableList(query->rtable,
+													  IsDistributedTableRTE))
 	{
 		/* there is a distributed table in the FROM clause */
 		return false;
@@ -662,7 +663,7 @@ RecursivelyPlanAllSubqueries(Node *node, RecursivePlanningContext *planningConte
 	if (IsA(node, Query))
 	{
 		Query *query = (Query *) node;
-		if (FindNodeCheckInRangeTableList(query->rtable, IsCitusTableRTE))
+		if (FindNodeMatchingCheckFunctionInRangeTableList(query->rtable, IsCitusTableRTE))
 		{
 			RecursivelyPlanSubquery(query, planningContext);
 		}
@@ -876,7 +877,7 @@ RecursivelyPlanSubqueryWalker(Node *node, RecursivePlanningContext *context)
 static bool
 ShouldRecursivelyPlanSubquery(Query *subquery, RecursivePlanningContext *context)
 {
-	if (FindNodeCheckInRangeTableList(subquery->rtable, IsLocalTableRTE))
+	if (FindNodeMatchingCheckFunctionInRangeTableList(subquery->rtable, IsLocalTableRTE))
 	{
 		/*
 		 * Postgres can always plan queries that don't require distributed planning.
@@ -1029,7 +1030,7 @@ RecursivelyPlanSetOperations(Query *query, Node *node,
 		Query *subquery = rangeTableEntry->subquery;
 
 		if (rangeTableEntry->rtekind == RTE_SUBQUERY &&
-			FindNodeCheck((Node *) subquery, IsDistributedTableRTE))
+			FindNodeMatchingCheckFunction((Node *) subquery, IsDistributedTableRTE))
 		{
 			RecursivelyPlanSubquery(subquery, context);
 		}

--- a/src/backend/distributed/utils/citus_clauses.c
+++ b/src/backend/distributed/utils/citus_clauses.c
@@ -57,7 +57,7 @@ RequiresCoordinatorEvaluation(Query *query)
 		return false;
 	}
 
-	return FindNodeCheck((Node *) query, CitusIsMutableFunction);
+	return FindNodeMatchingCheckFunction((Node *) query, CitusIsMutableFunction);
 }
 
 
@@ -152,7 +152,7 @@ PartiallyEvaluateExpression(Node *expression,
 													coordinatorEvaluationContext);
 		}
 
-		if (FindNodeCheck(expression, IsVariableExpression))
+		if (FindNodeMatchingCheckFunction(expression, IsVariableExpression))
 		{
 			/*
 			 * The expression contains a variable expression (e.g. a stable function,

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -187,9 +187,10 @@ typedef struct MultiExtendedOp
 extern MultiTreeRoot * MultiLogicalPlanCreate(Query *originalQuery, Query *queryTree,
 											  PlannerRestrictionContext *
 											  plannerRestrictionContext);
-extern bool FindNodeCheck(Node *node, bool (*check)(Node *));
+extern bool FindNodeMatchingCheckFunction(Node *node, bool (*check)(Node *));
 extern bool TargetListOnPartitionColumn(Query *query, List *targetEntryList);
-extern bool FindNodeCheckInRangeTableList(List *rtable, bool (*check)(Node *));
+extern bool FindNodeMatchingCheckFunctionInRangeTableList(List *rtable, bool (*check)(
+															  Node *));
 extern bool IsCitusTableRTE(Node *node);
 extern bool IsDistributedTableRTE(Node *node);
 extern bool IsReferenceTableRTE(Node *node);


### PR DESCRIPTION
FindNodeCheck is not clear about what the function is doing. They are
renamed to FindNodeWithFilterXXX. Also for choosing elements in these
functions, chooseFunc type is introduced. The reason I didn't use
filterFunc is because in the parameter it is a bit ambigous if it is
filtering out or if it refers to what is left. However `choose` is
clear. That is also the reason `WithFilter` is used in the function name
instead of `Filter` to make it more clear.
