### PR TITLE
Move local execution after remote execution

### DIFF
--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -119,7 +119,6 @@ static void SplitLocalAndRemotePlacements(List *taskPlacementList,
 static uint64 ExecuteLocalTaskPlan(PlannedStmt *taskPlan, char *queryString,
 								   TupleDestination *tupleDest, Task *task,
 								   ParamListInfo paramListInfo);
-static int ActivePlacementCount(uint64 shardId);
 static void RecordNonDistTableAccessesForTask(Task *task);
 static void LogLocalCommand(Task *task);
 static uint64 LocallyPlanAndExecuteMultipleQueries(List *queryStrings,
@@ -561,26 +560,18 @@ ExecuteLocalTaskPlan(PlannedStmt *taskPlan, char *queryString,
 	QueryEnvironment *queryEnv = create_queryEnv();
 	int eflags = 0;
 	uint64 totalRowsProcessed = 0;
-	bool storeTuples = true;
 
 	RecordNonDistTableAccessesForTask(task);
 
 	/*
-	 * For modifications to reference tables (or any replicated table in
-	 * general), remote execution have already stored the tuples and
-	 * incremented es_processed, so skip now.
-	 */
-	if (task->partiallyLocalOrRemote && !ReadOnlyTask(task->taskType) &&
-		ActivePlacementCount(task->anchorShardId) > 1)
-	{
-		storeTuples = false;
-	}
-
-	/*
 	 * Use the tupleStore provided by the scanState because it is shared accross
 	 * the other task executions and the adaptive executor.
+	 *
+	 * Also note that as long as the tupleDest is provided, local execution always
+	 * stores the tuples. This is also valid for partiallyLocalOrRemote tasks
+	 * as well.
 	 */
-	DestReceiver *destReceiver = tupleDest && storeTuples ?
+	DestReceiver *destReceiver = tupleDest ?
 								 CreateTupleDestDestReceiver(tupleDest, task,
 															 LOCAL_PLACEMENT_INDEX) :
 								 CreateDestReceiver(DestNone);
@@ -598,7 +589,7 @@ ExecuteLocalTaskPlan(PlannedStmt *taskPlan, char *queryString,
 	 * We'll set the executorState->es_processed later, for now only remember
 	 * the count.
 	 */
-	if (taskPlan->commandType != CMD_SELECT && storeTuples)
+	if (taskPlan->commandType != CMD_SELECT)
 	{
 		totalRowsProcessed = queryDesc->estate->es_processed;
 	}
@@ -609,25 +600,6 @@ ExecuteLocalTaskPlan(PlannedStmt *taskPlan, char *queryString,
 	FreeQueryDesc(queryDesc);
 
 	return totalRowsProcessed;
-}
-
-
-/*
- * ActivePlacementCount gets a shardId and returns the number of
- * active placements. If the input shardId is INVALID_SHARD_ID,
- * the function returns 0.
- */
-static int
-ActivePlacementCount(uint64 shardId)
-{
-	if (shardId == INVALID_SHARD_ID)
-	{
-		return 0;
-	}
-
-	List *activeShardPlacementList = ActiveShardPlacementList(shardId);
-
-	return list_length(activeShardPlacementList);
 }
 
 

--- a/src/test/regress/expected/citus_local_tables_queries.out
+++ b/src/test/regress/expected/citus_local_tables_queries.out
@@ -984,7 +984,6 @@ NOTICE:  truncate cascades to table "reference_table"
 NOTICE:  truncate cascades to table "distributed_table"
 NOTICE:  executing the command locally: TRUNCATE TABLE citus_local_table_queries.citus_local_table_xxxxx CASCADE
 NOTICE:  truncate cascades to table "reference_table_xxxxx"
-NOTICE:  executing the command locally: TRUNCATE TABLE citus_local_table_queries.reference_table_xxxxx CASCADE
 ERROR:  cannot execute DDL on table "reference_table" because there was a parallel DDL access to distributed table "distributed_table" in the same transaction
 ROLLBACK;
 BEGIN;

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -186,7 +186,7 @@ NOTICE:  executing the command locally: INSERT INTO local_commands_test_schema.r
 BEGIN;
   CREATE TABLE ref_table_1(a int);
   SELECT create_reference_table('ref_table_1');
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500033, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.ref_table_1 (a integer)');SELECT worker_apply_shard_ddl_command (1500033, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.ref_table_1 OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500033, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.ref_table_1 (a integer) ');SELECT worker_apply_shard_ddl_command (1500033, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.ref_table_1 OWNER TO postgres')
  create_reference_table
 ---------------------------------------------------------------------
 
@@ -229,18 +229,6 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM local_comm
 
   TRUNCATE ref_table CASCADE;
 NOTICE:  truncate cascades to table "dist_table"
-NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.ref_table_xxxxx CASCADE
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
-NOTICE:  truncate cascades to table "dist_table_xxxxx"
 ERROR:  cannot execute DDL on table "ref_table" because there was a parallel SELECT access to distributed table "dist_table" in the same transaction
 COMMIT;
 -- as we do not support local ANALYZE execution yet, below block would error out
@@ -271,7 +259,7 @@ NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schem
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.dist_table_xxxxx CASCADE
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.dist_table_xxxxx CASCADE
   ANALYZE ref_table;
-ERROR:  cannot execute command because a local execution has accessed a placement in the transaction
+ERROR:  cannot switch local execution status from local execution required to local execution disabled since it can cause visibility problems in the current transaction
 COMMIT;
 -- insert some data
 INSERT INTO ref_table VALUES(7);
@@ -665,17 +653,17 @@ NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1
 NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500130, 'local_commands_test_schema', 'ALTER TABLE dist_table ALTER COLUMN c SET NOT NULL;')
   CREATE TABLE another_dist_table(a int);
   SELECT create_distributed_table('another_dist_table', 'a', colocate_with:='dist_table');
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
-NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer)');SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500133, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500136, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500139, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500142, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500145, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500148, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500151, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500154, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500157, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500160, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'CREATE TABLE local_commands_test_schema.another_dist_table (a integer) ');SELECT worker_apply_shard_ddl_command (1500163, 'local_commands_test_schema', 'ALTER TABLE local_commands_test_schema.another_dist_table OWNER TO postgres')
  create_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/local_shard_utility_command_execution.out
+++ b/src/test/regress/expected/local_shard_utility_command_execution.out
@@ -259,7 +259,7 @@ NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schem
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.dist_table_xxxxx CASCADE
 NOTICE:  executing the command locally: TRUNCATE TABLE local_commands_test_schema.dist_table_xxxxx CASCADE
   ANALYZE ref_table;
-ERROR:  cannot switch local execution status from local execution required to local execution disabled since it can cause visibility problems in the current transaction
+ERROR:  cannot execute command because a local execution has accessed a placement in the transaction
 COMMIT;
 -- insert some data
 INSERT INTO ref_table VALUES(7);

--- a/src/test/regress/expected/tableam.out
+++ b/src/test/regress/expected/tableam.out
@@ -131,6 +131,7 @@ SELECT * FROM master_get_table_ddl_events('test_ref');
 
 -- replicate to coordinator
 SET client_min_messages TO WARNING;
+\set VERBOSIY terse
 SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
  ?column?
 ---------------------------------------------------------------------
@@ -140,7 +141,9 @@ SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
 RESET client_min_messages;
 delete from test_ref;
 WARNING:  fake_scan_getnextslot
+DETAIL:  from localhost:xxxxx
 ERROR:  fake_tuple_delete not implemented
+CONTEXT:  while executing command on localhost:xxxxx
 SELECT master_remove_node('localhost', :master_port);
  master_remove_node
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/tableam.sql
+++ b/src/test/regress/sql/tableam.sql
@@ -64,6 +64,7 @@ SELECT * FROM master_get_table_ddl_events('test_ref');
 
 -- replicate to coordinator
 SET client_min_messages TO WARNING;
+\set VERBOSIY terse
 SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
 RESET client_min_messages;
 delete from test_ref;


### PR DESCRIPTION
Before this commit, when both local and remote tasks
exist, the executor was starting the execution with
local execution. There is no strict requirements on
this.

Especially considering the adaptive connection management
improvements that we plan to roll soon, moving the local
execution after to the remote execution makes more sense.

The adaptive connection management for single node Citus
would look roughly as follows:

   - Try to connect back to the coordinator for running
     parallel queries.
        - If succeeds, go on and execute tasks in parallel
        - If fails, fallback to the local execution

So, we'll use local execution as a fallback mechanism. And,
moving it after to the remote execution allows us to implement
such further scenarios.
