### PR TITLE
Comment user provided input memory allocation

### DIFF
--- a/src/backend/distributed/operations/citus_tools.c
+++ b/src/backend/distributed/operations/citus_tools.c
@@ -112,7 +112,12 @@ master_run_on_worker(PG_FUNCTION_ARGS)
 						"function return type are not compatible")));
 	}
 
-	/* prepare storage for status and result values */
+	/*
+	 * prepare storage for status and result values.
+	 * commandCount is based on user input however, it is the length of list
+	 * instead of a user given integer, hence this should be safe here in terms
+	 * of memory allocation.
+	 */
 	bool *statusArray = palloc0(commandCount * sizeof(bool));
 	StringInfo *resultArray = palloc0(commandCount * sizeof(StringInfo));
 	for (int commandIndex = 0; commandIndex < commandCount; commandIndex++)


### PR DESCRIPTION
This comment is for one of the items in semester security review, memory allocations.

We should be careful about doing calculations for allocating memory based on user supplied input.  In `master_run_on_worker` it seems that it is safe currently since the `commandCount`  is the length of a user provided list. It might be dangerous if it was a user supplied integer, where they could give some unexpected values, which we would need to check with a check.
