### PR TITLE
Columnar: add chunk_group metadata table

### DIFF
--- a/src/backend/columnar/cstore_writer.c
+++ b/src/backend/columnar/cstore_writer.c
@@ -447,7 +447,7 @@ FlushStripe(TableWriteState *writeState)
 	uint32 lastChunkIndex = stripeBuffers->rowCount / chunkRowCount;
 	uint32 lastChunkRowCount = stripeBuffers->rowCount % chunkRowCount;
 	uint64 stripeSize = 0;
-	uint64 stripeRowCount = 0;
+	uint64 stripeRowCount = stripeBuffers->rowCount;
 
 	elog(DEBUG1, "Flushing Stripe of size %d", stripeBuffers->rowCount);
 
@@ -498,12 +498,6 @@ FlushStripe(TableWriteState *writeState)
 
 			stripeSize += valueBufferSize;
 		}
-	}
-
-	for (chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++)
-	{
-		stripeRowCount +=
-			stripeSkipList->chunkSkipNodeArray[0][chunkIndex].rowCount;
 	}
 
 	stripeMetadata = ReserveStripe(relation, stripeSize,

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -29,6 +29,17 @@ CREATE TABLE stripe (
 
 COMMENT ON TABLE stripe IS 'Columnar per stripe metadata';
 
+CREATE TABLE chunk_group (
+    storageid bigint NOT NULL,
+    stripeid bigint NOT NULL,
+    chunkid int NOT NULL,
+    row_count bigint NOT NULL,
+    PRIMARY KEY (storageid, stripeid, chunkid),
+    FOREIGN KEY (storageid, stripeid) REFERENCES stripe(storageid, stripeid) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE chunk_group IS 'Columnar chunk group metadata';
+
 CREATE TABLE chunk (
     storageid bigint NOT NULL,
     stripeid bigint NOT NULL,
@@ -45,7 +56,7 @@ CREATE TABLE chunk (
     value_compression_level int NOT NULL,
     value_decompressed_length bigint NOT NULL,
     PRIMARY KEY (storageid, stripeid, attnum, chunkid),
-    FOREIGN KEY (storageid, stripeid) REFERENCES stripe(storageid, stripeid) ON DELETE CASCADE
+    FOREIGN KEY (storageid, stripeid, chunkid) REFERENCES chunk_group(storageid, stripeid, chunkid) ON DELETE CASCADE
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE chunk IS 'Columnar per chunk metadata';

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -30,6 +30,7 @@ END IF;
 END$proc$;
 
 DROP TABLE chunk;
+DROP TABLE chunk_group;
 DROP TABLE stripe;
 DROP TABLE options;
 DROP SEQUENCE storageid_seq;

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -287,6 +287,8 @@ extern StripeMetadata ReserveStripe(Relation rel, uint64 size,
 extern void SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe,
 							   StripeSkipList *stripeSkipList,
 							   TupleDesc tupleDescriptor);
+extern void SaveChunkGroups(RelFileNode relfilenode, uint64 stripe,
+							List *chunkGroupRowCounts);
 extern StripeSkipList * ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe,
 										   TupleDesc tupleDescriptor,
 										   uint32 chunkCount);

--- a/src/test/regress/expected/am_create.out
+++ b/src/test/regress/expected/am_create.out
@@ -42,3 +42,18 @@ EXCEPTION WHEN invalid_parameter_value THEN
    return false;
 END;
 $$ LANGUAGE plpgsql;
+-- are chunk groups and chunks consistent?
+CREATE view chunk_group_consistency AS
+WITH a as (
+   SELECT storageid, stripeid, chunkid, min(value_count) as row_count
+   FROM columnar.chunk
+   GROUP BY 1,2,3
+), b as (
+   SELECT storageid, stripeid, chunkid, max(value_count) as row_count
+   FROM columnar.chunk
+   GROUP BY 1,2,3
+), c as (
+   (TABLE a EXCEPT TABLE b) UNION (TABLE b EXCEPT TABLE a) UNION
+   (TABLE a EXCEPT TABLE columnar.chunk_group) UNION (TABLE columnar.chunk_group EXCEPT TABLE a)
+)
+SELECT count(*) = 0 AS consistent FROM c;

--- a/src/test/regress/expected/am_insert.out
+++ b/src/test/regress/expected/am_insert.out
@@ -45,6 +45,12 @@ select count(*) from test_insert_command;
      3
 (1 row)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 drop table test_insert_command_data;
 drop table test_insert_command;
 -- test long attribute value insertion
@@ -61,6 +67,12 @@ CREATE TABLE test_cstore_long_text(int_val int, text_val text)
 USING columnar;
 -- store long text in cstore table
 INSERT INTO test_cstore_long_text SELECT * FROM test_long_text;
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- drop source table to remove original text from toast
 DROP TABLE test_long_text;
 -- check if text data is still available in cstore table
@@ -127,6 +139,12 @@ FROM test_toast_columnar;
  pg_column_size | pg_column_size | pg_column_size | pg_column_size
 ---------------------------------------------------------------------
            5004 |           5004 |           5004 |           5004
+(1 row)
+
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
 (1 row)
 
 DROP TABLE test_toast_row;

--- a/src/test/regress/expected/am_insert.out
+++ b/src/test/regress/expected/am_insert.out
@@ -149,3 +149,65 @@ SELECT * FROM chunk_group_consistency;
 
 DROP TABLE test_toast_row;
 DROP TABLE test_toast_columnar;
+-- Verify metadata for zero column tables.
+-- We support writing into zero column tables, but not reading from them.
+-- We test that metadata makes sense so we can fix the read path in future.
+CREATE TABLE zero_col() USING columnar;
+SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 10);
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO zero_col DEFAULT VALUES;
+INSERT INTO zero_col DEFAULT VALUES;
+INSERT INTO zero_col DEFAULT VALUES;
+INSERT INTO zero_col DEFAULT VALUES;
+CREATE TABLE zero_col_heap();
+INSERT INTO zero_col_heap DEFAULT VALUES;
+INSERT INTO zero_col_heap DEFAULT VALUES;
+INSERT INTO zero_col_heap DEFAULT VALUES;
+INSERT INTO zero_col_heap DEFAULT VALUES;
+INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
+INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
+INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
+INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
+INSERT INTO zero_col SELECT * FROM zero_col_heap;
+SELECT relname, stripeid, row_count FROM columnar.stripe a, pg_class b
+WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+ORDER BY 1,2,3;
+ relname  | stripeid | row_count
+---------------------------------------------------------------------
+ zero_col |        1 |         1
+ zero_col |        2 |         1
+ zero_col |        3 |         1
+ zero_col |        4 |         1
+ zero_col |        5 |        64
+(5 rows)
+
+SELECT relname, stripeid, value_count FROM columnar.chunk a, pg_class b
+WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+ORDER BY 1,2,3;
+ relname | stripeid | value_count
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT relname, stripeid, chunkid, row_count FROM columnar.chunk_group a, pg_class b
+WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+ORDER BY 1,2,3,4;
+ relname  | stripeid | chunkid | row_count
+---------------------------------------------------------------------
+ zero_col |        1 |       0 |         1
+ zero_col |        2 |       0 |         1
+ zero_col |        3 |       0 |         1
+ zero_col |        4 |       0 |         1
+ zero_col |        5 |       0 |        10
+ zero_col |        5 |       1 |        10
+ zero_col |        5 |       2 |        10
+ zero_col |        5 |       3 |        10
+ zero_col |        5 |       4 |        10
+ zero_col |        5 |       5 |        10
+ zero_col |        5 |       6 |         4
+(11 rows)
+
+DROP TABLE zero_col;

--- a/src/test/regress/expected/am_recursive.out
+++ b/src/test/regress/expected/am_recursive.out
@@ -72,6 +72,12 @@ SELECT * FROM t2;
  5 | 6
 (5 rows)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 TRUNCATE t1;
 TRUNCATE t2;
 --
@@ -101,6 +107,12 @@ SELECT * FROM t2;
  3 | 0
 (3 rows)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 TRUNCATE t1;
 TRUNCATE t2;
 --
@@ -124,6 +136,12 @@ SELECT * FROM t1 ORDER BY a, b;
  5 |  6
  5 | 10
 (10 rows)
+
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
 
 TRUNCATE t1;
 TRUNCATE t2;
@@ -165,6 +183,12 @@ SELECT * FROM t2 ORDER BY a, b;
  5 | 5
 (5 rows)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 TRUNCATE t1, t2, t3, t4;
 --
 -- INSERT into the same relation that was INSERTed into in the UDF
@@ -203,6 +227,12 @@ SELECT * FROM t3 ORDER BY a, b;
  a | b
 ---------------------------------------------------------------------
 (0 rows)
+
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
 
 DROP FUNCTION g(int), g2(int);
 TRUNCATE t1, t2, t3, t4;
@@ -247,6 +277,12 @@ SELECT * FROM t1 ORDER BY a, b;
  22 | 44
  23 | 46
 (10 rows)
+
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
 
 DROP FUNCTION f(int);
 DROP TABLE t1, t2, t3, t4;

--- a/src/test/regress/expected/am_truncate.out
+++ b/src/test/regress/expected/am_truncate.out
@@ -37,7 +37,19 @@ SELECT * FROM columnar_truncate_test;
  10 | 10
 (10 rows)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 TRUNCATE TABLE columnar_truncate_test;
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT * FROM columnar_truncate_test;
  a | b
 ---------------------------------------------------------------------
@@ -118,12 +130,24 @@ SELECT * from columnar_truncate_test_regular;
  20 | 20
 (11 rows)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- make sure multi truncate works
 -- notice that the same table might be repeated
 TRUNCATE TABLE columnar_truncate_test,
 			   columnar_truncate_test_regular,
 			   columnar_truncate_test_second,
    			   columnar_truncate_test;
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT * from columnar_truncate_test;
  a | b
 ---------------------------------------------------------------------
@@ -267,6 +291,12 @@ SELECT count(*) FROM truncate_schema.truncate_tbl;
 (1 row)
 
 \c - :current_user
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- cleanup
 DROP SCHEMA truncate_schema CASCADE;
 NOTICE:  drop cascades to table truncate_schema.truncate_tbl

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -27,6 +27,12 @@ SELECT count(*) FROM t_stripes;
 
 -- vacuum full should merge stripes together
 VACUUM FULL t;
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT sum(a), sum(b) FROM t;
  sum | sum
 ---------------------------------------------------------------------
@@ -60,6 +66,12 @@ SELECT count(*) FROM t_stripes;
 (1 row)
 
 VACUUM FULL t;
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT sum(a), sum(b) FROM t;
    sum   |   sum
 ---------------------------------------------------------------------
@@ -203,6 +215,12 @@ compression rate: 1.25x
 total row count: 5530, stripe count: 5, average rows per stripe: 1106
 chunk count: 7, containing data for dropped columns: 0, none compressed: 5, pglz compressed: 2
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT count(*) FROM t;
  count
 ---------------------------------------------------------------------
@@ -239,6 +257,12 @@ compression rate: 1.96x
 total row count: 7030, stripe count: 4, average rows per stripe: 1757
 chunk count: 8, containing data for dropped columns: 0, none compressed: 2, pglz compressed: 6
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 DROP TABLE t;
 DROP VIEW t_stripes;
 -- Make sure we cleaned the metadata for t too
@@ -261,5 +285,11 @@ total file size: 630784, total data size: 604480
 compression rate: 33.71x
 total row count: 1000000, stripe count: 1, average rows per stripe: 1000000
 chunk count: 30, containing data for dropped columns: 0, pglz compressed: 30
+
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
 
 DROP TABLE t;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -507,12 +507,13 @@ SELECT * FROM print_extension_changes();
                                                                                  | schema columnar
                                                                                  | sequence columnar.storageid_seq
                                                                                  | table columnar.chunk
+                                                                                 | table columnar.chunk_group
                                                                                  | table columnar.options
                                                                                  | table columnar.stripe
                                                                                  | view citus_shards
                                                                                  | view citus_tables
                                                                                  | view time_partitions
-(66 rows)
+(67 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version

--- a/src/test/regress/expected/multi_extension_0.out
+++ b/src/test/regress/expected/multi_extension_0.out
@@ -503,12 +503,13 @@ SELECT * FROM print_extension_changes();
                                                                                  | schema columnar
                                                                                  | sequence columnar.storageid_seq
                                                                                  | table columnar.chunk
+                                                                                 | table columnar.chunk_group
                                                                                  | table columnar.options
                                                                                  | table columnar.stripe
                                                                                  | view citus_shards
                                                                                  | view citus_tables
                                                                                  | view time_partitions
-(62 rows)
+(63 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -214,6 +214,7 @@ ORDER BY 1;
  sequence pg_dist_shardid_seq
  table citus.pg_dist_object
  table columnar.chunk
+ table columnar.chunk_group
  table columnar.options
  table columnar.stripe
  table pg_dist_authinfo
@@ -241,5 +242,5 @@ ORDER BY 1;
  view citus_worker_stat_activity
  view pg_dist_shard_placement
  view time_partitions
-(225 rows)
+(226 rows)
 

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -210,6 +210,7 @@ ORDER BY 1;
  sequence pg_dist_shardid_seq
  table citus.pg_dist_object
  table columnar.chunk
+ table columnar.chunk_group
  table columnar.options
  table columnar.stripe
  table pg_dist_authinfo
@@ -237,5 +238,5 @@ ORDER BY 1;
  view citus_worker_stat_activity
  view pg_dist_shard_placement
  view time_partitions
-(221 rows)
+(222 rows)
 

--- a/src/test/regress/input/am_load.source
+++ b/src/test/regress/input/am_load.source
@@ -43,4 +43,6 @@ speed of light,2.997e8
 
 SELECT * FROM famous_constants ORDER BY id, name;
 
+SELECT * FROM chunk_group_consistency;
+
 DROP TABLE famous_constants;

--- a/src/test/regress/output/am_load.source
+++ b/src/test/regress/output/am_load.source
@@ -39,4 +39,10 @@ SELECT * FROM famous_constants ORDER BY id, name;
     | speed of light | 2.997e+08
 (8 rows)
 
+SELECT * FROM chunk_group_consistency;
+ consistent
+---------------------------------------------------------------------
+ t
+(1 row)
+
 DROP TABLE famous_constants;

--- a/src/test/regress/sql/am_insert.sql
+++ b/src/test/regress/sql/am_insert.sql
@@ -22,6 +22,8 @@ select count(*) from test_insert_command_data;
 insert into test_insert_command select * from test_insert_command_data;
 select count(*) from test_insert_command;
 
+SELECT * FROM chunk_group_consistency;
+
 drop table test_insert_command_data;
 drop table test_insert_command;
 
@@ -42,6 +44,8 @@ USING columnar;
 
 -- store long text in cstore table
 INSERT INTO test_cstore_long_text SELECT * FROM test_long_text;
+
+SELECT * FROM chunk_group_consistency;
 
 -- drop source table to remove original text from toast
 DROP TABLE test_long_text;
@@ -94,6 +98,8 @@ SELECT
   pg_column_size(plain), pg_column_size(main),
   pg_column_size(external), pg_column_size(extended)
 FROM test_toast_columnar;
+
+SELECT * FROM chunk_group_consistency;
 
 DROP TABLE test_toast_row;
 DROP TABLE test_toast_columnar;

--- a/src/test/regress/sql/am_recursive.sql
+++ b/src/test/regress/sql/am_recursive.sql
@@ -39,6 +39,8 @@ INSERT INTO t2 SELECT t.a, t.a+1 FROM t;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
+SELECT * FROM chunk_group_consistency;
+
 TRUNCATE t1;
 TRUNCATE t2;
 
@@ -55,6 +57,8 @@ INSERT INTO t2 SELECT i, (select count(*) from t1) FROM generate_series(1, 3) i;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
+SELECT * FROM chunk_group_consistency;
+
 TRUNCATE t1;
 TRUNCATE t2;
 
@@ -67,6 +71,8 @@ WITH t AS (
 INSERT INTO t1 SELECT t.a, t.a+1 FROM t;
 
 SELECT * FROM t1 ORDER BY a, b;
+
+SELECT * FROM chunk_group_consistency;
 
 TRUNCATE t1;
 TRUNCATE t2;
@@ -99,6 +105,8 @@ INSERT INTO t4 SELECT i, g2(i) FROM generate_series(1, 5) i;
 
 SELECT * FROM t2 ORDER BY a, b;
 
+SELECT * FROM chunk_group_consistency;
+
 TRUNCATE t1, t2, t3, t4;
 
 --
@@ -112,6 +120,8 @@ SELECT * FROM t3 ORDER BY a, b;
 -- check that t1==t3 and t2==t4.
 ((table t1) except (table t3)) union ((table t3) except (table t1));
 ((table t2) except (table t4)) union ((table t4) except (table t2));
+
+SELECT * FROM chunk_group_consistency;
 
 DROP FUNCTION g(int), g2(int);
 TRUNCATE t1, t2, t3, t4;
@@ -137,6 +147,8 @@ SELECT f(10);
 SELECT f(0), f(20);
 
 SELECT * FROM t1 ORDER BY a, b;
+
+SELECT * FROM chunk_group_consistency;
 
 DROP FUNCTION f(int);
 DROP TABLE t1, t2, t3, t4;

--- a/src/test/regress/sql/am_truncate.sql
+++ b/src/test/regress/sql/am_truncate.sql
@@ -25,7 +25,11 @@ set columnar.compression to default;
 -- query rows
 SELECT * FROM columnar_truncate_test;
 
+SELECT * FROM chunk_group_consistency;
+
 TRUNCATE TABLE columnar_truncate_test;
+
+SELECT * FROM chunk_group_consistency;
 
 SELECT * FROM columnar_truncate_test;
 
@@ -47,12 +51,16 @@ SELECT * from columnar_truncate_test_second;
 
 SELECT * from columnar_truncate_test_regular;
 
+SELECT * FROM chunk_group_consistency;
+
 -- make sure multi truncate works
 -- notice that the same table might be repeated
 TRUNCATE TABLE columnar_truncate_test,
 			   columnar_truncate_test_regular,
 			   columnar_truncate_test_second,
    			   columnar_truncate_test;
+
+SELECT * FROM chunk_group_consistency;
 
 SELECT * from columnar_truncate_test;
 SELECT * from columnar_truncate_test_second;
@@ -135,6 +143,8 @@ SELECT count(*) FROM truncate_schema.truncate_tbl;
 TRUNCATE TABLE truncate_schema.truncate_tbl;
 SELECT count(*) FROM truncate_schema.truncate_tbl;
 \c - :current_user
+
+SELECT * FROM chunk_group_consistency;
 
 -- cleanup
 DROP SCHEMA truncate_schema CASCADE;

--- a/src/test/regress/sql/am_vacuum.sql
+++ b/src/test/regress/sql/am_vacuum.sql
@@ -20,6 +20,8 @@ SELECT count(*) FROM t_stripes;
 -- vacuum full should merge stripes together
 VACUUM FULL t;
 
+SELECT * FROM chunk_group_consistency;
+
 SELECT sum(a), sum(b) FROM t;
 SELECT count(*) FROM t_stripes;
 
@@ -31,6 +33,8 @@ SELECT sum(a), sum(b) FROM t;
 SELECT count(*) FROM t_stripes;
 
 VACUUM FULL t;
+
+SELECT * FROM chunk_group_consistency;
 
 SELECT sum(a), sum(b) FROM t;
 SELECT count(*) FROM t_stripes;
@@ -92,6 +96,8 @@ COMMIT;
 
 VACUUM VERBOSE t;
 
+SELECT * FROM chunk_group_consistency;
+
 SELECT count(*) FROM t;
 
 -- check that we report chunks with data for dropped columns
@@ -108,6 +114,8 @@ SELECT alter_columnar_table_set('t', compression => 'pglz');
 VACUUM FULL t;
 VACUUM VERBOSE t;
 
+SELECT * FROM chunk_group_consistency;
+
 DROP TABLE t;
 DROP VIEW t_stripes;
 
@@ -122,5 +130,7 @@ CREATE TABLE t(a int, b char, c text) USING columnar;
 INSERT INTO t SELECT 1, 'a', 'xyz' FROM generate_series(1, 1000000) i;
 
 VACUUM VERBOSE t;
+
+SELECT * FROM chunk_group_consistency;
 
 DROP TABLE t;


### PR DESCRIPTION
This is an step towards normalizing `value_count` field of `columnar.chunk`, which is the same value for all chunks in a chunk group. Additionally, we don't have any `columnar.chunk` metadata for a table with 0 columns, but we have chunk groups which don't contain any chunks.

Note that since we are close to release time, this PR just tries to do the minimum changes to have `columnar.chunk_group`, so we can refactor in the next release to use this table in read/write paths. In future releases we will drop `columnar.chunk.value_count`, but we don't do that in this PR to minimize the changes that needs to be tested.

This PR also fixes the write path for zero column columnar tables, so we can verify their metadata makes sense.
