### PR TITLE
Rethrow original concurrent index creation failure message

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -732,6 +732,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 		}
 		PG_CATCH();
 		{
+			/* CopyErrorData() requires (CurrentMemoryContext != ErrorContext) */
 			MemoryContextSwitchTo(savedContext);
 			ErrorData *edata = CopyErrorData();
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -731,12 +731,12 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 		}
 		PG_CATCH();
 		{
-			ereport(ERROR,
-					(errmsg("CONCURRENTLY-enabled index command failed"),
-					 errdetail("CONCURRENTLY-enabled index commands can fail partially, "
-							   "leaving behind an INVALID index."),
+			ereport(NOTICE,
+					(errmsg("CONCURRENTLY-enabled index commands can fail partially, "
+							"leaving behind an INVALID index."),
 					 errhint("Use DROP INDEX CONCURRENTLY IF EXISTS to remove the "
-							 "invalid index, then retry the original command.")));
+							 "invalid index.")));
+			PG_RE_THROW();
 		}
 		PG_END_TRY();
 	}

--- a/src/test/regress/expected/failure_create_index_concurrently.out
+++ b/src/test/regress/expected/failure_create_index_concurrently.out
@@ -26,9 +26,11 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").kill()');
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
+	   This probably means the server terminated abnormally
+	   before or while processing the request.
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -59,9 +61,11 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").kill()');
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
+	   This probably means the server terminated abnormally
+	   before or while processing the request.
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -86,9 +90,9 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").cancel(' || pg_backend_pid(
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  canceling statement due to user request
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -111,9 +115,9 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").cancel(' || pg_backend_pid(
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  canceling statement due to user request
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -137,9 +141,11 @@ SELECT citus.mitmproxy('conn.onQuery(query="DROP INDEX CONCURRENTLY").kill()');
 (1 row)
 
 DROP INDEX CONCURRENTLY IF EXISTS idx_index_test;
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
+	   This probably means the server terminated abnormally
+	   before or while processing the request.
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -154,9 +160,27 @@ WHERE nodeport = :worker_2_proxy_port;
  localhost |     9060 | t       | 4
 (1 row)
 
