### PR TITLE
Add a public.citus_tables view

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -367,14 +367,6 @@ ErrorIfNotSuitableToGetSize(Oid relationId)
 						errmsg("cannot calculate the size because relation %s is not "
 							   "distributed", escapedQueryString)));
 	}
-
-	if (IsCitusTableType(relationId, HASH_DISTRIBUTED) &&
-		!SingleReplicatedTable(relationId))
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot calculate the size because replication factor "
-							   "is greater than 1")));
-	}
 }
 
 

--- a/src/backend/distributed/sql/citus--9.5-1--10.0-1.sql
+++ b/src/backend/distributed/sql/citus--9.5-1--10.0-1.sql
@@ -1,7 +1,6 @@
 -- citus--9.5-1--10.0-1
 
--- bump version to 10.0-1
-
+#include "udfs/citus_tables/10.0-1.sql"
 #include "udfs/citus_finish_pg_upgrade/10.0-1.sql"
 
 #include "../../columnar/sql/columnar--9.5-1--10.0-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--10.0-1--9.5-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.0-1--9.5-1.sql
@@ -4,3 +4,5 @@
 #include "../udfs/citus_finish_pg_upgrade/9.5-1.sql"
 
 #include "../../../columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql"
+
+DROP VIEW public.citus_tables;

