### PR TITLE
Prevent citus local table creation via remote execution

### DIFF
--- a/src/backend/distributed/commands/create_citus_local_table.c
+++ b/src/backend/distributed/commands/create_citus_local_table.c
@@ -25,6 +25,7 @@
 #include "distributed/commands/sequence.h"
 #include "distributed/commands/utility_hook.h"
 #include "distributed/listutils.h"
+#include "distributed/local_executor.h"
 #include "distributed/metadata_sync.h"
 #include "distributed/multi_partitioning_utils.h"
 #include "distributed/namespace_utils.h"
@@ -112,6 +113,14 @@ CreateCitusLocalTable(Oid relationId, bool cascadeViaForeignKeys)
 
 	/* enable create_citus_local_table on an empty node */
 	InsertCoordinatorIfClusterEmpty();
+
+	/*
+	 * Creating Citus local tables relies on functions that accesses
+	 * shards locally (e.g., ExecuteAndLogDDLCommand()). As long as
+	 * we don't teach those functions to access shards remotely, we
+	 * cannot relax this check.
+	 */
+	SetLocalExecutionStatus(LOCAL_EXECUTION_REQUIRED);
 
 	/*
 	 * Lock target relation with an AccessExclusiveLock as we don't want

--- a/src/test/regress/expected/ref_citus_local_fkeys.out
+++ b/src/test/regress/expected/ref_citus_local_fkeys.out
@@ -221,6 +221,19 @@ BEGIN;
   ALTER TABLE citus_local_table_1 ADD CONSTRAINT multi_fkey FOREIGN KEY (a, b) REFERENCES citus_local_table_2(a, b);
 NOTICE:  executing the command locally: SELECT worker_apply_inter_shard_ddl_command (1506004, 'ref_citus_local_fkeys', 1506005, 'ref_citus_local_fkeys', 'ALTER TABLE citus_local_table_1 ADD CONSTRAINT multi_fkey FOREIGN KEY (a, b) REFERENCES citus_local_table_2(a, b);')
 COMMIT;
+-- when local execution is disabled, citus local table cannot be created
+BEGIN;
+	SET citus.enable_local_execution TO false;
+	CREATE TABLE referenced_table(id int primary key);
+	SELECT create_reference_table('referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+	CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE SET DEFAULT);
+ERROR:  cannot switch local execution status from local execution disabled to local execution enabled since it can cause visibility problems in the current transaction
+ROLLBACK;
 -- cleanup at exit
 DROP SCHEMA ref_citus_local_fkeys CASCADE;
 NOTICE:  drop cascades to 6 other objects

--- a/src/test/regress/sql/ref_citus_local_fkeys.sql
+++ b/src/test/regress/sql/ref_citus_local_fkeys.sql
@@ -148,5 +148,13 @@ BEGIN;
   ALTER TABLE citus_local_table_1 ADD CONSTRAINT multi_fkey FOREIGN KEY (a, b) REFERENCES citus_local_table_2(a, b);
 COMMIT;
 
+-- when local execution is disabled, citus local table cannot be created
+BEGIN;
+	SET citus.enable_local_execution TO false;
+	CREATE TABLE referenced_table(id int primary key);
+	SELECT create_reference_table('referenced_table');
+	CREATE TABLE referencing_table(id int, ref_id int, FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE SET DEFAULT);
+ROLLBACK;
+
 -- cleanup at exit
 DROP SCHEMA ref_citus_local_fkeys CASCADE;


### PR DESCRIPTION
/*
 * Creating Citus local tables relies on functions that accesses
 * shards locally (e.g., ExecuteAndLogDDLCommand()). As long as
 * we don't teach those functions to access shards remotely, we
 * cannot relax this check.
*/

Fixes #4535