### PR TITLE
Not try to sync metadata for local tables

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1138,7 +1138,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 	{
 		changeDependencyFor(RelationRelationId, sequenceOid,
 							RelationRelationId, sourceId, targetId);
-		if (ShouldSyncTableMetadata(sourceId))
+		if (IsCitusTable(sourceId) && ShouldSyncTableMetadata(sourceId))
 		{
 			Oid sequenceSchemaOid = get_rel_namespace(sequenceOid);
 			char *sequenceSchemaName = get_namespace_name(sequenceSchemaOid);

--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1138,7 +1138,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 	{
 		changeDependencyFor(RelationRelationId, sequenceOid,
 							RelationRelationId, sourceId, targetId);
-		if (IsCitusTable(sourceId) && ShouldSyncTableMetadata(sourceId))
+		if (ShouldSyncTableMetadata(sourceId))
 		{
 			Oid sequenceSchemaOid = get_rel_namespace(sequenceOid);
 			char *sequenceSchemaName = get_namespace_name(sequenceSchemaOid);

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -243,6 +243,11 @@ ClusterHasKnownMetadataWorkers()
 bool
 ShouldSyncTableMetadata(Oid relationId)
 {
+	if (!OidIsValid(relationId) || !IsCitusTable(relationId))
+	{
+		return false;
+	}
+
 	CitusTableCacheEntry *tableEntry = GetCitusTableCacheEntry(relationId);
 
 	bool streamingReplicated =

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -492,7 +492,8 @@ SELECT * FROM mat_view ORDER BY a;
  2
 (2 rows)
 
-CREATE TABLE local(a int);
+CREATE SEQUENCE c_seq;
+CREATE TABLE local(a int, b bigserial, c int default nextval('c_seq'));
 INSERT INTO local VALUES (3);
 create materialized view m_local as select * from local;
 create view v_local as select * from local;
@@ -615,9 +616,9 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.dist
 (1 row)
 
 SELECT * FROM m_local;
- a
+ a | b | c
 ---------------------------------------------------------------------
- 3
+ 3 | 1 | 1
 (1 row)
 
 SELECT * FROM m_ref;
@@ -635,9 +636,9 @@ SELECT * FROM m_dist;
 (2 rows)
 
 SELECT * FROM v_local;
- a
+ a | b | c
 ---------------------------------------------------------------------
- 3
+ 3 | 1 | 1
 (1 row)
 
 SELECT * FROM v_ref;

--- a/src/test/regress/sql/alter_table_set_access_method.sql
+++ b/src/test/regress/sql/alter_table_set_access_method.sql
@@ -156,7 +156,8 @@ CREATE MATERIALIZED VIEW mat_view AS SELECT * FROM mat_view_test;
 SELECT alter_table_set_access_method('mat_view_test','columnar');
 SELECT * FROM mat_view ORDER BY a;
 
-CREATE TABLE local(a int);
+CREATE SEQUENCE c_seq;
+CREATE TABLE local(a int, b bigserial, c int default nextval('c_seq'));
 INSERT INTO local VALUES (3);
 create materialized view m_local as select * from local;
 create view v_local as select * from local;


### PR DESCRIPTION
Fixes #4624

Since `ReplaceTable` calls `ShouldSyncTableMetadata` when fixing sequence dependencies,
we were erroring out when executing `alter_table_set_access_method` for local tables.

