### PR TITLE
Make sure to properly terminate not fully established connections

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2228,7 +2228,7 @@ RunDistributedExecution(DistributedExecution *execution)
 		/* always (re)build the wait event set the first time */
 		execution->rebuildWaitEventSet = true;
 
-		while (execution->unfinishedTaskCount > 0 && !cancellationReceived)
+		while (execution->unfinishedTaskCount > 0)
 		{
 			WorkerPool *workerPool = NULL;
 			foreach_ptr(workerPool, execution->workerList)
@@ -2269,6 +2269,11 @@ RunDistributedExecution(DistributedExecution *execution)
 			int eventCount = WaitEventSetWait(execution->waitEventSet, timeout, events,
 											  eventSetSize, WAIT_EVENT_CLIENT_READ);
 			ProcessWaitEvents(execution, events, eventCount, &cancellationReceived);
+			if (cancellationReceived)
+			{
+				/* user requested cancel, do not continue the execution */
+				break;
+			}
 		}
 
 		if (events != NULL)

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -413,6 +413,10 @@ typedef struct WorkerPool
 	 * use it anymore.
 	 */
 	WorkerPoolFailureState failureState;
+
+
+	double totalTaskExecutionTime;
+	int totalExecutedTasks;
 } WorkerPool;
 
 struct TaskPlacementExecution;
@@ -586,6 +590,10 @@ typedef struct TaskPlacementExecution
 
 	/* index in array of placement executions in a ShardCommandExecution */
 	int placementExecutionIndex;
+
+	TimestampTz executionStartTime;
+	TimestampTz executionEndTime;
+
 } TaskPlacementExecution;
 
 
@@ -630,6 +638,8 @@ static WorkerSession * FindOrCreateWorkerSession(WorkerPool *workerPool,
 static void ManageWorkerPool(WorkerPool *workerPool);
 static bool ShouldWaitForSlowStart(WorkerPool *workerPool);
 static int CalculateNewConnectionCount(WorkerPool *workerPool);
+static double AvgConnectionEstTimes(WorkerPool *workerPool);
+static double AvgTaskExecutionTimes(WorkerPool *workerPool);
 static void OpenNewConnections(WorkerPool *workerPool, int newConnectionCount,
 							   TransactionProperties *transactionProperties);
 static void CheckConnectionTimeout(WorkerPool *workerPool);
@@ -1649,6 +1659,8 @@ CleanUpSessions(DistributedExecution *execution)
 								session->sessionId, session->commandsSent)));
 
 		UnclaimConnection(connection);
+		if (connection->connectionState == MULTI_CONNECTION_CONNECTING)
+			elog(INFO, "connectting: %ld", session->sessionId);
 
 		if (connection->connectionState == MULTI_CONNECTION_CONNECTING ||
 			connection->connectionState == MULTI_CONNECTION_FAILED ||
@@ -2248,8 +2260,7 @@ RunDistributedExecution(DistributedExecution *execution)
 		 * irrespective of the current status of the tasks or the connections.
 		 */
 		while (!cancellationReceived &&
-			   (execution->unfinishedTaskCount > 0 ||
-				HasIncompleteConnectionEstablishment(execution)))
+			   execution->unfinishedTaskCount > 0)
 		{
 			WorkerPool *workerPool = NULL;
 			foreach_ptr(workerPool, execution->workerList)
@@ -2640,6 +2651,20 @@ CalculateNewConnectionCount(WorkerPool *workerPool)
 		newConnectionCount = Min(newConnectionsForReadyTasks, maxNewConnectionCount);
 		if (newConnectionCount > 0)
 		{
+			double avgConnTime = AvgConnectionEstTimes(workerPool);
+			double avgTaskExecutionTime = AvgTaskExecutionTimes(workerPool);
+
+			double expectedRemainingTaskExecutionTime =
+					(readyTaskCount * avgTaskExecutionTime) / (initiatedConnectionCount == 0 ? 1 : initiatedConnectionCount);
+
+			elog(INFO, "%f = %f - %f", avgConnTime, avgTaskExecutionTime, expectedRemainingTaskExecutionTime);
+			if (expectedRemainingTaskExecutionTime < avgConnTime)
+			{
+
+				elog(INFO, "yay");
+				return 0;
+			}
+
 			/* increase the open rate every cycle (like TCP slow start) */
 			workerPool->maxNewConnectionsPerCycle += 1;
 		}
@@ -2647,6 +2672,49 @@ CalculateNewConnectionCount(WorkerPool *workerPool)
 	return newConnectionCount;
 }
 
