### PR TITLE
fix NaN cost estimate on empty columnar tables

### DIFF
--- a/src/test/regress/expected/am_empty.out
+++ b/src/test/regress/expected/am_empty.out
@@ -94,6 +94,19 @@ truncate t_compressed;
 -- alter type
 alter table t_uncompressed alter column a type text;
 alter table t_compressed alter column a type text;
+-- verify cost of scanning an empty table is zero, not NaN
+explain table t_uncompressed;
+                                   QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on t_uncompressed  (cost=0.00..0.00 rows=1 width=32)
+(1 row)
+
+explain table t_compressed;
+                                  QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on t_compressed  (cost=0.00..0.00 rows=1 width=32)
+(1 row)
+
 -- drop
 drop table t_compressed;
 drop table t_uncompressed;

--- a/src/test/regress/sql/am_empty.sql
+++ b/src/test/regress/sql/am_empty.sql
@@ -43,6 +43,10 @@ truncate t_compressed;
 alter table t_uncompressed alter column a type text;
 alter table t_compressed alter column a type text;
 
+-- verify cost of scanning an empty table is zero, not NaN
+explain table t_uncompressed;
+explain table t_compressed;
+
 -- drop
 drop table t_compressed;
 drop table t_uncompressed;


### PR DESCRIPTION
Fixing a division by zero in the cost calculations for scanning a columnar table.

Due to how the columns in a columnar table are counted an empty table would result in a division by zero. Instead this patch keeps the column selection ratio on zero when this happens, resulting in an accurate cost of zero pages to scan a columnar table.

fixes #4589