### PR TITLE
Columnar: Fix lateral joins

### DIFF
--- a/src/test/regress/expected/am_query.out
+++ b/src/test/regress/expected/am_query.out
@@ -1,6 +1,8 @@
 --
--- Test querying cstore_fdw tables.
+-- Test querying columnar tables.
 --
+CREATE SCHEMA columnar_join;
+SET search_path to columnar_join, public;
 -- Settings to make the result deterministic
 SET datestyle = "ISO, YMD";
 -- Query uncompressed data
@@ -119,3 +121,63 @@ INSERT INTO union_second SELECT a, a FROM generate_series(11, 15) a;
 (10 rows)
 
 DROP TABLE union_first, union_second;
+-- https://github.com/citusdata/citus/issues/4600
+CREATE TABLE INT8_TBL_columnar(q1 int8, q2 int8) using columnar;
+INSERT INTO INT8_TBL_columnar VALUES('  123   ','  456');
+INSERT INTO INT8_TBL_columnar VALUES('123   ','4567890123456789');
+INSERT INTO INT8_TBL_columnar VALUES('4567890123456789','123');
+INSERT INTO INT8_TBL_columnar VALUES(+4567890123456789,'4567890123456789');
+INSERT INTO INT8_TBL_columnar VALUES('+4567890123456789','-4567890123456789');
+explain (costs off, summary off) select * from
+  INT8_TBL_columnar a left join lateral
+  (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
+   INT8_TBL_columnar b cross join INT8_TBL_columnar c) ss
+  on a.q2 = ss.bq1;
+                          QUERY PLAN
+---------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ColumnarScan) on int8_tbl_columnar a
+   ->  Nested Loop
+         ->  Custom Scan (ColumnarScan) on int8_tbl_columnar b
+               Filter: (a.q2 = q1)
+         ->  Custom Scan (ColumnarScan) on int8_tbl_columnar c
+(6 rows)
+
+explain (costs off, summary off)
+  SELECT COUNT(*) FROM INT8_TBL_columnar t1 JOIN
+  LATERAL (SELECT * FROM INT8_TBL_columnar t2 WHERE t1.q1 = t2.q1)
+  as foo ON (true);
+                              QUERY PLAN
+---------------------------------------------------------------------
+ Aggregate
+   ->  Hash Join
+         Hash Cond: (t2.q1 = t1.q1)
+         ->  Custom Scan (ColumnarScan) on int8_tbl_columnar t2
+         ->  Hash
+               ->  Custom Scan (ColumnarScan) on int8_tbl_columnar t1
+(6 rows)
+
+CREATE TABLE INT8_TBL_heap (LIKE INT8_TBL_columnar) ;
+INSERT INTO INT8_TBL_heap SELECT * FROM INT8_TBL_columnar;
+CREATE TABLE result_columnar AS
+select * from
+  INT8_TBL_columnar a left join lateral
+  (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
+   INT8_TBL_columnar b cross join INT8_TBL_columnar c) ss
+  on a.q2 = ss.bq1;
+CREATE TABLE result_regular AS
+select * from
+  INT8_TBL_heap a left join lateral
+  (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
+   INT8_TBL_heap b cross join INT8_TBL_heap c) ss
+  on a.q2 = ss.bq1;
+-- 2 results should be identical, so the following should be empty
+(table result_columnar EXCEPT table result_regular)
+UNION
+(table result_regular EXCEPT table result_columnar);
+ q1 | q2 | bq1 | cq1 | least
+---------------------------------------------------------------------
+(0 rows)
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA columnar_join CASCADE;


### PR DESCRIPTION
Scan node for columnar tables must be parameterized when they are participating in a lateral join. Previously we crashed because we didn't. This change sets `path->param_info` similar to how its done in `create_seqscan_path()` function at `postgres/src/backend/optimizer/util/pathnode.c`.

Fixes #4600 
