### PR TITLE
Separate schedules for mixed mode and normal mode in upgrade

### DIFF
--- a/src/test/regress/mixed_after_citus_upgrade_schedule
+++ b/src/test/regress/mixed_after_citus_upgrade_schedule
@@ -1,0 +1,2 @@
+test: upgrade_basic_after
+test: upgrade_pg_dist_object_test_after

--- a/src/test/regress/mixed_before_citus_upgrade_schedule
+++ b/src/test/regress/mixed_before_citus_upgrade_schedule
@@ -1,0 +1,2 @@
+test: upgrade_basic_before
+test: upgrade_pg_dist_object_test_before

--- a/src/test/regress/upgrade/config.py
+++ b/src/test/regress/upgrade/config.py
@@ -6,6 +6,8 @@ AFTER_PG_UPGRADE_SCHEDULE = './after_pg_upgrade_schedule'
 
 AFTER_CITUS_UPGRADE_COORD_SCHEDULE = './after_citus_upgrade_coord_schedule'
 BEFORE_CITUS_UPGRADE_COORD_SCHEDULE = './before_citus_upgrade_coord_schedule'
+MIXED_BEFORE_CITUS_UPGRADE_SCHEDULE = './mixed_before_citus_upgrade_schedule'
+MIXED_AFTER_CITUS_UPGRADE_SCHEDULE = './mixed_after_citus_upgrade_schedule'
 
 MASTER = 'master'
 # This should be updated when citus version changes


### PR DESCRIPTION
This is done so that we can have tests for only one of the modes instead of both of them.