### PR TITLE
Support dropping local table indexes along with a distributed index

### DIFF
--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -73,7 +73,6 @@ static void RangeVarCallbackForReindexIndex(const RangeVar *rel, Oid relOid, Oid
 											oldRelOid,
 											void *arg);
 static void ErrorIfUnsupportedIndexStmt(IndexStmt *createIndexStatement);
-static void ErrorIfUnsupportedDropIndexStmt(DropStmt *dropIndexStatement);
 static List * DropIndexTaskList(Oid relationId, Oid indexId, DropStmt *dropStmt);
 
 
@@ -696,17 +695,27 @@ PreprocessDropIndexStmt(Node *node, const char *dropIndexCommand,
 		bool isCitusRelation = IsCitusTable(relationId);
 		if (isCitusRelation)
 		{
+			if (OidIsValid(distributedIndexId))
+			{
+				/*
+				 * We already have a distributed index in the list, and Citus
+				 * currently only support dropping a single distributed index.
+				 */
+				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								errmsg("cannot drop multiple distributed objects in "
+									   "a single command"),
+								errhint("Try dropping each object in a separate DROP "
+										"command.")));
+			}
+
 			distributedIndexId = indexId;
 			distributedRelationId = relationId;
-			break;
 		}
 	}
 
 	if (OidIsValid(distributedIndexId))
 	{
 		DDLJob *ddlJob = palloc0(sizeof(DDLJob));
-
-		ErrorIfUnsupportedDropIndexStmt(dropIndexStatement);
 
 		if (AnyForeignKeyDependsOnIndex(distributedIndexId))
 		{
@@ -1166,26 +1175,6 @@ ErrorIfUnsupportedIndexStmt(IndexStmt *createIndexStatement)
 							errmsg("creating unique indexes on non-partition "
 								   "columns is currently unsupported")));
 		}
-	}
-}
-
-
-/*
- * ErrorIfUnsupportedDropIndexStmt checks if the corresponding drop index statement is
- * supported for distributed tables and errors out if it is not.
- */
-static void
-ErrorIfUnsupportedDropIndexStmt(DropStmt *dropIndexStatement)
-{
-	Assert(dropIndexStatement->removeType == OBJECT_INDEX);
-
-	if (list_length(dropIndexStatement->objects) > 1)
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot drop multiple distributed objects in a "
-							   "single command"),
-						errhint("Try dropping each object in a separate DROP "
-								"command.")));
 	}
 }
 

--- a/src/test/regress/expected/multi_index_statements.out
+++ b/src/test/regress/expected/multi_index_statements.out
@@ -222,11 +222,16 @@ DROP INDEX lineitem_orderkey_index, lineitem_partial_index;
 ERROR:  cannot drop multiple distributed objects in a single command
 HINT:  Try dropping each object in a separate DROP command.
 -- Verify that we can succesfully drop indexes
-DROP INDEX lineitem_orderkey_index;
-DROP INDEX lineitem_orderkey_index_new;
 DROP INDEX lineitem_partkey_desc_index;
 DROP INDEX lineitem_partial_index;
 DROP INDEX lineitem_colref_index;
+-- Verify that we can drop distributed indexes with local indexes
+CREATE TABLE local_table(a int, b int);
+CREATE INDEX local_index ON local_table(a);
+CREATE INDEX local_index2 ON local_table(b);
+DROP INDEX lineitem_orderkey_index, local_index;
+DROP INDEX IF EXISTS lineitem_orderkey_index_new, local_index2, non_existing_index;
+NOTICE:  index "non_existing_index" does not exist, skipping
 -- Verify that we handle if exists statements correctly
 DROP INDEX non_existent_index;
 ERROR:  index "non_existent_index" does not exist

--- a/src/test/regress/sql/multi_index_statements.sql
+++ b/src/test/regress/sql/multi_index_statements.sql
@@ -137,11 +137,16 @@ REINDEX SYSTEM regression;
 DROP INDEX lineitem_orderkey_index, lineitem_partial_index;
 
 -- Verify that we can succesfully drop indexes
-DROP INDEX lineitem_orderkey_index;
-DROP INDEX lineitem_orderkey_index_new;
 DROP INDEX lineitem_partkey_desc_index;
 DROP INDEX lineitem_partial_index;
 DROP INDEX lineitem_colref_index;
+
+-- Verify that we can drop distributed indexes with local indexes
+CREATE TABLE local_table(a int, b int);
+CREATE INDEX local_index ON local_table(a);
+CREATE INDEX local_index2 ON local_table(b);
+DROP INDEX lineitem_orderkey_index, local_index;
+DROP INDEX IF EXISTS lineitem_orderkey_index_new, local_index2, non_existing_index;
 
 -- Verify that we handle if exists statements correctly
 


### PR DESCRIPTION
DESCRIPTION: Support dropping local table indexes along with a distributed index

Allows users to drop multiple indexes in a single command. Increases DDL coverage. 
We used to error out when a user tries to drop more than one indexes at once, if at least one of them is distributed.
Example case:

`i1` is distributed, `i2` is not.
```
ahmet@ahmet:9700-5867=# drop index i1, i2;
ERROR:  cannot drop multiple distributed objects in a single command
```

The error message is ambiguous. Actually we are not trying to drop multiple distributed objects in a single command? This error comes from this code piece:
```
    if (list_length(dropIndexStatement->objects) > 1)
    {
        ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                        errmsg("cannot drop multiple distributed objects in a "
                               "single command"),
                        errhint("Try dropping each object in a separate DROP "
                                "command.")));
    }
```

Here, we check the number of index objects to be dropped, not only the distributed ones.

This PR removes that check and adds a check if there are more than one distributed indexes in a `DROP INDEX` statement. If there are, it errors out with the same error message as before. However, if only one of the indexes is distributed, then now we can drop all of them.

fixes: #4684 