### PR TITLE
Harden citus_tables against node failure

### DIFF
--- a/src/backend/distributed/sql/citus--9.5-1--10.0-1.sql
+++ b/src/backend/distributed/sql/citus--9.5-1--10.0-1.sql
@@ -1,5 +1,8 @@
 -- citus--9.5-1--10.0-1
 
+DROP FUNCTION IF EXISTS pg_catalog.citus_total_relation_size(regclass);
+
+#include "udfs/citus_total_relation_size/10.0-1.sql"
 #include "udfs/citus_tables/10.0-1.sql"
 #include "udfs/citus_finish_pg_upgrade/10.0-1.sql"
 

--- a/src/backend/distributed/sql/downgrades/citus--10.0-1--9.5-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.0-1--9.5-1.sql
@@ -6,3 +6,6 @@
 #include "../../../columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql"
 
 DROP VIEW public.citus_tables;
+DROP FUNCTION pg_catalog.citus_total_relation_size(regclass,boolean);
+
+#include "../udfs/citus_total_relation_size/7.0-1.sql"

--- a/src/backend/distributed/sql/udfs/citus_tables/10.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/10.0-1.sql
@@ -4,7 +4,7 @@ SELECT
   CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS "Citus Table Type",
   coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS "Distribution Column",
   colocationid AS "Colocation ID",
-  pg_size_pretty(citus_total_relation_size(logicalrelid)) AS "Size",
+  pg_size_pretty(citus_total_relation_size(logicalrelid, fail_on_error := false)) AS "Size",
   (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS "Shard Count",
   pg_get_userbyid(relowner) AS "Owner",
   amname AS "Access Method"

--- a/src/backend/distributed/sql/udfs/citus_tables/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/latest.sql
@@ -4,7 +4,7 @@ SELECT
   CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS "Citus Table Type",
   coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS "Distribution Column",
   colocationid AS "Colocation ID",
-  pg_size_pretty(citus_total_relation_size(logicalrelid)) AS "Size",
+  pg_size_pretty(citus_total_relation_size(logicalrelid, fail_on_error := false)) AS "Size",
   (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS "Shard Count",
   pg_get_userbyid(relowner) AS "Owner",
   amname AS "Access Method"

--- a/src/backend/distributed/sql/udfs/citus_total_relation_size/10.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_total_relation_size/10.0-1.sql
@@ -1,0 +1,6 @@
+CREATE FUNCTION pg_catalog.citus_total_relation_size(logicalrelid regclass, fail_on_error boolean default true)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_total_relation_size$$;
+COMMENT ON FUNCTION pg_catalog.citus_total_relation_size(logicalrelid regclass, boolean)
+    IS 'get total disk space used by the specified table';

--- a/src/backend/distributed/sql/udfs/citus_total_relation_size/7.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_total_relation_size/7.0-1.sql
@@ -1,0 +1,6 @@
+CREATE FUNCTION pg_catalog.citus_total_relation_size(logicalrelid regclass)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_total_relation_size$$;
+COMMENT ON FUNCTION pg_catalog.citus_total_relation_size(logicalrelid regclass)
+    IS 'get total disk space used by the specified table';

--- a/src/backend/distributed/sql/udfs/citus_total_relation_size/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_total_relation_size/latest.sql
@@ -1,0 +1,6 @@
+CREATE FUNCTION pg_catalog.citus_total_relation_size(logicalrelid regclass, fail_on_error boolean default true)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_total_relation_size$$;
+COMMENT ON FUNCTION pg_catalog.citus_total_relation_size(logicalrelid regclass, boolean)
+    IS 'get total disk space used by the specified table';

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -476,20 +476,22 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.0-1
 ALTER EXTENSION citus UPDATE TO '10.0-1';
 SELECT * FROM print_extension_changes();
- previous_object |                            current_object
+               previous_object                |                                current_object
 ---------------------------------------------------------------------
-                 | access method columnar
-                 | function alter_columnar_table_reset(regclass,boolean,boolean,boolean,boolean)
-                 | function alter_columnar_table_set(regclass,integer,integer,name,integer)
-                 | function citus_internal.columnar_ensure_objects_exist()
-                 | function columnar.columnar_handler(internal)
-                 | schema columnar
-                 | sequence columnar.storageid_seq
-                 | table columnar.columnar_skipnodes
-                 | table columnar.columnar_stripes
-                 | table columnar.options
-                 | view citus_tables
-(11 rows)
+ function citus_total_relation_size(regclass) |
+                                              | access method columnar
+                                              | function alter_columnar_table_reset(regclass,boolean,boolean,boolean,boolean)
+                                              | function alter_columnar_table_set(regclass,integer,integer,name,integer)
+                                              | function citus_internal.columnar_ensure_objects_exist()
+                                              | function citus_total_relation_size(regclass,boolean)
+                                              | function columnar.columnar_handler(internal)
+                                              | schema columnar
+                                              | sequence columnar.storageid_seq
+                                              | table columnar.columnar_skipnodes
+                                              | table columnar.columnar_stripes
+                                              | table columnar.options
+                                              | view citus_tables
+(13 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version

--- a/src/test/regress/expected/multi_extension_0.out
+++ b/src/test/regress/expected/multi_extension_0.out
@@ -476,16 +476,18 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.0-1
 ALTER EXTENSION citus UPDATE TO '10.0-1';
 SELECT * FROM print_extension_changes();
- previous_object |                    current_object
+               previous_object                |                     current_object
 ---------------------------------------------------------------------
-                 | function citus_internal.columnar_ensure_objects_exist()
-                 | schema columnar
-                 | sequence columnar.storageid_seq
-                 | table columnar.columnar_skipnodes
-                 | table columnar.columnar_stripes
-                 | table columnar.options
-                 | view citus_tables
-(7 rows)
+ function citus_total_relation_size(regclass) |
+                                              | function citus_internal.columnar_ensure_objects_exist()
+                                              | function citus_total_relation_size(regclass,boolean)
+                                              | schema columnar
+                                              | sequence columnar.storageid_seq
+                                              | table columnar.columnar_skipnodes
+                                              | table columnar.columnar_stripes
+                                              | table columnar.options
+                                              | view citus_tables
+(9 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -65,7 +65,7 @@ ORDER BY 1;
  function citus_table_is_visible(oid)
  function citus_table_size(regclass)
  function citus_text_send_as_jsonb(text)
- function citus_total_relation_size(regclass)
+ function citus_total_relation_size(regclass,boolean)
  function citus_truncate_trigger()
  function citus_validate_rebalance_strategy_functions(regproc,regproc,regproc)
  function citus_version()

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -62,7 +62,7 @@ ORDER BY 1;
  function citus_table_is_visible(oid)
  function citus_table_size(regclass)
  function citus_text_send_as_jsonb(text)
- function citus_total_relation_size(regclass)
+ function citus_total_relation_size(regclass,boolean)
  function citus_truncate_trigger()
  function citus_validate_rebalance_strategy_functions(regproc,regproc,regproc)
  function citus_version()


### PR DESCRIPTION
It would be nice if `citus_tables` keeps working even if a node is down to see what's going on in the cluster. 

This PR adds a flag to `citus_total_relation_size` function to continue (and return NULL) on error and uses that in `citus_tables`.