### PR TITLE
POC: Use chunk groups to read columnar data

### DIFF
--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -619,7 +619,7 @@ ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe, TupleDesc tupleDescri
 	index_close(index, AccessShareLock);
 	table_close(columnarChunk, AccessShareLock);
 
-	chunkList->chunkRowCounts =
+	chunkList->chunkGroupRowCounts =
 		ReadChunkGroupRowCounts(metapage->storageId, stripe, chunkCount);
 
 	return chunkList;
@@ -695,7 +695,7 @@ InsertStripeMetadataRow(uint64 storageId, StripeMetadata *stripe)
 		Int64GetDatum(stripe->dataLength),
 		Int32GetDatum(stripe->columnCount),
 		Int32GetDatum(stripe->chunkCount),
-		Int32GetDatum(stripe->chunkRowCount),
+		Int32GetDatum(stripe->chunkGroupRowCount),
 		Int64GetDatum(stripe->rowCount)
 	};
 
@@ -828,7 +828,7 @@ UnlockForStripeReservation(Relation rel, LOCKMODE mode)
 StripeMetadata
 ReserveStripe(Relation rel, uint64 sizeBytes,
 			  uint64 rowCount, uint64 columnCount,
-			  uint64 chunkCount, uint64 chunkRowCount)
+			  uint64 chunkCount, uint64 chunkGroupRowCount)
 {
 	StripeMetadata stripe = { 0 };
 	uint64 currLogicalHigh = 0;
@@ -876,7 +876,7 @@ ReserveStripe(Relation rel, uint64 sizeBytes,
 	stripe.fileOffset = resLogicalStart;
 	stripe.dataLength = sizeBytes;
 	stripe.chunkCount = chunkCount;
-	stripe.chunkRowCount = chunkRowCount;
+	stripe.chunkGroupRowCount = chunkGroupRowCount;
 	stripe.columnCount = columnCount;
 	stripe.rowCount = rowCount;
 	stripe.id = highestId + 1;
@@ -930,7 +930,7 @@ ReadDataFileStripeList(uint64 storageId, Snapshot snapshot)
 			datumArray[Anum_columnar_stripe_column_count - 1]);
 		stripeMetadata->chunkCount = DatumGetInt32(
 			datumArray[Anum_columnar_stripe_chunk_count - 1]);
-		stripeMetadata->chunkRowCount = DatumGetInt32(
+		stripeMetadata->chunkGroupRowCount = DatumGetInt32(
 			datumArray[Anum_columnar_stripe_chunk_row_count - 1]);
 		stripeMetadata->rowCount = DatumGetInt64(
 			datumArray[Anum_columnar_stripe_row_count - 1]);

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -140,6 +140,7 @@ typedef struct ColumnChunkSkipNode
 typedef struct StripeSkipList
 {
 	ColumnChunkSkipNode **chunkSkipNodeArray;
+	uint32 *chunkRowCounts;
 	uint32 columnCount;
 	uint32 chunkCount;
 } StripeSkipList;
@@ -202,13 +203,7 @@ typedef struct StripeBuffers
 	uint32 rowCount;
 	ColumnBuffers **columnBuffersArray;
 
-	/*
-	 * We might skip reading some chunks because they're refuted by the
-	 * WHERE clause. We keep number of selected chunks and number of rows
-	 * in each of them.
-	 */
-	uint32 selectedChunks;
-	uint32 *selectedChunkRowCount;
+	uint32 *selectedChunkGroupRowCounts;
 } StripeBuffers;
 
 

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -96,7 +96,7 @@ typedef struct StripeMetadata
 	uint64 dataLength;
 	uint32 columnCount;
 	uint32 chunkCount;
-	uint32 chunkRowCount;
+	uint32 chunkGroupRowCount;
 	uint64 rowCount;
 	uint64 id;
 } StripeMetadata;
@@ -140,7 +140,7 @@ typedef struct ColumnChunkSkipNode
 typedef struct StripeSkipList
 {
 	ColumnChunkSkipNode **chunkSkipNodeArray;
-	uint32 *chunkRowCounts;
+	uint32 *chunkGroupRowCounts;
 	uint32 columnCount;
 	uint32 chunkCount;
 } StripeSkipList;
@@ -251,7 +251,7 @@ extern int64 ColumnarReadChunkGroupsFiltered(TableReadState *state);
 extern FmgrInfo * GetFunctionInfoOrNull(Oid typeId, Oid accessMethodId,
 										int16 procedureId);
 extern ChunkData * CreateEmptyChunkData(uint32 columnCount, bool *columnMask,
-										uint32 chunkRowCount);
+										uint32 chunkGroupRowCount);
 extern void FreeChunkData(ChunkData *chunkData);
 extern uint64 ColumnarTableRowCount(Relation relation);
 extern bool CompressBuffer(StringInfo inputBuffer,
@@ -278,7 +278,7 @@ extern List * StripesForRelfilenode(RelFileNode relfilenode);
 extern uint64 GetHighestUsedAddress(RelFileNode relfilenode);
 extern StripeMetadata ReserveStripe(Relation rel, uint64 size,
 									uint64 rowCount, uint64 columnCount,
-									uint64 chunkCount, uint64 chunkRowCount);
+									uint64 chunkCount, uint64 chunkGroupRowCount);
 extern void SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe,
 							   StripeSkipList *stripeSkipList,
 							   TupleDesc tupleDescriptor);


### PR DESCRIPTION
We introduced `columnar.chunk_group` to normalize common data between chunks. We are planning to use it for reading in the next release.