### PR TITLE
Fix flappy failure test

### DIFF
--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -141,8 +141,8 @@ SELECT count(*) FROM products;
 (1 row)
 
 -- use OFFSET 1 to prevent printing the line where source
--- is the worker
-SELECT citus.dump_network_traffic() ORDER BY 1 OFFSET 1;
+-- is the worker, and LIMIT 1 in case there were multiple connections
+SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
         dump_network_traffic
 ---------------------------------------------------------------------
  (1,coordinator,"[initial message]")

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -81,8 +81,8 @@ SELECT count(*) FROM products;
 SELECT count(*) FROM products;
 
 -- use OFFSET 1 to prevent printing the line where source
--- is the worker
-SELECT citus.dump_network_traffic() ORDER BY 1 OFFSET 1;
+-- is the worker, and LIMIT 1 in case there were multiple connections
+SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
 
 SELECT citus.mitmproxy('conn.allow()');
 SET citus.shard_replication_factor TO 1;


### PR DESCRIPTION
Fix a common flappy test:
```sql
 -- use OFFSET 1 to prevent printing the line where source
 -- is the worker
 SELECT citus.dump_network_traffic() ORDER BY 1 OFFSET 1;
         dump_network_traffic         
 -------------------------------------
  (1,coordinator,"[initial message]")
-(1 row)
+ (2,coordinator,"[initial message]")
+(2 rows)
 
 SELECT citus.mitmproxy('conn.allow()');
```

The second line indicates there was an additional connection to the worker with the mitmproxy, which is expected.