### PR TITLE
Record non-distributed table accesses in local executor

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1183,23 +1183,42 @@ CanUseExclusiveConnections(Oid relationId, bool localTableEmpty)
 	}
 	else if (shouldRunSequential && ParallelQueryExecutedInTransaction())
 	{
+		/*
+		 * We decided to use sequential execution. It's either because relation
+		 * has a pre-existing foreign key to a reference table or because we
+		 * decided to use sequential execution due to a query executed in the
+		 * current xact beforehand.
+		 * We have specific error messages for either cases.
+		 */
+
 		char *relationName = get_rel_name(relationId);
 
-		/*
-		 * If there has already been a parallel query executed, the sequential mode
-		 * would still use the already opened parallel connections to the workers,
-		 * thus contradicting our purpose of using sequential mode.
-		 */
-		ereport(ERROR, (errmsg("cannot distribute relation \"%s\" in this "
-							   "transaction because it has a foreign key to "
-							   "a reference table", relationName),
-						errdetail("If a hash distributed table has a foreign key "
-								  "to a reference table, it has to be created "
-								  "in sequential mode before any parallel commands "
-								  "have been executed in the same transaction"),
-						errhint("Try re-running the transaction with "
-								"\"SET LOCAL citus.multi_shard_modify_mode TO "
-								"\'sequential\';\"")));
+		if (hasForeignKeyToReferenceTable)
+		{
+			/*
+			 * If there has already been a parallel query executed, the sequential mode
+			 * would still use the already opened parallel connections to the workers,
+			 * thus contradicting our purpose of using sequential mode.
+			 */
+			ereport(ERROR, (errmsg("cannot distribute relation \"%s\" in this "
+								   "transaction because it has a foreign key to "
+								   "a reference table", relationName),
+							errdetail("If a hash distributed table has a foreign key "
+									  "to a reference table, it has to be created "
+									  "in sequential mode before any parallel commands "
+									  "have been executed in the same transaction"),
+							errhint("Try re-running the transaction with "
+									"\"SET LOCAL citus.multi_shard_modify_mode TO "
+									"\'sequential\';\"")));
+		}
+		else if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
+		{
+			/* FIXME: TODO: I think we should actually return false here or improve error message(/hint) ? */
+			ereport(ERROR, (errmsg("cannot distribute \"%s\" in sequential mode "
+								   "a parallel query was executed in this transaction",
+								   relationName),
+							errhint("TODO: a proper hint ??")));
+		}
 	}
 	else if (shouldRunSequential)
 	{

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1183,49 +1183,26 @@ CanUseExclusiveConnections(Oid relationId, bool localTableEmpty)
 	}
 	else if (shouldRunSequential && ParallelQueryExecutedInTransaction())
 	{
+		char *relationName = get_rel_name(relationId);
+
 		/*
-		 * We decided to use sequential execution. It's either because relation
-		 * has a pre-existing foreign key to a reference table or because we
-		 * decided to use sequential execution due to a query executed in the
-		 * current xact beforehand.
+		 * If there has already been a parallel query executed, the sequential mode
+		 * would still use the already opened parallel connections to the workers,
+		 * thus contradicting our purpose of using sequential mode.
 		 */
-
-		if (hasForeignKeyToReferenceTable)
-		{
-			char *relationName = get_rel_name(relationId);
-
-			/*
-			 * If there has already been a parallel query executed, the sequential mode
-			 * would still use the already opened parallel connections to the workers,
-			 * thus contradicting our purpose of using sequential mode.
-			 */
-			ereport(ERROR, (errmsg("cannot distribute relation \"%s\" in this "
-								   "transaction because it has a foreign key to "
-								   "a reference table", relationName),
-							errdetail("If a hash distributed table has a foreign key "
-									  "to a reference table, it has to be created "
-									  "in sequential mode before any parallel commands "
-									  "have been executed in the same transaction"),
-							errhint("Try re-running the transaction with "
-									"\"SET LOCAL citus.multi_shard_modify_mode TO "
-									"\'sequential\';\"")));
-		}
-		else if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
-		{
-			/*
-			 * Parallel execution happened, table is empty and it doesn't have
-			 * any foreign key to a reference table but sequential execution is
-			 * enforced. It's okay to go with sequential execution ?
-			 */
-			return false;
-		}
+		ereport(ERROR, (errmsg("cannot distribute relation \"%s\" in this "
+							   "transaction because it has a foreign key to "
+							   "a reference table", relationName),
+						errdetail("If a hash distributed table has a foreign key "
+								  "to a reference table, it has to be created "
+								  "in sequential mode before any parallel commands "
+								  "have been executed in the same transaction"),
+						errhint("Try re-running the transaction with "
+								"\"SET LOCAL citus.multi_shard_modify_mode TO "
+								"\'sequential\';\"")));
 	}
 	else if (shouldRunSequential)
 	{
-		/*
-		 * Not a problem to sequentially execute both since table is already
-		 * empty and since parallel execution not happened
-		 */
 		return false;
 	}
 	else if (!localTableEmpty || IsMultiStatementTransaction())

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1213,11 +1213,12 @@ CanUseExclusiveConnections(Oid relationId, bool localTableEmpty)
 		}
 		else if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
 		{
-			/* FIXME: TODO: I think we should actually return false here or improve error message(/hint) ? */
-			ereport(ERROR, (errmsg("cannot distribute \"%s\" in sequential mode "
+			ereport(ERROR, (errmsg("cannot distribute \"%s\" in sequential mode because "
 								   "a parallel query was executed in this transaction",
 								   relationName),
-							errhint("TODO: a proper hint ??")));
+							errhint("If you have manually set "
+									"citus.multi_shard_modify_mode to 'sequential', "
+									"try with 'parallel' option. ")));
 		}
 	}
 	else if (shouldRunSequential)

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2288,7 +2288,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	copyDest->shardStateHash = CreateShardStateHash(TopTransactionContext);
 	copyDest->connectionStateHash = CreateConnectionStateHash(TopTransactionContext);
 
