### PR TITLE
Disallow cascade_via_foreign_keys if any partition rel has non-inherited fkeys

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1656,6 +1656,16 @@ UndistributeTable(Oid relationId, bool cascadeViaForeignKeys)
 		ereport(NOTICE, (errmsg("undistributing the partitions of %s",
 								quote_qualified_identifier(schemaName, relationName))));
 		List *partitionList = PartitionList(relationId);
+
+		/*
+		 * This is a less common pattern where foreing key is directly from/to
+		 * the partition relation as we already handled inherited foreign keys
+		 * on partitions either by erroring out or cascading via foreign keys.
+		 * It seems an acceptable limitation for now to ask users to drop such
+		 * foreign keys manually.
+		 */
+		ErrorIfAnyPartitionRelationInvolvedInNonInheritedFKey(partitionList);
+
 		Oid partitionRelationId = InvalidOid;
 		foreach_oid(partitionRelationId, partitionList)
 		{

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -174,6 +174,7 @@ extern bool ConstraintWithIdIsOfType(Oid constraintId, char targetConstraintType
 extern bool TableHasExternalForeignKeys(Oid relationId);
 extern List * GetForeignKeyOids(Oid relationId, int flags);
 extern Oid GetReferencedTableId(Oid foreignKeyId);
+extern bool RelationInvolvedInAnyNonInheritedForeignKeys(Oid relationId);
 
 
 /* function.c - forward declarations */
@@ -407,6 +408,7 @@ typedef enum CascadeOperationType
 extern void CascadeOperationForConnectedRelations(Oid relationId, LOCKMODE relLockMode,
 												  CascadeOperationType
 												  cascadeOperationType);
+extern void ErrorIfAnyPartitionRelationInvolvedInNonInheritedFKey(List *relationIdList);
 extern void ExecuteAndLogDDLCommandList(List *ddlCommandList);
 extern void ExecuteAndLogDDLCommand(const char *commandString);
 

--- a/src/test/regress/expected/undistribute_table_cascade.out
+++ b/src/test/regress/expected/undistribute_table_cascade.out
@@ -285,6 +285,26 @@ SELECT create_reference_table('reference_table_3');
 
 ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES reference_table_3(col_2);
 ALTER TABLE partitioned_table_2 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES reference_table_3(col_2);
+-- as pg < 12 doesn't support foreign keys between partitioned tables,
+-- define below foreign key conditionally instead of adding another
+-- test output
+DO $proc$
+BEGIN
+IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+  EXECUTE
+  $$
+  ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_15 FOREIGN KEY (col_1) REFERENCES partitioned_table_1(col_1);
+  $$;
+END IF;
+END$proc$;
+BEGIN;
+  SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
 BEGIN;
   SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
  undistribute_table
@@ -308,6 +328,103 @@ BEGIN;
  fkey_9  | partitioned_table_1         | reference_table_3
 (6 rows)
 
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY(col_1) REFERENCES reference_table_3(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY(col_1) REFERENCES reference_table_3(col_1);
+  SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY(col_1) REFERENCES reference_table_3(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_2_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_2_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+CREATE TABLE distributed_table_4 (col_1 INT UNIQUE, col_2 INT);
+SELECT create_distributed_table('distributed_table_4', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE distributed_table_4 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_2_100_200(col_1);
+  SELECT undistribute_table('distributed_table_4', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_2_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE distributed_table_4 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE distributed_table_4 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES distributed_table_4(col_1);
+  SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES distributed_table_4(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES distributed_table_4(col_1);
+  SELECT undistribute_table('distributed_table_4', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_2 ADD CONSTRAINT fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_2_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_2_100_200(col_1);
+  SELECT undistribute_table('reference_table_3', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_2_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_2_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_2_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_2_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_2_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_2_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_2_100_200 involved in a foreign key relationship that is not inherited from it's parent table
 ROLLBACK;
 -- as pg < 12 doesn't support foreign keys between partitioned tables,
 -- define below foreign key conditionally instead of adding another

--- a/src/test/regress/expected/undistribute_table_cascade.out
+++ b/src/test/regress/expected/undistribute_table_cascade.out
@@ -276,6 +276,25 @@ SELECT create_distributed_table('partitioned_table_2', 'col_1');
 
 (1 row)
 
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
+CREATE TABLE distributed_table_4 (col_1 INT UNIQUE, col_2 INT);
+SELECT create_distributed_table('distributed_table_4', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE distributed_table_4 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', true);
+ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
+ROLLBACK;
 CREATE TABLE reference_table_3 (col_1 INT UNIQUE, col_2 INT UNIQUE);
 SELECT create_reference_table('reference_table_3');
  create_reference_table
@@ -359,13 +378,6 @@ BEGIN;
   SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
 ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_1_100_200 involved in a foreign key relationship that is not inherited from it's parent table
 ROLLBACK;
-CREATE TABLE distributed_table_4 (col_1 INT UNIQUE, col_2 INT);
-SELECT create_distributed_table('distributed_table_4', 'col_1');
- create_distributed_table
----------------------------------------------------------------------
-
-(1 row)
-
 BEGIN;
   set citus.multi_shard_modify_mode to 'sequential';
   ALTER TABLE distributed_table_4 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY (col_1) REFERENCES partitioned_table_2_100_200(col_1);

--- a/src/test/regress/sql/undistribute_table_cascade.sql
+++ b/src/test/regress/sql/undistribute_table_cascade.sql
@@ -154,6 +154,21 @@ CREATE TABLE partitioned_table_2_100_200 PARTITION OF partitioned_table_2 FOR VA
 CREATE TABLE partitioned_table_2_200_300 PARTITION OF partitioned_table_2 FOR VALUES FROM (200) TO (300);
 SELECT create_distributed_table('partitioned_table_2', 'col_1');
 
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', true);
+ROLLBACK;
+
+CREATE TABLE distributed_table_4 (col_1 INT UNIQUE, col_2 INT);
+SELECT create_distributed_table('distributed_table_4', 'col_1');
+
+BEGIN;
+  set citus.multi_shard_modify_mode to 'sequential';
+  ALTER TABLE distributed_table_4 ADD CONSTRAINT fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_1_100_200(col_1);
+  SELECT undistribute_table('partitioned_table_1', true);
+ROLLBACK;
+
 CREATE TABLE reference_table_3 (col_1 INT UNIQUE, col_2 INT UNIQUE);
 SELECT create_reference_table('reference_table_3');
 
@@ -217,9 +232,6 @@ BEGIN;
   ALTER TABLE partitioned_table_1_100_200 ADD CONSTRAINT non_inherited_fkey FOREIGN KEY(col_1) REFERENCES partitioned_table_2_100_200(col_1);
   SELECT undistribute_table('partitioned_table_2', cascade_via_foreign_keys=>true);
 ROLLBACK;
-
-CREATE TABLE distributed_table_4 (col_1 INT UNIQUE, col_2 INT);
-SELECT create_distributed_table('distributed_table_4', 'col_1');
 
 BEGIN;
   set citus.multi_shard_modify_mode to 'sequential';


### PR DESCRIPTION
Fixes the issue described in the first comment of https://github.com/citusdata/citus/issues/4481.