### PR TITLE
Support INSERT/UPDATE queries with comp.type field access

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_11.c
+++ b/src/backend/distributed/deparser/ruleutils_11.c
@@ -3057,7 +3057,9 @@ get_insert_query_def(Query *query, deparse_context *context)
 	sep = "";
 	if (query->targetList)
 		appendStringInfoChar(buf, '(');
-	foreach(l, query->targetList)
+
+	List *targetList = ExtendFieldStoreTargetEntries(query->targetList);
+	foreach(l, targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(l);
 
@@ -3333,6 +3335,8 @@ get_update_query_targetlist_def(Query *query, List *targetList,
 
 	/* Add the comma separated list of 'attname = value' */
 	sep = "";
+
+	targetList = ExtendFieldStoreTargetEntries(targetList);
 	foreach(l, targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(l);

--- a/src/backend/distributed/deparser/ruleutils_12.c
+++ b/src/backend/distributed/deparser/ruleutils_12.c
@@ -3069,7 +3069,9 @@ get_insert_query_def(Query *query, deparse_context *context)
 	sep = "";
 	if (query->targetList)
 		appendStringInfoChar(buf, '(');
-	foreach(l, query->targetList)
+
+	List *targetList = ExtendFieldStoreTargetEntries(query->targetList);
+	foreach(l, targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(l);
 
@@ -3345,6 +3347,8 @@ get_update_query_targetlist_def(Query *query, List *targetList,
 
 	/* Add the comma separated list of 'attname = value' */
 	sep = "";
+
+	targetList = ExtendFieldStoreTargetEntries(targetList);
 	foreach(l, targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(l);

--- a/src/backend/distributed/deparser/ruleutils_13.c
+++ b/src/backend/distributed/deparser/ruleutils_13.c
@@ -2994,7 +2994,9 @@ get_insert_query_def(Query *query, deparse_context *context)
 	sep = "";
 	if (query->targetList)
 		appendStringInfoChar(buf, '(');
-	foreach(l, query->targetList)
+
+	List *targetList = ExtendFieldStoreTargetEntries(query->targetList);
+	foreach(l, targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(l);
 
@@ -3270,6 +3272,8 @@ get_update_query_targetlist_def(Query *query, List *targetList,
 
 	/* Add the comma separated list of 'attname = value' */
 	sep = "";
+
+	targetList = ExtendFieldStoreTargetEntries(targetList);
 	foreach(l, targetList)
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(l);

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -42,6 +42,7 @@ extern List * pg_get_table_grants(Oid relationId);
 extern bool contain_nextval_expression_walker(Node *node, void *context);
 extern char * pg_get_replica_identity_command(Oid tableRelationId);
 extern const char * RoleSpecString(RoleSpec *spec, bool withQuoteIdentifier);
+extern List * ExtendFieldStoreTargetEntries(List *targetList);
 
 /* Function declarations for version dependent PostgreSQL ruleutils functions */
 extern void pg_get_query_def(Query *query, StringInfo buffer);

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -380,6 +380,39 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('
 (2 rows)
 
 RESET citus.enable_create_type_propagation;
+CREATE TYPE ct1 as (int_1 int, int_2 int);
+CREATE TABLE field_indirection_test_1 (int_col int, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_1', 'int_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1, ct1_col.int_2) VALUES (0, 1, 2);
+SELECT * FROM field_indirection_test_1 ORDER BY int_col, ct1_col;
+ int_col | ct1_col
+---------------------------------------------------------------------
+       0 | (1,2)
+(1 row)
+
+CREATE TYPE ct2 as (int_2 int, text_1 text, int_1 int);
+CREATE TABLE field_indirection_test_2 (int_col int, ct2_col ct2, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_2', 'int_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2) VALUES (0, 1, 'text1', 2);
+INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2) VALUES (3, 4, 'text1', 5);
+UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
+SELECT * FROM field_indirection_test_2 ORDER BY int_col, ct2_col, ct1_col;
+ int_col |  ct2_col   | ct1_col
+---------------------------------------------------------------------
+       1 | (,text1,0) | (,2)
+       4 | (,text2,3) | (,10)
+(2 rows)
+
 -- clear objects
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -240,6 +240,24 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('
 
 RESET citus.enable_create_type_propagation;
 
+CREATE TYPE ct1 as (int_1 int, int_2 int);
+CREATE TABLE field_indirection_test_1 (int_col int, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_1', 'int_col');
+
+INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1, ct1_col.int_2) VALUES (0, 1, 2);
+SELECT * FROM field_indirection_test_1 ORDER BY int_col, ct1_col;
+
+CREATE TYPE ct2 as (int_2 int, text_1 text, int_1 int);
+CREATE TABLE field_indirection_test_2 (int_col int, ct2_col ct2, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_2', 'int_col');
+
+INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2) VALUES (0, 1, 'text1', 2);
+INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2) VALUES (3, 4, 'text1', 5);
+
+UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
+
+SELECT * FROM field_indirection_test_2 ORDER BY int_col, ct2_col, ct1_col;
+
 -- clear objects
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;


### PR DESCRIPTION
Related issue #1293 
Related another pr #4241 

Planner combines multiple fields accesses to same composite type column
in a single FieldStore object and "processIndirection" function that we
use to deparse such queries does not know how to handle such FieldStore
objects..

For that, we split field references in FieldStore objects into individual ones.

See more at https://github.com/citusdata/citus/issues/1293#issuecomment-706979013




