### PR TITLE
Cover postgres tables and missing commands for fkey graph invalidation

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -492,9 +492,9 @@ ColumnAppearsInForeignKey(char *columnName, Oid relationId)
 {
 	int searchForeignKeyColumnFlags = SEARCH_REFERENCING_RELATION |
 									  SEARCH_REFERENCED_RELATION;
-	List *foreignKeyIdsColumnAppeared =
+	List *foreignKeysColumnAppeared =
 		GetForeignKeyIdsForColumn(columnName, relationId, searchForeignKeyColumnFlags);
-	return list_length(foreignKeyIdsColumnAppeared) > 0;
+	return list_length(foreignKeysColumnAppeared) > 0;
 }
 
 

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -741,6 +741,23 @@ TableReferencing(Oid relationId)
 
 
 /*
+ * ConstraintWithNameIsOfType is a wrapper around ConstraintWithNameIsOfType that returns true
+ * if given constraint name identifies a uniqueness constraint, i.e:
+ *   - primary key constraint, or
+ *   - unique constraint
+ */
+bool
+ConstraintIsAUniquenessConstraint(char *inputConstaintName, Oid relationId)
+{
+	bool isUniqueConstraint = ConstraintWithNameIsOfType(inputConstaintName, relationId,
+														 CONSTRAINT_UNIQUE);
+	bool isPrimaryConstraint = ConstraintWithNameIsOfType(inputConstaintName, relationId,
+														  CONSTRAINT_PRIMARY);
+	return isUniqueConstraint || isPrimaryConstraint;
+}
+
+
+/*
  * ConstraintIsAForeignKey is a wrapper around ConstraintWithNameIsOfType that returns true
  * if given constraint name identifies a foreign key constraint.
  */

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -484,6 +484,21 @@ ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
 
 
 /*
+ * ColumnAppearsInForeignKey returns true if there is a foreign key constraint
+ * from/to given column.
+ */
+bool
+ColumnAppearsInForeignKey(char *columnName, Oid relationId)
+{
+	int searchForeignKeyColumnFlags = SEARCH_REFERENCING_RELATION |
+									  SEARCH_REFERENCED_RELATION;
+	List *foreignKeyIdsColumnAppeared =
+		GetForeignKeyIdsForColumn(columnName, relationId, searchForeignKeyColumnFlags);
+	return list_length(foreignKeyIdsColumnAppeared) > 0;
+}
+
+
+/*
  * ColumnAppearsInForeignKeyToReferenceTable checks if there is a foreign key
  * constraint from/to any reference table on the given column.
  */

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -101,8 +101,8 @@ PreprocessDropTableStmt(Node *node, const char *queryString)
 
 		Oid relationId = RangeVarGetRelid(tableRangeVar, AccessShareLock, missingOK);
 
-		/* we're not interested in non-valid, non-distributed relations */
-		if (relationId == InvalidOid || !IsCitusTable(relationId))
+		/* we're not interested in non-valid relations */
+		if (relationId == InvalidOid)
 		{
 			continue;
 		}
@@ -118,6 +118,12 @@ PreprocessDropTableStmt(Node *node, const char *queryString)
 		if ((TableReferenced(relationId) || TableReferencing(relationId)))
 		{
 			MarkInvalidateForeignKeyGraph();
+		}
+
+		/* we're not interested in non-distributed relations */
+		if (!IsCitusTable(relationId))
+		{
+			continue;
 		}
 
 		/* we're only interested in partitioned and mx tables */

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -200,12 +200,6 @@ PostprocessCreateTableStmt(CreateStmt *createStatement, const char *queryString)
 	{
 		ErrorOutForFKeyBetweenPostgresAndCitusLocalTable(relationId);
 	}
-
-	/* invalidate foreign key cache if the table involved in any foreign key */
-	if ((TableReferenced(relationId) || TableReferencing(relationId)))
-	{
-		InvalidateForeignKeyGraph();
-	}
 #endif
 
 	if (createStatement->inhRelations != NIL && createStatement->partbound != NULL)

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -204,7 +204,7 @@ PostprocessCreateTableStmt(CreateStmt *createStatement, const char *queryString)
 	/* invalidate foreign key cache if the table involved in any foreign key */
 	if ((TableReferenced(relationId) || TableReferencing(relationId)))
 	{
-		MarkInvalidateForeignKeyGraph();
+		InvalidateForeignKeyGraph();
 	}
 #endif
 
@@ -263,7 +263,7 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 	 */
 	if ((TableReferenced(parentRelationId) || TableReferencing(parentRelationId)))
 	{
-		MarkInvalidateForeignKeyGraph();
+		InvalidateForeignKeyGraph();
 	}
 }
 
@@ -353,7 +353,7 @@ PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 				 */
 				if ((TableReferenced(relationId) || TableReferencing(relationId)))
 				{
-					MarkInvalidateForeignKeyGraph();
+					InvalidateForeignKeyGraph();
 				}
 			}
 		}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -118,23 +118,23 @@ PreprocessDropTableStmt(Node *node, const char *queryString)
 			continue;
 		}
 
-		if (IsCitusTableType(relationId, REFERENCE_TABLE))
-		{
-			/* prevent concurrent EnsureReferenceTablesExistOnAllNodes */
-			int colocationId = CreateReferenceTableColocationId();
-			LockColocationId(colocationId, ExclusiveLock);
-		}
-
 		/* invalidate foreign key cache if the table involved in any foreign key */
 		if ((TableReferenced(relationId) || TableReferencing(relationId)))
 		{
 			MarkInvalidateForeignKeyGraph();
 		}
 
-		/* we're not interested in non-distributed relations */
+		/* we're not interested in non-distributed relations for the rest */
 		if (!IsCitusTable(relationId))
 		{
 			continue;
+		}
+
+		if (IsCitusTableType(relationId, REFERENCE_TABLE))
+		{
+			/* prevent concurrent EnsureReferenceTablesExistOnAllNodes */
+			int colocationId = CreateReferenceTableColocationId();
+			LockColocationId(colocationId, ExclusiveLock);
 		}
 
 		/* we're only interested in partitioned and mx tables */

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -251,19 +251,6 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 		CreateDistributedTable(relationId, parentDistributionColumn,
 							   parentDistributionMethod, parentRelationName,
 							   viaDeprecatedAPI);
-		return;
-	}
-
-	/*
-	 * If parent is a postgres local table, then invalidate foreign key cache
-	 * if the parent table is involved in any foreign key relationship. This is
-	 * because, partition tables inherit foreign keys from parent tables.
-	 * Note that if parent table is a citus table, then CreateDistributedTable
-	 * already invalidates foreign key cache and we handle that case above.
-	 */
-	if ((TableReferenced(parentRelationId) || TableReferencing(parentRelationId)))
-	{
-		InvalidateForeignKeyGraph();
 	}
 }
 
@@ -338,23 +325,6 @@ PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 				CreateDistributedTable(partitionRelationId, distributionColumn,
 									   distributionMethod, parentRelationName,
 									   viaDeprecatedAPI);
-			}
-
-			if (!IsCitusTable(relationId) &&
-				!IsCitusTable(partitionRelationId))
-			{
-				/*
-				 * If parent and child tables are postgres local tables, then invalidate
-				 * foreign key cache if the parent table is involved in any foreign key
-				 * relationship. This is because, partition tables inherit foreign keys
-				 * from parent tables.
-				 * Note that if parent table is a citus table, then CreateDistributedTable
-				 * already invalidates foreign key cache and we handle that case above.
-				 */
-				if ((TableReferenced(relationId) || TableReferencing(relationId)))
-				{
-					InvalidateForeignKeyGraph();
-				}
 			}
 		}
 	}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -188,6 +188,12 @@ PostprocessCreateTableStmt(CreateStmt *createStatement, const char *queryString)
 	{
 		ErrorOutForFKeyBetweenPostgresAndCitusLocalTable(relationId);
 	}
