### PR TITLE
expose transfer mode for ensure reference table existence

### DIFF
--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -420,7 +420,7 @@ ReplicateColocatedShardPlacement(int64 shardId, char *sourceNodeName,
 		 * Since this a long-running operation we do this after the error checks, but
 		 * before taking metadata locks.
 		 */
-		EnsureReferenceTablesExistOnAllNodes();
+		EnsureReferenceTablesExistOnAllNodesExtended(shardReplicationMode);
 	}
 
 	CopyShardTables(colocatedShardList, sourceNodeName, sourceNodePort,

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -44,7 +44,6 @@
 #include "utils/palloc.h"
 
 /* local function forward declarations */
-static char LookupShardTransferMode(Oid shardReplicationModeOid);
 static void ErrorIfTableCannotBeReplicated(Oid relationId);
 static void RepairShardPlacement(int64 shardId, const char *sourceNodeName,
 								 int32 sourceNodePort, const char *targetNodeName,
@@ -226,7 +225,7 @@ ErrorIfTableCannotBeReplicated(Oid relationId)
  * LookupShardTransferMode maps the oids of citus.shard_transfer_mode enum
  * values to a char.
  */
-static char
+char
 LookupShardTransferMode(Oid shardReplicationModeOid)
 {
 	char shardReplicationMode = 0;

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -176,5 +176,6 @@ extern ShardPlacement * SearchShardPlacementInList(List *shardPlacementList,
 extern ShardPlacement * SearchShardPlacementInListOrError(List *shardPlacementList,
 														  const char *nodeName,
 														  uint32 nodePort);
+extern char LookupShardTransferMode(Oid shardReplicationModeOid);
 
 #endif   /* COORDINATOR_PROTOCOL_H */

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -19,6 +19,7 @@
 #include "distributed/metadata_cache.h"
 
 extern void EnsureReferenceTablesExistOnAllNodes(void);
+extern void EnsureReferenceTablesExistOnAllNodesExtended(char transferMode);
 extern uint32 CreateReferenceTableColocationId(void);
 extern void DeleteAllReferenceTablePlacementsFromNodeGroup(int32 groupId);
 extern int CompareOids(const void *leftElement, const void *rightElement);


### PR DESCRIPTION
This is a preparation for a change in behaviour of how the rebalancer interacts with reference table existence.
To prevent merge conflicts this change is required in Community.