### PR TITLE
Local execution enforces citus.max_intermediate_result_size

### DIFF
--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -88,9 +88,10 @@
 #include "distributed/listutils.h"
 #include "distributed/local_executor.h"
 #include "distributed/local_plan_cache.h"
-#include "distributed/multi_executor.h"
 #include "distributed/coordinator_protocol.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/multi_executor.h"
+#include "distributed/multi_server_executor.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/remote_commands.h" /* to access LogRemoteCommands */
 #include "distributed/transaction_management.h"
@@ -284,10 +285,9 @@ ExecuteLocalTaskListExtended(List *taskList,
 			if (GetTaskQueryType(task) == TASK_QUERY_TEXT_LIST)
 			{
 				List *queryStringList = task->taskQuery.data.queryStringList;
-				totalRowsProcessed += LocallyPlanAndExecuteMultipleQueries(
-					queryStringList,
-					tupleDest,
-					task);
+				totalRowsProcessed +=
+					LocallyPlanAndExecuteMultipleQueries(queryStringList, tupleDest,
+														 task);
 				continue;
 			}
 

--- a/src/backend/distributed/executor/multi_server_executor.c
+++ b/src/backend/distributed/executor/multi_server_executor.c
@@ -27,6 +27,7 @@
 #include "distributed/multi_server_executor.h"
 #include "distributed/coordinator_protocol.h"
 #include "distributed/subplan_execution.h"
+#include "distributed/tuple_destination.h"
 #include "distributed/worker_protocol.h"
 #include "utils/lsyscache.h"
 
@@ -92,46 +93,4 @@ JobExecutorType(DistributedPlan *distributedPlan)
 	}
 
 	return MULTI_EXECUTOR_ADAPTIVE;
-}
-
-
-/*
- * CheckIfSizeLimitIsExceeded checks if the limit is exceeded by intermediate
- * results, if there is any.
- */
-bool
-CheckIfSizeLimitIsExceeded(DistributedExecutionStats *executionStats)
-{
-	if (!SubPlanLevel || MaxIntermediateResult < 0)
-	{
-		return false;
-	}
-
-	uint64 maxIntermediateResultInBytes = MaxIntermediateResult * 1024L;
-	if (executionStats->totalIntermediateResultSize < maxIntermediateResultInBytes)
-	{
-		return false;
-	}
-
-	return true;
-}
-
-
-/*
- * This function is called when the intermediate result size limitation is
- * exceeded. It basically errors out with a detailed explanation.
- */
-void
-ErrorSizeLimitIsExceeded()
-{
-	ereport(ERROR, (errmsg("the intermediate result size exceeds "
-						   "citus.max_intermediate_result_size (currently %d kB)",
-						   MaxIntermediateResult),
-					errdetail("Citus restricts the size of intermediate "
-							  "results of complex subqueries and CTEs to "
-							  "avoid accidentally pulling large result sets "
-							  "into once place."),
-					errhint("To run the current query, set "
-							"citus.max_intermediate_result_size to a higher"
-							" value or -1 to disable.")));
 }

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -311,7 +311,8 @@ typedef struct Task
 	/*
 	 * totalReceivedTupleData only counts the data for a single placement. So
 	 * for RETURNING DML this is not really correct. This is used by
-	 * EXPLAIN ANALYZE, to display the amount of received bytes.
+	 * EXPLAIN ANALYZE, to display the amount of received bytes. The local execution
+	 * does not increment this value, so only used for remote execution.
 	 */
 	uint64 totalReceivedTupleData;
 

--- a/src/include/distributed/multi_server_executor.h
+++ b/src/include/distributed/multi_server_executor.h
@@ -15,7 +15,6 @@
 #define MULTI_SERVER_EXECUTOR_H
 
 #include "distributed/multi_physical_planner.h"
-
 #include "distributed/worker_manager.h"
 
 /* Adaptive executor repartioning related defines */
@@ -34,18 +33,6 @@ typedef enum
 } MultiExecutorType;
 
 
-/*
- * DistributedExecutionStats holds the execution related stats.
- *
- * totalIntermediateResultSize is a counter to keep the size
- * of the intermediate results of complex subqueries and CTEs
- * so that we can put a limit on the size.
- */
-typedef struct DistributedExecutionStats
-{
-	uint64 totalIntermediateResultSize;
-} DistributedExecutionStats;
-
 /* Config variable managed via guc.c */
 extern int RemoteTaskCheckInterval;
 extern int TaskExecutorType;
@@ -55,7 +42,5 @@ extern int MultiTaskQueryLogLevel;
 
 /* Function declarations common to more than one executor */
 extern MultiExecutorType JobExecutorType(DistributedPlan *distributedPlan);
