### PR TITLE
Don't include stripe reservation locks in lock graph

### DIFF
--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -284,8 +284,8 @@ WriteColumnarOptions(Oid regclass, ColumnarOptions *options, bool overwrite)
 	}
 
 	systable_endscan_ordered(scanDescriptor);
-	index_close(index, NoLock);
-	relation_close(columnarOptions, NoLock);
+	index_close(index, AccessShareLock);
+	relation_close(columnarOptions, RowExclusiveLock);
 
 	return written;
 }
@@ -335,8 +335,8 @@ DeleteColumnarTableOptions(Oid regclass, bool missingOk)
 	}
 
 	systable_endscan_ordered(scanDescriptor);
-	index_close(index, NoLock);
-	relation_close(columnarOptions, NoLock);
+	index_close(index, AccessShareLock);
+	relation_close(columnarOptions, RowExclusiveLock);
 
 	return result;
 }
@@ -365,7 +365,7 @@ ReadColumnarOptions(Oid regclass, ColumnarOptions *options)
 	Relation index = try_relation_open(ColumnarOptionsIndexRegclass(), AccessShareLock);
 	if (index == NULL)
 	{
-		table_close(columnarOptions, NoLock);
+		table_close(columnarOptions, AccessShareLock);
 
 		/* extension has been dropped */
 		return false;
@@ -394,8 +394,8 @@ ReadColumnarOptions(Oid regclass, ColumnarOptions *options)
 	}
 
 	systable_endscan_ordered(scanDescriptor);
-	index_close(index, NoLock);
-	relation_close(columnarOptions, NoLock);
+	index_close(index, AccessShareLock);
+	relation_close(columnarOptions, AccessShareLock);
 
 	return true;
 }
@@ -464,7 +464,7 @@ SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe, StripeSkipList *chunk
 	}
 
 	FinishModifyRelation(modifyState);
-	table_close(columnarChunk, NoLock);
+	table_close(columnarChunk, RowExclusiveLock);
 
 	CommandCounterIncrement();
 }
@@ -610,8 +610,8 @@ ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe, TupleDesc tupleDescri
 	}
 
 	systable_endscan_ordered(scanDescriptor);
-	index_close(index, NoLock);
-	table_close(columnarChunk, NoLock);
+	index_close(index, AccessShareLock);
+	table_close(columnarChunk, AccessShareLock);
 
 	return chunkList;
 }
@@ -646,7 +646,7 @@ InsertStripeMetadataRow(uint64 storageId, StripeMetadata *stripe)
 
 	CommandCounterIncrement();
 
-	table_close(columnarStripes, NoLock);
+	table_close(columnarStripes, RowExclusiveLock);
 }
 
 
@@ -849,8 +849,8 @@ ReadDataFileStripeList(uint64 storageId, Snapshot snapshot)
 	}
 
 	systable_endscan_ordered(scanDescriptor);
-	index_close(index, NoLock);
-	table_close(columnarStripes, NoLock);
+	index_close(index, AccessShareLock);
+	table_close(columnarStripes, AccessShareLock);
 
 	return stripeMetadataList;
 }
@@ -911,8 +911,8 @@ DeleteMetadataRows(RelFileNode relfilenode)
 	FinishModifyRelation(modifyState);
 
 	systable_endscan_ordered(scanDescriptor);
-	index_close(index, NoLock);
-	table_close(columnarStripes, NoLock);
+	index_close(index, AccessShareLock);
+	table_close(columnarStripes, AccessShareLock);
 }
 
 

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -38,7 +38,10 @@ typedef enum AdvisoryLocktagClass
 	ADV_LOCKTAG_CLASS_CITUS_JOB = 6,
 	ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION = 7,
 	ADV_LOCKTAG_CLASS_CITUS_COLOCATED_SHARDS_METADATA = 8,
-	ADV_LOCKTAG_CLASS_CITUS_OPERATIONS = 9
+	ADV_LOCKTAG_CLASS_CITUS_OPERATIONS = 9,
+
+	/* Columnar lock types */
+	ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION = 10
 } AdvisoryLocktagClass;
 
 /* CitusOperations has constants for citus operations */
@@ -97,6 +100,13 @@ typedef enum CitusOperations
 						 (uint32) 0, \
 						 (uint32) operationId, \
 						 ADV_LOCKTAG_CLASS_CITUS_OPERATIONS)
+
+#define SET_LOCKTAG_COLUMNAR_STRIPE_RESERVATION(tag, relation) \
+	SET_LOCKTAG_ADVISORY(tag, \
+						 relation->rd_lockInfo.lockRelId.dbId, \
+						 relation->rd_lockInfo.lockRelId.relId, \
+						 0, \
+						 ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION)
 
 /* Lock shard/relation metadata for safe modifications */
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);


### PR DESCRIPTION
Stripe reservation locks are temporary & don't hold until end of transaction, so we shouldn't include them in the lock graph used for detecting distributed transactions.

This PR also releases metadata locks after accessing them.

The situation that was happening was:

1. Distributed transactions A and B concurrently did a multi-row INSERT that accessed multiple shards.
2. At time t, for shard 1, A's connection to worker got the stripe reservation lock so B's connection to worker waited for A.
3. At the same time t, for shard 2, B's connection to worker got the stripe reservation lock so A's connection to worker waited for B.
4. Citus assumed that these locks will hold until end of transaction so it reported a distributed deadlock.

But these locks were temporary & they didn't hold until end of transaction so if Citus waited more or we just ignored these locks the situation would resolve in a second.

Fixes https://github.com/citusdata/citus/issues/4646