### PR TITLE
Stronger check for triggers on columnar tables (#4493).

### DIFF
--- a/src/include/columnar/cstore_version_compat.h
+++ b/src/include/columnar/cstore_version_compat.h
@@ -32,20 +32,6 @@
 	ExplainPropertyInteger(qlabel, NULL, value, es)
 #endif
 
-#if PG_VERSION_NUM >= 130000
-#define CALL_PREVIOUS_UTILITY() \
-	PreviousProcessUtilityHook(plannedStatement, queryString, context, paramListInfo, \
-							   queryEnvironment, destReceiver, queryCompletion)
-#elif PG_VERSION_NUM >= 100000
-#define CALL_PREVIOUS_UTILITY() \
-	PreviousProcessUtilityHook(plannedStatement, queryString, context, paramListInfo, \
-							   queryEnvironment, destReceiver, completionTag)
-#else
-#define CALL_PREVIOUS_UTILITY() \
-	PreviousProcessUtilityHook(parseTree, queryString, context, paramListInfo, \
-							   destReceiver, completionTag)
-#endif
-
 #if PG_VERSION_NUM < 120000
 #define TTS_EMPTY(slot) ((slot)->tts_isempty)
 #define ExecForceStoreHeapTuple(tuple, slot, shouldFree) \

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -324,66 +324,19 @@ SELECT c.relname, a.amname FROM pg_class c, pg_am a where c.relname SIMILAR TO '
 (4 rows)
 
 -- test when the parent of a partition has foreign key to a reference table
-CREATE TABLE ref_table (a INT UNIQUE);
-SELECT create_reference_table('ref_table');
- create_reference_table
----------------------------------------------------------------------
-
-(1 row)
-
-INSERT INTO ref_table VALUES (2), (12);
-ALTER TABLE partitioned_table ADD CONSTRAINT fkey_to_ref FOREIGN KEY (a) REFERENCES ref_table(a);
-SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'partitioned_table'::regclass ORDER BY 1;
-        inhrelid
----------------------------------------------------------------------
- partitioned_table_1_5
- partitioned_table_6_10
-(2 rows)
-
-SELECT "Name", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'partitioned_table_6_10';
-          Name          | Access Method
----------------------------------------------------------------------
- partitioned_table_6_10 | heap
-(1 row)
-
-SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
-    WHERE (conrelid::regclass::text = 'partitioned_table_6_10') ORDER BY 1, 2;
-   Referencing Table    |               Definition
----------------------------------------------------------------------
- partitioned_table_6_10 | FOREIGN KEY (a) REFERENCES ref_table(a)
-(1 row)
-
-SELECT alter_table_set_access_method('partitioned_table_6_10', 'columnar');
+create table test_pk(n int primary key);
+create table test_fk_p(i int references test_pk(n)) partition by range(i);
+create table test_fk_p0 partition of test_fk_p for values from (0) to (10);
+create table test_fk_p1 partition of test_fk_p for values from (10) to (20);
+select alter_table_set_access_method('test_fk_p1', 'columnar');
 NOTICE:  any index will be dropped, because columnar tables cannot have indexes
-NOTICE:  creating a new table for alter_table_set_access_method.partitioned_table_6_10
-NOTICE:  Moving the data of alter_table_set_access_method.partitioned_table_6_10
-NOTICE:  Dropping the old alter_table_set_access_method.partitioned_table_6_10
-NOTICE:  Renaming the new table to alter_table_set_access_method.partitioned_table_6_10
- alter_table_set_access_method
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'partitioned_table'::regclass ORDER BY 1;
-        inhrelid
----------------------------------------------------------------------
- partitioned_table_1_5
- partitioned_table_6_10
-(2 rows)
-
-SELECT "Name", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'partitioned_table_6_10';
-          Name          | Access Method
----------------------------------------------------------------------
- partitioned_table_6_10 | columnar
-(1 row)
-
-SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
-    WHERE (conrelid::regclass::text = 'partitioned_table_6_10') ORDER BY 1, 2;
-   Referencing Table    |               Definition
----------------------------------------------------------------------
- partitioned_table_6_10 | FOREIGN KEY (a) REFERENCES ref_table(a)
-(1 row)
-
+NOTICE:  creating a new table for alter_table_set_access_method.test_fk_p1
+NOTICE:  Moving the data of alter_table_set_access_method.test_fk_p1
+NOTICE:  Dropping the old alter_table_set_access_method.test_fk_p1
+NOTICE:  Renaming the new table to alter_table_set_access_method.test_fk_p1
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
+HINT:  Consider an AFTER STATEMENT trigger instead.
+CONTEXT:  SQL statement "ALTER TABLE alter_table_set_access_method.test_fk_p ATTACH PARTITION alter_table_set_access_method.test_fk_p1 FOR VALUES FROM (10) TO (20);"
 SET client_min_messages TO WARNING;
 DROP SCHEMA alter_table_set_access_method CASCADE;
 SELECT 1 FROM master_remove_node('localhost', :master_port);

--- a/src/test/regress/expected/am_trigger.out
+++ b/src/test/regress/expected/am_trigger.out
@@ -46,7 +46,7 @@ create trigger tr_before_row before insert on test_tr
 -- after triggers require TIDs, which are not supported yet
 create trigger tr_after_row after insert on test_tr
   for each row execute procedure trr_after();
-ERROR:  AFTER ROW triggers are not supported for columnstore access method
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
 HINT:  Consider an AFTER STATEMENT trigger instead.
 insert into test_tr values(1);
 NOTICE:  BEFORE STATEMENT INSERT
@@ -84,6 +84,46 @@ SELECT * FROM test_tr ORDER BY i;
 (4 rows)
 
 drop table test_tr;
+--
+-- test implicit triggers created by foreign keys or partitions of a
+-- table with a trigger
+--
+create table test_tr_referenced(i int primary key);
+-- should fail when creating FK trigger
+create table test_tr_referencing(j int references test_tr_referenced(i)) using columnar;
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
+HINT:  Consider an AFTER STATEMENT trigger instead.
+drop table test_tr_referenced;
+create table test_tr_p(i int) partition by range(i);
+create trigger test_tr_p_tr after update on test_tr_p
+  for each row execute procedure trr_after();
+create table test_tr_p0 partition of test_tr_p
+  for values from (0) to (10);
+-- create columnar partition should fail
+create table test_tr_p1 partition of test_tr_p
+  for values from (10) to (20) using columnar;
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
+HINT:  Consider an AFTER STATEMENT trigger instead.
+create table test_tr_p2(i int) using columnar;
+-- attach columnar partition should fail
+alter table test_tr_p attach partition test_tr_p2 for values from (20) to (30);
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
+HINT:  Consider an AFTER STATEMENT trigger instead.
+drop table test_tr_p;
+create table test_pk(n int primary key);
+create table test_fk_p(i int references test_pk(n)) partition by range(i);
+create table test_fk_p0 partition of test_fk_p for values from (0) to (10);
+-- create columnar partition should fail
+create table test_fk_p1 partition of test_fk_p for values from (10) to (20) using columnar;
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
+HINT:  Consider an AFTER STATEMENT trigger instead.
+create table test_fk_p2(i int) using columnar;
+-- attach columnar partition should fail
+alter table test_fk_p attach partition test_fk_p2 for values from (20) to (30);
+ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
+HINT:  Consider an AFTER STATEMENT trigger instead.
+drop table test_fk_p;
+drop table test_pk;
 create table test_tr(i int) using columnar;
 -- we should be able to clean-up and continue gracefully if we
 -- error out in AFTER STATEMENT triggers.


### PR DESCRIPTION
Previously, we used a simple ProcessUtility_hook. Change to use an
object_access_hook instead.
