### PR TITLE
Don't escape undistribute_table error checks when cascade_via_foreign_keys=true

### DIFF
--- a/src/test/regress/expected/undistribute_table_cascade.out
+++ b/src/test/regress/expected/undistribute_table_cascade.out
@@ -309,6 +309,17 @@ BEGIN;
 (6 rows)
 
 ROLLBACK;
+-- show that we properly handle cases where undistribute_table is not supported
+-- error out when table is a partition table
+SELECT undistribute_table('partitioned_table_2_100_200', cascade_via_foreign_keys=>true);
+ERROR:  cannot undistribute table because it is a partition
+-- error if table does not exist
+SELECT undistribute_table('non_existent_table', cascade_via_foreign_keys=>true);
+ERROR:  relation "non_existent_table" does not exist at character 27
+-- error if table is a postgres table
+CREATE TABLE local_table(a int);
+SELECT undistribute_table('local_table', cascade_via_foreign_keys=>true);
+ERROR:  cannot undistribute table
 -- as pg < 12 doesn't support foreign keys between partitioned tables,
 -- define below foreign key conditionally instead of adding another
 -- test output

--- a/src/test/regress/sql/undistribute_table_cascade.sql
+++ b/src/test/regress/sql/undistribute_table_cascade.sql
@@ -171,6 +171,15 @@ BEGIN;
   ORDER BY 1,2,3;
 ROLLBACK;
 
+-- show that we properly handle cases where undistribute_table is not supported
+-- error out when table is a partition table
+SELECT undistribute_table('partitioned_table_2_100_200', cascade_via_foreign_keys=>true);
+-- error if table does not exist
+SELECT undistribute_table('non_existent_table', cascade_via_foreign_keys=>true);
+-- error if table is a postgres table
+CREATE TABLE local_table(a int);
+SELECT undistribute_table('local_table', cascade_via_foreign_keys=>true);
+
 -- as pg < 12 doesn't support foreign keys between partitioned tables,
 -- define below foreign key conditionally instead of adding another
 -- test output


### PR DESCRIPTION
#4481 tells two bugs introduced by #4457, this pr addresses the second issue given in https://github.com/citusdata/citus/issues/4481#issuecomment-756665262

