### PR TITLE
Columnar: set default compression as zstd if available

### DIFF
--- a/src/backend/columnar/cstore.c
+++ b/src/backend/columnar/cstore.c
@@ -24,9 +24,16 @@
 #include "columnar/cstore.h"
 
 /* Default values for option parameters */
-#define DEFAULT_COMPRESSION_TYPE COMPRESSION_NONE
 #define DEFAULT_STRIPE_ROW_COUNT 150000
 #define DEFAULT_CHUNK_ROW_COUNT 10000
+
+#if HAVE_LIBZSTD
+#define DEFAULT_COMPRESSION_TYPE COMPRESSION_ZSTD
+#elif HAVE_LIBLZ4
+#define DEFAULT_COMPRESSION_TYPE COMPRESSION_LZ4
+#else
+#define DEFAULT_COMPRESSION_TYPE COMPRESSION_PG_LZ
+#endif
 
 int cstore_compression = DEFAULT_COMPRESSION_TYPE;
 int cstore_stripe_row_count = DEFAULT_STRIPE_ROW_COUNT;

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -1,6 +1,7 @@
 --
 -- Testing we materialized views properly
 --
+SET columnar.compression TO 'none';
 CREATE TABLE t(a int, b int) USING columnar;
 INSERT INTO t SELECT floor(i / 4), 2 * i FROM generate_series(1, 10) i;
 CREATE MATERIALIZED VIEW t_view(a, bsum, cnt) USING columnar AS

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -1,5 +1,6 @@
 CREATE SCHEMA am_tableoptions;
 SET search_path TO am_tableoptions;
+SET columnar.compression TO 'none';
 CREATE TABLE table_options (a int) USING columnar;
 INSERT INTO table_options SELECT generate_series(1,100);
 -- show table_options settings

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -1,3 +1,4 @@
+SET columnar.compression TO 'none';
 SELECT count(distinct storageid) AS columnar_table_count FROM columnar.columnar_stripes \gset
 CREATE TABLE t(a int, b int) USING columnar;
 CREATE VIEW t_stripes AS

--- a/src/test/regress/expected/columnar_citus_integration.out
+++ b/src/test/regress/expected/columnar_citus_integration.out
@@ -1,3 +1,4 @@
+SET columnar.compression TO 'none';
 CREATE SCHEMA columnar_citus_integration;
 SET search_path TO columnar_citus_integration;
 SET citus.next_shard_id TO 20090000;

--- a/src/test/regress/spec/am_vacuum_vs_insert.spec
+++ b/src/test/regress/spec/am_vacuum_vs_insert.spec
@@ -1,5 +1,6 @@
 setup
 {
+    SET columnar.compression TO 'none';
     CREATE TABLE test_vacuum_vs_insert (a int, b int) USING columnar;
 }
 

--- a/src/test/regress/sql/am_matview.sql
+++ b/src/test/regress/sql/am_matview.sql
@@ -2,6 +2,8 @@
 -- Testing we materialized views properly
 --
 
+SET columnar.compression TO 'none';
+
 CREATE TABLE t(a int, b int) USING columnar;
 
 INSERT INTO t SELECT floor(i / 4), 2 * i FROM generate_series(1, 10) i;

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -1,5 +1,6 @@
 CREATE SCHEMA am_tableoptions;
 SET search_path TO am_tableoptions;
+SET columnar.compression TO 'none';
 
 CREATE TABLE table_options (a int) USING columnar;
 INSERT INTO table_options SELECT generate_series(1,100);

--- a/src/test/regress/sql/am_vacuum.sql
+++ b/src/test/regress/sql/am_vacuum.sql
@@ -1,3 +1,5 @@
+SET columnar.compression TO 'none';
+
 SELECT count(distinct storageid) AS columnar_table_count FROM columnar.columnar_stripes \gset
 
 CREATE TABLE t(a int, b int) USING columnar;

--- a/src/test/regress/sql/columnar_citus_integration.sql
+++ b/src/test/regress/sql/columnar_citus_integration.sql
@@ -1,3 +1,5 @@
+SET columnar.compression TO 'none';
+
 CREATE SCHEMA columnar_citus_integration;
 SET search_path TO columnar_citus_integration;
 SET citus.next_shard_id TO 20090000;


### PR DESCRIPTION
Use `zstd` as default compression method if available, then use `lz4` if `zstd` is not available, and use `pglz` if none of `lz4` or `zstd` are available.
