### PR TITLE
Detect vars referencing outer queries in local-dist table

### DIFF
--- a/src/backend/distributed/planner/local_distributed_join_planner.c
+++ b/src/backend/distributed/planner/local_distributed_join_planner.c
@@ -356,27 +356,6 @@ AllRangeTableEntriesHaveUniqueIndex(List *rangeTableEntryDetailsList)
 
 
 /*
- * ShouldConvertLocalTableJoinsToSubqueries returns true if we should
- * convert local-dist table joins to subqueries.
- */
-bool
-ShouldConvertLocalTableJoinsToSubqueries(List *rangeTableList)
-{
-	if (LocalTableJoinPolicy == LOCAL_JOIN_POLICY_NEVER)
-	{
-		/* user doesn't want Citus to enable local table joins */
-		return false;
-	}
-
-	if (!ContainsLocalTableDistributedTableJoin(rangeTableList))
-	{
-		return false;
-	}
-	return true;
-}
-
-
-/*
  * HasConstantFilterOnUniqueColumn returns true if the given rangeTableEntry has a constant
  * filter on a unique column.
  */

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -920,7 +920,7 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 		ExtractRangeTableEntryWalker((Node *) originalQuery, &rangeTableList);
 	}
 	bool containsLocalTableDistributedTableJoin =
-		ContainsLocalTableDistributedTableJoin(queryTree->rtable);
+		ContainsLocalTableDistributedTableJoin(queryTree->rtable, NULL, NULL);
 
 	RangeTblEntry *rangeTableEntry = NULL;
 	foreach_ptr(rangeTableEntry, rangeTableList)

--- a/src/backend/distributed/utils/var_utils.c
+++ b/src/backend/distributed/utils/var_utils.c
@@ -1,0 +1,112 @@
+/*-------------------------------------------------------------------------
+ *
+ * var_utils.c
+ *	  Utilities regarding vars
+ *
+ * Copyright (c) Citus Data, Inc.
+ *-------------------------------------------------------------------------
+ */
+
+#include "distributed/pg_version_constants.h"
+
+#include "postgres.h"
+
+#include "distributed/var_utils.h"
+
+#include "parser/parsetree.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/nodes.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/pg_list.h"
+#include "utils/builtins.h"
+#include "utils/guc.h"
+#include "utils/lsyscache.h"
+#include "nodes/primnodes.h"
+#if PG_VERSION_NUM >= PG_VERSION_12
+#include "nodes/pathnodes.h"
+#else
+#include "nodes/relation.h"
+#endif
+
+typedef struct PullTableContext
+{
+	List *rteList;
+	List *rtableList;
+}PullTableContext;
+
+
+static bool PullAllRangeTablesEntriesWalker(Node *node,
+											PullTableContext *pullTableContext);
+
+
+/*
+ * PullAllRangeTablesEntries collects all the range table entries that are referenced
+ * in the given query. The range table entry could be outside of the given query but a var
+ * could exist that points to it.
+ * rtableList should contain list of rtables up to this query from the top query.
+ */
+List *
+PullAllRangeTablesEntries(Query *query, List *rtableList)
+{
+	PullTableContext p;
+	p.rtableList = rtableList;
+	p.rteList = NIL;
+
+	query_or_expression_tree_walker((Node *) query,
+									PullAllRangeTablesEntriesWalker,
+									(void *) &p,
+									0);
+
+	return p.rteList;
+}
+
+
+/*
+ * PullAllRangeTablesEntriesWalker descends into the given node and collects
+ * all range table entries that are referenced by a Var.
+ */
+static bool
+PullAllRangeTablesEntriesWalker(Node *node, PullTableContext *pullTableContext)
+{
+	if (node == NULL)
+	{
+		return false;
+	}
+	if (IsA(node, Var))
+	{
+		Var *var = (Var *) node;
+
+		List *rtableList = pullTableContext->rtableList;
+		int index = var->varlevelsup;
+		if (index >= list_length(rtableList) || index < 0)
+		{
+			ereport(ERROR, (errmsg("unexpected state: %d is not between 0-%d", index,
+								   list_length(rtableList))));
+		}
+		List *rtable = (List *) list_nth(rtableList, index);
+		RangeTblEntry *rte = (RangeTblEntry *) list_nth(rtable, var->varno - 1);
+		pullTableContext->rteList = lappend(pullTableContext->rteList, rte);
+		return false;
+	}
+	if (IsA(node, PlaceHolderVar))
+	{
+		/* PlaceHolderVar *phv = (PlaceHolderVar *) node; */
+
+		/* we don't want to look into the contained expression */
+		return false;
+	}
+	if (IsA(node, Query))
+	{
+		/* Recurse into RTE subquery or not-yet-planned sublink subquery */
+
+		Query *query = (Query *) node;
+		pullTableContext->rtableList = lcons(query->rtable, pullTableContext->rtableList);
+		bool result = query_tree_walker(query, PullAllRangeTablesEntriesWalker,
+										(void *) pullTableContext, 0);
+		pullTableContext->rtableList = list_delete_first(pullTableContext->rtableList);
+		return result;
+	}
+	return expression_tree_walker(node, PullAllRangeTablesEntriesWalker,
+								  (void *) pullTableContext);
+}

