### PR TITLE
Release VXID lock after executing CREATE INDEX/REINDEX CONCURRENTLY on shell relation

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -917,13 +917,13 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 			 * Even if we started a new transaction, now we still hold
 			 * ExclusiveLock (acquired by VirtualXactLockTableInsert) on new
 			 * vxid and it is not released yet.
-
+			 *
 			 * Moreover, remote connections to localhost (that are opened by
 			 * Citus for shard level index commands) might enter into dead-lock
 			 * since they would attempt to acquire ShareLock on the same vxid
 			 * since postgres calls WaitForOlderSnapshots function when executing
 			 * CREATE INDEX (or REINDEX) CONCURRENTLY commands.
-
+			 *
 			 * To prevent self-deadlock, we release lock on vxid by explicitly
 			 * calling VirtualXactLockTableCleanup.
 			 */

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -488,11 +488,20 @@ COMMIT;
 CREATE INDEX single_node_i1 ON test(x);
 CREATE INDEX single_node_i2 ON test(x,y);
 REINDEX SCHEMA single_node;
+CREATE INDEX CONCURRENTLY test_concurrent_idx_x ON test(x);
+CREATE INDEX CONCURRENTLY test_concurrent_idx_y ON test(x);
 -- PG 11 does not support CONCURRENTLY
 -- and we do not want to add a new output
--- file just for that. Enable the test
--- once we remove PG_VERSION_11
---REINDEX SCHEMA CONCURRENTLY single_node;
+-- file just for that. Enable REINDEX CONCURRENTLY
+-- tests only when pg version > 11:
+SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
+\gset
+\if :server_version_above_eleven
+REINDEX INDEX CONCURRENTLY test_concurrent_idx_x;
+REINDEX INDEX CONCURRENTLY test_concurrent_idx_y;
+REINDEX TABLE CONCURRENTLY test;
+REINDEX SCHEMA single_node;
+\endif
 -- keep one of the indexes
 -- drop w/wout tx blocks
 BEGIN;

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -500,7 +500,7 @@ SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_v
 REINDEX INDEX CONCURRENTLY test_concurrent_idx_x;
 REINDEX INDEX CONCURRENTLY test_concurrent_idx_y;
 REINDEX TABLE CONCURRENTLY test;
-REINDEX SCHEMA single_node;
+REINDEX SCHEMA CONCURRENTLY single_node;
 \endif
 -- keep one of the indexes
 -- drop w/wout tx blocks

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -304,7 +304,7 @@ SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_v
 REINDEX INDEX CONCURRENTLY test_concurrent_idx_x;
 REINDEX INDEX CONCURRENTLY test_concurrent_idx_y;
 REINDEX TABLE CONCURRENTLY test;
-REINDEX SCHEMA single_node;
+REINDEX SCHEMA CONCURRENTLY single_node;
 \endif
 
 -- keep one of the indexes

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -290,11 +290,22 @@ CREATE INDEX single_node_i1 ON test(x);
 CREATE INDEX single_node_i2 ON test(x,y);
 REINDEX SCHEMA single_node;
 
+CREATE INDEX CONCURRENTLY test_concurrent_idx_x ON test(x);
+CREATE INDEX CONCURRENTLY test_concurrent_idx_y ON test(x);
+
 -- PG 11 does not support CONCURRENTLY
 -- and we do not want to add a new output
--- file just for that. Enable the test
--- once we remove PG_VERSION_11
---REINDEX SCHEMA CONCURRENTLY single_node;
+-- file just for that. Enable REINDEX CONCURRENTLY
+-- tests only when pg version > 11:
+
+SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
+\gset
+\if :server_version_above_eleven
+REINDEX INDEX CONCURRENTLY test_concurrent_idx_x;
+REINDEX INDEX CONCURRENTLY test_concurrent_idx_y;
+REINDEX TABLE CONCURRENTLY test;
+REINDEX SCHEMA single_node;
+\endif
 
 -- keep one of the indexes
 -- drop w/wout tx blocks


### PR DESCRIPTION
Even if we started a new transaction, now we still hold
ExclusiveLock (acquired by VirtualXactLockTableInsert) on new
vxid and it is not released yet.

Moreover, remote connections to localhost (that are opened by
Citus for shard level index commands) might enter into dead-lock
since they would attempt to acquire ShareLock on the same vxid
since postgres calls WaitForOlderSnapshots function when executing
CREATE INDEX (or REINDEX) CONCURRENTLY commands.

To prevent self-deadlock, we release lock on vxid by explicitly
calling VirtualXactLockTableCleanup.

Fixes #4675

See https://github.com/citusdata/citus/issues/4675#issuecomment-776698549

---

Question: Should we backport this to 9.5 (since it also applies to 9.5) ?
