### PR TITLE
add codecov upload task for pg_upgrade tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,8 @@ jobs:
            install-and-test-ext --target check-citus-upgrade-mixed --citus-pre-tar /install-pg11-citusv8.2.0.tar
            install-and-test-ext --target check-citus-upgrade-mixed --citus-pre-tar /install-pg11-citusv8.3.0.tar
           no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_11,upgrade'
 
   test-13_check-multi:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,8 @@ jobs:
           name: 'Install and test postgres upgrade'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext --target check-pg-upgrade --old-pg-version 11 --new-pg-version 12'
           no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_11_12,upgrade'
 
   test-12-13_check-pg-upgrade:
     docker:
@@ -238,6 +240,8 @@ jobs:
           name: 'Install and test postgres upgrade'
           command: 'chown -R circleci:circleci /home/circleci && install-and-test-ext --target check-pg-upgrade --old-pg-version 12 --new-pg-version 13'
           no_output_timeout: 2m
+      - codecov/upload:
+          flags: 'test_12_13,upgrade'
 
   test-12_check-multi:
     docker:


### PR DESCRIPTION
Small change that will upload lines hit during upgrades to codecov.
It got to our attention we are not capturing the codecov during upgrades in #4354 .
