### PR TITLE
Update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
 
   build-11:
     docker:
-      - image: 'heisenberg302/extbuilder:11.9'
+      - image: 'citus/extbuilder:11.9'
     steps:
       - checkout
       - run:
@@ -21,7 +21,7 @@ jobs:
 
   build-12:
     docker:
-      - image: 'heisenberg302/extbuilder:12.4'
+      - image: 'citus/extbuilder:12.4'
     steps:
       - checkout
       - run:
@@ -35,7 +35,7 @@ jobs:
 
   build-13:
     docker:
-      - image: 'heisenberg302/extbuilder:13beta'
+      - image: 'citus/extbuilder:13beta3'
     steps:
       - checkout
       - run:
@@ -101,17 +101,12 @@ jobs:
           command: ci/check_sql_snapshots.sh
   test-11_check-multi:
     docker:
-      - image: 'heisenberg302/exttester:11.9'
+      - image: 'citus/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name : "install necessary tools"
-          command: |
-              apt-get update
-              apt-get install -y autoconf build-essential libcurl4-openssl-dev libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev
       - run:
           name: 'Install and Test (check-multi)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi'
@@ -123,7 +118,7 @@ jobs:
 
   test-11_check-vanilla:
     docker:
-      - image: 'heisenberg302/exttester:11.9'
+      - image: 'citus/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -138,7 +133,7 @@ jobs:
 
   test-11_check-mx:
     docker:
-      - image: 'heisenberg302/exttester:11.9'
+      - image: 'citus/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -153,7 +148,7 @@ jobs:
 
   test-11_check-worker:
     docker:
-      - image: 'heisenberg302/exttester:11.9'
+      - image: 'citus/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -168,7 +163,7 @@ jobs:
 
   test-11_check-isolation:
     docker:
-      - image: 'heisenberg302/exttester:11.9'
+      - image: 'citus/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -182,7 +177,7 @@ jobs:
           flags: 'test_11,isolation'
   test-11_check-follower-cluster:
     docker:
-      - image: 'heisenberg302/exttester:11.9'
+      - image: 'citus/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -206,7 +201,7 @@ jobs:
           path: '/tmp/core_dumps'
   test-11_check-failure:
     docker:
-      - image: 'heisenberg302/failtester:11.9'
+      - image: 'citus/failtester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -219,17 +214,12 @@ jobs:
 
   test-11-12_check-pg-upgrade:
     docker:
-      - image: 'heisenberg302/pgupgradetester:latest'
+      - image: 'citus/pgupgradetester:latest'
     working_directory: /home/circleci/project
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name : "install necessary tools"
-          command: |
-              apt-get update
-              apt-get install -y autoconf build-essential libcurl4-openssl-dev libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev
       - run:
           name: 'Install and test postgres upgrade'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext --target check-pg-upgrade --old-pg-version 11 --new-pg-version 12'
@@ -237,7 +227,7 @@ jobs:
 
   test-12-13_check-pg-upgrade:
     docker:
-      - image: 'heisenberg302/pgupgradetester:latest'
+      - image: 'citus/pgupgradetester:latest'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -250,7 +240,7 @@ jobs:
 
   test-12_check-multi:
     docker:
-      - image: 'heisenberg302/exttester:12.4'
+      - image: 'citus/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -264,7 +254,7 @@ jobs:
           flags: 'test_12,multi'
   test-12_check-vanilla:
     docker:
-      - image: 'heisenberg302/exttester:12.4'
+      - image: 'citus/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -279,7 +269,7 @@ jobs:
 
   test-12_check-mx:
     docker:
-      - image: 'heisenberg302/exttester:12.4'
+      - image: 'citus/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -294,7 +284,7 @@ jobs:
 
   test-12_check-isolation:
     docker:
-      - image: 'heisenberg302/exttester:12.4'
+      - image: 'citus/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -309,7 +299,7 @@ jobs:
 
   test-12_check-worker:
     docker:
-      - image: 'heisenberg302/exttester:12.4'
+      - image: 'citus/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -324,7 +314,7 @@ jobs:
 
   test-12_check-follower-cluster:
     docker:
-      - image: 'heisenberg302/exttester:12.4'
+      - image: 'citus/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -349,7 +339,7 @@ jobs:
 
   test-12_check-failure:
     docker:
