### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_13.c
+++ b/src/backend/distributed/deparser/ruleutils_13.c
@@ -7763,6 +7763,7 @@ pg_get_triggerdef_worker(Oid trigid, bool pretty)
 		context.wrapColumn = WRAP_COLUMN_DEFAULT;
 		context.indentLevel = PRETTYINDENT_STD;
 		context.special_exprkind = EXPR_KIND_NONE;
+		context.appendparents = NULL;
 
 		get_rule_expr(qual, &context, false);
 


### PR DESCRIPTION
Valgrind found that, we were doing an if check on uninitialized variable
and it seems that this is on context.appendparents.

https://github.com/postgres/postgres/blob/ac22929a2613e122708bd0172508ac863c51c1cc/src/backend/utils/adt/ruleutils.c#L1054

Fixes #4289 