+-- test unique concurrent index creation failure when there are duplicates
+CREATE TABLE index_test_2 (a int, b int);
+SELECT create_distributed_table('index_test_2', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO index_test_2 VALUES (1, 1), (1, 2);
+CREATE UNIQUE INDEX CONCURRENTLY index_test_2_a_idx ON index_test_2(a);
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  could not create unique index "index_test_2_a_idx_1880019"
+DETAIL:  Key (a)=(1) is duplicated.
+CONTEXT:  while executing command on localhost:xxxxx
+DROP INDEX CONCURRENTLY IF EXISTS index_test_2_a_idx;
 RESET SEARCH_PATH;
 DROP SCHEMA index_schema CASCADE;
-NOTICE:  drop cascades to table index_schema.index_test
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table index_schema.index_test
+drop cascades to table index_schema.index_test_2
 -- verify index is not at worker 2 upon cleanup
 SELECT * FROM run_command_on_workers($$SELECT count(*) FROM pg_indexes WHERE indexname LIKE 'idx_index_test%' $$)
 WHERE nodeport = :worker_2_proxy_port;

--- a/src/test/regress/expected/failure_create_index_concurrently.out
+++ b/src/test/regress/expected/failure_create_index_concurrently.out
@@ -26,8 +26,8 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").kill()');
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
 ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
 	   This probably means the server terminated abnormally
 	   before or while processing the request.
@@ -61,8 +61,8 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").kill()');
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
 ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
 	   This probably means the server terminated abnormally
 	   before or while processing the request.
@@ -90,8 +90,8 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").cancel(' || pg_backend_pid(
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
 ERROR:  canceling statement due to user request
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
@@ -115,8 +115,8 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE").cancel(' || pg_backend_pid(
 (1 row)
 
 CREATE INDEX CONCURRENTLY idx_index_test ON index_test(id, value_1);
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
 ERROR:  canceling statement due to user request
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
@@ -141,8 +141,8 @@ SELECT citus.mitmproxy('conn.onQuery(query="DROP INDEX CONCURRENTLY").kill()');
 (1 row)
 
 DROP INDEX CONCURRENTLY IF EXISTS idx_index_test;
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
 ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
 	   This probably means the server terminated abnormally
 	   before or while processing the request.
@@ -170,8 +170,8 @@ SELECT create_distributed_table('index_test_2', 'a');
 
 INSERT INTO index_test_2 VALUES (1, 1), (1, 2);
 CREATE UNIQUE INDEX CONCURRENTLY index_test_2_a_idx ON index_test_2(a);
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
 ERROR:  could not create unique index "index_test_2_a_idx_1880019"
 DETAIL:  Key (a)=(1) is duplicated.
 CONTEXT:  while executing command on localhost:xxxxx

--- a/src/test/regress/expected/failure_create_index_concurrently.out
+++ b/src/test/regress/expected/failure_create_index_concurrently.out
@@ -176,6 +176,10 @@ ERROR:  could not create unique index "index_test_2_a_idx_1880019"
 DETAIL:  Key (a)=(1) is duplicated.
 CONTEXT:  while executing command on localhost:xxxxx
 DROP INDEX CONCURRENTLY IF EXISTS index_test_2_a_idx;
+-- verify that index creation doesn't fail when duplicates are removed
+DELETE FROM index_test_2 WHERE a = 1 AND b = 2;
+CREATE UNIQUE INDEX CONCURRENTLY index_test_2_a_idx ON index_test_2(a);
+DROP INDEX CONCURRENTLY IF EXISTS index_test_2_a_idx;
 RESET SEARCH_PATH;
 DROP SCHEMA index_schema CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -294,9 +294,10 @@ CREATE INDEX CONCURRENTLY ith_b_idx_102089 ON multi_index_statements.index_test_
 SET search_path TO multi_index_statements;
 -- should fail because worker index already exists
 CREATE INDEX CONCURRENTLY ith_b_idx ON index_test_hash(b);
-ERROR:  CONCURRENTLY-enabled index command failed
-DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
+NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  relation "ith_b_idx_102089" already exists
+CONTEXT:  while executing command on localhost:xxxxx
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid?
@@ -497,7 +498,7 @@ DROP INDEX f1;
 DROP INDEX ix_test_index_creation2;
 DROP INDEX ix_test_index_creation1_ix_test_index_creation1_ix_test_index_creation1_ix_test_index_creation1_ix_test_index_creation1;
 DROP INDEX CONCURRENTLY ith_b_idx;
-ERROR:  CONCURRENTLY-enabled index command failed
+ERROR:  index "ith_b_idx_102089" does not exist
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid?

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -294,10 +294,9 @@ CREATE INDEX CONCURRENTLY ith_b_idx_102089 ON multi_index_statements.index_test_
 SET search_path TO multi_index_statements;
 -- should fail because worker index already exists
 CREATE INDEX CONCURRENTLY ith_b_idx ON index_test_hash(b);
-NOTICE:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
-HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
-ERROR:  relation "ith_b_idx_102089" already exists
-CONTEXT:  while executing command on localhost:xxxxx
+ERROR:  CONCURRENTLY-enabled index command failed
+DETAIL:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+HINT:  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index, then retry the original command.
 -- the failure results in an INVALID index
 SELECT indisvalid AS "Index Valid?" FROM pg_index WHERE indexrelid='ith_b_idx'::regclass;
  Index Valid?

--- a/src/test/regress/sql/failure_create_index_concurrently.sql
+++ b/src/test/regress/sql/failure_create_index_concurrently.sql
@@ -88,6 +88,11 @@ INSERT INTO index_test_2 VALUES (1, 1), (1, 2);
 CREATE UNIQUE INDEX CONCURRENTLY index_test_2_a_idx ON index_test_2(a);
 DROP INDEX CONCURRENTLY IF EXISTS index_test_2_a_idx;
 
+-- verify that index creation doesn't fail when duplicates are removed
+DELETE FROM index_test_2 WHERE a = 1 AND b = 2;
+CREATE UNIQUE INDEX CONCURRENTLY index_test_2_a_idx ON index_test_2(a);
+DROP INDEX CONCURRENTLY IF EXISTS index_test_2_a_idx;
+
 RESET SEARCH_PATH;
 DROP SCHEMA index_schema CASCADE;
 

--- a/src/test/regress/sql/failure_create_index_concurrently.sql
+++ b/src/test/regress/sql/failure_create_index_concurrently.sql
@@ -81,6 +81,13 @@ SELECT citus.mitmproxy('conn.allow()');
 SELECT * FROM run_command_on_workers($$SELECT count(*) FROM pg_indexes WHERE indexname LIKE 'idx_index_test%' $$)
 WHERE nodeport = :worker_2_proxy_port;
 
+-- test unique concurrent index creation failure when there are duplicates
+CREATE TABLE index_test_2 (a int, b int);
+SELECT create_distributed_table('index_test_2', 'a');
+INSERT INTO index_test_2 VALUES (1, 1), (1, 2);
+CREATE UNIQUE INDEX CONCURRENTLY index_test_2_a_idx ON index_test_2(a);
+DROP INDEX CONCURRENTLY IF EXISTS index_test_2_a_idx;
+
 RESET SEARCH_PATH;
 DROP SCHEMA index_schema CASCADE;
 


### PR DESCRIPTION
DESCRIPTION: Rethrow original concurrent index creation failure message

I removed the general `ERROR:  CONCURRENTLY-enabled index command failed` and put the original ERROR message when the concurrent index creation fails. I left the hint of removing the invalid index after the failure.

TODO:

- [x] understand the issue better to provide a full solution
- [x] write tests accordingly

Fixes #3951 
