### PR TITLE
Fix Semmle errors

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1418,8 +1418,16 @@ CheckAlterDistributedTableConversionParameters(TableConversionState *con)
 
 		Var *colocateWithPartKey = DistPartitionKey(colocateWithTableOid);
 
-		if (con->distributionColumn &&
-			colocateWithPartKey->vartype != con->distributionKey->vartype)
+		if (colocateWithPartKey == NULL)
+		{
+			/* this should never happen */
+			ereport(ERROR, (errmsg("cannot colocate %s with %s because %s doesn't have a "
+								   "distribution column",
+								   con->relationName, con->colocateWith,
+								   con->colocateWith)));
+		}
+		else if (con->distributionColumn &&
+				 colocateWithPartKey->vartype != con->distributionKey->vartype)
 		{
 			ereport(ERROR, (errmsg("cannot colocate with %s and change distribution "
 								   "column to %s because data type of column %s is "

--- a/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
+++ b/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
@@ -68,6 +68,13 @@ CascadeOperationForConnectedRelations(Oid relationId, LOCKMODE lockMode,
 	InvalidateForeignKeyGraph();
 
 	List *fKeyConnectedRelationIdList = GetForeignKeyConnectedRelationIdList(relationId);
+
+	/* early exit if there are no connected relations */
+	if (fKeyConnectedRelationIdList == NIL)
+	{
+		return;
+	}
+
 	LockRelationsWithLockMode(fKeyConnectedRelationIdList, lockMode);
 
 	/*

--- a/src/backend/distributed/commands/index_pg_source.c
+++ b/src/backend/distributed/commands/index_pg_source.c
@@ -181,13 +181,13 @@ ChooseIndexColumnNames(List *indexElems)
 			{
 				break;          /* found nonconflicting name */
 			}
-			sprintf(nbuf, "%d", i);
+			sprintf(nbuf, "%d", i); /* lgtm[cpp/banned-api-usage-required-any] */
 
 			/* Ensure generated names are shorter than NAMEDATALEN */
 			nlen = pg_mbcliplen(origname, strlen(origname),
 								NAMEDATALEN - 1 - strlen(nbuf));
-			memcpy(buf, origname, nlen);
-			strcpy(buf + nlen, nbuf);
+			memcpy(buf, origname, nlen); /* lgtm[cpp/banned-api-usage-required-any] */
+			strcpy(buf + nlen, nbuf); /* lgtm[cpp/banned-api-usage-required-any] */
 			curname = buf;
 		}
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -682,7 +682,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		 * Ensure value is valid, we can't do some checks during CREATE
 		 * EXTENSION. This is important to register some invalidation callbacks.
 		 */
-		CitusHasBeenLoaded();
+		CitusHasBeenLoaded(); /* lgtm[cpp/return-value-ignored] */
 	}
 }
 

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -849,7 +849,7 @@ InitializeTableCacheEntry(int64 shardId)
 	Oid relationId = LookupShardRelationFromCatalog(shardId, missingOk);
 
 	/* trigger building the cache for the shard id */
-	GetCitusTableCacheEntry(relationId);
+	GetCitusTableCacheEntry(relationId); /* lgtm[cpp/return-value-ignored] */
 }
 
 

--- a/src/backend/distributed/operations/citus_tools.c
+++ b/src/backend/distributed/operations/citus_tools.c
@@ -509,7 +509,13 @@ ExecuteRemoteQueryOrCommand(char *nodeName, uint32 nodePort, char *queryString,
 		return false;
 	}
 
-	SendRemoteCommand(connection, queryString);
+	if (!SendRemoteCommand(connection, queryString))
+	{
+		appendStringInfo(queryResultString, "failed to send query to %s:%d", nodeName,
+						 (int) nodePort);
+		return false;
+	}
+
 	PGresult *queryResult = GetRemoteCommandResult(connection, raiseInterrupts);
 	bool success = EvaluateQueryResult(connection, queryResult, queryResultString);
 

--- a/src/backend/distributed/planner/local_distributed_join_planner.c
+++ b/src/backend/distributed/planner/local_distributed_join_planner.c
@@ -237,7 +237,7 @@ ResultRTEIdentity(Query *query)
 	int resultRTEIdentity = INVALID_RTE_IDENTITY;
 	if (IsModifyCommand(query))
 	{
-		RangeTblEntry *resultRTE = ExtractResultRelationRTE(query);
+		RangeTblEntry *resultRTE = ExtractResultRelationRTEOrError(query);
 		resultRTEIdentity = GetRTEIdentity(resultRTE);
 	}
 	return resultRTEIdentity;

--- a/src/backend/distributed/test/run_from_same_connection.c
+++ b/src/backend/distributed/test/run_from_same_connection.c
@@ -200,10 +200,14 @@ GetRemoteProcessId()
 
 	appendStringInfo(queryStringInfo, GET_PROCESS_ID);
 
-	ExecuteOptionalRemoteCommand(singleConnection, queryStringInfo->data, &result);
+	int queryResult = ExecuteOptionalRemoteCommand(singleConnection,
+												   queryStringInfo->data, &result);
+	if (queryResult != RESPONSE_OKAY)
+	{
+		PG_RETURN_VOID();
+	}
 
 	int64 rowCount = PQntuples(result);
-
 	if (rowCount != 1)
 	{
 		PG_RETURN_VOID();

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -87,8 +87,13 @@ fix_pre_citus10_partitioned_table_constraint_names(PG_FUNCTION_ARGS)
 	}
 
 	List *taskList = CreateFixPartitionConstraintsTaskList(relationId);
-	bool localExecutionSupported = true;
-	ExecuteUtilityTaskList(taskList, localExecutionSupported);
+
+	/* do not do anything if there are no constraints that should be fixed */
+	if (taskList != NIL)
+	{
+		bool localExecutionSupported = true;
+		ExecuteUtilityTaskList(taskList, localExecutionSupported);
+	}
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
I ran static analysis tools during release tests and this PR contains my fixes to some of the issues.

- [x] required items
- [x] recommended items
- [ ] best practice items
	- [x] ~"Equality test on floating point values may not behave as expected." (Enterprise feature, no action needed here)~
	- [x] Result of call to CitusHasBeenLoaded is ignored; 95% of calls to this function have their result used. src/backend/distributed/commands/utility_hook.c **SUPPRESSED**
	- [x] Result of call to GetCitusTableCacheEntry is ignored; 98% of calls to this function have their result used. src/backend/distributed/metadata/metadata_cache.c **SUPPRESSED**
	- [x] Result of call to SendRemoteCommand is ignored; 96% of calls to this function have their result used. src/backend/distributed/operations/citus_tools.c
	- [x] Result of call to ExecuteOptionalRemoteCommand is ignored; 90% of calls to this function have their result used. src/backend/distributed/test/run_from_same_connection.c
	- [ ] "94% of the statements in PreprocessAlterStatisticsOwnerStmt are duplicated in [PreprocessAlterStatisticsSchemaStmt]"
		- I asked @agedemenli to take a shot at this.
	- [x] "The result of this call to DistPartitionKey is not checked for null, but 70% of calls to DistPartitionKey check for null." at src/backend/distributed/commands/alter_table.c
		- See #4637 that I assigned to @halilozanakgul 
