### PR TITLE
fix parse error on pg11.8 for extension creation

### DIFF
--- a/src/backend/columnar/sql/udfs/columnar_handler/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/columnar_handler/10.0-1.sql
@@ -6,4 +6,12 @@ AS 'MODULE_PATHNAME', 'columnar_handler';
 COMMENT ON FUNCTION columnar.columnar_handler(internal)
     IS 'internal function returning the handler for columnar tables';
 
-CREATE ACCESS METHOD columnar TYPE TABLE HANDLER columnar.columnar_handler;
+-- postgres 11.8 does not support the syntax for table am, also it is seemingly trying
+-- to parse the upgrade file and erroring on unknown syntax.
+-- normally this section would not execute on postgres 11 anyway. To trick it to pass on
+-- 11.8 we wrap the statement in a plpgsql block together with an EXECUTE. This is valid
+-- syntax on 11.8 and will execute correctly in 12
+DO $create_table_am$
+BEGIN
+EXECUTE 'CREATE ACCESS METHOD columnar TYPE TABLE HANDLER columnar.columnar_handler';
+END $create_table_am$;

--- a/src/backend/columnar/sql/udfs/columnar_handler/latest.sql
+++ b/src/backend/columnar/sql/udfs/columnar_handler/latest.sql
@@ -6,4 +6,12 @@ AS 'MODULE_PATHNAME', 'columnar_handler';
 COMMENT ON FUNCTION columnar.columnar_handler(internal)
     IS 'internal function returning the handler for columnar tables';
 
-CREATE ACCESS METHOD columnar TYPE TABLE HANDLER columnar.columnar_handler;
+-- postgres 11.8 does not support the syntax for table am, also it is seemingly trying
+-- to parse the upgrade file and erroring on unknown syntax.
+-- normally this section would not execute on postgres 11 anyway. To trick it to pass on
+-- 11.8 we wrap the statement in a plpgsql block together with an EXECUTE. This is valid
+-- syntax on 11.8 and will execute correctly in 12
+DO $create_table_am$
+BEGIN
+EXECUTE 'CREATE ACCESS METHOD columnar TYPE TABLE HANDLER columnar.columnar_handler';
+END $create_table_am$;


### PR DESCRIPTION
In pg11.8 it seemingly tries to parse the full sql file creating the extension,
since we use syntax introduced in postgres 12 this fails.

This patch rewrites the statement not recognized by pg11.8 to be dynamically
executed from a string literal via `EXECUTE`.