### PR TITLE
Enable parallel query on EXPLAIN ANALYZE

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1063,7 +1063,7 @@ worker_save_query_explain_analyze(PG_FUNCTION_ARGS)
 
 	INSTR_TIME_SET_CURRENT(planStart);
 
-	PlannedStmt *plan = pg_plan_query_compat(query, NULL, 0, NULL);
+	PlannedStmt *plan = pg_plan_query_compat(query, NULL, CURSOR_OPT_PARALLEL_OK, NULL);
 
 	INSTR_TIME_SET_CURRENT(planDuration);
 	INSTR_TIME_SUBTRACT(planDuration, planStart);


### PR DESCRIPTION
It seems that we forgot to pass the relevant
flag to enable Postgres' parallel query
capabilities on the shards when user does
EXPLAIN ANALYZE on a distributed table.

DESCRIPTION: Enable Postgres' parallel query on EXPLAIN ANALYZE

Fixes #4314 

Reproduced the issue mentioned on #4314 with regular 
partitioned tables, and verified that it is fixed now. 

It is kind of hard to add tests for this change as they
might become flaky tests unless we load lots of data
or create lots of partitions. So, the latter alternative is
not great for the test execution times.