-      - image: 'heisenberg302/failtester:12.4'
+      - image: 'citus/failtester:12.4'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -362,7 +352,7 @@ jobs:
 
   test-11_check-citus-upgrade:
     docker:
-      - image: 'heisenberg302/citusupgradetester:11.9'
+      - image: 'citus/citusupgradetester:11.9'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -385,7 +375,7 @@ jobs:
 
   test-13_check-multi:
     docker:
-      - image: 'heisenberg302/exttester:13beta3'
+      - image: 'citus/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -400,7 +390,7 @@ jobs:
 
   test-13_check-mx:
     docker:
-      - image: 'heisenberg302/exttester:13beta3'
+      - image: 'citus/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -415,7 +405,7 @@ jobs:
 
   test-13_check-vanilla:
     docker:
-      - image: 'heisenberg302/exttester:13beta3'
+      - image: 'citus/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -430,7 +420,7 @@ jobs:
 
   test-13_check-worker:
     docker:
-      - image: 'heisenberg302/exttester:13beta3'
+      - image: 'citus/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -445,7 +435,7 @@ jobs:
 
   test-13_check-isolation:
     docker:
-      - image: 'heisenberg302/exttester:13beta3'
+      - image: 'citus/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -460,7 +450,7 @@ jobs:
 
   test-13_check-follower-cluster:
     docker:
-      - image: 'heisenberg302/exttester:13beta3'
+      - image: 'citus/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -485,7 +475,7 @@ jobs:
 
   test-13_check-failure:
     docker:
-      - image: 'heisenberg302/failtester:13beta'
+      - image: 'citus/failtester:13beta3'
     working_directory: /home/circleci/project
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ orbs:
   azure-cli: circleci/azure-cli@1.0.0
 
 jobs:
-  build:
+
+  build-11:
     docker:
-      - image: 'citus/extbuilder-13:latest'
+      - image: 'heisenberg302/extbuilder:11.9'
     steps:
       - checkout
       - run:
@@ -14,7 +15,38 @@ jobs:
           command: build-ext
       - persist_to_workspace:
           root: .