+
+static double
+AvgTaskExecutionTimes(WorkerPool *workerPool)
+{
+
+	if (workerPool->totalExecutedTasks == 0)
+		return 10000;
+
+	return workerPool->totalTaskExecutionTime / workerPool->totalExecutedTasks;
+}
+
+
+static
+double AvgConnectionEstTimes(WorkerPool *workerPool)
+{
+	double totalTimeUsec = 0;
+	int sessionCount = 0;
+
+
+	WorkerSession *session = NULL;
+	foreach_ptr(session, workerPool->sessionList)
+	{
+		MultiConnection *connection = session->connection;
+
+		if (connection->connectionState == MULTI_CONNECTION_CONNECTED)
+		{
+			long	 secs = 0;
+			int usecs = 0;
+
+			TimestampDifference(connection->connectionStart,
+								connection->connectionEnd,
+								&secs, &usecs);
+
+			totalTimeUsec += usecs;
+			++sessionCount;
+		}
+	}
+
+	if (sessionCount > 0)
+		return totalTimeUsec / sessionCount;
+
+	return 0;
+}
 
 /*
  * OpenNewConnections opens the given amount of connections for the given workerPool.
@@ -3244,6 +3312,27 @@ HandleMultiConnectionSuccess(WorkerSession *session)
 
 	workerPool->activeConnectionCount++;
 	workerPool->idleConnectionCount++;
+
+	if (connection->connectionEnd == 0)
+	{
+		connection->connectionEnd = GetCurrentTimestamp();
+
+		if (IsLoggableLevel(DEBUG4))
+		{
+			/* this code-block is inspired from log_disconnections() */
+			long	 secs = 0;
+			int usecs = 0;
+
+			TimestampDifference(connection->connectionStart,
+								connection->connectionEnd,
+								&secs, &usecs);
+			int msecs = usecs / 1000;
+
+			ereport(DEBUG4,
+					(errmsg("Connection establishment time for session %ld: "
+							"%03d msecs", session->sessionId, msecs)));
+		}
+	}
 }
 
 
@@ -3771,6 +3860,8 @@ StartPlacementExecutionOnSession(TaskPlacementExecution *placementExecution,
 			 */
 			SetLocalExecutionStatus(LOCAL_EXECUTION_DISABLED);
 		}
+
+		placementExecution->executionStartTime = GetCurrentTimestamp();
 	}
 
 	return querySent;
