### PR TITLE
Fix EXPLAIN ANALYZE exec when query returns no cols

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1489,8 +1489,7 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc)
 	 * column definition cannot be empty, so create a dummy column definition for
 	 * queries with no results.
 	 */
-	bool originalQueryResultHasNoColumns = (tupleDesc->natts == 0);
-	if (originalQueryResultHasNoColumns)
+	if (tupleDesc->natts == 0)
 	{
 		appendStringInfo(columnDef, "dummy_field int");
 	}
@@ -1519,7 +1518,7 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc)
 	 * Otherwise, number of columns that original query returned wouldn't match
 	 * number of columns returned by worker_save_query_explain_analyze.
 	 */
-	char *workerSaveQueryFetchCols = originalQueryResultHasNoColumns ? "" : "*";
+	char *workerSaveQueryFetchCols = (tupleDesc->natts == 0) ? "" : "*";
 	appendStringInfo(wrappedQuery,
 					 "SELECT %s FROM worker_save_query_explain_analyze(%s, %s) AS (%s)",
 					 workerSaveQueryFetchCols,

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -3014,5 +3014,20 @@ Limit (actual rows=1 loops=1)
                           Join Filter: (distributed_table_2.b = intermediate_result.r)
                           ->  Function Scan on read_intermediate_result intermediate_result (actual rows=1 loops=1)
                           ->  Seq Scan on distributed_table_2_570034 distributed_table_xxx (actual rows=1 loops=1)
+EXPLAIN :default_analyze_flags SELECT FROM (SELECT * FROM reference_table) subquery;
+Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on reference_table_570031 reference_table (actual rows=1 loops=1)
+PREPARE dummy_prep_stmt(int) AS SELECT FROM distributed_table_1;
+EXPLAIN :default_analyze_flags EXECUTE dummy_prep_stmt(50);
+Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+  Task Count: 2
+  Tasks Shown: One of 2
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on distributed_table_1_570032 distributed_table_xxx (actual rows=1 loops=1)
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -2956,3 +2956,63 @@ Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
 -- reset back
 reset citus.explain_analyze_sort_method;
 DROP TABLE explain_analyze_execution_time;
+CREATE SCHEMA multi_explain;
+SET search_path TO multi_explain;
+-- test EXPLAIN ANALYZE when original query returns no columns
+CREATE TABLE reference_table(a int);
+SELECT create_reference_table('reference_table');
+
+INSERT INTO reference_table VALUES (1);
+EXPLAIN :default_analyze_flags SELECT FROM reference_table;
+Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+  Task Count: 1
+  Tasks Shown: All
+  ->  Task
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on reference_table_570031 reference_table (actual rows=1 loops=1)
+CREATE TABLE distributed_table_1(a int, b int);
+SELECT create_distributed_table('distributed_table_1','a');
+
+INSERT INTO distributed_table_1 values (1,1);
+EXPLAIN :default_analyze_flags SELECT row_number() OVER() AS r FROM distributed_table_1;
+WindowAgg (actual rows=1 loops=1)
+  ->  Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+        Task Count: 2
+        Tasks Shown: One of 2
+        ->  Task
+              Node: host=localhost port=xxxxx dbname=regression
+              ->  Seq Scan on distributed_table_1_570032 distributed_table_xxx (actual rows=1 loops=1)
+CREATE TABLE distributed_table_2(a int, b int);
+SELECT create_distributed_table('distributed_table_2','a');
+
+INSERT INTO distributed_table_2 VALUES (1,1);
+EXPLAIN :default_analyze_flags
+WITH r AS (SELECT row_number() OVER () AS r FROM distributed_table_1)
+SELECT * FROM distributed_table_2
+JOIN r ON (r = distributed_table_2.b)
+LIMIT 3;
+Limit (actual rows=1 loops=1)
+  ->  Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+        ->  Distributed Subplan XXX_1
+              Intermediate Data Size: 14 bytes
+              Result destination: Send to 2 nodes
+              ->  WindowAgg (actual rows=1 loops=1)
+                    ->  Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
+                          Task Count: 2
+                          Tasks Shown: One of 2
+                          ->  Task
+                                Node: host=localhost port=xxxxx dbname=regression
+                                ->  Seq Scan on distributed_table_1_570032 distributed_table_xxx (actual rows=1 loops=1)
+        Task Count: 2
+        Tuple data received from nodes: 3 bytes
+        Tasks Shown: One of 2
+        ->  Task
+              Tuple data received from node: 3 bytes
+              Node: host=localhost port=xxxxx dbname=regression
+              ->  Limit (actual rows=1 loops=1)
+                    ->  Nested Loop (actual rows=1 loops=1)
+                          Join Filter: (distributed_table_2.b = intermediate_result.r)
+                          ->  Function Scan on read_intermediate_result intermediate_result (actual rows=1 loops=1)
+                          ->  Seq Scan on distributed_table_2_570034 distributed_table_xxx (actual rows=1 loops=1)
+SET client_min_messages TO ERROR;
+DROP SCHEMA multi_explain CASCADE;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -1079,5 +1079,10 @@ SELECT * FROM distributed_table_2
 JOIN r ON (r = distributed_table_2.b)
 LIMIT 3;
 
+EXPLAIN :default_analyze_flags SELECT FROM (SELECT * FROM reference_table) subquery;
+
+PREPARE dummy_prep_stmt(int) AS SELECT FROM distributed_table_1;
+EXPLAIN :default_analyze_flags EXECUTE dummy_prep_stmt(50);
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes EXPLAIN ANALYZE error when query returns no columns

We should not include dummy column if original task didn't return any
columns.
Otherwise, number of columns that original task returned wouldn't
match number of columns returned by worker_save_query_explain_analyze.

See https://github.com/citusdata/citus/issues/4643#issuecomment-775174252.

Fixes #4643