### PR TITLE
Disallow field indirection in INSERT/UPDATE queries

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -674,6 +674,15 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 			{
 				Assert(hasVarArgument || hasBadCoalesce);
 			}
+
+			if (IsA((Node *) targetEntry->expr, FieldStore))
+			{
+				/* DELETE cannot do field indirection already */
+				Assert(commandType == CMD_UPDATE || commandType == CMD_INSERT);
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "inserting or modifying composite type fields is not "
+									 "supported", NULL, NULL);
+			}
 		}
 
 		if (joinTree != NULL)

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -677,7 +677,7 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 				Assert(hasVarArgument || hasBadCoalesce);
 			}
 
-			if (ExprHasFieldStore(targetEntry->expr))			
+			if (ExprHasFieldStore(targetEntry->expr))
 			{
 				/* DELETE cannot do field indirection already */
 				Assert(commandType == CMD_UPDATE || commandType == CMD_INSERT);
@@ -780,7 +780,7 @@ has_field_store_walker(Node *node, void *context)
 		return true;
 	}
 
-	return expression_tree_walker(node, has_field_store_walker, context);		
+	return expression_tree_walker(node, has_field_store_walker, context);
 }
 
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -683,7 +683,9 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 				Assert(commandType == CMD_UPDATE || commandType == CMD_INSERT);
 				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 									 "inserting or modifying composite type fields is not "
-									 "supported", NULL, NULL);
+									 "supported", NULL,
+									 "Use whole column for inserting or modifying composite "
+									 "type fields");
 			}
 		}
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -684,8 +684,8 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 									 "inserting or modifying composite type fields is not "
 									 "supported", NULL,
-									 "Use whole column for inserting or modifying composite "
-									 "type fields");
+									 "Use the column name to insert or update the composite "
+									 "type as a single value");
 			}
 		}
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -130,8 +130,7 @@ static bool IsTidColumn(Node *node);
 static DeferredErrorMessage * ModifyPartialQuerySupported(Query *queryTree, bool
 														  multiShardQuery,
 														  Oid *distributedTableId);
-static bool ExprHasFieldStore(Expr *expr);
-static bool has_field_store_walker(Node *node, void *context);
+static bool NodeIsFieldStore(Node *node);
 static DeferredErrorMessage * DeferErrorIfUnsupportedModifyQueryWithLocalTable(
 	Query *query);
 static DeferredErrorMessage * DeferErrorIfUnsupportedModifyQueryWithCitusLocalTable(
@@ -677,7 +676,8 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 				Assert(hasVarArgument || hasBadCoalesce);
 			}
 
-			if (ExprHasFieldStore(targetEntry->expr))
+			if (FindNodeMatchingCheckFunction((Node *) targetEntry->expr,
+											  NodeIsFieldStore))
 			{
 				/* DELETE cannot do field indirection already */
 				Assert(commandType == CMD_UPDATE || commandType == CMD_INSERT);
@@ -754,35 +754,12 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 
 
 /*
- * ExprHasFieldStore returns true if given Expr is a FieldStore object
- * or it indirectly contains FieldStore object.
+ * NodeIsFieldStore returns true if given Node is a FieldStore object.
  */
 static bool
-ExprHasFieldStore(Expr *expr)
+NodeIsFieldStore(Node *node)
 {
-	void *context = NULL;
-	return has_field_store_walker((Node *) expr, context);
-}
-
-
-/*
- * has_field_store_walker walks over the Expr objects in given node and returns
- * true if it can find a FieldStore object.
- */
-static bool
-has_field_store_walker(Node *node, void *context)
-{
-	if (node == NULL)
-	{
-		return false;
-	}
-
-	if (IsA(node, FieldStore))
-	{
-		return true;
-	}
-
-	return expression_tree_walker(node, has_field_store_walker, context);
+	return node && IsA(node, FieldStore);
 }
 
 

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -380,6 +380,45 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('
 (2 rows)
 
 RESET citus.enable_create_type_propagation;
+CREATE TYPE ct1 as (int_1 int, int_2 int);
+CREATE TABLE field_indirection_test_1 (int_col int, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_1', 'int_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- not supported (field indirection in single row insert)
+INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1, ct1_col.int_2) VALUES (0, 1, 2);
+ERROR:  inserting or modifying composite type fields is not supported
+INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1) VALUES (0, 1);
+ERROR:  inserting or modifying composite type fields is not supported
+CREATE TYPE ct2 as (int_2 int, text_1 text, int_1 int);
+CREATE TABLE field_indirection_test_2 (int_col int, ct2_col ct2, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_2', 'int_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- not supported (field indirection in multi row insert)
+INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2)
+VALUES (0, 1, 'text1', 2), (3, 4, 'text1', 5);
+ERROR:  inserting or modifying composite type fields is not supported
+-- not supported (field indirection in update)
+UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
+ERROR:  inserting or modifying composite type fields is not supported
+-- below are supported as we don't do any field indirection
+INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)
+VALUES ('(1, "text1", 2)', 3, '(4, 5)'), ('(6, "text2", 7)', 8, '(9, 10)');
+UPDATE field_indirection_test_2 SET (ct2_col, ct1_col) = ('(10, "text10", 20)', '(40, 50)') WHERE int_col=8;
+SELECT * FROM field_indirection_test_2 ORDER BY 1,2,3;
+ int_col |      ct2_col      | ct1_col
+---------------------------------------------------------------------
+       3 | (1," text1",2)    | (4,5)
+       8 | (10," text10",20) | (40,50)
+(2 rows)
+
 -- clear objects
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -391,8 +391,10 @@ SELECT create_distributed_table('field_indirection_test_1', 'int_col');
 -- not supported (field indirection in single row insert)
 INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1, ct1_col.int_2) VALUES (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
 INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1) VALUES (0, 1);
 ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
 CREATE TYPE ct2 as (int_2 int, text_1 text, int_1 int);
 CREATE TABLE field_indirection_test_2 (int_col int, ct2_col ct2, ct1_col ct1);
 SELECT create_distributed_table('field_indirection_test_2', 'int_col');
