### PR TITLE
don't send unnecessary cancels

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -616,7 +616,17 @@ ShutdownConnection(MultiConnection *connection)
 	if (PQstatus(connection->pgConn) == CONNECTION_OK &&
 		PQtransactionStatus(connection->pgConn) == PQTRANS_ACTIVE)
 	{
-		SendCancelationRequest(connection);
+		bool sentCancel = SendCancelationRequest(connection);
+		if (sentCancel)
+		{
+			/*
+			 * If we have sent a cancelation we need to wait and consume the response to
+			 * make sure the cancelation is processed. In case of network delay
+			 * cancelation might hit other backend/query. Poolers might introduce out of
+			 * order delivery.
+			 */
+			ClearResultsDiscardWarnings(connection, false);
+		}
 	}
 	CitusPQFinish(connection);
 }

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -1042,6 +1042,12 @@ SendCancelationRequest(MultiConnection *connection)
 {
 	char errorBuffer[ERROR_BUFFER_SIZE] = { 0 };
 
+	if (!PQisBusy(connection->pgConn))
+	{
+		/* no statement in progress, nothing to cancel */
+		return false;
+	}
+
 	PGcancel *cancelObject = PQgetCancel(connection->pgConn);
 	if (cancelObject == NULL)
 	{


### PR DESCRIPTION
DESCRIPTION: don't send unnecessary cancels

Citus blindly sent cancelations to the workers in case of a connection shutdown, or a `ROLLBACK TO SAVEPOINT`. These cancel requests are handy to speedup the shutdown of a connection by stopping any query that was in progress.

Due top race-yness of networks, and a bug in pgbouncer (https://github.com/pgbouncer/pgbouncer/issues/245) these cancelations might inadvertently cancel subsequent commands sent to the server. To limit the impact of the bug and race-yness of networks we can safely omit sending the cancel if no query is currently being executed on the connection.