### PR TITLE
Columnar: don't double count chunks filtered

### DIFF
--- a/src/backend/columnar/cstore_customscan.c
+++ b/src/backend/columnar/cstore_customscan.c
@@ -490,9 +490,9 @@ ColumnarScan_ExplainCustomScan(CustomScanState *node, List *ancestors,
 
 	if (scanDesc != NULL)
 	{
-		int64 chunksFiltered = ColumnarGetChunksFiltered(scanDesc);
-		ExplainPropertyInteger("Columnar Chunks Removed by Filter", NULL,
-							   chunksFiltered, es);
+		int64 chunkGroupsFiltered = ColumnarGetChunkGroupsFiltered(scanDesc);
+		ExplainPropertyInteger("Columnar Chunk Groups Removed by Filter", NULL,
+							   chunkGroupsFiltered, es);
 	}
 }
 

--- a/src/backend/columnar/cstore_reader.c
+++ b/src/backend/columnar/cstore_reader.c
@@ -529,7 +529,7 @@ SelectedChunkMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 #else
 			predicateRefuted = predicate_refuted_by(constraintList, restrictInfoList);
 #endif
-			if (predicateRefuted)
+			if (predicateRefuted && selectedChunkMask[chunkIndex])
 			{
 				selectedChunkMask[chunkIndex] = false;
 				*chunksFiltered += 1;

--- a/src/backend/columnar/cstore_reader.c
+++ b/src/backend/columnar/cstore_reader.c
@@ -45,7 +45,7 @@ static StripeBuffers * LoadFilteredStripeBuffers(Relation relation,
 												 TupleDesc tupleDescriptor,
 												 List *projectedColumnList,
 												 List *whereClauseList,
-												 int64 *chunksFiltered);
+												 int64 *chunkGroupsFiltered);
 static void ReadStripeNextRow(StripeBuffers *stripeBuffers, List *projectedColumnList,
 							  uint64 chunkIndex, uint64 chunkRowIndex,
 							  ChunkData *chunkData, Datum *columnValues,
@@ -56,7 +56,7 @@ static ColumnBuffers * LoadColumnBuffers(Relation relation,
 										 Form_pg_attribute attributeForm);
 static bool * SelectedChunkMask(StripeSkipList *stripeSkipList,
 								List *projectedColumnList, List *whereClauseList,
-								int64 *chunksFiltered);
+								int64 *chunkGroupsFiltered);
 static List * BuildRestrictInfoList(List *whereClauseList);
 static Node * BuildBaseConstraint(Var *variable);
 static OpExpr * MakeOpExpression(Var *variable, int16 strategyNumber);
@@ -106,7 +106,7 @@ ColumnarBeginRead(Relation relation, TupleDesc tupleDescriptor,
 	readState->stripeBuffers = NULL;
 	readState->readStripeCount = 0;
 	readState->stripeReadRowCount = 0;
-	readState->chunksFiltered = 0;
+	readState->chunkGroupsFiltered = 0;
 	readState->tupleDescriptor = tupleDescriptor;
 	readState->stripeReadContext = stripeReadContext;
 	readState->chunkData = NULL;
@@ -158,7 +158,7 @@ ColumnarReadNextRow(TableReadState *readState, Datum *columnValues, bool *column
 																 readState->
 																 whereClauseList,
 																 &readState->
-																 chunksFiltered);
+																 chunkGroupsFiltered);
 		readState->readStripeCount++;
 		readState->currentStripeMetadata = stripeMetadata;
 