-          paths: [.]
+          paths:
+            - build-11/*
+            - install-11.tar
+
+  build-12:
+    docker:
+      - image: 'heisenberg302/extbuilder:12.4'
+    steps:
+      - checkout
+      - run:
+          name: 'Configure, Build, and Install'
+          command: build-ext
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build-12/*
+            - install-12.tar
+
+  build-13:
+    docker:
+      - image: 'heisenberg302/extbuilder:13beta'
+    steps:
+      - checkout
+      - run:
+          name: 'Configure, Build, and Install'
+          command: build-ext
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build-13/*
+            - install-13.tar
+
   check-style:
     docker:
       - image: 'citus/stylechecker:latest'
@@ -69,11 +101,17 @@ jobs:
           command: ci/check_sql_snapshots.sh
   test-11_check-multi:
     docker:
-      - image: 'citus/exttester-11:latest'
+      - image: 'heisenberg302/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
+      - run:
+          name : "install necessary tools"
+          command: |
+              apt-get update
+              apt-get install -y autoconf build-essential libcurl4-openssl-dev libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev
       - run:
           name: 'Install and Test (check-multi)'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext check-multi'
@@ -85,9 +123,10 @@ jobs:
 
   test-11_check-vanilla:
     docker:
-      - image: 'citus/exttester-11:latest'
+      - image: 'heisenberg302/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -99,9 +138,10 @@ jobs:
 
   test-11_check-mx:
     docker:
-      - image: 'citus/exttester-11:latest'
+      - image: 'heisenberg302/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -113,9 +153,10 @@ jobs:
 
   test-11_check-worker:
     docker:
-      - image: 'citus/exttester-11:latest'
+      - image: 'heisenberg302/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -127,9 +168,10 @@ jobs:
 
   test-11_check-isolation:
     docker:
-      - image: 'citus/exttester-11:latest'
+      - image: 'heisenberg302/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -140,9 +182,10 @@ jobs:
           flags: 'test_11,isolation'
   test-11_check-follower-cluster:
     docker:
-      - image: 'citus/exttester-11:latest'
+      - image: 'heisenberg302/exttester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -163,9 +206,10 @@ jobs:
           path: '/tmp/core_dumps'
   test-11_check-failure:
     docker:
-      - image: 'citus/failtester-11:latest'
+      - image: 'heisenberg302/failtester:11.9'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -175,11 +219,17 @@ jobs:
 
   test-11-12_check-pg-upgrade:
     docker:
-      - image: 'citus/pgupgradetester:latest'
+      - image: 'heisenberg302/pgupgradetester:latest'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
+      - run:
+          name : "install necessary tools"
+          command: |
+              apt-get update
+              apt-get install -y autoconf build-essential libcurl4-openssl-dev libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev
       - run:
           name: 'Install and test postgres upgrade'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext --target check-pg-upgrade --old-pg-version 11 --new-pg-version 12'
@@ -187,9 +237,10 @@ jobs:
 
   test-12-13_check-pg-upgrade:
     docker:
-      - image: 'citus/pgupgradetester:latest'
+      - image: 'heisenberg302/pgupgradetester:latest'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -199,9 +250,10 @@ jobs:
 
   test-12_check-multi:
     docker:
-      - image: 'citus/exttester-12:latest'
+      - image: 'heisenberg302/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -212,9 +264,10 @@ jobs:
           flags: 'test_12,multi'
   test-12_check-vanilla:
     docker:
-      - image: 'citus/exttester-12:latest'
+      - image: 'heisenberg302/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -226,9 +279,10 @@ jobs:
 
   test-12_check-mx:
     docker:
-      - image: 'citus/exttester-12:latest'
+      - image: 'heisenberg302/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -240,9 +294,10 @@ jobs:
 
   test-12_check-isolation:
     docker:
-      - image: 'citus/exttester-12:latest'
+      - image: 'heisenberg302/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
            at: .
       - run:
@@ -254,9 +309,10 @@ jobs:
 
   test-12_check-worker:
     docker:
-      - image: 'citus/exttester-12:latest'
+      - image: 'heisenberg302/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
            at: .
       - run:
@@ -268,9 +324,10 @@ jobs:
 
   test-12_check-follower-cluster:
     docker:
-      - image: 'citus/exttester-12:latest'
+      - image: 'heisenberg302/exttester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -292,9 +349,10 @@ jobs:
 
   test-12_check-failure:
     docker:
-      - image: 'citus/failtester-12:latest'
+      - image: 'heisenberg302/failtester:12.4'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -304,10 +362,12 @@ jobs:
 
   test-11_check-citus-upgrade:
     docker:
-      - image: 'citus/citusupgradetester-11:latest'
+      - image: 'heisenberg302/citusupgradetester:11.9'
     working_directory: /home/circleci/project
     steps:
-      - {attach_workspace: {at: .}}
+      - checkout
+      - attach_workspace:
+          at: .
       - run:
           name: 'Install and test citus upgrade'
           command: |
@@ -325,9 +385,10 @@ jobs:
 
   test-13_check-multi:
     docker:
-      - image: 'citus/exttester-13:latest'
+      - image: 'heisenberg302/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -339,9 +400,10 @@ jobs:
 
   test-13_check-mx:
     docker:
-      - image: 'citus/exttester-13:latest'
+      - image: 'heisenberg302/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -353,9 +415,10 @@ jobs:
 
   test-13_check-vanilla:
     docker:
-      - image: 'citus/exttester-13:latest'
+      - image: 'heisenberg302/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -367,9 +430,10 @@ jobs:
 
   test-13_check-worker:
     docker:
-      - image: 'citus/exttester-13:latest'
+      - image: 'heisenberg302/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
            at: .
       - run:
@@ -381,9 +445,10 @@ jobs:
 
   test-13_check-isolation:
     docker:
-      - image: 'citus/exttester-13:latest'
+      - image: 'heisenberg302/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
            at: .
       - run:
@@ -395,9 +460,10 @@ jobs:
 
   test-13_check-follower-cluster:
     docker:
-      - image: 'citus/exttester-13:latest'
+      - image: 'heisenberg302/exttester:13beta3'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -419,9 +485,10 @@ jobs:
 
   test-13_check-failure:
     docker:
-      - image: 'citus/failtester-13:latest'
+      - image: 'heisenberg302/failtester:13beta'
     working_directory: /home/circleci/project
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -472,77 +539,87 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+
       - check-merge-to-enterprise:
           filters:
             branches:
               ignore:
                 - /release-[0-9]+\.[0-9]+.*/ # match with releaseX.Y.*
 