@@ -405,9 +407,11 @@ SELECT create_distributed_table('field_indirection_test_2', 'int_col');
 INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2)
 VALUES (0, 1, 'text1', 2), (3, 4, 'text1', 5);
 ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
 -- not supported (field indirection in update)
 UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
 ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
 CREATE TYPE two_ints as (if1 int, if2 int);
 CREATE DOMAIN domain AS two_ints CHECK ((VALUE).if1 > 0);
 -- citus does not propagate domain objects
@@ -431,8 +435,10 @@ SELECT create_distributed_table('domain_indirection_test', 'f1');
 -- not supported (field indirection to underlying composite type)
 INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
 INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
 ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
 -- below are supported as we don't do any field indirection
 INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)
 VALUES ('(1, "text1", 2)', 3, '(4, 5)'), ('(6, "text2", 7)', 8, '(9, 10)');

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -391,10 +391,10 @@ SELECT create_distributed_table('field_indirection_test_1', 'int_col');
 -- not supported (field indirection in single row insert)
 INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1, ct1_col.int_2) VALUES (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1) VALUES (0, 1);
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 CREATE TYPE ct2 as (int_2 int, text_1 text, int_1 int);
 CREATE TABLE field_indirection_test_2 (int_col int, ct2_col ct2, ct1_col ct1);
 SELECT create_distributed_table('field_indirection_test_2', 'int_col');
@@ -407,11 +407,11 @@ SELECT create_distributed_table('field_indirection_test_2', 'int_col');
 INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2)
 VALUES (0, 1, 'text1', 2), (3, 4, 'text1', 5);
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 -- not supported (field indirection in update)
 UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 CREATE TYPE two_ints as (if1 int, if2 int);
 CREATE DOMAIN domain AS two_ints CHECK ((VALUE).if1 > 0);
 -- citus does not propagate domain objects
@@ -435,13 +435,13 @@ SELECT create_distributed_table('domain_indirection_test', 'f1');
 -- not supported (field indirection to underlying composite type)
 INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) VALUES (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 INSERT INTO domain_indirection_test (f1,f3.if1) VALUES (0, 1);
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 UPDATE domain_indirection_test SET domain_array[0].if2 = 5;
 ERROR:  inserting or modifying composite type fields is not supported
-HINT:  Use whole column for inserting or modifying composite type fields
+HINT:  Use the column name to insert or update the composite type as a single value
 -- below are supported as we don't do any field indirection
 INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)
 VALUES ('(1, "text1", 2)', 3, '(4, 5)'), ('(6, "text2", 7)', 8, '(9, 10)');

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -425,7 +425,7 @@ $$);
  (localhost,57638,t,"CREATE DOMAIN")
 (2 rows)
 