-	RecordRelationAccessIfReferenceTable(tableId, PLACEMENT_ACCESS_DML);
+	RecordRelationAccessIfNonDistTable(tableId, PLACEMENT_ACCESS_DML);
 
 	/*
 	 * For all the primary (e.g., writable) nodes, reserve a shared connection.

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -466,7 +466,7 @@ AssignPlacementListToConnection(List *placementAccessList, MultiConnection *conn
 
 		/* record the relation access */
 		Oid relationId = RelationIdForShard(placement->shardId);
-		RecordRelationAccessIfReferenceTable(relationId, accessType);
+		RecordRelationAccessIfNonDistTable(relationId, accessType);
 	}
 }
 

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -608,6 +608,11 @@ RecordNonDistTableAccessesForTask(Task *task)
 	ShardPlacement *taskPlacement = linitial(task->taskPlacementList);
 	List *placementAccessList = PlacementAccessListForTask(task, taskPlacement);
 
+	/* 
+	 * Here we don't need to iterate task->relationShardList to mark each
+	 * accessed relation because PlacementAccessListForTask already computes
+	 * and returns relations that task accesses.
+	 */
 	ShardPlacementAccess *placementAccess = NULL;
 	foreach_ptr(placementAccess, placementAccessList)
 	{

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -607,14 +607,19 @@ RecordNonDistTableAccessesForTask(Task *task)
 		return;
 	}
 
+	/*
+	 * We use only the first placement to find the relation accesses. It is
+	 * sufficient as PlacementAccessListForTask iterates relationShardList
+	 * field of the task and generates accesses per relation in the task.
+	 * As we are only interested in relations, not the placements, we can
+	 * skip rest of the placements.
+	 * Also, here we don't need to iterate relationShardList field of task
+	 * to mark each accessed relation because PlacementAccessListForTask
+	 * already computes and returns relations that task accesses.
+	 */
 	ShardPlacement *taskPlacement = linitial(taskPlacementList);
 	List *placementAccessList = PlacementAccessListForTask(task, taskPlacement);
 
