### PR TITLE
Choose the smallest colocation id among all matches

### DIFF
--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -541,12 +541,22 @@ ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType, 
 													indexOK, NULL, scanKeyCount, scanKey);
 
 	HeapTuple colocationTuple = systable_getnext(scanDescriptor);
-	if (HeapTupleIsValid(colocationTuple))
+
+	while (HeapTupleIsValid(colocationTuple))
 	{
 		Form_pg_dist_colocation colocationForm =
 			(Form_pg_dist_colocation) GETSTRUCT(colocationTuple);
 
-		colocationId = colocationForm->colocationid;
+		if (colocationId == INVALID_COLOCATION_ID || colocationId >
+			colocationForm->colocationid)
+		{
+			/*
+			 * We assign the smallest colocation id among all the matches so that we
+			 * assign the same colocation group for similar distributed tables
+			 */
+			colocationId = colocationForm->colocationid;
+		}
+		colocationTuple = systable_getnext(scanDescriptor);
 	}
 
 	systable_endscan(scanDescriptor);


### PR DESCRIPTION
Currently we choose an arbitrary colocation id from all the matches for
a colocation id. This could mean that 2 distributed tables, which have
the same scheme could go into different colocation groups. This fix
makes sure that the same match will go to the same colocation group.

DESCRIPTION: Choose the default colocation group deterministically
