### PR TITLE
Introduce cache entry/table utilities

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -97,14 +97,13 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 	CitusTableCacheEntry *distTable = GetCitusTableCacheEntry(colocatedRelationId);
 	Var *partitionColumn = distTable->partitionColumn;
 	bool colocatedWithReferenceTable = false;
-	if (partitionColumn == NULL)
-	if (IsReferenceTable(colocatedRelationId))
+	if (IsCitusTableType(colocatedRelationId, REFERENCE_TABLE))
 	{
 		/* This can happen if colocated with a reference table. Punt for now. */
 		ereport(DEBUG1, (errmsg(
 							 "will push down CALL for reference tables")));
 		colocatedWithReferenceTable = true;
-		Assert(IsReferenceTable(colocatedRelationId));
+		Assert(IsCitusTableType(colocatedRelationId, REFERENCE_TABLE));
 	}
 
 	ShardPlacement *placement = NULL;

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -28,6 +28,7 @@
 #include "distributed/adaptive_executor.h"
 #include "distributed/reference_table_utils.h"
 #include "distributed/remote_commands.h"
+#include "distributed/reference_table_utils.h"
 #include "distributed/shard_pruning.h"
 #include "distributed/tuple_destination.h"
 #include "distributed/version_compat.h"
@@ -97,6 +98,7 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 	Var *partitionColumn = distTable->partitionColumn;
 	bool colocatedWithReferenceTable = false;
 	if (partitionColumn == NULL)
+	if (IsReferenceTable(colocatedRelationId))
 	{
 		/* This can happen if colocated with a reference table. Punt for now. */
 		ereport(DEBUG1, (errmsg(

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -93,11 +93,12 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 								"be constant expressions")));
 		return false;
 	}
+	CitusTableCacheEntry *distTable = GetCitusTableCacheEntry(colocatedRelationId);
 
 	CitusTableCacheEntry *distTable = GetCitusTableCacheEntry(colocatedRelationId);
 	Var *partitionColumn = distTable->partitionColumn;
 	bool colocatedWithReferenceTable = false;
