### PR TITLE
Not consider single shard hash dist. tables as replicated

### DIFF
--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -465,7 +465,7 @@ SingleReplicatedTable(Oid relationId)
 	List *shardPlacementList = NIL;
 
 	/* we could have append/range distributed tables without shards */
-	if (list_length(shardList) <= 1)
+	if (list_length(shardList) == 0)
 	{
 		return false;
 	}


### PR DESCRIPTION
DESCRIPTION: Not consider single shard hash dist. tables as replicated

In https://github.com/citusdata/citus/issues/4291, user reported they get `cannot calculate the size because replication factor is greater than 1` error for single shard hash distributed tables.

As we started to support replicated tables in size function in https://github.com/citusdata/citus/pull/4309/ / 4098d33acb7576b13481ffc320aff1b88188582b, the issue was kind of fixed (or say hidden) on master but it is still reproducible up until 9.5.1

See https://github.com/citusdata/citus/issues/4291#issuecomment-745127161

Main reason behind this issue seems to be the wrong check in `SingleReplicatedTable`
