### PR TITLE
Fix possible SIGSEGV of a repalloc'ed List on undistribute_table calls

### DIFF
--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -1097,33 +1097,11 @@ GetDependingViews(Oid relationId)
 	List *dependingViews = NIL;
 	List *nodeQueue = list_make1(tableNode);
 	ViewDependencyNode *node = NULL;
-	ViewDependencyNode *dependingNode = NULL;
-
-#if PG_VERSION_NUM >= PG_VERSION_13
-
-	/*
-	 * We do not use foreach here because we may insert new nodes to the list,
-	 * and there is a risk of having the list repalloc'ed in PG13.
-	 *
-	 * For more information, see postgres commit with sha
-	 * 1cff1b95ab6ddae32faa3efe0d95a820dbfdc164
-	 * that changed the representation of Lists to expansible arrays, not chains
-	 * of cons-cells.
-	 */
-	for (int dependingNodesPosition = 0; dependingNodesPosition < list_length(nodeQueue);
-		 dependingNodesPosition++)
-	{
-		node = list_nth(nodeQueue, dependingNodesPosition);
-		for (int dependingNodePosition = 0; dependingNodePosition < list_length(
-				 node->dependingNodes); dependingNodePosition++)
-		{
-			dependingNode = list_nth(node->dependingNodes, dependingNodePosition);
-#else
 	foreach_ptr(node, nodeQueue)
 	{
+		ViewDependencyNode *dependingNode = NULL;
 		foreach_ptr(dependingNode, node->dependingNodes)
 		{
-#endif
 			dependingNode->remainingDependencyCount--;
 			if (dependingNode->remainingDependencyCount == 0)
 			{

--- a/src/include/distributed/listutils.h
+++ b/src/include/distributed/listutils.h
@@ -35,11 +35,38 @@ typedef struct ListCellAndListWrapper
 
 /*
  * foreach_ptr -
- *	  a convenience macro which loops through a pointer list without needing a
- *	  ListCell, just a declared pointer variable to store the pointer of the
- *	  cell in.
+ *	  a convenience macro which loops through a pointer List without needing a
+ *	  ListCell or and index variable, just a declared pointer variable to store
+ *    the iterated values.
  *
- *   How it works:
+ *    PostgreSQL 13 changed the representation of Lists to expansible arrays,
+ *    not chains of cons-cells. This changes the costs for accessing and
+ *    mutating List contents. Therefore different implementations are provided.
+ *
+ *    For more information, see postgres commit with sha
+ *    1cff1b95ab6ddae32faa3efe0d95a820dbfdc164
+ */
+
+#if PG_VERSION_NUM >= PG_VERSION_13
+
+/*
+ *    How it works:
+ *	  - An index is declared with the name {var}PositionDoNotUse and used
+ *	    throughout the for loop using ## to concat.
+ *	  - To assign to var it needs to be done in the condition of the for loop,
+ *	    because we cannot use the initializer since the index variable is
+ *	    declared there.
+ *	  - || true is used to always enter the loop even if var is NULL.
+ */
+#define foreach_ptr(var, l) \
+	for (int var ## PositionDoNotUse = 0; \
+		 (var ## PositionDoNotUse) < list_length(l) && \
+		 (((var) = list_nth(l, var ## PositionDoNotUse)) || true); \
+		 var ## PositionDoNotUse++)
+#else
+
+/*
+ *    How it works:
  *	  - A ListCell is declared with the name {var}CellDoNotUse and used
  *	    throughout the for loop using ## to concat.
  *	  - To assign to var it needs to be done in the condition of the for loop,
@@ -53,33 +80,49 @@ typedef struct ListCellAndListWrapper
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst(var ## CellDoNotUse)) || true); \
 		 var ## CellDoNotUse = lnext_compat(l, var ## CellDoNotUse))
-
+#endif
 
 /*
  * foreach_int -
  *	  a convenience macro which loops through an int list without needing a
- *	  ListCell, just a declared int variable to store the int of the cell in.
+ *	  ListCell or an index variable, just a declared int variable to store the
+ *	  iterated values.
  *	  For explanation of how it works see foreach_ptr.
  */
+#if PG_VERSION_NUM >= PG_VERSION_13
+#define foreach_int(var, l) \
+	for (int var ## PositionDoNotUse = 0; \
+		 (var ## PositionDoNotUse) < list_length(l) && \
+		 (((var) = list_nth_int(l, var ## PositionDoNotUse)) || true); \
+		 var ## PositionDoNotUse++)
+#else
 #define foreach_int(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_int(var ## CellDoNotUse)) || true); \
 		 var ## CellDoNotUse = lnext_compat(l, var ## CellDoNotUse))
-
+#endif
 
 /*
  * foreach_oid -
  *	  a convenience macro which loops through an oid list without needing a
- *	  ListCell, just a declared Oid variable to store the oid of the cell in.
+ *	  ListCell or an index variable, just a declared oid variable to store the
+ *	  iterated values.
  *	  For explanation of how it works see foreach_ptr.
  */
+#if PG_VERSION_NUM >= PG_VERSION_13
+#define foreach_oid(var, l) \
+	for (int var ## PositionDoNotUse = 0; \
+		 (var ## PositionDoNotUse) < list_length(l) && \
+		 (((var) = list_nth_oid(l, var ## PositionDoNotUse)) || true); \
+		 var ## PositionDoNotUse++)
+#else
 #define foreach_oid(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_oid(var ## CellDoNotUse)) || true); \
 		 var ## CellDoNotUse = lnext_compat(l, var ## CellDoNotUse))
-
+#endif
 
 /* utility functions declaration shared within this module */
 extern List * SortList(List *pointerList,


### PR DESCRIPTION
PG13 changed the representation of Lists to expansible arrays, not chains of cons-cells. A side effect is that if we add new elements to a list that does not have enough empty space, it has a risk of getting repalloc'ed. In PG13 the usual `foreach` macro depends on a simple pointer arithmetic on the array element that can potentially cause a segmentation fault in this scenario.

Details of this change on PostgreSQL can be seen in https://github.com/postgres/postgres/commit/1cff1b95ab6ddae32faa3efe0d95a820dbfdc164

Optional idea:
- Introduce a new macro or improve `foreach_ptr` to cover this scenario

Fixes #4288