### PR TITLE
Check table existence in EnsureRelationKindSupported

### DIFF
--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -478,6 +478,12 @@ void
 EnsureRelationKindSupported(Oid relationId)
 {
 	char relationKind = get_rel_relkind(relationId);
+	if (!relationKind)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("relation with OID %d does not exist",
+							   relationId)));
+	}
 
 	bool supportedRelationKind = RegularTable(relationId) ||
 								 relationKind == RELKIND_FOREIGN_TABLE;

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -4263,6 +4263,24 @@ CachedRelationNamespaceLookup(const char *relationName, Oid relnamespace,
 
 
 /*
+ * RelationExists returns whether a relation with the given OID exists.
+ */
+bool
+RelationExists(Oid relationId)
+{
+	HeapTuple relTuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relationId));
+
+	bool relationExists = HeapTupleIsValid(relTuple);
+	if (relationExists)
+	{
+		ReleaseSysCache(relTuple);
+	}
+
+	return relationExists;
+}
+
+
+/*
  * Register a relcache invalidation for a non-shared relation.
  *
  * We ignore the case that there's no corresponding pg_class entry - that

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -189,6 +189,7 @@ extern bool MajorVersionsCompatible(char *leftVersion, char *rightVersion);
 extern void ErrorIfInconsistentShardIntervals(CitusTableCacheEntry *cacheEntry);
 extern void EnsureModificationsCanRun(void);
 extern char LookupDistributionMethod(Oid distributionMethodOid);
+extern bool RelationExists(Oid relationId);
 
 /* access WorkerNodeHash */
 extern HTAB * GetWorkerNodeHash(void);

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -159,3 +159,6 @@ s/failed to roll back prepared transaction '.*'/failed to roll back prepared tra
 
 # Errors with binary decoding where OIDs should be normalized
 s/wrong data type: [0-9]+, expected [0-9]+/wrong data type: XXXX, expected XXXX/g
+
+# Errors with relation OID does not exist
+s/relation with OID [0-9]+ does not exist/relation with OID XXXX does not exist/g

--- a/src/test/regress/expected/undistribute_table.out
+++ b/src/test/regress/expected/undistribute_table.out
@@ -31,6 +31,14 @@ SELECT * FROM dist_table ORDER BY 1, 2, 3;
   2 | 3 | abcd
 (3 rows)
 
+-- we cannot immediately convert in the same statement, because
+-- the name->OID conversion happens at parse time.
+SELECT undistribute_table('dist_table'), create_distributed_table('dist_table', 'a');
+NOTICE:  Creating a new local table for undistribute_table.dist_table
+NOTICE:  Moving the data of undistribute_table.dist_table
+NOTICE:  Dropping the old undistribute_table.dist_table
+NOTICE:  Renaming the new table to undistribute_table.dist_table
+ERROR:  relation with OID XXXX does not exist
 SELECT undistribute_table('dist_table');
 NOTICE:  Creating a new local table for undistribute_table.dist_table
 NOTICE:  Moving the data of undistribute_table.dist_table

--- a/src/test/regress/sql/undistribute_table.sql
+++ b/src/test/regress/sql/undistribute_table.sql
@@ -11,6 +11,10 @@ SELECT logicalrelid FROM pg_dist_partition WHERE logicalrelid = 'dist_table'::re
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname LIKE 'dist\_table\_%'$$);
 SELECT * FROM dist_table ORDER BY 1, 2, 3;
 
+-- we cannot immediately convert in the same statement, because
+-- the name->OID conversion happens at parse time.
+SELECT undistribute_table('dist_table'), create_distributed_table('dist_table', 'a');
+
 SELECT undistribute_table('dist_table');
 
 SELECT logicalrelid FROM pg_dist_partition WHERE logicalrelid = 'dist_table'::regclass;


### PR DESCRIPTION
Check whether the table exists in EnsureRelationKindSupported, because if it does not we pass null to errmsg, which crashes on some platforms.

Fixes #4244