-CREATE TABLE domain_indirection_test (f1 int, f3 domain);
+CREATE TABLE domain_indirection_test (f1 int, f3 domain, domain_array domain[]);
 SELECT create_distributed_table('domain_indirection_test', 'f1');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -437,6 +437,9 @@ INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
 HINT:  Use whole column for inserting or modifying composite type fields
 INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
+ERROR:  inserting or modifying composite type fields is not supported
+HINT:  Use whole column for inserting or modifying composite type fields
+UPDATE domain_indirection_test SET domain_array[0].if2 = 5;
 ERROR:  inserting or modifying composite type fields is not supported
 HINT:  Use whole column for inserting or modifying composite type fields
 -- below are supported as we don't do any field indirection

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -433,10 +433,10 @@ SELECT create_distributed_table('domain_indirection_test', 'f1');
 (1 row)
 
 -- not supported (field indirection to underlying composite type)
-INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
+INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) VALUES (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
 HINT:  Use whole column for inserting or modifying composite type fields
-INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
+INSERT INTO domain_indirection_test (f1,f3.if1) VALUES (0, 1);
 ERROR:  inserting or modifying composite type fields is not supported
 HINT:  Use whole column for inserting or modifying composite type fields
 UPDATE domain_indirection_test SET domain_array[0].if2 = 5;

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -408,6 +408,31 @@ ERROR:  inserting or modifying composite type fields is not supported
 -- not supported (field indirection in update)
 UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
 ERROR:  inserting or modifying composite type fields is not supported
+-- not supported (field indirection to underlying composite type)
+CREATE TYPE two_ints as (if1 int, if2 int);
+CREATE DOMAIN domain AS two_ints CHECK ((VALUE).if1 > 0);
+-- citus does not propagate domain objects
+SELECT run_command_on_workers(
+$$
+    CREATE DOMAIN type_tests.domain AS type_tests.two_ints CHECK ((VALUE).if1 > 0);
+$$);
+       run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE DOMAIN")
+ (localhost,57638,t,"CREATE DOMAIN")
+(2 rows)
+
+CREATE TABLE domain_indirection_test (f1 int, f3 domain);
+SELECT create_distributed_table('domain_indirection_test', 'f1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
+ERROR:  inserting or modifying composite type fields is not supported
+INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
+ERROR:  inserting or modifying composite type fields is not supported
 -- below are supported as we don't do any field indirection
 INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)
 VALUES ('(1, "text1", 2)', 3, '(4, 5)'), ('(6, "text2", 7)', 8, '(9, 10)');

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -408,7 +408,6 @@ ERROR:  inserting or modifying composite type fields is not supported
 -- not supported (field indirection in update)
 UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
 ERROR:  inserting or modifying composite type fields is not supported
--- not supported (field indirection to underlying composite type)
 CREATE TYPE two_ints as (if1 int, if2 int);
 CREATE DOMAIN domain AS two_ints CHECK ((VALUE).if1 > 0);
 -- citus does not propagate domain objects
@@ -429,6 +428,7 @@ SELECT create_distributed_table('domain_indirection_test', 'f1');
 
 (1 row)
 
+-- not supported (field indirection to underlying composite type)
 INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
 ERROR:  inserting or modifying composite type fields is not supported
 INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -270,8 +270,8 @@ CREATE TABLE domain_indirection_test (f1 int, f3 domain, domain_array domain[]);
 SELECT create_distributed_table('domain_indirection_test', 'f1');
 
 -- not supported (field indirection to underlying composite type)
-INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
-INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
+INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) VALUES (0, 1, 2);
+INSERT INTO domain_indirection_test (f1,f3.if1) VALUES (0, 1);
 UPDATE domain_indirection_test SET domain_array[0].if2 = 5;
 
 -- below are supported as we don't do any field indirection

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -266,12 +266,13 @@ SELECT run_command_on_workers(
 $$
     CREATE DOMAIN type_tests.domain AS type_tests.two_ints CHECK ((VALUE).if1 > 0);
 $$);
-CREATE TABLE domain_indirection_test (f1 int, f3 domain);
+CREATE TABLE domain_indirection_test (f1 int, f3 domain, domain_array domain[]);
 SELECT create_distributed_table('domain_indirection_test', 'f1');
 
 -- not supported (field indirection to underlying composite type)
 INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
 INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
