### PR TITLE
Normalize VACUUM VERBOSE output

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -187,3 +187,6 @@ s/relation with OID [0-9]+ does not exist/relation with OID XXXX does not exist/
 
 # ignore DEBUG1 messages that Postgres generates
 /^DEBUG:  rehashing catalog cache id [0-9]+$/d
+
+# ignore timing statistics for VACUUM VERBOSE
+/CPU: user: .*s, system: .*s, elapsed: .*s/d

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -146,7 +146,6 @@ total row count: 2530, stripe count: 3, average rows per stripe: 843
 block count: 3, containing data for dropped columns: 0, none compressed: 3, pglz compressed: 0
 
 INFO:  "t": truncated 14 to 4 pages
-DETAIL:  CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s
 SELECT pg_size_pretty(pg_relation_size('t'));
  pg_size_pretty
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/am_vacuum_vs_insert.out
+++ b/src/test/regress/expected/am_vacuum_vs_insert.out
@@ -53,7 +53,6 @@ step s1-commit:
 s2: INFO:  vacuuming "public.test_vacuum_vs_insert"
 s2: INFO:  "test_vacuum_vs_insert": found 0 removable, 6 nonremovable row versions in 3 pages
 DETAIL:  0 dead row versions cannot be removed yet.
-CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s.
 step s2-vacuum-full: <... completed>
 step s2-select:
     SELECT * FROM test_vacuum_vs_insert;


### PR DESCRIPTION
This is to avoid flaky changes like the following in test outputs:

-CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s.
+CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.02 s.

