### PR TITLE
Remove unused parameters from round robin reordering and friends

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -209,7 +209,7 @@ static List * GreedyAssignTaskList(List *taskList);
 static Task * GreedyAssignTask(WorkerNode *workerNode, List *taskList,
 							   List *activeShardPlacementLists);
 static List * ReorderAndAssignTaskList(List *taskList,
-									   List * (*reorderFunction)(List *));
+									   ReorderFunction reorderFunction);
 static int CompareTasksByShardId(const void *leftElement, const void *rightElement);
 static List * ActiveShardPlacementLists(List *taskList);
 static List * ActivePlacementList(List *placementList);
@@ -5210,7 +5210,7 @@ List *
 FirstReplicaAssignTaskList(List *taskList)
 {
 	/* No additional reordering need take place for this algorithm */
-	List *(*reorderFunction)(List *) = NULL;
+	ReorderFunction reorderFunction = NULL;
 
 	taskList = ReorderAndAssignTaskList(taskList, reorderFunction);
 
@@ -5270,7 +5270,7 @@ RoundRobinReorder(List *placementList)
  * by rotation or shuffling). Returns the task list with placements assigned.
  */
 static List *
-ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(List *))
+ReorderAndAssignTaskList(List *taskList, ReorderFunction reorderFunction)
 {
 	List *assignedTaskList = NIL;
 	ListCell *taskCell = NULL;

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -209,7 +209,7 @@ static List * GreedyAssignTaskList(List *taskList);
 static Task * GreedyAssignTask(WorkerNode *workerNode, List *taskList,
 							   List *activeShardPlacementLists);
 static List * ReorderAndAssignTaskList(List *taskList,
-									   List * (*reorderFunction)(Task *, List *));
+									   List * (*reorderFunction)(List *));
 static int CompareTasksByShardId(const void *leftElement, const void *rightElement);
 static List * ActiveShardPlacementLists(List *taskList);
 static List * ActivePlacementList(List *placementList);
@@ -5210,7 +5210,7 @@ List *
 FirstReplicaAssignTaskList(List *taskList)
 {
 	/* No additional reordering need take place for this algorithm */
-	List *(*reorderFunction)(Task *, List *) = NULL;
+	List *(*reorderFunction)(List *) = NULL;
 
 	taskList = ReorderAndAssignTaskList(taskList, reorderFunction);
 
@@ -5237,8 +5237,8 @@ RoundRobinAssignTaskList(List *taskList)
 
 /*
  * RoundRobinReorder implements the core of the round-robin assignment policy.
- * It takes a task and placement list and rotates a copy of the placement list
- * based on the latest stable transaction id provided by PostgreSQL.
+ * It takes a placement list and rotates a copy of it based on the latest stable
+ * transaction id provided by PostgreSQL.
  *
  * We prefer to use transactionId as the seed for the rotation to use the replicas
  * in the same worker node within the same transaction. This becomes more important
@@ -5251,7 +5251,7 @@ RoundRobinAssignTaskList(List *taskList)
  * where as task-assignment happens duing the planning.
  */
 List *
-RoundRobinReorder(Task *task, List *placementList)
+RoundRobinReorder(List *placementList)
 {
 	TransactionId transactionId = GetMyProcLocalTransactionId();
 	uint32 activePlacementCount = list_length(placementList);
@@ -5270,7 +5270,7 @@ RoundRobinReorder(Task *task, List *placementList)
  * by rotation or shuffling). Returns the task list with placements assigned.
  */
 static List *
-ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(Task *, List *))
+ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(List *))
 {
 	List *assignedTaskList = NIL;
 	ListCell *taskCell = NULL;
@@ -5301,7 +5301,7 @@ ReorderAndAssignTaskList(List *taskList, List * (*reorderFunction)(Task *, List 
 		{
 			if (reorderFunction != NULL)
 			{
-				placementList = reorderFunction(task, placementList);
+				placementList = reorderFunction(placementList);
 			}
 			task->taskPlacementList = placementList;
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1817,7 +1817,7 @@ ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 		placementList = RemoveCoordinatorPlacement(placementList);
 
 		/* reorder the placement list */
-		List *reorderedPlacementList = RoundRobinReorder(task, placementList);
+		List *reorderedPlacementList = RoundRobinReorder(placementList);
 		task->taskPlacementList = reorderedPlacementList;
 
 		ShardPlacement *primaryPlacement = (ShardPlacement *) linitial(

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -507,6 +507,10 @@ typedef struct OperatorCacheEntry
 } OperatorCacheEntry;
 
 
+/* Named function pointer type for reordering Task lists */
+typedef List *(*ReorderFunction)(List *);
+
+
 /* Config variable managed via guc.c */
 extern int TaskAssignmentPolicy;
 extern bool EnableUniqueJobIds;

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -557,7 +557,7 @@ extern List * TaskListDifference(const List *list1, const List *list2);
 extern List * AssignAnchorShardTaskList(List *taskList);
 extern List * FirstReplicaAssignTaskList(List *taskList);
 extern List * RoundRobinAssignTaskList(List *taskList);
-extern List * RoundRobinReorder(Task *task, List *placementList);
+extern List * RoundRobinReorder(List *placementList);
 extern void SetPlacementNodeMetadata(ShardPlacement *placement, WorkerNode *workerNode);
 extern int CompareTasksByTaskId(const void *leftElement, const void *rightElement);
 


### PR DESCRIPTION
We have several functions for reordering task lists with unused parameters. When working on #4117 @marcocitus suggested that I remove those unused params in https://github.com/citusdata/citus/pull/4117#discussion_r472056484

To keep the original PR small, this PR contains only some refactoring around unused parameters.