### PR TITLE
Not take ShareUpdateExlusiveLock on pg_dist_transaction

### DIFF
--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -120,6 +120,9 @@ RecoverTwoPhaseCommits(void)
 {
 	int recoveredTransactionCount = 0;
 
+	/* take advisory lock first to avoid running concurrently */
+	LockTransactionRecovery(ShareUpdateExclusiveLock);
+
 	List *workerList = ActivePrimaryNodeList(NoLock);
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, workerList)
@@ -172,8 +175,6 @@ RecoverWorkerTransactions(WorkerNode *workerNode)
 
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
-	/* take advisory lock first to avoid running concurrently */
-	LockTransactionRecovery(ShareUpdateExclusiveLock);
 	Relation pgDistTransaction = table_open(DistTransactionRelationId(),
 											RowExclusiveLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistTransaction);

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -551,7 +551,7 @@ LockTransactionRecovery(LOCKMODE lockmode)
 	const bool sessionLock = false;
 	const bool dontWait = false;
 
-	SET_LOCKTAG_TRANSACTION_RECOVERY(tag);
+	SET_LOCKTAG_CITUS_OPERATION(tag, CITUS_TRANSACTION_RECOVERY);
 
 	(void) LockAcquire(&tag, lockmode, sessionLock, dontWait);
 }

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -543,6 +543,20 @@ UnlockShardResource(uint64 shardId, LOCKMODE lockmode)
 }
 
 
+/* LockTransactionRecovery acquires a lock for transaction recovery */
+void
+LockTransactionRecovery(LOCKMODE lockmode)
+{
+	LOCKTAG tag;
+	const bool sessionLock = false;
+	const bool dontWait = false;
+
+	SET_LOCKTAG_TRANSACTION_RECOVERY(tag);
+
+	(void) LockAcquire(&tag, lockmode, sessionLock, dontWait);
+}
+
+
 /*
  * LockJobResource acquires a lock for creating resources associated with the
  * given jobId. This resource is typically a job schema (namespace), and less

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -38,6 +38,7 @@ typedef enum AdvisoryLocktagClass
 	ADV_LOCKTAG_CLASS_CITUS_JOB = 6,
 	ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION = 7,
 	ADV_LOCKTAG_CLASS_CITUS_COLOCATED_SHARDS_METADATA = 8,
+	ADV_LOCKTAG_CLASS_CITUS_TRANSACTION_RECOVERY = 9
 } AdvisoryLocktagClass;
 
 
@@ -83,6 +84,12 @@ typedef enum AdvisoryLocktagClass
 						 (uint32) (colocationOrTableId), \
 						 ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION)
 
+#define SET_LOCKTAG_TRANSACTION_RECOVERY(tag) \
+	SET_LOCKTAG_ADVISORY(tag, \
+						 MyDatabaseId, \
+						 (uint32) 0, \
+						 (uint32) 0, \
+						 ADV_LOCKTAG_CLASS_CITUS_TRANSACTION_RECOVERY)
 
 /* Lock shard/relation metadata for safe modifications */
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
@@ -110,6 +117,9 @@ extern void UnlockColocationId(int colocationId, LOCKMODE lockMode);
 extern void LockShardListMetadata(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockShardsInPlacementListMetadata(List *shardPlacementList,
 											  LOCKMODE lockMode);
+
+extern void LockTransactionRecovery(LOCKMODE lockMode);
+
 extern void SerializeNonCommutativeWrites(List *shardIntervalList, LOCKMODE lockMode);
 extern void LockRelationShardResources(List *relationShardList, LOCKMODE lockMode);
 extern List * GetSortedReferenceShardIntervals(List *relationList);

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -38,9 +38,14 @@ typedef enum AdvisoryLocktagClass
 	ADV_LOCKTAG_CLASS_CITUS_JOB = 6,
 	ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION = 7,
 	ADV_LOCKTAG_CLASS_CITUS_COLOCATED_SHARDS_METADATA = 8,
-	ADV_LOCKTAG_CLASS_CITUS_TRANSACTION_RECOVERY = 9
+	ADV_LOCKTAG_CLASS_CITUS_OPERATIONS = 9
 } AdvisoryLocktagClass;
 
+/* CitusOperations has constants for citus operations */
+typedef enum CitusOperations
+{
+	CITUS_TRANSACTION_RECOVERY = 0
+} CitusOperations;
 
 /* reuse advisory lock, but with different, unused field 4 (4)*/
 #define SET_LOCKTAG_SHARD_METADATA_RESOURCE(tag, db, shardid) \
@@ -84,12 +89,14 @@ typedef enum AdvisoryLocktagClass
 						 (uint32) (colocationOrTableId), \
 						 ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION)
 
-#define SET_LOCKTAG_TRANSACTION_RECOVERY(tag) \
+/* advisory lock for citus operations, also it has the database hardcoded to MyDatabaseId,
+ * to ensure the locks are local to each database */
+#define SET_LOCKTAG_CITUS_OPERATION(tag, operationId) \
 	SET_LOCKTAG_ADVISORY(tag, \
 						 MyDatabaseId, \
 						 (uint32) 0, \
-						 (uint32) 0, \
-						 ADV_LOCKTAG_CLASS_CITUS_TRANSACTION_RECOVERY)
+						 (uint32) operationId, \
+						 ADV_LOCKTAG_CLASS_CITUS_OPERATIONS)
 
 /* Lock shard/relation metadata for safe modifications */
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);


### PR DESCRIPTION
DESCRIPTION: Fix a deadlock during transaction recovery

We were taking ShareUpdateExlusiveLock on pg_dist_transaction during
recovery to prevent multiple recoveries happening concurrenly. VACUUM(
not FULL) also takes ShareUpdateExclusiveLock, and they can conflict. It
seems that VACUUM will skip the table if there is a conflicting lock
already taken unless it is doing the vacuum to prevent id wraparound, in
which case there can be a deadlock. I guess the deadlock happens if:

- VACUUM takes a lock on pg_dist_transaction and is done for id
wraparound problem
- The transaction in the maintenance tries to take a lock but
cannot as that conflicts with the lock acquired by VACUUM
- The transaction in the maintenance daemon has a very old xid hence
VACUUM cannot proceed.

If we take a row exclusive lock in transaction recovery then it wouldn't
conflict with VACUUM hence it could proceed so the deadlock would be
resolved. To prevent concurrent transaction recoveries happening, an
advisory lock is taken with ShareUpdateExlusiveLock as before.

Fixes #2670.