### PR TITLE
Fix error thrown for foreign keys from citus local to dist tables

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -216,10 +216,11 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot create foreign key constraint "
 								   "since foreign keys from reference tables "
-								   "to distributed tables are not supported"),
-							errdetail("A reference table can only have foreign "
-									  "keys to other reference tables or citus "
-									  "local tables")));
+								   "and citus local tables to distributed tables "
+								   "are not supported"),
+							errdetail("Reference tables and citus local tables "
+									  "can only have foreign keys to reference "
+									  "tables and citus local tables")));
 		}
 
 		/*

--- a/src/test/regress/expected/citus_local_tables.out
+++ b/src/test/regress/expected/citus_local_tables.out
@@ -417,7 +417,7 @@ SET search_path TO citus_local_tables_test_schema;
 -- more tests at ref_citus_local_fkeys.sql
 -- between citus local tables and distributed tables
 ALTER TABLE citus_local_table_1 ADD CONSTRAINT fkey_c_to_dist FOREIGN KEY(a) references distributed_table(a);
-ERROR:  cannot create foreign key constraint since foreign keys from reference tables to distributed tables are not supported
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and citus local tables to distributed tables are not supported
 ALTER TABLE distributed_table ADD CONSTRAINT fkey_dist_to_c FOREIGN KEY(a) references citus_local_table_1(a);
 ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
 -- between citus local tables and local tables

--- a/src/test/regress/expected/multi_foreign_key.out
+++ b/src/test/regress/expected/multi_foreign_key.out
@@ -835,8 +835,8 @@ SELECT create_distributed_table('referenced_by_reference_table', 'id');
 
 CREATE TABLE reference_table(id int, referencing_column int REFERENCES referenced_by_reference_table(id));
 SELECT create_reference_table('reference_table');
-ERROR:  cannot create foreign key constraint since foreign keys from reference tables to distributed tables are not supported
-DETAIL:  A reference table can only have foreign keys to other reference tables or citus local tables
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and citus local tables to distributed tables are not supported
+DETAIL:  Reference tables and citus local tables can only have foreign keys to reference tables and citus local tables
 -- test foreign key creation on CREATE TABLE from + to reference table
 DROP TABLE reference_table;
 CREATE TABLE reference_table(id int PRIMARY KEY, referencing_column int);
@@ -886,8 +886,8 @@ SELECT create_reference_table('reference_table');
 (1 row)
 
 ALTER TABLE reference_table ADD CONSTRAINT fk FOREIGN KEY(referencing_column) REFERENCES referenced_by_reference_table(id);
-ERROR:  cannot create foreign key constraint since foreign keys from reference tables to distributed tables are not supported
-DETAIL:  A reference table can only have foreign keys to other reference tables or citus local tables
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and citus local tables to distributed tables are not supported
+DETAIL:  Reference tables and citus local tables can only have foreign keys to reference tables and citus local tables
 -- test foreign key creation on ALTER TABLE to reference table
 CREATE TABLE references_to_reference_table(id int, referencing_column int);
 SELECT create_distributed_table('references_to_reference_table', 'referencing_column');


### PR DESCRIPTION
Error message was wrong as left table can actually be a citus local table.
Also remove `other` word, as we can have self-referencing foreign key too.
