### PR TITLE
Add `ORDER BY` to some tests

### DIFF
--- a/src/test/regress/expected/coordinator_shouldhaveshards.out
+++ b/src/test/regress/expected/coordinator_shouldhaveshards.out
@@ -424,10 +424,10 @@ SELECT * FROM local JOIN dist_table ON (a = x) WHERE a = 1;;
 ERROR:  direct joins between distributed and local tables are not supported
 HINT:  Use CTE's or subqueries to select from local tables and use them in joins
 -- intermediate results are allowed
-WITH cte_1 AS (SELECT * FROM dist_table LIMIT 1)
+WITH cte_1 AS (SELECT * FROM dist_table ORDER BY 1 LIMIT 1)
 SELECT * FROM ref JOIN local ON (a = x) JOIN cte_1 ON (local.x = cte_1.a);
-NOTICE:  executing the command locally: SELECT a FROM coordinator_shouldhaveshards.dist_table_1503017 dist_table WHERE true LIMIT '1'::bigint
-NOTICE:  executing the command locally: SELECT a FROM coordinator_shouldhaveshards.dist_table_1503020 dist_table WHERE true LIMIT '1'::bigint
+NOTICE:  executing the command locally: SELECT a FROM coordinator_shouldhaveshards.dist_table_1503017 dist_table WHERE true ORDER BY a LIMIT '1'::bigint
+NOTICE:  executing the command locally: SELECT a FROM coordinator_shouldhaveshards.dist_table_1503020 dist_table WHERE true ORDER BY a LIMIT '1'::bigint
 NOTICE:  executing the command locally: SELECT ref.a, ref.b, local.x, local.y, cte_1.a FROM ((coordinator_shouldhaveshards.ref_1503016 ref JOIN coordinator_shouldhaveshards.local ON ((ref.a OPERATOR(pg_catalog.=) local.x))) JOIN (SELECT intermediate_result.a FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(a integer)) cte_1 ON ((local.x OPERATOR(pg_catalog.=) cte_1.a)))
  a | b | x | y | a
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/local_shard_copy.out
+++ b/src/test/regress/expected/local_shard_copy.out
@@ -177,37 +177,37 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_shar
 NOTICE:  executing the copy locally for shard xxxxx
 CONTEXT:  COPY distributed_table, line 1: "1, 100"
     -- verify the put ages.
-    SELECT * FROM distributed_table;
+    SELECT * FROM distributed_table ORDER BY 1,2 DESC;
 NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1570001 distributed_table WHERE true
 NOTICE:  executing the command locally: SELECT key, age FROM local_shard_copy.distributed_table_1570003 distributed_table WHERE true
  key | age
 ---------------------------------------------------------------------
+   1 | 100
+   2 | 200
+   3 | 300
+   4 | 400
+   5 | 500
   20 |  20
+  21 |  21
+  22 |  22
+  23 |  23
   24 |  24
   25 |  25
   26 |  26
-  31 |  31
-  33 |  33
-  35 |  35
-   1 | 100
-   5 | 500
-  21 |  21
-  28 |  28
-  34 |  34
-  38 |  38
-  39 |  39
-  36 |  36
-  37 |  37
-  40 |  40
-   3 | 300
-   4 | 400
-  22 |  22
-  23 |  23
   27 |  27
+  28 |  28
   29 |  29
   30 |  30
+  31 |  31
   32 |  32
-   2 | 200
+  33 |  33
+  34 |  34
+  35 |  35
+  36 |  36
+  37 |  37
+  38 |  38
+  39 |  39
+  40 |  40
 (26 rows)
 
 ROLLBACK;

--- a/src/test/regress/sql/coordinator_shouldhaveshards.sql
+++ b/src/test/regress/sql/coordinator_shouldhaveshards.sql
@@ -173,7 +173,7 @@ SELECT * FROM local JOIN dist_table ON (a = x);
 SELECT * FROM local JOIN dist_table ON (a = x) WHERE a = 1;;
 
 -- intermediate results are allowed
-WITH cte_1 AS (SELECT * FROM dist_table LIMIT 1)
+WITH cte_1 AS (SELECT * FROM dist_table ORDER BY 1 LIMIT 1)
 SELECT * FROM ref JOIN local ON (a = x) JOIN cte_1 ON (local.x = cte_1.a);
 
 -- full router query with CTE and local

--- a/src/test/regress/sql/local_shard_copy.sql
+++ b/src/test/regress/sql/local_shard_copy.sql
@@ -118,7 +118,7 @@ BEGIN;
 5, 500
 \.
     -- verify the put ages.
-    SELECT * FROM distributed_table;
+    SELECT * FROM distributed_table ORDER BY 1,2 DESC;
 
 ROLLBACK;
 


### PR DESCRIPTION
These tests may return inconsistent results on different executions, by adding `ORDER BY` we ensure the order.