### PR TITLE
Adds error messages with names of indexes that will be dropped when converting to columnar

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -522,8 +522,17 @@ ConvertTable(TableConversionState *con)
 	bool includeIndexes = true;
 	if (con->accessMethod && strcmp(con->accessMethod, "columnar") == 0)
 	{
-		ereport(NOTICE, (errmsg("any index will be dropped, because "
-								"columnar tables cannot have indexes")));
+		List *explicitIndexesOnTable = GetExplicitIndexOidList(con->relationId);
+		Oid indexOid = InvalidOid;
+		foreach_oid(indexOid, explicitIndexesOnTable)
+		{
+			ereport(NOTICE, (errmsg("the index %s on table %s will be dropped, "
+									"because columnar tables cannot have indexes",
+									get_rel_name(indexOid),
+									quote_qualified_identifier(con->schemaName,
+															   con->relationName))));
+		}
+
 		includeIndexes = false;
 	}
 	List *postLoadCommands = GetPostLoadTableCreationCommands(con->relationId,

--- a/src/backend/distributed/commands/create_citus_local_table.c
+++ b/src/backend/distributed/commands/create_citus_local_table.c
@@ -60,7 +60,6 @@ static char * GetRenameShardTriggerCommand(Oid shardRelationId, char *triggerNam
 										   uint64 shardId);
 static void DropRelationTruncateTriggers(Oid relationId);
 static char * GetDropTriggerCommand(Oid relationId, char *triggerName);
-static List * GetExplicitIndexOidList(Oid relationId);
 static List * GetRenameStatsCommandList(List *statsOidList, uint64 shardId);
 static void DropAndMoveDefaultSequenceOwnerships(Oid sourceRelationId,
 												 Oid targetRelationId);
@@ -733,7 +732,7 @@ GetDropTriggerCommand(Oid relationId, char *triggerName)
  *  - exclusion indexes
  * that are actually applied by the related constraints.
  */
-static List *
+List *
 GetExplicitIndexOidList(Oid relationId)
 {
 	int scanKeyCount = 1;

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -493,6 +493,7 @@ extern void ExecuteForeignKeyCreateCommandList(List *ddlCommandList,
 
 /* create_citus_local_table.c */
 extern void CreateCitusLocalTable(Oid relationId, bool cascadeViaForeignKeys);
+extern List * GetExplicitIndexOidList(Oid relationId);
 
 extern bool ShouldPropagateSetCommand(VariableSetStmt *setStmt);
 extern void PostprocessVariableSetStmt(VariableSetStmt *setStmt, const char *setCommand);

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -36,7 +36,6 @@ SELECT table_name, access_method FROM public.citus_tables WHERE table_name::text
 (1 row)
 
 SELECT alter_table_set_access_method('dist_table', 'columnar');
-NOTICE:  any index will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.dist_table
 NOTICE:  Moving the data of alter_table_set_access_method.dist_table
 NOTICE:  Dropping the old alter_table_set_access_method.dist_table
@@ -117,7 +116,6 @@ SELECT alter_table_set_access_method('partitioned_table', 'columnar');
 ERROR:  you cannot alter access method of a partitioned table
 -- test altering the partition's access method
 SELECT alter_table_set_access_method('partitioned_table_1_5', 'columnar');
-NOTICE:  any index will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.partitioned_table_1_5
 NOTICE:  Moving the data of alter_table_set_access_method.partitioned_table_1_5
 NOTICE:  Dropping the old alter_table_set_access_method.partitioned_table_1_5
@@ -215,13 +213,11 @@ SELECT event FROM time_partitioned ORDER BY 1;
 -- compress 2 old partitions
 CALL alter_old_partitions_set_access_method('time_partitioned', '2021-01-01', 'columnar');
 NOTICE:  converting time_partitioned_d00 with start time Sat Jan 01 00:00:00 2000 and end time Thu Dec 31 00:00:00 2009
-NOTICE:  any index will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.time_partitioned_d00
 NOTICE:  Moving the data of alter_table_set_access_method.time_partitioned_d00
 NOTICE:  Dropping the old alter_table_set_access_method.time_partitioned_d00
 NOTICE:  Renaming the new table to alter_table_set_access_method.time_partitioned_d00
 NOTICE:  converting time_partitioned_d10 with start time Fri Jan 01 00:00:00 2010 and end time Tue Dec 31 00:00:00 2019
-NOTICE:  any index will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.time_partitioned_d10
 NOTICE:  Moving the data of alter_table_set_access_method.time_partitioned_d10
 NOTICE:  Dropping the old alter_table_set_access_method.time_partitioned_d10
@@ -311,7 +307,8 @@ SELECT a.amname FROM pg_class c, pg_am a where c.relname = 'index_table' AND c.r
 (1 row)
 
 SELECT alter_table_set_access_method('index_table', 'columnar');
-NOTICE:  any index will be dropped, because columnar tables cannot have indexes
+NOTICE:  the index idx1 on table alter_table_set_access_method.index_table will be dropped, because columnar tables cannot have indexes
+NOTICE:  the index idx2 on table alter_table_set_access_method.index_table will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.index_table
 NOTICE:  Moving the data of alter_table_set_access_method.index_table
 NOTICE:  Dropping the old alter_table_set_access_method.index_table
@@ -447,7 +444,6 @@ create table test_fk_p(i int references test_pk(n)) partition by range(i);
 create table test_fk_p0 partition of test_fk_p for values from (0) to (10);
 create table test_fk_p1 partition of test_fk_p for values from (10) to (20);
 select alter_table_set_access_method('test_fk_p1', 'columnar');
-NOTICE:  any index will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.test_fk_p1
 NOTICE:  Moving the data of alter_table_set_access_method.test_fk_p1
 NOTICE:  Dropping the old alter_table_set_access_method.test_fk_p1


### PR DESCRIPTION
Now instead of saying "any index" the notice tells the names of the indexes that will not exists after converting to columnar.