### PR TITLE
Fix create index concurrently crash with local execution

### DIFF
--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -177,6 +177,7 @@ extern List * PreprocessDropIndexStmt(Node *dropIndexStatement,
 extern List * PostprocessIndexStmt(Node *node,
 								   const char *queryString);
 extern void ErrorIfUnsupportedAlterIndexStmt(AlterTableStmt *alterTableStatement);
+extern void MarkIndexValid(IndexStmt *indexStmt);
 
 /* objectaddress.c - forward declarations */
 extern ObjectAddress CreateExtensionStmtObjectAddress(Node *stmt, bool missing_ok);

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -45,6 +45,15 @@ typedef struct DDLJob
 {
 	Oid targetRelationId;      /* oid of the target distributed relation */
 	bool concurrentIndexCmd;   /* related to a CONCURRENTLY index command? */
+
+	/*
+	 * Whether to commit and start a new transaction before sending commands
+	 * (only applies to CONCURRENTLY commands). This is needed for REINDEX CONCURRENTLY
+	 * and CREATE INDEX CONCURRENTLY on local shards, which would otherwise
+	 * get blocked waiting for the current transaction to finish.
+	 */
+	bool startNewTransaction;
+
 	const char *commandString; /* initial (coordinator) DDL command string */
 	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -18,6 +18,13 @@ SELECT create_reference_table('squares');
 
 INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
 NOTICE:  executing the copy locally for shard xxxxx
+CREATE INDEX CONCURRENTLY squares_a_idx ON squares (a);
+SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
+\gset
+\if :server_version_above_eleven
+REINDEX INDEX CONCURRENTLY squares_a_idx;
+\endif
+DROP INDEX CONCURRENTLY squares_a_idx;
 -- should be executed locally
 SELECT count(*) FROM squares;
 NOTICE:  executing the command locally: SELECT count(*) AS count FROM replicate_ref_to_coordinator.squares_8000000 squares
@@ -43,16 +50,16 @@ BEGIN
 END; $$ language plpgsql VOLATILE;
 -- INSERT ... SELECT between reference tables
 BEGIN;
-EXPLAIN INSERT INTO squares SELECT a, a*a FROM numbers;
-                                          QUERY PLAN
+EXPLAIN (COSTS OFF) INSERT INTO squares SELECT a, a*a FROM numbers;
+                        QUERY PLAN
 ---------------------------------------------------------------------
- Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
+ Custom Scan (Citus Adaptive)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
-         ->  Insert on squares_8000000 citus_table_alias  (cost=0.00..41.88 rows=2550 width=8)
-               ->  Seq Scan on numbers_8000001 numbers  (cost=0.00..41.88 rows=2550 width=8)
+         ->  Insert on squares_8000000 citus_table_alias
+               ->  Seq Scan on numbers_8000001 numbers
 (7 rows)
 
 INSERT INTO squares SELECT a, a*a FROM numbers;
@@ -65,16 +72,16 @@ SELECT * FROM squares WHERE a >= 20 ORDER BY a;
 
 ROLLBACK;
 BEGIN;
-EXPLAIN INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
-                                          QUERY PLAN
+EXPLAIN (COSTS OFF) INSERT INTO numbers SELECT a FROM squares WHERE a < 3;
+                        QUERY PLAN
 ---------------------------------------------------------------------
- Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
+ Custom Scan (Citus Adaptive)
    Task Count: 1
    Tasks Shown: All
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
-         ->  Insert on numbers_8000001 citus_table_alias  (cost=0.00..38.25 rows=753 width=4)
-               ->  Seq Scan on squares_8000000 squares  (cost=0.00..38.25 rows=753 width=4)
+         ->  Insert on numbers_8000001 citus_table_alias
+               ->  Seq Scan on squares_8000000 squares
                      Filter: (a < 3)
 (8 rows)
 
@@ -392,8 +399,8 @@ CREATE MATERIALIZED VIEW numbers_v AS SELECT * FROM numbers WHERE a BETWEEN 1 AN
 NOTICE:  executing the command locally: SELECT a FROM replicate_ref_to_coordinator.numbers_8000001 numbers WHERE ((a OPERATOR(pg_catalog.>=) 1) AND (a OPERATOR(pg_catalog.<=) 10))
 REFRESH MATERIALIZED VIEW numbers_v;
 NOTICE:  executing the command locally: SELECT numbers.a FROM replicate_ref_to_coordinator.numbers_8000001 numbers WHERE ((numbers.a OPERATOR(pg_catalog.>=) 1) AND (numbers.a OPERATOR(pg_catalog.<=) 10))
-SELECT * FROM squares JOIN numbers_v ON squares.a = numbers_v.a;
-NOTICE:  executing the command locally: SELECT squares.a, squares.b, numbers_v.a FROM (replicate_ref_to_coordinator.squares_8000000 squares JOIN replicate_ref_to_coordinator.numbers_v ON ((squares.a OPERATOR(pg_catalog.=) numbers_v.a)))
+SELECT * FROM squares JOIN numbers_v ON squares.a = numbers_v.a ORDER BY 1;
+NOTICE:  executing the command locally: SELECT squares.a, squares.b, numbers_v.a FROM (replicate_ref_to_coordinator.squares_8000000 squares JOIN replicate_ref_to_coordinator.numbers_v ON ((squares.a OPERATOR(pg_catalog.=) numbers_v.a))) ORDER BY squares.a
  a | b | a
 ---------------------------------------------------------------------
  1 | 1 | 1


### PR DESCRIPTION
DESCRIPTION: Fixes create index concurrently crash with local execution

Stop using local execution for CREATE INDEX CONCURRENTLY. Start a new transaction before sending commands to localhost to avoid deadlock. Move marking the index as valid to the end of execution.

Overall, CREATE INDEX CONCURRENTLY seems quite shaky at the moment. We should maybe handle it separately from other DDL commands.

Fixes #4090 