--- a/src/include/distributed/local_distributed_join_planner.h
+++ b/src/include/distributed/local_distributed_join_planner.h
@@ -27,7 +27,6 @@ typedef enum
 
 extern int LocalTableJoinPolicy;
 
-extern bool ShouldConvertLocalTableJoinsToSubqueries(List *rangeTableList);
 extern void RecursivelyPlanLocalTableJoins(Query *query,
 										   RecursivePlanningContext *context);
 

--- a/src/include/distributed/recursive_planning.h
+++ b/src/include/distributed/recursive_planning.h
@@ -43,7 +43,9 @@ extern Query * BuildReadIntermediateResultsArrayQuery(List *targetEntryList,
 													  List *resultIdList,
 													  bool useBinaryCopyFormat);
 extern bool GeneratingSubplans(void);
-extern bool ContainsLocalTableDistributedTableJoin(List *rangeTableList);
+extern bool ContainsLocalTableDistributedTableJoin(List *rangeTableList,
+												   bool *containsLocalTableOut,
+												   bool *containsDistributedTableOut);
 extern void ReplaceRTERelationWithRteSubquery(RangeTblEntry *rangeTableEntry,
 											  List *requiredAttrNumbers,
 											  RecursivePlanningContext *context);

--- a/src/include/distributed/var_utils.h
+++ b/src/include/distributed/var_utils.h
@@ -1,0 +1,17 @@
+/*-------------------------------------------------------------------------
+ *
+ * var_utils.h
+ *	  Utilities regarding vars
+ *
+ * Copyright (c) Citus Data, Inc.
+ *-------------------------------------------------------------------------
+ */
+
+
+#ifndef VAR_UTILS
+#define VAR_UTILS
+#include "nodes/pg_list.h"
+#include "nodes/parsenodes.h"
+
+List * PullAllRangeTablesEntries(Query *query, List *rtableList);
+#endif

--- a/src/test/regress/expected/local_dist_join_mixed.out
+++ b/src/test/regress/expected/local_dist_join_mixed.out
@@ -652,8 +652,14 @@ WHERE
 				(SELECT *, random() FROM (SELECT *,random() FROM local WHERE d_upper.id = id) as foo2) as bar2
 					USING(id)
 			) IS NOT NULL;
-ERROR:  direct joins between distributed and local tables are not supported
-HINT:  Use CTE's or subqueries to select from local tables and use them in joins
+DEBUG:  Wrapping relation "local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_dist_join_mixed.distributed d_upper WHERE ((SELECT bar.id FROM ((SELECT foo.id, foo.name, foo.created_at, foo.random, random() AS random FROM (SELECT distributed.id, distributed.name, distributed.created_at, random() AS random FROM local_dist_join_mixed.distributed WHERE (distributed.id OPERATOR(pg_catalog.=) d_upper.id)) foo) bar(id, name, created_at, random, random_1) JOIN (SELECT foo2.id, foo2.title, foo2.random, random() AS random FROM (SELECT local.id, local.title, random() AS random FROM (SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local WHERE (d_upper.id OPERATOR(pg_catalog.=) local.id)) foo2) bar2(id, title, random, random_1) USING (id))) IS NOT NULL)
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
 -- subqueries in the target list
 -- router, should work
 select (SELECT local.id) FROM local, distributed WHERE distributed.id = 1 LIMIT 1;
@@ -682,8 +688,15 @@ SELECT
 FROM
 	distributed e
 ORDER BY 1,2 LIMIT 1;
