### PR TITLE
Refactor and fix DDL propagation

### DIFF
--- a/src/backend/distributed/commands/create_citus_local_table.c
+++ b/src/backend/distributed/commands/create_citus_local_table.c
@@ -287,8 +287,8 @@ GetShellTableDDLEventsForCitusLocalTable(Oid relationId)
 	 */
 	bool includeSequenceDefaults = true;
 
-	List *shellTableDDLEvents = GetTableDDLEvents(relationId,
-												  includeSequenceDefaults);
+	List *shellTableDDLEvents = GetFullTableCreationCommands(relationId,
+															 includeSequenceDefaults);
 	shellTableDDLEvents = list_concat(shellTableDDLEvents, foreignConstraintCommands);
 
 	return shellTableDDLEvents;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -398,7 +398,8 @@ MetadataCreateCommands(void)
 		}
 
 		List *workerSequenceDDLCommands = SequenceDDLCommandsForTable(relationId);
-		List *ddlCommandList = GetTableDDLEvents(relationId, includeSequenceDefaults);
+		List *ddlCommandList = GetFullTableCreationCommands(relationId,
+															includeSequenceDefaults);
 		char *tableOwnerResetCommand = TableOwnerResetCommand(relationId);
 		List *sequenceDependencyCommandList = SequenceDependencyCommandList(relationId);
 
@@ -510,12 +511,9 @@ GetDistributedTableDDLEvents(Oid relationId)
 		commandList = list_concat(commandList, sequenceDDLCommands);
 
 		/* commands to create the table */
-		List *tableDDLCommands = GetTableDDLEvents(relationId, includeSequenceDefaults);
+		List *tableDDLCommands = GetFullTableCreationCommands(relationId,
+															  includeSequenceDefaults);
 		commandList = list_concat(commandList, tableDDLCommands);
-
-		/* command to reset the table owner */
-		char *tableOwnerResetCommand = TableOwnerResetCommand(relationId);
-		commandList = lappend(commandList, tableOwnerResetCommand);
 
 		/* command to associate sequences with table */
 		List *sequenceDependencyCommandList = SequenceDependencyCommandList(relationId);

--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -221,7 +221,8 @@ master_get_table_ddl_events(PG_FUNCTION_ARGS)
 			functionContext->multi_call_memory_ctx);
 
 		/* allocate DDL statements, and then save position in DDL statements */
-		List *tableDDLEventList = GetTableDDLEvents(relationId, includeSequenceDefaults);
+		List *tableDDLEventList = GetFullTableCreationCommands(relationId,
+															   includeSequenceDefaults);
 		tableDDLEventCell = list_head(tableDDLEventList);
 		ListCellAndListWrapper *wrapper = palloc0(sizeof(ListCellAndListWrapper));
 		wrapper->list = tableDDLEventList;
@@ -522,7 +523,7 @@ ResolveRelationId(text *relationName, bool missingOk)
 
 
 /*
- * GetTableDDLEvents takes in a relationId, includeSequenceDefaults flag,
+ * GetFullTableCreationCommands takes in a relationId, includeSequenceDefaults flag,
  * and returns the list of DDL commands needed to reconstruct the relation.
  * When the flag includeSequenceDefaults is set, the function also creates
  * DEFAULT clauses for columns getting their default values from a sequence.
@@ -531,28 +532,30 @@ ResolveRelationId(text *relationName, bool missingOk)
  * constraint and trigger definitions.
  */
 List *
