### PR TITLE
Fix long explain analyze queries

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1461,7 +1461,7 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc)
 static List *
 SplitString(const char *str, char delimiter)
 {
-	size_t len = strnlen_s(str, RSIZE_MAX_STR);
+	size_t len = strnlen(str, RSIZE_MAX_STR);
 	if (len == 0)
 	{
 		return NIL;

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1461,7 +1461,7 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc)
 static List *
 SplitString(const char *str, char delimiter)
 {
-	size_t len = strnlen(str, RSIZE_MAX_STR);
+	size_t len = strnlen(str, RSIZE_MAX_MEM);
 	if (len == 0)
 	{
 		return NIL;

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -2913,4 +2913,74 @@ Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
               Tuples Inserted: 0
               Conflicting Tuples: 0
               ->  Seq Scan on users_table_2_570028 users_table_2 (actual rows=0 loops=1)
-DROP TABLE simple, users_table_2;
+-- https://github.com/citusdata/citus/issues/4169
+CREATE TABLE test (x int, y int);
+SELECT create_distributed_table('test', 'x');
+
+EXPLAIN  (VERBOSE on, COSTS off, ANALYZE on, TIMING off, SUMMARY off) SELECT * FROM (SELECT x, count(*), row_number() OVER (), lead(x) OVER (PARTITION BY x) FROM test a JOIN test b USING (x) JOIN test c JOIN test d JOIN test e JOIN test l JOIN test m JOIN test n USING (x) USING (x) USING (x) USING(x) USING(x) USING(x) JOIN test f USING (x) WHERE x = 2 OR x = 2 AND b.y > random() GROUP BY x ORDER BY x) foo ORDER BY 3 LIMIT 10;
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Output: xxxxxx
+  Task Count: 1
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: All
+  ->  Task
+        Query: SELECT x, count, row_number, lead FROM (SELECT a.x, count(*) AS count, row_number() OVER () AS row_number, lead(a.x) OVER (PARTITION BY a.x) AS lead FROM (((public.test_570030 a(x, y) JOIN public.test_570030 b(x, y) USING (x)) JOIN (public.test_570030 c(x, y) JOIN (public.test_570030 d(x, y) JOIN (public.test_570030 e(x, y) JOIN (public.test_570030 l(x, y) JOIN (public.test_570030 m(x, y) JOIN public.test_570030 n(x, y) USING (x)) USING (x)) USING (x)) USING (x)) USING (x)) USING (x)) JOIN public.test_570030 f(x, y) USING (x)) WHERE ((a.x OPERATOR(pg_catalog.=) 2) OR ((a.x OPERATOR(pg_catalog.=) 2) AND ((b.y)::double precision OPERATOR(pg_catalog.>) random()))) GROUP BY a.x ORDER BY a.x) foo ORDER BY row_number LIMIT 10
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Limit (actual rows=0 loops=1)
+              Output: xxxxxx
+              ->  Sort (actual rows=0 loops=1)
+                    Output: xxxxxx
+                    Sort Key: (row_number() OVER (?))
+                    Sort Method: quicksort  Memory: 25kB
+                    ->  WindowAgg (actual rows=0 loops=1)
+                          Output: xxxxxx
+                          ->  WindowAgg (actual rows=0 loops=1)
+                                Output: xxxxxx
+                                ->  GroupAggregate (actual rows=0 loops=1)
+                                      Output: xxxxxx
+                                      Group Key: a.x
+                                      ->  Nested Loop (actual rows=0 loops=1)
+                                            Output: xxxxxx
+                                            ->  Nested Loop (actual rows=0 loops=1)
+                                                  Output: xxxxxx
+                                                  ->  Nested Loop (actual rows=0 loops=1)
+                                                        Output: xxxxxx
+                                                        ->  Nested Loop (actual rows=0 loops=1)
+                                                              Output: xxxxxx
+                                                              ->  Seq Scan on public.test_570030 a (actual rows=0 loops=1)
+                                                                    Output: xxxxxx
+                                                                    Filter: (a.x = 2)
+                                                              ->  Materialize (never executed)
+                                                                    Output: xxxxxx
+                                                                    ->  Seq Scan on public.test_570030 b (never executed)
+                                                                          Output: xxxxxx
+                                                                          Filter: (b.x = 2)
+                                                        ->  Materialize (never executed)
+                                                              Output: xxxxxx
+                                                              ->  Nested Loop (never executed)
+                                                                    Output: xxxxxx
+                                                                    ->  Seq Scan on public.test_570030 c (never executed)
+                                                                          Output: xxxxxx
+                                                                          Filter: (c.x = 2)
+                                                                    ->  Materialize (never executed)
+                                                                          Output: xxxxxx
+                                                                          ->  Seq Scan on public.test_570030 d (never executed)
+                                                                                Output: xxxxxx
+                                                                                Filter: (d.x = 2)
+                                                  ->  Materialize (never executed)
+                                                        Output: xxxxxx
+                                                        ->  Nested Loop (never executed)
+                                                              Output: xxxxxx
+                                                              ->  Nested Loop (never executed)
+                                                                    Output: xxxxxx
+                                                                    ->  Seq Scan on public.test_570030 e (never executed)
+                                                                          Output: xxxxxx
+                                                                          Filter: (e.x = 2)
+                                                                    ->  Materialize (never executed)
+                                                                          Output: xxxxxx
+                                                                          ->  Seq Scan on public.test_570030 l (never executed)
+                                                                                Output: xxxxxx
+                                                                                Filter: (l.x = 2)
+                                                              ->  M
+DROP TABLE simple, users_table_2, test;

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -2982,5 +2982,21 @@ Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
                                                                           ->  Seq Scan on public.test_570030 l (never executed)
                                                                                 Output: xxxxxx
                                                                                 Filter: (l.x = 2)
-                                                              ->  M
+                                                              ->  Materialize (never executed)
+                                                                    Output: xxxxxx
+                                                                    ->  Nested Loop (never executed)
+                                                                          Output: xxxxxx
+                                                                          ->  Seq Scan on public.test_570030 m (never executed)
+                                                                                Output: xxxxxx
+                                                                                Filter: (m.x = 2)
+                                                                          ->  Materialize (never executed)
+                                                                                Output: xxxxxx
+                                                                                ->  Seq Scan on public.test_570030 n (never executed)
+                                                                                      Output: xxxxxx
+                                                                                      Filter: (n.x = 2)
+                                            ->  Materialize (never executed)
+                                                  Output: xxxxxx
+                                                  ->  Seq Scan on public.test_570030 f (never executed)
+                                                        Output: xxxxxx
+                                                        Filter: (f.x = 2)
 DROP TABLE simple, users_table_2, test;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -1032,4 +1032,9 @@ PREPARE p4 (int, int) AS insert into users_table_2 ( value_1, user_id) select va
 EXPLAIN :default_explain_flags execute p4(20,20);
 EXPLAIN :default_analyze_flags execute p4(20,20);
 
-DROP TABLE simple, users_table_2;
+-- https://github.com/citusdata/citus/issues/4169
+CREATE TABLE test (x int, y int);
+SELECT create_distributed_table('test', 'x');
+EXPLAIN  (VERBOSE on, COSTS off, ANALYZE on, TIMING off, SUMMARY off) SELECT * FROM (SELECT x, count(*), row_number() OVER (), lead(x) OVER (PARTITION BY x) FROM test a JOIN test b USING (x) JOIN test c JOIN test d JOIN test e JOIN test l JOIN test m JOIN test n USING (x) USING (x) USING (x) USING(x) USING(x) USING(x) JOIN test f USING (x) WHERE x = 2 OR x = 2 AND b.y > random() GROUP BY x ORDER BY x) foo ORDER BY 3 LIMIT 10;
+
+DROP TABLE simple, users_table_2, test;


### PR DESCRIPTION
DESCRIPTION: Fix truncation problem in some long explain analyze queries

In SplitString, we were only handling the first 4KB of the given string.
This was creating problem in EXPLAIN ANALYZE for certain queries. The
limit is increased from 4KB to 256MB. Also now we are not using
strnlen_s because it also has an upper limit of 4KB.

Fixes #4169 

