### PR TITLE
Add columnar test for json

### DIFF
--- a/src/test/regress/input/am_data_types.source
+++ b/src/test/regress/input/am_data_types.source
@@ -66,3 +66,8 @@ CREATE TABLE test_null_values (a int, b int[], c composite_type)
 COPY test_null_values FROM '@abs_srcdir@/data/null_values.csv' WITH CSV;
 
 SELECT * FROM test_null_values;
+
+CREATE TABLE test_json(j json) USING columnar;
+INSERT INTO test_json SELECT ('{"att": ' || g::text || '}')::json from generate_series(1,1000000) g;
+SELECT * FROM test_json WHERE (j->'att')::text::int8 > 999990;
+DROP TABLE test_json;

--- a/src/test/regress/output/am_data_types.source
+++ b/src/test/regress/output/am_data_types.source
@@ -76,3 +76,21 @@ SELECT * FROM test_null_values;
    |        | 
 (2 rows)
 
+CREATE TABLE test_json(j json) USING columnar;
+INSERT INTO test_json SELECT ('{"att": ' || g::text || '}')::json from generate_series(1,1000000) g;
+SELECT * FROM test_json WHERE (j->'att')::text::int8 > 999990;
+        j
+---------------------------------------------------------------------
+ {"att": 999991}
+ {"att": 999992}
+ {"att": 999993}
+ {"att": 999994}
+ {"att": 999995}
+ {"att": 999996}
+ {"att": 999997}
+ {"att": 999998}
+ {"att": 999999}
+ {"att": 1000000}
+(10 rows)
+
+DROP TABLE test_json;


### PR DESCRIPTION
To explicitly exercise the path with no comparison operators.