-ERROR:  direct joins between distributed and local tables are not supported
-HINT:  Use CTE's or subqueries to select from local tables and use them in joins
+DEBUG:  Wrapping relation "local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT name, (SELECT local.id FROM (SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local WHERE (local.id OPERATOR(pg_catalog.=) e.id)) AS id FROM local_dist_join_mixed.distributed e ORDER BY name, (SELECT local.id FROM (SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local WHERE (local.id OPERATOR(pg_catalog.=) e.id)) LIMIT 1
+DEBUG:  push down of limit count: 1
+ name | id
+---------------------------------------------------------------------
+ 0    |  0
+(1 row)
+
 -- set operations
 SELECT local.* FROM distributed JOIN local USING (id)
 	EXCEPT
@@ -1136,32 +1149,48 @@ DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS c
 (1 row)
 
 -- lateral joins
-SELECT COUNT(*) FROM (VALUES (1), (2), (3))  as f(x) LATERAL JOIN (SELECT * FROM local WHERE id  =  x) as bar;
-ERROR:  syntax error at or near "LATERAL"
+SELECT COUNT(*) FROM (VALUES (1), (2), (3))  as f(x) JOIN LATERAL (SELECT * FROM local WHERE id  =  x) as bar ON TRUE;
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
 SELECT COUNT(*) FROM local JOIN LATERAL (SELECT * FROM distributed WHERE local.id = distributed.id) as foo ON (true);
-DEBUG:  Wrapping relation "local" to a subquery
-DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.local WHERE true
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local JOIN LATERAL (SELECT distributed.id, distributed.name, distributed.created_at FROM local_dist_join_mixed.distributed WHERE (local.id OPERATOR(pg_catalog.=) distributed.id)) foo ON (true))
+DEBUG:  Wrapping relation "distributed" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.distributed WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (local_dist_join_mixed.local JOIN LATERAL (SELECT distributed.id, distributed.name, distributed.created_at FROM (SELECT NULL::integer AS "dummy-1", distributed_1.id, NULL::text AS name, NULL::timestamp with time zone AS created_at FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) distributed_1) distributed WHERE (local.id OPERATOR(pg_catalog.=) distributed.id)) foo ON (true))
  count
 ---------------------------------------------------------------------
    101
 (1 row)
 
 SELECT COUNT(*) FROM local JOIN LATERAL (SELECT * FROM distributed WHERE local.id > distributed.id) as foo ON (true);
-DEBUG:  Wrapping relation "local" to a subquery
-DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.local WHERE true
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local JOIN LATERAL (SELECT distributed.id, distributed.name, distributed.created_at FROM local_dist_join_mixed.distributed WHERE (local.id OPERATOR(pg_catalog.>) distributed.id)) foo ON (true))
+DEBUG:  Wrapping relation "distributed" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.distributed WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (local_dist_join_mixed.local JOIN LATERAL (SELECT distributed.id, distributed.name, distributed.created_at FROM (SELECT NULL::integer AS "dummy-1", distributed_1.id, NULL::text AS name, NULL::timestamp with time zone AS created_at FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) distributed_1) distributed WHERE (local.id OPERATOR(pg_catalog.>) distributed.id)) foo ON (true))
  count
 ---------------------------------------------------------------------
   5050
 (1 row)
 
 SELECT COUNT(*) FROM distributed JOIN LATERAL (SELECT * FROM local WHERE local.id = distributed.id) as foo ON (true);
-ERROR:  direct joins between distributed and local tables are not supported
-HINT:  Use CTE's or subqueries to select from local tables and use them in joins
+DEBUG:  Wrapping relation "local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (local_dist_join_mixed.distributed JOIN LATERAL (SELECT local.id, local.title FROM (SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local WHERE (local.id OPERATOR(pg_catalog.=) distributed.id)) foo ON (true))
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
 SELECT COUNT(*) FROM distributed JOIN LATERAL (SELECT * FROM local WHERE local.id > distributed.id) as foo ON (true);
-ERROR:  direct joins between distributed and local tables are not supported
-HINT:  Use CTE's or subqueries to select from local tables and use them in joins
+DEBUG:  Wrapping relation "local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT id FROM local_dist_join_mixed.local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (local_dist_join_mixed.distributed JOIN LATERAL (SELECT local.id, local.title FROM (SELECT NULL::integer AS "dummy-1", local_1.id, NULL::integer AS "dummy-3", NULL::text AS title, NULL::integer AS "dummy-5" FROM (SELECT intermediate_result.id FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id bigint)) local_1) local WHERE (local.id OPERATOR(pg_catalog.>) distributed.id)) foo ON (true))
+ count
+---------------------------------------------------------------------
+  5050
+(1 row)
+
 SELECT count(*) FROM distributed CROSS JOIN local;
 DEBUG:  Wrapping relation "local" to a subquery
 DEBUG:  generating subplan XXX_1 for subquery SELECT NULL::integer AS "dummy-1" FROM local_dist_join_mixed.local WHERE true

