### PR TITLE
Do not rely on set_rel_pathlist_hook for finding local relations

### DIFF
--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -1820,10 +1820,6 @@ FilterPlannerRestrictionForQuery(PlannerRestrictionContext *plannerRestrictionCo
 	filteredRelationRestrictionContext->allReferenceTables =
 		(totalRelationCount == referenceRelationCount);
 
-	/* we currently don't support local relations and we cannot come up to this point */
-	filteredRelationRestrictionContext->hasLocalRelation = false;
-	filteredRelationRestrictionContext->hasDistributedRelation = true;
-
 	/* finally set the relation and join restriction contexts */
 	filteredPlannerRestrictionContext->relationRestrictionContext =
 		filteredRelationRestrictionContext;

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -40,8 +40,6 @@ extern int PlannerLevel;
 
 typedef struct RelationRestrictionContext
 {
-	bool hasDistributedRelation;
-	bool hasLocalRelation;
 	bool allReferenceTables;
 	List *relationRestrictionList;
 } RelationRestrictionContext;
@@ -148,8 +146,10 @@ typedef struct RTEListProperties
 	/* includes hash, append and range partitioned tables */
 	bool hasDistributedTable;
 
-	/* union of above three */
+	/* union of hasReferenceTable, hasCitusLocalTable and hasDistributedTable */
 	bool hasCitusTable;
+
+	bool hasMaterializedView;
 } RTEListProperties;
 
 

--- a/src/test/regress/expected/materialized_view.out
+++ b/src/test/regress/expected/materialized_view.out
@@ -29,6 +29,15 @@ SELECT count(*) FROM temp_lineitem;
   1706
 (1 row)
 
+-- can create router materialized views
+CREATE MATERIALIZED VIEW mode_counts_router
+AS SELECT l_shipmode, count(*) FROM temp_lineitem WHERE  l_orderkey = 1 GROUP BY l_shipmode;
+SELECT  * FROM mode_counts_router;
+ l_shipmode | count
+---------------------------------------------------------------------
+ AIR        |     1
+(1 row)
+
 -- can create and query materialized views
 CREATE MATERIALIZED VIEW mode_counts
 AS SELECT l_shipmode, count(*) FROM temp_lineitem GROUP BY l_shipmode;
@@ -59,6 +68,7 @@ SELECT * FROM mode_counts WHERE l_shipmode = 'AIR' ORDER BY 2 DESC, 1 LIMIT 10;
 
 DROP MATERIALIZED VIEW mode_counts;
 DROP TABLE temp_lineitem CASCADE;
+NOTICE:  drop cascades to materialized view mode_counts_router
 -- Refresh single-shard materialized view
 CREATE MATERIALIZED VIEW materialized_view AS
 SELECT orders_hash_part.o_orderdate, total_price.price_sum

--- a/src/test/regress/expected/recursive_view_local_table.out
+++ b/src/test/regress/expected/recursive_view_local_table.out
@@ -1,0 +1,201 @@
+CREATE SCHEMA postgres_local_table;
+SET search_path TO postgres_local_table;
+CREATE TABLE local_table(a INT);
+INSERT INTO local_table VALUES (1),(2),(3);
+CREATE RECURSIVE VIEW recursive_view(val_1, val_2) AS
+(
+		VALUES(0,1)
+	UNION ALL
+		SELECT GREATEST(val_1,val_2),val_1 + val_2 AS local_table
+	FROM
+		recursive_view
+	WHERE val_2 < 50
+);
+CREATE RECURSIVE VIEW recursive_defined_non_recursive_view(c) AS (SELECT 1 FROM local_table);
+CREATE TABLE ref_table(a int, b INT);
+SELECT create_reference_table('ref_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO ref_table VALUES (1,1);
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON FALSE;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+(10 rows)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 1
+ 1 | 1
+(3 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+ 1 | 1
+(10 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 1
+ 1 | 1
+(3 rows)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 1
+ 1 | 1
+(3 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 1
+ 1 | 1
+(3 rows)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a);
+ERROR:  direct joins between distributed and local tables are not supported
+HINT:  Use CTE's or subqueries to select from local tables and use them in joins
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a) AND false;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a AND false);
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_view l WHERE l.val_1 = ref_table.a);
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_view l WHERE l.val_1 = ref_table.a) AND false;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_view l WHERE l.val_1 = ref_table.a AND false);
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_defined_non_recursive_view l WHERE l.c = ref_table.a);
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_defined_non_recursive_view l WHERE l.c = ref_table.a) AND false;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_defined_non_recursive_view l WHERE l.c = ref_table.a AND false);
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+DROP SCHEMA postgres_local_table CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table local_table
+drop cascades to view recursive_view
+drop cascades to view recursive_defined_non_recursive_view
+drop cascades to table ref_table

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -85,7 +85,7 @@ test: set_operation_and_local_tables
 
 test: subqueries_deep subquery_view subquery_partitioning subquery_complex_target_list subqueries_not_supported subquery_in_where
 test: non_colocated_leaf_subquery_joins non_colocated_subquery_joins non_colocated_join_order