-	/*
-	 * Here we don't need to iterate task->relationShardList to mark each
-	 * accessed relation because PlacementAccessListForTask already computes
-	 * and returns relations that task accesses.
-	 */
 	ShardPlacementAccess *placementAccess = NULL;
 	foreach_ptr(placementAccess, placementAccessList)
 	{

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -608,7 +608,7 @@ RecordNonDistTableAccessesForTask(Task *task)
 	ShardPlacement *taskPlacement = linitial(task->taskPlacementList);
 	List *placementAccessList = PlacementAccessListForTask(task, taskPlacement);
 
-	/* 
+	/*
 	 * Here we don't need to iterate task->relationShardList to mark each
 	 * accessed relation because PlacementAccessListForTask already computes
 	 * and returns relations that task accesses.

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -153,13 +153,13 @@ AllocateRelationAccessHash(void)
 
 
 /*
- * RecordRelationAccessIfReferenceTable marks the relation accessed if it is a
+ * RecordRelationAccessIfNonDistTable marks the relation accessed if it is a
  * reference relation.
  *
  * The function is a wrapper around RecordRelationAccessBase().
  */
 void
-RecordRelationAccessIfReferenceTable(Oid relationId, ShardPlacementAccessType accessType)
+RecordRelationAccessIfNonDistTable(Oid relationId, ShardPlacementAccessType accessType)
 {
 	if (!ShouldRecordRelationAccess())
 	{

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -492,6 +492,17 @@ RecordParallelRelationAccess(Oid relationId, ShardPlacementAccessType placementA
 	/* act accordingly if it's a conflicting access */
 	CheckConflictingParallelRelationAccesses(relationId, placementAccess);
 
+	/*
+	 * CheckConflictingParallelRelationAccesses might switch to sequential
+	 * execution. If that's the case, no need to continue because the executor
+	 * would take the necessary actions to switch to sequential execution
+	 * immediately.
+	 */
+	if (MultiShardConnectionType == SEQUENTIAL_CONNECTION)
+	{
+		return;
+	}
+
 	/* If a relation is partitioned, record accesses to all of its partitions as well. */
 	if (PartitionedTable(relationId))
 	{

--- a/src/include/distributed/relation_access_tracking.h
+++ b/src/include/distributed/relation_access_tracking.h
@@ -36,8 +36,8 @@ typedef enum RelationAccessMode
 
 extern void AllocateRelationAccessHash(void);
 extern void ResetRelationAccessHash(void);
-extern void RecordRelationAccessIfReferenceTable(Oid relationId,
-												 ShardPlacementAccessType accessType);
+extern void RecordRelationAccessIfNonDistTable(Oid relationId,
+											   ShardPlacementAccessType accessType);
 extern void RecordParallelRelationAccessForTaskList(List *taskList);
 extern void RecordParallelSelectAccess(Oid relationId);
 extern void RecordParallelModifyAccess(Oid relationId);

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -1268,8 +1268,8 @@ BEGIN;
 	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
 	SELECT create_distributed_table('test_table_2', 'id');
-ERROR:  cannot distribute "test_table_2" in sequential mode a parallel query was executed in this transaction
-HINT:  TODO: a proper hint ??
+ERROR:  cannot distribute "test_table_2" in sequential mode because a parallel query was executed in this transaction
+HINT:  If you have manually set citus.multi_shard_modify_mode to 'sequential', try with 'parallel' option.
 	CREATE TABLE test_table_1(id int PRIMARY KEY);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 	SELECT create_reference_table('test_table_1');

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -1268,22 +1268,15 @@ BEGIN;
 	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
 	SELECT create_distributed_table('test_table_2', 'id');
- create_distributed_table
----------------------------------------------------------------------
-
-(1 row)
-
-	CREATE TABLE test_table_1(id int PRIMARY KEY);
-	SELECT create_reference_table('test_table_1');
- create_reference_table
----------------------------------------------------------------------
-
-(1 row)
-
-	ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
-ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
-DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
+ERROR:  cannot distribute relation "test_table_2" in this transaction because it has a foreign key to a reference table
+DETAIL:  If a hash distributed table has a foreign key to a reference table, it has to be created in sequential mode before any parallel commands have been executed in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+	CREATE TABLE test_table_1(id int PRIMARY KEY);
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+	SELECT create_reference_table('test_table_1');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+	ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
 	-- make sure that the output isn't too verbose
  	SET LOCAL client_min_messages TO ERROR;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -1268,15 +1268,22 @@ BEGIN;
 	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
 	SELECT create_distributed_table('test_table_2', 'id');
-ERROR:  cannot distribute relation "test_table_2" in this transaction because it has a foreign key to a reference table
-DETAIL:  If a hash distributed table has a foreign key to a reference table, it has to be created in sequential mode before any parallel commands have been executed in the same transaction
-HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 	CREATE TABLE test_table_1(id int PRIMARY KEY);
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
 	SELECT create_reference_table('test_table_1');
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
 	ALTER TABLE test_table_2 ADD CONSTRAINT c_check FOREIGN KEY (value_1) REFERENCES test_table_1(id);
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ERROR:  cannot modify table "test_table_2" because there was a parallel operation on a distributed table in the transaction
+DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
+HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 	-- make sure that the output isn't too verbose
  	SET LOCAL client_min_messages TO ERROR;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -1268,9 +1268,8 @@ BEGIN;
 	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
 	CREATE TABLE test_table_2(id int PRIMARY KEY, value_1 int);
 	SELECT create_distributed_table('test_table_2', 'id');
-ERROR:  cannot distribute relation "test_table_2" in this transaction because it has a foreign key to a reference table
-DETAIL:  If a hash distributed table has a foreign key to a reference table, it has to be created in sequential mode before any parallel commands have been executed in the same transaction
-HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+ERROR:  cannot distribute "test_table_2" in sequential mode a parallel query was executed in this transaction
+HINT:  TODO: a proper hint ??
 	CREATE TABLE test_table_1(id int PRIMARY KEY);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 	SELECT create_reference_table('test_table_1');

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -629,7 +629,6 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 (2 rows)
 
 ROLLBACK;
--- Try a bunch of commands and expect failure at SELECT create_distributed_table
 BEGIN;
   -- here this SELECT will enforce the whole block for local execution
   SELECT COUNT(*) FROM ref_table;
@@ -664,14 +663,26 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500124, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500127, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500130, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
-  -- as we executed ALTER TABLE commands parallelly, below
-  -- SELECT create_distributed_table would error out
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
-ERROR:  cannot distribute "another_dist_table" in sequential mode a parallel query was executed in this transaction
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 COMMIT;
--- add a column to be dropped and a foreign key for next test
-ALTER TABLE dist_table ADD column c int;
+-- add a foreign key for next test
 ALTER TABLE dist_table ADD CONSTRAINT fkey_dist_to_ref FOREIGN KEY (b) REFERENCES ref_table(a);
 BEGIN;
   SELECT count(*) FROM ref_table;
@@ -740,17 +751,17 @@ NOTICE:  executing the command locally: SELECT a FROM local_commands_test_schema
 
   INSERT INTO partitioning_test VALUES (7, '2012-07-07');
   SELECT COUNT(*) FROM partitioning_test;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500133 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500136 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500139 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500142 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500145 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500148 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500151 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500154 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500157 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500160 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500163 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500165 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500168 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500171 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500174 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500177 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500180 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500183 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500186 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500189 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500192 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500195 partitioning_test WHERE true
  count
 ---------------------------------------------------------------------
      4
@@ -758,17 +769,17 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_comm
 
   -- execute bunch of DDL & DROP commands succesfully
   ALTER TABLE partitioning_test ADD column c int;
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500165, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500168, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500171, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500174, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500177, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500180, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500183, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500186, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500189, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500192, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500195, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
   TRUNCATE partitioning_test;
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.partitioning_test_xxxxx CASCADE
@@ -816,56 +827,56 @@ NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500165" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500197" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500168" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500200" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500171" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500203" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500174" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500206" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500177" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500209" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500180" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500212" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500183" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500215" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500186" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500218" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500189" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500221" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500192" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500224" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500195" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500227" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500197" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500229" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500200" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500232" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500203" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500235" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500206" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500238" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500209" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500241" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500212" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500244" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500215" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500247" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500218" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500250" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500221" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500253" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500224" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500256" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500227" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500259" does not exist, skipping
 ROLLBACK;
 -- below should be executed via remote connections
 TRUNCATE partitioning_test;
 DROP TABLE partitioning_test;
 -- cleanup at exit
 DROP SCHEMA local_commands_test_schema CASCADE;
-NOTICE:  drop cascades to 16 other objects
+NOTICE:  drop cascades to 28 other objects
 DROP SCHEMA foo_schema;
 SELECT 1 FROM master_set_node_property('localhost', :master_port, 'shouldhaveshards', false);
  ?column?

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -629,7 +629,6 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 (2 rows)
 
 ROLLBACK;
--- Try a bunch of commands and expect failure at SELECT create_distributed_table
 BEGIN;
   -- here this SELECT will enforce the whole block for local execution
   SELECT COUNT(*) FROM ref_table;
@@ -664,8 +663,7 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500124, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500127, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500130, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
-  -- as we create table via remote connections, below SELECT create_distributed_table
-  -- would error out
+  -- then create a distributed table succesfully
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -629,6 +629,7 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 (2 rows)
 
 ROLLBACK;
+-- Try a bunch of commands and expect failure at SELECT create_distributed_table
 BEGIN;
   -- here this SELECT will enforce the whole block for local execution
   SELECT COUNT(*) FROM ref_table;
@@ -663,11 +664,51 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500124, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500127, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500130, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
-  -- then create a distributed table succesfully
+  -- as we executed ALTER TABLE commands parallelly, below
+  -- SELECT create_distributed_table would error out
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
-ERROR:  cannot distribute relation "another_dist_table" in this transaction because it has a foreign key to a reference table
+ERROR:  cannot distribute "another_dist_table" in sequential mode a parallel query was executed in this transaction
 COMMIT;
+-- add a column to be dropped and a foreign key for next test
+ALTER TABLE dist_table ADD column c int;
+ALTER TABLE dist_table ADD CONSTRAINT fkey_dist_to_ref FOREIGN KEY (b) REFERENCES ref_table(a);
+BEGIN;
+  SELECT count(*) FROM ref_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.ref_table_1500035 ref_table
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+  -- should show parallel
+  SHOW citus.multi_shard_modify_mode ;
+ citus.multi_shard_modify_mode
+---------------------------------------------------------------------
+ parallel
+(1 row)
+
+  -- wants to do parallel execution but will switch to sequential mode
+  ALTER TABLE dist_table DROP COLUMN c;
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500100, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500103, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500106, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500109, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500112, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500115, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500118, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500121, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500124, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500127, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500130, 'local_commands_test_schema', 'ALTER TABLE dist_table DROP COLUMN c;')
+  -- should show sequential
+  SHOW citus.multi_shard_modify_mode;
+ citus.multi_shard_modify_mode
+---------------------------------------------------------------------
+ sequential
+(1 row)
+
+ROLLBACK;
 ---------------------------------------------------------------------
 ------------ partitioned tables -------------
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -666,7 +666,22 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
   -- then create a distributed table succesfully
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
-ERROR:  cannot distribute relation "another_dist_table" in this transaction because it has a foreign key to a reference table
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 COMMIT;
 ---------------------------------------------------------------------
 ------------ partitioned tables -------------
@@ -699,17 +714,17 @@ NOTICE:  executing the command locally: SELECT a FROM local_commands_test_schema
 
   INSERT INTO partitioning_test VALUES (7, '2012-07-07');
   SELECT COUNT(*) FROM partitioning_test;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500133 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500136 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500139 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500142 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500145 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500148 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500151 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500154 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500157 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500160 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500163 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500165 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500168 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500171 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500174 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500177 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500180 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500183 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500186 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500189 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500192 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500195 partitioning_test WHERE true
  count
 ---------------------------------------------------------------------
      4
@@ -717,17 +732,17 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_comm
 
   -- execute bunch of DDL & DROP commands succesfully
   ALTER TABLE partitioning_test ADD column c int;
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500165, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500168, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500171, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500174, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500177, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500180, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500183, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500186, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500189, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500192, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500195, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
   TRUNCATE partitioning_test;
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.partitioning_test_xxxxx CASCADE
@@ -775,56 +790,56 @@ NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500165" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500197" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500168" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500200" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500171" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500203" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500174" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500206" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500177" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500209" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500180" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500212" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500183" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500215" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500186" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500218" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500189" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500221" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500192" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500224" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500195" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500227" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500197" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500229" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500200" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500232" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500203" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500235" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500206" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500238" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500209" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500241" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500212" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500244" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500215" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500247" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500218" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500250" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500221" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500253" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500224" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500256" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500227" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500259" does not exist, skipping
 ROLLBACK;
 -- below should be executed via remote connections
 TRUNCATE partitioning_test;
 DROP TABLE partitioning_test;
 -- cleanup at exit
 DROP SCHEMA local_commands_test_schema CASCADE;
-NOTICE:  drop cascades to 16 other objects
+NOTICE:  drop cascades to 28 other objects
 DROP SCHEMA foo_schema;
 SELECT 1 FROM master_set_node_property('localhost', :master_port, 'shouldhaveshards', false);
  ?column?

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -666,22 +666,7 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
   -- then create a distributed table succesfully
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
- create_distributed_table
----------------------------------------------------------------------
-
-(1 row)
-
+ERROR:  cannot distribute relation "another_dist_table" in this transaction because it has a foreign key to a reference table
 COMMIT;
 ---------------------------------------------------------------------
 ------------ partitioned tables -------------
@@ -714,17 +699,17 @@ NOTICE:  executing the command locally: SELECT a FROM local_commands_test_schema
 
   INSERT INTO partitioning_test VALUES (7, '2012-07-07');
   SELECT COUNT(*) FROM partitioning_test;
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500165 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500168 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500171 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500174 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500177 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500180 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500183 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500186 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500189 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500192 partitioning_test WHERE true
-NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500195 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500133 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500136 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500139 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500142 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500145 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500148 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500151 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500154 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500157 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500160 partitioning_test WHERE true
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_commands_test_schema.partitioning_test_1500163 partitioning_test WHERE true
  count
 ---------------------------------------------------------------------
      4
@@ -732,17 +717,17 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_comm
 
   -- execute bunch of DDL & DROP commands succesfully
   ALTER TABLE partitioning_test ADD column c int;
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500165, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500168, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500171, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500174, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500177, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500180, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500183, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500186, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500189, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500192, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500195, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE partitioning_test ADD column c int;')
   TRUNCATE partitioning_test;
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.partitioning_test_xxxxx CASCADE
@@ -790,56 +775,56 @@ NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_xxxxx CASCADE
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500197" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500165" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500200" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500168" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500203" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500171" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500206" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500174" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500209" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500177" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500212" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500180" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500215" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500183" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500218" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500186" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500221" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500189" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500224" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500192" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2012_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2012_1500227" does not exist, skipping
+NOTICE:  table "partitioning_test_2012_1500195" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500229" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500197" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500232" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500200" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500235" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500203" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500238" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500206" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500241" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500209" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500244" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500212" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500247" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500215" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500250" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500218" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500253" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500221" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500256" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500224" does not exist, skipping
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS local_commands_test_schema.partitioning_test_2013_xxxxx CASCADE
-NOTICE:  table "partitioning_test_2013_1500259" does not exist, skipping
+NOTICE:  table "partitioning_test_2013_1500227" does not exist, skipping
 ROLLBACK;
 -- below should be executed via remote connections
 TRUNCATE partitioning_test;
 DROP TABLE partitioning_test;
 -- cleanup at exit
 DROP SCHEMA local_commands_test_schema CASCADE;
-NOTICE:  drop cascades to 28 other objects
+NOTICE:  drop cascades to 16 other objects
 DROP SCHEMA foo_schema;
 SELECT 1 FROM master_set_node_property('localhost', :master_port, 'shouldhaveshards', false);
  ?column?

--- a/src/test/regress/sql/local_shard_utility_command_execution.sql
+++ b/src/test/regress/sql/local_shard_utility_command_execution.sql
@@ -278,7 +278,6 @@ BEGIN;
   SELECT tablename FROM pg_tables where schemaname='foo_schema' ORDER BY tablename;
 ROLLBACK;
 
--- Try a bunch of commands and expect failure at SELECT create_distributed_table
 BEGIN;
   -- here this SELECT will enforce the whole block for local execution
   SELECT COUNT(*) FROM ref_table;
@@ -287,8 +286,7 @@ BEGIN;
   ALTER TABLE dist_table ADD column c int;
   ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;
 
-  -- as we create table via remote connections, below SELECT create_distributed_table
-  -- would error out
+  -- then create a distributed table succesfully
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
 COMMIT;

--- a/src/test/regress/sql/local_shard_utility_command_execution.sql
+++ b/src/test/regress/sql/local_shard_utility_command_execution.sql
@@ -278,7 +278,6 @@ BEGIN;
   SELECT tablename FROM pg_tables where schemaname='foo_schema' ORDER BY tablename;
 ROLLBACK;
 
--- Try a bunch of commands and expect failure at SELECT create_distributed_table
 BEGIN;
   -- here this SELECT will enforce the whole block for local execution
   SELECT COUNT(*) FROM ref_table;
@@ -287,14 +286,11 @@ BEGIN;
   ALTER TABLE dist_table ADD column c int;
   ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;
 
-  -- as we executed ALTER TABLE commands parallelly, below
-  -- SELECT create_distributed_table would error out
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
 COMMIT;
 
--- add a column to be dropped and a foreign key for next test
-ALTER TABLE dist_table ADD column c int;
+-- add a foreign key for next test
 ALTER TABLE dist_table ADD CONSTRAINT fkey_dist_to_ref FOREIGN KEY (b) REFERENCES ref_table(a);
 
 BEGIN;


### PR DESCRIPTION
DESCRIPTION: Record non-distributed table accesses in local executor

This is both a preparation for citus local tables and is a fix for a possible bug with single node citus (coord. is added to `pg_dist_node` with `shouldHaveShards=true`). In that case, we need to keep track of accesses to reference tables that are referenced by distributed tables in local executor too.