--- a/src/test/regress/expected/local_table_join_vars.out
+++ b/src/test/regress/expected/local_table_join_vars.out
@@ -279,7 +279,13 @@ DEBUG:  Wrapping relation "postgres_table" "p2" to a subquery
 DEBUG:  generating subplan XXX_2 for subquery SELECT NULL::integer AS "dummy-1" FROM local_table_join_vars.postgres_table p2 WHERE true
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT (SELECT count(*) AS count FROM (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) distributed_table.key)) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) p2_1) p2) AS count FROM local_table_join_vars.distributed_table
 ERROR:  correlated subqueries are not supported when the FROM clause contains a CTE or subquery
-RESET client_min_messages;
+SET client_min_messages to ERROR;
+DROP TABLE citus_local;
+SELECT master_remove_node('localhost', :master_port);
+ master_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
 \set VERBOSITY terse
 DROP SCHEMA local_table_join_vars CASCADE;
-NOTICE:  drop cascades to 11 other objects

--- a/src/test/regress/expected/local_table_join_vars.out
+++ b/src/test/regress/expected/local_table_join_vars.out
@@ -1,0 +1,285 @@
+CREATE SCHEMA local_table_join_vars;
+SET search_path TO local_table_join_vars;
+SET client_min_messages to ERROR;
+SELECT master_add_node('localhost', :master_port, groupId => 0) AS coordinator_nodeid \gset
+SET client_min_messages TO DEBUG1;
+CREATE TABLE postgres_table (key int, value text, value_2 jsonb);
+CREATE TABLE reference_table (key int, value text, value_2 jsonb);
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE distributed_table (key int, value text, value_2 jsonb);
+SELECT create_distributed_table('distributed_table', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE distributed_table_pkey (key int primary key, value text, value_2 jsonb);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "distributed_table_pkey_pkey" for table "distributed_table_pkey"
+SELECT create_distributed_table('distributed_table_pkey', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE distributed_table_windex (key int primary key, value text, value_2 jsonb);
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "distributed_table_windex_pkey" for table "distributed_table_windex"
+SELECT create_distributed_table('distributed_table_windex', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE UNIQUE INDEX key_index ON distributed_table_windex (key);
+CREATE TABLE citus_local(key int, value text);
+SELECT create_citus_local_table('citus_local');
+ create_citus_local_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE distributed_partitioned_table(key int, value text) PARTITION BY RANGE (key);
+CREATE TABLE distributed_partitioned_table_1 PARTITION OF distributed_partitioned_table FOR VALUES FROM (0) TO (50);
+CREATE TABLE distributed_partitioned_table_2 PARTITION OF distributed_partitioned_table FOR VALUES FROM (50) TO (200);
+SELECT create_distributed_table('distributed_partitioned_table', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE local_partitioned_table(key int, value text) PARTITION BY RANGE (key);
+CREATE TABLE local_partitioned_table_1 PARTITION OF local_partitioned_table FOR VALUES FROM (0) TO (50);
+CREATE TABLE local_partitioned_table_2 PARTITION OF local_partitioned_table FOR VALUES FROM (50) TO (200);
+CREATE TABLE distributed_table_composite (key int, value text, value_2 jsonb, primary key (key, value));
+DEBUG:  CREATE TABLE / PRIMARY KEY will create implicit index "distributed_table_composite_pkey" for table "distributed_table_composite"
+SELECT create_distributed_table('distributed_table_composite', 'key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO postgres_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO reference_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO distributed_table_windex SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO distributed_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO distributed_table_pkey SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO distributed_partitioned_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO distributed_table_composite SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO local_partitioned_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+-- vars referencing outer queries should work in SELECT
+SELECT (SELECT COUNT(*) FROM postgres_table WHERE postgres_table.key = distributed_table.key) FROM distributed_table ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) distributed_table.key)) AS count FROM local_table_join_vars.distributed_table ORDER BY (SELECT count(*) AS count FROM (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) distributed_table.key)) LIMIT 1
+DEBUG:  push down of limit count: 1
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+SELECT (SELECT COUNT(*) FROM postgres_table WHERE distributed_table.key = 5) FROM distributed_table ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT NULL::integer AS "dummy-1" FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) postgres_table_1) postgres_table WHERE (distributed_table.key OPERATOR(pg_catalog.=) 5)) AS count FROM local_table_join_vars.distributed_table ORDER BY (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) postgres_table_1) postgres_table WHERE (distributed_table.key OPERATOR(pg_catalog.=) 5)) LIMIT 1
+DEBUG:  push down of limit count: 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE postgres_table.key = 5) FROM postgres_table ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT NULL::integer AS "dummy-1" FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) distributed_table_1) distributed_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) 5)) AS count FROM local_table_join_vars.postgres_table ORDER BY (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) distributed_table_1) distributed_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) 5)) LIMIT 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE postgres_table.key = distributed_table.key) FROM postgres_table ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) distributed_table.key)) AS count FROM local_table_join_vars.postgres_table ORDER BY (SELECT count(*) AS count FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) distributed_table.key)) LIMIT 1
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- vars referencing outer queries should work in SELECT with citus local tables
+SELECT (SELECT COUNT(*) FROM citus_local WHERE citus_local.key = distributed_table.key) FROM distributed_table ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local WHERE (citus_local.key OPERATOR(pg_catalog.=) distributed_table.key)) AS count FROM local_table_join_vars.distributed_table ORDER BY (SELECT count(*) AS count FROM (SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local WHERE (citus_local.key OPERATOR(pg_catalog.=) distributed_table.key)) LIMIT 1
+DEBUG:  push down of limit count: 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT (SELECT COUNT(*) FROM citus_local WHERE distributed_table.key = 5) FROM distributed_table ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT NULL::integer AS "dummy-1" FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) citus_local_1) citus_local WHERE (distributed_table.key OPERATOR(pg_catalog.=) 5)) AS count FROM local_table_join_vars.distributed_table ORDER BY (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) citus_local_1) citus_local WHERE (distributed_table.key OPERATOR(pg_catalog.=) 5)) LIMIT 1
+DEBUG:  push down of limit count: 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE citus_local.key = 5) FROM citus_local ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT NULL::integer AS "dummy-1" FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) distributed_table_1) distributed_table WHERE (citus_local.key OPERATOR(pg_catalog.=) 5)) AS count FROM local_table_join_vars.citus_local ORDER BY (SELECT count(*) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) distributed_table_1) distributed_table WHERE (citus_local.key OPERATOR(pg_catalog.=) 5)) LIMIT 1
+ count
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE citus_local.key = distributed_table.key) FROM citus_local ORDER BY 1 LIMIT 1;
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT count(*) AS count FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (citus_local.key OPERATOR(pg_catalog.=) distributed_table.key)) AS count FROM local_table_join_vars.citus_local ORDER BY (SELECT count(*) AS count FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (citus_local.key OPERATOR(pg_catalog.=) distributed_table.key)) LIMIT 1
+ count
+---------------------------------------------------------------------
+(0 rows)
+
+-- vars referencing outer queries should work in WHERE
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM postgres_table WHERE key > distributed_table.key);
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.distributed_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT postgres_table.key FROM (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table WHERE (postgres_table.key OPERATOR(pg_catalog.>) distributed_table.key)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM postgres_table WHERE key in (SELECT key FROM distributed_table WHERE key > postgres_table.key);
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.postgres_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table.key FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (distributed_table.key OPERATOR(pg_catalog.>) postgres_table.key)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM postgres_table WHERE key in (SELECT key FROM distributed_table WHERE postgres_table.key > 5);
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.postgres_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table.key FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (postgres_table.key OPERATOR(pg_catalog.>) 5)))
+ count
+---------------------------------------------------------------------
+    95
+(1 row)
+
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM postgres_table WHERE distributed_table.key > 5);
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.distributed_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT postgres_table.key FROM (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table WHERE (distributed_table.key OPERATOR(pg_catalog.>) 5)))
+ count
+---------------------------------------------------------------------
+    95
+(1 row)
+
+-- vars referencing outer queries should work in WHERE with citus local tables
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local WHERE key > distributed_table.key);
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.distributed_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT citus_local.key FROM (SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local WHERE (citus_local.key OPERATOR(pg_catalog.>) distributed_table.key)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table WHERE key > citus_local.key);
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.citus_local WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table.key FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (distributed_table.key OPERATOR(pg_catalog.>) citus_local.key)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table WHERE citus_local.key > 5);
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.citus_local WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table.key FROM (SELECT distributed_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) distributed_table_1) distributed_table WHERE (citus_local.key OPERATOR(pg_catalog.>) 5)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local WHERE distributed_table.key > 5);
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.distributed_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT citus_local.key FROM (SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local WHERE (distributed_table.key OPERATOR(pg_catalog.>) 5)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- citus-local, local and dist should work
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local JOIN postgres_table USING(key) WHERE key > distributed_table.key);
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.distributed_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT citus_local.key FROM ((SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local JOIN (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table USING (key)) WHERE (citus_local.key OPERATOR(pg_catalog.>) distributed_table.key)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Will work when we fix "correlated subqueries are not supported when the FROM clause contains a CTE or subquery"
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table JOIN postgres_table USING(key) WHERE key > citus_local.key);
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table.key FROM (local_table_join_vars.distributed_table JOIN (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table USING (key)) WHERE (distributed_table.key OPERATOR(pg_catalog.>) citus_local.key)))
+ERROR:  correlated subqueries are not supported when the FROM clause contains a CTE or subquery
+-- Will work when we fix "correlated subqueries are not supported when the FROM clause contains a CTE or subquery"
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table JOIN postgres_table USING(key) WHERE citus_local.key > 5);
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT distributed_table.key FROM (local_table_join_vars.distributed_table JOIN (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table USING (key)) WHERE (citus_local.key OPERATOR(pg_catalog.>) 5)))
+ERROR:  correlated subqueries are not supported when the FROM clause contains a CTE or subquery
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local JOIN postgres_table USING(key) WHERE distributed_table.key > 5);
+DEBUG:  Wrapping relation "citus_local" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.citus_local WHERE true
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM local_table_join_vars.distributed_table WHERE (key OPERATOR(pg_catalog.=) ANY (SELECT citus_local.key FROM ((SELECT citus_local_1.key, NULL::text AS value FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) citus_local_1) citus_local JOIN (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table USING (key)) WHERE (distributed_table.key OPERATOR(pg_catalog.>) 5)))
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Will work when we fix "correlated subqueries are not supported when the FROM clause contains a CTE or subquery"
+SELECT (SELECT (SELECT COUNT(*) FROM postgres_table WHERE postgres_table.key = distributed_table.key) FROM postgres_table p2) FROM distributed_table;
+DEBUG:  Wrapping relation "postgres_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT key FROM local_table_join_vars.postgres_table WHERE true
+DEBUG:  Wrapping relation "postgres_table" "p2" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT NULL::integer AS "dummy-1" FROM local_table_join_vars.postgres_table p2 WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT (SELECT (SELECT count(*) AS count FROM (SELECT postgres_table_1.key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result.key FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(key integer)) postgres_table_1) postgres_table WHERE (postgres_table.key OPERATOR(pg_catalog.=) distributed_table.key)) AS count FROM (SELECT NULL::integer AS key, NULL::text AS value, NULL::jsonb AS value_2 FROM (SELECT intermediate_result."dummy-1" FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result("dummy-1" integer)) p2_1) p2) AS count FROM local_table_join_vars.distributed_table
+ERROR:  correlated subqueries are not supported when the FROM clause contains a CTE or subquery
+RESET client_min_messages;
+\set VERBOSITY terse
+DROP SCHEMA local_table_join_vars CASCADE;
+NOTICE:  drop cascades to 11 other objects