@@ -4349,6 +4440,29 @@ PlacementExecutionDone(TaskPlacementExecution *placementExecution, bool succeede
 	{
 		/* mark the placement execution as finished */
 		placementExecution->executionState = PLACEMENT_EXECUTION_FINISHED;
+
+		placementExecution->executionEndTime = GetCurrentTimestamp();
+
+		if (true)
+		{
+			/* this code-block is inspired from log_disconnections() */
+			long	 secs = 0;
+			int usecs = 0;
+
+			TimestampDifference(placementExecution->executionStartTime,
+					placementExecution->executionEndTime,
+								&secs, &usecs);
+			int msecs = usecs / 1000;
+
+			if(IsLoggableLevel(DEBUG4))
+			ereport(DEBUG4,
+					(errmsg("Task execution time for task %d: "
+							"%03d msecs", placementExecution->shardCommandExecution->task->taskId, msecs)));
+
+			workerPool->totalTaskExecutionTime += usecs;
+			workerPool->totalExecutedTasks += 1;
+		}
+
 	}
 	else if (CanFailoverPlacementExecutionToLocalExecution(placementExecution))
 	{

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -133,8 +133,9 @@ typedef struct MultiConnection
 	/* is the connection currently in use, and shouldn't be used by anything else */
 	bool claimedExclusively;
 
-	/* time connection establishment was started, for timeout */
+	/* time connection establishment was started & ended, for executor stats */
 	TimestampTz connectionStart;
+	TimestampTz connectionEnd;
 
 	/* membership in list of list of connections in ConnectionHashEntry */
 	dlist_node connectionNode;

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -104,11 +104,15 @@ SELECT name FROM r1 WHERE id = 2;
 
 -- verify a connection attempt was made to the intercepted node, this would have cause the
 -- connection to have been delayed and thus caused a timeout
-SELECT citus.dump_network_traffic();
-        dump_network_traffic
+-- Still, even if Citus does not use that connection, the establishment
+-- is finished. If Citus terminates the connection before it is fully
+-- established (or failed), Postgres would complain that
+SELECT conn, source FROM citus.dump_network_traffic() ORDER BY 1,2;
+ conn |   source
 ---------------------------------------------------------------------
- (0,coordinator,"[initial message]")
-(1 row)
+    0 | coordinator
+    0 | worker
+(2 rows)
 
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
@@ -140,13 +144,30 @@ SELECT count(*) FROM products;
      0
 (1 row)
 
+<<<<<<< HEAD
 -- use OFFSET 1 to prevent printing the line where source
 -- is the worker, and LIMIT 1 in case there were multiple connections
 SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
         dump_network_traffic
+=======
+-- verify all connection attempts was made to the intercepted node, this would have cause the
+-- first connection to have been delayed and thus caused a timeout
+-- Still, even if Citus does not use those connections, the establishments
+-- are finished. If Citus terminates the connection before it is fully
+-- established (or failed), Postgres would complain that
+SELECT conn, source FROM citus.dump_network_traffic() ORDER BY 1, 2;
+ conn |   source
+>>>>>>> 74d7c2b05... Make sure to properly terimate connections
 ---------------------------------------------------------------------
- (1,coordinator,"[initial message]")
-(1 row)
+    1 | coordinator
+    1 | worker
+    2 | coordinator
+    2 | worker
+    3 | coordinator
+    3 | worker
+    4 | coordinator
+    4 | worker
+(8 rows)
 
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -66,7 +66,10 @@ SELECT name FROM r1 WHERE id = 2;
 
 -- verify a connection attempt was made to the intercepted node, this would have cause the
 -- connection to have been delayed and thus caused a timeout
-SELECT citus.dump_network_traffic();
+-- Still, even if Citus does not use that connection, the establishment
+-- is finished. If Citus terminates the connection before it is fully
+-- established (or failed), Postgres would complain that
+SELECT conn, source FROM citus.dump_network_traffic() ORDER BY 1,2;
 
 SELECT citus.mitmproxy('conn.allow()');
 
@@ -80,9 +83,12 @@ SELECT citus.mitmproxy('conn.delay(500)');
 SELECT count(*) FROM products;
 SELECT count(*) FROM products;
 
--- use OFFSET 1 to prevent printing the line where source
--- is the worker, and LIMIT 1 in case there were multiple connections
-SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
+-- verify all connection attempts was made to the intercepted node, this would have cause the
+-- first connection to have been delayed and thus caused a timeout
+-- Still, even if Citus does not use those connections, the establishments
+-- are finished. If Citus terminates the connection before it is fully
+-- established (or failed), Postgres would complain that
+SELECT conn, source FROM citus.dump_network_traffic() ORDER BY 1, 2;
 
 SELECT citus.mitmproxy('conn.allow()');
 SET citus.shard_replication_factor TO 1;


### PR DESCRIPTION

Comment from the code:
```C
/*
 * Iterate until all the tasks are finished. Once all the tasks
 * are finished, ensure that that all the connection initializations
 * are also finished. Otherwise, those connections are terminated
 * abruptly before they are established (or failed). Instead, we let
 * the ConnectionStateMachine() to properly handle them.
 *
 * Note that we could have the connections that are not established
 * as a side effect of slow-start algorithm. At the time the algorithm
 * decides to establish new connections, the execution might have tasks
 * to finish. But, the execution might finish before the new connections
 * are established.
 */
```

 Note that the abruptly terminated connections lead to the following errors:
```
2020-11-16 21:09:09.800 CET [16633] LOG:  could not accept SSL connection: Connection reset by peer
2020-11-16 21:09:09.872 CET [16657] LOG:  could not accept SSL connection: Undefined error: 0
2020-11-16 21:09:09.894 CET [16667] LOG:  could not accept SSL connection: Connection reset by peer
```


To easily reproduce the issue:

- Create a single node Citus
- Add the coordinator to the metadata
- Create a distributed table with shards on the coordinator
- f.sql:  select count(*) from test;
-` pgbench -f /tmp/f.sql postgres -T 12 -c 40 -P 1 ` or `pgbench -f /tmp/f.sql postgres -T 12 -c 40 -P 1 -C` or anything else
