### PR TITLE
Read chunk row count from catalog tables

### DIFF
--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -201,6 +201,14 @@ typedef struct StripeBuffers
 	uint32 columnCount;
 	uint32 rowCount;
 	ColumnBuffers **columnBuffersArray;
+
+	/*
+	 * We might skip reading some chunks because they're refuted by the
+	 * WHERE clause. We keep number of selected chunks and number of rows
+	 * in each of them.
+	 */
+	uint32 selectedChunks;
+	uint32 *selectedChunkRowCount;
 } StripeBuffers;
 
 

--- a/src/test/regress/input/am_chunk_filtering.source
+++ b/src/test/regress/input/am_chunk_filtering.source
@@ -76,4 +76,12 @@ CREATE TABLE simple_chunk_filtering(i int) USING COLUMNAR;
 INSERT INTO simple_chunk_filtering SELECT generate_series(0,234567);
 EXPLAIN (analyze on, costs off, timing off, summary off)
   SELECT * FROM simple_chunk_filtering WHERE i > 123456;
+
+-- https://github.com/citusdata/citus/issues/4555
+TRUNCATE simple_chunk_filtering;
+INSERT INTO simple_chunk_filtering SELECT generate_series(0,200000);
+COPY (SELECT * FROM simple_chunk_filtering WHERE i > 180000) TO '/dev/null';
+EXPLAIN (analyze on, costs off, timing off, summary off)
+  SELECT * FROM simple_chunk_filtering WHERE i > 180000;
+
 DROP TABLE simple_chunk_filtering;

--- a/src/test/regress/output/am_chunk_filtering.source
+++ b/src/test/regress/output/am_chunk_filtering.source
@@ -130,4 +130,18 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
    Columnar Chunks Removed by Filter: 12
 (4 rows)
 
+-- https://github.com/citusdata/citus/issues/4555
+TRUNCATE simple_chunk_filtering;
+INSERT INTO simple_chunk_filtering SELECT generate_series(0,200000);
+COPY (SELECT * FROM simple_chunk_filtering WHERE i > 180000) TO '/dev/null';
+EXPLAIN (analyze on, costs off, timing off, summary off)
+  SELECT * FROM simple_chunk_filtering WHERE i > 180000;
+                                    QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on simple_chunk_filtering (actual rows=20000 loops=1)
+   Filter: (i > 180000)
+   Rows Removed by Filter: 1
+   Columnar Chunks Removed by Filter: 18
+(4 rows)
+
 DROP TABLE simple_chunk_filtering;


### PR DESCRIPTION
Fixes #4555.

Previously we calculated number of rows in a chunk based on index of the chunk, but this failed when some chunks were filtered out and loaded index of the chunk didn't match the on-disk index of the chunk.

This PR fixes that by reading the row count of a chunk from metadata tables instead.

