### PR TITLE
Fix alignment issue in DatumToBytea

### DIFF
--- a/src/backend/columnar/cstore_metadata_tables.c
+++ b/src/backend/columnar/cstore_metadata_tables.c
@@ -1087,7 +1087,11 @@ DatumToBytea(Datum value, Form_pg_attribute attrForm)
 	{
 		if (attrForm->attbyval)
 		{
-			store_att_byval(VARDATA(result), value, attrForm->attlen);
+			Datum tmp;
+			store_att_byval(&tmp, value, attrForm->attlen);
+
+			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
+					 &tmp, attrForm->attlen);
 		}
 		else
 		{


### PR DESCRIPTION
This changes DatumBytea to match postgres style & avoid memcpy between values which are not aligned.