### PR TITLE
Delete transactions when removing node

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -42,6 +42,7 @@
 #include "distributed/shardinterval_utils.h"
 #include "distributed/shared_connection_stats.h"
 #include "distributed/string_utils.h"
+#include "distributed/transaction_recovery.h"
 #include "distributed/version_compat.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
@@ -1131,6 +1132,12 @@ RemoveNodeFromCluster(char *nodeName, int32 nodePort)
 								"To proceed, either drop the distributed tables or use "
 								"undistribute_table() function to convert them to local tables")));
 		}
+
+		/*
+		 * Secondary nodes are read-only, never 2PC is used.
+		 * Hence, no items can be inserted to pg_dist_transaction for secondary nodes.
+		 */
+		DeleteWorkerTransactions(workerNode);
 	}
 
 	DeleteNodeRow(workerNode->workerName, nodePort);

--- a/src/include/distributed/transaction_recovery.h
+++ b/src/include/distributed/transaction_recovery.h
@@ -19,6 +19,6 @@ extern int Recover2PCInterval;
 /* Functions declarations for worker transactions */
 extern void LogTransactionRecord(int32 groupId, char *transactionName);
 extern int RecoverTwoPhaseCommits(void);
-
+extern void DeleteWorkerTransactions(WorkerNode *workerNode);
 
 #endif /* TRANSACTION_RECOVERY_H */

--- a/src/test/regress/expected/multi_read_from_secondaries.out
+++ b/src/test/regress/expected/multi_read_from_secondaries.out
@@ -23,7 +23,7 @@ INSERT INTO dest_table (a, b) VALUES (1, 1);
 INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (1, 5);
 INSERT INTO source_table (a, b) VALUES (10, 10);
--- simluate actually having secondary nodes
+-- simulate actually having secondary nodes
 SELECT nodeid, groupid, nodename, nodeport, noderack, isactive, noderole, nodecluster FROM pg_dist_node;
  nodeid | groupid | nodename  | nodeport | noderack | isactive | noderole | nodecluster
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -28,10 +28,31 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
      1
 (1 row)
 
+-- test recovery when removing node
+CREATE TABLE recovery_test (x int, y int);
+SELECT create_distributed_table('recovery_test','x');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP TABLE recovery_test;
 SELECT master_remove_node('localhost', :worker_2_port);
  master_remove_node
 ---------------------------------------------------------------------
 
+(1 row)
+
+SELECT recover_prepared_transactions();
+ recover_prepared_transactions
+---------------------------------------------------------------------
+                             0
+(1 row)
+
+SELECT count(*) FROM pg_dist_transaction;
+ count
+---------------------------------------------------------------------
+     0
 (1 row)
 
 -- verify node is removed
@@ -132,7 +153,7 @@ WHERE
     nodeport = :worker_2_port;
  shardid | shardstate | shardlength | nodename  | nodeport
 ---------------------------------------------------------------------
- 1380000 |          1 |           0 | localhost |    57638
+ 1380004 |          1 |           0 | localhost |    57638
 (1 row)
 
 SELECT shardcount, replicationfactor, distributioncolumntype
@@ -161,7 +182,7 @@ WHERE
     nodeport = :worker_2_port;
  shardid | shardstate | shardlength | nodename  | nodeport
 ---------------------------------------------------------------------
- 1380000 |          1 |           0 | localhost |    57638
+ 1380004 |          1 |           0 | localhost |    57638
 (1 row)
 
 \c - - - :master_port

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -1059,7 +1059,7 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
 --
 SET citus.replicate_reference_tables_on_activate TO off;
 SET citus.shard_replication_factor TO 1;
-select master_remove_node('localhost', :worker_2_port);
+SELECT master_remove_node('localhost', :worker_2_port);
  master_remove_node
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_transaction_recovery.out
+++ b/src/test/regress/expected/multi_transaction_recovery.out
@@ -362,6 +362,7 @@ SELECT pg_reload_conf();
 DROP TABLE test_recovery_ref;
 DROP TABLE test_recovery;
 DROP TABLE test_recovery_single;
+DROP TABLE test_reference_table;
 SELECT 1 FROM master_remove_node('localhost', :master_port);
  ?column?
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/multi_read_from_secondaries.sql
+++ b/src/test/regress/sql/multi_read_from_secondaries.sql
@@ -19,7 +19,7 @@ INSERT INTO dest_table (a, b) VALUES (2, 1);
 INSERT INTO source_table (a, b) VALUES (1, 5);
 INSERT INTO source_table (a, b) VALUES (10, 10);
 
--- simluate actually having secondary nodes
+-- simulate actually having secondary nodes
 SELECT nodeid, groupid, nodename, nodeport, noderack, isactive, noderole, nodecluster FROM pg_dist_node;
 UPDATE pg_dist_node SET noderole = 'secondary';
 

--- a/src/test/regress/sql/multi_remove_node_reference_table.sql
+++ b/src/test/regress/sql/multi_remove_node_reference_table.sql
@@ -26,7 +26,13 @@ SELECT master_remove_node('localhost', 55555);
 -- verify node exist before removal
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 
+-- test recovery when removing node
+CREATE TABLE recovery_test (x int, y int);
+SELECT create_distributed_table('recovery_test','x');
+DROP TABLE recovery_test;
 SELECT master_remove_node('localhost', :worker_2_port);
+SELECT recover_prepared_transactions();
+SELECT count(*) FROM pg_dist_transaction;
 
 -- verify node is removed
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -654,7 +654,7 @@ SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
 SET citus.replicate_reference_tables_on_activate TO off;
 SET citus.shard_replication_factor TO 1;
 
-select master_remove_node('localhost', :worker_2_port);
+SELECT master_remove_node('localhost', :worker_2_port);
 
 CREATE TABLE ref (a int primary key, b int);
 SELECT create_reference_table('ref');

--- a/src/test/regress/sql/multi_transaction_recovery.sql
+++ b/src/test/regress/sql/multi_transaction_recovery.sql
@@ -200,5 +200,6 @@ SELECT pg_reload_conf();
 DROP TABLE test_recovery_ref;
 DROP TABLE test_recovery;
 DROP TABLE test_recovery_single;
+DROP TABLE test_reference_table;
 
 SELECT 1 FROM master_remove_node('localhost', :master_port);


### PR DESCRIPTION
DESCRIPTION: Deletes transactions when removing a node

Records in pg_dist_transaction stick around forever after removing a node group. This PR solves this issue by deleting its records when removing a node.

fixes #1573