### PR TITLE
Shorten insert select connection leak test

### DIFF
--- a/src/test/regress/expected/insert_select_connection_leak.out
+++ b/src/test/regress/expected/insert_select_connection_leak.out
@@ -23,7 +23,7 @@ SELECT create_distributed_table('target_table', 'a');
 
 (1 row)
 
-INSERT INTO source_table SELECT i, 2 * i FROM generate_series(1, 10000) i;
+INSERT INTO source_table SELECT i, 2 * i FROM generate_series(1, 100) i;
 EXPLAIN (costs off) INSERT INTO target_table SELECT * FROM source_table;
                            QUERY PLAN
 ---------------------------------------------------------------------
@@ -81,7 +81,7 @@ INSERT INTO target_table SELECT * FROM source_table;
 SELECT worker_connection_count(:worker_1_port) AS worker_1_connections,
        worker_connection_count(:worker_2_port) AS worker_2_connections \gset
 SAVEPOINT s1;
-INSERT INTO target_table SELECT a, CASE WHEN a < 5000 THEN b ELSE null END  FROM source_table;
+INSERT INTO target_table SELECT a, CASE WHEN a < 50 THEN b ELSE null END  FROM source_table;
 ERROR:  null value in column "b" violates not-null constraint
 ROLLBACK TO SAVEPOINT s1;
 SELECT worker_connection_count(:worker_1_port) - :worker_1_connections AS leaked_worker_1_connections,

--- a/src/test/regress/sql/insert_select_connection_leak.sql
+++ b/src/test/regress/sql/insert_select_connection_leak.sql
@@ -18,7 +18,7 @@ SELECT create_distributed_table('source_table', 'a');
 CREATE TABLE target_table(a numeric, b int not null);
 SELECT create_distributed_table('target_table', 'a');
 
-INSERT INTO source_table SELECT i, 2 * i FROM generate_series(1, 10000) i;
+INSERT INTO source_table SELECT i, 2 * i FROM generate_series(1, 100) i;
 
 EXPLAIN (costs off) INSERT INTO target_table SELECT * FROM source_table;
 
@@ -57,7 +57,7 @@ INSERT INTO target_table SELECT * FROM source_table;
 SELECT worker_connection_count(:worker_1_port) AS worker_1_connections,
        worker_connection_count(:worker_2_port) AS worker_2_connections \gset
 SAVEPOINT s1;
-INSERT INTO target_table SELECT a, CASE WHEN a < 5000 THEN b ELSE null END  FROM source_table;
+INSERT INTO target_table SELECT a, CASE WHEN a < 50 THEN b ELSE null END  FROM source_table;
 ROLLBACK TO SAVEPOINT s1;
 SELECT worker_connection_count(:worker_1_port) - :worker_1_connections AS leaked_worker_1_connections,
        worker_connection_count(:worker_2_port) - :worker_2_connections AS leaked_worker_2_connections;


### PR DESCRIPTION
fixes #3474 . Size of the table is reduced, so other tables which are triggered later are also reduced by size. This test frequently fails on CircleCI because of the running time exceeding 120 seconds. With this changes, all of the CircleCI time experiments took ~2 seconds, none of them exceeding 3.5 seconds.

https://app.circleci.com/pipelines/github/citusdata/citus?branch=shorten-insert-select-test
