### PR TITLE
Columnar Store Storage Id

### DIFF
--- a/src/backend/columnar/cstore_customscan.c
+++ b/src/backend/columnar/cstore_customscan.c
@@ -215,15 +215,15 @@ static Cost
 CStoreScanCost(RangeTblEntry *rte)
 {
 	Relation rel = RelationIdGetRelation(rte->relid);
-	DataFileMetadata *metadata = ReadDataFileMetadata(rel->rd_node.relNode, false);
+	List *stripeList = StripesForRelfilenode(rel->rd_node);
+	RelationClose(rel);
+
 	uint32 maxColumnCount = 0;
 	uint64 totalStripeSize = 0;
 	ListCell *stripeMetadataCell = NULL;
-
-	RelationClose(rel);
 	rel = NULL;
 
-	foreach(stripeMetadataCell, metadata->stripeMetadataList)
+	foreach(stripeMetadataCell, stripeList)
 	{
 		StripeMetadata *stripeMetadata = (StripeMetadata *) lfirst(stripeMetadataCell);
 		totalStripeSize += stripeMetadata->dataLength;

--- a/src/backend/columnar/cstore_writer.c
+++ b/src/backend/columnar/cstore_writer.c
@@ -65,12 +65,10 @@ CStoreBeginWrite(RelFileNode relfilenode,
 				 uint64 stripeMaxRowCount, uint32 blockRowCount,
 				 TupleDesc tupleDescriptor)
 {
-	uint32 columnIndex = 0;
-
 	/* get comparison function pointers for each of the columns */
 	uint32 columnCount = tupleDescriptor->natts;
 	FmgrInfo **comparisonFunctionArray = palloc0(columnCount * sizeof(FmgrInfo *));
-	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
+	for (uint32 columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		FmgrInfo *comparisonFunction = NULL;
 		FormData_pg_attribute *attributeForm = TupleDescAttr(tupleDescriptor,
@@ -323,7 +321,7 @@ CreateEmptyStripeSkipList(uint32 stripeMaxRowCount, uint32 blockRowCount,
 }
 
 
-static void
+void
 WriteToSmgr(Relation rel, uint64 logicalOffset, char *data, uint32 dataLength)
 {
 	uint64 remaining = dataLength;
@@ -521,7 +519,7 @@ FlushStripe(TableWriteState *writeState)
 	}
 
 	/* create skip list and footer buffers */
-	SaveStripeSkipList(relation->rd_node.relNode,
+	SaveStripeSkipList(writeState->relfilenode,
 					   stripeMetadata.id,
 					   stripeSkipList, tupleDescriptor);
 

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -29,8 +29,8 @@ END$proc$;
 
 DROP TABLE cstore_skipnodes;
 DROP TABLE cstore_stripes;
-DROP TABLE cstore_data_files;
 DROP TABLE options;
+DROP SEQUENCE storageid_seq;
 
 DROP FUNCTION citus_internal.cstore_ensure_objects_exist();
 

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -190,3 +190,6 @@ s/relation with OID [0-9]+ does not exist/relation with OID XXXX does not exist/
 
 # ignore timing statistics for VACUUM VERBOSE
 /CPU: user: .*s, system: .*s, elapsed: .*s/d
+
+# normalize storage id of columnar tables
+s/^storage id: [0-9]+$/storage id: xxxxx/g

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -23,7 +23,6 @@
 /hyperscale_tutorial.out
 /am_block_filtering.out
 /am_copyto.out
-/am_create.out
 /am_data_types.out
 /am_load.out
 /fdw_block_filtering.out

--- a/src/test/regress/expected/am_create.out
+++ b/src/test/regress/expected/am_create.out
@@ -1,20 +1,24 @@
 --
 -- Test the CREATE statements related to cstore.
 --
-
-
 -- Create uncompressed table
 CREATE TABLE contestant (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
 	USING columnar;
-
-
 -- Create compressed table with automatically determined file path
 -- COMPRESSED
 CREATE TABLE contestant_compressed (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
 	USING columnar;
-
 -- Test that querying an empty table works
 ANALYZE contestant;
 SELECT count(*) FROM contestant;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Utility functions to be used throughout tests
+CREATE FUNCTION columnar_relation_storageid(relid oid) RETURNS bigint
+    LANGUAGE C STABLE STRICT
+    AS 'citus', $$columnar_relation_storageid$$;

--- a/src/test/regress/expected/am_drop.out
+++ b/src/test/regress/expected/am_drop.out
@@ -12,12 +12,12 @@
 -- 'postgres' directory is excluded from comparison to have the same result.
 -- store postgres database oid
 SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
-SELECT count(*) AS cstore_data_files_before_drop FROM cstore.cstore_data_files \gset
+SELECT count(distinct storageid) AS cstore_stripes_before_drop FROM cstore.cstore_stripes \gset
 -- DROP cstore_fdw tables
 DROP TABLE contestant;
 DROP TABLE contestant_compressed;
 -- make sure DROP deletes metadata
-SELECT :cstore_data_files_before_drop - count(*) FROM cstore.cstore_data_files;
+SELECT :cstore_stripes_before_drop - count(distinct storageid) FROM cstore.cstore_stripes;
  ?column?
 ---------------------------------------------------------------------
         2
@@ -26,10 +26,11 @@ SELECT :cstore_data_files_before_drop - count(*) FROM cstore.cstore_data_files;
 -- Create a cstore_fdw table under a schema and drop it.
 CREATE SCHEMA test_schema;
 CREATE TABLE test_schema.test_table(data int) USING columnar;
-SELECT count(*) AS cstore_data_files_before_drop FROM cstore.cstore_data_files \gset
+INSERT INTO test_schema.test_table VALUES (1);
+SELECT count(*) AS cstore_stripes_before_drop FROM cstore.cstore_stripes \gset
 DROP SCHEMA test_schema CASCADE;
 NOTICE:  drop cascades to table test_schema.test_table
-SELECT :cstore_data_files_before_drop - count(*) FROM cstore.cstore_data_files;
+SELECT :cstore_stripes_before_drop - count(distinct storageid) FROM cstore.cstore_stripes;
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -65,20 +65,15 @@ SELECT * FROM t_view a ORDER BY a;
 (6 rows)
 
 -- verify that we have created metadata entries for the materialized view
-SELECT relfilenode FROM pg_class WHERE relname='t_view' \gset
-SELECT count(*) FROM cstore.cstore_data_files WHERE relfilenode=:relfilenode;
+SELECT columnar_relation_storageid(oid) AS storageid
+FROM pg_class WHERE relname='t_view' \gset
+SELECT count(*) FROM cstore.cstore_stripes WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      1
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes WHERE relfilenode=:relfilenode;
- count
----------------------------------------------------------------------
-     1
-(1 row)
-
-SELECT count(*) FROM cstore.cstore_skipnodes WHERE relfilenode=:relfilenode;
+SELECT count(*) FROM cstore.cstore_skipnodes WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      3
@@ -87,19 +82,13 @@ SELECT count(*) FROM cstore.cstore_skipnodes WHERE relfilenode=:relfilenode;
 DROP TABLE t CASCADE;
 NOTICE:  drop cascades to materialized view t_view
 -- dropping must remove metadata
-SELECT count(*) FROM cstore.cstore_data_files WHERE relfilenode=:relfilenode;
+SELECT count(*) FROM cstore.cstore_stripes WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes WHERE relfilenode=:relfilenode;
- count
----------------------------------------------------------------------
-     0
-(1 row)
-
-SELECT count(*) FROM cstore.cstore_skipnodes WHERE relfilenode=:relfilenode;
+SELECT count(*) FROM cstore.cstore_skipnodes WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      0

--- a/src/test/regress/expected/am_recursive.out
+++ b/src/test/regress/expected/am_recursive.out
@@ -12,7 +12,7 @@ INSERT INTO t2 SELECT i, f(i) FROM generate_series(1, 5) i;
 -- there are no subtransactions, so above statement should batch
 -- INSERTs inside the UDF and create on stripe per table.
 SELECT relname, count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode=b.relfilenode AND relname IN ('t1', 't2')
+WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname IN ('t1', 't2')
 GROUP BY relname
 ORDER BY relname;
  relname | count

--- a/src/test/regress/expected/am_rollback.out
+++ b/src/test/regress/expected/am_rollback.out
@@ -2,6 +2,9 @@
 -- Testing we handle rollbacks properly
 --
 CREATE TABLE t(a int, b int) USING columnar;
+CREATE VIEW t_stripes AS
+SELECT * FROM cstore.cstore_stripes a, pg_class b
+WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname = 't';
 BEGIN;
 INSERT INTO t SELECT i, i+1 FROM generate_series(1, 10) i;
 ROLLBACK;
@@ -12,8 +15,7 @@ SELECT count(*) FROM t;
 (1 row)
 
 -- check stripe metadata also have been rolled-back
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode = b.relfilenode AND b.relname = 't';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      0
@@ -26,8 +28,7 @@ SELECT count(*) FROM t;
     10
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode = b.relfilenode AND b.relname = 't';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      1
@@ -73,11 +74,11 @@ SELECT count(*) FROM t;
     20
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode = b.relfilenode AND b.relname = 't';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      2
 (1 row)
 
 DROP TABLE t;
+DROP VIEW t_stripes;

--- a/src/test/regress/expected/am_truncate.out
+++ b/src/test/regress/expected/am_truncate.out
@@ -15,7 +15,7 @@ CREATE TABLE cstore_truncate_test_second (a int, b int) USING columnar;
 -- COMPRESSED
 CREATE TABLE cstore_truncate_test_compressed (a int, b int) USING columnar;
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
-SELECT count(*) AS cstore_data_files_before_truncate FROM cstore.cstore_data_files \gset
+SELECT count(distinct storageid) AS cstore_data_files_before_truncate FROM cstore.cstore_stripes \gset
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
 set cstore.compression = 'pglz';
 INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
@@ -147,7 +147,7 @@ SELECT * from cstore_truncate_test;
 (0 rows)
 
 -- make sure TRUNATE deletes metadata for old relfilenode
-SELECT :cstore_data_files_before_truncate - count(*) FROM cstore.cstore_data_files;
+SELECT :cstore_data_files_before_truncate - count(distinct storageid) FROM cstore.cstore_stripes;
  ?column?
 ---------------------------------------------------------------------
         0
@@ -161,7 +161,7 @@ TRUNCATE cstore_same_transaction_truncate;
 INSERT INTO cstore_same_transaction_truncate SELECT * FROM generate_series(20, 23);
 COMMIT;
 -- should output "1" for the newly created relation
-SELECT count(*) - :cstore_data_files_before_truncate FROM cstore.cstore_data_files;
+SELECT count(distinct storageid) - :cstore_data_files_before_truncate FROM cstore.cstore_stripes;
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -1,6 +1,9 @@
-SELECT count(*) AS columnar_table_count FROM cstore.cstore_data_files \gset
+SELECT count(distinct storageid) AS columnar_table_count FROM cstore.cstore_stripes \gset
 CREATE TABLE t(a int, b int) USING columnar;
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t';
+CREATE VIEW t_stripes AS
+SELECT * FROM cstore.cstore_stripes a, pg_class b
+WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      0
@@ -15,7 +18,7 @@ SELECT sum(a), sum(b) FROM t;
  465 | 9455
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      3
@@ -29,7 +32,7 @@ SELECT sum(a), sum(b) FROM t;
  465 | 9455
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      1
@@ -49,7 +52,7 @@ SELECT sum(a), sum(b) FROM t;
  3126715 | 6261955
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      4
@@ -62,7 +65,7 @@ SELECT sum(a), sum(b) FROM t;
  3126715 | 6261955
 (1 row)
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t';
+SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
      3
@@ -70,7 +73,9 @@ SELECT count(*) FROM cstore.cstore_stripes a, pg_class b WHERE a.relfilenode=b.r
 
 -- VACUUM FULL doesn't reclaim dropped columns, but converts them to NULLs
 ALTER TABLE t DROP COLUMN a;
-SELECT stripe, attr, block, minimum_value IS NULL, maximum_value IS NULL FROM cstore.cstore_skipnodes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t' ORDER BY 1, 2, 3;
+SELECT stripe, attr, block, minimum_value IS NULL, maximum_value IS NULL
+FROM cstore.cstore_skipnodes a, pg_class b
+WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
  stripe | attr | block | ?column? | ?column?
 ---------------------------------------------------------------------
       1 |    1 |     0 | f        | f
@@ -82,7 +87,9 @@ SELECT stripe, attr, block, minimum_value IS NULL, maximum_value IS NULL FROM cs
 (6 rows)
 
 VACUUM FULL t;
-SELECT stripe, attr, block, minimum_value IS NULL, maximum_value IS NULL FROM cstore.cstore_skipnodes a, pg_class b WHERE a.relfilenode=b.relfilenode AND b.relname='t' ORDER BY 1, 2, 3;
+SELECT stripe, attr, block, minimum_value IS NULL, maximum_value IS NULL
+FROM cstore.cstore_skipnodes a, pg_class b
+WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
  stripe | attr | block | ?column? | ?column?
 ---------------------------------------------------------------------
       1 |    1 |     0 | t        | t
@@ -94,7 +101,7 @@ SELECT stripe, attr, block, minimum_value IS NULL, maximum_value IS NULL FROM cs
 (6 rows)
 
 -- Make sure we cleaned-up the transient table metadata after VACUUM FULL commands
-SELECT count(*) - :columnar_table_count FROM cstore.cstore_data_files;
+SELECT count(distinct storageid) - :columnar_table_count FROM cstore.cstore_stripes;
  ?column?
 ---------------------------------------------------------------------
         1
@@ -112,14 +119,14 @@ SELECT count(*) FROM t;
 SELECT pg_size_pretty(pg_relation_size('t'));
  pg_size_pretty
 ---------------------------------------------------------------------
- 32 kB
+ 40 kB
 (1 row)
 
 INSERT INTO t SELECT i FROM generate_series(1, 10000) i;
 SELECT pg_size_pretty(pg_relation_size('t'));
  pg_size_pretty
 ---------------------------------------------------------------------
- 112 kB
+ 120 kB
 (1 row)
 
 SELECT count(*) FROM t;
@@ -134,22 +141,23 @@ ROLLBACK TO SAVEPOINT s1;
 SELECT pg_size_pretty(pg_relation_size('t'));
  pg_size_pretty
 ---------------------------------------------------------------------
- 112 kB
+ 120 kB
 (1 row)
 
 COMMIT;
 -- vacuum should truncate the relation to the usable space
 VACUUM VERBOSE t;
 INFO:  statistics for "t":
-total file size: 114688, total data size: 10754
+storage id: xxxxx
+total file size: 122880, total data size: 10754
 total row count: 2530, stripe count: 3, average rows per stripe: 843
 block count: 3, containing data for dropped columns: 0, none compressed: 3, pglz compressed: 0
 
-INFO:  "t": truncated 14 to 4 pages
+INFO:  "t": truncated 15 to 5 pages
 SELECT pg_size_pretty(pg_relation_size('t'));
  pg_size_pretty
 ---------------------------------------------------------------------
- 32 kB
+ 40 kB
 (1 row)
 
 SELECT count(*) FROM t;
@@ -187,7 +195,8 @@ INSERT INTO t SELECT i / 5 FROM generate_series(1, 1500) i;
 COMMIT;
 VACUUM VERBOSE t;
 INFO:  statistics for "t":
-total file size: 49152, total data size: 18808
+storage id: xxxxx
+total file size: 57344, total data size: 18808
 total row count: 5530, stripe count: 5, average rows per stripe: 1106
 block count: 7, containing data for dropped columns: 0, none compressed: 5, pglz compressed: 2
 
@@ -203,7 +212,8 @@ INSERT INTO t SELECT 1, i / 5 FROM generate_series(1, 1500) i;
 ALTER TABLE t DROP COLUMN c;
 VACUUM VERBOSE t;
 INFO:  statistics for "t":
-total file size: 65536, total data size: 31372
+storage id: xxxxx
+total file size: 73728, total data size: 31372
 total row count: 7030, stripe count: 6, average rows per stripe: 1171
 block count: 11, containing data for dropped columns: 2, none compressed: 9, pglz compressed: 2
 
@@ -219,13 +229,15 @@ SELECT alter_columnar_table_set('t', compression => 'pglz');
 VACUUM FULL t;
 VACUUM VERBOSE t;
 INFO:  statistics for "t":
-total file size: 49152, total data size: 15728
+storage id: xxxxx
+total file size: 57344, total data size: 15728
 total row count: 7030, stripe count: 4, average rows per stripe: 1757
 block count: 8, containing data for dropped columns: 0, none compressed: 2, pglz compressed: 6
 
 DROP TABLE t;
+DROP VIEW t_stripes;
 -- Make sure we cleaned the metadata for t too
-SELECT count(*) - :columnar_table_count FROM cstore.cstore_data_files;
+SELECT count(distinct storageid) - :columnar_table_count FROM cstore.cstore_stripes;
  ?column?
 ---------------------------------------------------------------------
         0

--- a/src/test/regress/expected/am_vacuum_vs_insert.out
+++ b/src/test/regress/expected/am_vacuum_vs_insert.out
@@ -11,7 +11,8 @@ step s1-insert:
     INSERT INTO test_vacuum_vs_insert SELECT i, 2 * i FROM generate_series(1, 3) i;
 
 s2: INFO:  statistics for "test_vacuum_vs_insert":
-total file size: 16384, total data size: 26
+storage id: xxxxx
+total file size: 24576, total data size: 26
 total row count: 3, stripe count: 1, average rows per stripe: 3
 block count: 2, containing data for dropped columns: 0, none compressed: 2, pglz compressed: 0
 
@@ -51,7 +52,7 @@ step s1-commit:
     COMMIT;
 
 s2: INFO:  vacuuming "public.test_vacuum_vs_insert"
-s2: INFO:  "test_vacuum_vs_insert": found 0 removable, 6 nonremovable row versions in 3 pages
+s2: INFO:  "test_vacuum_vs_insert": found 0 removable, 6 nonremovable row versions in 4 pages
 DETAIL:  0 dead row versions cannot be removed yet.
 step s2-vacuum-full: <... completed>
 step s2-select:

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -483,7 +483,7 @@ SELECT * FROM print_extension_changes();
                  | function citus_internal.cstore_ensure_objects_exist()
                  | function cstore.columnar_handler(internal)
                  | schema cstore
-                 | table cstore.cstore_data_files
+                 | sequence cstore.storageid_seq
                  | table cstore.cstore_skipnodes
                  | table cstore.cstore_stripes
                  | table cstore.options

--- a/src/test/regress/expected/multi_extension_0.out
+++ b/src/test/regress/expected/multi_extension_0.out
@@ -479,7 +479,7 @@ SELECT * FROM print_extension_changes();
 ---------------------------------------------------------------------
                  | function citus_internal.cstore_ensure_objects_exist()
                  | schema cstore
-                 | table cstore.cstore_data_files
+                 | sequence cstore.storageid_seq
                  | table cstore.cstore_skipnodes
                  | table cstore.cstore_stripes
                  | table cstore.options

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -185,13 +185,13 @@ ORDER BY 1;
  schema citus
  schema citus_internal
  schema cstore
+ sequence cstore.storageid_seq
  sequence pg_dist_colocationid_seq
  sequence pg_dist_groupid_seq
  sequence pg_dist_node_nodeid_seq
  sequence pg_dist_placement_placementid_seq
  sequence pg_dist_shardid_seq
  table citus.pg_dist_object
- table cstore.cstore_data_files
  table cstore.cstore_skipnodes
  table cstore.cstore_stripes
  table cstore.options

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -181,13 +181,13 @@ ORDER BY 1;
  schema citus
  schema citus_internal
  schema cstore
+ sequence cstore.storageid_seq
  sequence pg_dist_colocationid_seq
  sequence pg_dist_groupid_seq
  sequence pg_dist_node_nodeid_seq
  sequence pg_dist_placement_placementid_seq
  sequence pg_dist_shardid_seq
  table citus.pg_dist_object
- table cstore.cstore_data_files
  table cstore.cstore_skipnodes
  table cstore.cstore_stripes
  table cstore.options

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -22,7 +22,6 @@
 /hyperscale_tutorial.sql
 /am_block_filtering.sql
 /am_copyto.sql
-/am_create.sql
 /am_data_types.sql
 /am_load.sql
 /fdw_block_filtering.sql

--- a/src/test/regress/sql/am_create.sql
+++ b/src/test/regress/sql/am_create.sql
@@ -1,20 +1,25 @@
 --
 -- Test the CREATE statements related to cstore.
 --
+
+
 -- Create uncompressed table
 CREATE TABLE contestant (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
 	USING columnar;
+
+
 -- Create compressed table with automatically determined file path
 -- COMPRESSED
 CREATE TABLE contestant_compressed (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
 	USING columnar;
+
 -- Test that querying an empty table works
 ANALYZE contestant;
 SELECT count(*) FROM contestant;
- count 
--------
-     0
-(1 row)
 
+-- Utility functions to be used throughout tests
+CREATE FUNCTION columnar_relation_storageid(relid oid) RETURNS bigint
+    LANGUAGE C STABLE STRICT
+    AS 'citus', $$columnar_relation_storageid$$;

--- a/src/test/regress/sql/am_drop.sql
+++ b/src/test/regress/sql/am_drop.sql
@@ -15,22 +15,23 @@
 -- store postgres database oid
 SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 
-SELECT count(*) AS cstore_data_files_before_drop FROM cstore.cstore_data_files \gset
+SELECT count(distinct storageid) AS cstore_stripes_before_drop FROM cstore.cstore_stripes \gset
 
 -- DROP cstore_fdw tables
 DROP TABLE contestant;
 DROP TABLE contestant_compressed;
 
 -- make sure DROP deletes metadata
-SELECT :cstore_data_files_before_drop - count(*) FROM cstore.cstore_data_files;
+SELECT :cstore_stripes_before_drop - count(distinct storageid) FROM cstore.cstore_stripes;
 
 -- Create a cstore_fdw table under a schema and drop it.
 CREATE SCHEMA test_schema;
 CREATE TABLE test_schema.test_table(data int) USING columnar;
+INSERT INTO test_schema.test_table VALUES (1);
 
-SELECT count(*) AS cstore_data_files_before_drop FROM cstore.cstore_data_files \gset
+SELECT count(*) AS cstore_stripes_before_drop FROM cstore.cstore_stripes \gset
 DROP SCHEMA test_schema CASCADE;
-SELECT :cstore_data_files_before_drop - count(*) FROM cstore.cstore_data_files;
+SELECT :cstore_stripes_before_drop - count(distinct storageid) FROM cstore.cstore_stripes;
 
 SELECT current_database() datname \gset
 

--- a/src/test/regress/sql/am_matview.sql
+++ b/src/test/regress/sql/am_matview.sql
@@ -33,15 +33,14 @@ WHERE regclass = 't_view'::regclass;
 SELECT * FROM t_view a ORDER BY a;
 
 -- verify that we have created metadata entries for the materialized view
-SELECT relfilenode FROM pg_class WHERE relname='t_view' \gset
+SELECT columnar_relation_storageid(oid) AS storageid
+FROM pg_class WHERE relname='t_view' \gset
 
-SELECT count(*) FROM cstore.cstore_data_files WHERE relfilenode=:relfilenode;
-SELECT count(*) FROM cstore.cstore_stripes WHERE relfilenode=:relfilenode;
-SELECT count(*) FROM cstore.cstore_skipnodes WHERE relfilenode=:relfilenode;
+SELECT count(*) FROM cstore.cstore_stripes WHERE storageid=:storageid;
+SELECT count(*) FROM cstore.cstore_skipnodes WHERE storageid=:storageid;
 
 DROP TABLE t CASCADE;
 
 -- dropping must remove metadata
-SELECT count(*) FROM cstore.cstore_data_files WHERE relfilenode=:relfilenode;
-SELECT count(*) FROM cstore.cstore_stripes WHERE relfilenode=:relfilenode;
-SELECT count(*) FROM cstore.cstore_skipnodes WHERE relfilenode=:relfilenode;
+SELECT count(*) FROM cstore.cstore_stripes WHERE storageid=:storageid;
+SELECT count(*) FROM cstore.cstore_skipnodes WHERE storageid=:storageid;

--- a/src/test/regress/sql/am_recursive.sql
+++ b/src/test/regress/sql/am_recursive.sql
@@ -16,7 +16,7 @@ INSERT INTO t2 SELECT i, f(i) FROM generate_series(1, 5) i;
 -- there are no subtransactions, so above statement should batch
 -- INSERTs inside the UDF and create on stripe per table.
 SELECT relname, count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode=b.relfilenode AND relname IN ('t1', 't2')
+WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname IN ('t1', 't2')
 GROUP BY relname
 ORDER BY relname;
 

--- a/src/test/regress/sql/am_rollback.sql
+++ b/src/test/regress/sql/am_rollback.sql
@@ -4,20 +4,22 @@
 
 CREATE TABLE t(a int, b int) USING columnar;
 
+CREATE VIEW t_stripes AS
+SELECT * FROM cstore.cstore_stripes a, pg_class b
+WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname = 't';
+
 BEGIN;
 INSERT INTO t SELECT i, i+1 FROM generate_series(1, 10) i;
 ROLLBACK;
 SELECT count(*) FROM t;
 
 -- check stripe metadata also have been rolled-back
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode = b.relfilenode AND b.relname = 't';
+SELECT count(*) FROM t_stripes;
 
 INSERT INTO t SELECT i, i+1 FROM generate_series(1, 10) i;
 SELECT count(*) FROM t;
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode = b.relfilenode AND b.relname = 't';
+SELECT count(*) FROM t_stripes;
 
 -- savepoint rollback
 BEGIN;
@@ -36,7 +38,7 @@ COMMIT;
 
 SELECT count(*) FROM t;
 
-SELECT count(*) FROM cstore.cstore_stripes a, pg_class b
-WHERE a.relfilenode = b.relfilenode AND b.relname = 't';
+SELECT count(*) FROM t_stripes;
 
 DROP TABLE t;
+DROP VIEW t_stripes;

--- a/src/test/regress/sql/am_truncate.sql
+++ b/src/test/regress/sql/am_truncate.sql
@@ -13,7 +13,7 @@ CREATE TABLE cstore_truncate_test_second (a int, b int) USING columnar;
 CREATE TABLE cstore_truncate_test_compressed (a int, b int) USING columnar;
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
 
-SELECT count(*) AS cstore_data_files_before_truncate FROM cstore.cstore_data_files \gset
+SELECT count(distinct storageid) AS cstore_data_files_before_truncate FROM cstore.cstore_stripes \gset
 
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
 
@@ -63,7 +63,7 @@ TRUNCATE TABLE cstore_truncate_test;
 SELECT * from cstore_truncate_test;
 
 -- make sure TRUNATE deletes metadata for old relfilenode
-SELECT :cstore_data_files_before_truncate - count(*) FROM cstore.cstore_data_files;
+SELECT :cstore_data_files_before_truncate - count(distinct storageid) FROM cstore.cstore_stripes;
 
 -- test if truncation in the same transaction that created the table works properly
 BEGIN;
@@ -74,7 +74,7 @@ INSERT INTO cstore_same_transaction_truncate SELECT * FROM generate_series(20, 2
 COMMIT;
 
 -- should output "1" for the newly created relation
-SELECT count(*) - :cstore_data_files_before_truncate FROM cstore.cstore_data_files;
+SELECT count(distinct storageid) - :cstore_data_files_before_truncate FROM cstore.cstore_stripes;
 SELECT * FROM cstore_same_transaction_truncate;
 
 DROP TABLE cstore_same_transaction_truncate;


### PR DESCRIPTION
Associates each metadata row with a virtual storage id generated by us instead of using relfilenode. This storage id is stored in the first page of data file, so we can easily find out which metadata we should read for a given table.

The reason is that pg_upgrade can change relfilenodes, without giving us a chance to update our metadata rows. But same storage ids will persist between upgrades.
