### PR TITLE
Delegate reference procedures that read from reference tables

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -408,6 +408,31 @@ CompareShardPlacementsByWorker(const void *leftElement, const void *rightElement
 
 
 /*
+ * CompareShardPlacementsByGroupId compares two shard placements by their
+ * group id.
+ */
+int
+CompareShardPlacementsByGroupId(const void *leftElement, const void *rightElement)
+{
+	const ShardPlacement *leftPlacement = *((const ShardPlacement **) leftElement);
+	const ShardPlacement *rightPlacement = *((const ShardPlacement **) rightElement);
+
+	if (leftPlacement->groupId > rightPlacement->groupId)
+	{
+		return 1;
+	}
+	else if (leftPlacement->groupId < rightPlacement->groupId)
+	{
+		return -1;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+
+/*
  * TableShardReplicationFactor returns the current replication factor of the
  * given relation by looking into shard placements. It errors out if there
  * are different number of shard placements for different shards. It also

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1,3 +1,4 @@
+
 /*-------------------------------------------------------------------------
  *
  * multi_router_planner.c
@@ -164,7 +165,6 @@ static List * SingleShardTaskList(Query *query, uint64 jobId,
 								  List *relationShardList, List *placementList,
 								  uint64 shardId, bool parametersInQueryResolved);
 static bool RowLocksOnRelations(Node *node, List **rtiLockList);
-static List * RemoveCoordinatorPlacementIfNotSingleNode(List *placementList);
 static void ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 														TaskAssignmentPolicyType
 														taskAssignmentPolicy,
@@ -1836,7 +1836,7 @@ ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
  * If the list has a single element or no placements on the coordinator, the list
  * returned is unmodified.
  */
-static List *
+List *
 RemoveCoordinatorPlacementIfNotSingleNode(List *placementList)
 {
 	ListCell *placementCell = NULL;

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -149,6 +149,14 @@ extern bool HasOverlappingShardInterval(ShardInterval **shardIntervalArray,
 										Oid shardIntervalCollation,
 										FmgrInfo *shardIntervalSortCompareFunction);
 
+extern ShardPlacement * ShardPlacementForFunctionColocatedWithReferenceTable(
+	CitusTableCacheEntry *cacheEntry);
+extern ShardPlacement * ShardPlacementForFunctionColocatedWithDistTable(
+	DistObjectCacheEntry *procedure, FuncExpr *funcExpr, Var *partitionColumn,
+	CitusTableCacheEntry
+	*cacheEntry,
+	PlannedStmt *plan);
+
 extern bool CitusHasBeenLoaded(void);
 extern bool CheckCitusVersion(int elevel);
 extern bool CheckAvailableVersion(int elevel);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -114,6 +114,7 @@ extern List * AllShardPlacementsOnNodeGroup(int32 groupId);
 extern List * GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId);
 extern StringInfo GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList,
 														char *sizeQuery);
+extern List * RemoveCoordinatorPlacementIfNotSingleNode(List *placementList);
 
 /* Function declarations to modify shard and shard placement data */
 extern void InsertShardRow(Oid relationId, uint64 shardId, char storageType,
@@ -161,6 +162,8 @@ extern Datum StringToDatum(char *inputString, Oid dataType);
 extern char * DatumToString(Datum datum, Oid dataType);
 extern int CompareShardPlacementsByWorker(const void *leftElement,
 										  const void *rightElement);
+extern int CompareShardPlacementsByGroupId(const void *leftElement,
+										   const void *rightElement);
 extern ShardInterval * DeformedDistShardTupleToShardInterval(Datum *datumArray,
 															 bool *isNullArray,
 															 Oid intervalTypeId,

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -686,20 +686,11 @@ SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val
 -- colocate_with cannot be used without distribution key
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', colocate_with:='replicated_table_func_test_2');
 ERROR:  cannot distribute the function "eq_with_param_names" since the distribution argument is not valid
-HINT:  To provide "colocate_with" option, the distribution argument parameter should also be provided
+HINT:  To provide "colocate_with" option with a distributed table, the distribution argument parameter should also be provided
 -- a function cannot be colocated with a local table
 CREATE TABLE replicated_table_func_test_3 (a macaddr8);
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1', colocate_with:='replicated_table_func_test_3');
 ERROR:  relation replicated_table_func_test_3 is not distributed
--- a function cannot be colocated with a reference table
-SELECT create_reference_table('replicated_table_func_test_3');
- create_reference_table
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1', colocate_with:='replicated_table_func_test_3');
-ERROR:  cannot colocate function "eq_with_param_names" and table "replicated_table_func_test_3" because colocate_with option is only supported for hash distributed tables.
 -- finally, colocate the function with a distributed table
 SET citus.shard_replication_factor TO 1;
 CREATE TABLE replicated_table_func_test_4 (a macaddr);
@@ -741,6 +732,22 @@ WHERE pg_dist_partition.logicalrelid = 'replicated_table_func_test_4'::regclass 
  table_and_function_colocated
 ---------------------------------------------------------------------
  t
+(1 row)
+
+-- a function cannot be colocated with a reference table when a distribution column is provided
+SELECT create_reference_table('replicated_table_func_test_3');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1', colocate_with:='replicated_table_func_test_3');
+ERROR:  cannot colocate function "eq_with_param_names" and table "replicated_table_func_test_3" because distribution arguments are not supported when colocating with reference tables.
+-- a function can be colocated with a reference table when the distribution argument is omitted
+SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', colocate_with:='replicated_table_func_test_3');
+ create_distributed_function
+---------------------------------------------------------------------
+
 (1 row)
 
 -- function with a macaddr8 dist. arg can be colocated with macaddr

--- a/src/test/regress/expected/multi_mx_add_coordinator.out
+++ b/src/test/regress/expected/multi_mx_add_coordinator.out
@@ -37,7 +37,7 @@ SELECT verify_metadata('localhost', :worker_1_port),
  t               | t
 (1 row)
 
-CREATE TABLE ref(a int);
+CREATE TABLE ref(groupid int);
 SELECT create_reference_table('ref');
  create_reference_table
 ---------------------------------------------------------------------
@@ -92,6 +92,54 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM mx_add_coo
      0
 (1 row)
 
+-- test that distributed functions also use local execution
+CREATE OR REPLACE FUNCTION my_group_id()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $$
+DECLARE
+    gid int;
+BEGIN
+    SELECT groupid INTO gid
+    FROM pg_dist_local_group;
+
+    INSERT INTO mx_add_coordinator.ref(groupid) VALUES (gid);
+END;
+$$;
+SELECT create_distributed_function('my_group_id()', colocate_with := 'ref');
+DEBUG:  switching to sequential query execution mode
+DETAIL:  A distributed function is created. To make sure subsequent commands see the type correctly we need to make sure to use only one connection for all future commands
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+DEBUG:  pushing down the function call
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+DEBUG:  pushing down the function call
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+NOTICE:  executing the command locally: SELECT DISTINCT groupid FROM mx_add_coordinator.ref_7000000 ref ORDER BY groupid
+ groupid
+---------------------------------------------------------------------
+      14
+(1 row)
+
+TRUNCATE TABLE ref;
+NOTICE:  executing the command locally: TRUNCATE TABLE mx_add_coordinator.ref_xxxxx CASCADE
 -- for round-robin policy, always go to workers
 SET citus.task_assignment_policy TO "round-robin";
 SELECT count(*) FROM ref;
@@ -118,13 +166,47 @@ DEBUG:  Creating router plan
      0
 (1 row)
 
+SELECT my_group_id();
+DEBUG:  pushing down the function call
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+DEBUG:  pushing down the function call
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+DEBUG:  pushing down the function call
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ groupid
+---------------------------------------------------------------------
+      14
+      18
+(2 rows)
+
+TRUNCATE TABLE ref;
+NOTICE:  executing the command locally: TRUNCATE TABLE mx_add_coordinator.ref_xxxxx CASCADE
 -- modifications always go through local shard as well as remote ones
 INSERT INTO ref VALUES (1);
 DEBUG:  Creating router plan
-NOTICE:  executing the command locally: INSERT INTO mx_add_coordinator.ref_7000000 (a) VALUES (1)
+NOTICE:  executing the command locally: INSERT INTO mx_add_coordinator.ref_7000000 (groupid) VALUES (1)
 -- get it ready for the next executions
 TRUNCATE ref;
 NOTICE:  executing the command locally: TRUNCATE TABLE mx_add_coordinator.ref_xxxxx CASCADE
+ALTER TABLE ref RENAME COLUMN groupid TO a;
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (7000000, 'mx_add_coordinator', 'ALTER TABLE ref RENAME COLUMN groupid TO a;')
 -- test that changes from a metadata node is reflected in the coordinator placement
 \c - - - :worker_1_port
 SET search_path TO mx_add_coordinator,public;
@@ -183,9 +265,7 @@ SELECT verify_metadata('localhost', :worker_1_port),
  t               | t
 (1 row)
 
+SET client_min_messages TO error;
 DROP SCHEMA mx_add_coordinator CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table ref
-drop cascades to table ref_7000000
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/expected/multi_mx_call.out
+++ b/src/test/regress/expected/multi_mx_call.out
@@ -59,6 +59,56 @@ select create_distributed_table('mx_call_dist_table_enum', 'key');
 (1 row)
 
 insert into mx_call_dist_table_enum values (1,'S'),(2,'A'),(3,'D'),(4,'F');
+-- test that a distributed function can be colocated with a reference table
+CREATE TABLE ref(groupid int);
+SELECT create_reference_table('ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE OR REPLACE PROCEDURE my_group_id_proc()
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $$
+DECLARE
+    gid int;
+BEGIN
+    SELECT groupid INTO gid
+    FROM pg_dist_local_group;
+
+    INSERT INTO ref(groupid) VALUES (gid);
+END;
+$$;
+SELECT create_distributed_function('my_group_id_proc()', colocate_with := 'ref');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+CALL my_group_id_proc();
+CALL my_group_id_proc();
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+ groupid
+---------------------------------------------------------------------
+      14
+(1 row)
+
+TRUNCATE TABLE ref;
+-- test round robin task assignment policy uses different workers on consecutive procedure calls.
+SET citus.task_assignment_policy TO 'round-robin';
+CALL my_group_id_proc();
+CALL my_group_id_proc();
+CALL my_group_id_proc();
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+ groupid
+---------------------------------------------------------------------
+      14
+      18
+(2 rows)
+
+TRUNCATE TABLE ref;
+RESET citus.task_assignment_policy;
 CREATE PROCEDURE mx_call_proc(x int, INOUT y int)
 LANGUAGE plpgsql AS $$
 BEGIN
@@ -281,24 +331,19 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
  29
 (1 row)
 
--- We don't currently support colocating with reference tables
-select colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, 1);
+-- We support colocating with reference tables
+select colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_ref'::regclass, NULL);
  colocate_proc_with_table
 ---------------------------------------------------------------------
 
 (1 row)
 
 call multi_mx_call.mx_call_proc(2, 0);
-DEBUG:  cannot push down CALL for reference tables
-DEBUG:  generating subplan XXX_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
-PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
-PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
+DEBUG:  will push down CALL for reference tables
+DEBUG:  pushing down the procedure
  y
 ---------------------------------------------------------------------
- 29
+ 28
 (1 row)
 
 -- We don't currently support colocating with replicated tables
@@ -309,7 +354,7 @@ select colocate_proc_with_table('mx_call_proc', 'mx_call_dist_table_replica'::re
 (1 row)
 
 call multi_mx_call.mx_call_proc(2, 0);
-DEBUG:  cannot push down CALL for replicated distributed tables
+DEBUG:  cannot push down function call for replicated distributed tables
 DEBUG:  generating subplan XXX_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_call.mx_call_dist_table_1 t1 JOIN multi_mx_call.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
 CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_call.mx_call_dist_table_1 t1 join multi_mx_call.mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
@@ -485,4 +530,4 @@ PL/pgSQL function mx_call_proc(integer,integer) line 8 at assignment
 reset client_min_messages;
 \set VERBOSITY terse
 drop schema multi_mx_call cascade;
-NOTICE:  drop cascades to 11 other objects
+NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/multi_mx_function_call_delegation.out
+++ b/src/test/regress/expected/multi_mx_function_call_delegation.out
@@ -280,7 +280,7 @@ select colocate_proc_with_table('mx_call_func', 'mx_call_dist_table_1'::regclass
 (1 row)
 
 select mx_call_func(2, 0);
-DEBUG:  function call does not have a distribution argument
+DEBUG:  cannot push down invalid distribution_argument_index
 DEBUG:  generating subplan XXX_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_function_call_delegation.mx_call_dist_table_1 t1 JOIN multi_mx_function_call_delegation.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
 CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_function_call_delegation.mx_call_dist_table_1 t1 join multi_mx_function_call_delegation.mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_func(integer,integer) line 8 at assignment
@@ -299,7 +299,7 @@ select colocate_proc_with_table('mx_call_func', 'mx_call_dist_table_1'::regclass
 (1 row)
 
 select mx_call_func(2, 0);
-DEBUG:  function call does not have a distribution argument
+DEBUG:  cannot push down invalid distribution_argument_index
 DEBUG:  generating subplan XXX_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_function_call_delegation.mx_call_dist_table_1 t1 JOIN multi_mx_function_call_delegation.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
 CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_function_call_delegation.mx_call_dist_table_1 t1 join multi_mx_function_call_delegation.mx_call_dist_table_2 t2 on t1.id = t2.id)"
 PL/pgSQL function mx_call_func(integer,integer) line 8 at assignment
@@ -319,16 +319,10 @@ select colocate_proc_with_table('mx_call_func', 'mx_call_dist_table_ref'::regcla
 (1 row)
 
 select mx_call_func(2, 0);
-DEBUG:  cannnot push down function call for reference tables
-DEBUG:  generating subplan XXX_1 for subquery SELECT sum((t1.val OPERATOR(pg_catalog.+) t2.val)) AS sum FROM (multi_mx_function_call_delegation.mx_call_dist_table_1 t1 JOIN multi_mx_function_call_delegation.mx_call_dist_table_2 t2 ON ((t1.id OPERATOR(pg_catalog.=) t2.id)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_function_call_delegation.mx_call_dist_table_1 t1 join multi_mx_function_call_delegation.mx_call_dist_table_2 t2 on t1.id = t2.id)"
-PL/pgSQL function mx_call_func(integer,integer) line 8 at assignment
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (3 OPERATOR(pg_catalog.+) (SELECT intermediate_result.sum FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(sum bigint)))
-CONTEXT:  SQL statement "SELECT y + (select sum(t1.val + t2.val) from multi_mx_function_call_delegation.mx_call_dist_table_1 t1 join multi_mx_function_call_delegation.mx_call_dist_table_2 t2 on t1.id = t2.id)"
-PL/pgSQL function mx_call_func(integer,integer) line 8 at assignment
+DEBUG:  pushing down the function call
  mx_call_func
 ---------------------------------------------------------------------
-           29
+           28
 (1 row)
 
 -- We don't currently support colocating with replicated tables

--- a/src/test/regress/expected/multi_mx_function_table_reference.out
+++ b/src/test/regress/expected/multi_mx_function_table_reference.out
@@ -82,11 +82,89 @@ SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum 
  (localhost,57638,t,262152)
 (2 rows)
 
+-- test that a distributed function can be colocated with a reference table
+CREATE TABLE ref(groupid int);
+SELECT create_reference_table('ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE OR REPLACE FUNCTION my_group_id()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $$
+DECLARE
+    gid int;
+BEGIN
+    SELECT groupid INTO gid
+    FROM pg_dist_local_group;
+
+    INSERT INTO ref(groupid) VALUES (gid);
+END;
+$$;
+SELECT create_distributed_function('my_group_id()', colocate_with := 'ref');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+ groupid
+---------------------------------------------------------------------
+      14
+(1 row)
+
+TRUNCATE TABLE ref;
+-- test round robin task assignment policy uses different workers on consecutive function calls.
+SET citus.task_assignment_policy TO 'round-robin';
+SELECT my_group_id();
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT my_group_id();
+ my_group_id
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+ groupid
+---------------------------------------------------------------------
+      14
+      18
+(2 rows)
+
+TRUNCATE TABLE ref;
 -- clean up after testing
+RESET citus.task_assignment_policy;
 DROP SCHEMA function_table_reference CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table zoop_table
 drop cascades to function zoop(integer)
+drop cascades to table ref
+drop cascades to function my_group_id()
 -- make sure the worker is added at the end irregardless of anything failing to not make
 -- subsequent tests fail as well. All artifacts created during this test should have been
 -- dropped by the drop cascade above.

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -398,10 +398,6 @@ SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', colo
 CREATE TABLE replicated_table_func_test_3 (a macaddr8);
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1', colocate_with:='replicated_table_func_test_3');
 
--- a function cannot be colocated with a reference table
-SELECT create_reference_table('replicated_table_func_test_3');
-SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1', colocate_with:='replicated_table_func_test_3');
-
 -- finally, colocate the function with a distributed table
 SET citus.shard_replication_factor TO 1;
 CREATE TABLE replicated_table_func_test_4 (a macaddr);
@@ -422,6 +418,13 @@ SELECT pg_dist_partition.colocationid = objects.colocationid as table_and_functi
 FROM pg_dist_partition, citus.pg_dist_object as objects
 WHERE pg_dist_partition.logicalrelid = 'replicated_table_func_test_4'::regclass AND
 	  objects.objid = 'eq_with_param_names(macaddr, macaddr)'::regprocedure;
+
+-- a function cannot be colocated with a reference table when a distribution column is provided
+SELECT create_reference_table('replicated_table_func_test_3');
+SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1', colocate_with:='replicated_table_func_test_3');
+
+-- a function can be colocated with a reference table when the distribution argument is omitted
+SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', colocate_with:='replicated_table_func_test_3');
 
 -- function with a macaddr8 dist. arg can be colocated with macaddr
 -- column of a distributed table. In general, if there is a coercion

--- a/src/test/regress/sql/multi_mx_add_coordinator.sql
+++ b/src/test/regress/sql/multi_mx_add_coordinator.sql
@@ -21,7 +21,7 @@ SELECT wait_until_metadata_sync(30000);
 SELECT verify_metadata('localhost', :worker_1_port),
        verify_metadata('localhost', :worker_2_port);
 
-CREATE TABLE ref(a int);
+CREATE TABLE ref(groupid int);
 SELECT create_reference_table('ref');
 
 -- alter role from mx worker isn't propagated
@@ -44,17 +44,44 @@ SET client_min_messages TO DEBUG;
 SELECT count(*) FROM ref;
 SELECT count(*) FROM ref;
 
+-- test that distributed functions also use local execution
+CREATE OR REPLACE FUNCTION my_group_id()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $$
+DECLARE
+    gid int;
+BEGIN
+    SELECT groupid INTO gid
+    FROM pg_dist_local_group;
+
+    INSERT INTO mx_add_coordinator.ref(groupid) VALUES (gid);
+END;
+$$;
+SELECT create_distributed_function('my_group_id()', colocate_with := 'ref');
+SELECT my_group_id();
+SELECT my_group_id();
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+TRUNCATE TABLE ref;
 -- for round-robin policy, always go to workers
 SET citus.task_assignment_policy TO "round-robin";
 SELECT count(*) FROM ref;
 SELECT count(*) FROM ref;
 SELECT count(*) FROM ref;
 
+SELECT my_group_id();
+SELECT my_group_id();
+SELECT my_group_id();
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+TRUNCATE TABLE ref;
+
 -- modifications always go through local shard as well as remote ones
 INSERT INTO ref VALUES (1);
 
 -- get it ready for the next executions
 TRUNCATE ref;
+ALTER TABLE ref RENAME COLUMN groupid TO a;
 
 -- test that changes from a metadata node is reflected in the coordinator placement
 \c - - - :worker_1_port
@@ -86,6 +113,7 @@ SELECT wait_until_metadata_sync(30000);
 SELECT verify_metadata('localhost', :worker_1_port),
        verify_metadata('localhost', :worker_2_port);
 
+SET client_min_messages TO error;
 DROP SCHEMA mx_add_coordinator CASCADE;
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/sql/multi_mx_function_table_reference.sql
+++ b/src/test/regress/sql/multi_mx_function_table_reference.sql
@@ -50,7 +50,42 @@ SELECT public.wait_until_metadata_sync(30000);
 -- see numerictypmodin in postgres for how typmod is derived
 SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum = 2 AND attrelid = (SELECT typrelid FROM pg_type WHERE typname = 'zoop_table');$$);
 
+-- test that a distributed function can be colocated with a reference table
+CREATE TABLE ref(groupid int);
+SELECT create_reference_table('ref');
+
+CREATE OR REPLACE FUNCTION my_group_id()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $$
+DECLARE
+    gid int;
+BEGIN
+    SELECT groupid INTO gid
+    FROM pg_dist_local_group;
+
+    INSERT INTO ref(groupid) VALUES (gid);
+END;
+$$;
+
+SELECT create_distributed_function('my_group_id()', colocate_with := 'ref');
+
+SELECT my_group_id();
+SELECT my_group_id();
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+TRUNCATE TABLE ref;
+
+-- test round robin task assignment policy uses different workers on consecutive function calls.
+SET citus.task_assignment_policy TO 'round-robin';
+SELECT my_group_id();
+SELECT my_group_id();
+SELECT my_group_id();
+SELECT DISTINCT(groupid) FROM ref ORDER BY 1;
+TRUNCATE TABLE ref;
+
 -- clean up after testing
+RESET citus.task_assignment_policy;
 DROP SCHEMA function_table_reference CASCADE;
 
 -- make sure the worker is added at the end irregardless of anything failing to not make


### PR DESCRIPTION
DESCRIPTION: Introduces delegation of procedures that read from reference tables

TODO:
- [x] Refactor procedure delegation
- [x] Introduce logic to select placements for procedures to delegate reference table reads
  - [x] Use the first placement available
  - [x] Implement round-robin ~and other task assignment policies~
- [x] Refactor procedure delegation
- [x] Introduce logic to select placements for functions to delegate reference table reads
  - [x] Use the first placement available
  - [x] Implement round-robin ~and other task assignment policies~
- [x] Fix stuck `multi_mx_function_call_delegation` tests
- [x] Add all missing function comments

-----------

Potential code quality issues:
- [x] ~Static functions with the same name and slightly different signature: `ShardPlacementWhenColocatedWithReferenceTable` and `ShardPlacementWhenColocatedWithDistTable`~ Removed duplicate functions 

Fixes #3264 