@@ -327,7 +327,7 @@ ColumnarTableRowCount(Relation relation)
 static StripeBuffers *
 LoadFilteredStripeBuffers(Relation relation, StripeMetadata *stripeMetadata,
 						  TupleDesc tupleDescriptor, List *projectedColumnList,
-						  List *whereClauseList, int64 *chunksFiltered)
+						  List *whereClauseList, int64 *chunkGroupsFiltered)
 {
 	uint32 columnIndex = 0;
 	uint32 columnCount = tupleDescriptor->natts;
@@ -340,7 +340,7 @@ LoadFilteredStripeBuffers(Relation relation, StripeMetadata *stripeMetadata,
 														stripeMetadata->chunkCount);
 
 	bool *selectedChunkMask = SelectedChunkMask(stripeSkipList, projectedColumnList,
-												whereClauseList, chunksFiltered);
+												whereClauseList, chunkGroupsFiltered);
 
 	StripeSkipList *selectedChunkSkipList =
 		SelectedChunkSkipList(stripeSkipList, projectedColumnMask,
@@ -479,7 +479,7 @@ LoadColumnBuffers(Relation relation, ColumnChunkSkipNode *chunkSkipNodeArray,
  */
 static bool *
 SelectedChunkMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
-				  List *whereClauseList, int64 *chunksFiltered)
+				  List *whereClauseList, int64 *chunkGroupsFiltered)
 {
 	ListCell *columnCell = NULL;
 	uint32 chunkIndex = 0;
@@ -532,7 +532,7 @@ SelectedChunkMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 			if (predicateRefuted && selectedChunkMask[chunkIndex])
 			{
 				selectedChunkMask[chunkIndex] = false;
-				*chunksFiltered += 1;
+				*chunkGroupsFiltered += 1;
 			}
 		}
 	}

--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -1158,7 +1158,7 @@ columnar_tableam_finish()
  * Get the number of chunks filtered out during the given scan.
  */
 int64
-ColumnarGetChunksFiltered(TableScanDesc scanDesc)
+ColumnarGetChunkGroupsFiltered(TableScanDesc scanDesc)
 {
 	ColumnarScanDesc columnarScanDesc = (ColumnarScanDesc) scanDesc;
 	TableReadState *readState = columnarScanDesc->cs_readState;
@@ -1166,7 +1166,7 @@ ColumnarGetChunksFiltered(TableScanDesc scanDesc)
 	/* readState is initialized lazily */
 	if (readState != NULL)
 	{
-		return readState->chunksFiltered;
+		return readState->chunkGroupsFiltered;
 	}
 	else
 	{

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -232,7 +232,7 @@ typedef struct TableReadState
 	StripeBuffers *stripeBuffers;
 	uint32 readStripeCount;
 	uint64 stripeReadRowCount;
-	int64 chunksFiltered;
+	int64 chunkGroupsFiltered;
 	ChunkData *chunkData;
 	int32 deserializedChunkIndex;
 } TableReadState;

--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -18,7 +18,7 @@ extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot sna
 												 ParallelTableScanDesc parallel_scan,
 												 uint32 flags, Bitmapset *attr_needed,
 												 List *scanQual);
-extern int64 ColumnarGetChunksFiltered(TableScanDesc scanDesc);
+extern int64 ColumnarGetChunkGroupsFiltered(TableScanDesc scanDesc);
 extern bool IsColumnarTableAmTable(Oid relationId);
 extern TableDDLCommand * ColumnarGetTableOptionsDDL(Oid relationId);
 extern char * GetShardedTableDDLCommandColumnar(uint64 shardId, void *context);

--- a/src/test/regress/input/am_chunk_filtering.source
+++ b/src/test/regress/input/am_chunk_filtering.source
@@ -89,3 +89,15 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
   SELECT * FROM simple_chunk_filtering WHERE i > 180000;
 
 DROP TABLE simple_chunk_filtering;
+
+
+CREATE TABLE multi_column_chunk_filtering(a int, b int) USING columnar;
+INSERT INTO multi_column_chunk_filtering SELECT i,i+1 FROM generate_series(0,234567) i;
+
+EXPLAIN (analyze on, costs off, timing off, summary off)
+  SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000;
+
+EXPLAIN (analyze on, costs off, timing off, summary off)
+  SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000 AND b > 50000;
+
+DROP TABLE multi_column_chunk_filtering;

--- a/src/test/regress/output/am_chunk_filtering.source
+++ b/src/test/regress/output/am_chunk_filtering.source
@@ -127,7 +127,7 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
  Custom Scan (ColumnarScan) on simple_chunk_filtering (actual rows=111111 loops=1)
    Filter: (i > 123456)
    Rows Removed by Filter: 3457
