### PR TITLE
Introduce IsReferenceTableByCacheEntry utility function

### DIFF
--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -69,12 +69,21 @@ IsReferenceTable(Oid relationId)
 		return false;
 	}
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
+	return IsReferenceTableByCacheEntry(tableEntry);
+}
 
+
+/*
+ * IsReferenceTableByCacheEntry returns true if the given citus
+ * table cache entry belongs to a reference table.
+ */
+bool
+IsReferenceTableByCacheEntry(CitusTableCacheEntry *tableEntry)
+{
 	if (tableEntry->partitionMethod != DISTRIBUTE_BY_NONE)
 	{
 		return false;
 	}
-
 	return true;
 }
 

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -16,7 +16,10 @@
 
 #include "listutils.h"
 
+#include "distributed/metadata_cache.h"
+
 extern bool IsReferenceTable(Oid relationId);
+bool IsReferenceTableByCacheEntry(CitusTableCacheEntry *tableEntry);
 extern void EnsureReferenceTablesExistOnAllNodes(void);
 extern uint32 CreateReferenceTableColocationId(void);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);


### PR DESCRIPTION
We should have a single place to decide if a given table cache entry is a reference table or not. The changes in this PR shows that we were checking `partitionColumn` in one method and `partitionMethod` in another. If we have a single place we can easily change how a table is classified as reference table. This will be useful with citus local tables as well.