### PR TITLE
Fix minor issues with makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ check-style:
 	cd ${citus_abs_top_srcdir} && citus_indent --quiet --check
 .PHONY: reindent check-style
 
-# depend on install for now
-check: all install
+# depend on install-all so that downgrade scripts are installed as well
+check: all install-all
 	$(MAKE) -C src/test/regress check-full
 
 .PHONY: all check clean install install-downgrades install-all

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -90,11 +90,11 @@ install: cleanup-before-install
 
 # install and install-downgrades should be run sequentially
 install-all: install
-	make install-downgrades
+	$(MAKE) install-downgrades
 
 install-downgrades: $(generated_downgrade_sql_files)
 	$(INSTALL_DATA) $(generated_downgrade_sql_files) '$(DESTDIR)$(datadir)/$(datamoduledir)/'
 
 clean-full:
-	make clean
+	$(MAKE) clean
 	rm -rf $(safestringlib_builddir)

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -128,7 +128,7 @@ check-empty: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) $(EXTRA_TESTS)
 
-check-multi: all install-downgrades
+check-multi: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
@@ -140,7 +140,7 @@ check-multi-hyperscale-superuser: all
 	$(pg_regress_multi_check) --conninfo="$(conninfo)" --worker-1-public-hostname="$(worker_1_public_hostname)" --worker-2-public-hostname="$(worker_2_public_hostname)" --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule_hyperscale_superuser $(EXTRA_TESTS)
 
-check-multi-vg: all install-downgrades
+check-multi-vg: all
 	$(pg_regress_multi_check) --load-extension=citus --valgrind \
 	--pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
@@ -166,7 +166,7 @@ check-vanilla: all
 check-vanilla-internal:
 	$(pg_regress_multi_check) --load-extension=citus --vanillatest
 
-check-multi-mx: all install-downgrades
+check-multi-mx: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_mx_schedule $(EXTRA_TESTS)
 
@@ -231,6 +231,3 @@ clean-upgrade-artifacts:
 clean distclean maintainer-clean:
 	rm -f $(output_files) $(input_files)
 	rm -rf tmp_check/
-
-install-downgrades:
-	$(MAKE) -C ../../backend/distributed/ install-downgrades

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -128,7 +128,7 @@ check-empty: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) $(EXTRA_TESTS)
 
-check-multi: all
+check-multi: all install-downgrades
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
 
@@ -140,7 +140,7 @@ check-multi-hyperscale-superuser: all
 	$(pg_regress_multi_check) --conninfo="$(conninfo)" --worker-1-public-hostname="$(worker_1_public_hostname)" --worker-2-public-hostname="$(worker_2_public_hostname)" --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule_hyperscale_superuser $(EXTRA_TESTS)
 
-check-multi-vg: all
+check-multi-vg: all install-downgrades
 	$(pg_regress_multi_check) --load-extension=citus --valgrind \
 	--pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_schedule $(EXTRA_TESTS)
@@ -166,7 +166,7 @@ check-vanilla: all
 check-vanilla-internal:
 	$(pg_regress_multi_check) --load-extension=citus --vanillatest
 
-check-multi-mx: all
+check-multi-mx: all install-downgrades
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_mx_schedule $(EXTRA_TESTS)
 
@@ -231,3 +231,6 @@ clean-upgrade-artifacts:
 clean distclean maintainer-clean:
 	rm -f $(output_files) $(input_files)
 	rm -rf tmp_check/
+
+install-downgrades:
+	$(MAKE) -C ../../backend/distributed/ install-downgrades


### PR DESCRIPTION
This PR aims to fix 2 seperate issues with Makefile targets

1. Passing make args to make subcommands
It is advised to use `${MAKE}` instead of `make` in makefiles. This chage also removes the warnings:
> make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.

2. Installing downgrade scripts on `make check` so that `multi_extension` does not fail

Related: #4932 
Fixes: #4081