### PR TITLE
Columnar: Call nextval_internal instead of DirectFunctionCall.

### DIFF
--- a/src/test/regress/columnar_am_schedule
+++ b/src/test/regress/columnar_am_schedule
@@ -11,6 +11,7 @@ test: am_drop
 test: am_indexes
 test: columnar_fallback_scan
 test: columnar_partitioning
+test: columnar_permissions
 test: am_empty
 test: am_insert
 test: am_update_delete

--- a/src/test/regress/expected/columnar_permissions.out
+++ b/src/test/regress/expected/columnar_permissions.out
@@ -1,0 +1,13 @@
+select current_user \gset
+create user columnar_user;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+\c - columnar_user
+create table columnar_permissions(i int) using columnar;
+insert into columnar_permissions values(1);
+alter table columnar_permissions add column j int;
+insert into columnar_permissions values(2,20);
+vacuum columnar_permissions;
+truncate columnar_permissions;
+drop table columnar_permissions;
+\c - :current_user

--- a/src/test/regress/sql/columnar_permissions.sql
+++ b/src/test/regress/sql/columnar_permissions.sql
@@ -1,0 +1,17 @@
+
+select current_user \gset
+
+create user columnar_user;
+
+\c - columnar_user
+
+create table columnar_permissions(i int) using columnar;
+insert into columnar_permissions values(1);
+alter table columnar_permissions add column j int;
+insert into columnar_permissions values(2,20);
+vacuum columnar_permissions;
+truncate columnar_permissions;
+drop table columnar_permissions;
+
+\c - :current_user
+


### PR DESCRIPTION
Avoid switching security contexts, as that seems potentially dangerous from a security standpoint. Instead, call nextval_internal and bypass security checks.