### PR TITLE
Columnar: always disable parallel paths.

### DIFF
--- a/src/test/regress/columnar_am_schedule
+++ b/src/test/regress/columnar_am_schedule
@@ -8,6 +8,7 @@ test: am_query
 test: am_analyze
 test: am_data_types
 test: am_drop
+test: columnar_fallback_scan
 test: am_empty
 test: am_insert
 test: am_update_delete

--- a/src/test/regress/expected/columnar_fallback_scan.out
+++ b/src/test/regress/expected/columnar_fallback_scan.out
@@ -1,0 +1,53 @@
+--
+-- columnar_fallback_scan.sql
+--
+-- Test columnar.enable_custom_scan = false, which will use an
+-- ordinary sequential scan. It won't benefit from projection pushdown
+-- or qual pushdown, but it should return the correct results.
+--
+set columnar.enable_custom_scan = false;
+create table fallback_scan(i int) using columnar;
+-- large enough to test parallel_workers > 1
+select alter_columnar_table_set('fallback_scan', compression => 'none');
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+insert into fallback_scan select generate_series(1,150000);
+vacuum analyze fallback_scan;
+select count(*), min(i), max(i), avg(i) from fallback_scan;
+ count  | min |  max   |        avg
+---------------------------------------------------------------------
+ 150000 |   1 | 150000 | 75000.500000000000
+(1 row)
+
+--
+-- Negative test: try to force a parallel plan with at least two
+-- workers, but columnar should reject it and use a non-parallel scan.
+--
+set force_parallel_mode = regress;
+set min_parallel_table_scan_size = 1;
+set parallel_tuple_cost = 0;
+set max_parallel_workers = 4;
+set max_parallel_workers_per_gather = 4;
+explain (costs off) select count(*), min(i), max(i), avg(i) from fallback_scan;
+           QUERY PLAN
+---------------------------------------------------------------------
+ Aggregate
+   ->  Seq Scan on fallback_scan
+(2 rows)
+
+select count(*), min(i), max(i), avg(i) from fallback_scan;
+ count  | min |  max   |        avg
+---------------------------------------------------------------------
+ 150000 |   1 | 150000 | 75000.500000000000
+(1 row)
+
+set force_parallel_mode to default;
+set min_parallel_table_scan_size to default;
+set parallel_tuple_cost to default;
+set max_parallel_workers to default;
+set max_parallel_workers_per_gather to default;
+set columnar.enable_custom_scan to default;
+drop table fallback_scan;

--- a/src/test/regress/sql/columnar_fallback_scan.sql
+++ b/src/test/regress/sql/columnar_fallback_scan.sql
@@ -1,0 +1,39 @@
+--
+-- columnar_fallback_scan.sql
+--
+-- Test columnar.enable_custom_scan = false, which will use an
+-- ordinary sequential scan. It won't benefit from projection pushdown
+-- or qual pushdown, but it should return the correct results.
+--
+
+set columnar.enable_custom_scan = false;
+
+create table fallback_scan(i int) using columnar;
+-- large enough to test parallel_workers > 1
+select alter_columnar_table_set('fallback_scan', compression => 'none');
+insert into fallback_scan select generate_series(1,150000);
+vacuum analyze fallback_scan;
+
+select count(*), min(i), max(i), avg(i) from fallback_scan;
+
+--
+-- Negative test: try to force a parallel plan with at least two
+-- workers, but columnar should reject it and use a non-parallel scan.
+--
+set force_parallel_mode = regress;
+set min_parallel_table_scan_size = 1;
+set parallel_tuple_cost = 0;
+set max_parallel_workers = 4;
+set max_parallel_workers_per_gather = 4;
+explain (costs off) select count(*), min(i), max(i), avg(i) from fallback_scan;
+select count(*), min(i), max(i), avg(i) from fallback_scan;
+
+set force_parallel_mode to default;
+set min_parallel_table_scan_size to default;
+set parallel_tuple_cost to default;
+set max_parallel_workers to default;
+set max_parallel_workers_per_gather to default;
+
+set columnar.enable_custom_scan to default;
+
+drop table fallback_scan;


### PR DESCRIPTION
Previously, if columnar.enable_custom_scan was false, parallel paths
could remain, leading to an unexpected error.

Also, ensure that cheapest_parameterized_paths is cleared if a custom
scan is used.
