### PR TITLE
Run pg12 and pg13 separately

### DIFF
--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -85,7 +85,8 @@ test: set_operation_and_local_tables
 
 test: subqueries_deep subquery_view subquery_partitioning subquery_complex_target_list subqueries_not_supported subquery_in_where
 test: non_colocated_leaf_subquery_joins non_colocated_subquery_joins non_colocated_join_order
-test: subquery_prepared_statements pg12 cte_inline pg13 recursive_view_local_table
+test: subquery_prepared_statements cte_inline recursive_view_local_table
+test: pg13 pg12
 test: tableam
 
 # ----------
@@ -96,7 +97,8 @@ test: multi_explain hyperscale_tutorial partitioned_intermediate_results distrib
 test: multi_basic_queries cross_join multi_complex_expressions multi_subquery multi_subquery_complex_queries multi_subquery_behavioral_analytics
 test: multi_subquery_complex_reference_clause multi_subquery_window_functions multi_view multi_sql_function multi_prepare_sql
 test: sql_procedure multi_function_in_join row_types materialized_view undistribute_table
-test: multi_subquery_in_where_reference_clause join geqo adaptive_executor propagate_set_commands
+test: multi_subquery_in_where_reference_clause adaptive_executor propagate_set_commands
+test: join geqo
 test: multi_subquery_union multi_subquery_in_where_clause multi_subquery_misc statement_cancel_error_message
 test: multi_agg_distinct multi_agg_approximate_distinct multi_limit_clause_approximate multi_outer_join_reference multi_single_relation_subquery multi_prepare_plsql set_role_in_transaction
 test: multi_reference_table multi_select_for_update relation_access_tracking pg13_with_ties


### PR DESCRIPTION
It seems that sometimes we get `too many clients errors` with this set
of parallel tests, hence two of them are separated.

