### PR TITLE
Expand support for subqueries in target list through recursive planning

### DIFF
--- a/src/test/regress/expected/subquery_in_targetlist.out
+++ b/src/test/regress/expected/subquery_in_targetlist.out
@@ -446,9 +446,96 @@ GROUP BY user_id
        1 |    15
 (6 rows)
 
--- make sure that we don't pushdown subqueries in the target list if no FROM clause
+-- FROM is empty join tree, sublink can be recursively planned
 SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table ));
+ user_id
+---------------------------------------------------------------------
+       6
+(1 row)
+
+-- FROM is subquery with empty join tree, sublink can be recursively planned
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table ))
+FROM (SELECT 1) a;
+ user_id
+---------------------------------------------------------------------
+       6
+(1 row)
+
+-- correlated subquery with recurring from clause (prevents recursive planning of outer sublink)
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table) AND value_2 = a)
+FROM (SELECT 1 AS a) r;
 ERROR:  correlated subqueries are not supported when the FROM clause contains a subquery without FROM
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table) AND value_2 = r.user_id)
+FROM users_reference_table r;
+ERROR:  correlated subqueries are not supported when the FROM clause contains a reference table
+-- correlated subquery with recurring from clause (prevents recursive planning of inner sublink)
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table WHERE user_id = a))
+FROM (SELECT 1 AS a) r;
+ERROR:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+-- recurring from clause containing a subquery with sublink on distributed table, recursive planning saves the day
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table ))
+FROM (SELECT * FROM users_reference_table WHERE user_id IN (SELECT user_id FROM events_table)) r
+ORDER BY 1 LIMIT 3;
+ user_id
+---------------------------------------------------------------------
+       6
+       6
+       6
+(3 rows)
+
+-- recurring from clause containing a subquery with correlated sublink on distributed table
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table ))
+FROM (SELECT * FROM users_reference_table WHERE value_2 IN (SELECT value_2 FROM events_table WHERE events_table.user_id = users_reference_table.user_id)) r
+ORDER BY 1 LIMIT 3;
+ERROR:  correlated subqueries are not supported when the FROM clause contains a reference table
+-- recurring from clause with sublink with distributed table in sublink in where
+SELECT (SELECT DISTINCT user_id FROM users_reference_table WHERE user_id IN (SELECT user_id FROM users_table) AND user_id < 2), (SELECT 2), 3
+FROM users_reference_table r
+ORDER BY 1 LIMIT 3;
+ user_id | ?column? | ?column?
+---------------------------------------------------------------------
+       1 |        2 |        3
+       1 |        2 |        3
+       1 |        2 |        3
+(3 rows)
+
+-- recurring from clause with sublink with distributed table in sublink in target list
+SELECT (SELECT 1), (SELECT (SELECT user_id FROM users_table WHERE user_id < 2 GROUP BY user_id)
+        FROM users_reference_table WHERE user_id < 2 GROUP BY user_id)
+FROM users_reference_table r
+ORDER BY 1 LIMIT 3;
+ ?column? | user_id
+---------------------------------------------------------------------
+        1 |       1
+        1 |       1
+        1 |       1
+(3 rows)
+
+-- recurring from clause with correlated sublink with distributed table in sublink in target list
+SELECT (SELECT (SELECT user_id FROM users_table WHERE user_id = users_reference_table.user_id GROUP BY user_id)
+        FROM users_reference_table WHERE user_id < 2 GROUP BY user_id)
+FROM users_reference_table r
+ORDER BY 1 LIMIT 3;
+ERROR:  correlated subqueries are not supported when the FROM clause contains a reference table
+-- recurring from clause with correlated sublink with a recurring from clause and a distributed table in sublink
+SELECT (SELECT DISTINCT user_id FROM users_reference_table WHERE user_id IN (SELECT user_id FROM users_reference_table) AND value_2 = r.value_2 AND user_id < 2)
+FROM users_reference_table r
+ORDER BY 1 LIMIT 3;
+ user_id
+---------------------------------------------------------------------
+       1
+       1
+       1
+(3 rows)
+
+-- correlated subquery with recursively planned subquery in FROM (outer sublink)
+SELECT (SELECT DISTINCT user_id FROM users_table WHERE user_id = (SELECT max(user_id) FROM users_table WHERE user_id = r.user_id))
+FROM (SELECT user_id FROM users_table ORDER BY 1 LIMIT 3) r;
+ERROR:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+-- correlated subquery with recursively planned subquery in FROM (inner sublink)
+SELECT (SELECT (SELECT max(user_id) FROM users_table) FROM users_table WHERE user_id = r.user_id)
+FROM (SELECT user_id FROM users_table ORDER BY 1 LIMIT 3) r;
+ERROR:  correlated subqueries are not supported when the FROM clause contains a CTE or subquery
 -- not meaningful SELECT FOR UPDATE query that should fail
 SELECT count(*) FROM (SELECT
   (SELECT user_id FROM users_table WHERE user_id = u1.user_id FOR UPDATE)


### PR DESCRIPTION
#4360 left a gap where we give error messages about correlated subqueries when there is a subquery in the target list and a recurring FROM clause, even when the subquery is not correlated: https://github.com/citusdata/citus/pull/4360#discussion_r539921465 

The reason our error messages for sublinks exclusively talk about correlated subqueries is that non-correlated, pushdownable subqueries in WHERE are always recursively planned when the FROM clause recurs.

This PR expands that logic to do the same for subqueries in SELECT.