### PR TITLE
Make isolation_metadata_sync_deadlock more resilient

### DIFF
--- a/src/test/regress/expected/isolation_metadata_sync_deadlock.out
+++ b/src/test/regress/expected/isolation_metadata_sync_deadlock.out
@@ -5,7 +5,7 @@ create_distributed_table
 
 
 step enable-deadlock-detection:
-  ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO 1.1;
+  ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO 3;
 
 step reload-conf:
     SELECT pg_reload_conf();

--- a/src/test/regress/spec/isolation_metadata_sync_deadlock.spec
+++ b/src/test/regress/spec/isolation_metadata_sync_deadlock.spec
@@ -43,7 +43,7 @@ step "reset-retry-interval"
 
 step "enable-deadlock-detection"
 {
-  ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO 1.1;
+  ALTER SYSTEM SET citus.distributed_deadlock_detection_factor TO 3;
 }
 
 step "disable-deadlock-detection"


### PR DESCRIPTION
Sometimes tests failed with the following diff. It just depended on how fast deadlock detector kicks in after `s1-update-2`. If it is fast, then we don't see the `<waiting ...>`, otherwise we see it. This PR increases deadlock detector's interval to make the output more consistent. We are seeing this failure often recently.

Tries to fix https://github.com/citusdata/citus/issues/4615

```
diff -dU10 -w /home/circleci/project/src/test/regress/expected/isolation_metadata_sync_deadlock.out /home/circleci/project/src/test/regress/results/isolation_metadata_sync_deadlock.out
--- /home/circleci/project/src/test/regress/expected/isolation_metadata_sync_deadlock.out.modified	2021-02-06 06:39:53.593512339 +0000
+++ /home/circleci/project/src/test/regress/results/isolation_metadata_sync_deadlock.out.modified	2021-02-06 06:39:53.621512399 +0000
@@ -56,22 +56,21 @@
   SELECT pg_sleep(2);
 
 pg_sleep       
 
                
 step s2-update-1-on-worker: 
   SELECT run_commands_on_session_level_connection_to_node('UPDATE deadlock_detection_test SET some_val = 2 WHERE user_id = 1');
  <waiting ...>
 step s1-update-2: 
   UPDATE deadlock_detection_test SET some_val = 1 WHERE user_id = 2;
- <waiting ...>
-step s1-update-2: <... completed>
+
 step s2-update-1-on-worker: <... completed>
 run_commands_on_session_level_connection_to_node
 
                
 error in steps s1-update-2 s2-update-1-on-worker: ERROR:  canceling the transaction since it was involved in a distributed deadlock
 step s1-commit: 
   COMMIT;
```