### PR TITLE
Reduce test flappiness

### DIFF
--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -226,6 +226,7 @@ COMMIT;
 -- now, some of the optional connections would be skipped,
 -- and only 5 connections are used per node
 BEGIN;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
 	SELECT count(*), pg_sleep(0.1) FROM test;
  count | pg_sleep
 ---------------------------------------------------------------------
@@ -476,6 +477,7 @@ BEGIN;
 	-- when COPY is used with _max_query_parallelization
 	-- it ignores the shared pool size
 	SET LOCAL citus.force_max_query_parallelization TO ON;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
 	COPY test FROM PROGRAM 'seq 32';
 	SELECT
 		connection_count_to_node

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -211,7 +211,8 @@ test: multi_complex_count_distinct multi_select_distinct
 test: multi_modifications
 test: multi_distribution_metadata
 test: multi_generate_ddl_commands multi_create_shards multi_prune_shard_list multi_repair_shards
-test: multi_upsert multi_simple_queries multi_data_types master_copy_shard_placement
+test: multi_upsert multi_simple_queries multi_data_types
+test: master_copy_shard_placement
 # multi_utilities cannot be run in parallel with other tests because it checks
 # global locks
 test: multi_utilities

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -415,11 +415,15 @@ push(@pgOptions, "shared_preload_libraries='${sharedPreloadLibraries}'");
 # Avoid parallelism to stabilize explain plans
 push(@pgOptions, "max_parallel_workers_per_gather=0");
 
+# Help with debugging
+push(@pgOptions, "log_error_verbosity = 'verbose'");
+
 # Allow CREATE SUBSCRIPTION to work
 push(@pgOptions, "wal_level='logical'");
 
 # Citus options set for the tests
 push(@pgOptions, "citus.shard_count=4");
+push(@pgOptions, "citus.max_adaptive_executor_pool_size=4");
 push(@pgOptions, "citus.shard_max_size=1500kB");
 push(@pgOptions, "citus.repartition_join_bucket_count_per_node=2");
 push(@pgOptions, "citus.sort_returning='on'");

--- a/src/test/regress/sql/shared_connection_stats.sql
+++ b/src/test/regress/sql/shared_connection_stats.sql
@@ -148,6 +148,7 @@ COMMIT;
 -- now, some of the optional connections would be skipped,
 -- and only 5 connections are used per node
 BEGIN;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
 	SELECT count(*), pg_sleep(0.1) FROM test;
 	SELECT
 		connection_count_to_node
@@ -325,6 +326,7 @@ BEGIN;
 	-- when COPY is used with _max_query_parallelization
 	-- it ignores the shared pool size
 	SET LOCAL citus.force_max_query_parallelization TO ON;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
 	COPY test FROM PROGRAM 'seq 32';
 
 	SELECT


### PR DESCRIPTION
A few more improvements to reduce test flappiness:
- Reduce max_adaptive_executor_pool_size to avoid making many connections for fetch tasks during re-partitioning
- Use verbose logging to make it easier to chase down the source of errors in logs
- Move master_copy_shard_placement to its own schedule to avoid #4366