### PR TITLE
Grep Remote/Local commands

### DIFF
--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -513,8 +513,14 @@ LogLocalCommand(Task *task)
 		return;
 	}
 
+	const char *command = TaskQueryString(task);
+	if (!CommandMatchesLogGrepPattern(command))
+	{
+		return;
+	}
+
 	ereport(NOTICE, (errmsg("executing the command locally: %s",
-							ApplyLogRedaction(TaskQueryString(task)))));
+							ApplyLogRedaction(command))));
 }
 
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1088,6 +1088,18 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomStringVariable(
+		"citus.grep_remote_commands",
+		gettext_noop(
+			"Applies \"command\" like citus.grep_remote_commands, if returns "
+			"true, the command is logged."),
+		NULL,
+		&GrepRemoteCommands,
+		"",
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	DefineCustomIntVariable(
 		"citus.isolation_test_session_process_id",
 		NULL,

--- a/src/include/distributed/remote_commands.h
+++ b/src/include/distributed/remote_commands.h
@@ -20,6 +20,7 @@
 
 /* GUC, determining whether statements sent to remote nodes are logged */
 extern bool LogRemoteCommands;
+extern char *GrepRemoteCommands;
 
 /* GUC that determines the number of bytes after which remote COPY is flushed */
 extern int RemoteCopyFlushThreshold;
@@ -38,6 +39,7 @@ extern void ReportResultError(MultiConnection *connection, PGresult *result,
 							  int elevel);
 extern char * pchomp(const char *in);
 extern void LogRemoteCommand(MultiConnection *connection, const char *command);
+extern bool CommandMatchesLogGrepPattern(const char *command);
 
 /* wrappers around libpq functions, with command logging support */
 extern void ExecuteCriticalRemoteCommandList(MultiConnection *connection,

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -267,6 +267,68 @@ WITH cte_1 AS (UPDATE test SET y = y - 1 RETURNING *) SELECT * FROM cte_1 ORDER 
  5 | 6
 (5 rows)
 
+-- show that we can filter remote commands
+-- given that citus.grep_remote_commands, we log all commands
+SET citus.log_local_commands to true;
+SELECT count(*) FROM public.another_schema_table WHERE a = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM public.another_schema_table_90630515 another_schema_table WHERE (a OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- grep matches all commands
+SET citus.grep_remote_commands TO "%%";
+SELECT count(*) FROM public.another_schema_table WHERE a = 1;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM public.another_schema_table_90630515 another_schema_table WHERE (a OPERATOR(pg_catalog.=) 1)
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- only filter a specific shard for the local execution
+BEGIN;
+	SET LOCAL citus.grep_remote_commands TO "%90630515%";
+	SELECT count(*) FROM public.another_schema_table;
+NOTICE:  executing the command locally: SELECT count(*) AS count FROM public.another_schema_table_90630515 another_schema_table WHERE true
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	-- match nothing
+	SET LOCAL citus.grep_remote_commands TO '%nothing%';
+	SELECT count(*) FROM public.another_schema_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+COMMIT;
+-- only filter a specific shard for the remote execution
+BEGIN;
+	SET LOCAL citus.enable_local_execution TO FALSE;
+	SET LOCAL citus.grep_remote_commands TO '%90630515%';
+	SET LOCAL citus.log_remote_commands TO ON;
+	SELECT count(*) FROM public.another_schema_table;
+NOTICE:  issuing SELECT count(*) AS count FROM public.another_schema_table_90630515 another_schema_table WHERE true
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	-- match nothing
+	SET LOCAL citus.grep_remote_commands TO '%nothing%';
+	SELECT count(*) FROM public.another_schema_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+COMMIT;
+RESET citus.log_local_commands;
+RESET citus.grep_remote_commands;
 -- Test upsert with constraint
 CREATE TABLE upsert_test
 (


### PR DESCRIPTION
`SET citus.log_remote_commands TO ON;` typically generates excessive output. And, most of the time (including the tests) a single shard is good enough. This PR introduces the idea of `grep on remote commands`.

Internally, it uses `SELECT textlike(command, pattern)` and if returns true, the command is logged. This is equivalent to SQL LIKE operator: `SELECT command LIKE pattern`;

```SQL
set citus.log_remote_commands TO On;
select count(*) from table_1;
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102074 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102075 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102076 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102077 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102080 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102078 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102079 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102083 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102081 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102082 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102086 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102084 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102085 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102089 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102087 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102088 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102092 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102090 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102091 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102095 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102093 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102094 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102096 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102098 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102097 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102101 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 1
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102099 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102100 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102104 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9700 connectionId: 4
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102103 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102102 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 2
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102105 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9701 connectionId: 6
 count 
-------
     0
(1 row)
```

To:
```SQL

set citus.grep_remote_commands to "%102103%";
select count(*) from table_1;
NOTICE:  issuing SELECT count(*) AS count FROM table_1_102103 table_1 WHERE true
DETAIL:  on server onderkalaci@localhost:9702 connectionId: 3
 count 
-------
     0
(1 row)

Time: 9.125 ms
```
