### PR TITLE
Columnar: Fix ANALYZE for large number of rows.

### DIFF
--- a/src/test/regress/expected/am_analyze.out
+++ b/src/test/regress/expected/am_analyze.out
@@ -17,3 +17,9 @@ SELECT count(*) FROM pg_stats WHERE tablename='contestant_compressed';
      6
 (1 row)
 
+-- ANALYZE a table with lots of data to trigget qsort in analyze.c
+CREATE TABLE test_analyze(a int, b text, c char) USING columnar;
+INSERT INTO test_analyze SELECT floor(i / 1000), floor(i / 10)::text, 4 FROM generate_series(1, 100000) i;
+INSERT INTO test_analyze SELECT floor(i / 2), floor(i / 10)::text, 5 FROM generate_series(1000, 110000) i;
+ANALYZE test_analyze;
+DROP TABLE test_analyze;

--- a/src/test/regress/sql/am_analyze.sql
+++ b/src/test/regress/sql/am_analyze.sql
@@ -9,3 +9,11 @@ SELECT count(*) FROM pg_stats WHERE tablename='contestant';
 -- ANALYZE compressed table
 ANALYZE contestant_compressed;
 SELECT count(*) FROM pg_stats WHERE tablename='contestant_compressed';
+
+-- ANALYZE a table with lots of data to trigget qsort in analyze.c
+CREATE TABLE test_analyze(a int, b text, c char) USING columnar;
+INSERT INTO test_analyze SELECT floor(i / 1000), floor(i / 10)::text, 4 FROM generate_series(1, 100000) i;
+INSERT INTO test_analyze SELECT floor(i / 2), floor(i / 10)::text, 5 FROM generate_series(1000, 110000) i;
+
+ANALYZE test_analyze;
+DROP TABLE test_analyze;


### PR DESCRIPTION
acquire_sample_rows() in analyze.c sorts rows by item pointer if number of rows exceed target. We didn't set item pointer before, so columnar failed ANALYZE for large tables in an assertion. This PR fixes that by setting an item pointer for tuples returned by copy_heap_tuple.