-GetTableDDLEvents(Oid relationId, bool includeSequenceDefaults)
+GetFullTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 {
 	List *tableDDLEventList = NIL;
 
-	List *tableCreationCommandList = GetTableCreationCommands(relationId,
-															  includeSequenceDefaults);
-	tableDDLEventList = list_concat(tableDDLEventList, tableCreationCommandList);
+	List *preLoadCreationCommandList =
+		GetPreLoadTableCreationCommands(relationId, includeSequenceDefaults);
 
-	List *otherCommands = GetTableConstructionCommands(relationId);
-	tableDDLEventList = list_concat(tableDDLEventList, otherCommands);
+	tableDDLEventList = list_concat(tableDDLEventList, preLoadCreationCommandList);
+
+	List *postLoadCreationCommandList =
+		GetPostLoadTableCreationCommands(relationId);
+
+	tableDDLEventList = list_concat(tableDDLEventList, postLoadCreationCommandList);
 
 	return tableDDLEventList;
 }
 
 
 /*
- * GetTableConstructionCommands takes in a relationId and returns the list
- * of DDL commands needed to reconstruct the relation except the ones that actually
- * create the table.
+ * GetPostLoadTableCreationCommands takes in a relationId and returns the list
+ * of DDL commands that should be applied after loading the data.
  */
 List *
-GetTableConstructionCommands(Oid relationId)
+GetPostLoadTableCreationCommands(Oid relationId)
 {
 	List *tableDDLEventList = NIL;
 
@@ -601,12 +604,12 @@ GetTableReplicaIdentityCommand(Oid relationId)
 
 
 /*
- * GetTableCreationCommands takes in a relationId, and returns the list of DDL
- * commands needed to reconstruct the relation, excluding indexes and
- * constraints.
+ * GetPreLoadTableCreationCommands takes in a relationId, and returns the list of DDL
+ * commands needed to reconstruct the relation, excluding indexes and constraints,
+ * to facilitate faster data load.
  */
 List *
-GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
+GetPreLoadTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 {
 	List *tableDDLEventList = NIL;
 
@@ -625,30 +628,6 @@ GetTableCreationCommands(Oid relationId, bool includeSequenceDefaults)
 		}
 		tableDDLEventList = lappend(tableDDLEventList, serverDef);
 	}