--- a/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
+++ b/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
@@ -466,10 +466,16 @@ JOIN LATERAL
    WHERE u2.value = 15) AS u3 USING (value)
 WHERE (u2.value > 2
        AND FALSE);
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM push_down_filters.distributed_table WHERE true
 DEBUG:  Wrapping relation "local_table" "u2" to a subquery
-DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM push_down_filters.local_table u2 WHERE false
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((push_down_filters.distributed_table u1 JOIN (SELECT NULL::integer AS key, u2_1.value, NULL::timestamp with time zone AS "time" FROM (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value integer)) u2_1) u2 USING (value)) JOIN LATERAL (SELECT distributed_table.value, random() AS random FROM push_down_filters.distributed_table WHERE (u2.value OPERATOR(pg_catalog.=) 15)) u3 USING (value)) WHERE ((u2.value OPERATOR(pg_catalog.>) 2) AND false)
-ERROR:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+DEBUG:  generating subplan XXX_2 for subquery SELECT value FROM push_down_filters.local_table u2 WHERE false
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((push_down_filters.distributed_table u1 JOIN (SELECT NULL::integer AS key, u2_1.value, NULL::timestamp with time zone AS "time" FROM (SELECT intermediate_result.value FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(value integer)) u2_1) u2 USING (value)) JOIN LATERAL (SELECT distributed_table.value, random() AS random FROM (SELECT NULL::integer AS key, distributed_table_1.value, NULL::jsonb AS metadata FROM (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value integer)) distributed_table_1) distributed_table WHERE (u2.value OPERATOR(pg_catalog.=) 15)) u3 USING (value)) WHERE ((u2.value OPERATOR(pg_catalog.>) 2) AND false)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
 \set VERBOSITY terse
 RESET client_min_messages;
 DROP SCHEMA push_down_filters CASCADE;

