### PR TITLE
Remove useless pg version checks

### DIFF
--- a/src/backend/columnar/cstore_reader.c
+++ b/src/backend/columnar/cstore_reader.c
@@ -578,7 +578,6 @@ SelectedChunkMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 		Node *baseConstraint = BuildBaseConstraint(column);
 		for (chunkIndex = 0; chunkIndex < stripeSkipList->chunkCount; chunkIndex++)
 		{
-			bool predicateRefuted = false;
 			ColumnChunkSkipNode *chunkSkipNodeArray =
 				stripeSkipList->chunkSkipNodeArray[columnIndex];
 			ColumnChunkSkipNode *chunkSkipNode = &chunkSkipNodeArray[chunkIndex];
@@ -596,12 +595,8 @@ SelectedChunkMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 							 chunkSkipNode->maximumValue);
 
 			List *constraintList = list_make1(baseConstraint);
-#if (PG_VERSION_NUM >= 100000)
-			predicateRefuted = predicate_refuted_by(constraintList, restrictInfoList,
-													false);
-#else
-			predicateRefuted = predicate_refuted_by(constraintList, restrictInfoList);
-#endif
+			bool predicateRefuted =
+				predicate_refuted_by(constraintList, restrictInfoList, false);
 			if (predicateRefuted && selectedChunkMask[chunkIndex])
 			{
 				selectedChunkMask[chunkIndex] = false;

--- a/src/include/columnar/columnar_version_compat.h
+++ b/src/include/columnar/columnar_version_compat.h
@@ -14,23 +14,10 @@
 #ifndef COLUMNAR_COMPAT_H
 #define COLUMNAR_COMPAT_H
 
-#if PG_VERSION_NUM < 100000
-
-/* Accessor for the i'th attribute of tupdesc. */
-#define TupleDescAttr(tupdesc, i) ((tupdesc)->attrs[(i)])
-
-#endif
-
-#if PG_VERSION_NUM < 110000
-#define ALLOCSET_DEFAULT_SIZES ALLOCSET_DEFAULT_MINSIZE, ALLOCSET_DEFAULT_INITSIZE, \
-	ALLOCSET_DEFAULT_MAXSIZE
-#define ACLCHECK_OBJECT_TABLE ACL_KIND_CLASS
-#else
 #define ACLCHECK_OBJECT_TABLE OBJECT_TABLE
 
 #define ExplainPropertyLong(qlabel, value, es) \
 	ExplainPropertyInteger(qlabel, NULL, value, es)
-#endif
 
 #if PG_VERSION_NUM < 120000
 #define TTS_EMPTY(slot) ((slot)->tts_isempty)


### PR DESCRIPTION
Since we already don't support pg versions < 11, I think we can remove those three checks
