### PR TITLE
Columnar: improve naming of limit config variables.

### DIFF
--- a/src/backend/columnar/README.md
+++ b/src/backend/columnar/README.md
@@ -73,7 +73,7 @@ Set options using:
 ```sql
 alter_columnar_table_set(
     relid REGCLASS,
-    chunk_row_count INT4 DEFAULT NULL,
+    chunk_group_row_limit INT4 DEFAULT NULL,
     stripe_row_count INT4 DEFAULT NULL,
     compression NAME DEFAULT NULL,
     compression_level INT4)
@@ -102,7 +102,7 @@ The following options are available:
   stripe for _newly-inserted_ data. Existing stripes of data will not
   be changed and may have more rows than this maximum value. The
   default value is `150000`.
-* **chunk_row_count**: ``<integer>`` - the maximum number of rows per
+* **chunk_group_row_limit**: ``<integer>`` - the maximum number of rows per
   chunk for _newly-inserted_ data. Existing chunks of data will not be
   changed and may have more rows than this maximum value. The default
   value is `10000`.
@@ -119,7 +119,7 @@ following GUCs:
 * `columnar.compression`
 * `columnar.compression_level`
 * `columnar.stripe_row_count`
-* `columnar.chunk_row_count`
+* `columnar.chunk_group_row_limit`
 
 GUCs only affect newly-created *tables*, not any newly-created
 *stripes* on an existing table.

--- a/src/backend/columnar/README.md
+++ b/src/backend/columnar/README.md
@@ -74,7 +74,7 @@ Set options using:
 alter_columnar_table_set(
     relid REGCLASS,
     chunk_group_row_limit INT4 DEFAULT NULL,
-    stripe_row_count INT4 DEFAULT NULL,
+    stripe_row_limit INT4 DEFAULT NULL,
     compression NAME DEFAULT NULL,
     compression_level INT4)
 ```