--- a/src/test/regress/expected/recursive_view_local_table.out
+++ b/src/test/regress/expected/recursive_view_local_table.out
@@ -149,8 +149,11 @@ SELECT ref_table.* FROM ref_table JOIN (SELECT * FROM recursive_defined_non_recu
 (3 rows)
 
 SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a);
-ERROR:  direct joins between distributed and local tables are not supported
-HINT:  Use CTE's or subqueries to select from local tables and use them in joins
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+(1 row)
+
 SELECT ref_table.* FROM ref_table WHERE EXISTS (SELECT * FROM local_table l WHERE l.a = ref_table.a) AND false;
  a | b
 ---------------------------------------------------------------------

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -231,6 +231,7 @@ test: local_dist_join_modifications
 test: local_table_join
 test: local_dist_join_mixed
 test: citus_local_dist_joins
+test: local_table_join_vars
 
 # ---------
 # multi_copy creates hash and range-partitioned tables and performs COPY

--- a/src/test/regress/sql/local_dist_join_mixed.sql
+++ b/src/test/regress/sql/local_dist_join_mixed.sql
@@ -298,7 +298,7 @@ generate_Series(1,25)x;
 
 -- lateral joins
 
-SELECT COUNT(*) FROM (VALUES (1), (2), (3))  as f(x) LATERAL JOIN (SELECT * FROM local WHERE id  =  x) as bar;
+SELECT COUNT(*) FROM (VALUES (1), (2), (3))  as f(x) JOIN LATERAL (SELECT * FROM local WHERE id  =  x) as bar ON TRUE;
 
 SELECT COUNT(*) FROM local JOIN LATERAL (SELECT * FROM distributed WHERE local.id = distributed.id) as foo ON (true);
 SELECT COUNT(*) FROM local JOIN LATERAL (SELECT * FROM distributed WHERE local.id > distributed.id) as foo ON (true);

