### PR TITLE
Normalize isolation_metadata_sync_deadlock

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -207,3 +207,13 @@ s/ERROR:  cannot append to shardId [0-9]+/ERROR:  cannot append to shardId xxxxx
 
 # normalize partitioned table shard constraint name errors for upgrade_partition_constraints_(before|after)
 s/^(ERROR:  child table is missing constraint "\w+)_([0-9])+"/\1_xxxxxx"/g
+
+# normalize for distributed deadlock delay in isolation_metadata_sync_deadlock
+# isolation tester first detects a lock, but then deadlock detector cancels the
+# session. Sometimes happens that deadlock detector cancels the session before
+# lock detection, so we normalize it by removing these two lines.
+/^ <waiting ...>$/ {
+    N; /\nstep s1-update-2: <... completed>$/ {
+        s/.*//g
+    }
+}

--- a/src/test/regress/expected/isolation_metadata_sync_deadlock.out
+++ b/src/test/regress/expected/isolation_metadata_sync_deadlock.out
@@ -63,8 +63,7 @@ step s2-update-1-on-worker:
  <waiting ...>
 step s1-update-2:
   UPDATE deadlock_detection_test SET some_val = 1 WHERE user_id = 2;
- <waiting ...>
-step s1-update-2: <... completed>
+
 step s2-update-1-on-worker: <... completed>
 run_commands_on_session_level_connection_to_node
 


### PR DESCRIPTION
Sometimes tests failed with the following diff. It just depended on how fast deadlock detector kicks in after s1-update-2. If it is fast, then we don't see the <waiting ...>, otherwise we see it. This PR removes these 2 lines, so the output is the same in both cases.

Fixes #4615

```
diff -dU10 -w /home/circleci/project/src/test/regress/expected/isolation_metadata_sync_deadlock.out /home/circleci/project/src/test/regress/results/isolation_metadata_sync_deadlock.out
--- /home/circleci/project/src/test/regress/expected/isolation_metadata_sync_deadlock.out.modified	2021-02-06 06:39:53.593512339 +0000
+++ /home/circleci/project/src/test/regress/results/isolation_metadata_sync_deadlock.out.modified	2021-02-06 06:39:53.621512399 +0000
@@ -56,22 +56,21 @@
   SELECT pg_sleep(2);
 
 pg_sleep       
 
                
 step s2-update-1-on-worker: 
   SELECT run_commands_on_session_level_connection_to_node('UPDATE deadlock_detection_test SET some_val = 2 WHERE user_id = 1');
  <waiting ...>
 step s1-update-2: 
   UPDATE deadlock_detection_test SET some_val = 1 WHERE user_id = 2;
- <waiting ...>
-step s1-update-2: <... completed>
+
 step s2-update-1-on-worker: <... completed>
 run_commands_on_session_level_connection_to_node
 
                
 error in steps s1-update-2 s2-update-1-on-worker: ERROR:  canceling the transaction since it was involved in a distributed deadlock
 step s1-commit: 
   COMMIT;
```