--- a/src/backend/distributed/sql/udfs/citus_tables/10.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/10.0-1.sql
@@ -1,0 +1,20 @@
+CREATE VIEW public.citus_tables AS
+SELECT
+  logicalrelid AS "Name",
+  CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS "Citus Table Type",
+  coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS "Distribution Column",
+  colocationid AS "Colocation ID",
+  pg_size_pretty(citus_total_relation_size(logicalrelid)) AS "Size",
+  (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS "Shard Count",
+  pg_get_userbyid(relowner) AS "Owner",
+  amname AS "Access Method"
+FROM
+  pg_dist_partition p
+JOIN
+  pg_class c ON (p.logicalrelid = c.oid)
+LEFT JOIN
+  pg_am a ON (a.oid = c.relam)
+WHERE
+  partkey IS NOT NULL OR repmodel = 't'
+ORDER BY
+  logicalrelid::text;

--- a/src/backend/distributed/sql/udfs/citus_tables/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/latest.sql
@@ -1,0 +1,20 @@
+CREATE VIEW public.citus_tables AS
+SELECT
+  logicalrelid AS "Name",
+  CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS "Citus Table Type",
+  coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS "Distribution Column",
+  colocationid AS "Colocation ID",
+  pg_size_pretty(citus_total_relation_size(logicalrelid)) AS "Size",
+  (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS "Shard Count",
+  pg_get_userbyid(relowner) AS "Owner",
+  amname AS "Access Method"
+FROM
+  pg_dist_partition p
+JOIN
+  pg_class c ON (p.logicalrelid = c.oid)
+LEFT JOIN
+  pg_am a ON (a.oid = c.relam)
+WHERE
+  partkey IS NOT NULL OR repmodel = 't'
+ORDER BY
+  logicalrelid::text;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -82,18 +82,19 @@ FROM test.maintenance_worker();
  regression | regression       | postgres | postgres
 (1 row)
 
--- ensure no objects were created outside pg_catalog
-SELECT COUNT(*)
+-- ensure no unexpected objects were created outside pg_catalog
+SELECT pgio.type, pgio.identity
 FROM pg_depend AS pgd,
 	 pg_extension AS pge,
 	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore');
- count
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore')
+ORDER BY 1, 2;
+ type |      identity
 ---------------------------------------------------------------------
-     0
+ view | public.citus_tables
 (1 row)
 
 -- DROP EXTENSION pre-created by the regression suite
@@ -487,7 +488,8 @@ SELECT * FROM print_extension_changes();
                  | table cstore.cstore_skipnodes
                  | table cstore.cstore_stripes
                  | table cstore.options
-(10 rows)
+                 | view citus_tables
+(11 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version
@@ -497,18 +499,19 @@ SHOW citus.version;
  10.0devel
 (1 row)
 
--- ensure no objects were created outside pg_catalog
-SELECT COUNT(*)
+-- ensure no unexpected objects were created outside pg_catalog
+SELECT pgio.type, pgio.identity
 FROM pg_depend AS pgd,
 	 pg_extension AS pge,
 	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore');
- count
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore')
+ORDER BY 1, 2;
+ type |      identity
 ---------------------------------------------------------------------
-     0
+ view | public.citus_tables
 (1 row)
 
 -- see incompatible version errors out
@@ -593,10 +596,11 @@ SET citus.enable_version_checks TO 'true';
 ALTER EXTENSION citus UPDATE;
 -- if cache is invalidated succesfull, this \d should work without any problem
 \d
-      List of relations
- Schema | Name | Type | Owner
+            List of relations
+ Schema |     Name     | Type |  Owner
 ---------------------------------------------------------------------
-(0 rows)
+ public | citus_tables | view | postgres
+(1 row)
 
 \c - - - :master_port
 -- test https://github.com/citusdata/citus/issues/3409

--- a/src/test/regress/expected/multi_extension_0.out
+++ b/src/test/regress/expected/multi_extension_0.out
@@ -82,18 +82,19 @@ FROM test.maintenance_worker();
  regression | regression       | postgres | postgres
 (1 row)
 
--- ensure no objects were created outside pg_catalog
-SELECT COUNT(*)
+-- ensure no unexpected objects were created outside pg_catalog
+SELECT pgio.type, pgio.identity
 FROM pg_depend AS pgd,
 	 pg_extension AS pge,
 	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore');
- count
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore')
+ORDER BY 1, 2;
+ type |      identity
 ---------------------------------------------------------------------
-     0
+ view | public.citus_tables
 (1 row)
 
 -- DROP EXTENSION pre-created by the regression suite
@@ -483,7 +484,8 @@ SELECT * FROM print_extension_changes();
                  | table cstore.cstore_skipnodes
                  | table cstore.cstore_stripes
                  | table cstore.options
-(6 rows)
+                 | view citus_tables
+(7 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version
@@ -493,18 +495,19 @@ SHOW citus.version;
  10.0devel
 (1 row)
 
--- ensure no objects were created outside pg_catalog
-SELECT COUNT(*)
+-- ensure no unexpected objects were created outside pg_catalog
+SELECT pgio.type, pgio.identity
 FROM pg_depend AS pgd,
 	 pg_extension AS pge,
 	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore');
- count
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore')
+ORDER BY 1, 2;
+ type |      identity
 ---------------------------------------------------------------------
-     0
+ view | public.citus_tables
 (1 row)
 
 -- see incompatible version errors out
@@ -589,10 +592,11 @@ SET citus.enable_version_checks TO 'true';
 ALTER EXTENSION citus UPDATE;
 -- if cache is invalidated succesfull, this \d should work without any problem
 \d
-      List of relations
- Schema | Name | Type | Owner
+            List of relations
+ Schema |     Name     | Type |  Owner
 ---------------------------------------------------------------------
-(0 rows)
+ public | citus_tables | view | postgres
+(1 row)
 
 \c - - - :master_port
 -- test https://github.com/citusdata/citus/issues/3409

--- a/src/test/regress/expected/multi_mx_create_table.out
+++ b/src/test/regress/expected/multi_mx_create_table.out
@@ -484,3 +484,65 @@ ORDER BY colocationid, logicalrelid;
  articles_single_shard_hash_mx                          |      1390011 |           1 | h          | s
 (23 rows)
 
+-- check the citus_tables view
+SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+FROM citus_tables
+ORDER BY "Name"::text;
+                          Name                          | Citus Table Type | Distribution Column | Shard Count |  Owner
+---------------------------------------------------------------------
+ app_analytics_events_mx                                | distributed      | app_id              |           4 | postgres
+ articles_hash_mx                                       | distributed      | author_id           |           2 | postgres
+ articles_single_shard_hash_mx                          | distributed      | author_id           |           1 | postgres
+ citus_mx_test_schema.nation_hash                       | distributed      | n_nationkey         |          16 | postgres
+ citus_mx_test_schema.nation_hash_collation_search_path | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema.nation_hash_composite_types       | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema_join_1.nation_hash                | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema_join_1.nation_hash_2              | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema_join_2.nation_hash                | distributed      | n_nationkey         |           4 | postgres
+ company_employees_mx                                   | distributed      | company_id          |           4 | postgres
+ customer_mx                                            | reference        | <none>              |           1 | postgres
+ labs_mx                                                | distributed      | id                  |           1 | postgres
+ limit_orders_mx                                        | distributed      | id                  |           2 | postgres
+ lineitem_mx                                            | distributed      | l_orderkey          |          16 | postgres
+ multiple_hash_mx                                       | distributed      | category            |           2 | postgres
+ mx_ddl_table                                           | distributed      | key                 |           4 | postgres
+ nation_hash                                            | distributed      | n_nationkey         |          16 | postgres
+ nation_mx                                              | reference        | <none>              |           1 | postgres
+ objects_mx                                             | distributed      | id                  |           1 | postgres
+ orders_mx                                              | distributed      | o_orderkey          |          16 | postgres
+ part_mx                                                | reference        | <none>              |           1 | postgres
+ researchers_mx                                         | distributed      | lab_id              |           2 | postgres
+ supplier_mx                                            | reference        | <none>              |           1 | postgres
+(23 rows)
+
+\c - - - :worker_1_port
+SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+FROM citus_tables
+ORDER BY "Name"::text;
+                          Name                          | Citus Table Type | Distribution Column | Shard Count |  Owner
+---------------------------------------------------------------------
+ app_analytics_events_mx                                | distributed      | app_id              |           4 | postgres
+ articles_hash_mx                                       | distributed      | author_id           |           2 | postgres
+ articles_single_shard_hash_mx                          | distributed      | author_id           |           1 | postgres
+ citus_mx_test_schema.nation_hash                       | distributed      | n_nationkey         |          16 | postgres
+ citus_mx_test_schema.nation_hash_collation_search_path | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema.nation_hash_composite_types       | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema_join_1.nation_hash                | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema_join_1.nation_hash_2              | distributed      | n_nationkey         |           4 | postgres
+ citus_mx_test_schema_join_2.nation_hash                | distributed      | n_nationkey         |           4 | postgres
+ company_employees_mx                                   | distributed      | company_id          |           4 | postgres
+ customer_mx                                            | reference        | <none>              |           1 | postgres
+ labs_mx                                                | distributed      | id                  |           1 | postgres
+ limit_orders_mx                                        | distributed      | id                  |           2 | postgres
+ lineitem_mx                                            | distributed      | l_orderkey          |          16 | postgres
+ multiple_hash_mx                                       | distributed      | category            |           2 | postgres
+ mx_ddl_table                                           | distributed      | key                 |           4 | postgres
+ nation_hash                                            | distributed      | n_nationkey         |          16 | postgres
+ nation_mx                                              | reference        | <none>              |           1 | postgres
+ objects_mx                                             | distributed      | id                  |           1 | postgres
+ orders_mx                                              | distributed      | o_orderkey          |          16 | postgres
+ part_mx                                                | reference        | <none>              |           1 | postgres
+ researchers_mx                                         | distributed      | lab_id              |           2 | postgres
+ supplier_mx                                            | reference        | <none>              |           1 | postgres
+(23 rows)
+

--- a/src/test/regress/expected/multi_size_queries.out
+++ b/src/test/regress/expected/multi_size_queries.out
@@ -22,12 +22,25 @@ SELECT citus_total_relation_size('non_distributed_table');
 ERROR:  cannot calculate the size because relation 'non_distributed_table' is not distributed
 DROP TABLE non_distributed_table;
 -- Tests on distributed table with replication factor > 1
+VACUUM (FULL) lineitem_hash_part;
 SELECT citus_table_size('lineitem_hash_part');
-ERROR:  cannot calculate the size because replication factor is greater than 1
+ citus_table_size
+---------------------------------------------------------------------
+          3801088
+(1 row)
+
 SELECT citus_relation_size('lineitem_hash_part');
-ERROR:  cannot calculate the size because replication factor is greater than 1
+ citus_relation_size
+---------------------------------------------------------------------
+             3801088
+(1 row)
+
 SELECT citus_total_relation_size('lineitem_hash_part');
-ERROR:  cannot calculate the size because replication factor is greater than 1
+ citus_total_relation_size
+---------------------------------------------------------------------
+                   3801088
+(1 row)
+
 VACUUM (FULL) customer_copy_hash;
 -- Tests on distributed tables with streaming replication.
 SELECT citus_table_size('customer_copy_hash');

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -215,7 +215,8 @@ ORDER BY 1;
  view citus_shard_indexes_on_worker
  view citus_shards_on_worker
  view citus_stat_statements
+ view citus_tables
  view citus_worker_stat_activity
  view pg_dist_shard_placement
-(201 rows)
+(202 rows)
 

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -211,7 +211,8 @@ ORDER BY 1;
  view citus_shard_indexes_on_worker
  view citus_shards_on_worker
  view citus_stat_statements
+ view citus_tables
  view citus_worker_stat_activity
  view pg_dist_shard_placement
-(197 rows)
+(198 rows)
 

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -80,15 +80,16 @@ SELECT datname, current_database(),
     usename, (SELECT extowner::regrole::text FROM pg_extension WHERE extname = 'citus')
 FROM test.maintenance_worker();
 
--- ensure no objects were created outside pg_catalog
-SELECT COUNT(*)
+-- ensure no unexpected objects were created outside pg_catalog
+SELECT pgio.type, pgio.identity
 FROM pg_depend AS pgd,
 	 pg_extension AS pge,
 	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore');
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore')
+ORDER BY 1, 2;
 
 
 -- DROP EXTENSION pre-created by the regression suite
@@ -235,15 +236,16 @@ DROP TABLE prev_objects, extension_diff;
 -- show running version
 SHOW citus.version;
 
--- ensure no objects were created outside pg_catalog
-SELECT COUNT(*)
+-- ensure no unexpected objects were created outside pg_catalog
+SELECT pgio.type, pgio.identity
 FROM pg_depend AS pgd,
 	 pg_extension AS pge,
 	 LATERAL pg_identify_object(pgd.classid, pgd.objid, pgd.objsubid) AS pgio
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore');
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'cstore')
+ORDER BY 1, 2;
 
 -- see incompatible version errors out
 RESET citus.enable_version_checks;

--- a/src/test/regress/sql/multi_mx_create_table.sql
+++ b/src/test/regress/sql/multi_mx_create_table.sql
@@ -427,3 +427,16 @@ WITH shard_counts AS (
 SELECT logicalrelid, colocationid, shard_count, partmethod, repmodel
 FROM pg_dist_partition NATURAL JOIN shard_counts
 ORDER BY colocationid, logicalrelid;
+
+-- check the citus_tables view
+SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+FROM citus_tables
+ORDER BY "Name"::text;
+
+\c - - - :worker_1_port
+
+SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+FROM citus_tables
+ORDER BY "Name"::text;
+
+

--- a/src/test/regress/sql/multi_size_queries.sql
+++ b/src/test/regress/sql/multi_size_queries.sql
@@ -20,6 +20,8 @@ SELECT citus_total_relation_size('non_distributed_table');
 DROP TABLE non_distributed_table;
 
 -- Tests on distributed table with replication factor > 1
+VACUUM (FULL) lineitem_hash_part;
+
 SELECT citus_table_size('lineitem_hash_part');
 SELECT citus_relation_size('lineitem_hash_part');
 SELECT citus_total_relation_size('lineitem_hash_part');


### PR DESCRIPTION
DESCRIPTION: Adds a public.citus_tables view

Proposal for adding an easily-discovered view that shows all Citus tables and their sizes in a human readable format.

```sql
postgres=# \d
           List of relations
 Schema |     Name     | Type  | Owner 
--------+--------------+-------+-------
 public | citus_tables | view  | marco
 public | local        | table | marco
 public | ref          | table | marco
 public | test         | table | marco
(4 rows)

postgres=# table citus_tables;
┌──────────┬──────────────────┬─────────────────────┬───────────────┬─────────┬─────────────┬───────┬───────────────┐
│   Name   │ Citus Table Type │ Distribution Column │ Colocation ID │  Size   │ Shard Count │ Owner │ Access Method │
├──────────┼──────────────────┼─────────────────────┼───────────────┼─────────┼─────────────┼───────┼───────────────┤
│ foo.test │ distributed      │ x                   │             1 │ 0 bytes │          32 │ marco │ heap          │
│ ref      │ reference        │ <none>              │             2 │ 24 GB   │           1 │ marco │ heap          │
│ test     │ distributed      │ x                   │             1 │ 248 TB  │          32 │ marco │ heap          │
└──────────┴──────────────────┴─────────────────────┴───────────────┴─────────┴─────────────┴───────┴───────────────┘
(3 rows)
```
