### PR TITLE
Prevent citus local table creation from a catalog table

### DIFF
--- a/src/backend/distributed/commands/create_citus_local_table.c
+++ b/src/backend/distributed/commands/create_citus_local_table.c
@@ -202,6 +202,8 @@ ErrorIfUnsupportedCreateCitusLocalTable(Relation relation)
 							   "not exist")));
 	}
 
+	ErrorIfTableIsACatalogTable(relation);
+
 	Oid relationId = relation->rd_id;
 
 	ErrorIfCoordinatorNotAddedAsWorkerNode();

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -683,12 +683,7 @@ EnsureRelationCanBeDistributed(Oid relationId, Var *distributionColumn,
 	TupleDesc relationDesc = RelationGetDescr(relation);
 	char *relationName = RelationGetRelationName(relation);
 
-	if (relation->rd_rel->relnamespace == PG_CATALOG_NAMESPACE)
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot distribute catalog tables")));
-	}
-
+	ErrorIfTableIsACatalogTable(relation);
 
 	if (!RelationUsesHeapAccessMethodOrNone(relation))
 	{
@@ -831,6 +826,23 @@ EnsureRelationCanBeDistributed(Oid relationId, Var *distributionColumn,
 
 	ErrorIfUnsupportedPolicy(relation);
 	relation_close(relation, NoLock);
+}
+
+
+/*
+ * ErrorIfTableIsACatalogTable is a helper function to error out for citus
+ * table creation from a catalog table.
+ */
+void
+ErrorIfTableIsACatalogTable(Relation relation)
+{
+	if (relation->rd_rel->relnamespace != PG_CATALOG_NAMESPACE)
+	{
+		return;
+	}
+
+	ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("cannot create a citus table from a catalog table")));
 }
 
 

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -153,6 +153,7 @@ extern void EnsureHashDistributedTable(Oid relationId);
 extern void EnsureSequenceOwner(Oid sequenceOid);
 extern void EnsureFunctionOwner(Oid functionId);
 extern void EnsureSuperUser(void);
+extern void ErrorIfTableIsACatalogTable(Relation relation);
 extern void EnsureTableNotDistributed(Oid relationId);
 extern void EnsureReplicationSettings(Oid relationId, char replicationModel);
 extern bool RegularTable(Oid relationId);

--- a/src/test/regress/expected/citus_local_tables.out
+++ b/src/test/regress/expected/citus_local_tables.out
@@ -654,6 +654,9 @@ FROM (SELECT tableName FROM pg_catalog.pg_tables WHERE tablename LIKE 'citus_loc
  f                      | t
 (1 row)
 
+-- cannot create a citus local table from a catalog table
+SELECT create_citus_local_table('pg_class');
+ERROR:  cannot create a citus table from a catalog table
 -- cleanup at exit
 DROP SCHEMA citus_local_tables_test_schema, "CiTUS!LocalTables" CASCADE;
 NOTICE:  drop cascades to 18 other objects

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -319,6 +319,6 @@ DROP TABLE data_load_test1, data_load_test2;
 END;
 -- distributing catalog tables is not supported
 SELECT create_distributed_table('pg_class', 'relname');
-ERROR:  cannot distribute catalog tables
+ERROR:  cannot create a citus table from a catalog table
 SELECT create_reference_table('pg_class');
-ERROR:  cannot distribute catalog tables
+ERROR:  cannot create a citus table from a catalog table

--- a/src/test/regress/sql/citus_local_tables.sql
+++ b/src/test/regress/sql/citus_local_tables.sql
@@ -442,5 +442,8 @@ SELECT relation_is_a_known_shard('citus_local_table_4');
 SELECT citus_table_is_visible(tableName::regclass::oid), relation_is_a_known_shard(tableName::regclass)
 FROM (SELECT tableName FROM pg_catalog.pg_tables WHERE tablename LIKE 'citus_local_table_4_%') as tableName;
 
+-- cannot create a citus local table from a catalog table
+SELECT create_citus_local_table('pg_class');
+
 -- cleanup at exit
 DROP SCHEMA citus_local_tables_test_schema, "CiTUS!LocalTables" CASCADE;


### PR DESCRIPTION
We should prevent citus local table creation from a catalog table like we do [here](https://github.com/citusdata/citus/pull/3938/files#diff-32941da8b706afd7d084e4268b742eecR686-R692).