+
+	/* invalidate foreign key cache if the table involved in any foreign key */
+	if ((TableReferenced(relationId) || TableReferencing(relationId)))
+	{
+		MarkInvalidateForeignKeyGraph();
+	}
 #endif
 
 	if (createStatement->inhRelations != NIL && createStatement->partbound != NULL)

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1099,6 +1099,17 @@ AlterTableCmdDropsFkey(AlterTableCmd *command, Oid relationId)
 			}
 		}
 	}
+	else if (alterTableType == AT_DropColumn)
+	{
+		char *columnName = command->name;
+		if (ColumnAppearsInForeignKey(columnName, relationId))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
 
 
 /*

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -251,6 +251,19 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 		CreateDistributedTable(relationId, parentDistributionColumn,
 							   parentDistributionMethod, parentRelationName,
 							   viaDeprecatedAPI);
+		return;
+	}
+
+	/*
+	 * If parent is a postgres local table, then invalidate foreign key cache
+	 * if the parent table is involved in any foreign key relationship. This is
+	 * because, partition tables inherit foreign keys from parent tables.
+	 * Note that if parent table is a citus table, then CreateDistributedTable
+	 * already invalidates foreign key cache and we handle that case above.
+	 */
+	if ((TableReferenced(parentRelationId) || TableReferencing(parentRelationId)))
+	{
+		MarkInvalidateForeignKeyGraph();
 	}
 }
 
@@ -325,6 +338,23 @@ PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 				CreateDistributedTable(partitionRelationId, distributionColumn,
 									   distributionMethod, parentRelationName,
 									   viaDeprecatedAPI);
+			}
+
+			if (!IsCitusTable(relationId) &&
+				!IsCitusTable(partitionRelationId))
+			{
+				/*
+				 * If parent and child tables are postgres local tables, then invalidate
+				 * foreign key cache if the parent table is involved in any foreign key
+				 * relationship. This is because, partition tables inherit foreign keys
+				 * from parent tables.
+				 * Note that if parent table is a citus table, then CreateDistributedTable
+				 * already invalidates foreign key cache and we handle that case above.
+				 */
+				if ((TableReferenced(relationId) || TableReferencing(relationId)))
+				{
+					MarkInvalidateForeignKeyGraph();
+				}
 			}
 		}
 	}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1033,6 +1033,19 @@ AlterTableCmdAddsFKey(AlterTableCmd *command, Oid relationId)
 			return true;
 		}
 	}
+	else if (alterTableType == AT_AddColumn)
+	{
+		ColumnDef *columnDef = (ColumnDef *) command->def;
+		List *constraints = columnDef->constraints;
+		Constraint *constraint = NULL;
+		foreach_ptr(constraint, constraints)
+		{
+			if (constraint->contype == CONSTR_FOREIGN)
+			{
+				return true;
+			}
+		}
+	}
 
 	return false;
 }

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -55,8 +55,9 @@ static void ErrorIfAlterTableDefinesFKeyFromPostgresToCitusLocalTable(
 static List * GetAlterTableStmtFKeyConstraintList(AlterTableStmt *alterTableStatement);
 static List * GetAlterTableCommandFKeyConstraintList(AlterTableCmd *command);
 static bool AlterTableCommandTypeIsTrigger(AlterTableType alterTableType);
-static bool AlterTableHasCommandByFunc(AlterTableStmt *alterTableStatement,
-									   AlterTableCommandFunc alterTableCommandFunc);
+static bool FindAlterTableCmdMatchingCheckFunction(AlterTableStmt *alterTableStatement,
+												   AlterTableCommandFunc
+												   alterTableCommandFunc);
 static bool AlterTableCmdAddsOrDropsFkey(AlterTableCmd *command, Oid relationId);
 static bool AlterTableCmdAddsFKey(AlterTableCmd *command, Oid relationId);
 static bool AlterTableCmdDropsFkey(AlterTableCmd *command, Oid relationId);
@@ -408,7 +409,8 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand)
 	 */
 	ErrorIfAlterTableDefinesFKeyFromPostgresToCitusLocalTable(alterTableStatement);
 
-	if (AlterTableHasCommandByFunc(alterTableStatement, AlterTableCmdAddsOrDropsFkey))
+	if (FindAlterTableCmdMatchingCheckFunction(alterTableStatement,
+											   AlterTableCmdAddsOrDropsFkey))
 	{
 		MarkInvalidateForeignKeyGraph();
 	}
@@ -998,12 +1000,12 @@ PostprocessAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 
 /*
- * AlterTableHasCommandByFunc returns true if given alterTableCommandFunc returns
- * true for any subcommand of alterTableStatement.
+ * FindAlterTableCmdMatchingCheckFunction returns true if given alterTableCommandFunc
+ * returns true for any subcommand of alterTableStatement.
  */
 static bool