@@ -85,7 +85,7 @@ For example:
 SELECT alter_columnar_table_set(
     'my_columnar_table',
     compression => 'none',
-    stripe_row_count => 10000);
+    stripe_row_limit => 10000);
 ```
 
 The following options are available:
@@ -98,7 +98,7 @@ The following options are available:
   settings are from 1 through 19. If the compression method does not
   support the level chosen, the closest level will be selected
   instead.
-* **stripe_row_count**: ``<integer>`` - the maximum number of rows per
+* **stripe_row_limit**: ``<integer>`` - the maximum number of rows per
   stripe for _newly-inserted_ data. Existing stripes of data will not
   be changed and may have more rows than this maximum value. The
   default value is `150000`.
@@ -118,7 +118,7 @@ following GUCs:
 
 * `columnar.compression`
 * `columnar.compression_level`
-* `columnar.stripe_row_count`
+* `columnar.stripe_row_limit`
 * `columnar.chunk_group_row_limit`
 
 GUCs only affect newly-created *tables*, not any newly-created

--- a/src/backend/columnar/cstore.c
+++ b/src/backend/columnar/cstore.c
@@ -37,7 +37,7 @@
 
 int columnar_compression = DEFAULT_COMPRESSION_TYPE;
 int columnar_stripe_row_count = DEFAULT_STRIPE_ROW_COUNT;
-int columnar_chunk_row_count = DEFAULT_CHUNK_ROW_COUNT;
+int columnar_chunk_group_row_limit = DEFAULT_CHUNK_ROW_COUNT;
 int columnar_compression_level = 3;
 
 static const struct config_enum_entry columnar_compression_options[] =
@@ -94,10 +94,10 @@ columnar_init_gucs()
 							NULL,
 							NULL);
 
-	DefineCustomIntVariable("columnar.chunk_row_count",
+	DefineCustomIntVariable("columnar.chunk_group_row_limit",
 							"Maximum number of rows per chunk.",
 							NULL,
-							&columnar_chunk_row_count,
+							&columnar_chunk_group_row_limit,
 							DEFAULT_CHUNK_ROW_COUNT,
 							CHUNK_ROW_COUNT_MINIMUM,
 							CHUNK_ROW_COUNT_MAXIMUM,

--- a/src/backend/columnar/cstore.c
+++ b/src/backend/columnar/cstore.c
@@ -36,7 +36,7 @@
 #endif
 
 int columnar_compression = DEFAULT_COMPRESSION_TYPE;
-int columnar_stripe_row_count = DEFAULT_STRIPE_ROW_COUNT;
+int columnar_stripe_row_limit = DEFAULT_STRIPE_ROW_COUNT;
 int columnar_chunk_group_row_limit = DEFAULT_CHUNK_ROW_COUNT;
 int columnar_compression_level = 3;
 
@@ -81,10 +81,10 @@ columnar_init_gucs()
 							NULL,
 							NULL);
 
-	DefineCustomIntVariable("columnar.stripe_row_count",
+	DefineCustomIntVariable("columnar.stripe_row_limit",
 							"Maximum number of tuples per stripe.",
 							NULL,
-							&columnar_stripe_row_count,
+							&columnar_stripe_row_limit,
 							DEFAULT_STRIPE_ROW_COUNT,
 							STRIPE_ROW_COUNT_MINIMUM,
 							STRIPE_ROW_COUNT_MAXIMUM,

--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -135,8 +135,8 @@ typedef FormData_columnar_options *Form_columnar_options;
 #define Anum_columnar_stripe_data_length 4
 #define Anum_columnar_stripe_column_count 5
 #define Anum_columnar_stripe_chunk_count 6
-#define Anum_columnar_stripe_chunk_group_row_limit 7
-#define Anum_columnar_stripe_row_limit 8
+#define Anum_columnar_stripe_chunk_row_count 7
+#define Anum_columnar_stripe_row_count 8
 
 /* constants for columnar.chunk */
 #define Natts_columnar_chunk 14
@@ -144,7 +144,7 @@ typedef FormData_columnar_options *Form_columnar_options;
 #define Anum_columnar_chunk_stripe 2
 #define Anum_columnar_chunk_attr 3
 #define Anum_columnar_chunk_chunk 4
-#define Anum_columnar_chunk_group_row_limit 5
+#define Anum_columnar_chunk_value_count 5
 #define Anum_columnar_chunk_minimum_value 6
 #define Anum_columnar_chunk_maximum_value 7
 #define Anum_columnar_chunk_value_stream_offset 8
@@ -524,7 +524,7 @@ ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe, TupleDesc tupleDescri
 
 		ColumnChunkSkipNode *chunk =
 			&chunkList->chunkSkipNodeArray[columnIndex][chunkIndex];
-		chunk->rowCount = DatumGetInt64(datumArray[Anum_columnar_chunk_group_row_limit -
+		chunk->rowCount = DatumGetInt64(datumArray[Anum_columnar_chunk_value_count -
 												   1]);
 		chunk->valueChunkOffset =
 			DatumGetInt64(datumArray[Anum_columnar_chunk_value_stream_offset - 1]);
@@ -794,9 +794,9 @@ ReadDataFileStripeList(uint64 storageId, Snapshot snapshot)
 		stripeMetadata->chunkCount = DatumGetInt32(
 			datumArray[Anum_columnar_stripe_chunk_count - 1]);
 		stripeMetadata->chunkRowCount = DatumGetInt32(
-			datumArray[Anum_columnar_stripe_chunk_group_row_limit - 1]);
+			datumArray[Anum_columnar_stripe_chunk_row_count - 1]);
 		stripeMetadata->rowCount = DatumGetInt64(
-			datumArray[Anum_columnar_stripe_row_limit - 1]);
+			datumArray[Anum_columnar_stripe_row_count - 1]);
 
 		stripeMetadataList = lappend(stripeMetadataList, stripeMetadata);
 	}

--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -105,7 +105,7 @@ PG_FUNCTION_INFO_V1(columnar_relation_storageid);
 #define Natts_columnar_options 5
 #define Anum_columnar_options_regclass 1
 #define Anum_columnar_options_chunk_group_row_limit 2
-#define Anum_columnar_options_stripe_row_count 3
+#define Anum_columnar_options_stripe_row_limit 3
 #define Anum_columnar_options_compression_level 4
 #define Anum_columnar_options_compression 5
 
@@ -117,7 +117,7 @@ typedef struct FormData_columnar_options
 {
 	Oid regclass;
 	int32 chunk_group_row_limit;
-	int32 stripe_row_count;
+	int32 stripe_row_limit;
 	int32 compressionLevel;
 	NameData compression;
 
@@ -136,7 +136,7 @@ typedef FormData_columnar_options *Form_columnar_options;
 #define Anum_columnar_stripe_column_count 5
 #define Anum_columnar_stripe_chunk_count 6
 #define Anum_columnar_stripe_chunk_group_row_limit 7
-#define Anum_columnar_stripe_row_count 8
+#define Anum_columnar_stripe_row_limit 8
 
 /* constants for columnar.chunk */
 #define Natts_columnar_chunk 14
@@ -174,7 +174,7 @@ InitColumnarOptions(Oid regclass)
 
 	ColumnarOptions defaultOptions = {
 		.chunkRowCount = columnar_chunk_group_row_limit,
-		.stripeRowCount = columnar_stripe_row_count,
+		.stripeRowCount = columnar_stripe_row_limit,
 		.compressionType = columnar_compression,
 		.compressionLevel = columnar_compression_level
 	};
@@ -251,7 +251,7 @@ WriteColumnarOptions(Oid regclass, ColumnarOptions *options, bool overwrite)
 			/* update existing record */
 			bool update[Natts_columnar_options] = { 0 };
 			update[Anum_columnar_options_chunk_group_row_limit - 1] = true;
-			update[Anum_columnar_options_stripe_row_count - 1] = true;
+			update[Anum_columnar_options_stripe_row_limit - 1] = true;
 			update[Anum_columnar_options_compression_level - 1] = true;
 			update[Anum_columnar_options_compression - 1] = true;
 
@@ -371,7 +371,7 @@ ReadColumnarOptions(Oid regclass, ColumnarOptions *options)
 		Form_columnar_options tupOptions = (Form_columnar_options) GETSTRUCT(heapTuple);
 
 		options->chunkRowCount = tupOptions->chunk_group_row_limit;
-		options->stripeRowCount = tupOptions->stripe_row_count;
+		options->stripeRowCount = tupOptions->stripe_row_limit;
 		options->compressionLevel = tupOptions->compressionLevel;
 		options->compressionType = ParseCompressionType(NameStr(tupOptions->compression));
 	}
@@ -379,7 +379,7 @@ ReadColumnarOptions(Oid regclass, ColumnarOptions *options)
 	{
 		/* populate options with system defaults */
 		options->compressionType = columnar_compression;
-		options->stripeRowCount = columnar_stripe_row_count;
+		options->stripeRowCount = columnar_stripe_row_limit;
 		options->chunkRowCount = columnar_chunk_group_row_limit;
 		options->compressionLevel = columnar_compression_level;
 	}
@@ -796,7 +796,7 @@ ReadDataFileStripeList(uint64 storageId, Snapshot snapshot)
 		stripeMetadata->chunkRowCount = DatumGetInt32(
 			datumArray[Anum_columnar_stripe_chunk_group_row_limit - 1]);
 		stripeMetadata->rowCount = DatumGetInt64(
-			datumArray[Anum_columnar_stripe_row_count - 1]);
+			datumArray[Anum_columnar_stripe_row_limit - 1]);
 
 		stripeMetadataList = lappend(stripeMetadataList, stripeMetadata);
 	}

--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -1525,7 +1525,7 @@ CitusCreateAlterColumnarTableSet(char *qualifiedRelationName,
 	appendStringInfo(&buf,
 					 "SELECT alter_columnar_table_set(%s, "
 					 "chunk_group_row_limit => %d, "
-					 "stripe_row_count => %lu, "
+					 "stripe_row_limit => %lu, "
 					 "compression_level => %d, "
 					 "compression => %s);",
 					 quote_literal_cstr(qualifiedRelationName),
@@ -1635,7 +1635,7 @@ ColumnarGetTableOptionsDDL(Oid relationId)
  *   pg_catalog.alter_columnar_table_set(
  *        table_name regclass,
  *        chunk_group_row_limit int DEFAULT NULL,
- *        stripe_row_count int DEFAULT NULL,
+ *        stripe_row_limit int DEFAULT NULL,
  *        compression name DEFAULT null)
  *
  * All arguments except the table name are optional. The UDF is supposed to be called
@@ -1674,7 +1674,7 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
 				(errmsg("updating chunk row count to %d", options.chunkRowCount)));
 	}
 
-	/* stripe_row_count => not null */
+	/* stripe_row_limit => not null */
 	if (!PG_ARGISNULL(2))
 	{
 		options.stripeRowCount = PG_GETARG_INT32(2);
@@ -1745,7 +1745,7 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
  *   teset(
  *        table_name regclass,
  *        chunk_group_row_limit bool DEFAULT FALSE,
- *        stripe_row_count bool DEFAULT FALSE,
+ *        stripe_row_limit bool DEFAULT FALSE,
  *        compression bool DEFAULT FALSE)
  *
  * All arguments except the table name are optional. The UDF is supposed to be called
@@ -1781,10 +1781,10 @@ alter_columnar_table_reset(PG_FUNCTION_ARGS)
 				(errmsg("resetting chunk row count to %d", options.chunkRowCount)));
 	}
 
-	/* stripe_row_count => true */
+	/* stripe_row_limit => true */
 	if (!PG_ARGISNULL(2) && PG_GETARG_BOOL(2))
 	{
-		options.stripeRowCount = columnar_stripe_row_count;
+		options.stripeRowCount = columnar_stripe_row_limit;
 		ereport(DEBUG1,
 				(errmsg("resetting stripe row count to " UINT64_FORMAT,
 						options.stripeRowCount)));

--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -1524,7 +1524,7 @@ CitusCreateAlterColumnarTableSet(char *qualifiedRelationName,
 
 	appendStringInfo(&buf,
 					 "SELECT alter_columnar_table_set(%s, "
-					 "chunk_row_count => %d, "
+					 "chunk_group_row_limit => %d, "
 					 "stripe_row_count => %lu, "
 					 "compression_level => %d, "
 					 "compression => %s);",
@@ -1634,7 +1634,7 @@ ColumnarGetTableOptionsDDL(Oid relationId)
  * sql syntax:
  *   pg_catalog.alter_columnar_table_set(
  *        table_name regclass,
- *        chunk_row_count int DEFAULT NULL,
+ *        chunk_group_row_limit int DEFAULT NULL,
  *        stripe_row_count int DEFAULT NULL,
  *        compression name DEFAULT null)
  *
@@ -1666,7 +1666,7 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errmsg("unable to read current options for table")));
 	}
 
-	/* chunk_row_count => not null */
+	/* chunk_group_row_limit => not null */
 	if (!PG_ARGISNULL(1))
 	{
 		options.chunkRowCount = PG_GETARG_INT32(1);
@@ -1744,7 +1744,7 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
  *   pg_catalog.alter_columnar_table_re
  *   teset(
  *        table_name regclass,
- *        chunk_row_count bool DEFAULT FALSE,
+ *        chunk_group_row_limit bool DEFAULT FALSE,
  *        stripe_row_count bool DEFAULT FALSE,
  *        compression bool DEFAULT FALSE)
  *
@@ -1773,10 +1773,10 @@ alter_columnar_table_reset(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errmsg("unable to read current options for table")));
 	}
 
-	/* chunk_row_count => true */
+	/* chunk_group_row_limit => true */
 	if (!PG_ARGISNULL(1) && PG_GETARG_BOOL(1))
 	{
-		options.chunkRowCount = columnar_chunk_row_count;
+		options.chunkRowCount = columnar_chunk_group_row_limit;
 		ereport(DEBUG1,
 				(errmsg("resetting chunk row count to %d", options.chunkRowCount)));
 	}

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -8,7 +8,7 @@ CREATE SEQUENCE storageid_seq MINVALUE 10000000000 NO CYCLE;
 CREATE TABLE options (
     regclass regclass NOT NULL PRIMARY KEY,
     chunk_group_row_limit int NOT NULL,
-    stripe_row_count int NOT NULL,
+    stripe_row_limit int NOT NULL,
     compression_level int NOT NULL,
     compression name NOT NULL
 ) WITH (user_catalog_table = true);

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -7,7 +7,7 @@ CREATE SEQUENCE storageid_seq MINVALUE 10000000000 NO CYCLE;
 
 CREATE TABLE options (
     regclass regclass NOT NULL PRIMARY KEY,
-    chunk_row_count int NOT NULL,
+    chunk_group_row_limit int NOT NULL,
     stripe_row_count int NOT NULL,
     compression_level int NOT NULL,
     compression name NOT NULL
@@ -22,7 +22,7 @@ CREATE TABLE stripe (
     data_length bigint NOT NULL,
     column_count int NOT NULL,
     chunk_count int NOT NULL,
-    chunk_row_count int NOT NULL,
+    chunk_group_row_limit int NOT NULL,
     row_count bigint NOT NULL,
     PRIMARY KEY (storageid, stripeid)
 ) WITH (user_catalog_table = true);

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -22,7 +22,7 @@ CREATE TABLE stripe (
     data_length bigint NOT NULL,
     column_count int NOT NULL,
     chunk_count int NOT NULL,
-    chunk_group_row_limit int NOT NULL,
+    chunk_row_count int NOT NULL,
     row_count bigint NOT NULL,
     PRIMARY KEY (storageid, stripeid)
 ) WITH (user_catalog_table = true);
@@ -34,7 +34,7 @@ CREATE TABLE chunk (
     stripeid bigint NOT NULL,
     attnum int NOT NULL,
     chunkid int NOT NULL,
-    row_count bigint NOT NULL,
+    value_count bigint NOT NULL,
     minimum_value bytea,
     maximum_value bytea,
     value_stream_offset bigint NOT NULL,

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -9,14 +9,14 @@ IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
   EXECUTE $$
     DROP FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,
-        chunk_row_count bool,
+        chunk_group_row_limit bool,
         stripe_row_count bool,
         compression bool,
         compression_level bool);
 
     DROP FUNCTION pg_catalog.alter_columnar_table_set(
         table_name regclass,
-        chunk_row_count int,
+        chunk_group_row_limit int,
         stripe_row_count int,
         compression name,
         compression_level int);

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -10,14 +10,14 @@ IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
     DROP FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,
         chunk_group_row_limit bool,
-        stripe_row_count bool,
+        stripe_row_limit bool,
         compression bool,
         compression_level bool);
 
     DROP FUNCTION pg_catalog.alter_columnar_table_set(
         table_name regclass,
         chunk_group_row_limit int,
-        stripe_row_count int,
+        stripe_row_limit int,
         compression name,
         compression_level int);
 

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_reset/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_reset/10.0-1.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
-    chunk_row_count bool DEFAULT false,
+    chunk_group_row_limit bool DEFAULT false,
     stripe_row_count bool DEFAULT false,
     compression bool DEFAULT false,
     compression_level bool DEFAULT false)
@@ -10,7 +10,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_reset';
 
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
-    chunk_row_count bool,
+    chunk_group_row_limit bool,
     stripe_row_count bool,
     compression bool,
     compression_level bool)

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_reset/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_reset/10.0-1.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool DEFAULT false,
-    stripe_row_count bool DEFAULT false,
+    stripe_row_limit bool DEFAULT false,
     compression bool DEFAULT false,
     compression_level bool DEFAULT false)
     RETURNS void
@@ -11,7 +11,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_reset';
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool,
-    stripe_row_count bool,
+    stripe_row_limit bool,
     compression bool,
     compression_level bool)
 IS 'reset on or more options on a columnar table to the system defaults';

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_reset/latest.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_reset/latest.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
-    chunk_row_count bool DEFAULT false,
+    chunk_group_row_limit bool DEFAULT false,
     stripe_row_count bool DEFAULT false,
     compression bool DEFAULT false,
     compression_level bool DEFAULT false)
@@ -10,7 +10,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_reset';
 
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
-    chunk_row_count bool,
+    chunk_group_row_limit bool,
     stripe_row_count bool,
     compression bool,
     compression_level bool)

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_reset/latest.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_reset/latest.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool DEFAULT false,
-    stripe_row_count bool DEFAULT false,
+    stripe_row_limit bool DEFAULT false,
     compression bool DEFAULT false,
     compression_level bool DEFAULT false)
     RETURNS void
@@ -11,7 +11,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_reset';
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool,
-    stripe_row_count bool,
+    stripe_row_limit bool,
     compression bool,
     compression_level bool)
 IS 'reset on or more options on a columnar table to the system defaults';

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_set/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_set/10.0-1.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
-    chunk_row_count int DEFAULT NULL,
+    chunk_group_row_limit int DEFAULT NULL,
     stripe_row_count int DEFAULT NULL,
     compression name DEFAULT null,
     compression_level int DEFAULT NULL)
@@ -10,7 +10,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_set';
 
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
-    chunk_row_count int,
+    chunk_group_row_limit int,
     stripe_row_count int,
     compression name,
     compression_level int)

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_set/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_set/10.0-1.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int DEFAULT NULL,
-    stripe_row_count int DEFAULT NULL,
+    stripe_row_limit int DEFAULT NULL,
     compression name DEFAULT null,
     compression_level int DEFAULT NULL)
     RETURNS void
@@ -11,7 +11,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_set';
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int,
-    stripe_row_count int,
+    stripe_row_limit int,
     compression name,
     compression_level int)
 IS 'set one or more options on a columnar table, when set to NULL no change is made';

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_set/latest.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_set/latest.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
-    chunk_row_count int DEFAULT NULL,
+    chunk_group_row_limit int DEFAULT NULL,
     stripe_row_count int DEFAULT NULL,
     compression name DEFAULT null,
     compression_level int DEFAULT NULL)
@@ -10,7 +10,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_set';
 
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
-    chunk_row_count int,
+    chunk_group_row_limit int,
     stripe_row_count int,
     compression name,
     compression_level int)

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_set/latest.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_set/latest.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int DEFAULT NULL,
-    stripe_row_count int DEFAULT NULL,
+    stripe_row_limit int DEFAULT NULL,
     compression name DEFAULT null,
     compression_level int DEFAULT NULL)
     RETURNS void
@@ -11,7 +11,7 @@ AS 'MODULE_PATHNAME', 'alter_columnar_table_set';
 COMMENT ON FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int,
-    stripe_row_count int,
+    stripe_row_limit int,
     compression name,
     compression_level int)
 IS 'set one or more options on a columnar table, when set to NULL no change is made';

--- a/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/10.0-1.sql
@@ -30,13 +30,13 @@ IF NOT EXISTS (SELECT 1 FROM pg_am WHERE amname = 'columnar') THEN
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_set(
         table_name regclass,
         chunk_group_row_limit int,
-        stripe_row_count int,
+        stripe_row_limit int,
         compression name,
         compression_level int);
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,
         chunk_group_row_limit bool,
-        stripe_row_count bool,
+        stripe_row_limit bool,
         compression bool,
         compression_level bool);
 

--- a/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/10.0-1.sql
@@ -29,13 +29,13 @@ IF NOT EXISTS (SELECT 1 FROM pg_am WHERE amname = 'columnar') THEN
     ALTER EXTENSION citus ADD ACCESS METHOD columnar;
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_set(
         table_name regclass,
-        chunk_row_count int,
+        chunk_group_row_limit int,
         stripe_row_count int,
         compression name,
         compression_level int);
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,
-        chunk_row_count bool,
+        chunk_group_row_limit bool,
         stripe_row_count bool,
         compression bool,
         compression_level bool);

--- a/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/latest.sql
+++ b/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/latest.sql
@@ -30,13 +30,13 @@ IF NOT EXISTS (SELECT 1 FROM pg_am WHERE amname = 'columnar') THEN
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_set(
         table_name regclass,
         chunk_group_row_limit int,
-        stripe_row_count int,
+        stripe_row_limit int,
         compression name,
         compression_level int);
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,
         chunk_group_row_limit bool,
-        stripe_row_count bool,
+        stripe_row_limit bool,
         compression bool,
         compression_level bool);
 

--- a/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/latest.sql
+++ b/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/latest.sql
@@ -29,13 +29,13 @@ IF NOT EXISTS (SELECT 1 FROM pg_am WHERE amname = 'columnar') THEN
     ALTER EXTENSION citus ADD ACCESS METHOD columnar;
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_set(
         table_name regclass,
-        chunk_row_count int,
+        chunk_group_row_limit int,
         stripe_row_count int,
         compression name,
         compression_level int);
     ALTER EXTENSION citus ADD FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,
-        chunk_row_count bool,
+        chunk_group_row_limit bool,
         stripe_row_count bool,
         compression bool,
         compression_level bool);

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -27,7 +27,7 @@
 /* Defines for valid option names */
 #define OPTION_NAME_COMPRESSION_TYPE "compression"
 #define OPTION_NAME_STRIPE_ROW_COUNT "stripe_row_count"
-#define OPTION_NAME_CHUNK_ROW_COUNT "chunk_row_count"
+#define OPTION_NAME_CHUNK_ROW_COUNT "chunk_group_row_limit"
 
 /* Limits for option parameters */
 #define STRIPE_ROW_COUNT_MINIMUM 1000
@@ -263,7 +263,7 @@ typedef struct TableWriteState
 
 extern int columnar_compression;
 extern int columnar_stripe_row_count;
-extern int columnar_chunk_row_count;
+extern int columnar_chunk_group_row_limit;
 extern int columnar_compression_level;
 
 extern void columnar_init_gucs(void);

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -26,7 +26,7 @@
 
 /* Defines for valid option names */
 #define OPTION_NAME_COMPRESSION_TYPE "compression"
-#define OPTION_NAME_STRIPE_ROW_COUNT "stripe_row_count"
+#define OPTION_NAME_STRIPE_ROW_COUNT "stripe_row_limit"
 #define OPTION_NAME_CHUNK_ROW_COUNT "chunk_group_row_limit"
 
 /* Limits for option parameters */
@@ -262,7 +262,7 @@ typedef struct TableWriteState
 } TableWriteState;
 
 extern int columnar_compression;
-extern int columnar_stripe_row_count;
+extern int columnar_stripe_row_limit;
 extern int columnar_chunk_group_row_limit;
 extern int columnar_compression_level;
 

--- a/src/test/regress/expected/am_empty.out
+++ b/src/test/regress/expected/am_empty.out
@@ -11,7 +11,7 @@ SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
 
 (1 row)
 
-SELECT alter_columnar_table_set('t_compressed', stripe_row_count => 100);
+SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -24,7 +24,7 @@ SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
 (1 row)
 
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;
-   regclass   | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass   | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  t_compressed |             100 |              100 |                 3 | pglz
 (1 row)

--- a/src/test/regress/expected/am_empty.out
+++ b/src/test/regress/expected/am_empty.out
@@ -17,14 +17,14 @@ SELECT alter_columnar_table_set('t_compressed', stripe_row_count => 100);
 
 (1 row)
 
-SELECT alter_columnar_table_set('t_compressed', chunk_row_count => 100);
+SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
 (1 row)
 
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;
-   regclass   | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass   | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  t_compressed |             100 |              100 |                 3 | pglz
 (1 row)

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -26,7 +26,7 @@ SELECT * FROM t_view a ORDER BY a;
 -- show columnar options for materialized view
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
- regclass | chunk_row_count | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  t_view   |           10000 |           150000 |                 3 | none
 (1 row)
@@ -40,7 +40,7 @@ SELECT alter_columnar_table_set('t_view', compression => 'pglz');
 
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
- regclass | chunk_row_count | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  t_view   |           10000 |           150000 |                 3 | pglz
 (1 row)
@@ -49,7 +49,7 @@ REFRESH MATERIALIZED VIEW t_view;
 -- verify options have not been changed
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
- regclass | chunk_row_count | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  t_view   |           10000 |           150000 |                 3 | pglz
 (1 row)

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -26,7 +26,7 @@ SELECT * FROM t_view a ORDER BY a;
 -- show columnar options for materialized view
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
- regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  t_view   |           10000 |           150000 |                 3 | none
 (1 row)
@@ -40,7 +40,7 @@ SELECT alter_columnar_table_set('t_view', compression => 'pglz');
 
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
- regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  t_view   |           10000 |           150000 |                 3 | pglz
 (1 row)
@@ -49,7 +49,7 @@ REFRESH MATERIALIZED VIEW t_view;
 -- verify options have not been changed
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
- regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  t_view   |           10000 |           150000 |                 3 | pglz
 (1 row)

--- a/src/test/regress/expected/am_memory.out
+++ b/src/test/regress/expected/am_memory.out
@@ -13,7 +13,7 @@ CREATE FUNCTION top_memory_context_usage()
 	RETURNS BIGINT AS $$
 		SELECT TopMemoryContext FROM column_store_memory_stats();
 	$$ LANGUAGE SQL VOLATILE;
-SET columnar.stripe_row_count TO 50000;
+SET columnar.stripe_row_limit TO 50000;
 SET columnar.compression TO 'pglz';
 CREATE TABLE t (a int, tag text, memusage bigint) USING columnar;
 -- measure memory before doing writes

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -6,7 +6,7 @@ INSERT INTO table_options SELECT generate_series(1,100);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           150000 |                 3 | none
 (1 row)
@@ -21,7 +21,7 @@ SELECT alter_columnar_table_set('table_options', compression => 'pglz');
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           150000 |                 3 | pglz
 (1 row)
@@ -36,13 +36,13 @@ SELECT alter_columnar_table_set('table_options', compression_level => 5);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           150000 |                 5 | pglz
 (1 row)
 
--- test changing the chunk_row_count
-SELECT alter_columnar_table_set('table_options', chunk_row_count => 10);
+-- test changing the chunk_group_row_limit
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 10);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -51,12 +51,12 @@ SELECT alter_columnar_table_set('table_options', chunk_row_count => 10);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |              10 |           150000 |                 5 | pglz
 (1 row)
 
--- test changing the chunk_row_count
+-- test changing the chunk_group_row_limit
 SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
@@ -66,7 +66,7 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |              10 |              100 |                 5 | pglz
 (1 row)
@@ -76,13 +76,13 @@ VACUUM FULL table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |              10 |              100 |                 5 | pglz
 (1 row)
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk_row_count => 100, compression => 'none', compression_level => 7);
+SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -91,7 +91,7 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -101,7 +101,7 @@ VACUUM table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -111,7 +111,7 @@ VACUUM FULL table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -121,7 +121,7 @@ TRUNCATE table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -130,13 +130,13 @@ ALTER TABLE table_options ALTER COLUMN a TYPE bigint;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
 
 -- reset settings one by one to the version of the GUC's
-SET columnar.chunk_row_count TO 1000;
+SET columnar.chunk_group_row_limit TO 1000;
 SET columnar.stripe_row_count TO 10000;
 SET columnar.compression TO 'pglz';
 SET columnar.compression_level TO 11;
@@ -144,12 +144,12 @@ SET columnar.compression_level TO 11;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
 
-SELECT alter_columnar_table_reset('table_options', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -158,7 +158,7 @@ SELECT alter_columnar_table_reset('table_options', chunk_row_count => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |             1000 |                 7 | none
 (1 row)
@@ -172,7 +172,7 @@ SELECT alter_columnar_table_reset('table_options', stripe_row_count => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                 7 | none
 (1 row)
@@ -186,7 +186,7 @@ SELECT alter_columnar_table_reset('table_options', compression => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                 7 | pglz
 (1 row)
@@ -200,27 +200,27 @@ SELECT alter_columnar_table_reset('table_options', compression_level => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                11 | pglz
 (1 row)
 
 -- verify resetting all settings at once work
-SET columnar.chunk_row_count TO 10000;
+SET columnar.chunk_group_row_limit TO 10000;
 SET columnar.stripe_row_count TO 100000;
 SET columnar.compression TO 'none';
 SET columnar.compression_level TO 13;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                11 | pglz
 (1 row)
 
 SELECT alter_columnar_table_reset(
     'table_options',
-    chunk_row_count => true,
+    chunk_group_row_limit => true,
     stripe_row_count => true,
     compression => true,
     compression_level => true);
@@ -232,7 +232,7 @@ SELECT alter_columnar_table_reset(
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           100000 |                13 | none
 (1 row)
@@ -258,7 +258,7 @@ HINT:  compression level must be between 1 and 19
 DROP TABLE table_options;
 -- we expect no entries in çstore.options for anything not found int pg_class
 SELECT * FROM columnar.options o WHERE o.regclass NOT IN (SELECT oid FROM pg_class);
- regclass | chunk_row_count | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
 (0 rows)
 

--- a/src/test/regress/expected/am_tableoptions.out
+++ b/src/test/regress/expected/am_tableoptions.out
@@ -6,7 +6,7 @@ INSERT INTO table_options SELECT generate_series(1,100);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           150000 |                 3 | none
 (1 row)
@@ -21,7 +21,7 @@ SELECT alter_columnar_table_set('table_options', compression => 'pglz');
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           150000 |                 3 | pglz
 (1 row)
@@ -36,7 +36,7 @@ SELECT alter_columnar_table_set('table_options', compression_level => 5);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           150000 |                 5 | pglz
 (1 row)
@@ -51,13 +51,13 @@ SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 10);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |              10 |           150000 |                 5 | pglz
 (1 row)
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -66,7 +66,7 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |              10 |              100 |                 5 | pglz
 (1 row)
@@ -76,13 +76,13 @@ VACUUM FULL table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |              10 |              100 |                 5 | pglz
 (1 row)
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -91,7 +91,7 @@ SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -101,7 +101,7 @@ VACUUM table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -111,7 +111,7 @@ VACUUM FULL table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -121,7 +121,7 @@ TRUNCATE table_options;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -130,21 +130,21 @@ ALTER TABLE table_options ALTER COLUMN a TYPE bigint;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
 
 -- reset settings one by one to the version of the GUC's
 SET columnar.chunk_group_row_limit TO 1000;
-SET columnar.stripe_row_count TO 10000;
+SET columnar.stripe_row_limit TO 10000;
 SET columnar.compression TO 'pglz';
 SET columnar.compression_level TO 11;
 -- verify setting the GUC's didn't change the settings
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |             100 |             1000 |                 7 | none
 (1 row)
@@ -158,12 +158,12 @@ SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |             1000 |                 7 | none
 (1 row)
 
-SELECT alter_columnar_table_reset('table_options', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_options', stripe_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -172,7 +172,7 @@ SELECT alter_columnar_table_reset('table_options', stripe_row_count => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                 7 | none
 (1 row)
@@ -186,7 +186,7 @@ SELECT alter_columnar_table_reset('table_options', compression => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                 7 | pglz
 (1 row)
@@ -200,20 +200,20 @@ SELECT alter_columnar_table_reset('table_options', compression_level => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                11 | pglz
 (1 row)
 
 -- verify resetting all settings at once work
 SET columnar.chunk_group_row_limit TO 10000;
-SET columnar.stripe_row_count TO 100000;
+SET columnar.stripe_row_limit TO 100000;
 SET columnar.compression TO 'none';
 SET columnar.compression_level TO 13;
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |            1000 |            10000 |                11 | pglz
 (1 row)
@@ -221,7 +221,7 @@ WHERE regclass = 'table_options'::regclass;
 SELECT alter_columnar_table_reset(
     'table_options',
     chunk_group_row_limit => true,
-    stripe_row_count => true,
+    stripe_row_limit => true,
     compression => true,
     compression_level => true);
  alter_columnar_table_reset
@@ -232,7 +232,7 @@ SELECT alter_columnar_table_reset(
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
-   regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+   regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  table_options |           10000 |           100000 |                13 | none
 (1 row)
@@ -258,7 +258,7 @@ HINT:  compression level must be between 1 and 19
 DROP TABLE table_options;
 -- we expect no entries in çstore.options for anything not found int pg_class
 SELECT * FROM columnar.options o WHERE o.regclass NOT IN (SELECT oid FROM pg_class);
- regclass | chunk_group_row_limit | stripe_row_count | compression_level | compression
+ regclass | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
 (0 rows)
 

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -40,7 +40,7 @@ SELECT count(*) FROM t_stripes;
 (1 row)
 
 -- test the case when all data cannot fit into a single stripe
-SELECT alter_columnar_table_set('t', stripe_row_count => 1000);
+SELECT alter_columnar_table_set('t', stripe_row_limit => 1000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -173,7 +173,7 @@ SELECT count(*) FROM t;
 BEGIN;
 SELECT alter_columnar_table_set('t',
     chunk_group_row_limit => 1000,
-    stripe_row_count => 2000,
+    stripe_row_limit => 2000,
     compression => 'pglz');
  alter_columnar_table_set
 ---------------------------------------------------------------------
@@ -250,7 +250,7 @@ SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
 
 -- A table with high compression ratio
 SET columnar.compression TO 'pglz';
-SET columnar.stripe_row_count TO 1000000;
+SET columnar.stripe_row_limit TO 1000000;
 SET columnar.chunk_group_row_limit TO 100000;
 CREATE TABLE t(a int, b char, c text) USING columnar;
 INSERT INTO t SELECT 1, 'a', 'xyz' FROM generate_series(1, 1000000) i;

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -172,7 +172,7 @@ SELECT count(*) FROM t;
 -- then vacuum to print stats
 BEGIN;
 SELECT alter_columnar_table_set('t',
-    chunk_row_count => 1000,
+    chunk_group_row_limit => 1000,
     stripe_row_count => 2000,
     compression => 'pglz');
  alter_columnar_table_set
@@ -251,7 +251,7 @@ SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
 -- A table with high compression ratio
 SET columnar.compression TO 'pglz';
 SET columnar.stripe_row_count TO 1000000;
-SET columnar.chunk_row_count TO 100000;
+SET columnar.chunk_group_row_limit TO 100000;
 CREATE TABLE t(a int, b char, c text) USING columnar;
 INSERT INTO t SELECT 1, 'a', 'xyz' FROM generate_series(1, 1000000) i;
 VACUUM VERBOSE t;

--- a/src/test/regress/expected/columnar_citus_integration.out
+++ b/src/test/regress/expected/columnar_citus_integration.out
@@ -115,10 +115,10 @@ $cmd$);
  (localhost,57638,20090003,t,3)
 (4 rows)
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -129,7 +129,7 @@ $cmd$);
 (4 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -137,7 +137,7 @@ SELECT alter_columnar_table_set('table_option', chunk_row_count => 100);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -148,7 +148,7 @@ $cmd$);
 (4 rows)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option', chunk_group_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -156,7 +156,7 @@ SELECT alter_columnar_table_reset('table_option', chunk_row_count => true);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -220,7 +220,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 15);
@@ -237,7 +237,7 @@ SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
              run_command_on_placements
 ---------------------------------------------------------------------
@@ -406,10 +406,10 @@ $cmd$);
  (localhost,57638,20090011,t,3)
 (8 rows)
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -424,7 +424,7 @@ $cmd$);
 (8 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -432,7 +432,7 @@ SELECT alter_columnar_table_set('table_option', chunk_row_count => 100);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -447,7 +447,7 @@ $cmd$);
 (8 rows)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option', chunk_group_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -455,7 +455,7 @@ SELECT alter_columnar_table_reset('table_option', chunk_row_count => true);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -535,7 +535,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 19);
@@ -552,7 +552,7 @@ SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
              run_command_on_placements
 ---------------------------------------------------------------------
@@ -687,10 +687,10 @@ $cmd$);
  (localhost,57638,20090016,t,3)
 (2 rows)
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -699,7 +699,7 @@ $cmd$);
 (2 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -707,7 +707,7 @@ SELECT alter_columnar_table_set('table_option_reference', chunk_row_count => 100
 
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -716,7 +716,7 @@ $cmd$);
 (2 rows)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_reference', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option_reference', chunk_group_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -724,7 +724,7 @@ SELECT alter_columnar_table_reset('table_option_reference', chunk_row_count => t
 
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -780,7 +780,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_reference_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_reference_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
@@ -797,7 +797,7 @@ SELECT create_reference_table('table_option_reference_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_reference_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
             run_command_on_placements
 ---------------------------------------------------------------------
@@ -927,10 +927,10 @@ $cmd$);
  (localhost,57636,20090018,t,3)
 (1 row)
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -938,7 +938,7 @@ $cmd$);
 (1 row)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -946,7 +946,7 @@ SELECT alter_columnar_table_set('table_option_citus_local', chunk_row_count => 1
 
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -954,7 +954,7 @@ $cmd$);
 (1 row)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_citus_local', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option_citus_local', chunk_group_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -962,7 +962,7 @@ SELECT alter_columnar_table_reset('table_option_citus_local', chunk_row_count =>
 
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
      run_command_on_placements
 ---------------------------------------------------------------------
@@ -1014,7 +1014,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_citus_local_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_citus_local_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
@@ -1031,7 +1031,7 @@ SELECT citus_add_local_table_to_metadata('table_option_citus_local_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_citus_local_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
             run_command_on_placements
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/columnar_citus_integration.out
+++ b/src/test/regress/expected/columnar_citus_integration.out
@@ -166,10 +166,10 @@ $cmd$);
  (localhost,57638,20090003,t,10000)
 (4 rows)
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -180,7 +180,7 @@ $cmd$);
 (4 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -188,7 +188,7 @@ SELECT alter_columnar_table_set('table_option', stripe_row_count => 100);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -199,7 +199,7 @@ $cmd$);
 (4 rows)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option', stripe_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -207,7 +207,7 @@ SELECT alter_columnar_table_reset('table_option', stripe_row_count => true);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -221,7 +221,7 @@ $cmd$);
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 15);
  alter_columnar_table_set
@@ -237,7 +237,7 @@ SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
              run_command_on_placements
 ---------------------------------------------------------------------
@@ -469,10 +469,10 @@ $cmd$);
  (localhost,57638,20090011,t,10000)
 (8 rows)
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -487,7 +487,7 @@ $cmd$);
 (8 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -495,7 +495,7 @@ SELECT alter_columnar_table_set('table_option', stripe_row_count => 100);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -510,7 +510,7 @@ $cmd$);
 (8 rows)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option', stripe_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -518,7 +518,7 @@ SELECT alter_columnar_table_reset('table_option', stripe_row_count => true);
 
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -536,7 +536,7 @@ $cmd$);
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 19);
  alter_columnar_table_set
@@ -552,7 +552,7 @@ SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
              run_command_on_placements
 ---------------------------------------------------------------------
@@ -732,10 +732,10 @@ $cmd$);
  (localhost,57638,20090016,t,10000)
 (2 rows)
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -744,7 +744,7 @@ $cmd$);
 (2 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -752,7 +752,7 @@ SELECT alter_columnar_table_set('table_option_reference', stripe_row_count => 10
 
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -761,7 +761,7 @@ $cmd$);
 (2 rows)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_reference', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option_reference', stripe_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -769,7 +769,7 @@ SELECT alter_columnar_table_reset('table_option_reference', stripe_row_count => 
 
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -781,7 +781,7 @@ $cmd$);
 CREATE TABLE table_option_reference_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_reference_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
  alter_columnar_table_set
@@ -797,7 +797,7 @@ SELECT create_reference_table('table_option_reference_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_reference_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
             run_command_on_placements
 ---------------------------------------------------------------------
@@ -969,10 +969,10 @@ $cmd$);
  (localhost,57636,20090018,t,10000)
 (1 row)
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -980,7 +980,7 @@ $cmd$);
 (1 row)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 100);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -988,7 +988,7 @@ SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_count => 
 
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
     run_command_on_placements
 ---------------------------------------------------------------------
@@ -996,7 +996,7 @@ $cmd$);
 (1 row)
 
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_citus_local', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option_citus_local', stripe_row_limit => true);
  alter_columnar_table_reset
 ---------------------------------------------------------------------
 
@@ -1004,7 +1004,7 @@ SELECT alter_columnar_table_reset('table_option_citus_local', stripe_row_count =
 
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
       run_command_on_placements
 ---------------------------------------------------------------------
@@ -1015,7 +1015,7 @@ $cmd$);
 CREATE TABLE table_option_citus_local_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_citus_local_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
  alter_columnar_table_set
@@ -1031,7 +1031,7 @@ SELECT citus_add_local_table_to_metadata('table_option_citus_local_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_citus_local_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
             run_command_on_placements
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/upgrade_columnar_after.out
+++ b/src/test/regress/expected/upgrade_columnar_after.out
@@ -102,7 +102,7 @@ SELECT * FROM matview ORDER BY a;
 
 -- test we retained options
 SELECT * FROM columnar.options WHERE regclass = 'test_options_1'::regclass;
-    regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  test_options_1 |            1000 |             5000 |                 3 | pglz
 (1 row)
@@ -122,7 +122,7 @@ SELECT count(*), sum(a), sum(b) FROM test_options_1;
 (1 row)
 
 SELECT * FROM columnar.options WHERE regclass = 'test_options_2'::regclass;
-    regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
+    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
  test_options_2 |            2000 |             6000 |                13 | none
 (1 row)

--- a/src/test/regress/expected/upgrade_columnar_after.out
+++ b/src/test/regress/expected/upgrade_columnar_after.out
@@ -102,7 +102,7 @@ SELECT * FROM matview ORDER BY a;
 
 -- test we retained options
 SELECT * FROM columnar.options WHERE regclass = 'test_options_1'::regclass;
-    regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+    regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  test_options_1 |            1000 |             5000 |                 3 | pglz
 (1 row)
@@ -122,7 +122,7 @@ SELECT count(*), sum(a), sum(b) FROM test_options_1;
 (1 row)
 
 SELECT * FROM columnar.options WHERE regclass = 'test_options_2'::regclass;
-    regclass    | chunk_row_count | stripe_row_count | compression_level | compression
+    regclass    | chunk_group_row_limit | stripe_row_count | compression_level | compression
 ---------------------------------------------------------------------
  test_options_2 |            2000 |             6000 |                13 | none
 (1 row)

--- a/src/test/regress/expected/upgrade_columnar_before.out
+++ b/src/test/regress/expected/upgrade_columnar_before.out
@@ -116,13 +116,13 @@ SELECT :relfilenode_pre_alter <> :relfilenode_post_alter AS relfilenode_changed;
 -- Test that we retain options
 --
 SET columnar.stripe_row_count TO 5000;
-SET columnar.chunk_row_count TO 1000;
+SET columnar.chunk_group_row_limit TO 1000;
 SET columnar.compression TO 'pglz';
 CREATE TABLE test_options_1(a int, b int) USING columnar;
 INSERT INTO test_options_1 SELECT i, floor(i/1000) FROM generate_series(1, 10000) i;
 CREATE TABLE test_options_2(a int, b int) USING columnar;
 INSERT INTO test_options_2 SELECT i, floor(i/1000) FROM generate_series(1, 10000) i;
-SELECT alter_columnar_table_set('test_options_2', chunk_row_count => 2000);
+SELECT alter_columnar_table_set('test_options_2', chunk_group_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/upgrade_columnar_before.out
+++ b/src/test/regress/expected/upgrade_columnar_before.out
@@ -115,7 +115,7 @@ SELECT :relfilenode_pre_alter <> :relfilenode_post_alter AS relfilenode_changed;
 --
 -- Test that we retain options
 --
-SET columnar.stripe_row_count TO 5000;
+SET columnar.stripe_row_limit TO 5000;
 SET columnar.chunk_group_row_limit TO 1000;
 SET columnar.compression TO 'pglz';
 CREATE TABLE test_options_1(a int, b int) USING columnar;
@@ -128,7 +128,7 @@ SELECT alter_columnar_table_set('test_options_2', chunk_group_row_limit => 2000)
 
 (1 row)
 
-SELECT alter_columnar_table_set('test_options_2', stripe_row_count => 6000);
+SELECT alter_columnar_table_set('test_options_2', stripe_row_limit => 6000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 

--- a/src/test/regress/input/am_chunk_filtering.source
+++ b/src/test/regress/input/am_chunk_filtering.source
@@ -28,8 +28,8 @@ $$ LANGUAGE PLPGSQL;
 
 
 -- Create and load data
--- chunk_group_row_limit '1000', stripe_row_count '2000'
-set columnar.stripe_row_count = 2000;
+-- chunk_group_row_limit '1000', stripe_row_limit '2000'
+set columnar.stripe_row_limit = 2000;
 set columnar.chunk_group_row_limit = 1000;
 CREATE TABLE test_chunk_filtering (a int)
     USING columnar;
@@ -58,7 +58,7 @@ SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a < 2
 SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a < 0');
 SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a BETWEEN 990 AND 2010');
 
-set columnar.stripe_row_count to default;
+set columnar.stripe_row_limit to default;
 set columnar.chunk_group_row_limit to default;
 
 -- Verify that we are fine with collations which use a different alphabet order

--- a/src/test/regress/input/am_chunk_filtering.source
+++ b/src/test/regress/input/am_chunk_filtering.source
@@ -28,9 +28,9 @@ $$ LANGUAGE PLPGSQL;
 
 
 -- Create and load data
--- chunk_row_count '1000', stripe_row_count '2000'
+-- chunk_group_row_limit '1000', stripe_row_count '2000'
 set columnar.stripe_row_count = 2000;
-set columnar.chunk_row_count = 1000;
+set columnar.chunk_group_row_limit = 1000;
 CREATE TABLE test_chunk_filtering (a int)
     USING columnar;
 
@@ -59,7 +59,7 @@ SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a < 0
 SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a BETWEEN 990 AND 2010');
 
 set columnar.stripe_row_count to default;
-set columnar.chunk_row_count to default;
+set columnar.chunk_group_row_limit to default;
 
 -- Verify that we are fine with collations which use a different alphabet order
 CREATE TABLE collation_chunk_filtering_test(A text collate "da_DK")

--- a/src/test/regress/output/am_chunk_filtering.source
+++ b/src/test/regress/output/am_chunk_filtering.source
@@ -24,9 +24,9 @@ $$
     END;
 $$ LANGUAGE PLPGSQL;
 -- Create and load data
--- chunk_row_count '1000', stripe_row_count '2000'
+-- chunk_group_row_limit '1000', stripe_row_count '2000'
 set columnar.stripe_row_count = 2000;
-set columnar.chunk_row_count = 1000;
+set columnar.chunk_group_row_limit = 1000;
 CREATE TABLE test_chunk_filtering (a int)
     USING columnar;
 COPY test_chunk_filtering FROM '@abs_srcdir@/data/chunk_filtering.csv' WITH CSV;
@@ -107,7 +107,7 @@ SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a BET
 (1 row)
 
 set columnar.stripe_row_count to default;
-set columnar.chunk_row_count to default;
+set columnar.chunk_group_row_limit to default;
 -- Verify that we are fine with collations which use a different alphabet order
 CREATE TABLE collation_chunk_filtering_test(A text collate "da_DK")
     USING columnar;

--- a/src/test/regress/output/am_chunk_filtering.source
+++ b/src/test/regress/output/am_chunk_filtering.source
@@ -24,8 +24,8 @@ $$
     END;
 $$ LANGUAGE PLPGSQL;
 -- Create and load data
--- chunk_group_row_limit '1000', stripe_row_count '2000'
-set columnar.stripe_row_count = 2000;
+-- chunk_group_row_limit '1000', stripe_row_limit '2000'
+set columnar.stripe_row_limit = 2000;
 set columnar.chunk_group_row_limit = 1000;
 CREATE TABLE test_chunk_filtering (a int)
     USING columnar;
@@ -106,7 +106,7 @@ SELECT filtered_row_count('SELECT count(*) FROM test_chunk_filtering WHERE a BET
                3958
 (1 row)
 
-set columnar.stripe_row_count to default;
+set columnar.stripe_row_limit to default;
 set columnar.chunk_group_row_limit to default;
 -- Verify that we are fine with collations which use a different alphabet order
 CREATE TABLE collation_chunk_filtering_test(A text collate "da_DK")

--- a/src/test/regress/sql/am_empty.sql
+++ b/src/test/regress/sql/am_empty.sql
@@ -8,7 +8,7 @@ create table t_compressed(a int) using columnar;
 
 -- set options
 SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
-SELECT alter_columnar_table_set('t_compressed', stripe_row_count => 100);
+SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 100);
 SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
 
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;

--- a/src/test/regress/sql/am_empty.sql
+++ b/src/test/regress/sql/am_empty.sql
@@ -9,7 +9,7 @@ create table t_compressed(a int) using columnar;
 -- set options
 SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
 SELECT alter_columnar_table_set('t_compressed', stripe_row_count => 100);
-SELECT alter_columnar_table_set('t_compressed', chunk_row_count => 100);
+SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
 
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;
 

--- a/src/test/regress/sql/am_memory.sql
+++ b/src/test/regress/sql/am_memory.sql
@@ -17,7 +17,7 @@ CREATE FUNCTION top_memory_context_usage()
 		SELECT TopMemoryContext FROM column_store_memory_stats();
 	$$ LANGUAGE SQL VOLATILE;
 
-SET columnar.stripe_row_count TO 50000;
+SET columnar.stripe_row_limit TO 50000;
 SET columnar.compression TO 'pglz';
 CREATE TABLE t (a int, tag text, memusage bigint) USING columnar;
 

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -31,7 +31,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 100);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -45,7 +45,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -76,7 +76,7 @@ WHERE regclass = 'table_options'::regclass;
 
 -- reset settings one by one to the version of the GUC's
 SET columnar.chunk_group_row_limit TO 1000;
-SET columnar.stripe_row_count TO 10000;
+SET columnar.stripe_row_limit TO 10000;
 SET columnar.compression TO 'pglz';
 SET columnar.compression_level TO 11;
 
@@ -90,7 +90,7 @@ SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
-SELECT alter_columnar_table_reset('table_options', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_options', stripe_row_limit => true);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -110,7 +110,7 @@ WHERE regclass = 'table_options'::regclass;
 
 -- verify resetting all settings at once work
 SET columnar.chunk_group_row_limit TO 10000;
-SET columnar.stripe_row_count TO 100000;
+SET columnar.stripe_row_limit TO 100000;
 SET columnar.compression TO 'none';
 SET columnar.compression_level TO 13;
 
@@ -121,7 +121,7 @@ WHERE regclass = 'table_options'::regclass;
 SELECT alter_columnar_table_reset(
     'table_options',
     chunk_group_row_limit => true,
-    stripe_row_count => true,
+    stripe_row_limit => true,
     compression => true,
     compression_level => true);
 

--- a/src/test/regress/sql/am_tableoptions.sql
+++ b/src/test/regress/sql/am_tableoptions.sql
@@ -23,14 +23,14 @@ SELECT alter_columnar_table_set('table_options', compression_level => 5);
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
--- test changing the chunk_row_count
-SELECT alter_columnar_table_set('table_options', chunk_row_count => 10);
+-- test changing the chunk_group_row_limit
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 10);
 
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
--- test changing the chunk_row_count
+-- test changing the chunk_group_row_limit
 SELECT alter_columnar_table_set('table_options', stripe_row_count => 100);
 
 -- show table_options settings
@@ -45,7 +45,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk_row_count => 100, compression => 'none', compression_level => 7);
+SELECT alter_columnar_table_set('table_options', stripe_row_count => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -75,7 +75,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- reset settings one by one to the version of the GUC's
-SET columnar.chunk_row_count TO 1000;
+SET columnar.chunk_group_row_limit TO 1000;
 SET columnar.stripe_row_count TO 10000;
 SET columnar.compression TO 'pglz';
 SET columnar.compression_level TO 11;
@@ -85,7 +85,7 @@ SET columnar.compression_level TO 11;
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
-SELECT alter_columnar_table_reset('table_options', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
@@ -109,7 +109,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- verify resetting all settings at once work
-SET columnar.chunk_row_count TO 10000;
+SET columnar.chunk_group_row_limit TO 10000;
 SET columnar.stripe_row_count TO 100000;
 SET columnar.compression TO 'none';
 SET columnar.compression_level TO 13;
@@ -120,7 +120,7 @@ WHERE regclass = 'table_options'::regclass;
 
 SELECT alter_columnar_table_reset(
     'table_options',
-    chunk_row_count => true,
+    chunk_group_row_limit => true,
     stripe_row_count => true,
     compression => true,
     compression_level => true);

--- a/src/test/regress/sql/am_vacuum.sql
+++ b/src/test/regress/sql/am_vacuum.sql
@@ -24,7 +24,7 @@ SELECT sum(a), sum(b) FROM t;
 SELECT count(*) FROM t_stripes;
 
 -- test the case when all data cannot fit into a single stripe
-SELECT alter_columnar_table_set('t', stripe_row_count => 1000);
+SELECT alter_columnar_table_set('t', stripe_row_limit => 1000);
 INSERT INTO t SELECT i, 2 * i FROM generate_series(1,2500) i;
 
 SELECT sum(a), sum(b) FROM t;
@@ -77,7 +77,7 @@ SELECT count(*) FROM t;
 BEGIN;
 SELECT alter_columnar_table_set('t',
     chunk_group_row_limit => 1000,
-    stripe_row_count => 2000,
+    stripe_row_limit => 2000,
     compression => 'pglz');
 SAVEPOINT s1;
 INSERT INTO t SELECT i FROM generate_series(1, 1500) i;
@@ -116,7 +116,7 @@ SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
 
 -- A table with high compression ratio
 SET columnar.compression TO 'pglz';
-SET columnar.stripe_row_count TO 1000000;
+SET columnar.stripe_row_limit TO 1000000;
 SET columnar.chunk_group_row_limit TO 100000;
 CREATE TABLE t(a int, b char, c text) USING columnar;
 INSERT INTO t SELECT 1, 'a', 'xyz' FROM generate_series(1, 1000000) i;

--- a/src/test/regress/sql/am_vacuum.sql
+++ b/src/test/regress/sql/am_vacuum.sql
@@ -76,7 +76,7 @@ SELECT count(*) FROM t;
 
 BEGIN;
 SELECT alter_columnar_table_set('t',
-    chunk_row_count => 1000,
+    chunk_group_row_limit => 1000,
     stripe_row_count => 2000,
     compression => 'pglz');
 SAVEPOINT s1;
@@ -117,7 +117,7 @@ SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
 -- A table with high compression ratio
 SET columnar.compression TO 'pglz';
 SET columnar.stripe_row_count TO 1000000;
-SET columnar.chunk_row_count TO 100000;
+SET columnar.chunk_group_row_limit TO 100000;
 CREATE TABLE t(a int, b char, c text) USING columnar;
 INSERT INTO t SELECT 1, 'a', 'xyz' FROM generate_series(1, 1000000) i;
 

--- a/src/test/regress/sql/columnar_citus_integration.sql
+++ b/src/test/regress/sql/columnar_citus_integration.sql
@@ -66,36 +66,36 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option', stripe_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 15);
 SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works
@@ -166,36 +166,36 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option', stripe_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 19);
 SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works
@@ -263,36 +263,36 @@ SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_reference', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option_reference', stripe_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_reference_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_reference_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
 SELECT create_reference_table('table_option_reference_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_reference_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works
@@ -363,36 +363,36 @@ SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: stripe_row_count
+-- setting: stripe_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_count => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_citus_local', stripe_row_count => true);
+SELECT alter_columnar_table_reset('table_option_citus_local', stripe_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT stripe_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_citus_local_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_citus_local_2',
                                 chunk_group_row_limit => 100,
-                                stripe_row_count => 1000,
+                                stripe_row_limit => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
 SELECT citus_add_local_table_to_metadata('table_option_citus_local_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_citus_local_2',$cmd$
-  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works

--- a/src/test/regress/sql/columnar_citus_integration.sql
+++ b/src/test/regress/sql/columnar_citus_integration.sql
@@ -48,22 +48,22 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT compression_level FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option', chunk_group_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- setting: stripe_row_count
@@ -87,7 +87,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 15);
@@ -95,7 +95,7 @@ SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works
@@ -148,22 +148,22 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT compression_level FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option', chunk_group_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- setting: stripe_row_count
@@ -187,7 +187,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 19);
@@ -195,7 +195,7 @@ SELECT create_distributed_table('table_option_2', 'a');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works
@@ -245,22 +245,22 @@ SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT compression_level FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_reference', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option_reference', chunk_group_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- setting: stripe_row_count
@@ -284,7 +284,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_reference_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_reference_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
@@ -292,7 +292,7 @@ SELECT create_reference_table('table_option_reference_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_reference_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works
@@ -345,22 +345,22 @@ SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT compression_level FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
--- setting: chunk_row_count
+-- setting: chunk_group_row_limit
 -- get baseline for setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', chunk_row_count => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limit => 100);
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- reset setting
-SELECT alter_columnar_table_reset('table_option_citus_local', chunk_row_count => true);
+SELECT alter_columnar_table_reset('table_option_citus_local', chunk_group_row_limit => true);
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
-  SELECT chunk_row_count FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- setting: stripe_row_count
@@ -384,7 +384,7 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_citus_local_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_citus_local_2',
-                                chunk_row_count => 100,
+                                chunk_group_row_limit => 100,
                                 stripe_row_count => 1000,
                                 compression => 'pglz',
                                 compression_level => 9);
@@ -392,7 +392,7 @@ SELECT citus_add_local_table_to_metadata('table_option_citus_local_2');
 
 -- verify settings on placements
 SELECT run_command_on_placements('table_option_citus_local_2',$cmd$
-  SELECT ROW(chunk_row_count, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
+  SELECT ROW(chunk_group_row_limit, stripe_row_count, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 
 -- verify undistribute works

--- a/src/test/regress/sql/upgrade_columnar_before.sql
+++ b/src/test/regress/sql/upgrade_columnar_before.sql
@@ -95,7 +95,7 @@ SELECT :relfilenode_pre_alter <> :relfilenode_post_alter AS relfilenode_changed;
 -- Test that we retain options
 --
 
-SET columnar.stripe_row_count TO 5000;
+SET columnar.stripe_row_limit TO 5000;
 SET columnar.chunk_group_row_limit TO 1000;
 SET columnar.compression TO 'pglz';
 
@@ -105,7 +105,7 @@ INSERT INTO test_options_1 SELECT i, floor(i/1000) FROM generate_series(1, 10000
 CREATE TABLE test_options_2(a int, b int) USING columnar;
 INSERT INTO test_options_2 SELECT i, floor(i/1000) FROM generate_series(1, 10000) i;
 SELECT alter_columnar_table_set('test_options_2', chunk_group_row_limit => 2000);
-SELECT alter_columnar_table_set('test_options_2', stripe_row_count => 6000);
+SELECT alter_columnar_table_set('test_options_2', stripe_row_limit => 6000);
 SELECT alter_columnar_table_set('test_options_2', compression => 'none');
 SELECT alter_columnar_table_set('test_options_2', compression_level => 13);
 INSERT INTO test_options_2 SELECT i, floor(i/2000) FROM generate_series(1, 10000) i;

--- a/src/test/regress/sql/upgrade_columnar_before.sql
+++ b/src/test/regress/sql/upgrade_columnar_before.sql
@@ -96,7 +96,7 @@ SELECT :relfilenode_pre_alter <> :relfilenode_post_alter AS relfilenode_changed;
 --
 
 SET columnar.stripe_row_count TO 5000;
-SET columnar.chunk_row_count TO 1000;
+SET columnar.chunk_group_row_limit TO 1000;
 SET columnar.compression TO 'pglz';
 
 CREATE TABLE test_options_1(a int, b int) USING columnar;
@@ -104,7 +104,7 @@ INSERT INTO test_options_1 SELECT i, floor(i/1000) FROM generate_series(1, 10000
 
 CREATE TABLE test_options_2(a int, b int) USING columnar;
 INSERT INTO test_options_2 SELECT i, floor(i/1000) FROM generate_series(1, 10000) i;
-SELECT alter_columnar_table_set('test_options_2', chunk_row_count => 2000);
+SELECT alter_columnar_table_set('test_options_2', chunk_group_row_limit => 2000);
 SELECT alter_columnar_table_set('test_options_2', stripe_row_count => 6000);
 SELECT alter_columnar_table_set('test_options_2', compression => 'none');
 SELECT alter_columnar_table_set('test_options_2', compression_level => 13);


### PR DESCRIPTION
* Renames `chunk_row_count` to `chunk_group_row_limit`, since (1) chunk is sequence of values, not rows, (2) it is a limit on the count.

* Renames `stripe_row_count` to `stripe_row_limit`.