### PR TITLE
Columnar metadata changes

### DIFF
--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -153,16 +153,16 @@ typedef FormData_columnar_options *Form_columnar_options;
 #define Anum_columnar_chunk_stripe 2
 #define Anum_columnar_chunk_attr 3
 #define Anum_columnar_chunk_chunk 4
-#define Anum_columnar_chunk_value_count 5
-#define Anum_columnar_chunk_minimum_value 6
-#define Anum_columnar_chunk_maximum_value 7
-#define Anum_columnar_chunk_value_stream_offset 8
-#define Anum_columnar_chunk_value_stream_length 9
-#define Anum_columnar_chunk_exists_stream_offset 10
-#define Anum_columnar_chunk_exists_stream_length 11
-#define Anum_columnar_chunk_value_compression_type 12
-#define Anum_columnar_chunk_value_compression_level 13
-#define Anum_columnar_chunk_value_decompressed_size 14
+#define Anum_columnar_chunk_minimum_value 5
+#define Anum_columnar_chunk_maximum_value 6
+#define Anum_columnar_chunk_value_stream_offset 7
+#define Anum_columnar_chunk_value_stream_length 8
+#define Anum_columnar_chunk_exists_stream_offset 9
+#define Anum_columnar_chunk_exists_stream_length 10
+#define Anum_columnar_chunk_value_compression_type 11
+#define Anum_columnar_chunk_value_compression_level 12
+#define Anum_columnar_chunk_value_decompressed_size 13
+#define Anum_columnar_chunk_value_count 14
 
 
 /*
@@ -430,7 +430,6 @@ SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe, StripeSkipList *chunk
 				Int64GetDatum(stripe),
 				Int32GetDatum(columnIndex + 1),
 				Int32GetDatum(chunkIndex),
-				Int64GetDatum(chunk->rowCount),
 				0, /* to be filled below */
 				0, /* to be filled below */
 				Int64GetDatum(chunk->valueChunkOffset),
@@ -439,7 +438,8 @@ SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe, StripeSkipList *chunk
 				Int64GetDatum(chunk->existsLength),
 				Int32GetDatum(chunk->valueCompressionType),
 				Int32GetDatum(chunk->valueCompressionLevel),
