### PR TITLE
Disallow volatile functions on single shard update subqueries

### DIFF
--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -2314,11 +2314,6 @@ DEBUG:  query has a single distribution column value: 1
  52
 (7 rows)
 
--- https://github.com/citusdata/citus/issues/3624
-UPDATE articles_hash SET id = id
-WHERE author_id = 1 AND title IN (SELECT name FROM authors_reference WHERE random() > 0.5);
-DEBUG:  Creating router plan
-DEBUG:  query has a single distribution column value: 1
 SET client_min_messages to 'NOTICE';
 -- test that a connection failure marks placements invalid
 SET citus.shard_replication_factor TO 2;

--- a/src/test/regress/expected/multi_shard_update_delete.out
+++ b/src/test/regress/expected/multi_shard_update_delete.out
@@ -704,6 +704,12 @@ SET    value_2 = 5 * random()
 FROM   events_test_table
 WHERE  users_test_table.user_id = events_test_table.user_id;
 ERROR:  functions used in UPDATE queries on distributed tables must not be VOLATILE
+UPDATE users_test_table
+SET    value_1 = 3
+WHERE  user_id = 1 AND value_1 IN (SELECT value_1
+                                   FROM users_test_table
+                                   WHERE user_id = 1 AND value_2 > random());
+ERROR:  functions used in UPDATE queries on distributed tables must not be VOLATILE
 -- Recursive modify planner does not take care of following test because the query
 -- is fully pushdownable, yet not allowed because it would lead to inconsistent replicas.
 UPDATE users_test_table

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -1126,10 +1126,6 @@ SELECT id
 	WHERE author_id = 1
 	ORDER BY 1;
 
--- https://github.com/citusdata/citus/issues/3624
-UPDATE articles_hash SET id = id
-WHERE author_id = 1 AND title IN (SELECT name FROM authors_reference WHERE random() > 0.5);
-
 SET client_min_messages to 'NOTICE';
 
 -- test that a connection failure marks placements invalid

--- a/src/test/regress/sql/multi_shard_update_delete.sql
+++ b/src/test/regress/sql/multi_shard_update_delete.sql
@@ -579,6 +579,12 @@ SET    value_2 = 5 * random()
 FROM   events_test_table
 WHERE  users_test_table.user_id = events_test_table.user_id;
 
+UPDATE users_test_table
+SET    value_1 = 3
+WHERE  user_id = 1 AND value_1 IN (SELECT value_1
+                                   FROM users_test_table
+                                   WHERE user_id = 1 AND value_2 > random());
+
 -- Recursive modify planner does not take care of following test because the query
 -- is fully pushdownable, yet not allowed because it would lead to inconsistent replicas.
 UPDATE users_test_table


### PR DESCRIPTION
DESCRIPTION: Disallows volatile functions in UPDATE subqueries.

If there is a volatile function in the subquery of an UPDATE query, it was incorrectly evaluated on the coordinator node, as mentioned on https://github.com/citusdata/citus/issues/2148#issuecomment-504430905 :
```
UPDATE test SET y = 3 WHERE x = 3 AND y IN (SELECT y FROM test WHERE x = 3 AND y > random());
LOG:  issuing UPDATE public.test_102738 test SET y = 3 WHERE ((x OPERATOR(pg_catalog.=) 3) AND (y OPERATOR(pg_catalog.=) ANY (SELECT test_1.y FROM public.test_102738 test_1 WHERE ((test_1.x OPERATOR(pg_catalog.=) 3) AND ((test_1.y)::double precision OPERATOR(pg_catalog.>) '0.731105228886008'::double precision)))))
DETAIL:  on server localhost:9701
```

The same query now returns the error message:
```
ERROR:  0A000: functions used in UPDATE queries on distributed tables must not be VOLATILE
LOCATION:  SingleShardModifyQuerySupported, multi_router_planner.c:1290
```

This PR aims to resolve that by erroring out to prevent diverting from Vanilla behavior.

Note: I removed a test introduced in #3625 as it is no longer valid because it contains a volatile function in a subquery. It can possibly be rewritten, and I do not yet know how.

Fixes #2148