### PR TITLE
Columnar: few fixes

### DIFF
--- a/src/backend/columnar/cstore_writer.c
+++ b/src/backend/columnar/cstore_writer.c
@@ -112,7 +112,7 @@ CStoreBeginWrite(RelFileNode relfilenode,
 	writeState->stripeWriteContext = stripeWriteContext;
 	writeState->blockData = blockData;
 	writeState->compressionBuffer = NULL;
-	writeState->perTupleContext = AllocSetContextCreate(stripeWriteContext,
+	writeState->perTupleContext = AllocSetContextCreate(CurrentMemoryContext,
 														"CStore per tuple context",
 														ALLOCSET_DEFAULT_SIZES);
 

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -42,7 +42,7 @@ CREATE TABLE cstore_skipnodes (
     exists_stream_length bigint NOT NULL,
     value_compression_type int NOT NULL,
     PRIMARY KEY (storageid, stripe, attr, block),
-    FOREIGN KEY (storageid, stripe) REFERENCES cstore_stripes(storageid, stripe) ON DELETE CASCADE INITIALLY DEFERRED
+    FOREIGN KEY (storageid, stripe) REFERENCES cstore_stripes(storageid, stripe) ON DELETE CASCADE
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE cstore_skipnodes IS 'CStore per block metadata';

--- a/src/test/regress/expected/am_memory.out
+++ b/src/test/regress/expected/am_memory.out
@@ -81,7 +81,7 @@ write_clear_outside_xact | t
 INSERT INTO t
  SELECT i, 'last batch', 0 /* no need to record memusage per row */
  FROM generate_series(1, 50000) i;
-SELECT 1.0 * TopMemoryContext / :top_post BETWEEN 0.99 AND 1.01 AS top_growth_ok
+SELECT 1.0 * TopMemoryContext / :top_post BETWEEN 0.98 AND 1.02 AS top_growth_ok
 FROM column_store_memory_stats();
 -[ RECORD 1 ]-+--
 top_growth_ok | t

--- a/src/test/regress/sql/am_memory.sql
+++ b/src/test/regress/sql/am_memory.sql
@@ -85,7 +85,7 @@ INSERT INTO t
  SELECT i, 'last batch', 0 /* no need to record memusage per row */
  FROM generate_series(1, 50000) i;
 
-SELECT 1.0 * TopMemoryContext / :top_post BETWEEN 0.99 AND 1.01 AS top_growth_ok
+SELECT 1.0 * TopMemoryContext / :top_post BETWEEN 0.98 AND 1.02 AS top_growth_ok
 FROM column_store_memory_stats();
 
 -- before this change, max mem usage while executing inserts was 28MB and


### PR DESCRIPTION
1. Reparent `writeState->perTupleContext`. `MemoryContextReset` deletes its children, and we reset `stripeWriteContext` when flushing stripes. This made `perTupleContext` invalid and caused some crashes.
2. Remove `INITIALLY DEFERRED` from metadata tables. We don't need them to be deferred, and can cause errors for VACUUM FULL in postgres 13 (`ERROR:  cannot fire deferred trigger within security-restricted operation`) as in https://app.circleci.com/pipelines/github/citusdata/citus/11753/workflows/311b12fc-4614-44e3-a31b-ca0190d574f8/jobs/188535.
3. Relax memory growth constraints a bit, to make results more consistent between different setups.