-	if (IsCitusTableType(colocatedRelationId, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(colocatedRelationId, REFERENCE_TABLE))
 	{
 		/* This can happen if colocated with a reference table. Punt for now. */
 		ereport(DEBUG1, (errmsg(

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -94,11 +94,9 @@ CallFuncExprRemotely(CallStmt *callStmt, DistObjectCacheEntry *procedure,
 		return false;
 	}
 	CitusTableCacheEntry *distTable = GetCitusTableCacheEntry(colocatedRelationId);
-
-	CitusTableCacheEntry *distTable = GetCitusTableCacheEntry(colocatedRelationId);
 	Var *partitionColumn = distTable->partitionColumn;
 	bool colocatedWithReferenceTable = false;
-	if (IsCitusTableTypeCacheEntry(colocatedRelationId, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(distTable, REFERENCE_TABLE))
 	{
 		/* This can happen if colocated with a reference table. Punt for now. */
 		ereport(DEBUG1, (errmsg(

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -844,7 +844,7 @@ EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 	Var *sourceDistributionColumn = DistPartitionKeyOrError(sourceRelationId);
 
-	if (!IsCacheEntryCitusTableType(sourceTableEntry, HASH_DISTRIBUTED))
+	if (!IsCitusTableTypeCacheEntry(sourceTableEntry, HASH_DISTRIBUTED))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot distribute relation"),

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -844,7 +844,7 @@ EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 	Var *sourceDistributionColumn = DistPartitionKeyOrError(sourceRelationId);
 
-	if (!IsHashDistributedTableCacheEntry(sourceTableEntry))
+	if (!IsCacheEntryCitusTableType(sourceTableEntry, HASH_DISTRIBUTED))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot distribute relation"),

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -841,11 +841,10 @@ EnsureTableCanBeColocatedWith(Oid relationId, char replicationModel,
 							  Oid distributionColumnType, Oid sourceRelationId)
 {
 	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(sourceRelationId);
-	char sourceDistributionMethod = sourceTableEntry->partitionMethod;
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 	Var *sourceDistributionColumn = DistPartitionKeyOrError(sourceRelationId);
 
-	if (sourceDistributionMethod != DISTRIBUTE_BY_HASH)
+	if (!IsHashDistributedTableCacheEntry(sourceTableEntry))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot distribute relation"),

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -168,7 +168,7 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 		if (!selfReferencingTable)
 		{
 			referencedDistMethod = PartitionMethod(referencedTableId);
-			referencedDistKey = IsNonDistributedTable(referencedTableId) ?
+			referencedDistKey = IsCitusTableType(referencedTableId, CITUS_TABLE_WITH_NO_DIST_KEY) ?
 								NULL :
 								DistPartitionKey(referencedTableId);
 			referencedColocationId = TableColocationId(referencedTableId);
@@ -427,7 +427,7 @@ ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid relationId)
 		 * any foreign constraint from a distributed table to a local table.
 		 */
 		Assert(IsCitusTable(referencedTableId));
-		if (!IsReferenceTable(referencedTableId))
+		if (!IsCitusTableType(referencedTableId, REFERENCE_TABLE))
 		{
 			heapTuple = systable_getnext(scanDescriptor);
 			continue;
@@ -558,7 +558,7 @@ GetForeignKeyOidsToReferenceTables(Oid relationId)
 
 		Oid referencedTableOid = constraintForm->confrelid;
 
-		if (IsReferenceTable(referencedTableOid))
+		if (IsCitusTableType(referencedTableOid, REFERENCE_TABLE))
 		{
 			fkeyOidsToReferenceTables = lappend_oid(fkeyOidsToReferenceTables,
 													foreignKeyOid);

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -138,7 +138,6 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 
 		int referencingAttrIndex = -1;
 
-		char referencedDistMethod = 0;
 		Var *referencedDistKey = NULL;
 		int referencedAttrIndex = -1;
 		uint32 referencedColocationId = INVALID_COLOCATION_ID;
@@ -165,11 +164,11 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 		}
 
 		/* set referenced table related variables here if table is referencing itself */
-
+		char referencedDistMethod = 0;
 		if (!selfReferencingTable)
 		{
 			referencedDistMethod = PartitionMethod(referencedTableId);
-			referencedDistKey = (referencedDistMethod == DISTRIBUTE_BY_NONE) ?
+			referencedDistKey = IsNonDistributedTable(referencedTableId) ?
 								NULL :
 								DistPartitionKey(referencedTableId);
 			referencedColocationId = TableColocationId(referencedTableId);
@@ -428,7 +427,7 @@ ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid relationId)
 		 * any foreign constraint from a distributed table to a local table.
 		 */
 		Assert(IsCitusTable(referencedTableId));
-		if (PartitionMethod(referencedTableId) != DISTRIBUTE_BY_NONE)
+		if (!IsReferenceTable(referencedTableId))
 		{
 			heapTuple = systable_getnext(scanDescriptor);
 			continue;

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -168,7 +168,8 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 		if (!selfReferencingTable)
 		{
 			referencedDistMethod = PartitionMethod(referencedTableId);
-			referencedDistKey = IsCitusTableType(referencedTableId, CITUS_TABLE_WITH_NO_DIST_KEY) ?
+			referencedDistKey = IsCitusTableType(referencedTableId,
+												 CITUS_TABLE_WITH_NO_DIST_KEY) ?
 								NULL :
 								DistPartitionKey(referencedTableId);
 			referencedColocationId = TableColocationId(referencedTableId);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -501,7 +501,7 @@ EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnTyp
 	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(sourceRelationId);
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 
-	if (!IsCacheEntryCitusTableType(sourceTableEntry, HASH_DISTRIBUTED) && !IsCacheEntryCitusTableType(sourceTableEntry, REFERENCE_TABLE))
+	if (!IsCitusTableTypeCacheEntry(sourceTableEntry, HASH_DISTRIBUTED) && !IsCitusTableTypeCacheEntry(sourceTableEntry, REFERENCE_TABLE))
 	{
 		char *functionName = get_func_name(functionOid);
 		char *sourceRelationName = get_rel_name(sourceRelationId);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -167,7 +167,8 @@ create_distributed_function(PG_FUNCTION_ARGS)
 		if (pg_strncasecmp(colocateWithTableName, "default", NAMEDATALEN) != 0)
 		{
 			Oid colocationRelationId = ResolveRelationId(colocateWithText, false);
-			colocatedWithReferenceTable = IsCitusTableType(colocationRelationId, REFERENCE_TABLE);
+			colocatedWithReferenceTable = IsCitusTableType(colocationRelationId,
+														   REFERENCE_TABLE);
 		}
 	}
 
@@ -501,7 +502,8 @@ EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnTyp
 	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(sourceRelationId);
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 
-	if (!IsCitusTableTypeCacheEntry(sourceTableEntry, HASH_DISTRIBUTED) && !IsCitusTableTypeCacheEntry(sourceTableEntry, REFERENCE_TABLE))
+	if (!IsCitusTableTypeCacheEntry(sourceTableEntry, HASH_DISTRIBUTED) &&
+		!IsCitusTableTypeCacheEntry(sourceTableEntry, REFERENCE_TABLE))
 	{
 		char *functionName = get_func_name(functionOid);
 		char *sourceRelationName = get_rel_name(sourceRelationId);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -515,7 +515,7 @@ EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnTyp
 							   functionName, sourceRelationName)));
 	}
 
-	if (IsCitusTableTypeCacheEntry(sourceTableEntry, CITUS_TABLE_WITH_NO_DIST_KEY) &&
+	if (IsCitusTableTypeCacheEntry(sourceTableEntry, REFERENCE_TABLE) &&
 		distributionColumnType != InvalidOid)
 	{
 		char *functionName = get_func_name(functionOid);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -499,11 +499,9 @@ EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnTyp
 									  Oid sourceRelationId)
 {
 	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(sourceRelationId);
-	char sourceDistributionMethod = sourceTableEntry->partitionMethod;
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 
-	if (sourceDistributionMethod != DISTRIBUTE_BY_HASH &&
-		sourceDistributionMethod != DISTRIBUTE_BY_NONE)
+	if (!IsHashDistributedTableCacheEntry(sourceTableEntry) && !IsReferenceTableCacheEntry(sourceTableEntry))
 	{
 		char *functionName = get_func_name(functionOid);
 		char *sourceRelationName = get_rel_name(sourceRelationId);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -167,7 +167,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 		if (pg_strncasecmp(colocateWithTableName, "default", NAMEDATALEN) != 0)
 		{
 			Oid colocationRelationId = ResolveRelationId(colocateWithText, false);
-			colocatedWithReferenceTable = IsReferenceTable(colocationRelationId);
+			colocatedWithReferenceTable = IsCitusTableType(colocationRelationId, REFERENCE_TABLE);
 		}
 	}
 
@@ -501,7 +501,7 @@ EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnTyp
 	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(sourceRelationId);
 	char sourceReplicationModel = sourceTableEntry->replicationModel;
 
-	if (!IsHashDistributedTableCacheEntry(sourceTableEntry) && !IsReferenceTableCacheEntry(sourceTableEntry))
+	if (!IsCacheEntryCitusTableType(sourceTableEntry, HASH_DISTRIBUTED) && !IsCacheEntryCitusTableType(sourceTableEntry, REFERENCE_TABLE))
 	{
 		char *functionName = get_func_name(functionOid);
 		char *sourceRelationName = get_rel_name(sourceRelationId);
@@ -513,7 +513,7 @@ EnsureFunctionCanBeColocatedWithTable(Oid functionOid, Oid distributionColumnTyp
 							   functionName, sourceRelationName)));
 	}
 
-	if (sourceDistributionMethod == DISTRIBUTE_BY_NONE &&
+	if (IsCitusTableTypeCacheEntry(sourceTableEntry, CITUS_TABLE_WITH_NO_DIST_KEY) &&
 		distributionColumnType != InvalidOid)
 	{
 		char *functionName = get_func_name(functionOid);

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -800,19 +800,18 @@ ErrorIfUnsupportedIndexStmt(IndexStmt *createIndexStatement)
 		/* caller uses ShareLock for non-concurrent indexes, use the same lock here */
 		LOCKMODE lockMode = ShareLock;
 		Oid relationId = RangeVarGetRelid(relation, lockMode, missingOk);
-		char partitionMethod = PartitionMethod(relationId);
 		bool indexContainsPartitionColumn = false;
 
 		/*
-		 * Reference tables do not have partition key, and unique constraints
-		 * are allowed for them. Thus, we added a short-circuit for reference tables.
+		 * Non-distributed tables do not have partition key, and unique constraints
+		 * are allowed for them. Thus, we added a short-circuit for non-distributed tables.
 		 */
-		if (partitionMethod == DISTRIBUTE_BY_NONE)
+		if (IsNonDistributedTable(relationId))
 		{
 			return;
 		}
 
-		if (partitionMethod == DISTRIBUTE_BY_APPEND)
+		if (IsAppendDistributedTable(relationId))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("creating unique indexes on append-partitioned tables "

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -806,12 +806,12 @@ ErrorIfUnsupportedIndexStmt(IndexStmt *createIndexStatement)
 		 * Non-distributed tables do not have partition key, and unique constraints
 		 * are allowed for them. Thus, we added a short-circuit for non-distributed tables.
 		 */
-		if (IsNonDistributedTable(relationId))
+		if (IsCitusTableType(relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			return;
 		}
 
-		if (IsAppendDistributedTable(relationId))
+		if (IsCitusTableType(relationId, APPEND_DISTRIBUTED))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("creating unique indexes on append-partitioned tables "

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -368,13 +368,13 @@ CitusCopyFrom(CopyStmt *copyStatement, QueryCompletionCompat *completionTag)
 	/* disallow modifications to a partition table which have rep. factor > 1 */
 	EnsurePartitionTableNotReplicated(relationId);
 
-	if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) ||
-		IsCacheEntryCitusTableType(cacheEntry, RANGE_DISTRIBUTED) ||
-		IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) ||
+		IsCitusTableTypeCacheEntry(cacheEntry, RANGE_DISTRIBUTED) ||
+		IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		CopyToExistingShards(copyStatement, completionTag);
 	}
-	else if (IsCacheEntryCitusTableType(cacheEntry, APPEND_DISTRIBUTED))
+	else if (IsCitusTableTypeCacheEntry(cacheEntry, APPEND_DISTRIBUTED))
 	{
 		CopyToNewShards(copyStatement, completionTag, relationId);
 	}
@@ -2163,7 +2163,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	List *shardIntervalList = LoadShardIntervalList(tableId);
 	if (shardIntervalList == NIL)
 	{
-		if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED))
+		if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED))
 		{
 			ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 							errmsg("could not find any shards into which to copy"),
@@ -2182,7 +2182,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	}
 
 	/* error if any shard missing min/max values */
-	if (IsCacheEntryCitusTableType(cacheEntry, DISTRIBUTED_TABLE) &&
+	if (IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) &&
 		cacheEntry->hasUninitializedShardInterval)
 	{
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
@@ -2243,7 +2243,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 		attributeList = lappend(attributeList, columnNameValue);
 	}
 
-	if (IsCacheEntryCitusTableType(cacheEntry, DISTRIBUTED_TABLE) &&
+	if (IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) &&
 		copyDest->partitionColumnIndex == INVALID_PARTITION_COLUMN_INDEX)
 	{
 		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -93,7 +93,7 @@ PreprocessDropSchemaStmt(Node *node, const char *queryString)
 				continue;
 			}
 
-			if (IsReferenceTable(relationId))
+			if (IsCitusTableType(relationId, REFERENCE_TABLE))
 			{
 				/* prevent concurrent EnsureReferenceTablesExistOnAllNodes */
 				int colocationId = CreateReferenceTableColocationId();

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -86,7 +86,7 @@ PreprocessDropTableStmt(Node *node, const char *queryString)
 			continue;
 		}
 
-		if (IsReferenceTable(relationId))
+		if (IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
 			/* prevent concurrent EnsureReferenceTablesExistOnAllNodes */
 			int colocationId = CreateReferenceTableColocationId();
@@ -1230,7 +1230,7 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 			{
 				Oid rightRelationId = RangeVarGetRelid(constraint->pktable, NoLock,
 													   false);
-				if (IsReferenceTable(rightRelationId))
+				if (IsCitusTableType(rightRelationId, REFERENCE_TABLE))
 				{
 					executeSequentially = true;
 				}
@@ -1265,7 +1265,7 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 		{
 			Oid rightRelationId = RangeVarGetRelid(constraint->pktable, NoLock,
 												   false);
-			if (IsReferenceTable(rightRelationId))
+			if (IsCitusTableType(rightRelationId, REFERENCE_TABLE))
 			{
 				executeSequentially = true;
 			}
@@ -1286,7 +1286,7 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 	 * the distributed tables, thus contradicting our purpose of using
 	 * sequential mode.
 	 */
-	if (executeSequentially && !IsReferenceTable(relationId) &&
+	if (executeSequentially && !IsCitusTableType(relationId, REFERENCE_TABLE) &&
 		ParallelQueryExecutedInTransaction())
 	{
 		char *relationName = get_rel_name(relationId);
@@ -1344,7 +1344,7 @@ InterShardDDLTaskList(Oid leftRelationId, Oid rightRelationId,
 	 * since we only have one placement per worker. This hack is first implemented
 	 * for foreign constraint support from distributed tables to reference tables.
 	 */
-	if (IsReferenceTable(rightRelationId))
+	if (IsCitusTableType(rightRelationId, REFERENCE_TABLE))
 	{
 		int rightShardCount = list_length(rightShardList);
 		int leftShardCount = list_length(leftShardList);

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -74,14 +74,13 @@ citus_truncate_trigger(PG_FUNCTION_ARGS)
 	TriggerData *triggerData = (TriggerData *) fcinfo->context;
 	Relation truncatedRelation = triggerData->tg_relation;
 	Oid relationId = RelationGetRelid(truncatedRelation);
-	char partitionMethod = PartitionMethod(relationId);
 
 	if (!EnableDDLPropagation)
 	{
 		PG_RETURN_DATUM(PointerGetDatum(NULL));
 	}
 
-	if (partitionMethod == DISTRIBUTE_BY_APPEND)
+	if (IsAppendDistributedTable(relationId))
 	{
 		Oid schemaId = get_rel_namespace(relationId);
 		char *schemaName = get_namespace_name(schemaId);
@@ -317,8 +316,7 @@ ExecuteTruncateStmtSequentialIfNecessary(TruncateStmt *command)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
 
-		if (IsCitusTable(relationId) &&
-			PartitionMethod(relationId) == DISTRIBUTE_BY_NONE &&
+		if (IsReferenceTable(relationId) &&
 			TableReferenced(relationId))
 		{
 			char *relationName = get_rel_name(relationId);

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -80,7 +80,7 @@ citus_truncate_trigger(PG_FUNCTION_ARGS)
 		PG_RETURN_DATUM(PointerGetDatum(NULL));
 	}
 
-	if (IsAppendDistributedTable(relationId))
+	if (IsCitusTableType(relationId, APPEND_DISTRIBUTED))
 	{
 		Oid schemaId = get_rel_namespace(relationId);
 		char *schemaName = get_namespace_name(schemaId);
@@ -316,7 +316,7 @@ ExecuteTruncateStmtSequentialIfNecessary(TruncateStmt *command)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
 
-		if (IsReferenceTable(relationId) &&
+		if (IsCitusTableType(relationId, REFERENCE_TABLE) &&
 			TableReferenced(relationId))
 		{
 			char *relationName = get_rel_name(relationId);

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -779,7 +779,7 @@ AdaptiveExecutor(CitusScanState *scanState)
 			executorState->es_processed = execution->rowsProcessed;
 		}
 		else if (distributedPlan->targetRelationId != InvalidOid &&
-				 !IsReferenceTable(distributedPlan->targetRelationId))
+				 !IsCitusTableType(distributedPlan->targetRelationId, REFERENCE_TABLE))
 		{
 			/*
 			 * For reference tables we already add rowsProcessed on the local execution,
@@ -1536,7 +1536,7 @@ SelectForUpdateOnReferenceTable(List *taskList)
 	{
 		Oid relationId = relationRowLock->relationId;
 
-		if (IsReferenceTable(relationId))
+		if (IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
 			return true;
 		}

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -779,7 +779,7 @@ AdaptiveExecutor(CitusScanState *scanState)
 			executorState->es_processed = execution->rowsProcessed;
 		}
 		else if (distributedPlan->targetRelationId != InvalidOid &&
-				 PartitionMethod(distributedPlan->targetRelationId) != DISTRIBUTE_BY_NONE)
+				 !IsReferenceTable(distributedPlan->targetRelationId))
 		{
 			/*
 			 * For reference tables we already add rowsProcessed on the local execution,
@@ -1536,7 +1536,7 @@ SelectForUpdateOnReferenceTable(List *taskList)
 	{
 		Oid relationId = relationRowLock->relationId;
 
-		if (PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
+		if (IsReferenceTable(relationId))
 		{
 			return true;
 		}

--- a/src/backend/distributed/executor/distributed_execution_locks.c
+++ b/src/backend/distributed/executor/distributed_execution_locks.c
@@ -385,7 +385,7 @@ AcquireExecutorShardLocksForRelationRowLockList(List *relationRowLockList)
 		LockClauseStrength rowLockStrength = relationRowLock->rowLockStrength;
 		Oid relationId = relationRowLock->relationId;
 
-		if (IsReferenceTable(relationId))
+		if (IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
 			List *shardIntervalList = LoadShardIntervalList(relationId);
 

--- a/src/backend/distributed/executor/distributed_execution_locks.c
+++ b/src/backend/distributed/executor/distributed_execution_locks.c
@@ -385,7 +385,7 @@ AcquireExecutorShardLocksForRelationRowLockList(List *relationRowLockList)
 		LockClauseStrength rowLockStrength = relationRowLock->rowLockStrength;
 		Oid relationId = relationRowLock->relationId;
 
-		if (PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
+		if (IsReferenceTable(relationId))
 		{
 			List *shardIntervalList = LoadShardIntervalList(relationId);
 

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -172,8 +172,8 @@ PartitionTasklistResults(const char *resultIdPrefix, List *selectTaskList,
 						 CitusTableCacheEntry *targetRelation,
 						 bool binaryFormat)
 {
-	if (!IsHashDistributedTableCacheEntry(targetRelation) &&
-		!IsRangeDistributedTableCacheEntry(targetRelation))
+	if (!IsCacheEntryCitusTableType(targetRelation, HASH_DISTRIBUTED) &&
+		!IsCacheEntryCitusTableType(targetRelation, RANGE_DISTRIBUTED))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("repartitioning results of a tasklist is only supported "

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -172,8 +172,8 @@ PartitionTasklistResults(const char *resultIdPrefix, List *selectTaskList,
 						 CitusTableCacheEntry *targetRelation,
 						 bool binaryFormat)
 {
-	if (!IsCacheEntryCitusTableType(targetRelation, HASH_DISTRIBUTED) &&
-		!IsCacheEntryCitusTableType(targetRelation, RANGE_DISTRIBUTED))
+	if (!IsCitusTableTypeCacheEntry(targetRelation, HASH_DISTRIBUTED) &&
+		!IsCitusTableTypeCacheEntry(targetRelation, RANGE_DISTRIBUTED))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("repartitioning results of a tasklist is only supported "

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -172,8 +172,8 @@ PartitionTasklistResults(const char *resultIdPrefix, List *selectTaskList,
 						 CitusTableCacheEntry *targetRelation,
 						 bool binaryFormat)
 {
-	if (targetRelation->partitionMethod != DISTRIBUTE_BY_HASH &&
-		targetRelation->partitionMethod != DISTRIBUTE_BY_RANGE)
+	if (!IsHashDistributedTableCacheEntry(targetRelation) &&
+		!IsRangeDistributedTableCacheEntry(targetRelation))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("repartitioning results of a tasklist is only supported "

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -493,7 +493,7 @@ ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
 	bool stopOnFailure = false;
 
-	if (IsReferenceTable(targetRelationId))
+	if (IsCitusTableType(targetRelationId, REFERENCE_TABLE))
 	{
 		stopOnFailure = true;
 	}
@@ -534,7 +534,7 @@ ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
 	bool stopOnFailure = false;
 
-	if (IsReferenceTable(targetRelationId))
+	if (IsCitusTableType(targetRelationId, REFERENCE_TABLE))
 	{
 		stopOnFailure = true;
 	}
@@ -618,8 +618,8 @@ IsSupportedRedistributionTarget(Oid targetRelationId)
 {
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(targetRelationId);
 
-	if (!IsHashDistributedTableCacheEntry(tableEntry) &&
-		!IsRangeDistributedTableCacheEntry(tableEntry))
+	if (!IsCacheEntryCitusTableType(tableEntry, HASH_DISTRIBUTED) &&
+		!IsCacheEntryCitusTableType(tableEntry, RANGE_DISTRIBUTED))
 	{
 		return false;
 	}

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -620,9 +620,8 @@ IsSupportedRedistributionTarget(Oid targetRelationId)
 {
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(targetRelationId);
 
-	/* only range and hash-distributed tables are currently supported */
-	if (tableEntry->partitionMethod != DISTRIBUTE_BY_HASH &&
-		tableEntry->partitionMethod != DISTRIBUTE_BY_RANGE)
+	if (!IsHashDistributedTableCacheEntry(tableEntry) &&
+		!IsRangeDistributedTableCacheEntry(tableEntry))
 	{
 		return false;
 	}

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -493,8 +493,7 @@ ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
 	bool stopOnFailure = false;
 
-	char partitionMethod = PartitionMethod(targetRelationId);
-	if (partitionMethod == DISTRIBUTE_BY_NONE)
+	if (IsReferenceTable(targetRelationId))
 	{
 		stopOnFailure = true;
 	}
@@ -535,8 +534,7 @@ ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
 	bool stopOnFailure = false;
 
-	char partitionMethod = PartitionMethod(targetRelationId);
-	if (partitionMethod == DISTRIBUTE_BY_NONE)
+	if (IsReferenceTable(targetRelationId))
 	{
 		stopOnFailure = true;
 	}

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -618,8 +618,8 @@ IsSupportedRedistributionTarget(Oid targetRelationId)
 {
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(targetRelationId);
 
-	if (!IsCacheEntryCitusTableType(tableEntry, HASH_DISTRIBUTED) &&
-		!IsCacheEntryCitusTableType(tableEntry, RANGE_DISTRIBUTED))
+	if (!IsCitusTableTypeCacheEntry(tableEntry, HASH_DISTRIBUTED) &&
+		!IsCitusTableTypeCacheEntry(tableEntry, RANGE_DISTRIBUTED))
 	{
 		return false;
 	}

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -259,9 +259,9 @@ static void InvalidateCitusTableCacheEntrySlot(CitusTableCacheEntrySlot *cacheSl
 static void InvalidateDistTableCache(void);
 static void InvalidateDistObjectCache(void);
 static void InitializeTableCacheEntry(int64 shardId);
-static bool IsCitusTableTypeInternal(CitusTableCacheEntry* tableEntry, CitusTableType tableType); 
+static bool IsCitusTableTypeInternal(CitusTableCacheEntry *tableEntry, CitusTableType
+									 tableType);
 static bool RefreshTableCacheEntryIfInvalid(ShardIdCacheEntry *shardEntry);
-
 
 
 /* exports for SQL callable functions */
@@ -297,60 +297,87 @@ EnsureModificationsCanRun(void)
 	}
 }
 
+
 /*
  * IsCitusTableType returns true if the given table with relationId
- * belongs to a citus table that matches the given table type. If cache 
+ * belongs to a citus table that matches the given table type. If cache
  * entry already exists, prefer using IsCitusTableTypeCacheEntry to avoid
  * an extra lookup.
  */
-bool IsCitusTableType(Oid relationId, CitusTableType tableType) {
+bool
+IsCitusTableType(Oid relationId, CitusTableType tableType)
+{
 	CitusTableCacheEntry *tableEntry = LookupCitusTableCacheEntry(relationId);
-	// we are not interested in postgres tables
-	if (tableEntry == NULL) {
+
+	/* we are not interested in postgres tables */
+	if (tableEntry == NULL)
+	{
 		return false;
 	}
-	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 	return IsCitusTableTypeInternal(tableEntry, tableType);
 }
+
 
 /*
  * IsCitusTableTypeCacheEntry returns true if the given table cache entry
  * belongs to a citus table that matches the given table type.
  */
-bool IsCitusTableTypeCacheEntry(CitusTableCacheEntry* tableEntry, CitusTableType tableType) {
+bool
+IsCitusTableTypeCacheEntry(CitusTableCacheEntry *tableEntry, CitusTableType tableType)
+{
 	return IsCitusTableTypeInternal(tableEntry, tableType);
 }
+
 
 /*
  * IsCitusTableTypeInternal returns true if the given table entry belongs to
  * the given table type group. For definition of table types, see CitusTableType.
  */
-static bool IsCitusTableTypeInternal(CitusTableCacheEntry* tableEntry, CitusTableType tableType) {
-	switch(tableType) {
-		case HASH_DISTRIBUTED: {
+static bool
+IsCitusTableTypeInternal(CitusTableCacheEntry *tableEntry, CitusTableType tableType)
+{
+	switch (tableType)
+	{
+		case HASH_DISTRIBUTED:
+		{
 			return tableEntry->partitionMethod == DISTRIBUTE_BY_HASH;
 		}
-		case APPEND_DISTRIBUTED: {
+
+		case APPEND_DISTRIBUTED:
+		{
 			return tableEntry->partitionMethod == DISTRIBUTE_BY_APPEND;
 		}
-		case RANGE_DISTRIBUTED: {
+
+		case RANGE_DISTRIBUTED:
+		{
 			return tableEntry->partitionMethod == DISTRIBUTE_BY_RANGE;
 		}
-		case DISTRIBUTED_TABLE: {
-			return tableEntry->partitionMethod == DISTRIBUTE_BY_HASH || tableEntry->partitionMethod == DISTRIBUTE_BY_RANGE || tableEntry->partitionMethod == DISTRIBUTE_BY_APPEND;
+
+		case DISTRIBUTED_TABLE:
+		{
+			return tableEntry->partitionMethod == DISTRIBUTE_BY_HASH ||
+				   tableEntry->partitionMethod == DISTRIBUTE_BY_RANGE ||
+				   tableEntry->partitionMethod == DISTRIBUTE_BY_APPEND;
 		}
-		case REFERENCE_TABLE: {
+
+		case REFERENCE_TABLE:
+		{
 			return tableEntry->partitionMethod == DISTRIBUTE_BY_NONE;
 		}
-		case CITUS_TABLE_WITH_NO_DIST_KEY: {
+
+		case CITUS_TABLE_WITH_NO_DIST_KEY:
+		{
 			return tableEntry->partitionMethod == DISTRIBUTE_BY_NONE;
 		}
-		default: {
+
+		default:
+		{
 			ereport(ERROR, (errmsg("Unknown table type %d", tableType)));
 		}
 	}
 	return false;
 }
+
 
 /*
  * IsCitusTable returns whether relationId is a distributed relation or

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -300,7 +300,7 @@ EnsureModificationsCanRun(void)
 /*
  * IsCitusTableType returns true if the given table with relationId
  * belongs to a citus table that matches the given table type. If cache 
- * entry already exists, prefer using IsCacheEntryCitusTableType to avoid
+ * entry already exists, prefer using IsCitusTableTypeCacheEntry to avoid
  * an extra lookup.
  */
 bool IsCitusTableType(Oid relationId, CitusTableType tableType) {
@@ -314,10 +314,10 @@ bool IsCitusTableType(Oid relationId, CitusTableType tableType) {
 }
 
 /*
- * IsCacheEntryCitusTableType returns true if the given table cache entry
+ * IsCitusTableTypeCacheEntry returns true if the given table cache entry
  * belongs to a citus table that matches the given table type.
  */
-bool IsCacheEntryCitusTableType(CitusTableCacheEntry* tableEntry, CitusTableType tableType) {
+bool IsCitusTableTypeCacheEntry(CitusTableCacheEntry* tableEntry, CitusTableType tableType) {
 	return IsCitusTableTypeInternal(tableEntry, tableType);
 }
 
@@ -472,7 +472,7 @@ ReferenceTableShardId(uint64 shardId)
 {
 	ShardIdCacheEntry *shardIdEntry = LookupShardIdCacheEntry(shardId);
 	CitusTableCacheEntry *tableEntry = shardIdEntry->tableEntry;
-	return IsCacheEntryCitusTableType(tableEntry, REFERENCE_TABLE);
+	return IsCitusTableTypeCacheEntry(tableEntry, REFERENCE_TABLE);
 }
 
 

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -297,6 +297,95 @@ EnsureModificationsCanRun(void)
 
 
 /*
+ * IsReferenceTableCacheEntry returns true if the given citus
+ * table cache entry belongs to a reference table.
+ */
+bool
+IsReferenceTableCacheEntry(CitusTableCacheEntry *tableEntry)
+{
+	if (tableEntry->partitionMethod == DISTRIBUTE_BY_NONE)
+	{
+		return true;
+	}
+	return false;
+}
+
+
+/*
+ * IsDistributedTableCacheEntry returns true if the given citus
+ * table cache entry belongs to a distributed table.
+ */
+bool
+IsDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry)
+{
+	if (tableEntry->partitionMethod == DISTRIBUTE_BY_HASH ||
+		tableEntry->partitionMethod == DISTRIBUTE_BY_RANGE ||
+		tableEntry->partitionMethod == DISTRIBUTE_BY_APPEND)
+	{
+		return true;
+	}
+	return false;
+}
+
+
+/*
+ * IsHashDistributedTableCacheEntry returns true if the given citus
+ * table cache entry belongs to a hash distributed table.
+ */
+bool
+IsHashDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry)
+{
+	if (tableEntry->partitionMethod == DISTRIBUTE_BY_HASH)
+	{
+		return true;
+	}
+	return false;
+}
+
+
+/*
+ * IsRangeDistributedTableCacheEntry returns true if the given citus
+ * table cache entry belongs to a range distributed table.
+ */
+bool
+IsRangeDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry)
+{
+	if (tableEntry->partitionMethod == DISTRIBUTE_BY_RANGE)
+	{
+		return true;
+	}
+	return false;
+}
+
+
+/*
+ * IsAppendDistributedTableCacheEntry returns true if the given citus
+ * table cache entry belongs to an append distributed table.
+ */
+bool
+IsAppendDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry)
+{
+	if (tableEntry->partitionMethod == DISTRIBUTE_BY_APPEND)
+	{
+		return true;
+	}
+	return false;
+}
+
+
+/*
+ * IsNonDistributedTableCacheEntry returns true if the given citus
+ * table cache entry belongs to a non-distributed table such as reference
+ * tables.
+ */
+bool
+IsNonDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry)
+{
+	return !IsDistributedTableCacheEntry(tableEntry);
+}
+
+
+/*
  * IsCitusTable returns whether relationId is a distributed relation or
  * not.
  */

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -297,6 +297,102 @@ EnsureModificationsCanRun(void)
 
 
 /*
+ * IsNonDistributedTable returns whether the given relation ID identifies a
+ * non-distributed table such as reference table.
+ */
+bool
+IsNonDistributedTable(Oid relationId)
+{
+	if (!IsCitusTable(relationId))
+	{
+		return false;
+	}
+	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
+	return IsNonDistributedTableCacheEntry(tableEntry);
+}
+
+
+/*
+ * IsReferenceTable returns whether the given relation ID identifies a reference
+ * table.
+ */
+bool
+IsReferenceTable(Oid relationId)
+{
+	if (!IsCitusTable(relationId))
+	{
+		return false;
+	}
+	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
+	return IsReferenceTableCacheEntry(tableEntry);
+}
+
+
+/*
+ * IsDistributedTable returns whether the given relation ID identifies a distributed
+ * table. A distributed table can be of hash, range or append type.
+ */
+bool
+IsDistributedTable(Oid relationId)
+{
+	if (!IsCitusTable(relationId))
+	{
+		return false;
+	}
+	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
+	return IsDistributedTableCacheEntry(tableEntry);
+}
+
+
+/*
+ * IsHashDistributedTable returns true if the given relation is
+ * a hash distributed table.
+ */
+bool
+IsHashDistributedTable(Oid relationId)
+{
+	if (!IsCitusTable(relationId))
+	{
+		return false;
+	}
+	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(relationId);
+	return IsHashDistributedTableCacheEntry(sourceTableEntry);
+}
+
+
+/*
+ * IsRangeDistributedTable returns true if the given relation is
+ * a range distributed table.
+ */
+bool
+IsRangeDistributedTable(Oid relationId)
+{
+	if (!IsCitusTable(relationId))
+	{
+		return false;
+	}
+	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(relationId);
+	return IsRangeDistributedTableCacheEntry(sourceTableEntry);
+}
+
+
+/*
+ * IsAppendDistributedTable returns true if the given relation is
+ * an append distributed table.
+ */
+bool
+IsAppendDistributedTable(Oid relationId)
+{
+	if (!IsCitusTable(relationId))
+	{
+		return false;
+	}
+	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(relationId);
+	return IsAppendDistributedTableCacheEntry(sourceTableEntry);
+}
+
+
+/*
  * IsReferenceTableCacheEntry returns true if the given citus
  * table cache entry belongs to a reference table.
  */
@@ -505,9 +601,7 @@ ReferenceTableShardId(uint64 shardId)
 {
 	ShardIdCacheEntry *shardIdEntry = LookupShardIdCacheEntry(shardId);
 	CitusTableCacheEntry *tableEntry = shardIdEntry->tableEntry;
-	char partitionMethod = tableEntry->partitionMethod;
-
-	return partitionMethod == DISTRIBUTE_BY_NONE;
+	return IsReferenceTableCacheEntry(tableEntry);
 }
 
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -227,8 +227,8 @@ ShouldSyncTableMetadata(Oid relationId)
 	bool streamingReplicated =
 		(tableEntry->replicationModel == REPLICATION_MODEL_STREAMING);
 
-	bool mxTable = (streamingReplicated && IsHashDistributedTableCacheEntry(tableEntry));
-	if (mxTable || IsReferenceTableCacheEntry(tableEntry))
+	bool mxTable = (streamingReplicated && IsCacheEntryCitusTableType(tableEntry, HASH_DISTRIBUTED));
+	if (mxTable || IsCacheEntryCitusTableType(tableEntry, REFERENCE_TABLE))
 	{
 		return true;
 	}
@@ -628,7 +628,7 @@ DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)
 	char replicationModel = cacheEntry->replicationModel;
 	StringInfo tablePartitionKeyString = makeStringInfo();
 
-	if (IsNonDistributedTableCacheEntry(cacheEntry))
+	if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		appendStringInfo(tablePartitionKeyString, "NULL");
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -224,14 +224,11 @@ ShouldSyncTableMetadata(Oid relationId)
 {
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 
-	bool hashDistributed = (tableEntry->partitionMethod == DISTRIBUTE_BY_HASH);
 	bool streamingReplicated =
 		(tableEntry->replicationModel == REPLICATION_MODEL_STREAMING);
 
-	bool mxTable = (streamingReplicated && hashDistributed);
-	bool referenceTable = (tableEntry->partitionMethod == DISTRIBUTE_BY_NONE);
-
-	if (mxTable || referenceTable)
+	bool mxTable = (streamingReplicated && IsHashDistributedTableCacheEntry(tableEntry));
+	if (mxTable || IsReferenceTableCacheEntry(tableEntry))
 	{
 		return true;
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -628,7 +628,7 @@ DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)
 	char replicationModel = cacheEntry->replicationModel;
 	StringInfo tablePartitionKeyString = makeStringInfo();
 
-	if (distributionMethod == DISTRIBUTE_BY_NONE)
+	if (IsNonDistributedTableCacheEntry(cacheEntry))
 	{
 		appendStringInfo(tablePartitionKeyString, "NULL");
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -227,7 +227,8 @@ ShouldSyncTableMetadata(Oid relationId)
 	bool streamingReplicated =
 		(tableEntry->replicationModel == REPLICATION_MODEL_STREAMING);
 
-	bool mxTable = (streamingReplicated && IsCitusTableTypeCacheEntry(tableEntry, HASH_DISTRIBUTED));
+	bool mxTable = (streamingReplicated && IsCitusTableTypeCacheEntry(tableEntry,
+																	  HASH_DISTRIBUTED));
 	if (mxTable || IsCitusTableTypeCacheEntry(tableEntry, REFERENCE_TABLE))
 	{
 		return true;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -227,8 +227,8 @@ ShouldSyncTableMetadata(Oid relationId)
 	bool streamingReplicated =
 		(tableEntry->replicationModel == REPLICATION_MODEL_STREAMING);
 
-	bool mxTable = (streamingReplicated && IsCacheEntryCitusTableType(tableEntry, HASH_DISTRIBUTED));
-	if (mxTable || IsCacheEntryCitusTableType(tableEntry, REFERENCE_TABLE))
+	bool mxTable = (streamingReplicated && IsCitusTableTypeCacheEntry(tableEntry, HASH_DISTRIBUTED));
+	if (mxTable || IsCitusTableTypeCacheEntry(tableEntry, REFERENCE_TABLE))
 	{
 		return true;
 	}
@@ -628,7 +628,7 @@ DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)
 	char replicationModel = cacheEntry->replicationModel;
 	StringInfo tablePartitionKeyString = makeStringInfo();
 
-	if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		appendStringInfo(tablePartitionKeyString, "NULL");
 	}

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1422,8 +1422,7 @@ IsHashDistributedTable(Oid relationId)
 		return false;
 	}
 	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(relationId);
-	char sourceDistributionMethod = sourceTableEntry->partitionMethod;
-	return sourceDistributionMethod == DISTRIBUTE_BY_HASH;
+	return IsHashDistributedTableCacheEntry(sourceTableEntry);
 }
 
 

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -368,7 +368,7 @@ ErrorIfNotSuitableToGetSize(Oid relationId)
 							   "distributed", escapedQueryString)));
 	}
 
-	if (PartitionMethod(relationId) == DISTRIBUTE_BY_HASH &&
+	if (IsHashDistributedTable(relationId) &&
 		!SingleReplicatedTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1407,22 +1407,6 @@ EnsureHashDistributedTable(Oid relationId)
 						errmsg("relation %s should be a "
 							   "hash distributed table", get_rel_name(relationId))));
 	}
-}
-
-
-/*
- * IsHashDistributedTable returns true if the given relation is
- * a distributed table.
- */
-bool
-IsHashDistributedTable(Oid relationId)
-{
-	if (!IsCitusTable(relationId))
-	{
-		return false;
-	}
-	CitusTableCacheEntry *sourceTableEntry = GetCitusTableCacheEntry(relationId);
-	return IsHashDistributedTableCacheEntry(sourceTableEntry);
 }
 
 

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -368,7 +368,7 @@ ErrorIfNotSuitableToGetSize(Oid relationId)
 							   "distributed", escapedQueryString)));
 	}
 
-	if (IsHashDistributedTable(relationId) &&
+	if (IsCitusTableType(relationId, HASH_DISTRIBUTED) &&
 		!SingleReplicatedTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1401,7 +1401,7 @@ EnsureFunctionOwner(Oid functionId)
 void
 EnsureHashDistributedTable(Oid relationId)
 {
-	if (!IsHashDistributedTable(relationId))
+	if (!IsCitusTableType(relationId, HASH_DISTRIBUTED))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("relation %s should be a "

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -870,8 +870,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 						errmsg("relation is not distributed")));
 	}
 
-	char distributionMethod = PartitionMethod(relationId);
-	if (distributionMethod == DISTRIBUTE_BY_NONE)
+	if (IsNonDistributedTable(relationId))
 	{
 		List *shardIntervalList = LoadShardIntervalList(relationId);
 		if (shardIntervalList == NIL)
@@ -881,8 +880,8 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 
 		shardInterval = (ShardInterval *) linitial(shardIntervalList);
 	}
-	else if (distributionMethod == DISTRIBUTE_BY_HASH ||
-			 distributionMethod == DISTRIBUTE_BY_RANGE)
+	else if (IsHashDistributedTable(relationId) ||
+			 IsRangeDistributedTable(relationId))
 	{
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -870,7 +870,7 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 						errmsg("relation is not distributed")));
 	}
 
-	if (IsNonDistributedTable(relationId))
+	if (IsCitusTableType(relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		List *shardIntervalList = LoadShardIntervalList(relationId);
 		if (shardIntervalList == NIL)
@@ -880,8 +880,8 @@ get_shard_id_for_distribution_column(PG_FUNCTION_ARGS)
 
 		shardInterval = (ShardInterval *) linitial(shardIntervalList);
 	}
-	else if (IsHashDistributedTable(relationId) ||
-			 IsRangeDistributedTable(relationId))
+	else if (IsCitusTableType(relationId, HASH_DISTRIBUTED) ||
+			 IsCitusTableType(relationId, RANGE_DISTRIBUTED))
 	{
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -163,7 +163,7 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 	Node *whereClause = (Node *) deleteQuery->jointree->quals;
 	Node *deleteCriteria = eval_const_expressions(NULL, whereClause);
 
-	if (IsHashDistributedTable(relationId))
+	if (IsCitusTableType(relationId, HASH_DISTRIBUTED))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot delete from hash distributed table with this "
@@ -172,7 +172,7 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 								  "are not supported with master_apply_delete_command."),
 						errhint("Use the DELETE command instead.")));
 	}
-	else if (IsReferenceTable(relationId))
+	else if (IsCitusTableType(relationId, REFERENCE_TABLE))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot delete from reference table"),

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -163,8 +163,7 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 	Node *whereClause = (Node *) deleteQuery->jointree->quals;
 	Node *deleteCriteria = eval_const_expressions(NULL, whereClause);
 
-	char partitionMethod = PartitionMethod(relationId);
-	if (partitionMethod == DISTRIBUTE_BY_HASH)
+	if (IsHashDistributedTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot delete from hash distributed table with this "
@@ -173,7 +172,7 @@ master_apply_delete_command(PG_FUNCTION_ARGS)
 								  "are not supported with master_apply_delete_command."),
 						errhint("Use the DELETE command instead.")));
 	}
-	else if (partitionMethod == DISTRIBUTE_BY_NONE)
+	else if (IsReferenceTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot delete from reference table"),

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -410,7 +410,7 @@ ReplicateColocatedShardPlacement(int64 shardId, char *sourceNodeName,
 							   targetNodeName, targetNodePort);
 	}
 
-	if (!IsReferenceTable(distributedTableId))
+	if (!IsCitusTableType(distributedTableId, REFERENCE_TABLE))
 	{
 		/*
 		 * When copying a shard to a new node, we should first ensure that reference
@@ -492,7 +492,7 @@ EnsureTableListSuitableForReplication(List *tableIdList)
 			GetReferencingForeignConstaintCommands(tableId);
 
 		if (foreignConstraintCommandList != NIL &&
-			IsDistributedTable(tableId))
+			IsCitusTableType(tableId, DISTRIBUTED_TABLE))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot create foreign key constraint"),
@@ -850,7 +850,7 @@ CopyShardForeignConstraintCommandListGrouped(ShardInterval *shardInterval,
 		char *referencedSchemaName = get_namespace_name(referencedSchemaId);
 		char *escapedReferencedSchemaName = quote_literal_cstr(referencedSchemaName);
 
-		if (IsNonDistributedTable(referencedRelationId))
+		if (IsCitusTableType(referencedRelationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			referencedShardId = GetFirstShardId(referencedRelationId);
 		}

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -492,7 +492,7 @@ EnsureTableListSuitableForReplication(List *tableIdList)
 			GetReferencingForeignConstaintCommands(tableId);
 
 		if (foreignConstraintCommandList != NIL &&
-			PartitionMethod(tableId) != DISTRIBUTE_BY_NONE)
+			IsDistributedTable(tableId))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot create foreign key constraint"),
@@ -850,7 +850,7 @@ CopyShardForeignConstraintCommandListGrouped(ShardInterval *shardInterval,
 		char *referencedSchemaName = get_namespace_name(referencedSchemaId);
 		char *escapedReferencedSchemaName = quote_literal_cstr(referencedSchemaName);
 
-		if (PartitionMethod(referencedRelationId) == DISTRIBUTE_BY_NONE)
+		if (IsNonDistributedTable(referencedRelationId))
 		{
 			referencedShardId = GetFirstShardId(referencedRelationId);
 		}

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -586,7 +586,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 	relationShard->shardId = shardInterval->shardId;
 	List *relationShardList = list_make1(relationShard);
 
-	if (cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH &&
+	if (IsHashDistributedTableCacheEntry(cacheEntry) &&
 		cacheEntry->colocationId != INVALID_COLOCATION_ID)
 	{
 		shardIndex = ShardIndex(shardInterval);
@@ -609,7 +609,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 		{
 			fkeyShardId = GetFirstShardId(fkeyRelationid);
 		}
-		else if (cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH &&
+		else if (IsHashDistributedTableCacheEntry(cacheEntry) &&
 				 PartitionMethod(fkeyRelationid) == DISTRIBUTE_BY_HASH)
 		{
 			/* hash distributed tables should be colocated to have fkey */

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -252,7 +252,8 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 						errdetail("The underlying shard is not a regular table")));
 	}
 
-	if (IsCitusTableType(relationId, HASH_DISTRIBUTED) || IsCitusTableType(relationId, REFERENCE_TABLE))
+	if (IsCitusTableType(relationId, HASH_DISTRIBUTED) || IsCitusTableType(relationId,
+																		   REFERENCE_TABLE))
 	{
 		ereport(ERROR, (errmsg("cannot append to shardId " UINT64_FORMAT, shardId),
 						errdetail("We currently don't support appending to shards "

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -584,7 +584,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 	relationShard->shardId = shardInterval->shardId;
 	List *relationShardList = list_make1(relationShard);
 
-	if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) &&
+	if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) &&
 		cacheEntry->colocationId != INVALID_COLOCATION_ID)
 	{
 		shardIndex = ShardIndex(shardInterval);
@@ -607,7 +607,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 		{
 			fkeyShardId = GetFirstShardId(fkeyRelationid);
 		}
-		else if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) &&
+		else if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) &&
 				 IsCitusTableType(fkeyRelationid, HASH_DISTRIBUTED))
 		{
 			/* hash distributed tables should be colocated to have fkey */

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -143,7 +143,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 						errdetail("We currently don't support creating shards "
 								  "on hash-partitioned tables")));
 	}
-	else if (IsCitusTableType(relationId, REFERENCE_TABLE))
+	else if (IsCitusTableType(relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		ereport(ERROR, (errmsg("relation \"%s\" is a reference table",
 							   relationName),
@@ -253,7 +253,7 @@ master_append_table_to_shard(PG_FUNCTION_ARGS)
 	}
 
 	if (IsCitusTableType(relationId, HASH_DISTRIBUTED) || IsCitusTableType(relationId,
-																		   REFERENCE_TABLE))
+																		   CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		ereport(ERROR, (errmsg("cannot append to shardId " UINT64_FORMAT, shardId),
 						errdetail("We currently don't support appending to shards "

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -78,8 +78,7 @@ RebuildQueryStrings(Job *workerJob)
 			Query *copiedSubquery = copiedSubqueryRte->subquery;
 
 			/* there are no restrictions to add for reference tables */
-			char partitionMethod = PartitionMethod(shardInterval->relationId);
-			if (partitionMethod != DISTRIBUTE_BY_NONE)
+			if (IsDistributedTable(shardInterval->relationId))
 			{
 				AddShardIntervalRestrictionToSelect(copiedSubquery, shardInterval);
 			}

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -78,7 +78,7 @@ RebuildQueryStrings(Job *workerJob)
 			Query *copiedSubquery = copiedSubqueryRte->subquery;
 
 			/* there are no restrictions to add for reference tables */
-			if (IsDistributedTable(shardInterval->relationId))
+			if (IsCitusTableType(shardInterval->relationId, DISTRIBUTED_TABLE))
 			{
 				AddShardIntervalRestrictionToSelect(copiedSubquery, shardInterval);
 			}

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -306,8 +306,7 @@ ExtractReferenceTableRTEList(List *rteList)
 		}
 
 		Oid relationOid = rte->relid;
-		if (IsCitusTable(relationOid) && PartitionMethod(relationOid) ==
-			DISTRIBUTE_BY_NONE)
+		if (IsReferenceTable(relationOid))
 		{
 			referenceTableRTEList = lappend(referenceTableRTEList, rte);
 		}

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -287,36 +287,6 @@ ExtractRangeTableEntryList(Query *query)
 
 
 /*
- * ExtractClassifiedRangeTableEntryList extracts reference table rte's from
- * the given rte list.
- * Callers of this function are responsible for passing referenceTableRTEList
- * to be non-null and initially pointing to an empty list.
- */
-List *
-ExtractReferenceTableRTEList(List *rteList)
-{
-	List *referenceTableRTEList = NIL;
-
-	RangeTblEntry *rte = NULL;
-	foreach_ptr(rte, rteList)
-	{
-		if (rte->rtekind != RTE_RELATION || rte->relkind != RELKIND_RELATION)
-		{
-			continue;
-		}
-
-		Oid relationOid = rte->relid;
-		if (IsCitusTableType(relationOid, REFERENCE_TABLE))
-		{
-			referenceTableRTEList = lappend(referenceTableRTEList, rte);
-		}
-	}
-
-	return referenceTableRTEList;
-}
-
-
-/*
  * NeedsDistributedPlanning returns true if the Citus extension is loaded and
  * the query contains a distributed table.
  *

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -306,7 +306,7 @@ ExtractReferenceTableRTEList(List *rteList)
 		}
 
 		Oid relationOid = rte->relid;
-		if (IsReferenceTable(relationOid))
+		if (IsCitusTableType(relationOid, REFERENCE_TABLE))
 		{
 			referenceTableRTEList = lappend(referenceTableRTEList, rte);
 		}
@@ -1854,7 +1854,7 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 		cacheEntry = GetCitusTableCacheEntry(rte->relid);
 
 		relationRestrictionContext->allReferenceTables &=
-			IsReferenceTableCacheEntry(cacheEntry);
+			IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE);
 	}
 
 	relationRestrictionContext->relationRestrictionList =

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1854,7 +1854,7 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 		cacheEntry = GetCitusTableCacheEntry(rte->relid);
 
 		relationRestrictionContext->allReferenceTables &=
-			IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE);
+			IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE);
 	}
 
 	relationRestrictionContext->relationRestrictionList =

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1855,7 +1855,7 @@ multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,
 		cacheEntry = GetCitusTableCacheEntry(rte->relid);
 
 		relationRestrictionContext->allReferenceTables &=
-			(cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
+			IsReferenceTableCacheEntry(cacheEntry);
 	}
 
 	relationRestrictionContext->relationRestrictionList =

--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -129,9 +129,8 @@ GroupedByPartitionColumn(MultiNode *node, MultiExtendedOp *opNode)
 			return false;
 		}
 
-		char partitionMethod = PartitionMethod(relationId);
-		if (partitionMethod != DISTRIBUTE_BY_RANGE &&
-			partitionMethod != DISTRIBUTE_BY_HASH)
+		if (!IsRangeDistributedTable(relationId) &&
+			!IsHashDistributedTable(relationId))
 		{
 			/* only range- and hash-distributed tables are strictly partitioned  */
 			return false;
@@ -298,7 +297,7 @@ PartitionColumnInTableList(Var *column, List *tableNodeList)
 		{
 			Assert(partitionColumn->varno == tableNode->rangeTableId);
 
-			if (PartitionMethod(tableNode->relationId) != DISTRIBUTE_BY_APPEND)
+			if (!IsAppendDistributedTable(tableNode->relationId))
 			{
 				return true;
 			}

--- a/src/backend/distributed/planner/extended_op_node_utils.c
+++ b/src/backend/distributed/planner/extended_op_node_utils.c
@@ -129,8 +129,8 @@ GroupedByPartitionColumn(MultiNode *node, MultiExtendedOp *opNode)
 			return false;
 		}
 
-		if (!IsRangeDistributedTable(relationId) &&
-			!IsHashDistributedTable(relationId))
+		if (!IsCitusTableType(relationId, RANGE_DISTRIBUTED) &&
+			!IsCitusTableType(relationId, HASH_DISTRIBUTED))
 		{
 			/* only range- and hash-distributed tables are strictly partitioned  */
 			return false;
@@ -297,7 +297,7 @@ PartitionColumnInTableList(Var *column, List *tableNodeList)
 		{
 			Assert(partitionColumn->varno == tableNode->rangeTableId);
 
-			if (!IsAppendDistributedTable(tableNode->relationId))
+			if (!IsCitusTableType(tableNode->relationId, APPEND_DISTRIBUTED))
 			{
 				return true;
 			}

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -205,15 +205,15 @@ FastPathRouterQuery(Query *query, Node **distributionKeyValue)
 	/* we don't want to deal with append/range distributed tables */
 	Oid distributedTableId = rangeTableEntry->relid;
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(distributedTableId);
-	if (!(cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH ||
-		  cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE))
+	if (IsRangeDistributedTableCacheEntry(cacheEntry) ||
+		IsAppendDistributedTableCacheEntry(cacheEntry))
 	{
 		return false;
 	}
 
 	/* WHERE clause should not be empty for distributed tables */
 	if (joinTree == NULL ||
-		(cacheEntry->partitionMethod != DISTRIBUTE_BY_NONE && joinTree->quals == NULL))
+		(IsDistributedTableCacheEntry(cacheEntry) && joinTree->quals == NULL))
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -213,7 +213,8 @@ FastPathRouterQuery(Query *query, Node **distributionKeyValue)
 
 	/* WHERE clause should not be empty for distributed tables */
 	if (joinTree == NULL ||
-		(IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) && joinTree->quals == NULL))
+		(IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) && joinTree->quals ==
+		 NULL))
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -205,15 +205,15 @@ FastPathRouterQuery(Query *query, Node **distributionKeyValue)
 	/* we don't want to deal with append/range distributed tables */
 	Oid distributedTableId = rangeTableEntry->relid;
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(distributedTableId);
-	if (IsRangeDistributedTableCacheEntry(cacheEntry) ||
-		IsAppendDistributedTableCacheEntry(cacheEntry))
+	if (IsCacheEntryCitusTableType(cacheEntry, RANGE_DISTRIBUTED) ||
+		IsCacheEntryCitusTableType(cacheEntry, APPEND_DISTRIBUTED))
 	{
 		return false;
 	}
 
 	/* WHERE clause should not be empty for distributed tables */
 	if (joinTree == NULL ||
-		(IsDistributedTableCacheEntry(cacheEntry) && joinTree->quals == NULL))
+		(IsCacheEntryCitusTableType(cacheEntry, DISTRIBUTED_TABLE) && joinTree->quals == NULL))
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -205,15 +205,15 @@ FastPathRouterQuery(Query *query, Node **distributionKeyValue)
 	/* we don't want to deal with append/range distributed tables */
 	Oid distributedTableId = rangeTableEntry->relid;
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(distributedTableId);
-	if (IsCacheEntryCitusTableType(cacheEntry, RANGE_DISTRIBUTED) ||
-		IsCacheEntryCitusTableType(cacheEntry, APPEND_DISTRIBUTED))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, RANGE_DISTRIBUTED) ||
+		IsCitusTableTypeCacheEntry(cacheEntry, APPEND_DISTRIBUTED))
 	{
 		return false;
 	}
 
 	/* WHERE clause should not be empty for distributed tables */
 	if (joinTree == NULL ||
-		(IsCacheEntryCitusTableType(cacheEntry, DISTRIBUTED_TABLE) && joinTree->quals == NULL))
+		(IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) && joinTree->quals == NULL))
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -541,7 +541,6 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 {
 	Oid selectPartitionColumnTableId = InvalidOid;
 	Oid targetRelationId = insertRte->relid;
-	char targetPartitionMethod = PartitionMethod(targetRelationId);
 	ListCell *rangeTableCell = NULL;
 
 	/* we only do this check for INSERT ... SELECT queries */
@@ -589,7 +588,7 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 	 * If we're inserting into a reference table, all participating tables
 	 * should be reference tables as well.
 	 */
-	if (targetPartitionMethod == DISTRIBUTE_BY_NONE)
+	if (IsReferenceTable(targetRelationId))
 	{
 		if (!allReferenceTables)
 		{
@@ -1424,7 +1423,7 @@ NonPushableInsertSelectSupported(Query *insertSelectQuery)
 	}
 
 	RangeTblEntry *insertRte = ExtractResultRelationRTE(insertSelectQuery);
-	if (PartitionMethod(insertRte->relid) == DISTRIBUTE_BY_APPEND)
+	if (IsAppendDistributedTable(insertRte->relid))
 	{
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 							 "INSERT ... SELECT into an append-distributed table is "

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -588,7 +588,7 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 	 * If we're inserting into a reference table, all participating tables
 	 * should be reference tables as well.
 	 */
-	if (IsReferenceTable(targetRelationId))
+	if (IsCitusTableType(targetRelationId, REFERENCE_TABLE))
 	{
 		if (!allReferenceTables)
 		{
@@ -1423,7 +1423,7 @@ NonPushableInsertSelectSupported(Query *insertSelectQuery)
 	}
 
 	RangeTblEntry *insertRte = ExtractResultRelationRTE(insertSelectQuery);
-	if (IsAppendDistributedTable(insertRte->relid))
+	if (IsCitusTableType(insertRte->relid, APPEND_DISTRIBUTED))
 	{
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 							 "INSERT ... SELECT into an append-distributed table is "

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -823,12 +823,11 @@ ReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candidateTable,
 		return NULL;
 	}
 
-	char candidatePartitionMethod = PartitionMethod(candidateTable->relationId);
-	char leftPartitionMethod = PartitionMethod(currentJoinNode->tableEntry->relationId);
-
 	if (!IsSupportedReferenceJoin(joinType,
-								  leftPartitionMethod == DISTRIBUTE_BY_NONE,
-								  candidatePartitionMethod == DISTRIBUTE_BY_NONE))
+								  IsReferenceTable(
+									  currentJoinNode->tableEntry->relationId),
+								  IsReferenceTable(candidateTable->relationId)
+								  ))
 	{
 		return NULL;
 	}
@@ -874,12 +873,10 @@ static JoinOrderNode *
 CartesianProductReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candidateTable,
 							  List *applicableJoinClauses, JoinType joinType)
 {
-	char candidatePartitionMethod = PartitionMethod(candidateTable->relationId);
-	char leftPartitionMethod = PartitionMethod(currentJoinNode->tableEntry->relationId);
-
 	if (!IsSupportedReferenceJoin(joinType,
-								  leftPartitionMethod == DISTRIBUTE_BY_NONE,
-								  candidatePartitionMethod == DISTRIBUTE_BY_NONE))
+								  IsReferenceTable(
+									  currentJoinNode->tableEntry->relationId),
+								  IsReferenceTable(candidateTable->relationId)))
 	{
 		return NULL;
 	}

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -1383,7 +1383,7 @@ DistPartitionKey(Oid relationId)
 	CitusTableCacheEntry *partitionEntry = GetCitusTableCacheEntry(relationId);
 
 	/* non-distributed tables do not have partition column */
-	if (IsCacheEntryCitusTableType(partitionEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+	if (IsCitusTableTypeCacheEntry(partitionEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		return NULL;
 	}

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -824,9 +824,9 @@ ReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candidateTable,
 	}
 
 	if (!IsSupportedReferenceJoin(joinType,
-								  IsReferenceTable(
-									  currentJoinNode->tableEntry->relationId),
-								  IsReferenceTable(candidateTable->relationId)
+								  IsCitusTableType(
+									  currentJoinNode->tableEntry->relationId, REFERENCE_TABLE),
+								  IsCitusTableType(candidateTable->relationId, REFERENCE_TABLE)
 								  ))
 	{
 		return NULL;
@@ -874,9 +874,9 @@ CartesianProductReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candid
 							  List *applicableJoinClauses, JoinType joinType)
 {
 	if (!IsSupportedReferenceJoin(joinType,
-								  IsReferenceTable(
-									  currentJoinNode->tableEntry->relationId),
-								  IsReferenceTable(candidateTable->relationId)))
+								  IsCitusTableType(
+									  currentJoinNode->tableEntry->relationId, REFERENCE_TABLE),
+								  IsCitusTableType(candidateTable->relationId, REFERENCE_TABLE)))
 	{
 		return NULL;
 	}
@@ -1383,7 +1383,7 @@ DistPartitionKey(Oid relationId)
 	CitusTableCacheEntry *partitionEntry = GetCitusTableCacheEntry(relationId);
 
 	/* non-distributed tables do not have partition column */
-	if (IsNonDistributedTableCacheEntry(partitionEntry))
+	if (IsCacheEntryCitusTableType(partitionEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		return NULL;
 	}

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -1385,8 +1385,8 @@ DistPartitionKey(Oid relationId)
 {
 	CitusTableCacheEntry *partitionEntry = GetCitusTableCacheEntry(relationId);
 
-	/* reference tables do not have partition column */
-	if (partitionEntry->partitionMethod == DISTRIBUTE_BY_NONE)
+	/* non-distributed tables do not have partition column */
+	if (IsNonDistributedTableCacheEntry(partitionEntry))
 	{
 		return NULL;
 	}

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -825,8 +825,10 @@ ReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candidateTable,
 
 	if (!IsSupportedReferenceJoin(joinType,
 								  IsCitusTableType(
-									  currentJoinNode->tableEntry->relationId, REFERENCE_TABLE),
-								  IsCitusTableType(candidateTable->relationId, REFERENCE_TABLE)
+									  currentJoinNode->tableEntry->relationId,
+									  REFERENCE_TABLE),
+								  IsCitusTableType(candidateTable->relationId,
+												   REFERENCE_TABLE)
 								  ))
 	{
 		return NULL;
@@ -875,8 +877,10 @@ CartesianProductReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candid
 {
 	if (!IsSupportedReferenceJoin(joinType,
 								  IsCitusTableType(
-									  currentJoinNode->tableEntry->relationId, REFERENCE_TABLE),
-								  IsCitusTableType(candidateTable->relationId, REFERENCE_TABLE)))
+									  currentJoinNode->tableEntry->relationId,
+									  REFERENCE_TABLE),
+								  IsCitusTableType(candidateTable->relationId,
+												   REFERENCE_TABLE)))
 	{
 		return NULL;
 	}

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -823,13 +823,12 @@ ReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candidateTable,
 		return NULL;
 	}
 
-	if (!IsSupportedReferenceJoin(joinType,
-								  IsCitusTableType(
-									  currentJoinNode->tableEntry->relationId,
-									  REFERENCE_TABLE),
-								  IsCitusTableType(candidateTable->relationId,
-												   REFERENCE_TABLE)
-								  ))
+	bool leftIsReferenceTable = IsCitusTableType(
+		currentJoinNode->tableEntry->relationId,
+		REFERENCE_TABLE);
+	bool rightIsReferenceTable = IsCitusTableType(candidateTable->relationId,
+												  REFERENCE_TABLE);
+	if (!IsSupportedReferenceJoin(joinType, leftIsReferenceTable, rightIsReferenceTable))
 	{
 		return NULL;
 	}
@@ -875,12 +874,13 @@ static JoinOrderNode *
 CartesianProductReferenceJoin(JoinOrderNode *currentJoinNode, TableEntry *candidateTable,
 							  List *applicableJoinClauses, JoinType joinType)
 {
-	if (!IsSupportedReferenceJoin(joinType,
-								  IsCitusTableType(
-									  currentJoinNode->tableEntry->relationId,
-									  REFERENCE_TABLE),
-								  IsCitusTableType(candidateTable->relationId,
-												   REFERENCE_TABLE)))
+	bool leftIsReferenceTable = IsCitusTableType(
+		currentJoinNode->tableEntry->relationId,
+		REFERENCE_TABLE);
+	bool rightIsReferenceTable = IsCitusTableType(candidateTable->relationId,
+												  REFERENCE_TABLE);
+
+	if (!IsSupportedReferenceJoin(joinType, leftIsReferenceTable, rightIsReferenceTable))
 	{
 		return NULL;
 	}

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -4276,10 +4276,8 @@ TablePartitioningSupportsDistinct(List *tableNodeList, MultiExtendedOp *opNode,
 		 * We need to check that task results don't overlap. We can only do this
 		 * if table is range partitioned.
 		 */
-		char partitionMethod = PartitionMethod(relationId);
-
-		if (partitionMethod == DISTRIBUTE_BY_RANGE ||
-			partitionMethod == DISTRIBUTE_BY_HASH)
+		if (IsRangeDistributedTable(relationId) ||
+			IsHashDistributedTable(relationId))
 		{
 			Var *tablePartitionColumn = tableNode->partitionColumn;
 

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -4276,8 +4276,8 @@ TablePartitioningSupportsDistinct(List *tableNodeList, MultiExtendedOp *opNode,
 		 * We need to check that task results don't overlap. We can only do this
 		 * if table is range partitioned.
 		 */
-		if (IsRangeDistributedTable(relationId) ||
-			IsHashDistributedTable(relationId))
+		if (IsCitusTableType(relationId, RANGE_DISTRIBUTED) ||
+			IsCitusTableType(relationId, HASH_DISTRIBUTED))
 		{
 			Var *tablePartitionColumn = tableNode->partitionColumn;
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -230,7 +230,7 @@ TargetListOnPartitionColumn(Query *query, List *targetEntryList)
 		 * If the expression belongs to a non-distributed table continue searching for
 		 * other partition keys.
 		 */
-		if (IsNonDistributedTable(relationId))
+		if (IsCitusTableType(relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			continue;
 		}
@@ -341,7 +341,7 @@ bool
 IsDistributedTableRTE(Node *node)
 {
 	Oid relationId = NodeTryGetRteRelid(node);
-	return relationId != InvalidOid && IsDistributedTable(relationId);
+	return relationId != InvalidOid && IsCitusTableType(relationId, DISTRIBUTED_TABLE);
 }
 
 
@@ -353,7 +353,7 @@ bool
 IsReferenceTableRTE(Node *node)
 {
 	Oid relationId = NodeTryGetRteRelid(node);
-	return relationId != InvalidOid && IsReferenceTable(relationId);
+	return relationId != InvalidOid && IsCitusTableType(relationId, REFERENCE_TABLE);
 }
 
 
@@ -1020,11 +1020,11 @@ ErrorHintRequired(const char *errorHint, Query *queryTree)
 	foreach(relationIdCell, distributedRelationIdList)
 	{
 		Oid relationId = lfirst_oid(relationIdCell);
-		if (IsReferenceTable(relationId))
+		if (IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
 			continue;
 		}
-		else if (IsHashDistributedTable(relationId))
+		else if (IsCitusTableType(relationId, HASH_DISTRIBUTED))
 		{
 			int colocationId = TableColocationId(relationId);
 			colocationIdList = list_append_unique_int(colocationIdList, colocationId);

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2141,7 +2141,7 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		ListCell *shardIntervalCell = NULL;
 
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-		if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+		if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			continue;
 		}
@@ -2425,7 +2425,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 		ShardInterval *shardInterval = NULL;
 
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-		if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+		if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			/* non-distributed tables have only one shard */
 			shardInterval = cacheEntry->sortedShardIntervalArray[0];
@@ -2536,13 +2536,13 @@ CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
 	FmgrInfo *comparisonFunction = firstTableCache->shardIntervalCompareFunction;
 
 	/* reference tables are always & only copartitioned with reference tables */
-	if (IsCacheEntryCitusTableType(firstTableCache, REFERENCE_TABLE) &&
-		IsCacheEntryCitusTableType(secondTableCache, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(firstTableCache, REFERENCE_TABLE) &&
+		IsCitusTableTypeCacheEntry(secondTableCache, REFERENCE_TABLE))
 	{
 		return true;
 	}
-	else if (IsCacheEntryCitusTableType(firstTableCache, REFERENCE_TABLE) ||
-			 IsCacheEntryCitusTableType(secondTableCache, REFERENCE_TABLE))
+	else if (IsCitusTableTypeCacheEntry(firstTableCache, REFERENCE_TABLE) ||
+			 IsCitusTableTypeCacheEntry(secondTableCache, REFERENCE_TABLE))
 	{
 		return false;
 	}
@@ -2577,8 +2577,8 @@ CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
 	 * different values for the same value. int vs bigint can be given as an
 	 * example.
 	 */
-	if (IsCacheEntryCitusTableType(firstTableCache, HASH_DISTRIBUTED) ||
-		IsCacheEntryCitusTableType(secondTableCache, HASH_DISTRIBUTED))
+	if (IsCitusTableTypeCacheEntry(firstTableCache, HASH_DISTRIBUTED) ||
+		IsCitusTableTypeCacheEntry(secondTableCache, HASH_DISTRIBUTED))
 	{
 		return false;
 	}
@@ -3923,7 +3923,7 @@ ShardIntervalsOverlap(ShardInterval *firstInterval, ShardInterval *secondInterva
 	CitusTableCacheEntry *intervalRelation =
 		GetCitusTableCacheEntry(firstInterval->relationId);
 
-	Assert(IsCacheEntryCitusTableType(intervalRelation, DISTRIBUTED_TABLE));
+	Assert(IsCitusTableTypeCacheEntry(intervalRelation, DISTRIBUTED_TABLE));
 
 	FmgrInfo *comparisonFunction = intervalRelation->shardIntervalCompareFunction;
 	Oid collation = intervalRelation->partitionColumn->varcollid;

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2536,13 +2536,13 @@ CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
 	FmgrInfo *comparisonFunction = firstTableCache->shardIntervalCompareFunction;
 
 	/* reference tables are always & only copartitioned with reference tables */
-	if (IsCitusTableTypeCacheEntry(firstTableCache, REFERENCE_TABLE) &&
-		IsCitusTableTypeCacheEntry(secondTableCache, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(firstTableCache, CITUS_TABLE_WITH_NO_DIST_KEY) &&
+		IsCitusTableTypeCacheEntry(secondTableCache, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		return true;
 	}
-	else if (IsCitusTableTypeCacheEntry(firstTableCache, REFERENCE_TABLE) ||
-			 IsCitusTableTypeCacheEntry(secondTableCache, REFERENCE_TABLE))
+	else if (IsCitusTableTypeCacheEntry(firstTableCache, CITUS_TABLE_WITH_NO_DIST_KEY) ||
+			 IsCitusTableTypeCacheEntry(secondTableCache, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1880,7 +1880,7 @@ SingleShardTaskList(Query *query, uint64 jobId, List *relationShardList,
 		CitusTableCacheEntry *modificationTableCacheEntry = GetCitusTableCacheEntry(
 			updateOrDeleteRTE->relid);
 
-		if (IsCacheEntryCitusTableType(modificationTableCacheEntry, REFERENCE_TABLE) &&
+		if (IsCitusTableTypeCacheEntry(modificationTableCacheEntry, REFERENCE_TABLE) &&
 			SelectsFromDistributedTable(rangeTableList, query))
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2005,7 +2005,7 @@ SelectsFromDistributedTable(List *rangeTableList, Query *query)
 
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(
 			rangeTableEntry->relid);
-		if (IsCacheEntryCitusTableType(cacheEntry, DISTRIBUTED_TABLE) &&
+		if (IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) &&
 			(resultRangeTableEntry == NULL || resultRangeTableEntry->relid !=
 			 rangeTableEntry->relid))
 		{
@@ -2704,7 +2704,7 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 	Assert(query->commandType == CMD_INSERT);
 
 	/* reference tables can only have one shard */
-	if (IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE))
 	{
 		List *shardIntervalList = LoadShardIntervalList(distributedTableId);
 
@@ -2803,8 +2803,8 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 												   missingOk);
 		}
 
-		if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) ||
-			IsCacheEntryCitusTableType(cacheEntry, RANGE_DISTRIBUTED))
+		if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) ||
+			IsCitusTableTypeCacheEntry(cacheEntry, RANGE_DISTRIBUTED))
 		{
 			Datum partitionValue = partitionValueConst->constvalue;
 
@@ -3483,7 +3483,7 @@ ErrorIfQueryHasUnroutableModifyingCTE(Query *queryTree)
 			CitusTableCacheEntry *modificationTableCacheEntry =
 				GetCitusTableCacheEntry(distributedTableId);
 
-			if (IsCacheEntryCitusTableType(modificationTableCacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+			if (IsCitusTableTypeCacheEntry(modificationTableCacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 			{
 				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 									 "cannot router plan modification of a non-distributed table",

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -305,7 +305,8 @@ ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
 	{
 		partitionColumn = MakeInt4Column();
 	}
-	else if (IsCitusTableType(relationId, RANGE_DISTRIBUTED) || IsCitusTableType(relationId, APPEND_DISTRIBUTED))
+	else if (IsCitusTableType(relationId, RANGE_DISTRIBUTED) || IsCitusTableType(
+				 relationId, APPEND_DISTRIBUTED))
 	{
 		Assert(rteIndex > 0);
 		partitionColumn = PartitionColumn(relationId, rteIndex);
@@ -3353,7 +3354,8 @@ MultiRouterPlannableQuery(Query *query)
 				uint32 tableReplicationFactor = TableShardReplicationFactor(
 					distributedTableId);
 
-				if (tableReplicationFactor > 1 && IsCitusTableType(distributedTableId, DISTRIBUTED_TABLE))
+				if (tableReplicationFactor > 1 && IsCitusTableType(distributedTableId,
+																   DISTRIBUTED_TABLE))
 				{
 					return DeferredError(
 						ERRCODE_FEATURE_NOT_SUPPORTED,
@@ -3483,7 +3485,8 @@ ErrorIfQueryHasUnroutableModifyingCTE(Query *queryTree)
 			CitusTableCacheEntry *modificationTableCacheEntry =
 				GetCitusTableCacheEntry(distributedTableId);
 
-			if (IsCitusTableTypeCacheEntry(modificationTableCacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+			if (IsCitusTableTypeCacheEntry(modificationTableCacheEntry,
+										   CITUS_TABLE_WITH_NO_DIST_KEY))
 			{
 				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 									 "cannot router plan modification of a non-distributed table",

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2705,7 +2705,7 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 	Assert(query->commandType == CMD_INSERT);
 
 	/* reference tables can only have one shard */
-	if (IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		List *shardIntervalList = LoadShardIntervalList(distributedTableId);
 

--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -154,7 +154,7 @@ AnchorRte(Query *subquery)
 		{
 			Oid relationId = currentRte->relid;
 
-			if (IsNonDistributedTable(relationId))
+			if (IsCitusTableType(relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 			{
 				/*
 				 * Non-distributed tables should not be the anchor rte since they

--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -25,6 +25,7 @@
 #include "distributed/query_colocation_checker.h"
 #include "distributed/pg_dist_partition.h"
 #include "distributed/relation_restriction_equivalence.h"
+#include "distributed/metadata_cache.h"
 #include "distributed/multi_logical_planner.h" /* only to access utility functions */
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
@@ -153,10 +154,10 @@ AnchorRte(Query *subquery)
 		{
 			Oid relationId = currentRte->relid;
 
-			if (PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
+			if (IsNonDistributedTable(relationId))
 			{
 				/*
-				 * Reference tables should not be the anchor rte since they
+				 * Non-distributed tables should not be the anchor rte since they
 				 * don't have distribution key.
 				 */
 				continue;

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1445,8 +1445,7 @@ HasRecurringTuples(Node *node, RecurringTuplesType *recurType)
 		if (rangeTableEntry->rtekind == RTE_RELATION)
 		{
 			Oid relationId = rangeTableEntry->relid;
-			if (IsCitusTable(relationId) &&
-				PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
+			if (IsReferenceTable(relationId))
 			{
 				*recurType = RECURRING_TUPLES_REFERENCE_TABLE;
 

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1445,7 +1445,7 @@ HasRecurringTuples(Node *node, RecurringTuplesType *recurType)
 		if (rangeTableEntry->rtekind == RTE_RELATION)
 		{
 			Oid relationId = rangeTableEntry->relid;
-			if (IsReferenceTable(relationId))
+			if (IsCitusTableType(relationId, REFERENCE_TABLE))
 			{
 				*recurType = RECURRING_TUPLES_REFERENCE_TABLE;
 

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -605,8 +605,10 @@ ReferenceRelationCount(RelationRestrictionContext *restrictionContext)
 	{
 		RelationRestriction *relationRestriction =
 			(RelationRestriction *) lfirst(relationRestrictionCell);
+		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(
+			relationRestriction->relationId);
 
-		if (PartitionMethod(relationRestriction->relationId) == DISTRIBUTE_BY_NONE)
+		if (IsReferenceTableCacheEntry(cacheEntry))
 		{
 			referenceRelationCount++;
 		}
@@ -657,8 +659,8 @@ EquivalenceListContainsRelationsEquality(List *attributeEquivalenceList,
 			(RelationRestriction *) lfirst(relationRestrictionCell);
 		int rteIdentity = GetRTEIdentity(relationRestriction->rte);
 
-		/* we shouldn't check for the equality of reference tables */
-		if (PartitionMethod(relationRestriction->relationId) == DISTRIBUTE_BY_NONE)
+		/* we shouldn't check for the equality of non-distributed tables */
+		if (IsNonDistributedTable(relationRestriction->relationId))
 		{
 			continue;
 		}
@@ -1721,7 +1723,7 @@ AllRelationsInRestrictionContextColocated(RelationRestrictionContext *restrictio
 	{
 		Oid relationId = relationRestriction->relationId;
 
-		if (PartitionMethod(relationId) == DISTRIBUTE_BY_NONE)
+		if (IsNonDistributedTable(relationId))
 		{
 			continue;
 		}

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -660,7 +660,8 @@ EquivalenceListContainsRelationsEquality(List *attributeEquivalenceList,
 		int rteIdentity = GetRTEIdentity(relationRestriction->rte);
 
 		/* we shouldn't check for the equality of non-distributed tables */
-		if (IsCitusTableType(relationRestriction->relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
+		if (IsCitusTableType(relationRestriction->relationId,
+							 CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			continue;
 		}

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -608,7 +608,7 @@ ReferenceRelationCount(RelationRestrictionContext *restrictionContext)
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(
 			relationRestriction->relationId);
 
-		if (IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE))
+		if (IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE))
 		{
 			referenceRelationCount++;
 		}

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -608,7 +608,7 @@ ReferenceRelationCount(RelationRestrictionContext *restrictionContext)
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(
 			relationRestriction->relationId);
 
-		if (IsReferenceTableCacheEntry(cacheEntry))
+		if (IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE))
 		{
 			referenceRelationCount++;
 		}
@@ -660,7 +660,7 @@ EquivalenceListContainsRelationsEquality(List *attributeEquivalenceList,
 		int rteIdentity = GetRTEIdentity(relationRestriction->rte);
 
 		/* we shouldn't check for the equality of non-distributed tables */
-		if (IsNonDistributedTable(relationRestriction->relationId))
+		if (IsCitusTableType(relationRestriction->relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			continue;
 		}
@@ -1723,7 +1723,7 @@ AllRelationsInRestrictionContextColocated(RelationRestrictionContext *restrictio
 	{
 		Oid relationId = relationRestriction->relationId;
 
-		if (IsNonDistributedTable(relationId))
+		if (IsCitusTableType(relationId, CITUS_TABLE_WITH_NO_DIST_KEY))
 		{
 			continue;
 		}

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -339,7 +339,7 @@ PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 	}
 
 	/* short circuit for non-distributed tables such as reference table */
-	if (IsNonDistributedTableCacheEntry(cacheEntry))
+	if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		prunedList = ShardArrayToList(cacheEntry->sortedShardIntervalArray,
 									  cacheEntry->shardIntervalArrayLength);

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -339,7 +339,7 @@ PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 	}
 
 	/* short circuit for non-distributed tables such as reference table */
-	if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		prunedList = ShardArrayToList(cacheEntry->sortedShardIntervalArray,
 									  cacheEntry->shardIntervalArrayLength);

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -306,8 +306,8 @@ static int ConstraintCount(PruningTreeNode *node);
  * PruneShards returns all shards from a distributed table that cannot be
  * proven to be eliminated by whereClauseList.
  *
- * For reference tables, the function simply returns the single shard that the
- * table has.
+ * For non-distributed tables such as reference table, the function
+ * simply returns the single shard that the table has.
  *
  * When there is a single <partition column> = <constant> filter in the where
  * clause list, the constant is written to the partitionValueConst pointer.
@@ -338,8 +338,8 @@ PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 		return NIL;
 	}
 
-	/* short circuit for reference tables */
-	if (partitionMethod == DISTRIBUTE_BY_NONE)
+	/* short circuit for non-distributed tables such as reference table */
+	if (IsNonDistributedTableCacheEntry(cacheEntry))
 	{
 		prunedList = ShardArrayToList(cacheEntry->sortedShardIntervalArray,
 									  cacheEntry->shardIntervalArrayLength);

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -74,7 +74,7 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 	 */
 	int partitionColumnIndex = 0;
 
-	if (IsCacheEntryCitusTableType(targetRelation, DISTRIBUTED_TABLE) && IsA(
+	if (IsCitusTableTypeCacheEntry(targetRelation, DISTRIBUTED_TABLE) && IsA(
 			targetRelation->partitionColumn, Var))
 	{
 		partitionColumnIndex = targetRelation->partitionColumn->varattno - 1;
@@ -146,7 +146,7 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 	 * Here SELECT query's target list should match column list of target relation,
 	 * so their partition column indexes are equal.
 	 */
-	int partitionColumnIndex = IsCacheEntryCitusTableType(targetRelation, DISTRIBUTED_TABLE) ?
+	int partitionColumnIndex = IsCitusTableTypeCacheEntry(targetRelation, DISTRIBUTED_TABLE) ?
 							   targetRelation->partitionColumn->varattno - 1 : 0;
 
 	List **shardResultIds = RedistributeTaskListResults(resultIdPrefix, taskList,

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -74,7 +74,7 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 	 */
 	int partitionColumnIndex = 0;
 
-	if (IsDistributedTableCacheEntry(targetRelation) && IsA(
+	if (IsCacheEntryCitusTableType(targetRelation, DISTRIBUTED_TABLE) && IsA(
 			targetRelation->partitionColumn, Var))
 	{
 		partitionColumnIndex = targetRelation->partitionColumn->varattno - 1;
@@ -146,7 +146,7 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 	 * Here SELECT query's target list should match column list of target relation,
 	 * so their partition column indexes are equal.
 	 */
-	int partitionColumnIndex = IsDistributedTableCacheEntry(targetRelation) ?
+	int partitionColumnIndex = IsCacheEntryCitusTableType(targetRelation, DISTRIBUTED_TABLE) ?
 							   targetRelation->partitionColumn->varattno - 1 : 0;
 
 	List **shardResultIds = RedistributeTaskListResults(resultIdPrefix, taskList,

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -74,7 +74,7 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 	 */
 	int partitionColumnIndex = 0;
 
-	if (targetRelation->partitionMethod != DISTRIBUTE_BY_NONE && IsA(
+	if (IsDistributedTableCacheEntry(targetRelation) && IsA(
 			targetRelation->partitionColumn, Var))
 	{
 		partitionColumnIndex = targetRelation->partitionColumn->varattno - 1;
@@ -146,7 +146,7 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 	 * Here SELECT query's target list should match column list of target relation,
 	 * so their partition column indexes are equal.
 	 */
-	int partitionColumnIndex = targetRelation->partitionMethod != DISTRIBUTE_BY_NONE ?
+	int partitionColumnIndex = IsDistributedTableCacheEntry(targetRelation) ?
 							   targetRelation->partitionColumn->varattno - 1 : 0;
 
 	List **shardResultIds = RedistributeTaskListResults(resultIdPrefix, taskList,

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -146,7 +146,8 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 	 * Here SELECT query's target list should match column list of target relation,
 	 * so their partition column indexes are equal.
 	 */
-	int partitionColumnIndex = IsCitusTableTypeCacheEntry(targetRelation, DISTRIBUTED_TABLE) ?
+	int partitionColumnIndex = IsCitusTableTypeCacheEntry(targetRelation,
+														  DISTRIBUTED_TABLE) ?
 							   targetRelation->partitionColumn->varattno - 1 : 0;
 
 	List **shardResultIds = RedistributeTaskListResults(resultIdPrefix, taskList,

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -173,7 +173,7 @@ RecordRelationAccessIfReferenceTable(Oid relationId, ShardPlacementAccessType ac
 	 * recursively calling RecordRelationAccessBase(), so becareful about
 	 * removing this check.
 	 */
-	if (!IsReferenceTable(relationId))
+	if (!IsCitusTableType(relationId, REFERENCE_TABLE))
 	{
 		return;
 	}
@@ -697,7 +697,7 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 
-	if (!(IsReferenceTableCacheEntry(cacheEntry) &&
+	if (!(IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE) &&
 		  cacheEntry->referencingRelationsViaForeignKey != NIL))
 	{
 		return;
@@ -817,7 +817,7 @@ CheckConflictingParallelRelationAccesses(Oid relationId, ShardPlacementAccessTyp
 	}
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-	if (!(IsHashDistributedTableCacheEntry(cacheEntry) &&
+	if (!(IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) &&
 		  cacheEntry->referencedRelationsViaForeignKey != NIL))
 	{
 		return;
@@ -893,7 +893,7 @@ HoldsConflictingLockWithReferencedRelations(Oid relationId, ShardPlacementAccess
 	foreach_oid(referencedRelation, cacheEntry->referencedRelationsViaForeignKey)
 	{
 		/* we're only interested in foreign keys to reference tables */
-		if (!IsReferenceTable(referencedRelation))
+		if (!IsCitusTableType(referencedRelation, REFERENCE_TABLE))
 		{
 			continue;
 		}
@@ -955,7 +955,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 	bool holdsConflictingLocks = false;
 
-	Assert(IsReferenceTableCacheEntry(cacheEntry));
+	Assert(IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE));
 
 	Oid referencingRelation = InvalidOid;
 	foreach_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)
@@ -964,7 +964,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 		 * We're only interested in foreign keys to reference tables from
 		 * hash distributed tables.
 		 */
-		if (!IsHashDistributedTable(referencingRelation))
+		if (!IsCitusTableType(referencingRelation, HASH_DISTRIBUTED))
 		{
 			continue;
 		}

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -697,7 +697,7 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 
-	if (!(cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE &&
+	if (!(IsReferenceTableCacheEntry(cacheEntry) &&
 		  cacheEntry->referencingRelationsViaForeignKey != NIL))
 	{
 		return;
@@ -817,7 +817,7 @@ CheckConflictingParallelRelationAccesses(Oid relationId, ShardPlacementAccessTyp
 	}
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-	if (!(cacheEntry->partitionMethod == DISTRIBUTE_BY_HASH &&
+	if (!(IsHashDistributedTableCacheEntry(cacheEntry) &&
 		  cacheEntry->referencedRelationsViaForeignKey != NIL))
 	{
 		return;
@@ -955,7 +955,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 	bool holdsConflictingLocks = false;
 
-	Assert(PartitionMethod(relationId) == DISTRIBUTE_BY_NONE);
+	Assert(IsReferenceTableCacheEntry(cacheEntry));
 
 	Oid referencingRelation = InvalidOid;
 	foreach_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -697,7 +697,7 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 
-	if (!(IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE) &&
+	if (!(IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE) &&
 		  cacheEntry->referencingRelationsViaForeignKey != NIL))
 	{
 		return;
@@ -817,7 +817,7 @@ CheckConflictingParallelRelationAccesses(Oid relationId, ShardPlacementAccessTyp
 	}
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-	if (!(IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) &&
+	if (!(IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) &&
 		  cacheEntry->referencedRelationsViaForeignKey != NIL))
 	{
 		return;
@@ -955,7 +955,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 	bool holdsConflictingLocks = false;
 
-	Assert(IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE));
+	Assert(IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE));
 
 	Oid referencingRelation = InvalidOid;
 	foreach_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -173,7 +173,7 @@ RecordRelationAccessIfReferenceTable(Oid relationId, ShardPlacementAccessType ac
 	 * recursively calling RecordRelationAccessBase(), so becareful about
 	 * removing this check.
 	 */
-	if (PartitionMethod(relationId) != DISTRIBUTE_BY_NONE)
+	if (!IsReferenceTable(relationId))
 	{
 		return;
 	}
@@ -893,7 +893,7 @@ HoldsConflictingLockWithReferencedRelations(Oid relationId, ShardPlacementAccess
 	foreach_oid(referencedRelation, cacheEntry->referencedRelationsViaForeignKey)
 	{
 		/* we're only interested in foreign keys to reference tables */
-		if (PartitionMethod(referencedRelation) != DISTRIBUTE_BY_NONE)
+		if (!IsReferenceTable(referencedRelation))
 		{
 			continue;
 		}
@@ -964,8 +964,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 		 * We're only interested in foreign keys to reference tables from
 		 * hash distributed tables.
 		 */
-		if (!IsCitusTable(referencingRelation) ||
-			PartitionMethod(referencingRelation) != DISTRIBUTE_BY_HASH)
+		if (!IsHashDistributedTable(referencingRelation))
 		{
 			continue;
 		}

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -921,14 +921,13 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	List *colocatedShardList = NIL;
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(distributedTableId);
-	char partitionMethod = cacheEntry->partitionMethod;
 
 	/*
-	 * If distribution type of the table is not hash or reference, each shard of
+	 * If distribution type of the table is append or range, each shard of
 	 * the shard is only co-located with itself.
 	 */
-	if ((partitionMethod == DISTRIBUTE_BY_APPEND) ||
-		(partitionMethod == DISTRIBUTE_BY_RANGE))
+	if (IsAppendDistributedTableCacheEntry(cacheEntry) ||
+		IsRangeDistributedTableCacheEntry(cacheEntry))
 	{
 		ShardInterval *copyShardInterval = CopyShardInterval(shardInterval);
 

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -926,8 +926,8 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	 * If distribution type of the table is append or range, each shard of
 	 * the shard is only co-located with itself.
 	 */
-	if (IsCacheEntryCitusTableType(cacheEntry, APPEND_DISTRIBUTED) ||
-		IsCacheEntryCitusTableType(cacheEntry, RANGE_DISTRIBUTED))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, APPEND_DISTRIBUTED) ||
+		IsCitusTableTypeCacheEntry(cacheEntry, RANGE_DISTRIBUTED))
 	{
 		ShardInterval *copyShardInterval = CopyShardInterval(shardInterval);
 

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -431,11 +431,11 @@ ShardsIntervalsEqual(ShardInterval *leftShardInterval, ShardInterval *rightShard
 		return false;
 	}
 
-	if (IsHashDistributedTable(leftShardInterval->relationId))
+	if (IsCitusTableType(leftShardInterval->relationId, HASH_DISTRIBUTED))
 	{
 		return HashPartitionedShardIntervalsEqual(leftShardInterval, rightShardInterval);
 	}
-	else if (IsReferenceTable(leftShardInterval->relationId))
+	else if (IsCitusTableType(leftShardInterval->relationId, REFERENCE_TABLE))
 	{
 		/*
 		 * Reference tables has only a single shard and all reference tables
@@ -926,8 +926,8 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	 * If distribution type of the table is append or range, each shard of
 	 * the shard is only co-located with itself.
 	 */
-	if (IsAppendDistributedTableCacheEntry(cacheEntry) ||
-		IsRangeDistributedTableCacheEntry(cacheEntry))
+	if (IsCacheEntryCitusTableType(cacheEntry, APPEND_DISTRIBUTED) ||
+		IsCacheEntryCitusTableType(cacheEntry, RANGE_DISTRIBUTED))
 	{
 		ShardInterval *copyShardInterval = CopyShardInterval(shardInterval);
 

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -431,11 +431,11 @@ ShardsIntervalsEqual(ShardInterval *leftShardInterval, ShardInterval *rightShard
 		return false;
 	}
 
-	if (leftIntervalPartitionMethod == DISTRIBUTE_BY_HASH)
+	if (IsHashDistributedTable(leftShardInterval->relationId))
 	{
 		return HashPartitionedShardIntervalsEqual(leftShardInterval, rightShardInterval);
 	}
-	else if (leftIntervalPartitionMethod == DISTRIBUTE_BY_NONE)
+	else if (IsReferenceTable(leftShardInterval->relationId))
 	{
 		/*
 		 * Reference tables has only a single shard and all reference tables

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -435,7 +435,8 @@ ShardsIntervalsEqual(ShardInterval *leftShardInterval, ShardInterval *rightShard
 	{
 		return HashPartitionedShardIntervalsEqual(leftShardInterval, rightShardInterval);
 	}
-	else if (IsCitusTableType(leftShardInterval->relationId, REFERENCE_TABLE))
+	else if (IsCitusTableType(leftShardInterval->relationId,
+							  CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		/*
 		 * Reference tables has only a single shard and all reference tables

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -69,22 +69,7 @@ IsReferenceTable(Oid relationId)
 		return false;
 	}
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
-	return IsReferenceTableByCacheEntry(tableEntry);
-}
-
-
-/*
- * IsReferenceTableByCacheEntry returns true if the given citus
- * table cache entry belongs to a reference table.
- */
-bool
-IsReferenceTableByCacheEntry(CitusTableCacheEntry *tableEntry)
-{
-	if (tableEntry->partitionMethod != DISTRIBUTE_BY_NONE)
-	{
-		return false;
-	}
-	return true;
+	return IsReferenceTableCacheEntry(tableEntry);
 }
 
 
@@ -359,7 +344,7 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 
-	if (tableEntry->partitionMethod == DISTRIBUTE_BY_NONE)
+	if (IsReferenceTableCacheEntry(tableEntry))
 	{
 		char *relationName = get_rel_name(relationId);
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -69,12 +69,21 @@ IsReferenceTable(Oid relationId)
 		return false;
 	}
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
+	return IsReferenceTableByCacheEntry(tableEntry);
+}
 
+
+/*
+ * IsReferenceTableByCacheEntry returns true if the given citus
+ * table cache entry belongs to a reference table.
+ */
+bool
+IsReferenceTableByCacheEntry(CitusTableCacheEntry *tableEntry)
+{
 	if (tableEntry->partitionMethod != DISTRIBUTE_BY_NONE)
 	{
 		return false;
 	}
-
 	return true;
 }
 

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -56,23 +56,6 @@ static bool AnyRelationsModifiedInTransaction(List *relationIdList);
 PG_FUNCTION_INFO_V1(upgrade_to_reference_table);
 PG_FUNCTION_INFO_V1(replicate_reference_tables);
 
-
-/*
- * IsReferenceTable returns whether the given relation ID identifies a reference
- * table.
- */
-bool
-IsReferenceTable(Oid relationId)
-{
-	if (!IsCitusTable(relationId))
-	{
-		return false;
-	}
-	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
-	return IsReferenceTableCacheEntry(tableEntry);
-}
-
-
 /*
  * replicate_reference_tables is a UDF to ensure that allreference tables are
  * replicated to all nodes.

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -327,7 +327,7 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 
-	if (IsReferenceTableCacheEntry(tableEntry))
+	if (IsCacheEntryCitusTableType(tableEntry, REFERENCE_TABLE))
 	{
 		char *relationName = get_rel_name(relationId);
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -327,7 +327,7 @@ upgrade_to_reference_table(PG_FUNCTION_ARGS)
 
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 
-	if (IsCacheEntryCitusTableType(tableEntry, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(tableEntry, REFERENCE_TABLE))
 	{
 		char *relationName = get_rel_name(relationId);
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -395,7 +395,7 @@ SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 	uint32 colocationId = citusTable->colocationId;
 
 	if (colocationId == INVALID_COLOCATION_ID ||
-		citusTable->partitionMethod != DISTRIBUTE_BY_HASH)
+		!IsHashDistributedTableCacheEntry(citusTable))
 	{
 		SET_LOCKTAG_SHARD_METADATA_RESOURCE(*tag, MyDatabaseId, shardId);
 	}

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -493,7 +493,7 @@ GetSortedReferenceShardIntervals(List *relationList)
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, relationList)
 	{
-		if (PartitionMethod(relationId) != DISTRIBUTE_BY_NONE)
+		if (!IsReferenceTable(relationId))
 		{
 			continue;
 		}

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -395,7 +395,7 @@ SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 	uint32 colocationId = citusTable->colocationId;
 
 	if (colocationId == INVALID_COLOCATION_ID ||
-		!IsHashDistributedTableCacheEntry(citusTable))
+		!IsCacheEntryCitusTableType(citusTable, HASH_DISTRIBUTED))
 	{
 		SET_LOCKTAG_SHARD_METADATA_RESOURCE(*tag, MyDatabaseId, shardId);
 	}
@@ -493,7 +493,7 @@ GetSortedReferenceShardIntervals(List *relationList)
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, relationList)
 	{
-		if (!IsReferenceTable(relationId))
+		if (!IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
 			continue;
 		}

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -395,7 +395,7 @@ SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 	uint32 colocationId = citusTable->colocationId;
 
 	if (colocationId == INVALID_COLOCATION_ID ||
-		!IsCacheEntryCitusTableType(citusTable, HASH_DISTRIBUTED))
+		!IsCitusTableTypeCacheEntry(citusTable, HASH_DISTRIBUTED))
 	{
 		SET_LOCKTAG_SHARD_METADATA_RESOURCE(*tag, MyDatabaseId, shardId);
 	}

--- a/src/backend/distributed/utils/shard_utils.c
+++ b/src/backend/distributed/utils/shard_utils.c
@@ -49,7 +49,7 @@ GetReferenceTableLocalShardOid(Oid referenceTableOid)
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(referenceTableOid);
 
 	/* given OID should belong to a valid reference table */
-	Assert(cacheEntry != NULL && IsReferenceTableCacheEntry(cacheEntry));
+	Assert(cacheEntry != NULL && IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE));
 
 	const ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[0];
 	uint64 referenceTableShardId = shardInterval->shardId;

--- a/src/backend/distributed/utils/shard_utils.c
+++ b/src/backend/distributed/utils/shard_utils.c
@@ -49,7 +49,7 @@ GetReferenceTableLocalShardOid(Oid referenceTableOid)
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(referenceTableOid);
 
 	/* given OID should belong to a valid reference table */
-	Assert(cacheEntry != NULL && IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE));
+	Assert(cacheEntry != NULL && IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE));
 
 	const ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[0];
 	uint64 referenceTableShardId = shardInterval->shardId;

--- a/src/backend/distributed/utils/shard_utils.c
+++ b/src/backend/distributed/utils/shard_utils.c
@@ -46,10 +46,10 @@ GetTableLocalShardOid(Oid citusTableOid, uint64 shardId)
 Oid
 GetReferenceTableLocalShardOid(Oid referenceTableOid)
 {
-	const CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(referenceTableOid);
+	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(referenceTableOid);
 
 	/* given OID should belong to a valid reference table */
-	Assert(cacheEntry != NULL && cacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
+	Assert(cacheEntry != NULL && IsReferenceTableCacheEntry(cacheEntry));
 
 	const ShardInterval *shardInterval = cacheEntry->sortedShardIntervalArray[0];
 	uint64 referenceTableShardId = shardInterval->shardId;

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -240,13 +240,13 @@ ShardIndex(ShardInterval *shardInterval)
 	Datum shardMinValue = shardInterval->minValue;
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(distributedTableId);
-	char partitionMethod = cacheEntry->partitionMethod;
 
 	/*
 	 * Note that, we can also support append and range distributed tables, but
 	 * currently it is not required.
 	 */
-	if (partitionMethod != DISTRIBUTE_BY_HASH && partitionMethod != DISTRIBUTE_BY_NONE)
+	if (!IsHashDistributedTableCacheEntry(cacheEntry) && !IsReferenceTableCacheEntry(
+			cacheEntry))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("finding index of a given shard is only supported for "
@@ -254,7 +254,7 @@ ShardIndex(ShardInterval *shardInterval)
 	}
 
 	/* short-circuit for reference tables */
-	if (partitionMethod == DISTRIBUTE_BY_NONE)
+	if (IsReferenceTableCacheEntry(cacheEntry))
 	{
 		/* reference tables has only a single shard, so the index is fixed to 0 */
 		shardIndex = 0;

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -245,7 +245,7 @@ ShardIndex(ShardInterval *shardInterval)
 	 * Note that, we can also support append and range distributed tables, but
 	 * currently it is not required.
 	 */
-	if (!IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) && !IsCacheEntryCitusTableType(
+	if (!IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) && !IsCitusTableTypeCacheEntry(
 			cacheEntry, REFERENCE_TABLE))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -254,7 +254,7 @@ ShardIndex(ShardInterval *shardInterval)
 	}
 
 	/* short-circuit for reference tables */
-	if (IsCacheEntryCitusTableType(cacheEntry, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE))
 	{
 		/* reference tables has only a single shard, so the index is fixed to 0 */
 		shardIndex = 0;
@@ -279,7 +279,7 @@ FindShardInterval(Datum partitionColumnValue, CitusTableCacheEntry *cacheEntry)
 {
 	Datum searchedValue = partitionColumnValue;
 
-	if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED))
 	{
 		searchedValue = FunctionCall1Coll(cacheEntry->hashFunction,
 										  cacheEntry->partitionColumn->varcollid,
@@ -315,7 +315,7 @@ FindShardIntervalIndex(Datum searchedValue, CitusTableCacheEntry *cacheEntry)
 	ShardInterval **shardIntervalCache = cacheEntry->sortedShardIntervalArray;
 	int shardCount = cacheEntry->shardIntervalArrayLength;
 	FmgrInfo *compareFunction = cacheEntry->shardIntervalCompareFunction;
-	bool useBinarySearch = (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED) ||
+	bool useBinarySearch = (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) ||
 							!cacheEntry->hasUniformHashDistribution);
 	int shardIndex = INVALID_SHARD_INDEX;
 
@@ -324,7 +324,7 @@ FindShardIntervalIndex(Datum searchedValue, CitusTableCacheEntry *cacheEntry)
 		return INVALID_SHARD_INDEX;
 	}
 
-	if (IsCacheEntryCitusTableType(cacheEntry, HASH_DISTRIBUTED))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED))
 	{
 		if (useBinarySearch)
 		{
@@ -351,7 +351,7 @@ FindShardIntervalIndex(Datum searchedValue, CitusTableCacheEntry *cacheEntry)
 			shardIndex = CalculateUniformHashRangeIndex(hashedValue, shardCount);
 		}
 	}
-	else if (IsCacheEntryCitusTableType(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
+	else if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		/* non-distributed tables have a single shard, all values mapped to that shard */
 		Assert(shardCount == 1);

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -255,7 +255,7 @@ ShardIndex(ShardInterval *shardInterval)
 	}
 
 	/* short-circuit for reference tables */
-	if (IsCitusTableTypeCacheEntry(cacheEntry, REFERENCE_TABLE))
+	if (IsCitusTableTypeCacheEntry(cacheEntry, CITUS_TABLE_WITH_NO_DIST_KEY))
 	{
 		/* reference tables has only a single shard, so the index is fixed to 0 */
 		shardIndex = 0;

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -245,7 +245,8 @@ ShardIndex(ShardInterval *shardInterval)
 	 * Note that, we can also support append and range distributed tables, but
 	 * currently it is not required.
 	 */
-	if (!IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) && !IsCitusTableTypeCacheEntry(
+	if (!IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) &&
+		!IsCitusTableTypeCacheEntry(
 			cacheEntry, REFERENCE_TABLE))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -194,7 +194,7 @@ DistributedTablesSize(List *distTableOids)
 		 * Ignore hash partitioned tables with size greater than 1, since
 		 * citus_table_size() doesn't work on them.
 		 */
-		if (PartitionMethod(relationId) == DISTRIBUTE_BY_HASH &&
+		if (IsHashDistributedTable(relationId) &&
 			!SingleReplicatedTable(relationId))
 		{
 			table_close(relation, AccessShareLock);

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -194,7 +194,7 @@ DistributedTablesSize(List *distTableOids)
 		 * Ignore hash partitioned tables with size greater than 1, since
 		 * citus_table_size() doesn't work on them.
 		 */
-		if (IsHashDistributedTable(relationId) &&
+		if (IsCitusTableType(relationId, HASH_DISTRIBUTED) &&
 			!SingleReplicatedTable(relationId))
 		{
 			table_close(relation, AccessShareLock);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -196,7 +196,6 @@ extern PlannedStmt * distributed_planner(Query *parse,
 
 
 extern List * ExtractRangeTableEntryList(Query *query);
-extern List * ExtractReferenceTableRTEList(List *rteList);
 extern bool NeedsDistributedPlanning(Query *query);
 extern struct DistributedPlan * GetDistributedPlan(CustomScan *node);
 extern void multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOptInfo,

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -121,10 +121,15 @@ typedef enum
 	HASH_DISTRIBUTED,
 	APPEND_DISTRIBUTED,
 	RANGE_DISTRIBUTED,
-	DISTRIBUTED_TABLE, /* hash, range or append distributed table */
+
+	/* hash, range or append distributed table */
+	DISTRIBUTED_TABLE,
+
 	REFERENCE_TABLE,
 	CITUS_LOCAL_TABLE,
-	CITUS_TABLE_WITH_NO_DIST_KEY /* table without a dist key such as reference table */
+
+	/* table without a dist key such as reference table */
+	CITUS_TABLE_WITH_NO_DIST_KEY
 } CitusTableType;
 
 extern bool IsCitusTableType(Oid relationId, CitusTableType tableType);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -116,19 +116,20 @@ typedef struct DistObjectCacheEntry
 	int colocationId;
 } DistObjectCacheEntry;
 
-extern bool IsNonDistributedTable(Oid relationId);
-extern bool IsReferenceTable(Oid relationId);
-extern bool IsDistributedTable(Oid relationId);
-extern bool IsAppendDistributedTable(Oid relationId);
-extern bool IsHashDistributedTable(Oid relationId);
-extern bool IsRangeDistributedTable(Oid relationId);
-extern bool IsNonDistributedTable(Oid relationId);
-extern bool IsReferenceTableCacheEntry(CitusTableCacheEntry *tableEntry);
-extern bool IsDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
-extern bool IsHashDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
-extern bool IsAppendDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
-extern bool IsRangeDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
-extern bool IsNonDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
+typedef enum
+{
+	HASH_DISTRIBUTED,
+	APPEND_DISTRIBUTED,
+	RANGE_DISTRIBUTED,
+	DISTRIBUTED_TABLE,
+	REFERENCE_TABLE,
+	CITUS_LOCAL_TABLE,
+	CITUS_TABLE_WITH_NO_DIST_KEY
+} CitusTableType;
+
+extern bool IsCitusTableType(Oid relationId, CitusTableType tableType);
+extern bool IsCacheEntryCitusTableType(CitusTableCacheEntry* tableEtnry, CitusTableType tableType);
+
 extern bool IsCitusTable(Oid relationId);
 extern List * CitusTableList(void);
 extern ShardInterval * LoadShardInterval(uint64 shardId);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -121,14 +121,15 @@ typedef enum
 	HASH_DISTRIBUTED,
 	APPEND_DISTRIBUTED,
 	RANGE_DISTRIBUTED,
-	DISTRIBUTED_TABLE,
+	DISTRIBUTED_TABLE, /* hash, range or append distributed table */
 	REFERENCE_TABLE,
 	CITUS_LOCAL_TABLE,
-	CITUS_TABLE_WITH_NO_DIST_KEY
+	CITUS_TABLE_WITH_NO_DIST_KEY /* table without a dist key such as reference table */
 } CitusTableType;
 
 extern bool IsCitusTableType(Oid relationId, CitusTableType tableType);
-extern bool IsCitusTableTypeCacheEntry(CitusTableCacheEntry* tableEtnry, CitusTableType tableType);
+extern bool IsCitusTableTypeCacheEntry(CitusTableCacheEntry *tableEtnry, CitusTableType
+									   tableType);
 
 extern bool IsCitusTable(Oid relationId);
 extern List * CitusTableList(void);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -116,7 +116,12 @@ typedef struct DistObjectCacheEntry
 	int colocationId;
 } DistObjectCacheEntry;
 
-
+extern bool IsReferenceTableCacheEntry(CitusTableCacheEntry *tableEntry);
+extern bool IsDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
+extern bool IsHashDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
+extern bool IsAppendDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
+extern bool IsRangeDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
+extern bool IsNonDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
 extern bool IsCitusTable(Oid relationId);
 extern List * CitusTableList(void);
 extern ShardInterval * LoadShardInterval(uint64 shardId);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -116,6 +116,13 @@ typedef struct DistObjectCacheEntry
 	int colocationId;
 } DistObjectCacheEntry;
 
+extern bool IsNonDistributedTable(Oid relationId);
+extern bool IsReferenceTable(Oid relationId);
+extern bool IsDistributedTable(Oid relationId);
+extern bool IsAppendDistributedTable(Oid relationId);
+extern bool IsHashDistributedTable(Oid relationId);
+extern bool IsRangeDistributedTable(Oid relationId);
+extern bool IsNonDistributedTable(Oid relationId);
 extern bool IsReferenceTableCacheEntry(CitusTableCacheEntry *tableEntry);
 extern bool IsDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);
 extern bool IsHashDistributedTableCacheEntry(CitusTableCacheEntry *tableEntry);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -128,7 +128,7 @@ typedef enum
 } CitusTableType;
 
 extern bool IsCitusTableType(Oid relationId, CitusTableType tableType);
-extern bool IsCacheEntryCitusTableType(CitusTableCacheEntry* tableEtnry, CitusTableType tableType);
+extern bool IsCitusTableTypeCacheEntry(CitusTableCacheEntry* tableEtnry, CitusTableType tableType);
 
 extern bool IsCitusTable(Oid relationId);
 extern List * CitusTableList(void);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -150,7 +150,6 @@ extern void EnsureTablePermissions(Oid relationId, AclMode mode);
 extern void EnsureTableOwner(Oid relationId);
 extern void EnsureSchemaOwner(Oid schemaId);
 extern void EnsureHashDistributedTable(Oid relationId);
-extern bool IsHashDistributedTable(Oid relationId);
 extern void EnsureSequenceOwner(Oid sequenceOid);
 extern void EnsureFunctionOwner(Oid functionId);
 extern void EnsureSuperUser(void);

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -16,7 +16,10 @@
 
 #include "listutils.h"
 
+#include "distributed/metadata_cache.h"
+
 extern bool IsReferenceTable(Oid relationId);
+bool IsReferenceTableByCacheEntry(CitusTableCacheEntry *tableEntry);
 extern void EnsureReferenceTablesExistOnAllNodes(void);
 extern uint32 CreateReferenceTableColocationId(void);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -19,7 +19,7 @@
 #include "distributed/metadata_cache.h"
 
 extern bool IsReferenceTable(Oid relationId);
-bool IsReferenceTableByCacheEntry(CitusTableCacheEntry *tableEntry);
+bool IsReferenceTableCacheEntry(CitusTableCacheEntry *tableEntry);
 extern void EnsureReferenceTablesExistOnAllNodes(void);
 extern uint32 CreateReferenceTableColocationId(void);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -18,8 +18,6 @@
 
 #include "distributed/metadata_cache.h"
 
-extern bool IsReferenceTable(Oid relationId);
-bool IsReferenceTableCacheEntry(CitusTableCacheEntry *tableEntry);
 extern void EnsureReferenceTablesExistOnAllNodes(void);
 extern uint32 CreateReferenceTableColocationId(void);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);


### PR DESCRIPTION
In the codebase, when we need to learn the type of a table we use different methods, one of the common ones is to check the partition method, for example we say that a table is a reference table if its partition method is `DISTRIBUTE_BY_NONE`. This creates a mapping in the code, a developer doesn't need to know this mapping. In the codebase what we care about is almost always is the following two:
- What is the type of citus cache entry, is it reference table, hash distributed table etc?
- What is the type of table with given `oid`, is is reference table, hash distributed table etc?

In order to accomplish this, some utility functions are created. This also makes it easier to add new table types to the codebase. For example when we add citus-local tables, they will also have `DISTRIBUTE_BY_NONE` as their replication model hence all the lines that had this check for reference tables will possibly fail. There are some parts where we care about if a table is `reference table` and some parts where we care it is a `distributed table` (hash, range, append) or if it is a table without a partition key.

There are still some places with `DISTRIBUTE_BY_NONE`  etc checks, we can possibly do the refactoring for them separately since for them we pass the partition method as a parameter to function(so relation id or cache entry doesn't exist).

The new APIs:

```c
IsCitusTableType(relationId, CitusTableType);  // this will be used when we don't have cache entry but relation id, this does an extra lookup from metadata cache
IsCitusTableTypeCacheEntry(cacheEntry, CitusTableType); // this will be used when we have cache entry
```

Where a table types can be:

```c
typedef enum
{
	HASH_DISTRIBUTED,
	APPEND_DISTRIBUTED,
	RANGE_DISTRIBUTED,
	DISTRIBUTED_TABLE, /* hash, range or append distributed table */
	REFERENCE_TABLE,
	CITUS_LOCAL_TABLE,
	CITUS_TABLE_WITH_NO_DIST_KEY /* table without a dist key such as reference table */
} CitusTableType;
```