### PR TITLE
Record parallel relation accesses dynamically in the executor

### DIFF
--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -266,14 +266,20 @@ RecordPlacementAccessToCache(Oid relationId, ShardPlacementAccessType accessType
 
 
 /*
- * RecordParallelRelationAccessForTaskList gets a task list and records
+ * EnforceRestrictionsOnParallelRelationAccess gets a task list and records
  * the necessary parallel relation accesses for the task list.
+ *
+ * Depending on the current state, the function may do one of the three
+ * things. First, simply record parallel relation access and return. Second,
+ * throw an error noting that the state is not eligable for parallel access.
+ * Third, set the execution mode to sequential. For the details, see
+ * EnforceRestrictionsOnParallelRelationAccess().
  *
  * This function is used to enforce foreign keys from distributed
  * tables to reference tables.
  */
 void
-RecordParallelRelationAccessForTaskList(List *taskList)
+EnforceRestrictionsOnParallelRelationAccess(List *taskList)
 {
 	if (list_length(taskList) < 1)
 	{

--- a/src/include/distributed/relation_access_tracking.h
+++ b/src/include/distributed/relation_access_tracking.h
@@ -38,7 +38,7 @@ extern void AllocateRelationAccessHash(void);
 extern void ResetRelationAccessHash(void);
 extern void RecordRelationAccessIfReferenceTable(Oid relationId,
 												 ShardPlacementAccessType accessType);
-extern void RecordParallelRelationAccessForTaskList(List *taskList);
+extern void EnforceRestrictionsOnParallelRelationAccess(List *taskList);
 extern void RecordParallelSelectAccess(Oid relationId);
 extern void RecordParallelModifyAccess(Oid relationId);
 extern void RecordParallelDDLAccess(Oid relationId);

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -44,6 +44,11 @@ INSERT INTO on_update_fkey_table SELECT i, i % 100  FROM generate_series(0, 1000
 INSERT INTO unrelated_dist_table SELECT i, i % 100  FROM generate_series(0, 1000) i;
 -- in order to see when the mode automatically swithces to sequential execution
 SET client_min_messages TO DEBUG1;
+-- to make the tests consistent, we should force parallelism
+-- otherwise distinguishing parallel queries might be hard
+-- as the executor is smart enough to use as less connections
+-- as possible
+SET citus.force_max_query_parallelization TO ON;
 -- case 1.1: SELECT to a reference table is followed by a parallel SELECT to a distributed table
 BEGIN;
 	SELECT count(*) FROM reference_table;
@@ -1080,6 +1085,9 @@ HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_m
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 ROLLBACK;
 BEGIN;
+	-- we cannot force in this case as that breaks the
+        -- transaction visibility
+	SET LOCAL citus.force_max_query_parallelization TO OFF;
 	CREATE TABLE test_table_1(id int PRIMARY KEY);
 	SELECT create_reference_table('test_table_1');
  create_reference_table

--- a/src/test/regress/expected/relation_access_tracking.out
+++ b/src/test/regress/expected/relation_access_tracking.out
@@ -100,6 +100,11 @@ INSERT INTO table_3 SELECT i, i FROM generate_series(0,100) i;
 INSERT INTO table_4 SELECT i, i FROM generate_series(0,100) i;
 INSERT INTO table_5 SELECT i, i FROM generate_series(0,100) i;
 INSERT INTO table_6 SELECT i, i FROM generate_series(0,100) i;
+-- to make the tests consistent, we should force parallelism
+-- otherwise distinguishing parallel queries might be hard
+-- as the executor is smart enough to use as less connections
+-- as possible
+SET citus.force_max_query_parallelization TO ON;
 -- create_distributed_table works fine
 BEGIN;
 	CREATE TABLE table_7 (key int, value int);
@@ -150,7 +155,7 @@ BEGIN;
  table_1    | not_parallel_accessed | not_parallel_accessed | not_parallel_accessed
 (1 row)
 
-	SELECT count(*) FROM table_1 WHERE key = 1 OR key = 2;
+	SELECT count(*) FROM table_1 WHERE key = 2 OR key = 4;
  count
 ---------------------------------------------------------------------
      2

--- a/src/test/regress/sql/relation_access_tracking.sql
+++ b/src/test/regress/sql/relation_access_tracking.sql
@@ -89,6 +89,12 @@ INSERT INTO table_4 SELECT i, i FROM generate_series(0,100) i;
 INSERT INTO table_5 SELECT i, i FROM generate_series(0,100) i;
 INSERT INTO table_6 SELECT i, i FROM generate_series(0,100) i;
 
+-- to make the tests consistent, we should force parallelism
+-- otherwise distinguishing parallel queries might be hard
+-- as the executor is smart enough to use as less connections
+-- as possible
+SET citus.force_max_query_parallelization TO ON;
+
 -- create_distributed_table works fine
 BEGIN;
 	CREATE TABLE table_7 (key int, value int);
@@ -106,7 +112,7 @@ BEGIN;
 	SELECT * FROM relation_accesses WHERE table_name = 'table_1';
 	SELECT count(*) FROM table_1 WHERE key = 1;
 	SELECT * FROM relation_accesses WHERE table_name = 'table_1';
-	SELECT count(*) FROM table_1 WHERE key = 1 OR key = 2;
+	SELECT count(*) FROM table_1 WHERE key = 2 OR key = 4;
 	SELECT * FROM relation_accesses WHERE table_name = 'table_1';
 	INSERT INTO table_1 VALUES (1,1);
 	SELECT * FROM relation_accesses WHERE table_name = 'table_1';


### PR DESCRIPTION
Before this commit, the parallel relation access was based on
the number of tasks, not the actual connections used
by the executor.

With this commit, the executor reacts immediately as soon as
the executor requires the second connection to a given node.

The previous logic was problematic for several reasons:

- It had various hacks to make the logic work
- It was not intuitive, easy to follow. It as also fragile, as
  new developments should always consider parallel records
  as opposed to it being automatically
- With the local executor, we were deciding the parallel accesses
  even before we consider local tasks
- The old logic was relying on number of the tasks, which doesn't
  mean much. For example, create_reference_table() creates
  multiple tasks per node, all of which use the same connection.

The downside of this new logic is that the same tx block may work on
some executions and may not for others. The reason is that if the
execution should be prohibited because of foreign keys to reference
tables, the new logic would successfully finish if the execution
requires a single connection only. Still, the fix is straight-forward,
the user just should set `citus.multi_shard_modify_mode` to `sequential`
as instructed by the error hint.
