### PR TITLE
add placeholder for enterprise modules

### DIFF
--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -19,6 +19,8 @@ DATA_built = $(generated_sql_files)
 
 # directories with source files
 SUBDIRS = . commands connection ddl deparser executor metadata operations planner progress relay safeclib test transaction utils worker
+# enterprise modules
+SUBDIRS +=
 
 # Symlinks are not copied over to the build directory if a separete build
 # directory is used during configure (such as on CI)


### PR DESCRIPTION
We often have merge conflicts on the difference in the modules we compile for enterprise and community. This makes the merge of cstore harder and resulted in conflicts here. Due to the complexity the merge already is I moved most of the conflicts.

With this PR we add a placeholder for enterprise modules. In the enterprise repo we can add our enterprise specific modules to this placeholder. This removes any conflicts we might have when adding new modules to the community version or the enterprise source.

By design, this PR conflicts with enterprise :D will create an enterprise PR linking here to show how this will prevent future conflicts