### PR TITLE
Add a utility to process each table index

### DIFF
--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -67,6 +67,8 @@ typedef enum ExtractForeignKeyConstraintsMode
 /* cluster.c - forward declarations */
 extern List * PreprocessClusterStmt(Node *node, const char *clusterCommand);
 
+/* index.c */
+typedef void (*PGIndexProcessor)(Form_pg_index, List **);
 
 /* call.c */
 extern bool CallDistributedProcedureRemotely(CallStmt *callStmt, DestReceiver *dest);
@@ -183,6 +185,8 @@ extern List * PostprocessIndexStmt(Node *node,
 								   const char *queryString);
 extern void ErrorIfUnsupportedAlterIndexStmt(AlterTableStmt *alterTableStatement);
 extern void MarkIndexValid(IndexStmt *indexStmt);
+extern List * ExecuteFunctionOnEachTableIndex(Oid relationId, PGIndexProcessor
+											  pgIndexProcessor);
 
 /* objectaddress.c - forward declarations */
 extern ObjectAddress CreateExtensionStmtObjectAddress(Node *stmt, bool missing_ok);


### PR DESCRIPTION
A utility function is added so that each caller can implement a handler
for each index on a given table. This means that the caller doesn't need
to worry about how to access each index, the only thing that it needs to
do each to implement a function to which each index on the table is
passed iteratively.

Used in #4358 