### PR TITLE
Ensure table owner when using alter_columnar_table_set/alter_columnar_table_reset

### DIFF
--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -1662,6 +1662,8 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
 							   quote_identifier(RelationGetRelationName(rel)))));
 	}
 
+	EnsureTableOwner(relationId);
+
 	ColumnarOptions options = { 0 };
 	if (!ReadColumnarOptions(relationId, &options))
 	{

--- a/src/backend/columnar/cstore_tableam.c
+++ b/src/backend/columnar/cstore_tableam.c
@@ -1771,6 +1771,8 @@ alter_columnar_table_reset(PG_FUNCTION_ARGS)
 							   quote_identifier(RelationGetRelationName(rel)))));
 	}
 
+	EnsureTableOwner(relationId);
+
 	ColumnarOptions options = { 0 };
 	if (!ReadColumnarOptions(relationId, &options))
 	{

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -656,8 +656,11 @@ NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
 SET ROLE read_access;
 -- user shouldn't be able to execute alter_columnar_table_set
--- for a columnar table that it doesn't own
+-- or alter_columnar_table_reset for a columnar table that it
+-- doesn't own
 SELECT alter_columnar_table_set('test_pg12.superuser_columnar_table', chunk_group_row_limit => 100);
+ERROR:  permission denied for schema test_pg12
+SELECT alter_columnar_table_reset('test_pg12.superuser_columnar_table');
 ERROR:  permission denied for schema test_pg12
 RESET ROLE;
 DROP USER read_access;

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -650,8 +650,19 @@ SELECT citus_remove_node('localhost', :master_port);
 
 (1 row)
 
+CREATE TABLE superuser_columnar_table (a int) USING columnar;
+CREATE USER read_access;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SET ROLE read_access;
+-- user shouldn't be able to execute alter_columnar_table_set
+-- for a columnar table that it doesn't own
+SELECT alter_columnar_table_set('test_pg12.superuser_columnar_table', chunk_group_row_limit => 100);
+ERROR:  permission denied for schema test_pg12
+RESET ROLE;
+DROP USER read_access;
 \set VERBOSITY terse
 drop schema test_pg12 cascade;
-NOTICE:  drop cascades to 15 other objects
+NOTICE:  drop cascades to 16 other objects
 \set VERBOSITY default
 SET citus.shard_replication_factor to 2;

--- a/src/test/regress/sql/pg12.sql
+++ b/src/test/regress/sql/pg12.sql
@@ -389,8 +389,10 @@ CREATE USER read_access;
 SET ROLE read_access;
 
 -- user shouldn't be able to execute alter_columnar_table_set
--- for a columnar table that it doesn't own
+-- or alter_columnar_table_reset for a columnar table that it
+-- doesn't own
 SELECT alter_columnar_table_set('test_pg12.superuser_columnar_table', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_reset('test_pg12.superuser_columnar_table');
 
 RESET ROLE;
 DROP USER read_access;

--- a/src/test/regress/sql/pg12.sql
+++ b/src/test/regress/sql/pg12.sql
@@ -383,6 +383,18 @@ ROLLBACK;
 RESET citus.replicate_reference_tables_on_activate;
 SELECT citus_remove_node('localhost', :master_port);
 
+CREATE TABLE superuser_columnar_table (a int) USING columnar;
+
+CREATE USER read_access;
+SET ROLE read_access;
+
+-- user shouldn't be able to execute alter_columnar_table_set
+-- for a columnar table that it doesn't own
+SELECT alter_columnar_table_set('test_pg12.superuser_columnar_table', chunk_group_row_limit => 100);
+
+RESET ROLE;
+DROP USER read_access;
+
 \set VERBOSITY terse
 drop schema test_pg12 cascade;
 \set VERBOSITY default


### PR DESCRIPTION
DESCRIPTION: Prevents using `alter_columnar_table_set` and `alter_columnar_table_reset` on a columnar table not owned by the user