-   Columnar Chunks Removed by Filter: 12
+   Columnar Chunk Groups Removed by Filter: 12
 (4 rows)
 
 SET columnar.enable_qual_pushdown = false;
@@ -138,7 +138,7 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
  Custom Scan (ColumnarScan) on simple_chunk_filtering (actual rows=111111 loops=1)
    Filter: (i > 123456)
    Rows Removed by Filter: 123457
-   Columnar Chunks Removed by Filter: 0
+   Columnar Chunk Groups Removed by Filter: 0
 (4 rows)
 
 SET columnar.enable_qual_pushdown TO DEFAULT;
@@ -153,7 +153,7 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
  Custom Scan (ColumnarScan) on simple_chunk_filtering (actual rows=20000 loops=1)
    Filter: (i > 180000)
    Rows Removed by Filter: 1
-   Columnar Chunks Removed by Filter: 18
+   Columnar Chunk Groups Removed by Filter: 18
 (4 rows)
 
 DROP TABLE simple_chunk_filtering;
@@ -167,7 +167,7 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
    ->  Custom Scan (ColumnarScan) on multi_column_chunk_filtering (actual rows=184567 loops=1)
          Filter: (a > 50000)
          Rows Removed by Filter: 1
-         Columnar Chunks Removed by Filter: 5
+         Columnar Chunk Groups Removed by Filter: 5
 (5 rows)
 
 EXPLAIN (analyze on, costs off, timing off, summary off)
@@ -178,7 +178,7 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
    ->  Custom Scan (ColumnarScan) on multi_column_chunk_filtering (actual rows=184567 loops=1)
          Filter: ((a > 50000) AND (b > 50000))
          Rows Removed by Filter: 1
-         Columnar Chunks Removed by Filter: 5
+         Columnar Chunk Groups Removed by Filter: 5
 (5 rows)
 
 DROP TABLE multi_column_chunk_filtering;

--- a/src/test/regress/output/am_chunk_filtering.source
+++ b/src/test/regress/output/am_chunk_filtering.source
@@ -157,3 +157,28 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
 (4 rows)
 
 DROP TABLE simple_chunk_filtering;
+CREATE TABLE multi_column_chunk_filtering(a int, b int) USING columnar;
+INSERT INTO multi_column_chunk_filtering SELECT i,i+1 FROM generate_series(0,234567) i;
+EXPLAIN (analyze on, costs off, timing off, summary off)
+  SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000;
+                                          QUERY PLAN
+---------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ColumnarScan) on multi_column_chunk_filtering (actual rows=184567 loops=1)
+         Filter: (a > 50000)
+         Rows Removed by Filter: 1
+         Columnar Chunks Removed by Filter: 5
+(5 rows)
+
+EXPLAIN (analyze on, costs off, timing off, summary off)
+  SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000 AND b > 50000;
+                                          QUERY PLAN
+---------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (ColumnarScan) on multi_column_chunk_filtering (actual rows=184567 loops=1)
+         Filter: ((a > 50000) AND (b > 50000))
+         Rows Removed by Filter: 1
+         Columnar Chunks Removed by Filter: 5
+(5 rows)
+
+DROP TABLE multi_column_chunk_filtering;


### PR DESCRIPTION
When ranges for multiple chunks refuted the WHERE clause, the number reported in EXPLAN ANALYZE counted each 10k group multiple times.

For example, in the following case we reported 5 filtered chunks in the 1st query but 10 filtered chunks in the 2nd query. But in each of them only 5 10k group was filtered out.

```sql
CREATE TABLE multi_column_chunk_filtering(a int, b int) USING columnar;
INSERT INTO multi_column_chunk_filtering SELECT i,i+1 FROM generate_series(0,234567) i;

EXPLAIN (analyze on, costs off, timing off, summary off)
  SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000;

EXPLAIN (analyze on, costs off, timing off, summary off)
  SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000 AND b > 50000;
```

It might be more useful for the user to report 5 for both of them, so they can reason that "the higher, the better". Otherwise there can be queries where higher is worse.