-extern bool CheckIfSizeLimitIsExceeded(DistributedExecutionStats *executionStats);
-extern void ErrorSizeLimitIsExceeded(void);
 
 #endif /* MULTI_SERVER_EXECUTOR_H */

--- a/src/include/distributed/tuple_destination.h
+++ b/src/include/distributed/tuple_destination.h
@@ -15,7 +15,22 @@
 #include "tcop/dest.h"
 #include "utils/tuplestore.h"
 
+
 typedef struct TupleDestination TupleDestination;
+
+
+/*
+ * TupleDestinationStats holds the size related stats.
+ *
+ * totalIntermediateResultSize is a counter to keep the size
+ * of the intermediate results of complex subqueries and CTEs
+ * so that we can put a limit on the size.
+ */
+typedef struct TupleDestinationStats
+{
+	uint64 totalIntermediateResultSize;
+} TupleDestinationStats;
+
 
 /*
  * TupleDestination provides a generic interface for where to send tuples.
@@ -36,6 +51,12 @@ struct TupleDestination
 
 	/* tupleDescForQuery returns tuple descriptor for a query number. Can return NULL. */
 	TupleDesc (*tupleDescForQuery)(TupleDestination *self, int queryNumber);
+
+	/*
+	 * Used to enforce citus.max_intermediate_result_size, could be NULL
+	 * if the caller is not interested in the size.
+	 */
+	TupleDestinationStats *tupleDestinationStats;
 };
 
 extern TupleDestination * CreateTupleStoreTupleDest(Tuplestorestate *tupleStore, TupleDesc

--- a/src/test/regress/expected/limit_intermediate_size.out
+++ b/src/test/regress/expected/limit_intermediate_size.out
@@ -133,12 +133,10 @@ WITH cte AS (
 	SELECT * FROM cte2, cte3 WHERE cte2.value_1 IN (SELECT value_2 FROM cte3)
 )
 SELECT count(*) FROM cte;
- count
----------------------------------------------------------------------
-  1824
-(1 row)
-
--- this will fail in real_time_executor
+ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 3 kB)
+DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
+HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
+-- this will fail in remote execution
 SET citus.max_intermediate_result_size TO 2;
 WITH cte AS (
 	WITH cte2 AS (

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -93,6 +93,34 @@ WITH cte_1 AS (UPDATE test SET y = y - 1 RETURNING *) SELECT * FROM cte_1 ORDER 
  5 | 6
 (5 rows)
 
+-- we should be able to limit intermediate results
+BEGIN;
+       SET LOCAL citus.max_intermediate_result_size TO 0;
+       WITH cte_1 AS (SELECT * FROM test OFFSET 0) SELECT * FROM cte_1;
+ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 0 kB)
+DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
+HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
+ROLLBACK;
+-- the first cte (cte_1) does not exceed the limit
+-- but the second (cte_2) exceeds, so we error out
+BEGIN;
+	SET LOCAL citus.max_intermediate_result_size TO '1kB';
+	INSERT INTO  test SELECT i,i from generate_series(0,1000)i;
+	-- only pulls 1 row, should not hit the limit
+	WITH cte_1 AS (SELECT * FROM test LIMIT 1) SELECT count(*) FROM cte_1;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+	-- cte_1 only pulls 1 row, but cte_2 all rows
+	WITH cte_1 AS (SELECT * FROM test LIMIT 1),
+	     cte_2 AS (SELECT * FROM test OFFSET 0)
+	SELECT count(*) FROM cte_1, cte_2;
+ERROR:  the intermediate result size exceeds citus.max_intermediate_result_size (currently 1 kB)
+DETAIL:  Citus restricts the size of intermediate results of complex subqueries and CTEs to avoid accidentally pulling large result sets into once place.
+HINT:  To run the current query, set citus.max_intermediate_result_size to a higher value or -1 to disable.
+ROLLBACK;
 -- single shard and multi-shard delete
 -- inside a transaction block
 BEGIN;

--- a/src/test/regress/sql/limit_intermediate_size.sql
+++ b/src/test/regress/sql/limit_intermediate_size.sql
@@ -116,7 +116,7 @@ WITH cte AS (
 SELECT count(*) FROM cte;
 
 
--- this will fail in real_time_executor
+-- this will fail in remote execution
 SET citus.max_intermediate_result_size TO 2;
 WITH cte AS (
 	WITH cte2 AS (


### PR DESCRIPTION
With this commit, we make sure that local execution adds the
intermediate result size as the distributed execution adds. Plus,
it enforces the citus.max_intermediate_result_size value.

The only point that keeps me thinking is that for the same data size, the intermediate result size we calculate may differ if it comes over network or locally. I guess, there is nothing we can do about that.

DESCRIPTION: Local execution enforces ` citus.max_intermediate_result_size`


Fixes #4235