### PR TITLE
Fix hostname length check in StartNodeUserDatabaseConnection

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -251,13 +251,14 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
 	bool found;
 
 	/* do some minimal input checks */
-	strlcpy(key.hostname, hostname, MAX_NODE_LENGTH);
 	if (strlen(hostname) > MAX_NODE_LENGTH)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("hostname exceeds the maximum length of %d",
 							   MAX_NODE_LENGTH)));
 	}
+
+	strlcpy(key.hostname, hostname, MAX_NODE_LENGTH);
 
 	key.port = port;
 	if (user)


### PR DESCRIPTION
Copying string before `hostname` length check makes the check useless