### PR TITLE
Delete all upgrade test artifacts before check-citus-upgrade-local

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -212,18 +212,21 @@ check-citus-upgrade-mixed:
 		--citus-post-tar=$(citus-post-tar) \
 		--mixed
 
-check-citus-upgrade-local:
+check-citus-upgrade-local: clean-upgrade-artifacts
 	$(citus_upgrade_check) \
 		--bindir=$(bindir) \
 		--pgxsdir=$(pgxsdir) \
 		--citus-old-version=$(citus-old-version)
 
-check-citus-upgrade-mixed-local:
+check-citus-upgrade-mixed-local: clean-upgrade-artifacts
 	$(citus_upgrade_check) \
 		--bindir=$(bindir) \
 		--pgxsdir=$(pgxsdir) \
 		--citus-old-version=$(citus-old-version) \
 		--mixed
+
+clean-upgrade-artifacts:
+	rm -rf $(citus_abs_srcdir)/tmp_citus_tarballs/ $(citus_abs_srcdir)/tmp_citus_upgrade/ /tmp/citus_copy/
 
 clean distclean maintainer-clean:
 	rm -f $(output_files) $(input_files)

--- a/src/test/regress/upgrade/generate_citus_tarballs.sh
+++ b/src/test/regress/upgrade/generate_citus_tarballs.sh
@@ -49,10 +49,6 @@ build_ext() {
   citus_version="$1"
   basedir="${base}/${citus_version}"
 
-  if test -f "${base}/install-citus${citus_version}.tar"; then
-    return
-  fi
-
   mkdir -p "${basedir}"
   cd "${basedir}"
   citus_dir=${basedir}/citus_$citus_version


### PR DESCRIPTION
During development cycle, consecutive upgrade test runs do not work.
- We create tarballs, and later copy the whole git working directory to a seperate directory `/tmp/citus_copy/` This results in an ever increasing tarball size that includes the previous tarball in it.
- We get permission errors on Mac, or docker setups on consecutive runs

To test this PR, try to run citus upgrade tests locally, twice.