### PR TITLE
Fix segfault when adding/dropping fkey from ref to citus local via remote exec

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -2049,8 +2049,9 @@ SetInterShardDDLTaskPlacementList(Task *task, ShardInterval *leftShardInterval,
 		 * to a citus local table, then we will execute ADD/DROP constraint
 		 * command only for coordinator placement of reference table.
 		 */
-		task->taskPlacementList = GroupShardPlacementsForTableOnGroup(leftRelationId,
-																	  COORDINATOR_GROUP_ID);
+		uint64 leftShardId = leftShardInterval->shardId;
+		task->taskPlacementList = ActiveShardPlacementListOnGroup(leftShardId,
+																  COORDINATOR_GROUP_ID);
 	}
 	else
 	{

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -964,6 +964,30 @@ NodeGroupHasShardPlacements(int32 groupId, bool onlyConsiderActivePlacements)
 
 
 /*
+ * ActiveShardPlacementListOnGroup returns a list of active shard placements
+ * that are sitting on group with groupId for given shardId.
+ */
+List *
+ActiveShardPlacementListOnGroup(uint64 shardId, int32 groupId)
+{
+	List *activeShardPlacementListOnGroup = NIL;
+
+	List *activePlacementList = ActiveShardPlacementList(shardId);
+	ShardPlacement *shardPlacement = NULL;
+	foreach_ptr(shardPlacement, activePlacementList)
+	{
+		if (shardPlacement->groupId == groupId)
+		{
+			activeShardPlacementListOnGroup = lappend(activeShardPlacementListOnGroup,
+													  shardPlacement);
+		}
+	}
+
+	return activeShardPlacementListOnGroup;
+}
+
+
+/*
  * ActiveShardPlacementList finds shard placements for the given shardId from
  * system catalogs, chooses placements that are in active state, and returns
  * these shard placements in a new list.

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -188,6 +188,7 @@ extern ShardInterval * CopyShardInterval(ShardInterval *srcInterval);
 extern uint64 ShardLength(uint64 shardId);
 extern bool NodeGroupHasShardPlacements(int32 groupId,
 										bool onlyConsiderActivePlacements);
+extern List * ActiveShardPlacementListOnGroup(uint64 shardId, int32 groupId);
 extern List * ActiveShardPlacementList(uint64 shardId);
 extern ShardPlacement * ActiveShardPlacement(uint64 shardId, bool missingOk);
 extern List * BuildShardPlacementList(ShardInterval *shardInterval);

--- a/src/test/regress/expected/ref_citus_local_fkeys.out
+++ b/src/test/regress/expected/ref_citus_local_fkeys.out
@@ -169,6 +169,12 @@ ROLLBACK;
 -- .. and we allow such foreign keys with NO ACTION behavior
 ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES citus_local_table(l1) ON DELETE NO ACTION;
 NOTICE:  executing the command locally: SELECT worker_apply_inter_shard_ddl_command (1506003, 'ref_citus_local_fkeys', 1506002, 'ref_citus_local_fkeys', 'ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES citus_local_table(l1) ON DELETE NO ACTION;')
+-- show that adding/dropping foreign keys from reference to citus local
+-- tables works fine with remote execution too
+SET citus.enable_local_execution TO OFF;
+ALTER TABLE reference_table DROP CONSTRAINT fkey_ref_to_local;
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES citus_local_table(l1) ON DELETE NO ACTION;
+SET citus.enable_local_execution TO ON;
 -- show that we are checking for foreign key constraint after defining, this should fail
 INSERT INTO reference_table VALUES (4);
 NOTICE:  executing the command locally: INSERT INTO ref_citus_local_fkeys.reference_table_1506003 (r1) VALUES (4)

--- a/src/test/regress/sql/ref_citus_local_fkeys.sql
+++ b/src/test/regress/sql/ref_citus_local_fkeys.sql
@@ -113,6 +113,13 @@ ROLLBACK;
 -- .. and we allow such foreign keys with NO ACTION behavior
 ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES citus_local_table(l1) ON DELETE NO ACTION;
 
+-- show that adding/dropping foreign keys from reference to citus local
+-- tables works fine with remote execution too
+SET citus.enable_local_execution TO OFF;
+ALTER TABLE reference_table DROP CONSTRAINT fkey_ref_to_local;
+ALTER TABLE reference_table ADD CONSTRAINT fkey_ref_to_local FOREIGN KEY(r1) REFERENCES citus_local_table(l1) ON DELETE NO ACTION;
+SET citus.enable_local_execution TO ON;
+
 -- show that we are checking for foreign key constraint after defining, this should fail
 INSERT INTO reference_table VALUES (4);
 


### PR DESCRIPTION
DESCRIPTION: Fixes a crash when adding/dropping foreign key from reference to citus local table via remote execution

Fixes #4527 
