### PR TITLE
refactor options to their own table linked to the regclass

### DIFF
--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -550,13 +550,7 @@ cstore_relation_set_new_filenode(Relation rel,
 	SMgrRelation srel = RelationCreateStorage(*newrnode, persistence);
 	InitCStoreDataFileMetadata(newrnode->relNode);
 
-	/* populate with default options */
-	ColumnarOptions defaultOptions = {
-		.blockRowCount = cstore_block_row_count,
-		.stripeRowCount = cstore_stripe_row_count,
-		.compressionType = cstore_compression
-	};
-	SetColumnarOptions(rel->rd_id, &defaultOptions);
+	InitColumnarOptions(rel->rd_id);
 
 	smgrclose(srel);
 }

--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -1173,6 +1173,7 @@ CStoreTableAMObjectAccessHook(ObjectAccessType access, Oid classId, Oid objectId
 		Relation rel = table_open(objectId, AccessExclusiveLock);
 		Oid relfilenode = rel->rd_node.relNode;
 		DeleteDataFileMetadataRowIfExists(relfilenode);
+		DeleteColumnarTableOptions(rel->rd_id, true);
 
 		MarkRelfilenodeDropped(relfilenode, GetCurrentSubTransactionId());
 

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -3,11 +3,17 @@
 CREATE SCHEMA cstore;
 SET search_path TO cstore;
 
-CREATE TABLE cstore_data_files (
-    relfilenode oid NOT NULL,
+CREATE TABLE options (
+    regclass regclass NOT NULL PRIMARY KEY,
     block_row_count int NOT NULL,
     stripe_row_count int NOT NULL,
-    compression name NOT NULL,
+    compression name NOT NULL
+);
+
+COMMENT ON TABLE options IS 'columnar table specific options, maintained by alter_columnar_table_set';
+
+CREATE TABLE cstore_data_files (
+    relfilenode oid NOT NULL,
     version_major bigint NOT NULL,
     version_minor bigint NOT NULL,
     PRIMARY KEY (relfilenode)
@@ -48,16 +54,6 @@ CREATE TABLE cstore_skipnodes (
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE cstore_skipnodes IS 'CStore per block metadata';
-
-CREATE VIEW columnar_options AS
-SELECT c.oid::regclass regclass,
-       d.block_row_count,
-       d.stripe_row_count,
-       d.compression
-FROM pg_class c
-JOIN cstore.cstore_data_files d USING(relfilenode);
-
-COMMENT ON VIEW columnar_options IS 'CStore per table settings';
 
 DO $proc$
 BEGIN

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -27,10 +27,10 @@ IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
 END IF;
 END$proc$;
 
-DROP VIEW columnar_options;
 DROP TABLE cstore_skipnodes;
 DROP TABLE cstore_stripes;
 DROP TABLE cstore_data_files;
+DROP TABLE options;
 
 DROP FUNCTION citus_internal.cstore_ensure_objects_exist();
 

--- a/src/include/columnar/cstore.h
+++ b/src/include/columnar/cstore.h
@@ -287,6 +287,7 @@ extern char * CompressionTypeStr(CompressionType type);
 /* cstore_metadata_tables.c */
 extern bool InitColumnarOptions(Oid regclass);
 extern void SetColumnarOptions(Oid regclass, ColumnarOptions *options);
+extern bool DeleteColumnarTableOptions(Oid regclass, bool missingOk);
 extern bool ReadColumnarOptions(Oid regclass, ColumnarOptions *options);
 extern void DeleteDataFileMetadataRowIfExists(Oid relfilenode);
 extern void InitCStoreDataFileMetadata(Oid relfilenode);

--- a/src/include/columnar/cstore.h
+++ b/src/include/columnar/cstore.h
@@ -285,6 +285,7 @@ extern StringInfo DecompressBuffer(StringInfo buffer, CompressionType compressio
 extern char * CompressionTypeStr(CompressionType type);
 
 /* cstore_metadata_tables.c */
+extern bool InitColumnarOptions(Oid regclass);
 extern void SetColumnarOptions(Oid regclass, ColumnarOptions *options);
 extern bool ReadColumnarOptions(Oid regclass, ColumnarOptions *options);
 extern void DeleteDataFileMetadataRowIfExists(Oid relfilenode);

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -22,7 +22,37 @@ SELECT * FROM t_view a ORDER BY a;
  2 |   54 |   3
 (3 rows)
 
+-- show columnar options for materialized view
+SELECT * FROM cstore.options
+WHERE regclass = 't_view'::regclass;
+ regclass | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ t_view   |           10000 |           150000 | none
+(1 row)
+
+-- show we can set options on a materialized view
+SELECT alter_columnar_table_set('t_view', compression => 'pglz');
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM cstore.options
+WHERE regclass = 't_view'::regclass;
+ regclass | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ t_view   |           10000 |           150000 | pglz
+(1 row)
+
 REFRESH MATERIALIZED VIEW t_view;
+-- verify options have not been changed
+SELECT * FROM cstore.options
+WHERE regclass = 't_view'::regclass;
+ regclass | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ t_view   |           10000 |           150000 | pglz
+(1 row)
+
 SELECT * FROM t_view a ORDER BY a;
  a | bsum | cnt
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -3,7 +3,7 @@ SET search_path TO am_tableoptions;
 CREATE TABLE table_options (a int) USING columnar;
 INSERT INTO table_options SELECT generate_series(1,100);
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -18,7 +18,7 @@ SELECT alter_columnar_table_set('table_options', compression => 'pglz');
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -33,7 +33,7 @@ SELECT alter_columnar_table_set('table_options', block_row_count => 10);
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -48,7 +48,7 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -58,7 +58,7 @@ WHERE regclass = 'table_options'::regclass;
 -- VACUUM FULL creates a new table, make sure it copies settings from the table you are vacuuming
 VACUUM FULL table_options;
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -73,7 +73,7 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, block
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -86,7 +86,7 @@ SET cstore.stripe_row_count TO 10000;
 SET cstore.compression TO 'pglz';
 -- verify setting the GUC's didn't change the settings
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -100,7 +100,7 @@ SELECT alter_columnar_table_reset('table_options', block_row_count => true);
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -114,7 +114,7 @@ SELECT alter_columnar_table_reset('table_options', stripe_row_count => true);
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -128,7 +128,7 @@ SELECT alter_columnar_table_reset('table_options', compression => true);
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -140,7 +140,7 @@ SET cstore.block_row_count TO 10000;
 SET cstore.stripe_row_count TO 100000;
 SET cstore.compression TO 'none';
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------
@@ -158,7 +158,7 @@ SELECT alter_columnar_table_reset(
 (1 row)
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | block_row_count | stripe_row_count | compression
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -80,8 +80,37 @@ WHERE regclass = 'table_options'::regclass;
  table_options |             100 |             1000 | none
 (1 row)
 
+-- make sure table options are not changed when VACUUM a table
+VACUUM table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+   regclass    | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ table_options |             100 |             1000 | none
+(1 row)
+
+-- make sure table options are not changed when VACUUM FULL a table
+VACUUM FULL table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+   regclass    | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ table_options |             100 |             1000 | none
+(1 row)
+
 -- make sure table options are not changed when truncating a table
 TRUNCATE table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+   regclass    | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ table_options |             100 |             1000 | none
+(1 row)
+
+ALTER TABLE table_options ALTER COLUMN a TYPE bigint;
 -- show table_options settings
 SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -185,5 +185,13 @@ ERROR:  table not_a_cstore_table is not a cstore table
 -- verify you can't use a compression that is not known
 SELECT alter_columnar_table_set('table_options', compression => 'foobar');
 ERROR:  unknown compression type for cstore table: foobar
+-- verify options are removed when table is dropped
+DROP TABLE table_options;
+-- we expect no entries in çstore.options for anything not found int pg_class
+SELECT * FROM cstore.options o WHERE o.regclass NOT IN (SELECT oid FROM pg_class);
+ regclass | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+(0 rows)
+
 SET client_min_messages TO warning;
 DROP SCHEMA am_tableoptions CASCADE;

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -80,6 +80,16 @@ WHERE regclass = 'table_options'::regclass;
  table_options |             100 |             1000 | none
 (1 row)
 
+-- make sure table options are not changed when truncating a table
+TRUNCATE table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+   regclass    | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ table_options |             100 |             1000 | none
+(1 row)
+
 -- reset settings one by one to the version of the GUC's
 SET cstore.block_row_count TO 1000;
 SET cstore.stripe_row_count TO 10000;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -475,7 +475,7 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.0-1
 ALTER EXTENSION citus UPDATE TO '10.0-1';
 SELECT * FROM print_extension_changes();
- previous_object |                           current_object
+ previous_object |                            current_object
 ---------------------------------------------------------------------
                  | access method columnar
                  | function alter_columnar_table_reset(regclass,boolean,boolean,boolean)
@@ -486,7 +486,7 @@ SELECT * FROM print_extension_changes();
                  | table cstore.cstore_data_files
                  | table cstore.cstore_skipnodes
                  | table cstore.cstore_stripes
-                 | view cstore.columnar_options
+                 | table cstore.options
 (10 rows)
 
 DROP TABLE prev_objects, extension_diff;

--- a/src/test/regress/expected/multi_extension_0.out
+++ b/src/test/regress/expected/multi_extension_0.out
@@ -482,7 +482,7 @@ SELECT * FROM print_extension_changes();
                  | table cstore.cstore_data_files
                  | table cstore.cstore_skipnodes
                  | table cstore.cstore_stripes
-                 | view cstore.columnar_options
+                 | table cstore.options
 (6 rows)
 
 DROP TABLE prev_objects, extension_diff;

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -194,6 +194,7 @@ ORDER BY 1;
  table cstore.cstore_data_files
  table cstore.cstore_skipnodes
  table cstore.cstore_stripes
+ table cstore.options
  table pg_dist_authinfo
  table pg_dist_colocation
  table pg_dist_local_group
@@ -215,7 +216,6 @@ ORDER BY 1;
  view citus_shards_on_worker
  view citus_stat_statements
  view citus_worker_stat_activity
- view cstore.columnar_options
  view pg_dist_shard_placement
 (201 rows)
 

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -190,6 +190,7 @@ ORDER BY 1;
  table cstore.cstore_data_files
  table cstore.cstore_skipnodes
  table cstore.cstore_stripes
+ table cstore.options
  table pg_dist_authinfo
  table pg_dist_colocation
  table pg_dist_local_group
@@ -211,7 +212,6 @@ ORDER BY 1;
  view citus_shards_on_worker
  view citus_stat_statements
  view citus_worker_stat_activity
- view cstore.columnar_options
  view pg_dist_shard_placement
 (197 rows)
 

--- a/src/test/regress/sql/am_matview.sql
+++ b/src/test/regress/sql/am_matview.sql
@@ -15,7 +15,20 @@ INSERT INTO t SELECT floor(i / 4), 2 * i FROM generate_series(11, 20) i;
 
 SELECT * FROM t_view a ORDER BY a;
 
+-- show columnar options for materialized view
+SELECT * FROM cstore.options
+WHERE regclass = 't_view'::regclass;
+
+-- show we can set options on a materialized view
+SELECT alter_columnar_table_set('t_view', compression => 'pglz');
+SELECT * FROM cstore.options
+WHERE regclass = 't_view'::regclass;
+
 REFRESH MATERIALIZED VIEW t_view;
+
+-- verify options have not been changed
+SELECT * FROM cstore.options
+WHERE regclass = 't_view'::regclass;
 
 SELECT * FROM t_view a ORDER BY a;
 

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -5,42 +5,42 @@ CREATE TABLE table_options (a int) USING columnar;
 INSERT INTO table_options SELECT generate_series(1,100);
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the compression
 SELECT alter_columnar_table_set('table_options', compression => 'pglz');
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the block_row_count
 SELECT alter_columnar_table_set('table_options', block_row_count => 10);
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the block_row_count
 SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- VACUUM FULL creates a new table, make sure it copies settings from the table you are vacuuming
 VACUUM FULL table_options;
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- set all settings at the same time
 SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, block_row_count => 100, compression => 'none');
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- reset settings one by one to the version of the GUC's
@@ -50,24 +50,24 @@ SET cstore.compression TO 'pglz';
 
 -- verify setting the GUC's didn't change the settings
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 SELECT alter_columnar_table_reset('table_options', block_row_count => true);
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 SELECT alter_columnar_table_reset('table_options', stripe_row_count => true);
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 SELECT alter_columnar_table_reset('table_options', compression => true);
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- verify resetting all settings at once work
@@ -76,7 +76,7 @@ SET cstore.stripe_row_count TO 100000;
 SET cstore.compression TO 'none';
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 SELECT alter_columnar_table_reset(
@@ -86,7 +86,7 @@ SELECT alter_columnar_table_reset(
     compression => true);
 
 -- show table_options settings
-SELECT * FROM cstore.columnar_options
+SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
 -- verify edge cases

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -105,5 +105,10 @@ SELECT alter_columnar_table_reset('not_a_cstore_table', compression => true);
 -- verify you can't use a compression that is not known
 SELECT alter_columnar_table_set('table_options', compression => 'foobar');
 
+-- verify options are removed when table is dropped
+DROP TABLE table_options;
+-- we expect no entries in çstore.options for anything not found int pg_class
+SELECT * FROM cstore.options o WHERE o.regclass NOT IN (SELECT oid FROM pg_class);
+
 SET client_min_messages TO warning;
 DROP SCHEMA am_tableoptions CASCADE;

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -43,9 +43,25 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, block
 SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
+-- make sure table options are not changed when VACUUM a table
+VACUUM table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+
+-- make sure table options are not changed when VACUUM FULL a table
+VACUUM FULL table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+
 -- make sure table options are not changed when truncating a table
 TRUNCATE table_options;
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
 
+ALTER TABLE table_options ALTER COLUMN a TYPE bigint;
 -- show table_options settings
 SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -43,6 +43,13 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, block
 SELECT * FROM cstore.options
 WHERE regclass = 'table_options'::regclass;
 
+-- make sure table options are not changed when truncating a table
+TRUNCATE table_options;
+
+-- show table_options settings
+SELECT * FROM cstore.options
+WHERE regclass = 'table_options'::regclass;
+
 -- reset settings one by one to the version of the GUC's
 SET cstore.block_row_count TO 1000;
 SET cstore.stripe_row_count TO 10000;


### PR DESCRIPTION
DESCRIPTION: Refactor Columnar table options to their own relation

Columnar options were by accident linked to the relfilenode instead of the regclass/relation oid. This PR moves everything related to columnar options to their own catalog table.

Tests pass, however there are obvious tests missing.
 - [ ] upgrade test
 - [x] drop tables should remove options