### PR TITLE
Refactor foreign key functions to use table types

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -897,10 +897,8 @@ GetForeignKeyOids(Oid relationId, int flags)
 {
 	AttrNumber pgConstraintTargetAttrNumber = InvalidAttrNumber;
 
-	bool extractReferencing PG_USED_FOR_ASSERTS_ONLY =
-		(flags & INCLUDE_REFERENCING_CONSTRAINTS);
-	bool extractReferenced PG_USED_FOR_ASSERTS_ONLY =
-		(flags & INCLUDE_REFERENCED_CONSTRAINTS);
+	bool extractReferencing = (flags & INCLUDE_REFERENCING_CONSTRAINTS);
+	bool extractReferenced = (flags & INCLUDE_REFERENCED_CONSTRAINTS);
 
 	/*
 	 * Only one of them should be passed at a time since the way we scan
@@ -913,14 +911,14 @@ GetForeignKeyOids(Oid relationId, int flags)
 	bool useIndex = false;
 	Oid indexOid = InvalidOid;
 
-	if (flags & INCLUDE_REFERENCING_CONSTRAINTS)
+	if (extractReferencing)
 	{
 		pgConstraintTargetAttrNumber = Anum_pg_constraint_conrelid;
 
 		useIndex = true;
 		indexOid = ConstraintRelidTypidNameIndexId;
 	}
-	else if (flags & INCLUDE_REFERENCED_CONSTRAINTS)
+	else if (extractReferenced)
 	{
 		pgConstraintTargetAttrNumber = Anum_pg_constraint_confrelid;
 	}

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -63,14 +63,22 @@ typedef enum ExtractForeignKeyConstraintsMode
 	/* exclude the self-referencing foreign keys */
 	EXCLUDE_SELF_REFERENCES = 1 << 2,
 
-	/* include foreign keys only when the other table is a distributed table*/
-	ONLY_DISTRIBUTED_TABLES = 1 << 3,
+	/* any combination of the 4 flags below is supported */
+	/* include foreign keys when the other table is a distributed table*/
+	INCLUDE_DISTRIBUTED_TABLES = 1 << 3,
 
-	/* include foreign keys only when the other table is a reference table*/
-	ONLY_REFERENCE_TABLES = 1 << 4,
+	/* include foreign keys when the other table is a reference table*/
+	INCLUDE_REFERENCE_TABLES = 1 << 4,
 
-	/* include foreign keys only when the other table is a citus local table*/
-	ONLY_CITUS_LOCAL_TABLES = 1 << 5
+	/* include foreign keys when the other table is a citus local table*/
+	INCLUDE_CITUS_LOCAL_TABLES = 1 << 5,
+
+	/* include foreign keys when the other table is a Postgres local table*/
+	INCLUDE_LOCAL_TABLES = 1 << 6,
+
+	/* include foreign keys regardless of the other table's type */
+	INCLUDE_ALL_TABLE_TYPES = INCLUDE_DISTRIBUTED_TABLES | INCLUDE_REFERENCE_TABLES |
+							  INCLUDE_CITUS_LOCAL_TABLES | INCLUDE_LOCAL_TABLES
 } ExtractForeignKeyConstraintMode;
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -61,7 +61,16 @@ typedef enum ExtractForeignKeyConstraintsMode
 	INCLUDE_REFERENCED_CONSTRAINTS = 1 << 1,
 
 	/* exclude the self-referencing foreign keys */
-	EXCLUDE_SELF_REFERENCES = 1 << 2
+	EXCLUDE_SELF_REFERENCES = 1 << 2,
+
+	/* include foreign keys only when the other table is a distributed table*/
+	ONLY_DISTRIBUTED_TABLES = 1 << 3,
+
+	/* include foreign keys only when the other table is a reference table*/
+	ONLY_REFERENCE_TABLES = 1 << 4,
+
+	/* include foreign keys only when the other table is a citus local table*/
+	ONLY_CITUS_LOCAL_TABLES = 1 << 5
 } ExtractForeignKeyConstraintMode;
 
 


### PR DESCRIPTION
Refactors GetForeignKeyOids function to filter by table types.

Now the GetForeignKeyOids function's flags also receive ONLY_DISTRIBUTED_TABLES, ONLY_REFERENCE_TABLES and ONLY_CITUS_LOCAL_TABLES flags. And the function filters accordingly.
Also removed some functions that are now unnecessary