### PR TITLE
Fix memory issues around deparsing index commands 

### DIFF
--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -757,6 +757,9 @@ deparse_shard_reindex_statement(ReindexStmt *origStmt, Oid distrelid, int64 shar
 
 		/* extend relation and index name using shard identifier */
 		AppendShardIdToName(&relationName, shardid);
+
+		/* AppendShardIdToName might invalidate original pointer, assign it back */
+		reindexStmt->relation->relname = relationName;
 	}
 
 	appendStringInfoString(buffer, "REINDEX ");

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -684,16 +684,13 @@ deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64 shardid,
 							  StringInfo buffer)
 {
 	IndexStmt *indexStmt = copyObject(origStmt); /* copy to avoid modifications */
-	char *relationName = indexStmt->relation->relname;
-	char *indexName = indexStmt->idxname;
 
 	/* extend relation and index name using shard identifier */
-	AppendShardIdToName(&relationName, shardid);
-	AppendShardIdToName(&indexName, shardid);
+	AppendShardIdToName(&(indexStmt->relation->relname), shardid);
+	AppendShardIdToName(&(indexStmt->idxname), shardid);
 
-	/* AppendShardIdToName might invalidate original pointer, assign it back */
-	indexStmt->relation->relname = relationName;
-	indexStmt->idxname = indexName;
+	char *relationName = indexStmt->relation->relname;
+	char *indexName = indexStmt->idxname;
 
 	/* use extended shard name and transformed stmt for deparsing */
 	List *deparseContext = deparse_context_for(relationName, distrelid);
@@ -753,13 +750,10 @@ deparse_shard_reindex_statement(ReindexStmt *origStmt, Oid distrelid, int64 shar
 	if (reindexStmt->kind == REINDEX_OBJECT_INDEX ||
 		reindexStmt->kind == REINDEX_OBJECT_TABLE)
 	{
-		relationName = reindexStmt->relation->relname;
-
 		/* extend relation and index name using shard identifier */
-		AppendShardIdToName(&relationName, shardid);
+		AppendShardIdToName(&(reindexStmt->relation->relname), shardid);
 
-		/* AppendShardIdToName might invalidate original pointer, assign it back */
-		reindexStmt->relation->relname = relationName;
+		relationName = reindexStmt->relation->relname;
 	}
 
 	appendStringInfoString(buffer, "REINDEX ");

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -691,6 +691,10 @@ deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64 shardid,
 	AppendShardIdToName(&relationName, shardid);
 	AppendShardIdToName(&indexName, shardid);
 
+	/* AppendShardIdToName might invalidate original pointer, assign it back */
+	indexStmt->relation->relname = relationName;
+	indexStmt->idxname = indexName;
+
 	/* use extended shard name and transformed stmt for deparsing */
 	List *deparseContext = deparse_context_for(relationName, distrelid);
 	indexStmt = transformIndexStmt(distrelid, indexStmt, NULL);


### PR DESCRIPTION
DESCRIPTION: Fixes memory issues around deparsing index commands

Fixes #4258

------

When calling `AppendShardIdToName`, doing below is problematic:

```c
// assume we already have "char *originalStringToAppend"
char *anotherStrReference = originalStringToAppend;
AppendShardIdToName(&anotherStrReference);
```

This is because, `AppendShardIdToName` might invalidate `originalStringToAppend` as it calls `repalloc`.

If we want to update the original string here, either:
* we should assign `anotherStrReference` back to `originalStringToAppend` after calling AppendShardIdToName(`anotherStrReference`) or,
* we should directly pass `&stringToAppend` to `AppendShardIdToName`.

Or, if we don't want to update the original string here, we should instead do:

```c
// assume we already have "char *originalStringToAppend"
char *anotherStrReference = pstrdup(originalStringToAppend);
AppendShardIdToName(&anotherStrReference);
```

Please also see (see https://github.com/citusdata/citus/issues/4258#issuecomment-713709216).

-----

(For easier review, split the work into commits, I will remove reference to issue
number in commit message and squash commits before merging)

First commit (35fd53e) fixes https://github.com/citusdata/citus/issues/4258.
Then I looked into all usages of `AppendShardIdToName` in codebase, and a similar pattern exists in in the same file, in `deparse_shard_reindex_statement`, second commit (5b26824) fixes this.

----

I tested the pr by running `make check-base-vg` with pg13.0. However, I'm planning to start a custom valgrind job with `make check-multi-vg` after merging the pr.

Unfortunately I cannot add a regression test for that, any ideas ?