-AlterTableHasCommandByFunc(AlterTableStmt *alterTableStatement,
-						   AlterTableCommandFunc alterTableCommandFunc)
+FindAlterTableCmdMatchingCheckFunction(AlterTableStmt *alterTableStatement,
+									   AlterTableCommandFunc alterTableCommandFunc)
 {
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *command = NULL;

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -955,6 +955,8 @@ InvalidateForeignKeyGraphForDDL(void)
 {
 	if (shouldInvalidateForeignKeyGraph)
 	{
+		ereport(DEBUG1, (errmsg("DDL command invalidates foreign key graph")));
+
 		InvalidateForeignKeyGraph();
 
 		shouldInvalidateForeignKeyGraph = false;

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -543,16 +543,6 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 		PostprocessCreateTableStmt(createStatement, queryString);
 	}
 
-	/*
-	 * Re-forming the foreign key graph relies on the command being executed
-	 * on the local table first. However, in order to decide whether the
-	 * command leads to an invalidation, we need to check before the command
-	 * is being executed since we read pg_constraint table. Thus, we maintain a
-	 * local flag and do the invalidation after multi_ProcessUtility,
-	 * before ExecuteDistributedDDLJob().
-	 */
-	InvalidateForeignKeyGraphForDDL();
-
 	if (EnableDDLPropagation)
 	{
 		if (ops && ops->postprocess)
@@ -586,6 +576,16 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 
 		PostprocessAlterTableStmtAttachPartition(alterTableStatement, queryString);
 	}
+
+	/*
+	 * Re-forming the foreign key graph relies on the command being executed
+	 * on the local table first. However, in order to decide whether the
+	 * command leads to an invalidation, we need to check before the command
+	 * is being executed since we read pg_constraint table. Thus, we maintain a
+	 * local flag and do the invalidation after multi_ProcessUtility,
+	 * before ExecuteDistributedDDLJob().
+	 */
+	InvalidateForeignKeyGraphForDDL();
 
 	/* after local command has completed, finish by executing worker DDLJobs, if any */
 	if (ddlJobs != NIL)

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -517,6 +517,17 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 	{
 		PostStandardProcessUtility(parsetree);
 
+		/*
+		 * We call MarkInvalidateForeignKeyGraph in preprocess without knowing
+		 * that if command would fail or not. However, we don't want to invalidate
+		 * foreign key graph for failed DDL commands, so here we don't call
+		 * InvalidateForeignKeyGraphForDDL.
+		 * On the other hand, we should still reset shouldInvalidateForeignKeyGraph
+		 * flag as next DDL command still relies on this flag to invalidate foreign
+		 * key graph.
+		 */
+		shouldInvalidateForeignKeyGraph = false;
+
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -955,7 +955,7 @@ InvalidateForeignKeyGraphForDDL(void)
 {
 	if (shouldInvalidateForeignKeyGraph)
 	{
-		ereport(DEBUG1, (errmsg("DDL command invalidates foreign key graph")));
+		ereport(DEBUG4, (errmsg("DDL command invalidates foreign key graph")));
 
 		InvalidateForeignKeyGraph();
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -536,13 +536,6 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 	 * Post process for ddl statements
 	 */
 
-	if (IsA(parsetree, CreateStmt))
-	{
-		CreateStmt *createStatement = (CreateStmt *) parsetree;
-
-		PostprocessCreateTableStmt(createStatement, queryString);
-	}
-
 	if (EnableDDLPropagation)
 	{
 		if (ops && ops->postprocess)
@@ -564,6 +557,13 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 							 errhint("Connect to worker nodes directly to manually "
 									 "rename the role")));
 		}
+	}
+
+	if (IsA(parsetree, CreateStmt))
+	{
+		CreateStmt *createStatement = (CreateStmt *) parsetree;
+
+		PostprocessCreateTableStmt(createStatement, queryString);
 	}
 
 	/*

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -159,7 +159,7 @@ extern void ErrorIfUnsupportedForeignConstraintExists(Relation relation,
 													  Var *distributionColumn,
 													  uint32 colocationId);
 extern void ErrorOutForFKeyBetweenPostgresAndCitusLocalTable(Oid localTableId);
-extern bool ColumnReferencedByAnyForeignKey(char *columnName, Oid relationId);
+extern bool ColumnAppearsInForeignKey(char *columnName, Oid relationId);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetReferencingForeignConstaintCommands(Oid relationOid);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -167,6 +167,7 @@ extern bool HasForeignKeyToCitusLocalTable(Oid relationId);
 extern bool HasForeignKeyToReferenceTable(Oid relationOid);
 extern bool TableReferenced(Oid relationOid);
 extern bool TableReferencing(Oid relationOid);
+extern bool ConstraintIsAUniquenessConstraint(char *inputConstaintName, Oid relationId);
 extern bool ConstraintIsAForeignKey(char *inputConstaintName, Oid relationOid);
 extern bool ConstraintWithNameIsOfType(char *inputConstaintName, Oid relationId,
 									   char targetConstraintType);

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -176,6 +176,11 @@ s/(->.*Scan on\ +)(.*)(_[0-9]+)(_[0-9]+) \2(_[0-9]+|_xxx)?/\1\2\3\4 \2_xxx/g
 s/(partitioning_hash_join_test)(_[0-9]|_xxx)?(\.[a-zA-Z]+)/\1_xxx\3/g
 s/(partitioning_hash_test)(_[0-9]|_xxx)?(\.[a-zA-Z]+)/\1_xxx\3/g
 
+# multi_foreign_key_relation_graph.out
+# suppress shardId's in drop constraint logs as the order of cascaded objects might be flaky
+# e.g: drop cascades to constraint fkey_6_3000081 on table fkey_graph.distributed_table_1_3000081
+s/(drop cascades to constraint fkey_[0-9]+_)([0-9]+)( on table fkey_graph\..+_)\2/\1xxx\3xxx/g
+
 # Errors with binary decoding where OIDs should be normalized
 s/wrong data type: [0-9]+, expected [0-9]+/wrong data type: XXXX, expected XXXX/g
 

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -181,6 +181,9 @@ s/(partitioning_hash_test)(_[0-9]|_xxx)?(\.[a-zA-Z]+)/\1_xxx\3/g
 # e.g: drop cascades to constraint fkey_6_3000081 on table fkey_graph.distributed_table_1_3000081
 s/(drop cascades to constraint fkey_[0-9]+_)([0-9]+)( on table fkey_graph\..+_)\2/\1xxx\3xxx/g
 
+# remove DEBUG1 messages specific to pg11 that are about foreign key validation
+/^DEBUG:\ +validating foreign key constraint/d
+
 # Errors with binary decoding where OIDs should be normalized
 s/wrong data type: [0-9]+, expected [0-9]+/wrong data type: XXXX, expected XXXX/g
 

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -306,6 +306,7 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE on_update_fkey_table ADD COLUMN X INT;
+DEBUG:  DDL command invalidates foreign key graph
 ERROR:  cannot execute parallel DDL on table "on_update_fkey_table" after SELECT command on reference table "reference_table" because there is a foreign key between them and "reference_table" has been accessed in this transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
@@ -1399,6 +1400,7 @@ ADD CONSTRAINT
 	fkey_delete FOREIGN KEY(value_1)
 REFERENCES
 	reference_table(id) ON DELETE CASCADE;
+DEBUG:  DDL command invalidates foreign key graph
 INSERT INTO reference_table SELECT i FROM generate_series(0, 10) i;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 DEBUG:  Collecting INSERT ... SELECT results on coordinator

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -192,7 +192,6 @@ BEGIN;
 
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE bigint;
 DEBUG:  rewriting table "on_update_fkey_table"
-DEBUG:  validating foreign key constraint "fkey"
 ROLLBACK;
 BEGIN;
 	SELECT count(*) FROM transitive_reference_table;
@@ -203,7 +202,6 @@ BEGIN;
 
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE bigint;
 DEBUG:  rewriting table "on_update_fkey_table"
-DEBUG:  validating foreign key constraint "fkey"
 ROLLBACK;
 -- case 1.6: SELECT to a reference table is followed by an unrelated DDL
 BEGIN;
@@ -487,7 +485,6 @@ DEBUG:  switching to sequential query execution mode
 DETAIL:  Table "reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE bigint;
 DEBUG:  rewriting table "on_update_fkey_table"
-DEBUG:  validating foreign key constraint "fkey"
 ROLLBACK;
 BEGIN;
 	UPDATE transitive_reference_table SET id = 101 WHERE id = 99;
@@ -495,7 +492,6 @@ DEBUG:  switching to sequential query execution mode
 DETAIL:  Table "transitive_reference_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE bigint;
 DEBUG:  rewriting table "on_update_fkey_table"
-DEBUG:  validating foreign key constraint "fkey"
 ROLLBACK;
 -- case 2.6: UPDATE to a reference table is followed by an unrelated DDL
 BEGIN;
@@ -616,31 +612,25 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 	CREATE INDEX fkey_test_index_1 ON on_update_fkey_table(value_1);
 ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "transitive_reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 	CREATE INDEX fkey_test_index_1 ON on_update_fkey_table(value_1);
 ROLLBACK;
 -- case 4.6: DDL to reference table followed by a DDL to dist table, both touching fkey columns
 BEGIN;
 	ALTER TABLE reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE smallint;
 DEBUG:  rewriting table "on_update_fkey_table"
-DEBUG:  validating foreign key constraint "fkey"
 ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "transitive_reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 	ALTER TABLE on_update_fkey_table ALTER COLUMN value_1 SET DATA TYPE smallint;
 DEBUG:  rewriting table "on_update_fkey_table"
-DEBUG:  validating foreign key constraint "fkey"
 ROLLBACK;
 -- case 3.7: DDL to a reference table is followed by COPY
 BEGIN;
@@ -672,13 +662,11 @@ ROLLBACK;
 BEGIN;
 	ALTER TABLE reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 	TRUNCATE on_update_fkey_table;
 ROLLBACK;
 BEGIN;
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "transitive_reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 	TRUNCATE on_update_fkey_table;
 ROLLBACK;
 ---------------------------------------------------------------------
@@ -771,7 +759,6 @@ BEGIN;
 
 	ALTER TABLE reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 ERROR:  cannot execute DDL on table "reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;
@@ -784,7 +771,6 @@ BEGIN;
 
 	ALTER TABLE transitive_reference_table ALTER COLUMN id SET DATA TYPE smallint;
 DEBUG:  rewriting table "transitive_reference_table"
-DEBUG:  validating foreign key constraint "fkey"
 ERROR:  cannot execute DDL on table "transitive_reference_table" because there was a parallel SELECT access to distributed table "on_update_fkey_table" in the same transaction
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
 ROLLBACK;

--- a/src/test/regress/expected/foreign_key_restriction_enforcement.out
+++ b/src/test/regress/expected/foreign_key_restriction_enforcement.out
@@ -304,7 +304,6 @@ BEGIN;
 (1 row)
 
 	ALTER TABLE on_update_fkey_table ADD COLUMN X INT;
-DEBUG:  DDL command invalidates foreign key graph
 ERROR:  cannot execute parallel DDL on table "on_update_fkey_table" after SELECT command on reference table "reference_table" because there is a foreign key between them and "reference_table" has been accessed in this transaction
 DETAIL:  When there is a foreign key to a reference table, Citus needs to perform all operations over a single connection per node to ensure consistency.
 HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
@@ -1386,7 +1385,6 @@ ADD CONSTRAINT
 	fkey_delete FOREIGN KEY(value_1)
 REFERENCES
 	reference_table(id) ON DELETE CASCADE;
-DEBUG:  DDL command invalidates foreign key graph
 INSERT INTO reference_table SELECT i FROM generate_series(0, 10) i;
 DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
 DEBUG:  Collecting INSERT ... SELECT results on coordinator

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -711,15 +711,17 @@ ORDER BY tablename;
 
 CREATE TABLE local_table_1 (col int unique);
 CREATE TABLE local_table_2 (col int unique);
--- show that we do not trigger updating foreign key graph when
+-- show that we trigger updating foreign key graph when
 -- defining/dropping foreign keys between postgres tables
 ALTER TABLE local_table_1 ADD CONSTRAINT fkey_1 FOREIGN KEY (col) REFERENCES local_table_2(col);
 SELECT oid::regclass::text AS tablename
 FROM get_foreign_key_connected_relations('local_table_2') AS f(oid oid)
 ORDER BY tablename;
- tablename
+   tablename
 ---------------------------------------------------------------------
-(0 rows)
+ local_table_1
+ local_table_2
+(2 rows)
 
 ALTER TABLE local_table_1 DROP CONSTRAINT fkey_1;
 SELECT oid::regclass::text AS tablename
@@ -734,6 +736,195 @@ SELECT oid::regclass::text AS tablename
 FROM get_foreign_key_connected_relations('non_existent_table') AS f(oid oid)
 ORDER BY tablename;
 ERROR:  relation "non_existent_table" does not exist
+\set VERBOSITY TERSE
+SET client_min_messages TO DEBUG1;
+BEGIN;
+  ALTER TABLE distributed_table_2 DROP CONSTRAINT distributed_table_2_col_key CASCADE;
+NOTICE:  drop cascades to constraint fkey_4 on table distributed_table_3
+DEBUG:  DDL command invalidates foreign key graph
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+  ALTER TABLE distributed_table_3 DROP CONSTRAINT distributed_table_3_col_key CASCADE;
+NOTICE:  drop cascades to constraint fkey_6 on table distributed_table_1
+DEBUG:  DDL command invalidates foreign key graph
+DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
+DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
+DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
+DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
+  -- show that we process drop constraint commands that are dropping uniquness
+  -- constraints and then invalidate fkey graph. So we shouldn't see
+  -- distributed_table_3 as it was split via above drop constraint commands
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('distributed_table_2') AS f(oid oid)
+  ORDER BY tablename;
+      tablename
+---------------------------------------------------------------------
+ distributed_table_1
+ distributed_table_2
+ reference_table_1
+ reference_table_2
+(4 rows)
+
+ROLLBACK;
+-- Below two commands normally would invalidate foreign key graph.
+-- But as they fail due to lacking of CASCADE, we don't invalidate
+-- foreign key graph.
+ALTER TABLE distributed_table_2 DROP CONSTRAINT distributed_table_2_col_key;
+ERROR:  cannot drop constraint distributed_table_2_col_key on table distributed_table_2 because other objects depend on it
+ALTER TABLE reference_table_2 DROP COLUMN col;
+ERROR:  cannot drop column col of table reference_table_2 because other objects depend on it
+-- but we invalidate foreign key graph in below two transaction blocks
+BEGIN;
+  ALTER TABLE distributed_table_2 DROP CONSTRAINT distributed_table_2_col_key CASCADE;
+NOTICE:  drop cascades to constraint fkey_4 on table distributed_table_3
+DEBUG:  DDL command invalidates foreign key graph
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+ROLLBACK;
+BEGIN;
+  ALTER TABLE reference_table_2 DROP COLUMN col CASCADE;
+NOTICE:  drop cascades to constraint fkey_5 on table distributed_table_2
+DEBUG:  DDL command invalidates foreign key graph
+DEBUG:  drop cascades to 2 other objects
+DETAIL:  drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
+drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
+DEBUG:  drop cascades to 2 other objects
+DETAIL:  drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
+drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
+ROLLBACK;
+-- now we should see distributed_table_2 as well since we rollback'ed
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('distributed_table_2') AS f(oid oid)
+ORDER BY tablename;
+      tablename
+---------------------------------------------------------------------
+ distributed_table_1
+ distributed_table_2
+ distributed_table_3
+ reference_table_1
+ reference_table_2
+(5 rows)
+
+BEGIN;
+  DROP TABLE distributed_table_2 CASCADE;
+NOTICE:  drop cascades to constraint fkey_4 on table distributed_table_3
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+DEBUG:  DDL command invalidates foreign key graph
+  -- should only see reference_table_1 & reference_table_2
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('reference_table_1') AS f(oid oid)
+  ORDER BY tablename;
+     tablename
+---------------------------------------------------------------------
+ reference_table_1
+ reference_table_2
+(2 rows)
+
+ROLLBACK;
+BEGIN;
+  ALTER TABLE distributed_table_2 ADD CONSTRAINT fkey_55 FOREIGN KEY (col) REFERENCES reference_table_2(col);
+DEBUG:  DDL command invalidates foreign key graph
+  ALTER TABLE distributed_table_1 ADD CONSTRAINT fkey_66 FOREIGN KEY (col) REFERENCES distributed_table_3(col);
+DEBUG:  DDL command invalidates foreign key graph
+  -- show that we handle multiple edges between nodes in foreign key graph
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('reference_table_1') AS f(oid oid)
+  ORDER BY tablename;
+      tablename
+---------------------------------------------------------------------
+ distributed_table_1
+ distributed_table_2
+ distributed_table_3
+ reference_table_1
+ reference_table_2
+(5 rows)
+
+ROLLBACK;
+BEGIN;
+  -- hide "verifying table" log because the order we print it changes
+  -- in different pg versions
+  set client_min_messages to error;
+  ALTER TABLE distributed_table_2 ADD CONSTRAINT pkey PRIMARY KEY (col);
+  set client_min_messages to debug1;
+  -- show that droping a constraint not involved in any foreign key
+  -- constraint doesn't invalidate foreign key graph
+  ALTER TABLE distributed_table_2 DROP CONSTRAINT pkey;
+ROLLBACK;
+BEGIN;
+  CREATE TABLE local_table_3 (col int PRIMARY KEY);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pkey" for table "local_table_3"
+  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
+DEBUG:  DDL command invalidates foreign key graph
+  CREATE TABLE local_table_4 (col int PRIMARY KEY REFERENCES local_table_3 (col));
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_4_pkey" for table "local_table_4"
+DEBUG:  DDL command invalidates foreign key graph
+  -- we invalidate foreign key graph for add column & create table
+  -- commands defining foreign keys too
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('local_table_3') AS f(oid oid)
+  ORDER BY tablename;
+   tablename
+---------------------------------------------------------------------
+ local_table_1
+ local_table_3
+ local_table_4
+(3 rows)
+
+ROLLBACK;
+BEGIN;
+  CREATE TABLE local_table_3 (col int PRIMARY KEY);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pkey" for table "local_table_3"
+  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
+DEBUG:  DDL command invalidates foreign key graph
+  ALTER TABLE local_table_1 DROP COLUMN another_col;
+DEBUG:  DDL command invalidates foreign key graph
+  -- we invalidate foreign key graph for drop column commands dropping
+  -- referencing columns, should not print anything
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('local_table_1') AS f(oid oid)
+  ORDER BY tablename;
+ tablename
+---------------------------------------------------------------------
+(0 rows)
+
+ROLLBACK;
+BEGIN;
+  CREATE TABLE local_table_3 (col int PRIMARY KEY);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pkey" for table "local_table_3"
+  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
+DEBUG:  DDL command invalidates foreign key graph
+  ALTER TABLE local_table_3 DROP COLUMN col CASCADE;
+NOTICE:  drop cascades to constraint local_table_1_another_col_fkey on table local_table_1
+DEBUG:  DDL command invalidates foreign key graph
+  -- we invalidate foreign key graph for drop column commands dropping
+  -- referenced columns, should not print anything
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('local_table_1') AS f(oid oid)
+  ORDER BY tablename;
+ tablename
+---------------------------------------------------------------------
+(0 rows)
+
+ROLLBACK;
+CREATE TABLE local_table_4 (col int);
+-- Normally, we would decide to invalidate foreign key graph for below
+-- ddl. But as it fails, we won't invalidate foreign key graph.
+ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_4(col);
+ERROR:  there is no unique constraint matching given keys for referenced table "local_table_4"
+-- When ddl command fails, we reset flag that we use to invalidate
+-- foreign key graph so that next command doesn't invalidate foreign
+-- key graph.
+ALTER TABLE local_table_1 ADD COLUMN unrelated_column int;
+-- show that droping a table not referenced and not referencing to any table
+-- does not invalidate foreign key graph
+DROP TABLE local_table_4;
 set client_min_messages to error;
 SET search_path TO public;
 DROP SCHEMA fkey_graph CASCADE;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -963,10 +963,25 @@ ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_8 FOREIGN KEY (col_1) REFERE
 DEBUG:  DDL command invalidates foreign key graph
 ALTER TABLE partitioned_table_2 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
 DEBUG:  DDL command invalidates foreign key graph
--- show that we don't invalidate foreign key graph for attach partition commands
 CREATE TABLE partitioned_table_1_300_400 PARTITION OF partitioned_table_1 FOR VALUES FROM (300) TO (400);
 DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_300_400_col_1_key" for table "partitioned_table_1_300_400"
 DEBUG:  switching to sequential query execution mode
+-- we invalidate foreign key graph as attach partition creates a new distributed table
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('partitioned_table_1_300_400') AS f(oid oid)
+ORDER BY tablename;
+          tablename
+---------------------------------------------------------------------
+ partitioned_table_1
+ partitioned_table_1_100_200
+ partitioned_table_1_200_300
+ partitioned_table_1_300_400
+ partitioned_table_2
+ partitioned_table_2_100_200
+ partitioned_table_2_200_300
+ reference_table_4
+(8 rows)
+
 set client_min_messages to error;
 SET search_path TO public;
 DROP SCHEMA fkey_graph CASCADE;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -737,22 +737,10 @@ FROM get_foreign_key_connected_relations('non_existent_table') AS f(oid oid)
 ORDER BY tablename;
 ERROR:  relation "non_existent_table" does not exist
 \set VERBOSITY TERSE
-SET client_min_messages TO DEBUG1;
+SET client_min_messages TO ERROR;
 BEGIN;
   ALTER TABLE distributed_table_2 DROP CONSTRAINT distributed_table_2_col_key CASCADE;
-NOTICE:  drop cascades to constraint fkey_4 on table distributed_table_3
-DEBUG:  DDL command invalidates foreign key graph
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
   ALTER TABLE distributed_table_3 DROP CONSTRAINT distributed_table_3_col_key CASCADE;
-NOTICE:  drop cascades to constraint fkey_6 on table distributed_table_1
-DEBUG:  DDL command invalidates foreign key graph
-DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
-DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
-DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
-DEBUG:  drop cascades to constraint fkey_6_xxx on table fkey_graph.distributed_table_1_xxx
   -- show that we process drop constraint commands that are dropping uniquness
   -- constraints and then invalidate fkey graph. So we shouldn't see
   -- distributed_table_3 as it was split via above drop constraint commands
@@ -778,23 +766,28 @@ ERROR:  cannot drop column col of table reference_table_2 because other objects 
 -- but we invalidate foreign key graph in below two transaction blocks
 BEGIN;
   ALTER TABLE distributed_table_2 DROP CONSTRAINT distributed_table_2_col_key CASCADE;
-NOTICE:  drop cascades to constraint fkey_4 on table distributed_table_3
-DEBUG:  DDL command invalidates foreign key graph
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('distributed_table_2') AS f(oid oid)
+  ORDER BY tablename;
+      tablename
+---------------------------------------------------------------------
+ distributed_table_1
+ distributed_table_2
+ distributed_table_3
+ reference_table_1
+ reference_table_2
+(5 rows)
+
 ROLLBACK;
 BEGIN;
   ALTER TABLE reference_table_2 DROP COLUMN col CASCADE;
-NOTICE:  drop cascades to constraint fkey_5 on table distributed_table_2
-DEBUG:  DDL command invalidates foreign key graph
-DEBUG:  drop cascades to 2 other objects
-DETAIL:  drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
-drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
-DEBUG:  drop cascades to 2 other objects
-DETAIL:  drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
-drop cascades to constraint fkey_5_xxx on table fkey_graph.distributed_table_2_xxx
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('reference_table_2') AS f(oid oid)
+  ORDER BY tablename;
+ tablename
+---------------------------------------------------------------------
+(0 rows)
+
 ROLLBACK;
 -- now we should see distributed_table_2 as well since we rollback'ed
 SELECT oid::regclass::text AS tablename
@@ -811,12 +804,6 @@ ORDER BY tablename;
 
 BEGIN;
   DROP TABLE distributed_table_2 CASCADE;
-NOTICE:  drop cascades to constraint fkey_4 on table distributed_table_3
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  drop cascades to constraint fkey_4_xxx on table fkey_graph.distributed_table_3_xxx
-DEBUG:  DDL command invalidates foreign key graph
   -- should only see reference_table_1 & reference_table_2
   SELECT oid::regclass::text AS tablename
   FROM get_foreign_key_connected_relations('reference_table_1') AS f(oid oid)
@@ -830,9 +817,7 @@ DEBUG:  DDL command invalidates foreign key graph
 ROLLBACK;
 BEGIN;
   ALTER TABLE distributed_table_2 ADD CONSTRAINT fkey_55 FOREIGN KEY (col) REFERENCES reference_table_2(col);
-DEBUG:  DDL command invalidates foreign key graph
   ALTER TABLE distributed_table_1 ADD CONSTRAINT fkey_66 FOREIGN KEY (col) REFERENCES distributed_table_3(col);
-DEBUG:  DDL command invalidates foreign key graph
   -- show that we handle multiple edges between nodes in foreign key graph
   SELECT oid::regclass::text AS tablename
   FROM get_foreign_key_connected_relations('reference_table_1') AS f(oid oid)
@@ -848,22 +833,27 @@ DEBUG:  DDL command invalidates foreign key graph
 
 ROLLBACK;
 BEGIN;
-  -- hide "verifying table" log because the order we print it changes
-  -- in different pg versions
-  set client_min_messages to error;
   ALTER TABLE distributed_table_2 ADD CONSTRAINT pkey PRIMARY KEY (col);
-  set client_min_messages to debug1;
   -- show that droping a constraint not involved in any foreign key
   -- constraint doesn't invalidate foreign key graph
   ALTER TABLE distributed_table_2 DROP CONSTRAINT pkey;
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('distributed_table_2') AS f(oid oid)
+  ORDER BY tablename;
+      tablename
+---------------------------------------------------------------------
+ distributed_table_1
+ distributed_table_2
+ distributed_table_3
+ reference_table_1
+ reference_table_2
+(5 rows)
+
 ROLLBACK;
 BEGIN;
   CREATE TABLE local_table_3 (col int PRIMARY KEY);
-DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pkey" for table "local_table_3"
   ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
-DEBUG:  DDL command invalidates foreign key graph
   CREATE TABLE local_table_4 (col int PRIMARY KEY REFERENCES local_table_3 (col));
-DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_4_pkey" for table "local_table_4"
   -- we invalidate foreign key graph for add column & create table
   -- commands defining foreign keys too
   SELECT oid::regclass::text AS tablename
@@ -879,11 +869,8 @@ DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_4_pke
 ROLLBACK;
 BEGIN;
   CREATE TABLE local_table_3 (col int PRIMARY KEY);
-DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pkey" for table "local_table_3"
   ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
-DEBUG:  DDL command invalidates foreign key graph
   ALTER TABLE local_table_1 DROP COLUMN another_col;
-DEBUG:  DDL command invalidates foreign key graph
   -- we invalidate foreign key graph for drop column commands dropping
   -- referencing columns, should not print anything
   SELECT oid::regclass::text AS tablename
@@ -896,12 +883,8 @@ DEBUG:  DDL command invalidates foreign key graph
 ROLLBACK;
 BEGIN;
   CREATE TABLE local_table_3 (col int PRIMARY KEY);
-DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pkey" for table "local_table_3"
   ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
-DEBUG:  DDL command invalidates foreign key graph
   ALTER TABLE local_table_3 DROP COLUMN col CASCADE;
-NOTICE:  drop cascades to constraint local_table_1_another_col_fkey on table local_table_1
-DEBUG:  DDL command invalidates foreign key graph
   -- we invalidate foreign key graph for drop column commands dropping
   -- referenced columns, should not print anything
   SELECT oid::regclass::text AS tablename
@@ -925,11 +908,8 @@ ALTER TABLE local_table_1 ADD COLUMN unrelated_column int;
 -- does not invalidate foreign key graph
 DROP TABLE local_table_4;
 CREATE TABLE partitioned_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_col_1_key" for table "partitioned_table_1"
 CREATE TABLE partitioned_table_1_100_200 PARTITION OF partitioned_table_1 FOR VALUES FROM (100) TO (200);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_100_200_col_1_key" for table "partitioned_table_1_100_200"
 CREATE TABLE partitioned_table_1_200_300 PARTITION OF partitioned_table_1 FOR VALUES FROM (200) TO (300);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_200_300_col_1_key" for table "partitioned_table_1_200_300"
 SELECT create_distributed_table('partitioned_table_1', 'col_1');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -937,11 +917,8 @@ SELECT create_distributed_table('partitioned_table_1', 'col_1');
 (1 row)
 
 CREATE TABLE partitioned_table_2 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_2_col_1_key" for table "partitioned_table_2"
 CREATE TABLE partitioned_table_2_100_200 PARTITION OF partitioned_table_2 FOR VALUES FROM (100) TO (200);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_2_100_200_col_1_key" for table "partitioned_table_2_100_200"
 CREATE TABLE partitioned_table_2_200_300 PARTITION OF partitioned_table_2 FOR VALUES FROM (200) TO (300);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_2_200_300_col_1_key" for table "partitioned_table_2_200_300"
 SELECT create_distributed_table('partitioned_table_2', 'col_1');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -949,8 +926,6 @@ SELECT create_distributed_table('partitioned_table_2', 'col_1');
 (1 row)
 
 CREATE TABLE reference_table_4 (col_1 INT UNIQUE, col_2 INT UNIQUE);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "reference_table_4_col_1_key" for table "reference_table_4"
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "reference_table_4_col_2_key" for table "reference_table_4"
 SELECT create_reference_table('reference_table_4');
  create_reference_table
 ---------------------------------------------------------------------
@@ -959,12 +934,8 @@ SELECT create_reference_table('reference_table_4');
 
 -- observe foreign key graph invalidation with partitioned tables
 ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_8 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
-DEBUG:  DDL command invalidates foreign key graph
 ALTER TABLE partitioned_table_2 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
-DEBUG:  DDL command invalidates foreign key graph
 CREATE TABLE partitioned_table_1_300_400 PARTITION OF partitioned_table_1 FOR VALUES FROM (300) TO (400);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_300_400_col_1_key" for table "partitioned_table_1_300_400"
-DEBUG:  switching to sequential query execution mode
 -- we invalidate foreign key graph as attach partition creates a new distributed table
 SELECT oid::regclass::text AS tablename
 FROM get_foreign_key_connected_relations('partitioned_table_1_300_400') AS f(oid oid)
@@ -982,25 +953,18 @@ ORDER BY tablename;
 (8 rows)
 
 CREATE TABLE local_partitioned_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_col_1_key" for table "local_partitioned_table_1"
 CREATE TABLE local_table_5 (col_1 INT UNIQUE, col_2 INT);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_table_5_col_1_key" for table "local_table_5"
 -- in below two show that attaching a partition doesn't invalidate
 -- foreign key cache as parent table isn't involved in any foreign
 -- key relationship
 CREATE TABLE local_partitioned_table_1_100_200 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (100) TO (200);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_100_200_col_1_key" for table "local_partitioned_table_1_100_200"
 CREATE TABLE local_partitioned_table_1_200_300 (col_1 INT UNIQUE, col_2 INT);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_200_300_col_1_key" for table "local_partitioned_table_1_200_300"
 ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_200_300 FOR VALUES FROM (200) TO (300);
-DEBUG:  verifying table "local_partitioned_table_1_200_300"
 -- define a foreign key from partitioned table
 ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES local_table_5(col_1);
-DEBUG:  DDL command invalidates foreign key graph
 -- in below two show that attaching partition invalidates foreign
 -- key cache as parent table is involved in a foreign key relationship
 CREATE TABLE local_partitioned_table_1_300_400 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (300) TO (400);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_300_400_col_1_key" for table "local_partitioned_table_1_300_400"
 SELECT oid::regclass::text AS tablename
 FROM get_foreign_key_connected_relations('local_partitioned_table_1_300_400') AS f(oid oid)
 ORDER BY tablename;
@@ -1014,9 +978,7 @@ ORDER BY tablename;
 (5 rows)
 
 CREATE TABLE local_partitioned_table_1_500_600 (col_1 INT UNIQUE, col_2 INT);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_500_600_col_1_key" for table "local_partitioned_table_1_500_600"
 ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_500_600 FOR VALUES FROM (500) TO (600);
-DEBUG:  verifying table "local_partitioned_table_1_500_600"
 SELECT oid::regclass::text AS tablename
 FROM get_foreign_key_connected_relations('local_table_5') AS f(oid oid)
 ORDER BY tablename;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -984,29 +984,29 @@ ORDER BY tablename;
 
 CREATE TABLE local_partitioned_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
 DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_col_1_key" for table "local_partitioned_table_1"
-CREATE TABLE local_partitioned_table_2 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_2_col_1_key" for table "local_partitioned_table_2"
+CREATE TABLE local_table_5 (col_1 INT UNIQUE, col_2 INT);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_table_5_col_1_key" for table "local_table_5"
 -- in below two show that attaching a partition doesn't invalidate
 -- foreign key cache as parent table isn't involved in any foreign
 -- key relationship
 CREATE TABLE local_partitioned_table_1_100_200 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (100) TO (200);
 DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_100_200_col_1_key" for table "local_partitioned_table_1_100_200"
-CREATE TABLE local_partitioned_table_2_100_200 (col_1 INT UNIQUE, col_2 INT);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_2_100_200_col_1_key" for table "local_partitioned_table_2_100_200"
-ALTER TABLE local_partitioned_table_2 ATTACH PARTITION local_partitioned_table_2_100_200 FOR VALUES FROM (100) TO (200);
-DEBUG:  verifying table "local_partitioned_table_2_100_200"
--- define foreign key between parent tables
-ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES local_partitioned_table_2(col_1);
+CREATE TABLE local_partitioned_table_1_200_300 (col_1 INT UNIQUE, col_2 INT);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_200_300_col_1_key" for table "local_partitioned_table_1_200_300"
+ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_200_300 FOR VALUES FROM (200) TO (300);
+DEBUG:  verifying table "local_partitioned_table_1_200_300"
+-- define a foreign key from partitioned table
+ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES local_table_5(col_1);
 DEBUG:  DDL command invalidates foreign key graph
 -- in below two show that attaching partition invalidates foreign
 -- key cache as parent table is involved in a foreign key relationship
-CREATE TABLE local_partitioned_table_2_200_300 PARTITION OF local_partitioned_table_2 FOR VALUES FROM (200) TO (300);
-DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_2_200_300_col_1_key" for table "local_partitioned_table_2_200_300"
-DEBUG:  DDL command invalidates foreign key graph
-CREATE TABLE local_partitioned_table_1_300_400 (col_1 INT UNIQUE, col_2 INT);
+CREATE TABLE local_partitioned_table_1_300_400 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (300) TO (400);
 DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_300_400_col_1_key" for table "local_partitioned_table_1_300_400"
-ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_300_400 FOR VALUES FROM (300) TO (400);
-DEBUG:  verifying table "local_partitioned_table_1_300_400"
+DEBUG:  DDL command invalidates foreign key graph
+CREATE TABLE local_partitioned_table_1_500_600 (col_1 INT UNIQUE, col_2 INT);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_500_600_col_1_key" for table "local_partitioned_table_1_500_600"
+ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_500_600 FOR VALUES FROM (500) TO (600);
+DEBUG:  verifying table "local_partitioned_table_1_500_600"
 DEBUG:  DDL command invalidates foreign key graph
 set client_min_messages to error;
 SET search_path TO public;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -852,10 +852,19 @@ BEGIN;
 ROLLBACK;
 BEGIN;
   CREATE TABLE local_table_3 (col int PRIMARY KEY);
-  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
   CREATE TABLE local_table_4 (col int PRIMARY KEY REFERENCES local_table_3 (col));
-  -- we invalidate foreign key graph for add column & create table
-  -- commands defining foreign keys too
+  -- show that we don't invalidate foreign key graph for create table
+  -- commands defining foreign keys, should not print anything
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('local_table_3') AS f(oid oid)
+  ORDER BY tablename;
+ tablename
+---------------------------------------------------------------------
+(0 rows)
+
+  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
+  -- we invalidate foreign key graph for add column
+  -- commands defining foreign keys
   SELECT oid::regclass::text AS tablename
   FROM get_foreign_key_connected_relations('local_table_3') AS f(oid oid)
   ORDER BY tablename;
@@ -988,9 +997,8 @@ ORDER BY tablename;
  local_partitioned_table_1_100_200
  local_partitioned_table_1_200_300
  local_partitioned_table_1_300_400
- local_partitioned_table_1_500_600
  local_table_5
-(6 rows)
+(5 rows)
 
 set client_min_messages to error;
 SET search_path TO public;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -982,6 +982,32 @@ ORDER BY tablename;
  reference_table_4
 (8 rows)
 
+CREATE TABLE local_partitioned_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_col_1_key" for table "local_partitioned_table_1"
+CREATE TABLE local_partitioned_table_2 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_2_col_1_key" for table "local_partitioned_table_2"
+-- in below two show that attaching a partition doesn't invalidate
+-- foreign key cache as parent table isn't involved in any foreign
+-- key relationship
+CREATE TABLE local_partitioned_table_1_100_200 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (100) TO (200);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_100_200_col_1_key" for table "local_partitioned_table_1_100_200"
+CREATE TABLE local_partitioned_table_2_100_200 (col_1 INT UNIQUE, col_2 INT);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_2_100_200_col_1_key" for table "local_partitioned_table_2_100_200"
+ALTER TABLE local_partitioned_table_2 ATTACH PARTITION local_partitioned_table_2_100_200 FOR VALUES FROM (100) TO (200);
+DEBUG:  verifying table "local_partitioned_table_2_100_200"
+-- define foreign key between parent tables
+ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES local_partitioned_table_2(col_1);
+DEBUG:  DDL command invalidates foreign key graph
+-- in below two show that attaching partition invalidates foreign
+-- key cache as parent table is involved in a foreign key relationship
+CREATE TABLE local_partitioned_table_2_200_300 PARTITION OF local_partitioned_table_2 FOR VALUES FROM (200) TO (300);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_2_200_300_col_1_key" for table "local_partitioned_table_2_200_300"
+DEBUG:  DDL command invalidates foreign key graph
+CREATE TABLE local_partitioned_table_1_300_400 (col_1 INT UNIQUE, col_2 INT);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_300_400_col_1_key" for table "local_partitioned_table_1_300_400"
+ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_300_400 FOR VALUES FROM (300) TO (400);
+DEBUG:  verifying table "local_partitioned_table_1_300_400"
+DEBUG:  DDL command invalidates foreign key graph
 set client_min_messages to error;
 SET search_path TO public;
 DROP SCHEMA fkey_graph CASCADE;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -864,7 +864,6 @@ DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_3_pke
 DEBUG:  DDL command invalidates foreign key graph
   CREATE TABLE local_table_4 (col int PRIMARY KEY REFERENCES local_table_3 (col));
 DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "local_table_4_pkey" for table "local_table_4"
-DEBUG:  DDL command invalidates foreign key graph
   -- we invalidate foreign key graph for add column & create table
   -- commands defining foreign keys too
   SELECT oid::regclass::text AS tablename
@@ -1002,12 +1001,35 @@ DEBUG:  DDL command invalidates foreign key graph
 -- key cache as parent table is involved in a foreign key relationship
 CREATE TABLE local_partitioned_table_1_300_400 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (300) TO (400);
 DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_300_400_col_1_key" for table "local_partitioned_table_1_300_400"
-DEBUG:  DDL command invalidates foreign key graph
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('local_partitioned_table_1_300_400') AS f(oid oid)
+ORDER BY tablename;
+             tablename
+---------------------------------------------------------------------
+ local_partitioned_table_1
+ local_partitioned_table_1_100_200
+ local_partitioned_table_1_200_300
+ local_partitioned_table_1_300_400
+ local_table_5
+(5 rows)
+
 CREATE TABLE local_partitioned_table_1_500_600 (col_1 INT UNIQUE, col_2 INT);
 DEBUG:  CREATE TABLE / UNIQUE will create implicit index "local_partitioned_table_1_500_600_col_1_key" for table "local_partitioned_table_1_500_600"
 ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_500_600 FOR VALUES FROM (500) TO (600);
 DEBUG:  verifying table "local_partitioned_table_1_500_600"
-DEBUG:  DDL command invalidates foreign key graph
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('local_table_5') AS f(oid oid)
+ORDER BY tablename;
+             tablename
+---------------------------------------------------------------------
+ local_partitioned_table_1
+ local_partitioned_table_1_100_200
+ local_partitioned_table_1_200_300
+ local_partitioned_table_1_300_400
+ local_partitioned_table_1_500_600
+ local_table_5
+(6 rows)
+
 set client_min_messages to error;
 SET search_path TO public;
 DROP SCHEMA fkey_graph CASCADE;

--- a/src/test/regress/expected/multi_foreign_key_relation_graph.out
+++ b/src/test/regress/expected/multi_foreign_key_relation_graph.out
@@ -925,6 +925,48 @@ ALTER TABLE local_table_1 ADD COLUMN unrelated_column int;
 -- show that droping a table not referenced and not referencing to any table
 -- does not invalidate foreign key graph
 DROP TABLE local_table_4;
+CREATE TABLE partitioned_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_col_1_key" for table "partitioned_table_1"
+CREATE TABLE partitioned_table_1_100_200 PARTITION OF partitioned_table_1 FOR VALUES FROM (100) TO (200);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_100_200_col_1_key" for table "partitioned_table_1_100_200"
+CREATE TABLE partitioned_table_1_200_300 PARTITION OF partitioned_table_1 FOR VALUES FROM (200) TO (300);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_200_300_col_1_key" for table "partitioned_table_1_200_300"
+SELECT create_distributed_table('partitioned_table_1', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE partitioned_table_2 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_2_col_1_key" for table "partitioned_table_2"
+CREATE TABLE partitioned_table_2_100_200 PARTITION OF partitioned_table_2 FOR VALUES FROM (100) TO (200);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_2_100_200_col_1_key" for table "partitioned_table_2_100_200"
+CREATE TABLE partitioned_table_2_200_300 PARTITION OF partitioned_table_2 FOR VALUES FROM (200) TO (300);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_2_200_300_col_1_key" for table "partitioned_table_2_200_300"
+SELECT create_distributed_table('partitioned_table_2', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE reference_table_4 (col_1 INT UNIQUE, col_2 INT UNIQUE);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "reference_table_4_col_1_key" for table "reference_table_4"
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "reference_table_4_col_2_key" for table "reference_table_4"
+SELECT create_reference_table('reference_table_4');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- observe foreign key graph invalidation with partitioned tables
+ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_8 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
+DEBUG:  DDL command invalidates foreign key graph
+ALTER TABLE partitioned_table_2 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
+DEBUG:  DDL command invalidates foreign key graph
+-- show that we don't invalidate foreign key graph for attach partition commands
+CREATE TABLE partitioned_table_1_300_400 PARTITION OF partitioned_table_1 FOR VALUES FROM (300) TO (400);
+DEBUG:  CREATE TABLE / UNIQUE will create implicit index "partitioned_table_1_300_400_col_1_key" for table "partitioned_table_1_300_400"
+DEBUG:  switching to sequential query execution mode
 set client_min_messages to error;
 SET search_path TO public;
 DROP SCHEMA fkey_graph CASCADE;

--- a/src/test/regress/sql/multi_foreign_key_relation_graph.sql
+++ b/src/test/regress/sql/multi_foreign_key_relation_graph.sql
@@ -448,7 +448,7 @@ FROM get_foreign_key_connected_relations('partitioned_table_1_300_400') AS f(oid
 ORDER BY tablename;
 
 CREATE TABLE local_partitioned_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
-CREATE TABLE local_partitioned_table_2 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+CREATE TABLE local_table_5 (col_1 INT UNIQUE, col_2 INT);
 
 -- in below two show that attaching a partition doesn't invalidate
 -- foreign key cache as parent table isn't involved in any foreign
@@ -456,19 +456,19 @@ CREATE TABLE local_partitioned_table_2 (col_1 INT UNIQUE, col_2 INT) PARTITION B
 
 CREATE TABLE local_partitioned_table_1_100_200 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (100) TO (200);
 
-CREATE TABLE local_partitioned_table_2_100_200 (col_1 INT UNIQUE, col_2 INT);
-ALTER TABLE local_partitioned_table_2 ATTACH PARTITION local_partitioned_table_2_100_200 FOR VALUES FROM (100) TO (200);
+CREATE TABLE local_partitioned_table_1_200_300 (col_1 INT UNIQUE, col_2 INT);
+ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_200_300 FOR VALUES FROM (200) TO (300);
 
--- define foreign key between parent tables
-ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES local_partitioned_table_2(col_1);
+-- define a foreign key from partitioned table
+ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES local_table_5(col_1);
 
 -- in below two show that attaching partition invalidates foreign
 -- key cache as parent table is involved in a foreign key relationship
 
-CREATE TABLE local_partitioned_table_2_200_300 PARTITION OF local_partitioned_table_2 FOR VALUES FROM (200) TO (300);
+CREATE TABLE local_partitioned_table_1_300_400 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (300) TO (400);
 
-CREATE TABLE local_partitioned_table_1_300_400 (col_1 INT UNIQUE, col_2 INT);
-ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_300_400 FOR VALUES FROM (300) TO (400);
+CREATE TABLE local_partitioned_table_1_500_600 (col_1 INT UNIQUE, col_2 INT);
+ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_500_600 FOR VALUES FROM (500) TO (600);
 
 set client_min_messages to error;
 

--- a/src/test/regress/sql/multi_foreign_key_relation_graph.sql
+++ b/src/test/regress/sql/multi_foreign_key_relation_graph.sql
@@ -467,8 +467,16 @@ ALTER TABLE local_partitioned_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1)
 
 CREATE TABLE local_partitioned_table_1_300_400 PARTITION OF local_partitioned_table_1 FOR VALUES FROM (300) TO (400);
 
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('local_partitioned_table_1_300_400') AS f(oid oid)
+ORDER BY tablename;
+
 CREATE TABLE local_partitioned_table_1_500_600 (col_1 INT UNIQUE, col_2 INT);
 ALTER TABLE local_partitioned_table_1 ATTACH PARTITION local_partitioned_table_1_500_600 FOR VALUES FROM (500) TO (600);
+
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('local_table_5') AS f(oid oid)
+ORDER BY tablename;
 
 set client_min_messages to error;
 

--- a/src/test/regress/sql/multi_foreign_key_relation_graph.sql
+++ b/src/test/regress/sql/multi_foreign_key_relation_graph.sql
@@ -440,8 +440,12 @@ SELECT create_reference_table('reference_table_4');
 ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_8 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
 ALTER TABLE partitioned_table_2 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES reference_table_4(col_2);
 
--- show that we don't invalidate foreign key graph for attach partition commands
 CREATE TABLE partitioned_table_1_300_400 PARTITION OF partitioned_table_1 FOR VALUES FROM (300) TO (400);
+
+-- we invalidate foreign key graph as attach partition creates a new distributed table
+SELECT oid::regclass::text AS tablename
+FROM get_foreign_key_connected_relations('partitioned_table_1_300_400') AS f(oid oid)
+ORDER BY tablename;
 
 set client_min_messages to error;
 

--- a/src/test/regress/sql/multi_foreign_key_relation_graph.sql
+++ b/src/test/regress/sql/multi_foreign_key_relation_graph.sql
@@ -381,12 +381,18 @@ ROLLBACK;
 
 BEGIN;
   CREATE TABLE local_table_3 (col int PRIMARY KEY);
-  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
 
   CREATE TABLE local_table_4 (col int PRIMARY KEY REFERENCES local_table_3 (col));
+  -- show that we don't invalidate foreign key graph for create table
+  -- commands defining foreign keys, should not print anything
+  SELECT oid::regclass::text AS tablename
+  FROM get_foreign_key_connected_relations('local_table_3') AS f(oid oid)
+  ORDER BY tablename;
 
-  -- we invalidate foreign key graph for add column & create table
-  -- commands defining foreign keys too
+  ALTER TABLE local_table_1 ADD COLUMN another_col int REFERENCES local_table_3(col);
+
+  -- we invalidate foreign key graph for add column
+  -- commands defining foreign keys
   SELECT oid::regclass::text AS tablename
   FROM get_foreign_key_connected_relations('local_table_3') AS f(oid oid)
   ORDER BY tablename;


### PR DESCRIPTION
For #4415, we need to improve foreign key graph coverage before implementing cascading logic for `create_citus_local_table` & `undistribute_table` APIs.

-------

Commits bring following:

Cover
* postgres tables for `DROP TABLE` commands
* postgres tables for `CREATE TABLE` commands when for pg version < 13
* `ADD COLUMN` commands defining foreign keys
* `DROP unique/primary CONSTRAINT` commands that might drop foreign keys
* `DROP COLUMN` commands dropping columns in the either side of foreign keys
* ~`CREATE/ATTACH PARTITION` commands when parent table involved in a foreign key relationship~

for foreign key graph invalidation. Also:

* ~Previously we were actually not invalidating foreign key graph for `CREATE TABLE` commands. Fix this as well.~
* Handle `ADD FOREIGN KEY` & `DROP FOREIGN KEY` commands in preprocess as `PostprocessAlterTableStmt` doesn't process postgres tables.
* Make sure that we reset `shouldInvalidateForeignKeyGraph` if DDL command fails.

