### PR TITLE
Prevent undistribute_table calls for partitions

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1592,6 +1592,16 @@ UndistributeTable(Oid relationId)
 							   "because it is a foreign table.")));
 	}
 
+	if (PartitionTable(relationId))
+	{
+		Oid parentRelationId = PartitionParentOid(relationId);
+		char *parentRelationName = get_rel_name(parentRelationId);
+		ereport(ERROR, (errmsg("Cannot undistribute table "
+							   "because it is a partition."),
+						errhint("Undistribute the partitioned table \"%s\" instead.",
+								parentRelationName)));
+	}
+
 	List *preLoadCommands = GetPreLoadTableCreationCommands(relationId, true);
 	List *postLoadCommands = GetPostLoadTableCreationCommands(relationId);
 

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1560,45 +1560,44 @@ UndistributeTable(Oid relationId)
 	Relation relation = try_relation_open(relationId, ExclusiveLock);
 	if (relation == NULL)
 	{
-		ereport(ERROR, (errmsg("Cannot undistribute table"),
-						errdetail("No such distributed table exists. "
-								  "Might have already been undistributed.")));
+		ereport(ERROR, (errmsg("cannot undistribute table"),
+						errdetail("because no such distributed table exists")));
 	}
 
 	relation_close(relation, NoLock);
 
 	if (!IsCitusTable(relationId))
 	{
-		ereport(ERROR, (errmsg("Cannot undistribute table."),
-						errdetail("The table is not distributed.")));
+		ereport(ERROR, (errmsg("cannot undistribute table "),
+						errdetail("because the table is not distributed")));
 	}
 
 	if (TableReferencing(relationId))
 	{
-		ereport(ERROR, (errmsg("Cannot undistribute table "
-							   "because it has a foreign key.")));
+		ereport(ERROR, (errmsg("cannot undistribute table "
+							   "because it has a foreign key")));
 	}
 
 	if (TableReferenced(relationId))
 	{
-		ereport(ERROR, (errmsg("Cannot undistribute table "
-							   "because a foreign key references to it.")));
+		ereport(ERROR, (errmsg("cannot undistribute table "
+							   "because a foreign key references to it")));
 	}
 
 	char relationKind = get_rel_relkind(relationId);
 	if (relationKind == RELKIND_FOREIGN_TABLE)
 	{
-		ereport(ERROR, (errmsg("Cannot undistribute table "
-							   "because it is a foreign table.")));
+		ereport(ERROR, (errmsg("cannot undistribute table "
+							   "because it is a foreign table")));
 	}
 
 	if (PartitionTable(relationId))
 	{
 		Oid parentRelationId = PartitionParentOid(relationId);
 		char *parentRelationName = get_rel_name(parentRelationId);
-		ereport(ERROR, (errmsg("Cannot undistribute table "
-							   "because it is a partition."),
-						errhint("Undistribute the partitioned table \"%s\" instead.",
+		ereport(ERROR, (errmsg("cannot undistribute table "
+							   "because it is a partition"),
+						errhint("undistribute the partitioned table \"%s\" instead",
 								parentRelationName)));
 	}
 
@@ -1620,7 +1619,7 @@ UndistributeTable(Oid relationId)
 
 	if (PartitionedTable(relationId))
 	{
-		ereport(NOTICE, (errmsg("Undistributing the partitions of %s",
+		ereport(NOTICE, (errmsg("undistributing the partitions of %s",
 								quote_qualified_identifier(schemaName, relationName))));
 		List *partitionList = PartitionList(relationId);
 		Oid partitionRelationId = InvalidOid;
@@ -1651,7 +1650,7 @@ UndistributeTable(Oid relationId)
 
 	char *tableCreationCommand = NULL;
 
-	ereport(NOTICE, (errmsg("Creating a new local table for %s",
+	ereport(NOTICE, (errmsg("creating a new local table for %s",
 							quote_qualified_identifier(schemaName, relationName))));
 
 	foreach_ptr(tableCreationCommand, preLoadCommands)

--- a/src/test/regress/expected/citus_local_tables.out
+++ b/src/test/regress/expected/citus_local_tables.out
@@ -333,7 +333,7 @@ ERROR:  Table 'citus_local_table_1' is a citus local table. Replicating shard of
 -- undistribute_table is supported
 BEGIN;
   SELECT undistribute_table('citus_local_table_1');
-NOTICE:  Creating a new local table for citus_local_tables_test_schema.citus_local_table_1
+NOTICE:  creating a new local table for citus_local_tables_test_schema.citus_local_table_1
 NOTICE:  Moving the data of citus_local_tables_test_schema.citus_local_table_1
 NOTICE:  executing the command locally: SELECT a FROM citus_local_tables_test_schema.citus_local_table_1_1504027 citus_local_table_1
 NOTICE:  Dropping the old citus_local_tables_test_schema.citus_local_table_1
@@ -559,7 +559,7 @@ FROM pg_dist_partition WHERE logicalrelid = 'citus_local_table_4'::regclass;
 (1 row)
 
 SELECT column_name_to_column('citus_local_table_4', 'a');
-                                                 column_name_to_column
+                                                  column_name_to_column
 ---------------------------------------------------------------------
  {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
 (1 row)

--- a/src/test/regress/expected/isolation_undistribute_table.out
+++ b/src/test/regress/expected/isolation_undistribute_table.out
@@ -17,7 +17,7 @@ step s1-commit:
     COMMIT;
 
 step s2-undistribute: <... completed>
-error in steps s1-commit s2-undistribute: ERROR:  Cannot undistribute table
+error in steps s1-commit s2-undistribute: ERROR:  cannot undistribute table
 
 starting permutation: s1-begin s1-undistribute s2-select s1-commit
 step s1-begin:

--- a/src/test/regress/expected/pg13_with_ties.out
+++ b/src/test/regress/expected/pg13_with_ties.out
@@ -154,7 +154,7 @@ SELECT * FROM with_ties_table_2 ORDER BY a, b;
 TRUNCATE with_ties_table_2;
 -- test INSERT SELECTs into distributed table with a different distribution column
 SELECT undistribute_table('with_ties_table_2');
-NOTICE:  Creating a new local table for public.with_ties_table_2
+NOTICE:  creating a new local table for public.with_ties_table_2
 NOTICE:  Moving the data of public.with_ties_table_2
 NOTICE:  Dropping the old public.with_ties_table_2
 NOTICE:  Renaming the new table to public.with_ties_table_2

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -775,7 +775,7 @@ RESET citus.task_executor_type;
 -- make sure undistribute table works fine
 ALTER TABLE test DROP CONSTRAINT foreign_key;
 SELECT undistribute_table('test_2');
-NOTICE:  Creating a new local table for single_node.test_2
+NOTICE:  creating a new local table for single_node.test_2
 NOTICE:  Moving the data of single_node.test_2
 NOTICE:  Dropping the old single_node.test_2
 NOTICE:  Renaming the new table to single_node.test_2

--- a/src/test/regress/expected/undistribute_table.out
+++ b/src/test/regress/expected/undistribute_table.out
@@ -194,6 +194,11 @@ SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
   7 | 2
 (1 row)
 
+-- undistributing partitions are not supported
+SELECT undistribute_table('partitioned_table_1_5');
+ERROR:  Cannot undistribute table because it is a partition.
+HINT:  Undistribute the partitioned table "partitioned_table" instead.
+-- we can undistribute partitioned parent tables
 SELECT undistribute_table('partitioned_table');
 NOTICE:  Undistributing the partitions of undistribute_table.partitioned_table
 NOTICE:  Creating a new local table for undistribute_table.partitioned_table_1_5

--- a/src/test/regress/expected/undistribute_table.out
+++ b/src/test/regress/expected/undistribute_table.out
@@ -34,13 +34,13 @@ SELECT * FROM dist_table ORDER BY 1, 2, 3;
 -- we cannot immediately convert in the same statement, because
 -- the name->OID conversion happens at parse time.
 SELECT undistribute_table('dist_table'), create_distributed_table('dist_table', 'a');
-NOTICE:  Creating a new local table for undistribute_table.dist_table
+NOTICE:  creating a new local table for undistribute_table.dist_table
 NOTICE:  Moving the data of undistribute_table.dist_table
 NOTICE:  Dropping the old undistribute_table.dist_table
 NOTICE:  Renaming the new table to undistribute_table.dist_table
 ERROR:  relation with OID XXXX does not exist
 SELECT undistribute_table('dist_table');
-NOTICE:  Creating a new local table for undistribute_table.dist_table
+NOTICE:  creating a new local table for undistribute_table.dist_table
 NOTICE:  Moving the data of undistribute_table.dist_table
 NOTICE:  Dropping the old undistribute_table.dist_table
 NOTICE:  Renaming the new table to undistribute_table.dist_table
@@ -87,7 +87,7 @@ SELECT * FROM pg_indexes WHERE tablename = 'dist_table';
 (1 row)
 
 SELECT undistribute_table('dist_table');
-NOTICE:  Creating a new local table for undistribute_table.dist_table
+NOTICE:  creating a new local table for undistribute_table.dist_table
 NOTICE:  Moving the data of undistribute_table.dist_table
 NOTICE:  Dropping the old undistribute_table.dist_table
 NOTICE:  Renaming the new table to undistribute_table.dist_table
@@ -122,9 +122,9 @@ SELECT create_distributed_table('referencing_table', 'id');
 
 INSERT INTO referencing_table VALUES (4, 6, 'cba'), (1, 1, 'dcba'), (2, 3, 'aaa');
 SELECT undistribute_table('referenced_table');
-ERROR:  Cannot undistribute table because a foreign key references to it.
+ERROR:  cannot undistribute table because a foreign key references to it
 SELECT undistribute_table('referencing_table');
-ERROR:  Cannot undistribute table because it has a foreign key.
+ERROR:  cannot undistribute table because it has a foreign key
 DROP TABLE referenced_table, referencing_table;
 -- test distributed foreign tables
 -- we expect errors
@@ -140,7 +140,7 @@ NOTICE:  foreign-data wrapper "fake_fdw" does not have an extension defined
 (1 row)
 
 SELECT undistribute_table('foreign_table');
-ERROR:  Cannot undistribute table because it is a foreign table.
+ERROR:  cannot undistribute table because it is a foreign table
 DROP FOREIGN TABLE foreign_table;
 -- test partitioned tables
 CREATE TABLE partitioned_table (id INT, a INT) PARTITION BY RANGE (id);
@@ -196,20 +196,20 @@ SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
 
 -- undistributing partitions are not supported
 SELECT undistribute_table('partitioned_table_1_5');
-ERROR:  Cannot undistribute table because it is a partition.
-HINT:  Undistribute the partitioned table "partitioned_table" instead.
+ERROR:  cannot undistribute table because it is a partition
+HINT:  undistribute the partitioned table "partitioned_table" instead
 -- we can undistribute partitioned parent tables
 SELECT undistribute_table('partitioned_table');
-NOTICE:  Undistributing the partitions of undistribute_table.partitioned_table
-NOTICE:  Creating a new local table for undistribute_table.partitioned_table_1_5
+NOTICE:  undistributing the partitions of undistribute_table.partitioned_table
+NOTICE:  creating a new local table for undistribute_table.partitioned_table_1_5
 NOTICE:  Moving the data of undistribute_table.partitioned_table_1_5
 NOTICE:  Dropping the old undistribute_table.partitioned_table_1_5
 NOTICE:  Renaming the new table to undistribute_table.partitioned_table_1_5
-NOTICE:  Creating a new local table for undistribute_table.partitioned_table_6_10
+NOTICE:  creating a new local table for undistribute_table.partitioned_table_6_10
 NOTICE:  Moving the data of undistribute_table.partitioned_table_6_10
 NOTICE:  Dropping the old undistribute_table.partitioned_table_6_10
 NOTICE:  Renaming the new table to undistribute_table.partitioned_table_6_10
-NOTICE:  Creating a new local table for undistribute_table.partitioned_table
+NOTICE:  creating a new local table for undistribute_table.partitioned_table
 NOTICE:  Moving the data of undistribute_table.partitioned_table
 NOTICE:  Dropping the old undistribute_table.partitioned_table
 NOTICE:  Renaming the new table to undistribute_table.partitioned_table
@@ -281,7 +281,7 @@ SELECT * FROM seq_table ORDER BY a;
 (3 rows)
 
 SELECT undistribute_table('seq_table');
-NOTICE:  Creating a new local table for undistribute_table.seq_table
+NOTICE:  creating a new local table for undistribute_table.seq_table
 NOTICE:  Moving the data of undistribute_table.seq_table
 NOTICE:  Dropping the old undistribute_table.seq_table
 NOTICE:  Renaming the new table to undistribute_table.seq_table
@@ -346,7 +346,7 @@ SELECT * FROM another_schema.undis_view3 ORDER BY 1, 2;
 (3 rows)
 
 SELECT undistribute_table('view_table');
-NOTICE:  Creating a new local table for undistribute_table.view_table
+NOTICE:  creating a new local table for undistribute_table.view_table
 NOTICE:  Moving the data of undistribute_table.view_table
 NOTICE:  Dropping the old undistribute_table.view_table
 NOTICE:  drop cascades to 3 other objects

--- a/src/test/regress/sql/undistribute_table.sql
+++ b/src/test/regress/sql/undistribute_table.sql
@@ -77,6 +77,9 @@ SELECT * FROM partitioned_table ORDER BY 1, 2;
 SELECT * FROM partitioned_table_1_5 ORDER BY 1, 2;
 SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
 
+-- undistributing partitions are not supported
+SELECT undistribute_table('partitioned_table_1_5');
+-- we can undistribute partitioned parent tables
 SELECT undistribute_table('partitioned_table');
 
 SELECT logicalrelid FROM pg_dist_partition WHERE logicalrelid::regclass::text LIKE 'partitioned\_table%'  ORDER BY 1;


### PR DESCRIPTION
We should error out when attempting to undistribute a partition, because the user might not expect the partition to be detached, and the behaviour for partially distributed partitioned tables is undefined.

On error we give out a hint to try `undistribute_table` on the parent table.

Fixes #4285 
Based on #4279 (Wait until #4279 gets merged first)