### PR TITLE
Columnar: Fix VACUUM for empty tables

### DIFF
--- a/src/test/regress/columnar_am_schedule
+++ b/src/test/regress/columnar_am_schedule
@@ -8,6 +8,7 @@ test: am_query
 test: am_analyze
 test: am_data_types
 test: am_drop
+test: am_empty
 test: am_insert
 test: am_copyto
 test: am_alter

--- a/src/test/regress/expected/am_empty.out
+++ b/src/test/regress/expected/am_empty.out
@@ -1,0 +1,97 @@
+--
+-- Test different operations on empty columnar tables.
+--
+SET citus.compression to 'none';
+create table t_uncompressed(a int) using columnar;
+create table t_compressed(a int) using columnar;
+-- set options
+SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT alter_columnar_table_set('t_compressed', stripe_row_count => 100);
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT alter_columnar_table_set('t_compressed', block_row_count => 100);
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM cstore.options WHERE regclass = 't_compressed'::regclass;
+   regclass   | block_row_count | stripe_row_count | compression
+---------------------------------------------------------------------
+ t_compressed |             100 |              100 | pglz
+(1 row)
+
+-- select
+select * from t_uncompressed;
+ a
+---------------------------------------------------------------------
+(0 rows)
+
+select count(*) from t_uncompressed;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+select * from t_compressed;
+ a
+---------------------------------------------------------------------
+(0 rows)
+
+select count(*) from t_compressed;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- explain
+explain (costs off, summary off, timing off) select * from t_uncompressed;
+                 QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (CStoreScan) on t_uncompressed
+(1 row)
+
+explain (costs off, summary off, timing off) select * from t_compressed;
+                QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (CStoreScan) on t_compressed
+(1 row)
+
+-- vacuum
+vacuum verbose t_compressed;
+INFO:  statistics for "t_compressed":
+storage id: -1
+total file size: 0, total data size: 0
+total row count: 0, stripe count: 0, average rows per stripe: 0
+block count: 0, containing data for dropped columns: 0, none compressed: 0, pglz compressed: 0
+
+vacuum verbose t_uncompressed;
+INFO:  statistics for "t_uncompressed":
+storage id: -1
+total file size: 0, total data size: 0
+total row count: 0, stripe count: 0, average rows per stripe: 0
+block count: 0, containing data for dropped columns: 0, none compressed: 0, pglz compressed: 0
+
+-- vacuum full
+vacuum full t_compressed;
+vacuum full t_uncompressed;
+-- analyze
+analyze t_uncompressed;
+analyze t_compressed;
+-- truncate
+truncate t_uncompressed;
+truncate t_compressed;
+-- alter type
+alter table t_uncompressed alter column a type text;
+alter table t_compressed alter column a type text;
+-- drop
+drop table t_compressed;
+drop table t_uncompressed;

--- a/src/test/regress/sql/am_empty.sql
+++ b/src/test/regress/sql/am_empty.sql
@@ -1,0 +1,48 @@
+--
+-- Test different operations on empty columnar tables.
+--
+
+SET citus.compression to 'none';
+create table t_uncompressed(a int) using columnar;
+create table t_compressed(a int) using columnar;
+
+-- set options
+SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
+SELECT alter_columnar_table_set('t_compressed', stripe_row_count => 100);
+SELECT alter_columnar_table_set('t_compressed', block_row_count => 100);
+
+SELECT * FROM cstore.options WHERE regclass = 't_compressed'::regclass;
+
+-- select
+select * from t_uncompressed;
+select count(*) from t_uncompressed;
+select * from t_compressed;
+select count(*) from t_compressed;
+
+-- explain
+explain (costs off, summary off, timing off) select * from t_uncompressed;
+explain (costs off, summary off, timing off) select * from t_compressed;
+
+-- vacuum
+vacuum verbose t_compressed;
+vacuum verbose t_uncompressed;
+
+-- vacuum full
+vacuum full t_compressed;
+vacuum full t_uncompressed;
+
+-- analyze
+analyze t_uncompressed;
+analyze t_compressed;
+
+-- truncate
+truncate t_uncompressed;
+truncate t_compressed;
+
+-- alter type
+alter table t_uncompressed alter column a type text;
+alter table t_compressed alter column a type text;
+
+-- drop
+drop table t_compressed;
+drop table t_uncompressed;


### PR DESCRIPTION
Previously we threw a division by zero exception when calculating average rows per stripes. Also adds tests to verify other operations work gracefully.

After fixing the division by zero, VACUUM for empty table started throwing "Metapage is not initialized", for which I made the change to `GetHighestUsedAddress()`. Note that `GetHighestUsedAddress()` is used only for truncate stage of VACUUM.