### PR TITLE
Prevent undistribute_table calls for foreign tables

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1585,6 +1585,12 @@ UndistributeTable(Oid relationId)
 							   "because a foreign key references to it.")));
 	}
 
+	char relationKind = get_rel_relkind(relationId);
+	if (relationKind == RELKIND_FOREIGN_TABLE)
+	{
+		ereport(ERROR, (errmsg("Cannot undistribute table "
+							   "because it is a foreign table.")));
+	}
 
 	List *preLoadCommands = GetPreLoadTableCreationCommands(relationId, true);
 	List *postLoadCommands = GetPostLoadTableCreationCommands(relationId);

--- a/src/test/regress/expected/undistribute_table.out
+++ b/src/test/regress/expected/undistribute_table.out
@@ -126,6 +126,22 @@ ERROR:  Cannot undistribute table because a foreign key references to it.
 SELECT undistribute_table('referencing_table');
 ERROR:  Cannot undistribute table because it has a foreign key.
 DROP TABLE referenced_table, referencing_table;
+-- test distributed foreign tables
+-- we expect errors
+CREATE FOREIGN TABLE foreign_table (
+  id bigint not null,
+  full_name text not null default ''
+) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true');
+SELECT create_distributed_table('foreign_table', 'id');
+NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT undistribute_table('foreign_table');
+ERROR:  Cannot undistribute table because it is a foreign table.
+DROP FOREIGN TABLE foreign_table;
 -- test partitioned tables
 CREATE TABLE partitioned_table (id INT, a INT) PARTITION BY RANGE (id);
 CREATE TABLE partitioned_table_1_5 PARTITION OF partitioned_table FOR VALUES FROM (1) TO (5);

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -65,6 +65,10 @@ test: ensure_no_intermediate_data_leak
 # ----------
 test: multi_partitioning_utils multi_partitioning replicated_partitioned_table
 
+# ----------
+# Tests for foreign data wrapper support
+# ----------
+test: multi_create_fdw
 
 # ----------
 # Tests for recursive subquery planning
@@ -199,7 +203,6 @@ test: multi_outer_join
 # Note that the order of the following tests are important. multi_complex_count_distinct
 # is independent from the rest of the group, it is added to increase parallelism.
 # ---
-test: multi_create_fdw
 test: multi_complex_count_distinct multi_select_distinct
 test: multi_modifications
 test: multi_distribution_metadata

--- a/src/test/regress/sql/undistribute_table.sql
+++ b/src/test/regress/sql/undistribute_table.sql
@@ -52,6 +52,17 @@ SELECT undistribute_table('referencing_table');
 
 DROP TABLE referenced_table, referencing_table;
 
+-- test distributed foreign tables
+-- we expect errors
+CREATE FOREIGN TABLE foreign_table (
+  id bigint not null,
+  full_name text not null default ''
+) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true');
+SELECT create_distributed_table('foreign_table', 'id');
+SELECT undistribute_table('foreign_table');
+
+DROP FOREIGN TABLE foreign_table;
+
 -- test partitioned tables
 CREATE TABLE partitioned_table (id INT, a INT) PARTITION BY RANGE (id);
 CREATE TABLE partitioned_table_1_5 PARTITION OF partitioned_table FOR VALUES FROM (1) TO (5);


### PR DESCRIPTION
To undistribute a table, the list of commands for a foreign table are quite different than regular distributed tables. Therefore Citus should error out until the support for foreign tables are covered.

fixes #4274 

TODO:
- [x] add some tests with a foreign distributed table so that the newly introduced lines are covered by the test suite