### PR TITLE
Fix a flaky test in mixed_relkind_tests

### DIFF
--- a/src/test/regress/expected/mixed_relkind_tests.out
+++ b/src/test/regress/expected/mixed_relkind_tests.out
@@ -212,15 +212,15 @@ SELECT * FROM mat_view_on_dist UNION SELECT 1 ORDER BY 1;
 
 SET client_min_messages TO DEBUG1;
 -- can push down the union in subquery
-SELECT * FROM (SELECT * FROM partitioned_distributed_table UNION SELECT * FROM partitioned_distributed_table) AS foo;
+SELECT * FROM (SELECT * FROM partitioned_distributed_table UNION SELECT * FROM partitioned_distributed_table) AS foo ORDER BY 1,2;
  a | b
 ---------------------------------------------------------------------
- 1 | 2
- 5 | 6
- 4 | 5
- 3 | 4
  0 | 1
+ 1 | 2
  2 | 3
+ 3 | 4
+ 4 | 5
+ 5 | 6
 (6 rows)
 
 -- cannot push down the subquery, should evaluate subquery by creating a subplan

--- a/src/test/regress/sql/mixed_relkind_tests.sql
+++ b/src/test/regress/sql/mixed_relkind_tests.sql
@@ -78,7 +78,7 @@ SELECT * FROM mat_view_on_dist UNION SELECT 1 ORDER BY 1;
 SET client_min_messages TO DEBUG1;
 
 -- can push down the union in subquery
-SELECT * FROM (SELECT * FROM partitioned_distributed_table UNION SELECT * FROM partitioned_distributed_table) AS foo;
+SELECT * FROM (SELECT * FROM partitioned_distributed_table UNION SELECT * FROM partitioned_distributed_table) AS foo ORDER BY 1,2;
 
 -- cannot push down the subquery, should evaluate subquery by creating a subplan
 SELECT COUNT(*) FROM (SELECT b, random() FROM partitioned_distributed_table GROUP BY b) AS foo;


### PR DESCRIPTION
Introduced in https://github.com/citusdata/citus/pull/4294.

This was flaky:

```diff
+ test -f /home/circleci/project/build-11/src/test/regress/regression.diffs
+ cat /home/circleci/project/build-11/src/test/regress/regression.diffs
--- /home/circleci/project/src/test/regress/expected/mixed_relkind_tests.out.modified    2020-11-06 07:31:56.495259598 +0000
+++ /home/circleci/project/build-11/src/test/regress/results/mixed_relkind_tests.out.modified    2020-11-06 07:31:56.503259693 +0000
@@ -208,25 +208,25 @@
  a
 ---
  1
 (1 row)

 SET client_min_messages TO DEBUG1;
 -- can push down the union in subquery
 SELECT * FROM (SELECT * FROM partitioned_distributed_table UNION SELECT * FROM partitioned_distributed_table) AS foo;
  a | b
 ---+---
- 1 | 2
- 5 | 6
  4 | 5
  3 | 4
  0 | 1
+ 1 | 2
+ 5 | 6
  2 | 3
 (6 rows)
```