### PR TITLE
Fix insert query with CTEs/sublinks/subqueries etc

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -344,6 +344,10 @@ CitusBeginModifyScan(CustomScanState *node, EState *estate, int eflags)
 		 * Given that pruning is deferred always for INSERTs, we get here
 		 * !EnableFastPathRouterPlanner  as well.
 		 */
+		if (jobQuery->commandType == CMD_INSERT)
+		{
+			currentPlan->fastPathRouterPlan = true;
+		}
 		Assert(currentPlan->fastPathRouterPlan || !EnableFastPathRouterPlanner);
 
 		/*

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -342,13 +342,12 @@ CitusBeginModifyScan(CustomScanState *node, EState *estate, int eflags)
 		/*
 		 * At this point, we're about to do the shard pruning for fast-path queries.
 		 * Given that pruning is deferred always for INSERTs, we get here
-		 * !EnableFastPathRouterPlanner  as well.
+		 * !EnableFastPathRouterPlanner  as well. Given that INSERT statements with
+		 * CTEs/sublinks etc are not eligible for fast-path router plan, we get here
+		 * jobQuery->commandType == CMD_INSERT as well.
 		 */
-		if (jobQuery->commandType == CMD_INSERT)
-		{
-			currentPlan->fastPathRouterPlan = true;
-		}
-		Assert(currentPlan->fastPathRouterPlan || !EnableFastPathRouterPlanner);
+		Assert(currentPlan->fastPathRouterPlan || !EnableFastPathRouterPlanner ||
+			   jobQuery->commandType == CMD_INSERT);
 
 		/*
 		 * We can only now decide which shard to use, so we need to build a new task

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -564,7 +564,7 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 			if (queryTree->commandType == CMD_INSERT)
 			{
 				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-									 "Router planner doesn't support common table expressions with non-select queries.",
+									 "Router planner doesn't support common table expressions with INSERT queries.",
 									 NULL, NULL);
 			}
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -560,16 +560,17 @@ ModifyPartialQuerySupported(Query *queryTree, bool multiShardQuery,
 			CommonTableExpr *cte = (CommonTableExpr *) lfirst(cteCell);
 			Query *cteQuery = (Query *) cte->ctequery;
 
+			/* CTEs still not supported for INSERTs. */
+			if (queryTree->commandType == CMD_INSERT)
+			{
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "Router planner doesn't support common table expressions with non-select queries.",
+									 NULL, NULL);
+			}
+
 			if (cteQuery->commandType != CMD_SELECT)
 			{
-				/* Modifying CTEs still not supported for INSERTs & multi shard queries. */
-				if (queryTree->commandType == CMD_INSERT)
-				{
-					return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-										 "Router planner doesn't support non-select common table expressions with non-select queries.",
-										 NULL, NULL);
-				}
-
+				/* Modifying CTEs still not supported for multi shard queries. */
 				if (multiShardQuery)
 				{
 					return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -41,7 +41,7 @@ SELECT create_distributed_table('articles_hash', 'author_id');
 
 (1 row)
 
-CREATE TABLE authors_reference ( name varchar(20), id bigint );
+CREATE TABLE authors_reference (id int, name text);
 SELECT create_reference_table('authors_reference');
  create_reference_table
 ---------------------------------------------------------------------
@@ -2110,6 +2110,26 @@ DEBUG:  query has a single distribution column value: 4
 ---------------------------------------------------------------------
      0
 (1 row)
+
+-- test INSERT using values from generate_series() and repeat() functions
+INSERT INTO authors_reference (id, name) VALUES (generate_series(1, 10), repeat('Migjeni', 3));
+DEBUG:  Creating router plan
+SELECT * FROM authors_reference;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id |         name
+---------------------------------------------------------------------
+  1 | MigjeniMigjeniMigjeni
+  2 | MigjeniMigjeniMigjeni
+  3 | MigjeniMigjeniMigjeni
+  4 | MigjeniMigjeniMigjeni
+  5 | MigjeniMigjeniMigjeni
+  6 | MigjeniMigjeniMigjeni
+  7 | MigjeniMigjeniMigjeni
+  8 | MigjeniMigjeniMigjeni
+  9 | MigjeniMigjeniMigjeni
+ 10 | MigjeniMigjeniMigjeni
+(10 rows)
 
 SET client_min_messages to 'NOTICE';
 DROP FUNCTION author_articles_max_id();

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -2114,7 +2114,7 @@ DEBUG:  query has a single distribution column value: 4
 -- test INSERT using values from generate_series() and repeat() functions
 INSERT INTO authors_reference (id, name) VALUES (generate_series(1, 10), repeat('Migjeni', 3));
 DEBUG:  Creating router plan
-SELECT * FROM authors_reference;
+SELECT * FROM authors_reference ORDER BY 1, 2;
 DEBUG:  Distributed planning for a fast-path router query
 DEBUG:  Creating router plan
  id |         name

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -718,8 +718,8 @@ SELECT create_distributed_table('hash_parted ', 'a');
 
 (1 row)
 
-INSERT INTO hash_parted VALUES (1, generate_series(1,10));
-SELECT * FROM hash_parted;
+INSERT INTO hash_parted VALUES (1, generate_series(1, 10));
+SELECT * FROM hash_parted ORDER BY 1, 2;
  a | b
 ---------------------------------------------------------------------
  1 |  1
@@ -748,9 +748,22 @@ SELECT create_distributed_table('parent_tab', 'id');
 
 (1 row)
 
-INSERT INTO parent_tab VALUES (generate_series(0, 29));
+INSERT INTO parent_tab VALUES (generate_series(0, 3));
 ERROR:  failed to evaluate partition key in insert
 HINT:  try using constant values for partition column
+-- now it should work
+CREATE TABLE parent_tab_1_2 PARTITION OF parent_tab FOR VALUES FROM (1) to (2);
+ALTER TABLE parent_tab ADD COLUMN b int;
+INSERT INTO parent_tab VALUES (1, generate_series(0, 3));
+SELECT * FROM parent_tab ORDER BY 1, 2;
+ id | b
+---------------------------------------------------------------------
+  1 | 0
+  1 | 1
+  1 | 2
+  1 | 3
+(4 rows)
+
 -- make sure that parallel accesses are good
 SET citus.force_max_query_parallelization TO ON;
 SELECT * FROM test_2 ORDER BY 1 DESC;

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -694,6 +694,63 @@ SELECT * FROM collections_list, collections_list_0 WHERE collections_list.key=co
  100 |             0 | 10000 | 100 |             0 | 10000
 (1 row)
 
+-- test hash distribution using INSERT with generate_series() function
+CREATE OR REPLACE FUNCTION part_hashint4_noop(value int4, seed int8)
+RETURNS int8 AS $$
+SELECT value + seed;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OPERATOR CLASS part_test_int4_ops
+FOR TYPE int4
+USING HASH AS
+operator 1 =,
+function 2 part_hashint4_noop(int4, int8);
+CREATE TABLE hash_parted (
+       a int,
+  b int
+) PARTITION BY HASH (a part_test_int4_ops);
+CREATE TABLE hpart0 PARTITION OF hash_parted FOR VALUES WITH (modulus 4, remainder 0);
+CREATE TABLE hpart1 PARTITION OF hash_parted FOR VALUES WITH (modulus 4, remainder 1);
+CREATE TABLE hpart2 PARTITION OF hash_parted FOR VALUES WITH (modulus 4, remainder 2);
+CREATE TABLE hpart3 PARTITION OF hash_parted FOR VALUES WITH (modulus 4, remainder 3);
+SELECT create_distributed_table('hash_parted ', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO hash_parted VALUES (1, generate_series(1,10));
+SELECT * FROM hash_parted;
+ a | b
+---------------------------------------------------------------------
+ 1 |  1
+ 1 |  2
+ 1 |  3
+ 1 |  4
+ 1 |  5
+ 1 |  6
+ 1 |  7
+ 1 |  8
+ 1 |  9
+ 1 | 10
+(10 rows)
+
+ALTER TABLE hash_parted DETACH PARTITION hpart0;
+ALTER TABLE hash_parted DETACH PARTITION hpart1;
+ALTER TABLE hash_parted DETACH PARTITION hpart2;
+ALTER TABLE hash_parted DETACH PARTITION hpart3;
+-- test range partition without creating partitions and inserting with generate_series()
+-- should error out even in plain PG since no partition of relation "parent_tab" is found for row
+-- in Citus it errors out because it fails to evaluate partition key in insert
+CREATE TABLE parent_tab (id int) PARTITION BY RANGE (id);
+SELECT create_distributed_table('parent_tab', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO parent_tab VALUES (generate_series(0, 29));
+ERROR:  failed to evaluate partition key in insert
+HINT:  try using constant values for partition column
 -- make sure that parallel accesses are good
 SET citus.force_max_query_parallelization TO ON;
 SELECT * FROM test_2 ORDER BY 1 DESC;

--- a/src/test/regress/expected/with_modifying.out
+++ b/src/test/regress/expected/with_modifying.out
@@ -822,6 +822,33 @@ EXECUTE olu(1,ARRAY[1,2],ARRAY[1,2]);
  {1}       | {1}       | {NULL}
 (1 row)
 
+-- test insert query with insert CTE
+WITH insert_cte AS
+       (INSERT INTO with_modifying.modify_table VALUES (23, 7))
+INSERT INTO with_modifying.anchor_table VALUES (1998);
+SELECT * FROM with_modifying.modify_table WHERE id = 23 AND val = 7;
+ id | val
+---------------------------------------------------------------------
+ 23 |   7
+(1 row)
+
+SELECT * FROM with_modifying.anchor_table WHERE id = 1998;
+  id
+---------------------------------------------------------------------
+ 1998
+(1 row)
+
+-- test insert query with select CTE
+WITH select_cte AS
+       (SELECT * FROM with_modifying.modify_table)
+INSERT INTO with_modifying.anchor_table VALUES (1990);
+SELECT * FROM with_modifying.anchor_table WHERE id = 1990;
+  id
+---------------------------------------------------------------------
+ 1990
+(1 row)
+
+DELETE FROM with_modifying.anchor_table WHERE id IN (1990, 1998);
 -- Test with replication factor 2
 SET citus.shard_replication_factor to 2;
 DROP TABLE modify_table;

--- a/src/test/regress/expected/with_modifying.out
+++ b/src/test/regress/expected/with_modifying.out
@@ -838,6 +838,32 @@ SELECT * FROM with_modifying.anchor_table WHERE id = 1998;
  1998
 (1 row)
 
+-- test insert query with multiple CTEs
+WITH select_cte AS (SELECT * FROM with_modifying.anchor_table),
+       modifying_cte AS (INSERT INTO with_modifying.anchor_table SELECT * FROM select_cte)
+INSERT INTO with_modifying.anchor_table VALUES (1995);
+SELECT * FROM with_modifying.anchor_table ORDER BY 1;
+  id
+---------------------------------------------------------------------
+    1
+    1
+    2
+    2
+ 1995
+ 1998
+ 1998
+(7 rows)
+
+-- test with returning
+WITH returning_cte AS (INSERT INTO with_modifying.anchor_table values (1997) RETURNING *)
+INSERT INTO with_modifying.anchor_table VALUES (1996);
+SELECT * FROM with_modifying.anchor_table WHERE id IN (1996, 1997) ORDER BY 1;
+  id
+---------------------------------------------------------------------
+ 1996
+ 1997
+(2 rows)
+
 -- test insert query with select CTE
 WITH select_cte AS
        (SELECT * FROM with_modifying.modify_table)
@@ -848,7 +874,17 @@ SELECT * FROM with_modifying.anchor_table WHERE id = 1990;
  1990
 (1 row)
 
-DELETE FROM with_modifying.anchor_table WHERE id IN (1990, 1998);
+-- even if we do multi-row insert, it is not fast path router due to cte
+WITH select_cte AS (SELECT 1 AS col)
+INSERT INTO with_modifying.anchor_table VALUES (1991), (1992);
+SELECT * FROM with_modifying.anchor_table WHERE id IN (1991, 1992) ORDER BY 1;
+  id
+---------------------------------------------------------------------
+ 1991
+ 1992
+(2 rows)
+
+DELETE FROM with_modifying.anchor_table WHERE id IN (1990, 1991, 1992, 1995, 1996, 1997, 1998);
 -- Test with replication factor 2
 SET citus.shard_replication_factor to 2;
 DROP TABLE modify_table;

--- a/src/test/regress/sql/multi_router_planner_fast_path.sql
+++ b/src/test/regress/sql/multi_router_planner_fast_path.sql
@@ -852,7 +852,7 @@ SELECT count(*) FILTER (where value = 15) FROM collections_list_2 WHERE key = 4;
 
 -- test INSERT using values from generate_series() and repeat() functions
 INSERT INTO authors_reference (id, name) VALUES (generate_series(1, 10), repeat('Migjeni', 3));
-SELECT * FROM authors_reference;
+SELECT * FROM authors_reference ORDER BY 1, 2;
 
 SET client_min_messages to 'NOTICE';
 

--- a/src/test/regress/sql/multi_router_planner_fast_path.sql
+++ b/src/test/regress/sql/multi_router_planner_fast_path.sql
@@ -49,7 +49,7 @@ SET citus.shard_replication_factor TO 1;
 SET citus.shard_count TO 2;
 SELECT create_distributed_table('articles_hash', 'author_id');
 
-CREATE TABLE authors_reference ( name varchar(20), id bigint );
+CREATE TABLE authors_reference (id int, name text);
 SELECT create_reference_table('authors_reference');
 
 -- create a bunch of test data
@@ -849,6 +849,10 @@ UPDATE collections_list SET value = 15 WHERE key = 4;
 SELECT count(*) FILTER (where value = 15) FROM collections_list WHERE key = 4;
 SELECT count(*) FILTER (where value = 15) FROM collections_list_1 WHERE key = 4;
 SELECT count(*) FILTER (where value = 15) FROM collections_list_2 WHERE key = 4;
+
+-- test INSERT using values from generate_series() and repeat() functions
+INSERT INTO authors_reference (id, name) VALUES (generate_series(1, 10), repeat('Migjeni', 3));
+SELECT * FROM authors_reference;
 
 SET client_min_messages to 'NOTICE';
 

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -432,9 +432,9 @@ CREATE TABLE hpart3 PARTITION OF hash_parted FOR VALUES WITH (modulus 4, remaind
 
 SELECT create_distributed_table('hash_parted ', 'a');
 
-INSERT INTO hash_parted VALUES (1, generate_series(1,10));
+INSERT INTO hash_parted VALUES (1, generate_series(1, 10));
 
-SELECT * FROM hash_parted;
+SELECT * FROM hash_parted ORDER BY 1, 2;
 
 ALTER TABLE hash_parted DETACH PARTITION hpart0;
 ALTER TABLE hash_parted DETACH PARTITION hpart1;
@@ -446,7 +446,12 @@ ALTER TABLE hash_parted DETACH PARTITION hpart3;
 -- in Citus it errors out because it fails to evaluate partition key in insert
 CREATE TABLE parent_tab (id int) PARTITION BY RANGE (id);
 SELECT create_distributed_table('parent_tab', 'id');
-INSERT INTO parent_tab VALUES (generate_series(0, 29));
+INSERT INTO parent_tab VALUES (generate_series(0, 3));
+-- now it should work
+CREATE TABLE parent_tab_1_2 PARTITION OF parent_tab FOR VALUES FROM (1) to (2);
+ALTER TABLE parent_tab ADD COLUMN b int;
+INSERT INTO parent_tab VALUES (1, generate_series(0, 3));
+SELECT * FROM parent_tab ORDER BY 1, 2;
 
 -- make sure that parallel accesses are good
 SET citus.force_max_query_parallelization TO ON;

--- a/src/test/regress/sql/with_modifying.sql
+++ b/src/test/regress/sql/with_modifying.sql
@@ -491,6 +491,20 @@ EXECUTE olu(1,ARRAY[1,2],ARRAY[1,2]);
 EXECUTE olu(1,ARRAY[1,2],ARRAY[1,2]);
 EXECUTE olu(1,ARRAY[1,2],ARRAY[1,2]);
 
+-- test insert query with insert CTE
+WITH insert_cte AS
+	(INSERT INTO with_modifying.modify_table VALUES (23, 7))
+INSERT INTO with_modifying.anchor_table VALUES (1998);
+SELECT * FROM with_modifying.modify_table WHERE id = 23 AND val = 7;
+SELECT * FROM with_modifying.anchor_table WHERE id = 1998;
+
+-- test insert query with select CTE
+WITH select_cte AS
+	(SELECT * FROM with_modifying.modify_table)
+INSERT INTO with_modifying.anchor_table VALUES (1990);
+SELECT * FROM with_modifying.anchor_table WHERE id = 1990;
+DELETE FROM with_modifying.anchor_table WHERE id IN (1990, 1998);
+
 -- Test with replication factor 2
 SET citus.shard_replication_factor to 2;
 


### PR DESCRIPTION
DESCRIPTION: Fix insert query with CTEs/sublinks/subqueries etc

Fixes #4663 
Other than handling the failing assert, the following `SELECT` cte with an `INSERT` query isn't routable, therefore it is added to the checks in `multi_router_planner.c`, otherwise it fails.
```SQL
with wcte as (select * from table1)
  insert into table2 values ('hello world');
```

Also fixes #4091 as pointed out by @onurctirtir . The examples in this issue are all different cases of deferred pruning of `INSERT` queries with CTEs, sublinks, subqueries etc for which `fastPathRouterPlan` attribute is false. That's why the assert failed and we had a crash.