### PR TITLE
Skip shell table vacuum

### DIFF
--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -305,6 +305,7 @@ extern ObjectWithArgs * ObjectWithArgsFromOid(Oid funcOid);
 
 /* vacuum.c - forward declarations */
 extern void PostprocessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand);
+extern List * ExtractCitusShellTablesFromVacuum(Node *parsetree);
 
 /* trigger.c - forward declarations */
 extern List * GetExplicitTriggerCommandList(Oid relationId);

--- a/src/test/regress/expected/local_shard_execution.out
+++ b/src/test/regress/expected/local_shard_execution.out
@@ -702,10 +702,9 @@ BEGIN;
   11 | 29    | 121
 (1 row)
 
-	-- this is already disallowed because VACUUM cannot be executed in tx block
-	-- adding in case this is supported some day
+	-- here we don't error because we skip the vacuum on shell table
+	-- and the vacuum on shard placements are not executed in a transaction block
 	VACUUM second_distributed_table;
-ERROR:  VACUUM cannot run inside a transaction block
 ROLLBACK;
 -- make sure that functions can use local execution
 CREATE OR REPLACE PROCEDURE only_local_execution() AS $$

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -112,6 +112,11 @@ BEGIN;
 
 ROLLBACK;
 VACUUM test;
+VACUUM test, test_2;
+VACUUM ref, test;
+VACUUM ANALYZE test(x);
+ANALYZE ref;
+ANALYZE test_2;
 BEGIN;
 	ALTER TABLE test ADD COLUMN z INT DEFAULT 66;
 	SELECT count(*) FROM test WHERE z = 66;

--- a/src/test/regress/sql/local_shard_execution.sql
+++ b/src/test/regress/sql/local_shard_execution.sql
@@ -378,8 +378,8 @@ ROLLBACK;
 BEGIN;
 	INSERT INTO distributed_table VALUES (11, '111',29) ON CONFLICT(key) DO UPDATE SET value = '29' RETURNING *;
 
-	-- this is already disallowed because VACUUM cannot be executed in tx block
-	-- adding in case this is supported some day
+	-- here we don't error because we skip the vacuum on shell table
+	-- and the vacuum on shard placements are not executed in a transaction block
 	VACUUM second_distributed_table;
 ROLLBACK;
 

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -58,6 +58,11 @@ BEGIN;
 ROLLBACK;
 
 VACUUM test;
+VACUUM test, test_2;
+VACUUM ref, test;
+VACUUM ANALYZE test(x);
+ANALYZE ref;
+ANALYZE test_2;
 
 BEGIN;
 	ALTER TABLE test ADD COLUMN z INT DEFAULT 66;


### PR DESCRIPTION
This is an alternative approach to fix #4187 instead of #4221.

We don't really need to run VACUUM on shell tables hence I like this approach more instead of #4221.

In this approach, we basically skip VACUUM execution on shell tables. One side-effect of this approach is that a VACUUM in a transaction will not error because when we send VACUUM commands to shard placements, we don't do it inside a transaction block even if it is in a transaction block.

