### PR TITLE
Allow Citus local tables with 2PC

### DIFF
--- a/src/test/regress/expected/citus_local_tables_queries_mx.out
+++ b/src/test/regress/expected/citus_local_tables_queries_mx.out
@@ -1015,6 +1015,82 @@ BEGIN;
 (0 rows)
 
 COMMIT;
+-- users are not allowed to use
+-- citus local tables in prepared statements
+-- from the worker nodes
+BEGIN;
+	INSERT INTO citus_local_table VALUES (3), (4);
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+BEGIN;
+	SELECT count(*) FROM citus_local_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+BEGIN;
+	SELECT count(*) FROM reference_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	SELECT count(*) FROM citus_local_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+BEGIN;
+	SELECT count(*) FROM citus_local_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+	SELECT count(*) FROM reference_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+BEGIN;
+	SELECT count(*) FROM citus_local_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+	SELECT count(*) FROM distributed_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+BEGIN;
+	SELECT count(*) FROM distributed_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	SELECT count(*) FROM citus_local_table;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
 \c - - - :master_port
 -- cleanup at exit
 DROP SCHEMA citus_local_table_queries_mx CASCADE;

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -1207,6 +1207,128 @@ SELECT citus_add_local_table_to_metadata('local_table_2', cascade_via_foreign_ke
 
 (1 row)
 
+CREATE TABLE distributed_table_tx_blck (col_1 INT UNIQUE);
+SELECT create_distributed_table('distributed_table_tx_blck', 'col_1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE ref_table_tx_blck (col_1 INT UNIQUE);
+SELECT create_reference_table('ref_table_tx_blck');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- make sure that we can do 2PC with a citus local table
+BEGIN;
+	INSERT INTO local_table_1 VALUES (1);
+ PREPARE TRANSACTION 'citus_local_tx';
+ ROLLBACK PREPARED 'citus_local_tx';
+-- make sure that we can do 2PC with citus local tables
+-- multiple statements
+BEGIN;
+	INSERT INTO local_table_1 VALUES (1);
+	INSERT INTO local_table_1 VALUES (2);
+ PREPARE TRANSACTION 'citus_local_tx';
+ ROLLBACK PREPARED 'citus_local_tx';
+-- make sure that we cannot do 2PC with citus local tables
+-- when local execution is disabled
+BEGIN;
+	SET citus.enable_local_execution TO false;
+	INSERT INTO local_table_1 VALUES (1);
+	INSERT INTO local_table_1 VALUES (2);
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+-- make sure that we cannot do 2PC with citus local tables
+-- when it is used with distributed tables on the tx block
+BEGIN;
+	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
+	INSERT INTO local_table_1 VALUES (1);
+	SELECT count(*) FROM distributed_table_tx_blck;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+-- make sure that we cannot do 2PC with citus local tables
+-- when it is used with distributed tables on the tx block
+BEGIN;
+	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
+	SELECT count(*) FROM distributed_table_tx_blck;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	INSERT INTO local_table_1 VALUES (1);
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+-- make sure that we cannot do 2PC with citus local tables
+-- when it is used with distributed tables on the tx block
+-- even if local execution is disabled
+BEGIN;
+	SET citus.enable_local_execution TO false;
+	SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
+	SELECT count(*) FROM distributed_table_tx_blck;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	INSERT INTO local_table_1 VALUES (1);
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+ -- make sure that we cannot do 2PC with citus local
+ -- tables and reference tables
+ BEGIN;
+ 	SELECT count(*) FROM ref_table_tx_blck;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ 	INSERT INTO local_table_1 VALUES (1);
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+ BEGIN;
+ 	INSERT INTO local_table_1 VALUES (1);
+ 	SELECT count(*) FROM ref_table_tx_blck;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+ BEGIN;
+ 	SELECT count(*) FROM local_table_1;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ 	SELECT count(*) FROM ref_table_tx_blck;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
+ BEGIN;
+ 	 INSERT INTO ref_table_tx_blck VALUES (1000);
+ 	SELECT count(*) FROM local_table_1;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ PREPARE TRANSACTION 'citus_local_tx';
+ERROR:  cannot use 2PC in transactions involving multiple servers
 CREATE PROCEDURE call_delegation(x int) LANGUAGE plpgsql AS $$
 BEGIN
 	 INSERT INTO test (x) VALUES ($1);

--- a/src/test/regress/sql/citus_local_tables_queries_mx.sql
+++ b/src/test/regress/sql/citus_local_tables_queries_mx.sql
@@ -658,6 +658,33 @@ BEGIN;
 	SELECT * FROM reference_table ORDER BY 1,2;
 COMMIT;
 
+-- users are not allowed to use
+-- citus local tables in prepared statements
+-- from the worker nodes
+BEGIN;
+	INSERT INTO citus_local_table VALUES (3), (4);
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+BEGIN;
+	SELECT count(*) FROM citus_local_table;
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+BEGIN;
+	SELECT count(*) FROM reference_table;
+	SELECT count(*) FROM citus_local_table;
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+BEGIN;
+	SELECT count(*) FROM citus_local_table;
+	SELECT count(*) FROM reference_table;
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+BEGIN;
+	SELECT count(*) FROM citus_local_table;
+	SELECT count(*) FROM distributed_table;
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+BEGIN;
+	SELECT count(*) FROM distributed_table;
+	SELECT count(*) FROM citus_local_table;
+PREPARE TRANSACTION 'citus_local_tx_on_mx';
+
+
 \c - - - :master_port
 -- cleanup at exit
 DROP SCHEMA citus_local_table_queries_mx CASCADE;


### PR DESCRIPTION
This pr has some implications, so we should discuss a little further:

- The experience on Citus MX is different than coordinator for local tables. Do we really want this? 
- The root of the problem is that `DistributedExecutionRequiresRollback ()` decides on remote transaction's rollback behavior. But, at that point we really don't know whether any remote transaction would happen or not.  
     -  Especially with our "failover to local" logic, moving `DecideTransactionPropertiesForTaskList ()` after deciding  on local vs remote tasks (e.g., `CreateDistributedExecution()`) is not enough. We have to defer this decision to after running remote execution (e.g., `RunDistributedExecution()`), which also complicates the code quite a bit. 
     - That's why, I ended up relying on `ShouldExecuteTasksLocally ` in `DecideTransactionPropertiesForTaskList ` which is not great 

May fix #4509