### PR TITLE
Merge enterprise branch if it exists

### DIFF
--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -62,7 +62,10 @@ if git merge --no-commit "origin/$PR_BRANCH"; then
     fi
 
     # check that we can compile after the merge
-    check_compile
+    if check_compile; then 
+        exit 0
+    fi
+    echo "WARN: Failed to compile after community PR branch was merged into enterprise"
     exit 0
 fi
 

--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -54,6 +54,13 @@ git checkout "enterprise/enterprise-master"
 
 if git merge --no-commit "origin/$PR_BRANCH"; then
     echo "INFO: community PR branch could be merged into enterprise-master"
+
+    if git fetch enterprise "$PR_BRANCH" ; then
+        # we merge the enterprise branch if it exists since it might contain enterprise specific things
+        # that are necessary for enterprise to compile
+        git merge --no-commit "enterprise/$PR_BRANCH"
+    fi
+
     # check that we can compile after the merge
     check_compile
     exit 0

--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -54,19 +54,12 @@ git checkout "enterprise/enterprise-master"
 
 if git merge --no-commit "origin/$PR_BRANCH"; then
     echo "INFO: community PR branch could be merged into enterprise-master"
-
-    if git fetch enterprise "$PR_BRANCH" ; then
-        # we merge the enterprise branch if it exists since it might contain enterprise specific things
-        # that are necessary for enterprise to compile
-        git merge --no-commit "enterprise/$PR_BRANCH"
-    fi
-
     # check that we can compile after the merge
-    if check_compile; then 
+    if check_compile; then
         exit 0
     fi
+
     echo "WARN: Failed to compile after community PR branch was merged into enterprise"
-    exit 0
 fi
 
 # undo partial merge


### PR DESCRIPTION
We should merge the enterprise branch if it exists in the check
enterpise merge job, otherwise the following can happen:
- there is some change on community that breaks the compilation on
enterprise without creating any conflicts
- we fix the compilation issue by opening a branch on enterprise
- the job doesn't see the enterprise specific fix because it doesn't try
to merge enterprise branch if there are no conflicts