-test: subquery_prepared_statements pg12 cte_inline pg13
+test: subquery_prepared_statements pg12 cte_inline pg13 recursive_view_local_table
 test: tableam
 
 # ----------

--- a/src/test/regress/sql/materialized_view.sql
+++ b/src/test/regress/sql/materialized_view.sql
@@ -19,6 +19,11 @@ SELECT count(*) FROM temp_lineitem;
 INSERT INTO temp_lineitem SELECT * FROM air_shipped_lineitems WHERE l_shipmode = 'MAIL';
 SELECT count(*) FROM temp_lineitem;
 
+-- can create router materialized views
+CREATE MATERIALIZED VIEW mode_counts_router
+AS SELECT l_shipmode, count(*) FROM temp_lineitem WHERE  l_orderkey = 1 GROUP BY l_shipmode;
+SELECT  * FROM mode_counts_router;
+
 -- can create and query materialized views
 CREATE MATERIALIZED VIEW mode_counts
 AS SELECT l_shipmode, count(*) FROM temp_lineitem GROUP BY l_shipmode;

--- a/src/test/regress/sql/recursive_view_local_table.sql
+++ b/src/test/regress/sql/recursive_view_local_table.sql
@@ -1,0 +1,55 @@
+CREATE SCHEMA postgres_local_table;
+SET search_path TO postgres_local_table;
+
+CREATE TABLE local_table(a INT);
+INSERT INTO local_table VALUES (1),(2),(3);
+
+CREATE RECURSIVE VIEW recursive_view(val_1, val_2) AS
+(
+		VALUES(0,1)
+	UNION ALL
+		SELECT GREATEST(val_1,val_2),val_1 + val_2 AS local_table
+	FROM
+		recursive_view
+	WHERE val_2 < 50
+);
+
+CREATE RECURSIVE VIEW recursive_defined_non_recursive_view(c) AS (SELECT 1 FROM local_table);
+
+CREATE TABLE ref_table(a int, b INT);
+SELECT create_reference_table('ref_table');
+INSERT INTO ref_table VALUES (1,1);
+
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON FALSE;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM (SELECT 1, random() FROM local_table) as s WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table LEFT OUTER JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON FALSE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE FALSE) AS sub ON TRUE ORDER BY 1,2;
+SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recursive_view WHERE TRUE) AS sub ON TRUE ORDER BY 1,2;
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a);
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a) AND false;
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a AND false);
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_view l WHERE l.val_1 = ref_table.a);
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_view l WHERE l.val_1 = ref_table.a) AND false;
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_view l WHERE l.val_1 = ref_table.a AND false);
+
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_defined_non_recursive_view l WHERE l.c = ref_table.a);
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_defined_non_recursive_view l WHERE l.c = ref_table.a) AND false;
+SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM recursive_defined_non_recursive_view l WHERE l.c = ref_table.a AND false);
+
+
+DROP SCHEMA postgres_local_table CASCADE;


### PR DESCRIPTION
When a relation is used on an OUTER JOIN with FALSE filters,
set_rel_pathlist_hook may not be called for the table.

There might be other cases as well, so do not rely on the hook
for classification of the tables.

DESCRIPTION: Fixes a bug that cause failures when RECURSIVE VIEW joined reference table

Fixes #4280