### PR TITLE
Rename citus_tables column names to be query-friendly

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_tables/10.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/10.0-1.sql
@@ -1,13 +1,13 @@
 CREATE VIEW public.citus_tables AS
 SELECT
-  logicalrelid AS "Name",
-  CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS "Citus Table Type",
-  coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS "Distribution Column",
-  colocationid AS "Colocation ID",
-  pg_size_pretty(citus_total_relation_size(logicalrelid, fail_on_error := false)) AS "Size",
-  (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS "Shard Count",
-  pg_get_userbyid(relowner) AS "Owner",
-  amname AS "Access Method"
+  logicalrelid AS table_name,
+  CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS citus_table_type,
+  coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS distribution_column,
+  colocationid AS colocation_id,
+  pg_size_pretty(citus_total_relation_size(logicalrelid, fail_on_error := false)) AS table_size,
+  (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS shard_count,
+  pg_get_userbyid(relowner) AS table_owner,
+  amname AS access_method
 FROM
   pg_dist_partition p
 JOIN

--- a/src/backend/distributed/sql/udfs/citus_tables/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/latest.sql
@@ -1,13 +1,13 @@
 CREATE VIEW public.citus_tables AS
 SELECT
-  logicalrelid AS "Name",
-  CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS "Citus Table Type",
-  coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS "Distribution Column",
-  colocationid AS "Colocation ID",
-  pg_size_pretty(citus_total_relation_size(logicalrelid, fail_on_error := false)) AS "Size",
-  (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS "Shard Count",
-  pg_get_userbyid(relowner) AS "Owner",
-  amname AS "Access Method"
+  logicalrelid AS table_name,
+  CASE WHEN partkey IS NOT NULL THEN 'distributed' ELSE 'reference' END AS citus_table_type,
+  coalesce(column_to_column_name(logicalrelid, partkey), '<none>') AS distribution_column,
+  colocationid AS colocation_id,
+  pg_size_pretty(citus_total_relation_size(logicalrelid, fail_on_error := false)) AS table_size,
+  (select count(*) from pg_dist_shard where logicalrelid = p.logicalrelid) AS shard_count,
+  pg_get_userbyid(relowner) AS table_owner,
+  amname AS access_method
 FROM
   pg_dist_partition p
 JOIN

--- a/src/test/regress/expected/alter_distributed_table.out
+++ b/src/test/regress/expected/alter_distributed_table.out
@@ -32,17 +32,17 @@ SELECT create_distributed_table ('colocation_table_2', 'a', colocate_with := 'no
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | a                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -61,17 +61,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -90,17 +90,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -119,17 +119,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  colocation_table, dist_table
@@ -151,17 +151,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.colocation_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           8
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           8
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  colocation_table, dist_table
@@ -179,17 +179,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           8
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |          10
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -230,8 +230,8 @@ SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'p
  partitioned_table_6_10
 (2 rows)
 
-SELECT "Name"::text, "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
-          Name          | Distribution Column | Shard Count
+SELECT table_name::text, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
+       table_name       | distribution_column | shard_count
 ---------------------------------------------------------------------
  partitioned_table      | id                  |           4
  partitioned_table_1_5  | id                  |           4
@@ -302,8 +302,8 @@ SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'p
  partitioned_table_6_10
 (2 rows)
 
-SELECT "Name"::text, "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
-          Name          | Distribution Column | Shard Count
+SELECT table_name::text, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
+       table_name       | distribution_column | shard_count
 ---------------------------------------------------------------------
  partitioned_table      | a                   |          10
  partitioned_table_1_5  | a                   |          10
@@ -478,8 +478,8 @@ SELECT create_distributed_table('columnar_table', 'a', colocate_with:='none');
 
 (1 row)
 
-SELECT "Name"::text, "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'columnar_table';
-      Name      | Shard Count | Access Method
+SELECT table_name::text, shard_count, access_method FROM public.citus_tables WHERE table_name::text = 'columnar_table';
+   table_name   | shard_count | access_method
 ---------------------------------------------------------------------
  columnar_table |           4 | columnar
 (1 row)
@@ -490,8 +490,8 @@ SELECT alter_distributed_table('columnar_table', shard_count:=6);
 
 (1 row)
 
-SELECT "Name"::text, "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'columnar_table';
-      Name      | Shard Count | Access Method
+SELECT table_name::text, shard_count, access_method FROM public.citus_tables WHERE table_name::text = 'columnar_table';
+   table_name   | shard_count | access_method
 ---------------------------------------------------------------------
  columnar_table |           6 | columnar
 (1 row)
@@ -524,8 +524,8 @@ SELECT alter_distributed_table('metadata_sync_table', shard_count:=8);
 
 (1 row)
 
-SELECT "Name", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'metadata_sync_table';
-        Name         | Shard Count
+SELECT table_name, shard_count FROM public.citus_tables WHERE table_name::text = 'metadata_sync_table';
+     table_name      | shard_count
 ---------------------------------------------------------------------
  metadata_sync_table |           8
 (1 row)

--- a/src/test/regress/expected/alter_distributed_table_0.out
+++ b/src/test/regress/expected/alter_distributed_table_0.out
@@ -32,17 +32,17 @@ SELECT create_distributed_table ('colocation_table_2', 'a', colocate_with := 'no
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | a                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -61,17 +61,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -90,17 +90,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -119,17 +119,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           4
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  colocation_table, dist_table
@@ -151,17 +151,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.colocation_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           8
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |           8
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  colocation_table, dist_table
@@ -179,17 +179,17 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-        Name        | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+     table_name     | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
  colocation_table   | distributed      | a                   |           8
  colocation_table_2 | distributed      | a                   |           4
  dist_table         | distributed      | b                   |          10
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  colocation_table
@@ -230,8 +230,8 @@ SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'p
  partitioned_table_6_10
 (2 rows)
 
-SELECT "Name"::text, "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
-          Name          | Distribution Column | Shard Count
+SELECT table_name::text, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
+       table_name       | distribution_column | shard_count
 ---------------------------------------------------------------------
  partitioned_table      | id                  |           4
  partitioned_table_1_5  | id                  |           4
@@ -302,8 +302,8 @@ SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'p
  partitioned_table_6_10
 (2 rows)
 
-SELECT "Name"::text, "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
-          Name          | Distribution Column | Shard Count
+SELECT table_name::text, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
+       table_name       | distribution_column | shard_count
 ---------------------------------------------------------------------
  partitioned_table      | a                   |          10
  partitioned_table_1_5  | a                   |          10
@@ -473,9 +473,9 @@ SELECT alter_distributed_table('col_with_ref_to_dist', shard_count:=6, cascade_t
 -- test altering columnar table
 CREATE TABLE columnar_table (a INT) USING columnar;
 SELECT create_distributed_table('columnar_table', 'a', colocate_with:='none');
-SELECT "Name"::text, "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'columnar_table';
+SELECT table_name::text, shard_count, access_method FROM public.citus_tables WHERE table_name::text = 'columnar_table';
 SELECT alter_distributed_table('columnar_table', shard_count:=6);
-SELECT "Name"::text, "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'columnar_table';
+SELECT table_name::text, shard_count, access_method FROM public.citus_tables WHERE table_name::text = 'columnar_table';
 \endif
 -- test with metadata sync
 SET citus.replication_model TO 'streaming';
@@ -504,8 +504,8 @@ SELECT alter_distributed_table('metadata_sync_table', shard_count:=8);
 
 (1 row)
 
-SELECT "Name", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'metadata_sync_table';
-        Name         | Shard Count
+SELECT table_name, shard_count FROM public.citus_tables WHERE table_name::text = 'metadata_sync_table';
+     table_name      | shard_count
 ---------------------------------------------------------------------
  metadata_sync_table |           8
 (1 row)

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -29,8 +29,8 @@ SELECT create_distributed_table ('dist_table', 'a');
 (1 row)
 
 INSERT INTO dist_table VALUES (1, 1), (2, 2), (3, 3);
-SELECT "Name", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'dist_table' ORDER BY 1;
-    Name    | Access Method
+SELECT table_name, access_method FROM public.citus_tables WHERE table_name::text = 'dist_table' ORDER BY 1;
+ table_name | access_method
 ---------------------------------------------------------------------
  dist_table | heap
 (1 row)
@@ -46,8 +46,8 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.dist_table
 
 (1 row)
 
-SELECT "Name", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'dist_table' ORDER BY 1;
-    Name    | Access Method
+SELECT table_name, access_method FROM public.citus_tables WHERE table_name::text = 'dist_table' ORDER BY 1;
+ table_name | access_method
 ---------------------------------------------------------------------
  dist_table | columnar
 (1 row)
@@ -85,8 +85,8 @@ SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'p
  partitioned_table_6_10
 (2 rows)
 
-SELECT "Name"::text, "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
-          Name          | Access Method
+SELECT table_name::text, access_method FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
+       table_name       | access_method
 ---------------------------------------------------------------------
  partitioned_table      |
  partitioned_table_1_5  | heap
@@ -149,8 +149,8 @@ SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'p
  partitioned_table_6_10
 (2 rows)
 
-SELECT "Name"::text, "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
-          Name          | Access Method
+SELECT table_name::text, access_method FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
+       table_name       | access_method
 ---------------------------------------------------------------------
  partitioned_table      |
  partitioned_table_1_5  | columnar
@@ -363,8 +363,8 @@ SELECT create_citus_local_table('table_type_citus_local');
 (1 row)
 
 CREATE TABLE table_type_pg_local (a INT);
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'table\_type%' ORDER BY 1;
-      Name       | Citus Table Type | Distribution Column | Shard Count | Access Method
+SELECT table_name, citus_table_type, distribution_column, shard_count, access_method FROM public.citus_tables WHERE table_name::text LIKE 'table\_type%' ORDER BY 1;
+   table_name    | citus_table_type | distribution_column | shard_count | access_method
 ---------------------------------------------------------------------
  table_type_dist | distributed      | a                   |           4 | heap
  table_type_ref  | reference        | <none>              |           1 | heap
@@ -425,8 +425,8 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_citu
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'table\_type%' ORDER BY 1;
-      Name       | Citus Table Type | Distribution Column | Shard Count | Access Method
+SELECT table_name, citus_table_type, distribution_column, shard_count, access_method FROM public.citus_tables WHERE table_name::text LIKE 'table\_type%' ORDER BY 1;
+   table_name    | citus_table_type | distribution_column | shard_count | access_method
 ---------------------------------------------------------------------
  table_type_dist | distributed      | a                   |           4 | fake_am
  table_type_ref  | reference        | <none>              |           1 | fake_am

--- a/src/test/regress/expected/coordinator_shouldhaveshards.out
+++ b/src/test/regress/expected/coordinator_shouldhaveshards.out
@@ -647,15 +647,15 @@ INSERT INTO adt_col VALUES (3, 4), (5, 6), (7, 8);
 NOTICE:  executing the command locally: INSERT INTO coordinator_shouldhaveshards.adt_col_1503064 AS citus_table_alias (a, b) VALUES (5,6)
 INSERT INTO adt_ref VALUES (3), (5);
 NOTICE:  executing the command locally: INSERT INTO coordinator_shouldhaveshards.adt_ref_1503068 AS citus_table_alias (a) VALUES (5)
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           4
- adt_ref   | distributed      | a                   |           4
- adt_table | distributed      | a                   |           4
+ adt_col    | distributed      | a                   |           4
+ adt_ref    | distributed      | a                   |           4
+ adt_table  | distributed      | a                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref, adt_table
@@ -677,15 +677,15 @@ SELECT alter_distributed_table('adt_table', shard_count:=6, cascade_to_colocated
 (1 row)
 
 SET client_min_messages TO DEFAULT;
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           6
- adt_ref   | distributed      | a                   |           6
- adt_table | distributed      | a                   |           6
+ adt_col    | distributed      | a                   |           6
+ adt_ref    | distributed      | a                   |           6
+ adt_table  | distributed      | a                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref, adt_table
@@ -709,15 +709,15 @@ NOTICE:  Renaming the new table to coordinator_shouldhaveshards.adt_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           6
- adt_ref   | distributed      | a                   |           6
- adt_table | distributed      | b                   |           6
+ adt_col    | distributed      | a                   |           6
+ adt_ref    | distributed      | a                   |           6
+ adt_table  | distributed      | b                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref
@@ -771,10 +771,10 @@ SELECT COUNT(*) FROM adt_table;
 (1 row)
 
 END;
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'adt_table';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text = 'adt_table';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_table | distributed      | a                   |           6
+ adt_table  | distributed      | a                   |           6
 (1 row)
 
 SET client_min_messages TO DEFAULT;

--- a/src/test/regress/expected/multi_mx_alter_distributed_table.out
+++ b/src/test/regress/expected/multi_mx_alter_distributed_table.out
@@ -26,15 +26,15 @@ SELECT create_distributed_table('adt_ref', 'a', colocate_with:='adt_table');
 INSERT INTO adt_table VALUES (1, 2), (3, 4), (5, 6);
 INSERT INTO adt_col VALUES (3, 4), (5, 6), (7, 8);
 INSERT INTO adt_ref VALUES (3), (5);
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           4
- adt_ref   | distributed      | a                   |           4
- adt_table | distributed      | a                   |           4
+ adt_col    | distributed      | a                   |           4
+ adt_ref    | distributed      | a                   |           4
+ adt_table  | distributed      | a                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref, adt_table
@@ -56,15 +56,15 @@ SELECT alter_distributed_table('adt_table', shard_count:=6, cascade_to_colocated
 (1 row)
 
 SET client_min_messages TO DEFAULT;
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           6
- adt_ref   | distributed      | a                   |           6
- adt_table | distributed      | a                   |           6
+ adt_col    | distributed      | a                   |           6
+ adt_ref    | distributed      | a                   |           6
+ adt_table  | distributed      | a                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref, adt_table
@@ -88,15 +88,15 @@ NOTICE:  Renaming the new table to mx_alter_distributed_table.adt_table
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           6
- adt_ref   | distributed      | a                   |           6
- adt_table | distributed      | b                   |           6
+ adt_col    | distributed      | a                   |           6
+ adt_ref    | distributed      | a                   |           6
+ adt_table  | distributed      | b                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref
@@ -153,10 +153,10 @@ SELECT COUNT(*) FROM adt_table;
 (1 row)
 
 END;
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'adt_table';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text = 'adt_table';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_table | distributed      | a                   |           6
+ adt_table  | distributed      | a                   |           6
 (1 row)
 
 SET client_min_messages TO WARNING;

--- a/src/test/regress/expected/multi_mx_create_table.out
+++ b/src/test/regress/expected/multi_mx_create_table.out
@@ -485,10 +485,10 @@ ORDER BY colocationid, logicalrelid;
 (23 rows)
 
 -- check the citus_tables view
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+SELECT table_name, citus_table_type, distribution_column, shard_count, table_owner
 FROM citus_tables
-ORDER BY "Name"::text;
-                          Name                          | Citus Table Type | Distribution Column | Shard Count |  Owner
+ORDER BY table_name::text;
+                       table_name                       | citus_table_type | distribution_column | shard_count | table_owner
 ---------------------------------------------------------------------
  app_analytics_events_mx                                | distributed      | app_id              |           4 | postgres
  articles_hash_mx                                       | distributed      | author_id           |           2 | postgres
@@ -516,10 +516,10 @@ ORDER BY "Name"::text;
 (23 rows)
 
 \c - - - :worker_1_port
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+SELECT table_name, citus_table_type, distribution_column, shard_count, table_owner
 FROM citus_tables
-ORDER BY "Name"::text;
-                          Name                          | Citus Table Type | Distribution Column | Shard Count |  Owner
+ORDER BY table_name::text;
+                       table_name                       | citus_table_type | distribution_column | shard_count | table_owner
 ---------------------------------------------------------------------
  app_analytics_events_mx                                | distributed      | app_id              |           4 | postgres
  articles_hash_mx                                       | distributed      | author_id           |           2 | postgres

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -1313,15 +1313,15 @@ SELECT create_distributed_table('adt_ref', 'a', colocate_with:='adt_table');
 INSERT INTO adt_table VALUES (1, 2), (3, 4), (5, 6);
 INSERT INTO adt_col VALUES (3, 4), (5, 6), (7, 8);
 INSERT INTO adt_ref VALUES (3), (5);
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           4
- adt_ref   | distributed      | a                   |           4
- adt_table | distributed      | a                   |           4
+ adt_col    | distributed      | a                   |           4
+ adt_ref    | distributed      | a                   |           4
+ adt_table  | distributed      | a                   |           4
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref, adt_table
@@ -1341,15 +1341,15 @@ SELECT alter_distributed_table('adt_table', shard_count:=6, cascade_to_colocated
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           6
- adt_ref   | distributed      | a                   |           6
- adt_table | distributed      | a                   |           6
+ adt_col    | distributed      | a                   |           6
+ adt_ref    | distributed      | a                   |           6
+ adt_table  | distributed      | a                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
       Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref, adt_table
@@ -1369,15 +1369,15 @@ SELECT alter_distributed_table('adt_table', distribution_column:='b', colocate_w
 
 (1 row)
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_col   | distributed      | a                   |           6
- adt_ref   | distributed      | a                   |           6
- adt_table | distributed      | b                   |           6
+ adt_col    | distributed      | a                   |           6
+ adt_ref    | distributed      | a                   |           6
+ adt_table  | distributed      | b                   |           6
 (3 rows)
 
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
  Colocation Groups
 ---------------------------------------------------------------------
  adt_col, adt_ref
@@ -1430,10 +1430,10 @@ SELECT COUNT(*) FROM adt_table;
 (1 row)
 
 END;
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'adt_table';
-   Name    | Citus Table Type | Distribution Column | Shard Count
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text = 'adt_table';
+ table_name | citus_table_type | distribution_column | shard_count
 ---------------------------------------------------------------------
- adt_table | distributed      | a                   |           6
+ adt_table  | distributed      | a                   |           6
 (1 row)
 
 \c - - - :master_port

--- a/src/test/regress/sql/alter_distributed_table.sql
+++ b/src/test/regress/sql/alter_distributed_table.sql
@@ -18,45 +18,45 @@ CREATE TABLE colocation_table_2 (a INT, b INT);
 SELECT create_distributed_table ('colocation_table_2', 'a', colocate_with := 'none');
 
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
 
 -- test altering distribution column
 SELECT alter_distributed_table('dist_table', distribution_column := 'b');
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
 
 -- test altering shard count
 SELECT alter_distributed_table('dist_table', shard_count := 6);
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
 
 -- test altering colocation, note that shard count will also change
 SELECT alter_distributed_table('dist_table', colocate_with := 'alter_distributed_table.colocation_table');
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
 
 -- test altering shard count with cascading, note that the colocation will be kept
 SELECT alter_distributed_table('dist_table', shard_count := 8, cascade_to_colocated := true);
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
 
 -- test altering shard count without cascading, note that the colocation will be broken
 SELECT alter_distributed_table('dist_table', shard_count := 10, cascade_to_colocated := false);
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2');
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
-    WHERE "Name" IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2');
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables
+    WHERE table_name IN ('dist_table', 'colocation_table', 'colocation_table_2') GROUP BY colocation_id ORDER BY 1;
 
 
 -- test partitions
@@ -69,7 +69,7 @@ INSERT INTO partitioned_table VALUES (2, 12), (7, 2);
 SELECT logicalrelid::text FROM pg_dist_partition WHERE logicalrelid::regclass::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname LIKE 'partitioned\_table%'$$);
 SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'partitioned_table'::regclass ORDER BY 1;
-SELECT "Name"::text, "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
+SELECT table_name::text, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT * FROM partitioned_table ORDER BY 1, 2;
 SELECT * FROM partitioned_table_1_5 ORDER BY 1, 2;
 SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
@@ -83,7 +83,7 @@ SELECT alter_distributed_table('partitioned_table_1_5', shard_count := 10, distr
 SELECT logicalrelid::text FROM pg_dist_partition WHERE logicalrelid::regclass::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname LIKE 'partitioned\_table%'$$);
 SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'partitioned_table'::regclass ORDER BY 1;
-SELECT "Name"::text, "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
+SELECT table_name::text, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT * FROM partitioned_table ORDER BY 1, 2;
 SELECT * FROM partitioned_table_1_5 ORDER BY 1, 2;
 SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
@@ -141,9 +141,9 @@ SELECT alter_distributed_table('col_with_ref_to_dist', shard_count:=6, cascade_t
 -- test altering columnar table
 CREATE TABLE columnar_table (a INT) USING columnar;
 SELECT create_distributed_table('columnar_table', 'a', colocate_with:='none');
-SELECT "Name"::text, "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'columnar_table';
+SELECT table_name::text, shard_count, access_method FROM public.citus_tables WHERE table_name::text = 'columnar_table';
 SELECT alter_distributed_table('columnar_table', shard_count:=6);
-SELECT "Name"::text, "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'columnar_table';
+SELECT table_name::text, shard_count, access_method FROM public.citus_tables WHERE table_name::text = 'columnar_table';
 \endif
 
 
@@ -157,7 +157,7 @@ SELECT create_distributed_table('metadata_sync_table', 'a', colocate_with:='none
 SELECT alter_distributed_table('metadata_sync_table', shard_count:=6);
 SELECT alter_distributed_table('metadata_sync_table', shard_count:=8);
 
-SELECT "Name", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'metadata_sync_table';
+SELECT table_name, shard_count FROM public.citus_tables WHERE table_name::text = 'metadata_sync_table';
 
 SET citus.replication_model TO DEFAULT;
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);

--- a/src/test/regress/sql/alter_table_set_access_method.sql
+++ b/src/test/regress/sql/alter_table_set_access_method.sql
@@ -24,9 +24,9 @@ CREATE TABLE dist_table (a INT, b INT);
 SELECT create_distributed_table ('dist_table', 'a');
 INSERT INTO dist_table VALUES (1, 1), (2, 2), (3, 3);
 
-SELECT "Name", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'dist_table' ORDER BY 1;
+SELECT table_name, access_method FROM public.citus_tables WHERE table_name::text = 'dist_table' ORDER BY 1;
 SELECT alter_table_set_access_method('dist_table', 'columnar');
-SELECT "Name", "Access Method" FROM public.citus_tables WHERE "Name"::text = 'dist_table' ORDER BY 1;
+SELECT table_name, access_method FROM public.citus_tables WHERE table_name::text = 'dist_table' ORDER BY 1;
 
 
 -- test partitions
@@ -39,7 +39,7 @@ INSERT INTO partitioned_table VALUES (2, 12), (7, 2);
 SELECT logicalrelid::text FROM pg_dist_partition WHERE logicalrelid::regclass::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname LIKE 'partitioned\_table%'$$);
 SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'partitioned_table'::regclass ORDER BY 1;
-SELECT "Name"::text, "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
+SELECT table_name::text, access_method FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT * FROM partitioned_table ORDER BY 1, 2;
 SELECT * FROM partitioned_table_1_5 ORDER BY 1, 2;
 SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
@@ -52,7 +52,7 @@ SELECT alter_table_set_access_method('partitioned_table_1_5', 'columnar');
 SELECT logicalrelid::text FROM pg_dist_partition WHERE logicalrelid::regclass::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname LIKE 'partitioned\_table%'$$);
 SELECT inhrelid::regclass::text FROM pg_catalog.pg_inherits WHERE inhparent = 'partitioned_table'::regclass ORDER BY 1;
-SELECT "Name"::text, "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'partitioned\_table%' ORDER BY 1;
+SELECT table_name::text, access_method FROM public.citus_tables WHERE table_name::text LIKE 'partitioned\_table%' ORDER BY 1;
 SELECT * FROM partitioned_table ORDER BY 1, 2;
 SELECT * FROM partitioned_table_1_5 ORDER BY 1, 2;
 SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
@@ -121,7 +121,7 @@ CREATE TABLE table_type_citus_local(a INT);
 SELECT create_citus_local_table('table_type_citus_local');
 CREATE TABLE table_type_pg_local (a INT);
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'table\_type%' ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count, access_method FROM public.citus_tables WHERE table_name::text LIKE 'table\_type%' ORDER BY 1;
 SELECT c.relname, a.amname FROM pg_class c, pg_am a where c.relname SIMILAR TO 'table_type\D*' AND c.relnamespace = 'alter_table_set_access_method'::regnamespace AND c.relam = a.oid;
 
 SELECT alter_table_set_access_method('table_type_dist', 'fake_am');
@@ -129,7 +129,7 @@ SELECT alter_table_set_access_method('table_type_ref', 'fake_am');
 SELECT alter_table_set_access_method('table_type_pg_local', 'fake_am');
 SELECT alter_table_set_access_method('table_type_citus_local', 'fake_am');
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Access Method" FROM public.citus_tables WHERE "Name"::text LIKE 'table\_type%' ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count, access_method FROM public.citus_tables WHERE table_name::text LIKE 'table\_type%' ORDER BY 1;
 SELECT c.relname, a.amname FROM pg_class c, pg_am a where c.relname SIMILAR TO 'table_type\D*' AND c.relnamespace = 'alter_table_set_access_method'::regnamespace AND c.relam = a.oid;
 
 -- test when the parent of a partition has foreign key to a reference table

--- a/src/test/regress/sql/coordinator_shouldhaveshards.sql
+++ b/src/test/regress/sql/coordinator_shouldhaveshards.sql
@@ -287,8 +287,8 @@ INSERT INTO adt_table VALUES (1, 2), (3, 4), (5, 6);
 INSERT INTO adt_col VALUES (3, 4), (5, 6), (7, 8);
 INSERT INTO adt_ref VALUES (3), (5);
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
@@ -296,15 +296,15 @@ SET client_min_messages TO WARNING;
 SELECT alter_distributed_table('adt_table', shard_count:=6, cascade_to_colocated:=true);
 SET client_min_messages TO DEFAULT;
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
 SELECT alter_distributed_table('adt_table', distribution_column:='b', colocate_with:='none');
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
@@ -319,7 +319,7 @@ SELECT alter_distributed_table('adt_table', distribution_column:='a');
 SELECT COUNT(*) FROM adt_table;
 END;
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'adt_table';
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text = 'adt_table';
 SET client_min_messages TO DEFAULT;
 
 

--- a/src/test/regress/sql/multi_mx_alter_distributed_table.sql
+++ b/src/test/regress/sql/multi_mx_alter_distributed_table.sql
@@ -15,8 +15,8 @@ INSERT INTO adt_table VALUES (1, 2), (3, 4), (5, 6);
 INSERT INTO adt_col VALUES (3, 4), (5, 6), (7, 8);
 INSERT INTO adt_ref VALUES (3), (5);
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
@@ -24,15 +24,15 @@ SET client_min_messages TO WARNING;
 SELECT alter_distributed_table('adt_table', shard_count:=6, cascade_to_colocated:=true);
 SET client_min_messages TO DEFAULT;
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
 SELECT alter_distributed_table('adt_table', distribution_column:='b', colocate_with:='none');
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
@@ -46,7 +46,7 @@ SELECT alter_distributed_table('adt_table', distribution_column:='a');
 SELECT COUNT(*) FROM adt_table;
 END;
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'adt_table';
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text = 'adt_table';
 
 SET client_min_messages TO WARNING;
 DROP SCHEMA mx_alter_distributed_table CASCADE;

--- a/src/test/regress/sql/multi_mx_create_table.sql
+++ b/src/test/regress/sql/multi_mx_create_table.sql
@@ -429,15 +429,15 @@ FROM pg_dist_partition NATURAL JOIN shard_counts
 ORDER BY colocationid, logicalrelid;
 
 -- check the citus_tables view
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+SELECT table_name, citus_table_type, distribution_column, shard_count, table_owner
 FROM citus_tables
-ORDER BY "Name"::text;
+ORDER BY table_name::text;
 
 \c - - - :worker_1_port
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count", "Owner"
+SELECT table_name, citus_table_type, distribution_column, shard_count, table_owner
 FROM citus_tables
-ORDER BY "Name"::text;
+ORDER BY table_name::text;
 
 
 SELECT shard_name, table_name, citus_table_type, shard_size FROM citus_shards ORDER BY shard_name::text;

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -714,22 +714,22 @@ INSERT INTO adt_table VALUES (1, 2), (3, 4), (5, 6);
 INSERT INTO adt_col VALUES (3, 4), (5, 6), (7, 8);
 INSERT INTO adt_ref VALUES (3), (5);
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
 SELECT alter_distributed_table('adt_table', shard_count:=6, cascade_to_colocated:=true);
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
 SELECT alter_distributed_table('adt_table', distribution_column:='b', colocate_with:='none');
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%';
-SELECT STRING_AGG("Name"::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE "Name"::text LIKE 'adt%' GROUP BY "Colocation ID" ORDER BY 1;
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text LIKE 'adt%';
+SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM public.citus_tables WHERE table_name::text LIKE 'adt%' GROUP BY colocation_id ORDER BY 1;
 SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid, true) AS "Definition" FROM  pg_constraint
     WHERE (conrelid::regclass::text = 'adt_col' OR confrelid::regclass::text = 'adt_col') ORDER BY 1;
 
@@ -743,7 +743,7 @@ SELECT alter_distributed_table('adt_table', distribution_column:='a');
 SELECT COUNT(*) FROM adt_table;
 END;
 
-SELECT "Name", "Citus Table Type", "Distribution Column", "Shard Count" FROM public.citus_tables WHERE "Name"::text = 'adt_table';
+SELECT table_name, citus_table_type, distribution_column, shard_count FROM public.citus_tables WHERE table_name::text = 'adt_table';
 
 
 \c - - - :master_port


### PR DESCRIPTION
The citus_tables column names were modelled after \d to optimize for readability, but in practice it's a useful view to query as demonstrated by our regression tests. This changes makes it easier to query the view by using column_names instead of "Column Names".