### PR TITLE
Moves Creation of ALTER INDEX STATISTICS Commands Next to Index Commands

### DIFF
--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -736,6 +736,10 @@ GatherIndexAndConstraintDefinitionList(Form_pg_index indexForm, List **indexDDLE
 		*indexDDLEventList = lappend(*indexDDLEventList, makeTableDDLCommandString(
 										 clusteredDef));
 	}
+
+	/* we need alter index commands for altered targets on expression indexes */
+	List *alterIndexStatisticsCommands = GetAlterIndexStatisticsCommands(indexId);
+	*indexDDLEventList = list_concat(*indexDDLEventList, alterIndexStatisticsCommands);
 }
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -348,6 +348,7 @@ extern List * PreprocessAlterStatisticsOwnerStmt(Node *node, const char *querySt
 												 processUtilityContext);
 extern List * GetExplicitStatisticsCommandList(Oid relationId);
 extern List * GetExplicitStatisticsSchemaIdList(Oid relationId);
+extern List * GetAlterIndexStatisticsCommands(Oid indexOid);
 
 /* subscription.c - forward declarations */
 extern Node * ProcessCreateSubscriptionStmt(CreateSubscriptionStmt *createSubStmt);

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -294,11 +294,15 @@ DROP TABLE time_partitioned;
 -- the index will be dropped
 CREATE TABLE index_table (a INT) ;
 CREATE INDEX idx1 ON index_table (a);
+-- also create an index with statistics
+CREATE INDEX idx2 ON index_table ((a+1));
+ALTER INDEX idx2 ALTER COLUMN 1 SET STATISTICS 300;
 SELECT indexname FROM pg_indexes WHERE schemaname = 'alter_table_set_access_method' AND tablename = 'index_table';
  indexname
 ---------------------------------------------------------------------
  idx1
-(1 row)
+ idx2
+(2 rows)
 
 SELECT a.amname FROM pg_class c, pg_am a where c.relname = 'index_table' AND c.relnamespace = 'alter_table_set_access_method'::regnamespace AND c.relam = a.oid;
  amname

--- a/src/test/regress/sql/alter_table_set_access_method.sql
+++ b/src/test/regress/sql/alter_table_set_access_method.sql
@@ -99,6 +99,9 @@ DROP TABLE time_partitioned;
 -- the index will be dropped
 CREATE TABLE index_table (a INT) USING heap;
 CREATE INDEX idx1 ON index_table (a);
+-- also create an index with statistics
+CREATE INDEX idx2 ON index_table ((a+1));
+ALTER INDEX idx2 ALTER COLUMN 1 SET STATISTICS 300;
 SELECT indexname FROM pg_indexes WHERE schemaname = 'alter_table_set_access_method' AND tablename = 'index_table';
 SELECT a.amname FROM pg_class c, pg_am a where c.relname = 'index_table' AND c.relnamespace = 'alter_table_set_access_method'::regnamespace AND c.relam = a.oid;
 SELECT alter_table_set_access_method('index_table', 'columnar');


### PR DESCRIPTION
Fixes #4519

Moves the call of  `GetAlterIndexStatisticsCommands` from `GetExplicitStatisticsCommandList` to `GatherIndexAndConstraintDefinitionList`