-      - build
+
+      - build-11
+      - build-12
+      - build-13
+
       - check-style
       - check-sql-snapshots
 
       - test-11_check-multi:
-          requires: [build]
+          requires: [build-11]
       - test-11_check-vanilla:
-          requires: [build]
+          requires: [build-11]
       - test-11_check-isolation:
-          requires: [build]
+          requires: [build-11]
       - test-11_check-mx:
-          requires: [build]
+          requires: [build-11]
       - test-11_check-worker:
-          requires: [build]
+          requires: [build-11]
       - test-11_check-follower-cluster:
-          requires: [build]
+          requires: [build-11]
       - test-11_check-failure:
-          requires: [build]
+          requires: [build-11]
 
       - test-12_check-multi:
-          requires: [build]
+          requires: [build-12]
       - test-12_check-vanilla:
-          requires: [build]
+          requires: [build-12]
       - test-12_check-isolation:
-          requires: [build]
+          requires: [build-12]
       - test-12_check-mx:
-          requires: [build]
+          requires: [build-12]
       - test-12_check-worker:
-          requires: [build]
+          requires: [build-12]
       - test-12_check-follower-cluster:
-          requires: [build]
+          requires: [build-12]
       - test-12_check-failure:
-          requires: [build]
+          requires: [build-12]
 
       - test-13_check-multi:
-          requires: [build]
+          requires: [build-13]
       - test-13_check-vanilla:
-          requires: [build]
+          requires: [build-13]
       - test-13_check-isolation:
-          requires: [build]
+          requires: [build-13]
       - test-13_check-mx:
-          requires: [build]
+          requires: [build-13]
       - test-13_check-worker:
-          requires: [build]
+          requires: [build-13]
       - test-13_check-follower-cluster:
-          requires: [build]
+          requires: [build-13]
       - test-13_check-failure:
-          requires: [build]
+          requires: [build-13]
 
       - test-11-12_check-pg-upgrade:
-          requires: [build]
+          requires:
+            - build-11
+            - build-12
+
       - test-12-13_check-pg-upgrade:
-          requires: [build]
+          requires:
+            - build-12
+            - build-13
 
       - test-11_check-citus-upgrade:
-          requires: [build]
+          requires: [build-11]
 
       - ch_benchmark:
-          requires: [build]
+          requires: [build-13]
           filters:
             branches:
               only:
                 - /ch_benchmark\/.*/ # match with ch_benchmark/ prefix
       - tpcc_benchmark:
-          requires: [build]
+          requires: [build-13]
           filters:
             branches:
               only:

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -136,6 +136,9 @@ s/pg_catalog.citus_extradata_container\([0-9]+/pg_catalog.citus_extradata_contai
 # ignore referene table replication messages
 /replicating reference table.*$/d
 
+# ignore memory usage output
+/.*Memory Usage:.*/d
+
 s/Citus.*currently supports/Citus currently supports/g
 
 # Warnings in multi_explain

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -2280,7 +2280,6 @@ Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
                     Hash Cond: (ref_table.a = intermediate_result.a)
                     ->  Seq Scan on ref_table_570021 ref_table (actual rows=10 loops=1)
                     ->  Hash (actual rows=10 loops=1)
-                          Buckets: 1024  Batches: 1  Memory Usage: 9kB
                           ->  Function Scan on read_intermediate_result intermediate_result (actual rows=10 loops=1)
 EXPLAIN :default_analyze_flags
 SELECT count(distinct a) FROM (SELECT GREATEST(random(), 2) r, a FROM dist_table) t NATURAL JOIN ref_table;


### PR DESCRIPTION
The build image was a single one and it would contain pg11, pg12 and
pg13. Now it is separated so that we can build each pg major
independently.

Tags are used as full postgres versions so that we can know which
version we use by looking at the tag. For example exttester:11.9 would
mean we are using pg11.9.

pg11 is updated from 11.5 to 11.9.
pg12 is updated from 12rc to 12.4.
pg13 is updated to 13beta3.

Ones the general structure is "approved", the repos will be updated as `citus` from `heisenberg302`.