### PR TITLE
Improve the relation restriction counters

### DIFF
--- a/src/include/distributed/relation_restriction_equivalence.h
+++ b/src/include/distributed/relation_restriction_equivalence.h
@@ -13,7 +13,7 @@
 #define RELATION_RESTRICTION_EQUIVALENCE_H
 
 #include "distributed/distributed_planner.h"
-
+#include "distributed/metadata_cache.h"
 
 extern bool AllDistributionKeysInQueryAreEqual(Query *originalQuery,
 											   PlannerRestrictionContext *
@@ -29,7 +29,8 @@ bool RestrictionEquivalenceForPartitionKeysViaEquivalences(PlannerRestrictionCon
 														   allAttributeEquivalenceList);
 extern List * GenerateAllAttributeEquivalences(PlannerRestrictionContext *
 											   plannerRestrictionContext);
-extern uint32 ReferenceRelationCount(RelationRestrictionContext *restrictionContext);
+extern uint32 UniqueRelationCount(RelationRestrictionContext *restrictionContext,
+								  CitusTableType tableType);
 
 extern List * DistributedRelationIdList(Query *query);
 extern PlannerRestrictionContext * FilterPlannerRestrictionForQuery(

--- a/src/test/regress/expected/subquery_basics.out
+++ b/src/test/regress/expected/subquery_basics.out
@@ -2,6 +2,65 @@
 -- test recursive planning functionality
 -- ===================================================================
 SET client_min_messages TO DEBUG1;
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	user_id, value_1
+FROM
+	(SELECT user_id, value_1 FROM users_table) as foo
+ORDER BY 1 DESC, 2 DESC LIMIT 3;
+DEBUG:  push down of limit count: 3
+ user_id | value_1
+---------------------------------------------------------------------
+       6 |       5
+       6 |       5
+       6 |       3
+(3 rows)
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	sum(sel_val_1), sum(sel_val_2)
+FROM
+	(SELECT max(value_1) as  sel_val_1, min(value_2) as sel_val_2 FROM users_table GROUP BY user_id) as foo;
+ sum | sum
+---------------------------------------------------------------------
+  29 |   1
+(1 row)
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	min(user_id), max(value_1)
+FROM
+	(SELECT user_id, value_1 FROM users_table) as foo;
+ min | max
+---------------------------------------------------------------------
+   1 |   5
+(1 row)
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	min(user_id)
+FROM
+	(SELECT user_id, value_1 FROM users_table GROUP BY user_id, value_1) as bar;
+ min
+---------------------------------------------------------------------
+   1
+(1 row)
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	min(user_id), sum(max_value_1)
+FROM
+	(SELECT user_id, max(value_1) as max_value_1 FROM users_table GROUP BY user_id) as bar;
+ min | sum
+---------------------------------------------------------------------
+   1 |  29
+(1 row)
+
 -- subqueries in FROM clause with LIMIT should be recursively planned
 SELECT
    user_id

--- a/src/test/regress/sql/subquery_basics.sql
+++ b/src/test/regress/sql/subquery_basics.sql
@@ -1,8 +1,43 @@
 -- ===================================================================
 -- test recursive planning functionality
 -- ===================================================================
-
 SET client_min_messages TO DEBUG1;
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	user_id, value_1
+FROM
+	(SELECT user_id, value_1 FROM users_table) as foo
+ORDER BY 1 DESC, 2 DESC LIMIT 3;
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	sum(sel_val_1), sum(sel_val_2)
+FROM
+	(SELECT max(value_1) as  sel_val_1, min(value_2) as sel_val_2 FROM users_table GROUP BY user_id) as foo;
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	min(user_id), max(value_1)
+FROM
+	(SELECT user_id, value_1 FROM users_table) as foo;
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	min(user_id)
+FROM
+	(SELECT user_id, value_1 FROM users_table GROUP BY user_id, value_1) as bar;
+
+-- the subquery is safe to pushdown, should not
+-- recursively plan
+SELECT
+	min(user_id), sum(max_value_1)
+FROM
+	(SELECT user_id, max(value_1) as max_value_1 FROM users_table GROUP BY user_id) as bar;
 
 -- subqueries in FROM clause with LIMIT should be recursively planned
 SELECT


### PR DESCRIPTION
It seems like Postgres could call set_rel_pathlist() for
the same relation multiple times. This breaks the logic
where we assume relationCount equals to the number of
entries in relationRestrictionList.

In summary, relationRestrictionList may contain duplicate
entries.

DESCRIPTION: Prevent pull-push execution for simple pushdownable subqueries

Fixes  #4252