-				Int64GetDatum(chunk->decompressedValueSize)
+				Int64GetDatum(chunk->decompressedValueSize),
+				Int64GetDatum(chunk->rowCount)
 			};
 
 			bool nulls[Natts_columnar_chunk] = { false };

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -16,7 +16,7 @@ CREATE TABLE options (
 COMMENT ON TABLE options IS 'columnar table specific options, maintained by alter_columnar_table_set';
 
 CREATE TABLE stripe (
-    storageid bigint NOT NULL,
+    storage_id bigint NOT NULL,
     stripe_num bigint NOT NULL,
     file_offset bigint NOT NULL,
     data_length bigint NOT NULL,
@@ -24,24 +24,24 @@ CREATE TABLE stripe (
     chunk_count int NOT NULL,
     chunk_row_count int NOT NULL,
     row_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripe_num)
+    PRIMARY KEY (storage_id, stripe_num)
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE stripe IS 'Columnar per stripe metadata';
 
 CREATE TABLE chunk_group (
-    storageid bigint NOT NULL,
+    storage_id bigint NOT NULL,
     stripe_num bigint NOT NULL,
     chunk_num int NOT NULL,
     row_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripe_num, chunk_num),
-    FOREIGN KEY (storageid, stripe_num) REFERENCES stripe(storageid, stripe_num) ON DELETE CASCADE
+    PRIMARY KEY (storage_id, stripe_num, chunk_num),
+    FOREIGN KEY (storage_id, stripe_num) REFERENCES stripe(storage_id, stripe_num) ON DELETE CASCADE
 );
 
 COMMENT ON TABLE chunk_group IS 'Columnar chunk group metadata';
 
 CREATE TABLE chunk (
-    storageid bigint NOT NULL,
+    storage_id bigint NOT NULL,
     stripe_num bigint NOT NULL,
     attr_num int NOT NULL,
     chunk_num int NOT NULL,
@@ -55,8 +55,8 @@ CREATE TABLE chunk (
     value_compression_level int NOT NULL,
     value_decompressed_length bigint NOT NULL,
     value_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripe_num, attr_num, chunk_num),
-    FOREIGN KEY (storageid, stripe_num, chunk_num) REFERENCES chunk_group(storageid, stripe_num, chunk_num) ON DELETE CASCADE
+    PRIMARY KEY (storage_id, stripe_num, attr_num, chunk_num),
+    FOREIGN KEY (storage_id, stripe_num, chunk_num) REFERENCES chunk_group(storage_id, stripe_num, chunk_num) ON DELETE CASCADE
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE chunk IS 'Columnar per chunk metadata';

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -17,34 +17,34 @@ COMMENT ON TABLE options IS 'columnar table specific options, maintained by alte
 
 CREATE TABLE stripe (
     storageid bigint NOT NULL,
-    stripeid bigint NOT NULL,
+    stripe_num bigint NOT NULL,
     file_offset bigint NOT NULL,
     data_length bigint NOT NULL,
     column_count int NOT NULL,
     chunk_count int NOT NULL,
     chunk_row_count int NOT NULL,
     row_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripeid)
+    PRIMARY KEY (storageid, stripe_num)
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE stripe IS 'Columnar per stripe metadata';
 
 CREATE TABLE chunk_group (
     storageid bigint NOT NULL,
-    stripeid bigint NOT NULL,
-    chunkid int NOT NULL,
+    stripe_num bigint NOT NULL,
+    chunk_num int NOT NULL,
     row_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripeid, chunkid),
-    FOREIGN KEY (storageid, stripeid) REFERENCES stripe(storageid, stripeid) ON DELETE CASCADE
+    PRIMARY KEY (storageid, stripe_num, chunk_num),
+    FOREIGN KEY (storageid, stripe_num) REFERENCES stripe(storageid, stripe_num) ON DELETE CASCADE
 );
 
 COMMENT ON TABLE chunk_group IS 'Columnar chunk group metadata';
 
 CREATE TABLE chunk (
     storageid bigint NOT NULL,
-    stripeid bigint NOT NULL,
-    attnum int NOT NULL,
-    chunkid int NOT NULL,
+    stripe_num bigint NOT NULL,
+    attr_num int NOT NULL,
+    chunk_num int NOT NULL,
     minimum_value bytea,
     maximum_value bytea,
     value_stream_offset bigint NOT NULL,
@@ -55,8 +55,8 @@ CREATE TABLE chunk (
     value_compression_level int NOT NULL,
     value_decompressed_length bigint NOT NULL,
     value_count bigint NOT NULL,
-    PRIMARY KEY (storageid, stripeid, attnum, chunkid),
-    FOREIGN KEY (storageid, stripeid, chunkid) REFERENCES chunk_group(storageid, stripeid, chunkid) ON DELETE CASCADE
+    PRIMARY KEY (storageid, stripe_num, attr_num, chunk_num),
+    FOREIGN KEY (storageid, stripe_num, chunk_num) REFERENCES chunk_group(storageid, stripe_num, chunk_num) ON DELETE CASCADE
 ) WITH (user_catalog_table = true);
 
 COMMENT ON TABLE chunk IS 'Columnar per chunk metadata';

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -45,7 +45,6 @@ CREATE TABLE chunk (
     stripeid bigint NOT NULL,
     attnum int NOT NULL,
     chunkid int NOT NULL,
-    value_count bigint NOT NULL,
     minimum_value bytea,
     maximum_value bytea,
     value_stream_offset bigint NOT NULL,
@@ -55,6 +54,7 @@ CREATE TABLE chunk (
     value_compression_type int NOT NULL,
     value_compression_level int NOT NULL,
     value_decompressed_length bigint NOT NULL,
+    value_count bigint NOT NULL,
     PRIMARY KEY (storageid, stripeid, attnum, chunkid),
     FOREIGN KEY (storageid, stripeid, chunkid) REFERENCES chunk_group(storageid, stripeid, chunkid) ON DELETE CASCADE
 ) WITH (user_catalog_table = true);

--- a/src/test/regress/expected/am_create.out
+++ b/src/test/regress/expected/am_create.out
@@ -45,11 +45,11 @@ $$ LANGUAGE plpgsql;
 -- are chunk groups and chunks consistent?
 CREATE view chunk_group_consistency AS
 WITH a as (
-   SELECT storageid, stripe_num, chunk_num, min(value_count) as row_count
+   SELECT storage_id, stripe_num, chunk_num, min(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), b as (
-   SELECT storageid, stripe_num, chunk_num, max(value_count) as row_count
+   SELECT storage_id, stripe_num, chunk_num, max(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), c as (

--- a/src/test/regress/expected/am_create.out
+++ b/src/test/regress/expected/am_create.out
@@ -45,11 +45,11 @@ $$ LANGUAGE plpgsql;
 -- are chunk groups and chunks consistent?
 CREATE view chunk_group_consistency AS
 WITH a as (
-   SELECT storageid, stripeid, chunkid, min(value_count) as row_count
+   SELECT storageid, stripe_num, chunk_num, min(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), b as (
-   SELECT storageid, stripeid, chunkid, max(value_count) as row_count
+   SELECT storageid, stripe_num, chunk_num, max(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), c as (

--- a/src/test/regress/expected/am_drop.out
+++ b/src/test/regress/expected/am_drop.out
@@ -12,12 +12,12 @@
 -- 'postgres' directory is excluded from comparison to have the same result.
 -- store postgres database oid
 SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
-SELECT count(distinct storageid) AS columnar_stripes_before_drop FROM columnar.stripe \gset
+SELECT count(distinct storage_id) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 -- DROP columnar tables
 DROP TABLE contestant;
 DROP TABLE contestant_compressed;
 -- make sure DROP deletes metadata
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
+SELECT :columnar_stripes_before_drop - count(distinct storage_id) FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         2
@@ -30,7 +30,7 @@ INSERT INTO test_schema.test_table VALUES (1);
 SELECT count(*) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 DROP SCHEMA test_schema CASCADE;
 NOTICE:  drop cascades to table test_schema.test_table
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
+SELECT :columnar_stripes_before_drop - count(distinct storage_id) FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/expected/am_insert.out
+++ b/src/test/regress/expected/am_insert.out
@@ -173,10 +173,10 @@ INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col SELECT * FROM zero_col_heap;
-SELECT relname, stripeid, row_count FROM columnar.stripe a, pg_class b
+SELECT relname, stripe_num, row_count FROM columnar.stripe a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
 ORDER BY 1,2,3;
- relname  | stripeid | row_count
+ relname  | stripe_num | row_count
 ---------------------------------------------------------------------
  zero_col |        1 |         1
  zero_col |        2 |         1
@@ -185,17 +185,17 @@ ORDER BY 1,2,3;
  zero_col |        5 |        64
 (5 rows)
 
-SELECT relname, stripeid, value_count FROM columnar.chunk a, pg_class b
+SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
 ORDER BY 1,2,3;
- relname | stripeid | value_count
+ relname | stripe_num | value_count
 ---------------------------------------------------------------------
 (0 rows)
 
-SELECT relname, stripeid, chunkid, row_count FROM columnar.chunk_group a, pg_class b
+SELECT relname, stripe_num, chunk_num, row_count FROM columnar.chunk_group a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
 ORDER BY 1,2,3,4;
- relname  | stripeid | chunkid | row_count
+ relname  | stripe_num | chunk_num | row_count
 ---------------------------------------------------------------------
  zero_col |        1 |       0 |         1
  zero_col |        2 |       0 |         1

--- a/src/test/regress/expected/am_insert.out
+++ b/src/test/regress/expected/am_insert.out
@@ -174,7 +174,7 @@ INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col SELECT * FROM zero_col_heap;
 SELECT relname, stripe_num, row_count FROM columnar.stripe a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3;
  relname  | stripe_num | row_count
 ---------------------------------------------------------------------
@@ -186,14 +186,14 @@ ORDER BY 1,2,3;
 (5 rows)
 
 SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3;
  relname | stripe_num | value_count
 ---------------------------------------------------------------------
 (0 rows)
 
 SELECT relname, stripe_num, chunk_num, row_count FROM columnar.chunk_group a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3,4;
  relname  | stripe_num | chunk_num | row_count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/am_matview.out
+++ b/src/test/regress/expected/am_matview.out
@@ -68,13 +68,13 @@ SELECT * FROM t_view a ORDER BY a;
 -- verify that we have created metadata entries for the materialized view
 SELECT columnar_relation_storageid(oid) AS storageid
 FROM pg_class WHERE relname='t_view' \gset
-SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storage_id=:storageid;
  count
 ---------------------------------------------------------------------
      1
 (1 row)
 
-SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storage_id=:storageid;
  count
 ---------------------------------------------------------------------
      3
@@ -83,13 +83,13 @@ SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
 DROP TABLE t CASCADE;
 NOTICE:  drop cascades to materialized view t_view
 -- dropping must remove metadata
-SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storage_id=:storageid;
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
-SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storage_id=:storageid;
  count
 ---------------------------------------------------------------------
      0

--- a/src/test/regress/expected/am_recursive.out
+++ b/src/test/regress/expected/am_recursive.out
@@ -12,7 +12,7 @@ INSERT INTO t2 SELECT i, f(i) FROM generate_series(1, 5) i;
 -- there are no subtransactions, so above statement should batch
 -- INSERTs inside the UDF and create on stripe per table.
 SELECT relname, count(*) FROM columnar.stripe a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname IN ('t1', 't2')
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname IN ('t1', 't2')
 GROUP BY relname
 ORDER BY relname;
  relname | count

--- a/src/test/regress/expected/am_rollback.out
+++ b/src/test/regress/expected/am_rollback.out
@@ -4,7 +4,7 @@
 CREATE TABLE t(a int, b int) USING columnar;
 CREATE VIEW t_stripes AS
 SELECT * FROM columnar.stripe a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname = 't';
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname = 't';
 BEGIN;
 INSERT INTO t SELECT i, i+1 FROM generate_series(1, 10) i;
 ROLLBACK;

--- a/src/test/regress/expected/am_truncate.out
+++ b/src/test/regress/expected/am_truncate.out
@@ -15,7 +15,7 @@ CREATE TABLE columnar_truncate_test_second (a int, b int) USING columnar;
 -- COMPRESSED
 CREATE TABLE columnar_truncate_test_compressed (a int, b int) USING columnar;
 CREATE TABLE columnar_truncate_test_regular (a int, b int);
-SELECT count(distinct storageid) AS columnar_data_files_before_truncate FROM columnar.stripe \gset
+SELECT count(distinct storage_id) AS columnar_data_files_before_truncate FROM columnar.stripe \gset
 INSERT INTO columnar_truncate_test select a, a from generate_series(1, 10) a;
 set columnar.compression = 'pglz';
 INSERT INTO columnar_truncate_test_compressed select a, a from generate_series(1, 10) a;
@@ -171,7 +171,7 @@ SELECT * from columnar_truncate_test;
 (0 rows)
 
 -- make sure TRUNATE deletes metadata for old relfilenode
-SELECT :columnar_data_files_before_truncate - count(distinct storageid) FROM columnar.stripe;
+SELECT :columnar_data_files_before_truncate - count(distinct storage_id) FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         0
@@ -185,7 +185,7 @@ TRUNCATE columnar_same_transaction_truncate;
 INSERT INTO columnar_same_transaction_truncate SELECT * FROM generate_series(20, 23);
 COMMIT;
 -- should output "1" for the newly created relation
-SELECT count(distinct storageid) - :columnar_data_files_before_truncate FROM columnar.stripe;
+SELECT count(distinct storage_id) - :columnar_data_files_before_truncate FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         1

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -1,9 +1,9 @@
 SET columnar.compression TO 'none';
-SELECT count(distinct storageid) AS columnar_table_count FROM columnar.stripe \gset
+SELECT count(distinct storage_id) AS columnar_table_count FROM columnar.stripe \gset
 CREATE TABLE t(a int, b int) USING columnar;
 CREATE VIEW t_stripes AS
 SELECT * FROM columnar.stripe a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t';
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname='t';
 SELECT count(*) FROM t_stripes;
  count
 ---------------------------------------------------------------------
@@ -88,7 +88,7 @@ SELECT count(*) FROM t_stripes;
 ALTER TABLE t DROP COLUMN a;
 SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
  stripe_num | attr_num | chunk_num | ?column? | ?column?
 ---------------------------------------------------------------------
         1 |      1 |       0 | f        | f
@@ -102,7 +102,7 @@ WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER B
 VACUUM FULL t;
 SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
  stripe_num | attr_num | chunk_num | ?column? | ?column?
 ---------------------------------------------------------------------
         1 |      1 |       0 | t        | t
@@ -114,7 +114,7 @@ WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER B
 (6 rows)
 
 -- Make sure we cleaned-up the transient table metadata after VACUUM FULL commands
-SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
+SELECT count(distinct storage_id) - :columnar_table_count FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         1
@@ -266,7 +266,7 @@ SELECT * FROM chunk_group_consistency;
 DROP TABLE t;
 DROP VIEW t_stripes;
 -- Make sure we cleaned the metadata for t too
-SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
+SELECT count(distinct storage_id) - :columnar_table_count FROM columnar.stripe;
  ?column?
 ---------------------------------------------------------------------
         0

--- a/src/test/regress/expected/am_vacuum.out
+++ b/src/test/regress/expected/am_vacuum.out
@@ -86,10 +86,10 @@ SELECT count(*) FROM t_stripes;
 
 -- VACUUM FULL doesn't reclaim dropped columns, but converts them to NULLs
 ALTER TABLE t DROP COLUMN a;
-SELECT stripeid, attnum, chunkid, minimum_value IS NULL, maximum_value IS NULL
+SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
- stripeid | attnum | chunkid | ?column? | ?column?
+ stripe_num | attr_num | chunk_num | ?column? | ?column?
 ---------------------------------------------------------------------
         1 |      1 |       0 | f        | f
         1 |      2 |       0 | f        | f
@@ -100,10 +100,10 @@ WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER B
 (6 rows)
 
 VACUUM FULL t;
-SELECT stripeid, attnum, chunkid, minimum_value IS NULL, maximum_value IS NULL
+SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
- stripeid | attnum | chunkid | ?column? | ?column?
+ stripe_num | attr_num | chunk_num | ?column? | ?column?
 ---------------------------------------------------------------------
         1 |      1 |       0 | t        | t
         1 |      2 |       0 | f        | f

--- a/src/test/regress/sql/am_create.sql
+++ b/src/test/regress/sql/am_create.sql
@@ -49,11 +49,11 @@ $$ LANGUAGE plpgsql;
 -- are chunk groups and chunks consistent?
 CREATE view chunk_group_consistency AS
 WITH a as (
-   SELECT storageid, stripe_num, chunk_num, min(value_count) as row_count
+   SELECT storage_id, stripe_num, chunk_num, min(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), b as (
-   SELECT storageid, stripe_num, chunk_num, max(value_count) as row_count
+   SELECT storage_id, stripe_num, chunk_num, max(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), c as (

--- a/src/test/regress/sql/am_create.sql
+++ b/src/test/regress/sql/am_create.sql
@@ -49,11 +49,11 @@ $$ LANGUAGE plpgsql;
 -- are chunk groups and chunks consistent?
 CREATE view chunk_group_consistency AS
 WITH a as (
-   SELECT storageid, stripeid, chunkid, min(value_count) as row_count
+   SELECT storageid, stripe_num, chunk_num, min(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), b as (
-   SELECT storageid, stripeid, chunkid, max(value_count) as row_count
+   SELECT storageid, stripe_num, chunk_num, max(value_count) as row_count
    FROM columnar.chunk
    GROUP BY 1,2,3
 ), c as (

--- a/src/test/regress/sql/am_drop.sql
+++ b/src/test/regress/sql/am_drop.sql
@@ -15,14 +15,14 @@
 -- store postgres database oid
 SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 
-SELECT count(distinct storageid) AS columnar_stripes_before_drop FROM columnar.stripe \gset
+SELECT count(distinct storage_id) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 
 -- DROP columnar tables
 DROP TABLE contestant;
 DROP TABLE contestant_compressed;
 
 -- make sure DROP deletes metadata
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
+SELECT :columnar_stripes_before_drop - count(distinct storage_id) FROM columnar.stripe;
 
 -- Create a columnar table under a schema and drop it.
 CREATE SCHEMA test_schema;
@@ -31,7 +31,7 @@ INSERT INTO test_schema.test_table VALUES (1);
 
 SELECT count(*) AS columnar_stripes_before_drop FROM columnar.stripe \gset
 DROP SCHEMA test_schema CASCADE;
-SELECT :columnar_stripes_before_drop - count(distinct storageid) FROM columnar.stripe;
+SELECT :columnar_stripes_before_drop - count(distinct storage_id) FROM columnar.stripe;
 
 SELECT current_database() datname \gset
 

--- a/src/test/regress/sql/am_insert.sql
+++ b/src/test/regress/sql/am_insert.sql
@@ -128,15 +128,15 @@ INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 
 INSERT INTO zero_col SELECT * FROM zero_col_heap;
 
-SELECT relname, stripeid, row_count FROM columnar.stripe a, pg_class b
+SELECT relname, stripe_num, row_count FROM columnar.stripe a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
 ORDER BY 1,2,3;
 
-SELECT relname, stripeid, value_count FROM columnar.chunk a, pg_class b
+SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
 ORDER BY 1,2,3;
 
-SELECT relname, stripeid, chunkid, row_count FROM columnar.chunk_group a, pg_class b
+SELECT relname, stripe_num, chunk_num, row_count FROM columnar.chunk_group a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
 ORDER BY 1,2,3,4;
 

--- a/src/test/regress/sql/am_insert.sql
+++ b/src/test/regress/sql/am_insert.sql
@@ -129,15 +129,15 @@ INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col SELECT * FROM zero_col_heap;
 
 SELECT relname, stripe_num, row_count FROM columnar.stripe a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3;
 
 SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3;
 
 SELECT relname, stripe_num, chunk_num, row_count FROM columnar.chunk_group a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname = 'zero_col'
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3,4;
 
 DROP TABLE zero_col;

--- a/src/test/regress/sql/am_matview.sql
+++ b/src/test/regress/sql/am_matview.sql
@@ -38,11 +38,11 @@ SELECT * FROM t_view a ORDER BY a;
 SELECT columnar_relation_storageid(oid) AS storageid
 FROM pg_class WHERE relname='t_view' \gset
 
-SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
-SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storage_id=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storage_id=:storageid;
 
 DROP TABLE t CASCADE;
 
 -- dropping must remove metadata
-SELECT count(*) FROM columnar.stripe WHERE storageid=:storageid;
-SELECT count(*) FROM columnar.chunk WHERE storageid=:storageid;
+SELECT count(*) FROM columnar.stripe WHERE storage_id=:storageid;
+SELECT count(*) FROM columnar.chunk WHERE storage_id=:storageid;

--- a/src/test/regress/sql/am_recursive.sql
+++ b/src/test/regress/sql/am_recursive.sql
@@ -16,7 +16,7 @@ INSERT INTO t2 SELECT i, f(i) FROM generate_series(1, 5) i;
 -- there are no subtransactions, so above statement should batch
 -- INSERTs inside the UDF and create on stripe per table.
 SELECT relname, count(*) FROM columnar.stripe a, pg_class b
-WHERE columnar_relation_storageid(b.oid)=a.storageid AND relname IN ('t1', 't2')
+WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname IN ('t1', 't2')
 GROUP BY relname
 ORDER BY relname;
 

--- a/src/test/regress/sql/am_rollback.sql
+++ b/src/test/regress/sql/am_rollback.sql
@@ -6,7 +6,7 @@ CREATE TABLE t(a int, b int) USING columnar;
 
 CREATE VIEW t_stripes AS
 SELECT * FROM columnar.stripe a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname = 't';
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname = 't';
 
 BEGIN;
 INSERT INTO t SELECT i, i+1 FROM generate_series(1, 10) i;

--- a/src/test/regress/sql/am_truncate.sql
+++ b/src/test/regress/sql/am_truncate.sql
@@ -13,7 +13,7 @@ CREATE TABLE columnar_truncate_test_second (a int, b int) USING columnar;
 CREATE TABLE columnar_truncate_test_compressed (a int, b int) USING columnar;
 CREATE TABLE columnar_truncate_test_regular (a int, b int);
 
-SELECT count(distinct storageid) AS columnar_data_files_before_truncate FROM columnar.stripe \gset
+SELECT count(distinct storage_id) AS columnar_data_files_before_truncate FROM columnar.stripe \gset
 
 INSERT INTO columnar_truncate_test select a, a from generate_series(1, 10) a;
 
@@ -71,7 +71,7 @@ TRUNCATE TABLE columnar_truncate_test;
 SELECT * from columnar_truncate_test;
 
 -- make sure TRUNATE deletes metadata for old relfilenode
-SELECT :columnar_data_files_before_truncate - count(distinct storageid) FROM columnar.stripe;
+SELECT :columnar_data_files_before_truncate - count(distinct storage_id) FROM columnar.stripe;
 
 -- test if truncation in the same transaction that created the table works properly
 BEGIN;
@@ -82,7 +82,7 @@ INSERT INTO columnar_same_transaction_truncate SELECT * FROM generate_series(20,
 COMMIT;
 
 -- should output "1" for the newly created relation
-SELECT count(distinct storageid) - :columnar_data_files_before_truncate FROM columnar.stripe;
+SELECT count(distinct storage_id) - :columnar_data_files_before_truncate FROM columnar.stripe;
 SELECT * FROM columnar_same_transaction_truncate;
 
 DROP TABLE columnar_same_transaction_truncate;

--- a/src/test/regress/sql/am_vacuum.sql
+++ b/src/test/regress/sql/am_vacuum.sql
@@ -1,12 +1,12 @@
 SET columnar.compression TO 'none';
 
-SELECT count(distinct storageid) AS columnar_table_count FROM columnar.stripe \gset
+SELECT count(distinct storage_id) AS columnar_table_count FROM columnar.stripe \gset
 
 CREATE TABLE t(a int, b int) USING columnar;
 
 CREATE VIEW t_stripes AS
 SELECT * FROM columnar.stripe a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t';
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname='t';
 
 SELECT count(*) FROM t_stripes;
 
@@ -44,16 +44,16 @@ ALTER TABLE t DROP COLUMN a;
 
 SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
 
 VACUUM FULL t;
 
 SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
-WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
+WHERE a.storage_id = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
 
 -- Make sure we cleaned-up the transient table metadata after VACUUM FULL commands
-SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
+SELECT count(distinct storage_id) - :columnar_table_count FROM columnar.stripe;
 
 -- do this in a transaction so concurrent autovacuum doesn't interfere with results
 BEGIN;
@@ -120,7 +120,7 @@ DROP TABLE t;
 DROP VIEW t_stripes;
 
 -- Make sure we cleaned the metadata for t too
-SELECT count(distinct storageid) - :columnar_table_count FROM columnar.stripe;
+SELECT count(distinct storage_id) - :columnar_table_count FROM columnar.stripe;
 
 -- A table with high compression ratio
 SET columnar.compression TO 'pglz';

--- a/src/test/regress/sql/am_vacuum.sql
+++ b/src/test/regress/sql/am_vacuum.sql
@@ -42,13 +42,13 @@ SELECT count(*) FROM t_stripes;
 -- VACUUM FULL doesn't reclaim dropped columns, but converts them to NULLs
 ALTER TABLE t DROP COLUMN a;
 
-SELECT stripeid, attnum, chunkid, minimum_value IS NULL, maximum_value IS NULL
+SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
 
 VACUUM FULL t;
 
-SELECT stripeid, attnum, chunkid, minimum_value IS NULL, maximum_value IS NULL
+SELECT stripe_num, attr_num, chunk_num, minimum_value IS NULL, maximum_value IS NULL
 FROM columnar.chunk a, pg_class b
 WHERE a.storageid = columnar_relation_storageid(b.oid) AND b.relname='t' ORDER BY 1, 2, 3;
 


### PR DESCRIPTION
1. Moves `chunk.value_count` to the last position so dropping it in the next release doesn't affect position of other attributes.
2. Renames `stripeid` to `stripe_num` and `chunkid` to `chunk_num` since they are not globally unique & are just indexes in their top level structure.
3. Renames `attnum` to `attr_num` and `storageid` to `storage_id` so all attributes are consistently snake_case named.