### PR TITLE
Fix a flaky behaviour in shared_connection_stats

### DIFF
--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -227,10 +227,10 @@ COMMIT;
 -- and only 5 connections are used per node
 BEGIN;
 	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
-	SELECT count(*), pg_sleep(0.1) FROM test;
- count | pg_sleep
+	with cte_1 as (select pg_sleep(0.1) is null, a from test) SELECT a from cte_1 ORDER By 1 LIMIT 1;
+ a
 ---------------------------------------------------------------------
-   101 |
+ 0
 (1 row)
 
 	SELECT

--- a/src/test/regress/sql/shared_connection_stats.sql
+++ b/src/test/regress/sql/shared_connection_stats.sql
@@ -149,7 +149,7 @@ COMMIT;
 -- and only 5 connections are used per node
 BEGIN;
 	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
-	SELECT count(*), pg_sleep(0.1) FROM test;
+	with cte_1 as (select pg_sleep(0.1) is null, a from test) SELECT a from cte_1 ORDER By 1 LIMIT 1;
 	SELECT
 		connection_count_to_node
 	FROM


### PR DESCRIPTION
With the previous query, we were not pushing down the pg_sleep hence the
number of connections to a worker could be different from run to run.
