### PR TITLE
Increase test resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
   test-11_check-multi:
     docker:
       - image: 'citus/exttester:11.9'
+    resource_class: xlarge
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -202,6 +203,7 @@ jobs:
   test-11_check-failure:
     docker:
       - image: 'citus/failtester:11.9'
+    resource_class: xlarge
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -241,6 +243,7 @@ jobs:
   test-12_check-multi:
     docker:
       - image: 'citus/exttester:12.4'
+    resource_class: xlarge
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -340,6 +343,7 @@ jobs:
   test-12_check-failure:
     docker:
       - image: 'citus/failtester:12.4'
+    resource_class: xlarge
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -376,6 +380,7 @@ jobs:
   test-13_check-multi:
     docker:
       - image: 'citus/exttester:13beta3'
+    resource_class: xlarge
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -476,6 +481,7 @@ jobs:
   test-13_check-failure:
     docker:
       - image: 'citus/failtester:13beta3'
+    resource_class: xlarge
     working_directory: /home/circleci/project
     steps:
       - checkout


### PR DESCRIPTION
I thought that we could use better machines for the tests that are slow such as `check-multi, check-failure`:

![image](https://user-images.githubusercontent.com/17179875/93783054-f5777600-fc33-11ea-82f6-75a13d38102f.png)


This increases the size from medium to xlarge for those. In check-multi we have many parallel tests but with the default size (2 CPU) the maximum parallelism isn't achieved.

![image](https://user-images.githubusercontent.com/17179875/93790072-48086080-fc3b-11ea-8bb5-823095b3fb6f.png)
