### PR TITLE
Call 6 times not 7 in subquery_prepared_statements

### DIFF
--- a/src/test/regress/expected/subquery_prepared_statements.out
+++ b/src/test/regress/expected/subquery_prepared_statements.out
@@ -119,16 +119,6 @@ EXECUTE subquery_prepare_without_param;
  (5,4)
 (5 rows)
 
-EXECUTE subquery_prepare_without_param;
- values_of_subquery
----------------------------------------------------------------------
- (6,4)
- (6,3)
- (6,2)
- (6,1)
- (5,4)
-(5 rows)
-
 EXECUTE subquery_prepare_param_on_partkey(1);
 DEBUG:  push down of limit count: 5
 DEBUG:  generating subplan XXX_1 for subquery SELECT DISTINCT ROW(users_table.user_id, events_table.event_type)::subquery_prepared_statements.xy AS values_of_subquery FROM public.users_table, public.events_table WHERE ((users_table.user_id OPERATOR(pg_catalog.=) events_table.user_id) AND ((users_table.user_id OPERATOR(pg_catalog.=) 1) OR (users_table.user_id OPERATOR(pg_catalog.=) 2)) AND (events_table.event_type OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2, 3, 4]))) ORDER BY ROW(users_table.user_id, events_table.event_type)::subquery_prepared_statements.xy DESC LIMIT 5

--- a/src/test/regress/sql/subquery_prepared_statements.sql
+++ b/src/test/regress/sql/subquery_prepared_statements.sql
@@ -64,7 +64,6 @@ EXECUTE subquery_prepare_without_param;
 EXECUTE subquery_prepare_without_param;
 EXECUTE subquery_prepare_without_param;
 EXECUTE subquery_prepare_without_param;
-EXECUTE subquery_prepare_without_param;
 
 
 EXECUTE subquery_prepare_param_on_partkey(1);


### PR DESCRIPTION
We were calling `subquery_prepare_without_param` 7 times however we wanted to call it 6 times, as the comment also says so. This test was flaky, hopefully this will resolve that too.