### PR TITLE
Move stripe.chunk_count to last position

### DIFF
--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -139,9 +139,9 @@ typedef FormData_columnar_options *Form_columnar_options;
 #define Anum_columnar_stripe_file_offset 3
 #define Anum_columnar_stripe_data_length 4
 #define Anum_columnar_stripe_column_count 5
-#define Anum_columnar_stripe_chunk_count 6
-#define Anum_columnar_stripe_chunk_row_count 7
-#define Anum_columnar_stripe_row_count 8
+#define Anum_columnar_stripe_chunk_row_count 6
+#define Anum_columnar_stripe_row_count 7
+#define Anum_columnar_stripe_chunk_count 8
 
 /* constants for columnar.chunk_group */
 #define Natts_columnar_chunkgroup 4
@@ -633,9 +633,9 @@ InsertStripeMetadataRow(uint64 storageId, StripeMetadata *stripe)
 		Int64GetDatum(stripe->fileOffset),
 		Int64GetDatum(stripe->dataLength),
 		Int32GetDatum(stripe->columnCount),
-		Int32GetDatum(stripe->chunkCount),
 		Int32GetDatum(stripe->chunkRowCount),
-		Int64GetDatum(stripe->rowCount)
+		Int64GetDatum(stripe->rowCount),
+		Int32GetDatum(stripe->chunkCount)
 	};
 
 	Oid columnarStripesOid = ColumnarStripeRelationId();

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -21,9 +21,9 @@ CREATE TABLE stripe (
     file_offset bigint NOT NULL,
     data_length bigint NOT NULL,
     column_count int NOT NULL,
-    chunk_count int NOT NULL,
     chunk_row_count int NOT NULL,
     row_count bigint NOT NULL,
+    chunk_group_count int NOT NULL,
     PRIMARY KEY (storage_id, stripe_num)
 ) WITH (user_catalog_table = true);
 

--- a/src/test/regress/expected/am_create.out
+++ b/src/test/regress/expected/am_create.out
@@ -55,5 +55,15 @@ WITH a as (
 ), c as (
    (TABLE a EXCEPT TABLE b) UNION (TABLE b EXCEPT TABLE a) UNION
    (TABLE a EXCEPT TABLE columnar.chunk_group) UNION (TABLE columnar.chunk_group EXCEPT TABLE a)
+), d as (
+   SELECT storage_id, stripe_num, count(*) as chunk_group_count
+   FROM columnar.chunk_group
+   GROUP BY 1,2
+), e as (
+   SELECT storage_id, stripe_num, chunk_group_count
+   FROM columnar.stripe
+), f as (
+   (TABLE d EXCEPT TABLE d) UNION (TABLE e EXCEPT TABLE d)
 )
-SELECT count(*) = 0 AS consistent FROM c;
+SELECT (SELECT count(*) = 0 FROM c) AND
+       (SELECT count(*) = 0 FROM f) as consistent;

--- a/src/test/regress/expected/am_insert.out
+++ b/src/test/regress/expected/am_insert.out
@@ -173,16 +173,16 @@ INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 INSERT INTO zero_col SELECT * FROM zero_col_heap;
-SELECT relname, stripe_num, row_count FROM columnar.stripe a, pg_class b
+SELECT relname, stripe_num, chunk_group_count, row_count FROM columnar.stripe a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
-ORDER BY 1,2,3;
- relname  | stripe_num | row_count
+ORDER BY 1,2,3,4;
+ relname  | stripe_num | chunk_group_count | row_count
 ---------------------------------------------------------------------
- zero_col |        1 |         1
- zero_col |        2 |         1
- zero_col |        3 |         1
- zero_col |        4 |         1
- zero_col |        5 |        64
+ zero_col |          1 |                 1 |         1
+ zero_col |          2 |                 1 |         1
+ zero_col |          3 |                 1 |         1
+ zero_col |          4 |                 1 |         1
+ zero_col |          5 |                 7 |        64
 (5 rows)
 
 SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
@@ -197,17 +197,17 @@ WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3,4;
  relname  | stripe_num | chunk_group_num | row_count
 ---------------------------------------------------------------------
- zero_col |        1 |       0 |         1
- zero_col |        2 |       0 |         1
- zero_col |        3 |       0 |         1
- zero_col |        4 |       0 |         1
- zero_col |        5 |       0 |        10
- zero_col |        5 |       1 |        10
- zero_col |        5 |       2 |        10
- zero_col |        5 |       3 |        10
- zero_col |        5 |       4 |        10
- zero_col |        5 |       5 |        10
- zero_col |        5 |       6 |         4
+ zero_col |          1 |               0 |         1
+ zero_col |          2 |               0 |         1
+ zero_col |          3 |               0 |         1
+ zero_col |          4 |               0 |         1
+ zero_col |          5 |               0 |        10
+ zero_col |          5 |               1 |        10
+ zero_col |          5 |               2 |        10
+ zero_col |          5 |               3 |        10
+ zero_col |          5 |               4 |        10
+ zero_col |          5 |               5 |        10
+ zero_col |          5 |               6 |         4
 (11 rows)
 
 DROP TABLE zero_col;

--- a/src/test/regress/sql/am_create.sql
+++ b/src/test/regress/sql/am_create.sql
@@ -59,5 +59,15 @@ WITH a as (
 ), c as (
    (TABLE a EXCEPT TABLE b) UNION (TABLE b EXCEPT TABLE a) UNION
    (TABLE a EXCEPT TABLE columnar.chunk_group) UNION (TABLE columnar.chunk_group EXCEPT TABLE a)
+), d as (
+   SELECT storage_id, stripe_num, count(*) as chunk_group_count
+   FROM columnar.chunk_group
+   GROUP BY 1,2
+), e as (
+   SELECT storage_id, stripe_num, chunk_group_count
+   FROM columnar.stripe
+), f as (
+   (TABLE d EXCEPT TABLE d) UNION (TABLE e EXCEPT TABLE d)
 )
-SELECT count(*) = 0 AS consistent FROM c;
+SELECT (SELECT count(*) = 0 FROM c) AND
+       (SELECT count(*) = 0 FROM f) as consistent;

--- a/src/test/regress/sql/am_insert.sql
+++ b/src/test/regress/sql/am_insert.sql
@@ -128,9 +128,9 @@ INSERT INTO zero_col_heap SELECT * FROM zero_col_heap;
 
 INSERT INTO zero_col SELECT * FROM zero_col_heap;
 
-SELECT relname, stripe_num, row_count FROM columnar.stripe a, pg_class b
+SELECT relname, stripe_num, chunk_group_count, row_count FROM columnar.stripe a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
-ORDER BY 1,2,3;
+ORDER BY 1,2,3,4;
 
 SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
 WHERE columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'


### PR DESCRIPTION
`columnar.stripe.chunk_count` is redundant and is equal to `columnar.chunk_group` rows associated with the stripe. We want to drop it in the next release, so we move it to the last position so it doesn't change attnum of other columns.