--- a/src/test/regress/sql/local_table_join_vars.sql
+++ b/src/test/regress/sql/local_table_join_vars.sql
@@ -1,0 +1,84 @@
+CREATE SCHEMA local_table_join_vars;
+SET search_path TO local_table_join_vars;
+
+SET client_min_messages to ERROR;
+SELECT master_add_node('localhost', :master_port, groupId => 0) AS coordinator_nodeid \gset
+
+SET client_min_messages TO DEBUG1;
+
+CREATE TABLE postgres_table (key int, value text, value_2 jsonb);
+CREATE TABLE reference_table (key int, value text, value_2 jsonb);
+SELECT create_reference_table('reference_table');
+CREATE TABLE distributed_table (key int, value text, value_2 jsonb);
+SELECT create_distributed_table('distributed_table', 'key');
+
+CREATE TABLE distributed_table_pkey (key int primary key, value text, value_2 jsonb);
+SELECT create_distributed_table('distributed_table_pkey', 'key');
+
+CREATE TABLE distributed_table_windex (key int primary key, value text, value_2 jsonb);
+SELECT create_distributed_table('distributed_table_windex', 'key');
+CREATE UNIQUE INDEX key_index ON distributed_table_windex (key);
+
+CREATE TABLE citus_local(key int, value text);
+SELECT create_citus_local_table('citus_local');
+
+CREATE TABLE distributed_partitioned_table(key int, value text) PARTITION BY RANGE (key);
+CREATE TABLE distributed_partitioned_table_1 PARTITION OF distributed_partitioned_table FOR VALUES FROM (0) TO (50);
+CREATE TABLE distributed_partitioned_table_2 PARTITION OF distributed_partitioned_table FOR VALUES FROM (50) TO (200);
+SELECT create_distributed_table('distributed_partitioned_table', 'key');
+
+CREATE TABLE local_partitioned_table(key int, value text) PARTITION BY RANGE (key);
+CREATE TABLE local_partitioned_table_1 PARTITION OF local_partitioned_table FOR VALUES FROM (0) TO (50);
+CREATE TABLE local_partitioned_table_2 PARTITION OF local_partitioned_table FOR VALUES FROM (50) TO (200);
+
+CREATE TABLE distributed_table_composite (key int, value text, value_2 jsonb, primary key (key, value));
+SELECT create_distributed_table('distributed_table_composite', 'key');
+
+INSERT INTO postgres_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO reference_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO distributed_table_windex SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO distributed_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO distributed_table_pkey SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO distributed_partitioned_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO distributed_table_composite SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+INSERT INTO local_partitioned_table SELECT i, i::varchar(256) FROM generate_series(1, 100) i;
+
+-- vars referencing outer queries should work in SELECT
+SELECT (SELECT COUNT(*) FROM postgres_table WHERE postgres_table.key = distributed_table.key) FROM distributed_table ORDER BY 1 LIMIT 1;
+SELECT (SELECT COUNT(*) FROM postgres_table WHERE distributed_table.key = 5) FROM distributed_table ORDER BY 1 LIMIT 1;
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE postgres_table.key = 5) FROM postgres_table ORDER BY 1 LIMIT 1;
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE postgres_table.key = distributed_table.key) FROM postgres_table ORDER BY 1 LIMIT 1;
+
+-- vars referencing outer queries should work in SELECT with citus local tables
+SELECT (SELECT COUNT(*) FROM citus_local WHERE citus_local.key = distributed_table.key) FROM distributed_table ORDER BY 1 LIMIT 1;
+SELECT (SELECT COUNT(*) FROM citus_local WHERE distributed_table.key = 5) FROM distributed_table ORDER BY 1 LIMIT 1;
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE citus_local.key = 5) FROM citus_local ORDER BY 1 LIMIT 1;
+SELECT (SELECT COUNT(*) FROM distributed_table WHERE citus_local.key = distributed_table.key) FROM citus_local ORDER BY 1 LIMIT 1;
+
+-- vars referencing outer queries should work in WHERE
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM postgres_table WHERE key > distributed_table.key);
+SELECT COUNT(*) FROM postgres_table WHERE key in (SELECT key FROM distributed_table WHERE key > postgres_table.key);
+SELECT COUNT(*) FROM postgres_table WHERE key in (SELECT key FROM distributed_table WHERE postgres_table.key > 5);
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM postgres_table WHERE distributed_table.key > 5);
+
+-- vars referencing outer queries should work in WHERE with citus local tables
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local WHERE key > distributed_table.key);
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table WHERE key > citus_local.key);
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table WHERE citus_local.key > 5);
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local WHERE distributed_table.key > 5);
+
+-- citus-local, local and dist should work
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local JOIN postgres_table USING(key) WHERE key > distributed_table.key);
+-- Will work when we fix "correlated subqueries are not supported when the FROM clause contains a CTE or subquery"
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table JOIN postgres_table USING(key) WHERE key > citus_local.key);
+-- Will work when we fix "correlated subqueries are not supported when the FROM clause contains a CTE or subquery"
+SELECT COUNT(*) FROM citus_local WHERE key in (SELECT key FROM distributed_table JOIN postgres_table USING(key) WHERE citus_local.key > 5);
+SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local JOIN postgres_table USING(key) WHERE distributed_table.key > 5);
+
+-- Will work when we fix "correlated subqueries are not supported when the FROM clause contains a CTE or subquery"
+SELECT (SELECT (SELECT COUNT(*) FROM postgres_table WHERE postgres_table.key = distributed_table.key) FROM postgres_table p2) FROM distributed_table;
+
+
+RESET client_min_messages;
+\set VERBOSITY terse
+DROP SCHEMA local_table_join_vars CASCADE;

--- a/src/test/regress/sql/local_table_join_vars.sql
+++ b/src/test/regress/sql/local_table_join_vars.sql
@@ -79,6 +79,8 @@ SELECT COUNT(*) FROM distributed_table WHERE key in (SELECT key FROM citus_local
 SELECT (SELECT (SELECT COUNT(*) FROM postgres_table WHERE postgres_table.key = distributed_table.key) FROM postgres_table p2) FROM distributed_table;
 
 
-RESET client_min_messages;
+SET client_min_messages to ERROR;
+DROP TABLE citus_local;
+SELECT master_remove_node('localhost', :master_port);
 \set VERBOSITY terse
 DROP SCHEMA local_table_join_vars CASCADE;


### PR DESCRIPTION
We were checking just range table list to detect local-dist table joins
but there can be vars referencing to outer queries which belong to a
distributed table.