+UPDATE domain_indirection_test SET domain_array[0].if2 = 5;
 
 -- below are supported as we don't do any field indirection
 INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -259,6 +259,20 @@ VALUES (0, 1, 'text1', 2), (3, 4, 'text1', 5);
 -- not supported (field indirection in update)
 UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
 
+-- not supported (field indirection to underlying composite type)
+CREATE TYPE two_ints as (if1 int, if2 int);
+CREATE DOMAIN domain AS two_ints CHECK ((VALUE).if1 > 0);
+-- citus does not propagate domain objects
+SELECT run_command_on_workers(
+$$
+    CREATE DOMAIN type_tests.domain AS type_tests.two_ints CHECK ((VALUE).if1 > 0);
+$$);
+CREATE TABLE domain_indirection_test (f1 int, f3 domain);
+SELECT create_distributed_table('domain_indirection_test', 'f1');
+
+INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
+INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
+
 -- below are supported as we don't do any field indirection
 INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)
 VALUES ('(1, "text1", 2)', 3, '(4, 5)'), ('(6, "text2", 7)', 8, '(9, 10)');

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -240,6 +240,32 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname IN ('
 
 RESET citus.enable_create_type_propagation;
 
+CREATE TYPE ct1 as (int_1 int, int_2 int);
+CREATE TABLE field_indirection_test_1 (int_col int, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_1', 'int_col');
+
+-- not supported (field indirection in single row insert)
+INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1, ct1_col.int_2) VALUES (0, 1, 2);
+INSERT INTO field_indirection_test_1 (int_col, ct1_col.int_1) VALUES (0, 1);
+
+CREATE TYPE ct2 as (int_2 int, text_1 text, int_1 int);
+CREATE TABLE field_indirection_test_2 (int_col int, ct2_col ct2, ct1_col ct1);
+SELECT create_distributed_table('field_indirection_test_2', 'int_col');
+
+-- not supported (field indirection in multi row insert)
+INSERT INTO field_indirection_test_2 (ct2_col.int_1, int_col, ct2_col.text_1, ct1_col.int_2)
+VALUES (0, 1, 'text1', 2), (3, 4, 'text1', 5);
+
+-- not supported (field indirection in update)
+UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
+
+-- below are supported as we don't do any field indirection
+INSERT INTO field_indirection_test_2 (ct2_col, int_col, ct1_col)
+VALUES ('(1, "text1", 2)', 3, '(4, 5)'), ('(6, "text2", 7)', 8, '(9, 10)');
+UPDATE field_indirection_test_2 SET (ct2_col, ct1_col) = ('(10, "text10", 20)', '(40, 50)') WHERE int_col=8;
+
+SELECT * FROM field_indirection_test_2 ORDER BY 1,2,3;
+
 -- clear objects
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -259,7 +259,6 @@ VALUES (0, 1, 'text1', 2), (3, 4, 'text1', 5);
 -- not supported (field indirection in update)
 UPDATE field_indirection_test_2 SET (ct2_col.text_1, ct1_col.int_2) = ('text2', 10) WHERE int_col=4;
 
--- not supported (field indirection to underlying composite type)
 CREATE TYPE two_ints as (if1 int, if2 int);
 CREATE DOMAIN domain AS two_ints CHECK ((VALUE).if1 > 0);
 -- citus does not propagate domain objects
@@ -270,6 +269,7 @@ $$);
 CREATE TABLE domain_indirection_test (f1 int, f3 domain);
 SELECT create_distributed_table('domain_indirection_test', 'f1');
 
+-- not supported (field indirection to underlying composite type)
 INSERT INTO domain_indirection_test (f1,f3.if1, f3.if2) values (0, 1, 2);
 INSERT INTO domain_indirection_test (f1,f3.if1) values (0, 1);
 


### PR DESCRIPTION
DESCRIPTION: Disallows field indirection in INSERT/UPDATE queries

As described in https://github.com/citusdata/citus/issues/1293, we were not handling field indirection in INSERT/UPDATE queries. 
Changes in https://github.com/citusdata/citus/pull/4234 attempt to fix this issue but not sufficient and requires more scoping (https://github.com/citusdata/citus/pull/4234#issuecomment-707658066).
So for now, we disallow field indirection.
