### PR TITLE
Fix flappy test: Run subquery_prepared_statements by itself

### DIFF
--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -84,8 +84,9 @@ test: set_operations
 test: set_operation_and_local_tables
 
 test: subqueries_deep subquery_view subquery_partitioning subquery_complex_target_list subqueries_not_supported subquery_in_where
+test: subquery_prepared_statements
 test: non_colocated_leaf_subquery_joins non_colocated_subquery_joins non_colocated_join_order
-test: subquery_prepared_statements cte_inline recursive_view_local_table
+test: cte_inline recursive_view_local_table
 test: pg13 pg12
 test: tableam
 


### PR DESCRIPTION
We sporadically see planner debug messages showing up in subquery_prepared_statements because the prepared statement cache gets invalidated by a concurrent operation, hence a query gets replanned. 