-
-	List *tableBuildingCommands = GetTableBuildingCommands(relationId,
-														   includeSequenceDefaults);
-	tableDDLEventList = list_concat(tableDDLEventList,
-									tableBuildingCommands);
-
-	/* revert back to original search_path */
-	PopOverrideSearchPath();
-
-	return tableDDLEventList;
-}
-
-
-/*
- * GetTableBuildingCommands takes in a relationId, and returns the list of DDL
- * commands needed to rebuild the relation. This does not include the schema
- * and the server commands.
- */
-List *
-GetTableBuildingCommands(Oid relationId, bool includeSequenceDefaults)
-{
-	List *tableDDLEventList = NIL;
-
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
 	/* fetch table schema and column option definitions */
 	char *tableSchemaDef = pg_get_tableschemadef_string(relationId,

--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -562,9 +562,6 @@ GetTableConstructionCommands(Oid relationId)
 	List *replicaIdentityEvents = GetTableReplicaIdentityCommand(relationId);
 	tableDDLEventList = list_concat(tableDDLEventList, replicaIdentityEvents);
 
-	List *policyCommands = CreatePolicyCommands(relationId);
-	tableDDLEventList = list_concat(tableDDLEventList, policyCommands);
-
 	List *triggerCommands = GetExplicitTriggerCommandList(relationId);
 	tableDDLEventList = list_concat(tableDDLEventList, triggerCommands);
 
@@ -669,6 +666,9 @@ GetTableBuildingCommands(Oid relationId, bool includeSequenceDefaults)
 	{
 		tableDDLEventList = lappend(tableDDLEventList, tableOwnerDef);
 	}
+
+	List *policyCommands = CreatePolicyCommands(relationId);
+	tableDDLEventList = list_concat(tableDDLEventList, policyCommands);
 
 	/* revert back to original search_path */
 	PopOverrideSearchPath();

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -775,7 +775,7 @@ CopyShardCommandList(ShardInterval *shardInterval, const char *sourceNodeName,
 											  copyShardDataCommand->data);
 	}
 
-	List *indexCommandList = GetTableIndexAndConstraintCommands(relationId);
+	List *indexCommandList = GetTableConstructionCommands(relationId);
 	indexCommandList = WorkerApplyShardDDLCommandList(indexCommandList, shardId);
 
 	copyShardToNodeCommandsList = list_concat(copyShardToNodeCommandsList,

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -775,7 +775,7 @@ CopyShardCommandList(ShardInterval *shardInterval, const char *sourceNodeName,
 											  copyShardDataCommand->data);
 	}
 
-	List *indexCommandList = GetTableConstructionCommands(relationId);
+	List *indexCommandList = GetPostLoadTableCreationCommands(relationId);
 	indexCommandList = WorkerApplyShardDDLCommandList(indexCommandList, shardId);
 
 	copyShardToNodeCommandsList = list_concat(copyShardToNodeCommandsList,
@@ -980,8 +980,8 @@ RecreateTableDDLCommandList(Oid relationId)
 	}
 
 	List *dropCommandList = list_make1(dropCommand->data);
-	List *createCommandList = GetTableCreationCommands(relationId,
-													   includeSequenceDefaults);
+	List *createCommandList = GetPreLoadTableCreationCommands(relationId,
+															  includeSequenceDefaults);
 	List *recreateCommandList = list_concat(dropCommandList, createCommandList);
 
 	return recreateCommandList;

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -396,7 +396,8 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 	List *foreignConstraintCommandList =
 		GetReferencingForeignConstaintCommands(relationId);
 	bool includeSequenceDefaults = false;
-	List *ddlCommandList = GetTableDDLEvents(relationId, includeSequenceDefaults);
+	List *ddlCommandList = GetFullTableCreationCommands(relationId,
+														includeSequenceDefaults);
 	uint32 connectionFlag = FOR_DDL;
 	char *relationOwner = TableOwner(relationId);
 
@@ -500,8 +501,8 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 					  bool useExclusiveConnection, bool colocatedShard)
 {
 	bool includeSequenceDefaults = false;
-	List *ddlCommandList = GetTableDDLEvents(distributedRelationId,
-											 includeSequenceDefaults);
+	List *ddlCommandList = GetFullTableCreationCommands(distributedRelationId,
+														includeSequenceDefaults);
 	List *foreignConstraintCommandList =
 		GetReferencingForeignConstaintCommands(distributedRelationId);
 

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -100,10 +100,10 @@ extern bool CStoreTable(Oid relationId);
 extern uint64 GetNextShardId(void);
 extern uint64 GetNextPlacementId(void);
 extern Oid ResolveRelationId(text *relationName, bool missingOk);
-extern List * GetTableDDLEvents(Oid relationId, bool forShardCreation);
-extern List * GetTableConstructionCommands(Oid relationId);
-extern List * GetTableCreationCommands(Oid relationId, bool forShardCreation);
-extern List * GetTableBuildingCommands(Oid relationId, bool includeSequenceDefaults);
+extern List * GetFullTableCreationCommands(Oid relationId, bool includeSequenceDefaults);
+extern List * GetPostLoadTableCreationCommands(Oid relationId);
+extern List * GetPreLoadTableCreationCommands(Oid relationId,
+											  bool includeSequenceDefaults);
 extern List * GetTableIndexAndConstraintCommands(Oid relationId);
 extern bool IndexImpliedByAConstraint(Form_pg_index indexForm);
 extern char ShardStorageType(Oid relationId);


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that caused replica identity to not be propagated on shard repair

We generated replica identity and RLS commands in GetTableDDLEvents, but shard repairs/moves called GetTableCreationCommands and GetTableIndexAndConstraintCommands directly, and therefore excluded replica identity and RLS commands

This PR fixes it by moving RLS commands to GetTableCreationCommands, and calling GetTableConstructionCommands instead of GetTableIndexAndConstraintCommands from the shard repair/move logic to include replica identity.