### PR TITLE
Fixes the table used in the error message

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -280,7 +280,7 @@ PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 			if (!IsCitusTable(relationId) &&
 				IsCitusTable(partitionRelationId))
 			{
-				char *parentRelationName = get_rel_name(partitionRelationId);
+				char *parentRelationName = get_rel_name(relationId);
 
 				ereport(ERROR, (errmsg("non-distributed tables cannot have "
 									   "distributed partitions"),

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -295,7 +295,7 @@ SELECT create_distributed_table('partitioning_test_failure_2009', 'id');
 
 ALTER TABLE partitioning_test_failure ATTACH PARTITION partitioning_test_failure_2009 FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
 ERROR:  non-distributed tables cannot have distributed partitions
-HINT:  Distribute the partitioned table "partitioning_test_failure_2009" instead
+HINT:  Distribute the partitioned table "partitioning_test_failure" instead
 -- multi-level partitioning is not allowed
 DROP TABLE partitioning_test_failure_2009;
 CREATE TABLE partitioning_test_failure_2009 PARTITION OF partitioning_test_failure FOR VALUES FROM ('2009-01-01') TO ('2010-01-01') PARTITION BY RANGE (time);


### PR DESCRIPTION
Fixes the table name in the HINT.

```
CREATE TABLE parent_table (a INT) PARTITION BY RANGE (a);
CREATE TABLE child_table (a INT);

SELECT create_distributed_table ('child_table', 'a');

ALTER TABLE parent_table ATTACH PARTITION child_table FOR VALUES FROM (1) TO (5);
```

Error message was:

```
ERROR:  non-distributed tables cannot have distributed partitions
HINT:  Distribute the partitioned table "child_table" instead
```

Now:
```
ERROR:  non-distributed tables cannot have distributed partitions
HINT:  Distribute the partitioned table "parent_table" instead
```