### PR TITLE
Enable reference/distributed table creation from citus local tables

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -29,6 +29,7 @@
 #include "fmgr.h"
 
 #include "access/hash.h"
+#include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/pg_am.h"
 #include "columnar/cstore.h"

--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -738,6 +738,9 @@ ConvertTable(TableConversionState *con)
 		}
 	}
 
+	/* increment command counter so that next command can see the new table */
+	CommandCounterIncrement();
+
 	return ret;
 }
 

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -77,7 +77,6 @@ static void ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
 										  int *referencedAttrIndex);
 static List * GetForeignKeyIdsForColumn(char *columnName, Oid relationId,
 										int searchForeignKeyColumnFlags);
-static List * GetForeignConstraintCommandsInternal(Oid relationId, int flags);
 static Oid get_relation_constraint_oid_compat(HeapTuple heapTuple);
 static bool IsTableTypeIncluded(Oid relationId, int flags);
 static void UpdateConstraintIsValid(Oid constraintId, bool isValid);
@@ -663,7 +662,7 @@ GetForeignConstraintFromDistributedTablesCommands(Oid relationId)
  * DDL commands to recreate the foreign key constraints returned by
  * GetForeignKeyOids. See more details at the underlying function.
  */
-static List *
+List *
 GetForeignConstraintCommandsInternal(Oid relationId, int flags)
 {
 	List *foreignKeyOids = GetForeignKeyOids(relationId, flags);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -166,6 +166,7 @@ extern List * GetReferencingForeignConstaintCommands(Oid relationOid);
 extern List * GetForeignConstraintToReferenceTablesCommands(Oid relationId);
 extern List * GetForeignConstraintToDistributedTablesCommands(Oid relationId);
 extern List * GetForeignConstraintFromDistributedTablesCommands(Oid relationId);
+extern List * GetForeignConstraintCommandsInternal(Oid relationId, int flags);
 extern bool HasForeignKeyToCitusLocalTable(Oid relationId);
 extern bool HasForeignKeyToReferenceTable(Oid relationOid);
 extern bool TableReferenced(Oid relationOid);
@@ -412,6 +413,7 @@ extern void CascadeOperationForConnectedRelations(Oid relationId, LOCKMODE relLo
 												  CascadeOperationType
 												  cascadeOperationType);
 extern void ErrorIfAnyPartitionRelationInvolvedInNonInheritedFKey(List *relationIdList);
+extern void DropRelationForeignKeys(Oid relationId, int flags);
 extern void ExecuteAndLogDDLCommandList(List *ddlCommandList);
 extern void ExecuteAndLogDDLCommand(const char *commandString);
 

--- a/src/test/regress/expected/create_ref_dist_from_citus_local.out
+++ b/src/test/regress/expected/create_ref_dist_from_citus_local.out
@@ -1,0 +1,369 @@
+\set VERBOSITY terse
+SET citus.next_shard_id TO 1800000;
+SET citus.shard_replication_factor TO 1;
+CREATE SCHEMA create_ref_dist_from_citus_local;
+SET search_path TO create_ref_dist_from_citus_local;
+SET client_min_messages to ERROR;
+-- ensure that coordinator is added to pg_dist_node
+SELECT 1 FROM master_add_node('localhost', :master_port, groupId => 0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+CREATE TABLE citus_local_table_1 (col_1 INT UNIQUE);
+CREATE TABLE citus_local_table_2 (col_1 INT UNIQUE);
+CREATE TABLE citus_local_table_3 (col_1 INT UNIQUE);
+CREATE TABLE citus_local_table_4 (col_1 INT UNIQUE);
+ALTER TABLE citus_local_table_2 ADD CONSTRAINT fkey_1 FOREIGN KEY (col_1) REFERENCES citus_local_table_1(col_1);
+ALTER TABLE citus_local_table_3 ADD CONSTRAINT fkey_2 FOREIGN KEY (col_1) REFERENCES citus_local_table_1(col_1);
+ALTER TABLE citus_local_table_1 ADD CONSTRAINT fkey_3 FOREIGN KEY (col_1) REFERENCES citus_local_table_3(col_1);
+ALTER TABLE citus_local_table_1 ADD CONSTRAINT fkey_4 FOREIGN KEY (col_1) REFERENCES citus_local_table_4(col_1);
+ALTER TABLE citus_local_table_4 ADD CONSTRAINT fkey_5 FOREIGN KEY (col_1) REFERENCES citus_local_table_3(col_1);
+ALTER TABLE citus_local_table_4 ADD CONSTRAINT fkey_6 FOREIGN KEY (col_1) REFERENCES citus_local_table_4(col_1);
+SELECT create_citus_local_table('citus_local_table_1', cascade_via_foreign_keys=>true);
+ create_citus_local_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE reference_table_1(col_1 INT UNIQUE, col_2 INT UNIQUE);
+CREATE TABLE reference_table_2(col_1 INT UNIQUE, col_2 INT UNIQUE);
+SELECT create_reference_table('reference_table_1');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_reference_table('reference_table_2');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE citus_local_table_4 ADD CONSTRAINT fkey_7 FOREIGN KEY (col_1) REFERENCES reference_table_1(col_1);
+ALTER TABLE reference_table_2 ADD CONSTRAINT fkey_8 FOREIGN KEY (col_1) REFERENCES citus_local_table_2(col_1);
+CREATE TABLE distributed_table_1(col_1 INT UNIQUE, col_2 INT);
+CREATE TABLE partitioned_dist_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+SELECT create_distributed_table('distributed_table_1', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('partitioned_dist_table_1', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE partitioned_dist_table_1 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES distributed_table_1(col_1);
+ALTER TABLE distributed_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES reference_table_2(col_2);
+ALTER TABLE partitioned_dist_table_1 ADD CONSTRAINT fkey_11 FOREIGN KEY (col_1) REFERENCES reference_table_1(col_2);
+-- As we will heavily rely on this feature after implementing automatic
+-- convertion of postgres tables to citus local tables, let's have a
+-- complex foreign key graph to see everything is fine.
+--
+--  distributed_table_1  <----------------    partitioned_dist_table_1
+--           |                                           |
+--           v                                           v
+--  reference_table_2                 _          reference_table_1
+--           |                       | |                 ^
+--           v                       | v                 |
+-- citus_local_table_2 -> citus_local_table_1 -> citus_local_table_4
+--                                   ^ |                 |
+--                                   | v                 |
+--                           citus_local_table_3 <--------
+-- Now print metadata after each of create_reference/distributed_table
+-- operations to show that everything is fine. Also show that we
+-- preserve foreign keys.
+BEGIN;
+  SELECT create_reference_table('citus_local_table_1');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+        tablename         | partmethod | repmodel
+---------------------------------------------------------------------
+ citus_local_table_1      | n          | t
+ citus_local_table_2      | n          | c
+ citus_local_table_3      | n          | c
+ citus_local_table_4      | n          | c
+ distributed_table_1      | h          | c
+ partitioned_dist_table_1 | h          | c
+ reference_table_1        | n          | t
+ reference_table_2        | n          | t
+(8 rows)
+
+  SELECT COUNT(*)=11 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  SELECT create_reference_table('citus_local_table_2');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+        tablename         | partmethod | repmodel
+---------------------------------------------------------------------
+ citus_local_table_1      | n          | c
+ citus_local_table_2      | n          | t
+ citus_local_table_3      | n          | c
+ citus_local_table_4      | n          | c
+ distributed_table_1      | h          | c
+ partitioned_dist_table_1 | h          | c
+ reference_table_1        | n          | t
+ reference_table_2        | n          | t
+(8 rows)
+
+  SELECT COUNT(*)=11 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- those two errors out as they reference to citus local tables but
+-- distributed tables cannot reference to postgres or citus local tables
+SELECT create_distributed_table('citus_local_table_1', 'col_1');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+SELECT create_distributed_table('citus_local_table_4', 'col_1');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+BEGIN;
+  SELECT create_reference_table('citus_local_table_2');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  -- this would error out
+  SELECT create_reference_table('citus_local_table_2');
+ERROR:  table "citus_local_table_2" is already distributed
+ROLLBACK;
+-- test with a standalone table
+CREATE TABLE citus_local_table_5 (col_1 INT UNIQUE);
+SELECT create_citus_local_table('citus_local_table_5');
+ create_citus_local_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  -- this would error out
+  SELECT create_reference_table('citus_local_table_5');
+ERROR:  table "citus_local_table_5" is already distributed
+ROLLBACK;
+BEGIN;
+  SELECT create_reference_table('citus_local_table_5');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_5(col_1);
+  SELECT create_reference_table('citus_local_table_5');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+        tablename         | partmethod | repmodel
+---------------------------------------------------------------------
+ citus_local_table_1      | n          | c
+ citus_local_table_2      | n          | c
+ citus_local_table_3      | n          | c
+ citus_local_table_4      | n          | c
+ citus_local_table_5      | h          | c
+ distributed_table_1      | h          | c
+ partitioned_dist_table_1 | h          | c
+ reference_table_1        | n          | t
+ reference_table_2        | n          | t
+(9 rows)
+
+  SELECT COUNT(*)=11 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_5(col_1);
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+        tablename         | partmethod | repmodel
+---------------------------------------------------------------------
+ citus_local_table_1      | n          | c
+ citus_local_table_2      | n          | c
+ citus_local_table_3      | n          | c
+ citus_local_table_4      | n          | c
+ citus_local_table_5      | h          | c
+ distributed_table_1      | h          | c
+ partitioned_dist_table_1 | h          | c
+ reference_table_1        | n          | t
+ reference_table_2        | n          | t
+(9 rows)
+
+  SELECT COUNT(*)=12 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  -- define a self reference and a foreign key to reference table
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_5(col_1);
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_13 FOREIGN KEY (col_1) REFERENCES reference_table_1(col_1);
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+        tablename         | partmethod | repmodel
+---------------------------------------------------------------------
+ citus_local_table_1      | n          | c
+ citus_local_table_2      | n          | c
+ citus_local_table_3      | n          | c
+ citus_local_table_4      | n          | c
+ citus_local_table_5      | h          | c
+ distributed_table_1      | h          | c
+ partitioned_dist_table_1 | h          | c
+ reference_table_1        | n          | t
+ reference_table_2        | n          | t
+(9 rows)
+
+  SELECT COUNT(*)=13 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+CREATE TABLE citus_local_table_6 (col_1 INT UNIQUE);
+SELECT create_citus_local_table('citus_local_table_6');
+ create_citus_local_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  -- errors out as foreign keys from distributed tables to citus
+  -- local tables are not supported
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+ROLLBACK;
+BEGIN;
+  -- errors out as foreign keys from citus local tables to distributed
+  -- tables are not supported
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  SELECT create_distributed_table('citus_local_table_6', 'col_1');
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and citus local tables to distributed tables are not supported
+ROLLBACK;
+-- have some more tests with foreign keys between citus local
+-- and reference tables
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  SELECT create_reference_table('citus_local_table_5');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  SELECT create_reference_table('citus_local_table_6');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  CREATE FUNCTION update_value() RETURNS trigger AS $update_value$
+  BEGIN
+      NEW.value := value+1 ;
+      RETURN NEW;
+  END;
+  $update_value$ LANGUAGE plpgsql;
+  CREATE TRIGGER update_value_dist
+  AFTER INSERT ON citus_local_table_6
+  FOR EACH ROW EXECUTE FUNCTION update_value();
+  -- show that we error out as we don't supprt triggers on distributed tables
+  SELECT create_distributed_table('citus_local_table_6', 'col_1');
+ERROR:  cannot distribute relation "citus_local_table_6" because it has triggers
+ROLLBACK;
+-- make sure that creating append / range distributed tables is also ok
+BEGIN;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  ALTER TABLE citus_local_table_5 DROP CONSTRAINT citus_local_table_5_col_1_key;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+-- cleanup at exit
+DROP SCHEMA create_ref_dist_from_citus_local CASCADE;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -324,7 +324,7 @@ test: replicate_reference_tables_to_coordinator
 test: coordinator_shouldhaveshards
 test: local_shard_utility_command_execution
 test: citus_local_tables
-test: multi_row_router_insert mixed_relkind_tests
+test: multi_row_router_insert mixed_relkind_tests create_ref_dist_from_citus_local
 test: undistribute_table_cascade
 test: create_citus_local_table_cascade
 

--- a/src/test/regress/sql/create_ref_dist_from_citus_local.sql
+++ b/src/test/regress/sql/create_ref_dist_from_citus_local.sql
@@ -1,0 +1,217 @@
+\set VERBOSITY terse
+
+SET citus.next_shard_id TO 1800000;
+SET citus.shard_replication_factor TO 1;
+
+CREATE SCHEMA create_ref_dist_from_citus_local;
+SET search_path TO create_ref_dist_from_citus_local;
+
+SET client_min_messages to ERROR;
+
+-- ensure that coordinator is added to pg_dist_node
+SELECT 1 FROM master_add_node('localhost', :master_port, groupId => 0);
+
+CREATE TABLE citus_local_table_1 (col_1 INT UNIQUE);
+CREATE TABLE citus_local_table_2 (col_1 INT UNIQUE);
+CREATE TABLE citus_local_table_3 (col_1 INT UNIQUE);
+CREATE TABLE citus_local_table_4 (col_1 INT UNIQUE);
+ALTER TABLE citus_local_table_2 ADD CONSTRAINT fkey_1 FOREIGN KEY (col_1) REFERENCES citus_local_table_1(col_1);
+ALTER TABLE citus_local_table_3 ADD CONSTRAINT fkey_2 FOREIGN KEY (col_1) REFERENCES citus_local_table_1(col_1);
+ALTER TABLE citus_local_table_1 ADD CONSTRAINT fkey_3 FOREIGN KEY (col_1) REFERENCES citus_local_table_3(col_1);
+ALTER TABLE citus_local_table_1 ADD CONSTRAINT fkey_4 FOREIGN KEY (col_1) REFERENCES citus_local_table_4(col_1);
+ALTER TABLE citus_local_table_4 ADD CONSTRAINT fkey_5 FOREIGN KEY (col_1) REFERENCES citus_local_table_3(col_1);
+ALTER TABLE citus_local_table_4 ADD CONSTRAINT fkey_6 FOREIGN KEY (col_1) REFERENCES citus_local_table_4(col_1);
+
+SELECT create_citus_local_table('citus_local_table_1', cascade_via_foreign_keys=>true);
+
+CREATE TABLE reference_table_1(col_1 INT UNIQUE, col_2 INT UNIQUE);
+CREATE TABLE reference_table_2(col_1 INT UNIQUE, col_2 INT UNIQUE);
+
+SELECT create_reference_table('reference_table_1');
+SELECT create_reference_table('reference_table_2');
+
+ALTER TABLE citus_local_table_4 ADD CONSTRAINT fkey_7 FOREIGN KEY (col_1) REFERENCES reference_table_1(col_1);
+ALTER TABLE reference_table_2 ADD CONSTRAINT fkey_8 FOREIGN KEY (col_1) REFERENCES citus_local_table_2(col_1);
+
+CREATE TABLE distributed_table_1(col_1 INT UNIQUE, col_2 INT);
+CREATE TABLE partitioned_dist_table_1 (col_1 INT UNIQUE, col_2 INT) PARTITION BY RANGE (col_1);
+
+SELECT create_distributed_table('distributed_table_1', 'col_1');
+SELECT create_distributed_table('partitioned_dist_table_1', 'col_1');
+
+ALTER TABLE partitioned_dist_table_1 ADD CONSTRAINT fkey_9 FOREIGN KEY (col_1) REFERENCES distributed_table_1(col_1);
+ALTER TABLE distributed_table_1 ADD CONSTRAINT fkey_10 FOREIGN KEY (col_1) REFERENCES reference_table_2(col_2);
+ALTER TABLE partitioned_dist_table_1 ADD CONSTRAINT fkey_11 FOREIGN KEY (col_1) REFERENCES reference_table_1(col_2);
+
+-- As we will heavily rely on this feature after implementing automatic
+-- convertion of postgres tables to citus local tables, let's have a
+-- complex foreign key graph to see everything is fine.
+--
+--  distributed_table_1  <----------------    partitioned_dist_table_1
+--           |                                           |
+--           v                                           v
+--  reference_table_2                 _          reference_table_1
+--           |                       | |                 ^
+--           v                       | v                 |
+-- citus_local_table_2 -> citus_local_table_1 -> citus_local_table_4
+--                                   ^ |                 |
+--                                   | v                 |
+--                           citus_local_table_3 <--------
+
+-- Now print metadata after each of create_reference/distributed_table
+-- operations to show that everything is fine. Also show that we
+-- preserve foreign keys.
+
+BEGIN;
+  SELECT create_reference_table('citus_local_table_1');
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+
+  SELECT COUNT(*)=11 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ROLLBACK;
+
+BEGIN;
+  SELECT create_reference_table('citus_local_table_2');
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+
+  SELECT COUNT(*)=11 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ROLLBACK;
+
+-- those two errors out as they reference to citus local tables but
+-- distributed tables cannot reference to postgres or citus local tables
+SELECT create_distributed_table('citus_local_table_1', 'col_1');
+SELECT create_distributed_table('citus_local_table_4', 'col_1');
+
+BEGIN;
+  SELECT create_reference_table('citus_local_table_2');
+  -- this would error out
+  SELECT create_reference_table('citus_local_table_2');
+ROLLBACK;
+
+-- test with a standalone table
+CREATE TABLE citus_local_table_5 (col_1 INT UNIQUE);
+SELECT create_citus_local_table('citus_local_table_5');
+
+BEGIN;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+  -- this would error out
+  SELECT create_reference_table('citus_local_table_5');
+ROLLBACK;
+
+BEGIN;
+  SELECT create_reference_table('citus_local_table_5');
+ROLLBACK;
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_5(col_1);
+  SELECT create_reference_table('citus_local_table_5');
+ROLLBACK;
+
+BEGIN;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+
+  SELECT COUNT(*)=11 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ROLLBACK;
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_5(col_1);
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+
+  SELECT COUNT(*)=12 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ROLLBACK;
+
+BEGIN;
+  -- define a self reference and a foreign key to reference table
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_5(col_1);
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_13 FOREIGN KEY (col_1) REFERENCES reference_table_1(col_1);
+
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+
+  SELECT logicalrelid::text AS tablename, partmethod, repmodel FROM pg_dist_partition
+  WHERE logicalrelid::text IN (SELECT tablename FROM pg_tables WHERE schemaname='create_ref_dist_from_citus_local')
+  ORDER BY tablename;
+
+  SELECT COUNT(*)=13 FROM pg_constraint
+  WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname='create_ref_dist_from_citus_local') AND
+        conname ~ '^fkey\_\d+$';
+ROLLBACK;
+
+CREATE TABLE citus_local_table_6 (col_1 INT UNIQUE);
+SELECT create_citus_local_table('citus_local_table_6');
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  -- errors out as foreign keys from distributed tables to citus
+  -- local tables are not supported
+  SELECT create_distributed_table('citus_local_table_5', 'col_1');
+ROLLBACK;
+
+BEGIN;
+  -- errors out as foreign keys from citus local tables to distributed
+  -- tables are not supported
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  SELECT create_distributed_table('citus_local_table_6', 'col_1');
+ROLLBACK;
+
+-- have some more tests with foreign keys between citus local
+-- and reference tables
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  SELECT create_reference_table('citus_local_table_5');
+ROLLBACK;
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 ADD CONSTRAINT fkey_12 FOREIGN KEY (col_1) REFERENCES citus_local_table_6(col_1);
+  SELECT create_reference_table('citus_local_table_6');
+ROLLBACK;
+
+BEGIN;
+  CREATE FUNCTION update_value() RETURNS trigger AS $update_value$
+  BEGIN
+      NEW.value := value+1 ;
+      RETURN NEW;
+  END;
+  $update_value$ LANGUAGE plpgsql;
+
+  CREATE TRIGGER update_value_dist
+  AFTER INSERT ON citus_local_table_6
+  FOR EACH ROW EXECUTE PROCEDURE update_value();
+
+  -- show that we error out as we don't supprt triggers on distributed tables
+  SELECT create_distributed_table('citus_local_table_6', 'col_1');
+ROLLBACK;
+
+-- make sure that creating append / range distributed tables is also ok
+BEGIN;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1', 'range');
+ROLLBACK;
+
+BEGIN;
+  ALTER TABLE citus_local_table_5 DROP CONSTRAINT citus_local_table_5_col_1_key;
+  SELECT create_distributed_table('citus_local_table_5', 'col_1', 'append');
+ROLLBACK;
+
+-- cleanup at exit
+DROP SCHEMA create_ref_dist_from_citus_local CASCADE;


### PR DESCRIPTION
As part of #4415, we need to enable `create_reference_table`/`create_distributed_table` calls made for citus local tables to improve user experience.
