### PR TITLE
More meaningful columnar metadata table names

### DIFF
--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -15,25 +15,25 @@ CREATE TABLE options (
 
 COMMENT ON TABLE options IS 'columnar table specific options, maintained by alter_columnar_table_set';
 
-CREATE TABLE columnar_stripes (
+CREATE TABLE stripe (
     storageid bigint NOT NULL,
-    stripe bigint NOT NULL,
+    stripeid bigint NOT NULL,
     file_offset bigint NOT NULL,
     data_length bigint NOT NULL,
     column_count int NOT NULL,
     chunk_count int NOT NULL,
     chunk_row_count int NOT NULL,
     row_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripe)
+    PRIMARY KEY (storageid, stripeid)
 ) WITH (user_catalog_table = true);
 
-COMMENT ON TABLE columnar_stripes IS 'Columnar per stripe metadata';
+COMMENT ON TABLE stripe IS 'Columnar per stripe metadata';
 
-CREATE TABLE columnar_skipnodes (
+CREATE TABLE chunk (
     storageid bigint NOT NULL,
-    stripe bigint NOT NULL,
-    attr int NOT NULL,
-    chunk int NOT NULL,
+    stripeid bigint NOT NULL,
+    attnum int NOT NULL,
+    chunkid int NOT NULL,
     row_count bigint NOT NULL,
     minimum_value bytea,
     maximum_value bytea,
@@ -44,11 +44,11 @@ CREATE TABLE columnar_skipnodes (
     value_compression_type int NOT NULL,
     value_compression_level int NOT NULL,
     value_decompressed_length bigint NOT NULL,
-    PRIMARY KEY (storageid, stripe, attr, chunk),
-    FOREIGN KEY (storageid, stripe) REFERENCES columnar_stripes(storageid, stripe) ON DELETE CASCADE
+    PRIMARY KEY (storageid, stripeid, attnum, chunkid),
+    FOREIGN KEY (storageid, stripeid) REFERENCES stripe(storageid, stripeid) ON DELETE CASCADE
 ) WITH (user_catalog_table = true);
 
-COMMENT ON TABLE columnar_skipnodes IS 'Columnar per chunk metadata';
+COMMENT ON TABLE chunk IS 'Columnar per chunk metadata';
 
 DO $proc$
 BEGIN

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -29,8 +29,8 @@ IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
 END IF;
 END$proc$;
 
-DROP TABLE columnar_skipnodes;
-DROP TABLE columnar_stripes;
+DROP TABLE chunk;
+DROP TABLE stripe;
 DROP TABLE options;
 DROP SEQUENCE storageid_seq;
 

--- a/src/test/regress/expected/am_drop.out
+++ b/src/test/regress/expected/am_drop.out
@@ -12,12 +12,12 @@
 -- 'postgres' directory is excluded from comparison to have the same result.
 -- store postgres database oid
 SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
-SELECT count(distinct storageid) AS columnar_stripes_before_drop FROM columnar.columnar_stripes \gset
+SELECT count(distinct storageid) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 -- DROP columnar tables
 DROP TABLE contestant;
 DROP TABLE contestant_compressed;
 -- make sure DROP deletes metadata
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.columnar_stripes;
+SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         2
@@ -27,10 +27,10 @@ SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.c
 CREATE SCHEMA test_schema;
 CREATE TABLE test_schema.test_table(data int) USING columnar;
 INSERT INTO test_schema.test_table VALUES (1);
-SELECT count(*) AS columnar_stripes_before_drop FROM columnar.columnar_stripes \gset
+SELECT count(*) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 DROP SCHEMA test_schema CASCADE;
 NOTICE:  drop cascades to table test_schema.test_table
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.columnar_stripes;
+SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -68,13 +68,13 @@ SELECT * FROM t_view a ORDER BY a;
 -- verify that we have created metadata entries for the materialized view
 SELECT columnar_relation_storageid(oid) AS storageid
 FROM pg_class WHERE relname='t_view' \gset
-SELECT count(*) FROM columnar.columnar_stripes WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      1
 (1 row)
 
-SELECT count(*) FROM columnar.columnar_skipnodes WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      3
@@ -83,13 +83,13 @@ SELECT count(*) FROM columnar.columnar_skipnodes WHERE storageid=:storageid;
 DROP TABLE t CASCADE;
 NOTICE:  drop cascades to materialized view t_view
 -- dropping must remove metadata
-SELECT count(*) FROM columnar.columnar_stripes WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
-SELECT count(*) FROM columnar.columnar_skipnodes WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
  count
 ---------------------------------------------------------------------
      0

--- a/src/test/regress/expected/am_recursive.out
+++ b/src/test/regress/expected/am_recursive.out
@@ -11,7 +11,7 @@ $$ LANGUAGE SQL;
 INSERT INTO t2 SELECT i, f(i) FROM generate_series(1, 5) i;
 -- there are no subtransactions, so above statement should batch
 -- INSERTs inside the UDF and create on stripe per table.
-SELECT relname, count(*) FROM columnar.columnar_stripes a, pg_class b
+SELECT relname, count(*) FROM columnar.stripe a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname IN ('t1', 't2')
 GROUP BY relname
 ORDER BY relname;

--- a/src/test/regress/expected/am_rollback.out
+++ b/src/test/regress/expected/am_rollback.out
@@ -3,7 +3,7 @@
 --
 CREATE TABLE t(a int, b int) USING columnar;
 CREATE VIEW t_stripes AS
-SELECT * FROM columnar.columnar_stripes a, pg_class b
+SELECT * FROM columnar.stripe a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname = 't';
 BEGIN;
 INSERT INTO t SELECT i, i+1 FROM generate_series(1, 10) i;

--- a/src/test/regress/expected/am_truncate.out
+++ b/src/test/regress/expected/am_truncate.out
@@ -15,7 +15,7 @@ CREATE TABLE columnar_truncate_test_second (a int, b int) USING columnar;
 -- COMPRESSED
 CREATE TABLE columnar_truncate_test_compressed (a int, b int) USING columnar;
 CREATE TABLE columnar_truncate_test_regular (a int, b int);
-SELECT count(distinct storageid) AS columnar_data_files_before_truncate FROM columnar.columnar_stripes \gset
+SELECT count(distinct storageid) AS columnar_data_files_before_truncate FROM columnar.stripe \gset
 INSERT INTO columnar_truncate_test select a, a from generate_series(1, 10) a;
 set columnar.compression = 'pglz';
 INSERT INTO columnar_truncate_test_compressed select a, a from generate_series(1, 10) a;
@@ -147,7 +147,7 @@ SELECT * from columnar_truncate_test;
 (0 rows)
 
 -- make sure TRUNATE deletes metadata for old relfilenode
-SELECT :columnar_data_files_before_truncate - count(distinct storageid) FROM columnar.columnar_stripes;
+SELECT :columnar_data_files_before_truncate - count(distinct storageid) FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         0
@@ -161,7 +161,7 @@ TRUNCATE columnar_same_transaction_truncate;
 INSERT INTO columnar_same_transaction_truncate SELECT * FROM generate_series(20, 23);
 COMMIT;
 -- should output "1" for the newly created relation
-SELECT count(distinct storageid) - :columnar_data_files_before_truncate FROM columnar.columnar_stripes;
+SELECT count(distinct storageid) - :columnar_data_files_before_truncate FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -1,8 +1,8 @@
 SET columnar.compression TO 'none';
-SELECT count(distinct storageid) AS columnar_table_count FROM columnar.columnar_stripes \gset
+SELECT count(distinct storageid) AS columnar_table_count FROM columnar.stripe \gset
 CREATE TABLE t(a int, b int) USING columnar;
 CREATE VIEW t_stripes AS
-SELECT * FROM columnar.columnar_stripes a, pg_class b
+SELECT * FROM columnar.stripe a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t';
 SELECT count(*) FROM t_stripes;
  count
@@ -74,35 +74,35 @@ SELECT count(*) FROM t_stripes;
 
 -- VACUUM FULL doesn't reclaim dropped columns, but converts them to NULLs
 ALTER TABLE t DROP COLUMN a;
-SELECT stripe, attr, chunk, minimum_value IS NULL, maximum_value IS NULL
-FROM columnar.columnar_skipnodes a, pg_class b
+SELECT stripeid, attnum, chunkid, minimum_value IS NULL, maximum_value IS NULL
+FROM columnar.chunk a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
- stripe | attr | chunk | ?column? | ?column?
+ stripeid | attnum | chunkid | ?column? | ?column?
 ---------------------------------------------------------------------
-      1 |    1 |     0 | f        | f
-      1 |    2 |     0 | f        | f
-      2 |    1 |     0 | f        | f
-      2 |    2 |     0 | f        | f
-      3 |    1 |     0 | f        | f
-      3 |    2 |     0 | f        | f
+        1 |      1 |       0 | f        | f
+        1 |      2 |       0 | f        | f
+        2 |      1 |       0 | f        | f
+        2 |      2 |       0 | f        | f
+        3 |      1 |       0 | f        | f
+        3 |      2 |       0 | f        | f
 (6 rows)
 
 VACUUM FULL t;
-SELECT stripe, attr, chunk, minimum_value IS NULL, maximum_value IS NULL
-FROM columnar.columnar_skipnodes a, pg_class b
+SELECT stripeid, attnum, chunkid, minimum_value IS NULL, maximum_value IS NULL
+FROM columnar.chunk a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
- stripe | attr | chunk | ?column? | ?column?
+ stripeid | attnum | chunkid | ?column? | ?column?
 ---------------------------------------------------------------------
-      1 |    1 |     0 | t        | t
-      1 |    2 |     0 | f        | f
-      2 |    1 |     0 | t        | t
-      2 |    2 |     0 | f        | f
-      3 |    1 |     0 | t        | t
-      3 |    2 |     0 | f        | f
+        1 |      1 |       0 | t        | t
+        1 |      2 |       0 | f        | f
+        2 |      1 |       0 | t        | t
+        2 |      2 |       0 | f        | f
+        3 |      1 |       0 | t        | t
+        3 |      2 |       0 | f        | f
 (6 rows)
 
 -- Make sure we cleaned-up the transient table metadata after VACUUM FULL commands
-SELECT count(distinct storageid) - :columnar_table_count FROM columnar.columnar_stripes;
+SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         1
@@ -242,7 +242,7 @@ chunk count: 8, containing data for dropped columns: 0, none compressed: 2, pglz
 DROP TABLE t;
 DROP VIEW t_stripes;
 -- Make sure we cleaned the metadata for t too
-SELECT count(distinct storageid) - :columnar_table_count FROM columnar.columnar_stripes;
+SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         0

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -499,9 +499,9 @@ SELECT * FROM print_extension_changes();
                                                                                  | function worker_change_sequence_dependency(regclass,regclass,regclass)
                                                                                  | schema columnar
                                                                                  | sequence columnar.storageid_seq
-                                                                                 | table columnar.columnar_skipnodes
-                                                                                 | table columnar.columnar_stripes
+                                                                                 | table columnar.chunk
                                                                                  | table columnar.options
+                                                                                 | table columnar.stripe
                                                                                  | view citus_shards
                                                                                  | view citus_tables
                                                                                  | view time_partitions

--- a/src/test/regress/expected/multi_extension_0.out
+++ b/src/test/regress/expected/multi_extension_0.out
@@ -495,9 +495,9 @@ SELECT * FROM print_extension_changes();
                                                                                  | function worker_change_sequence_dependency(regclass,regclass,regclass)
                                                                                  | schema columnar
                                                                                  | sequence columnar.storageid_seq
-                                                                                 | table columnar.columnar_skipnodes
-                                                                                 | table columnar.columnar_stripes
+                                                                                 | table columnar.chunk
                                                                                  | table columnar.options
+                                                                                 | table columnar.stripe
                                                                                  | view citus_shards
                                                                                  | view citus_tables
                                                                                  | view time_partitions

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -209,9 +209,9 @@ ORDER BY 1;
  sequence pg_dist_placement_placementid_seq
  sequence pg_dist_shardid_seq
  table citus.pg_dist_object
- table columnar.columnar_skipnodes
- table columnar.columnar_stripes
+ table columnar.chunk
  table columnar.options
+ table columnar.stripe
  table pg_dist_authinfo
  table pg_dist_colocation
  table pg_dist_local_group

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -205,9 +205,9 @@ ORDER BY 1;
  sequence pg_dist_placement_placementid_seq
  sequence pg_dist_shardid_seq
  table citus.pg_dist_object
- table columnar.columnar_skipnodes
- table columnar.columnar_stripes
+ table columnar.chunk
  table columnar.options
+ table columnar.stripe
  table pg_dist_authinfo
  table pg_dist_colocation
  table pg_dist_local_group

--- a/src/test/regress/sql/am_drop.sql
+++ b/src/test/regress/sql/am_drop.sql
@@ -15,23 +15,23 @@
 -- store postgres database oid
 SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 
-SELECT count(distinct storageid) AS columnar_stripes_before_drop FROM columnar.columnar_stripes \gset
+SELECT count(distinct storageid) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 
 -- DROP columnar tables
 DROP TABLE contestant;
 DROP TABLE contestant_compressed;
 
 -- make sure DROP deletes metadata
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.columnar_stripes;
+SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
 
 -- Create a columnar table under a schema and drop it.
 CREATE SCHEMA test_schema;
 CREATE TABLE test_schema.test_table(data int) USING columnar;
 INSERT INTO test_schema.test_table VALUES (1);
 
-SELECT count(*) AS columnar_stripes_before_drop FROM columnar.columnar_stripes \gset
+SELECT count(*) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 DROP SCHEMA test_schema CASCADE;
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.columnar_stripes;
+SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
 
 SELECT current_database() datname \gset
 

--- a/src/test/regress/sql/am_matview.sql
+++ b/src/test/regress/sql/am_matview.sql
@@ -38,11 +38,11 @@ SELECT * FROM t_view a ORDER BY a;
 SELECT columnar_relation_storageid(oid) AS storageid
 FROM pg_class WHERE relname='t_view' \gset
 
-SELECT count(*) FROM columnar.columnar_stripes WHERE storageid=:storageid;
-SELECT count(*) FROM columnar.columnar_skipnodes WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
 
 DROP TABLE t CASCADE;
 
 -- dropping must remove metadata
-SELECT count(*) FROM columnar.columnar_stripes WHERE storageid=:storageid;
-SELECT count(*) FROM columnar.columnar_skipnodes WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;

--- a/src/test/regress/sql/am_recursive.sql
+++ b/src/test/regress/sql/am_recursive.sql
@@ -15,7 +15,7 @@ INSERT INTO t2 SELECT i, f(i) FROM generate_series(1, 5) i;
 
 -- there are no subtransactions, so above statement should batch
 -- INSERTs inside the UDF and create on stripe per table.
-SELECT relname, count(*) FROM columnar.columnar_stripes a, pg_class b
+SELECT relname, count(*) FROM columnar.stripe a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname IN ('t1', 't2')
 GROUP BY relname
 ORDER BY relname;

--- a/src/test/regress/sql/am_rollback.sql
+++ b/src/test/regress/sql/am_rollback.sql
@@ -5,7 +5,7 @@
 CREATE TABLE t(a int, b int) USING columnar;
 
 CREATE VIEW t_stripes AS
-SELECT * FROM columnar.columnar_stripes a, pg_class b
+SELECT * FROM columnar.stripe a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname = 't';
 
 BEGIN;

--- a/src/test/regress/sql/am_truncate.sql
+++ b/src/test/regress/sql/am_truncate.sql
@@ -13,7 +13,7 @@ CREATE TABLE columnar_truncate_test_second (a int, b int) USING columnar;
 CREATE TABLE columnar_truncate_test_compressed (a int, b int) USING columnar;
 CREATE TABLE columnar_truncate_test_regular (a int, b int);
 
-SELECT count(distinct storageid) AS columnar_data_files_before_truncate FROM columnar.columnar_stripes \gset
+SELECT count(distinct storageid) AS columnar_data_files_before_truncate FROM columnar.stripe \gset
 
 INSERT INTO columnar_truncate_test select a, a from generate_series(1, 10) a;
 
@@ -63,7 +63,7 @@ TRUNCATE TABLE columnar_truncate_test;
 SELECT * from columnar_truncate_test;
 
 -- make sure TRUNATE deletes metadata for old relfilenode
-SELECT :columnar_data_files_before_truncate - count(distinct storageid) FROM columnar.columnar_stripes;
+SELECT :columnar_data_files_before_truncate - count(distinct storageid) FROM columnar.stripe;
 
 -- test if truncation in the same transaction that created the table works properly
 BEGIN;
@@ -74,7 +74,7 @@ INSERT INTO columnar_same_transaction_truncate SELECT * FROM generate_series(20,
 COMMIT;
 
 -- should output "1" for the newly created relation
-SELECT count(distinct storageid) - :columnar_data_files_before_truncate FROM columnar.columnar_stripes;
+SELECT count(distinct storageid) - :columnar_data_files_before_truncate FROM columnar.stripe;
 SELECT * FROM columnar_same_transaction_truncate;
 
 DROP TABLE columnar_same_transaction_truncate;


### PR DESCRIPTION
Renames `columnar.columnar_stripes` to `columnar.stripe`, and `columnar.columnar_skipnodes` to `columnar.chunk`.